### PR TITLE
[prim] update register CDC scheme

### DIFF
--- a/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
+++ b/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
@@ -151,6 +151,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.operation.d),
     .qs         (),
+    .ds         (),
     .phase      (phase_operation),
     .err_update (err_update_operation),
     .err_storage(err_storage_operation)
@@ -172,6 +173,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.mode.d),
     .qs         (),
+    .ds         (),
     .phase      (phase_mode),
     .err_update (err_update_mode),
     .err_storage(err_storage_mode)
@@ -193,6 +195,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.key_len.d),
     .qs         (),
+    .ds         (),
     .phase      (phase_key_len),
     .err_update (err_update_key_len),
     .err_storage(err_storage_key_len)
@@ -214,6 +217,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.sideload.d),
     .qs         (),
+    .ds         (),
     .phase      (phase_key_sideload),
     .err_update (err_update_sideload),
     .err_storage(err_storage_sideload)
@@ -235,6 +239,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.prng_reseed_rate.d),
     .qs         (),
+    .ds         (),
     .phase      (phase_prng_reseed_rate),
     .err_update (err_update_prng_reseed_rate),
     .err_storage(err_storage_prng_reseed_rate)
@@ -256,6 +261,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.manual_operation.d),
     .qs         (),
+    .ds         (),
     .phase      (phase_manual_operation),
     .err_update (err_update_manual_operation),
     .err_storage(err_storage_manual_operation)
@@ -277,6 +283,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.force_zero_masks.d),
     .qs         (),
+    .ds         (),
     .phase      (phase_force_zero_masks),
     .err_update (err_update_force_zero_masks),
     .err_storage(err_storage_force_zero_masks)

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -246,6 +246,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_ctrl_update_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_ctrl_update_err.qe = alert_test_qe;
@@ -261,6 +262,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_fault.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault.qe = alert_test_qe;
@@ -281,6 +283,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share0_0_flds_we[0]),
     .q      (reg2hw.key_share0[0].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[0].qe = key_share0_0_qe;
@@ -301,6 +304,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share0_1_flds_we[0]),
     .q      (reg2hw.key_share0[1].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[1].qe = key_share0_1_qe;
@@ -321,6 +325,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share0_2_flds_we[0]),
     .q      (reg2hw.key_share0[2].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[2].qe = key_share0_2_qe;
@@ -341,6 +346,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share0_3_flds_we[0]),
     .q      (reg2hw.key_share0[3].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[3].qe = key_share0_3_qe;
@@ -361,6 +367,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share0_4_flds_we[0]),
     .q      (reg2hw.key_share0[4].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[4].qe = key_share0_4_qe;
@@ -381,6 +388,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share0_5_flds_we[0]),
     .q      (reg2hw.key_share0[5].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[5].qe = key_share0_5_qe;
@@ -401,6 +409,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share0_6_flds_we[0]),
     .q      (reg2hw.key_share0[6].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[6].qe = key_share0_6_qe;
@@ -421,6 +430,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share0_7_flds_we[0]),
     .q      (reg2hw.key_share0[7].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[7].qe = key_share0_7_qe;
@@ -441,6 +451,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share1_0_flds_we[0]),
     .q      (reg2hw.key_share1[0].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[0].qe = key_share1_0_qe;
@@ -461,6 +472,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share1_1_flds_we[0]),
     .q      (reg2hw.key_share1[1].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[1].qe = key_share1_1_qe;
@@ -481,6 +493,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share1_2_flds_we[0]),
     .q      (reg2hw.key_share1[2].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[2].qe = key_share1_2_qe;
@@ -501,6 +514,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share1_3_flds_we[0]),
     .q      (reg2hw.key_share1[3].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[3].qe = key_share1_3_qe;
@@ -521,6 +535,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share1_4_flds_we[0]),
     .q      (reg2hw.key_share1[4].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[4].qe = key_share1_4_qe;
@@ -541,6 +556,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share1_5_flds_we[0]),
     .q      (reg2hw.key_share1[5].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[5].qe = key_share1_5_qe;
@@ -561,6 +577,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share1_6_flds_we[0]),
     .q      (reg2hw.key_share1[6].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[6].qe = key_share1_6_qe;
@@ -581,6 +598,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (key_share1_7_flds_we[0]),
     .q      (reg2hw.key_share1[7].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[7].qe = key_share1_7_qe;
@@ -601,6 +619,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (iv_0_flds_we[0]),
     .q      (reg2hw.iv[0].q),
+    .ds     (),
     .qs     (iv_0_qs)
   );
   assign reg2hw.iv[0].qe = iv_0_qe;
@@ -621,6 +640,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (iv_1_flds_we[0]),
     .q      (reg2hw.iv[1].q),
+    .ds     (),
     .qs     (iv_1_qs)
   );
   assign reg2hw.iv[1].qe = iv_1_qe;
@@ -641,6 +661,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (iv_2_flds_we[0]),
     .q      (reg2hw.iv[2].q),
+    .ds     (),
     .qs     (iv_2_qs)
   );
   assign reg2hw.iv[2].qe = iv_2_qe;
@@ -661,6 +682,7 @@ module aes_reg_top (
     .qre    (),
     .qe     (iv_3_flds_we[0]),
     .q      (reg2hw.iv[3].q),
+    .ds     (),
     .qs     (iv_3_qs)
   );
   assign reg2hw.iv[3].qe = iv_3_qe;
@@ -698,6 +720,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (data_in_0_flds_we[0]),
     .q      (reg2hw.data_in[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -737,6 +760,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (data_in_1_flds_we[0]),
     .q      (reg2hw.data_in[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -776,6 +800,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (data_in_2_flds_we[0]),
     .q      (reg2hw.data_in[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -815,6 +840,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (data_in_3_flds_we[0]),
     .q      (reg2hw.data_in[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -834,6 +860,7 @@ module aes_reg_top (
     .qre    (reg2hw.data_out[0].re),
     .qe     (),
     .q      (reg2hw.data_out[0].q),
+    .ds     (),
     .qs     (data_out_0_qs)
   );
 
@@ -850,6 +877,7 @@ module aes_reg_top (
     .qre    (reg2hw.data_out[1].re),
     .qe     (),
     .q      (reg2hw.data_out[1].q),
+    .ds     (),
     .qs     (data_out_1_qs)
   );
 
@@ -866,6 +894,7 @@ module aes_reg_top (
     .qre    (reg2hw.data_out[2].re),
     .qe     (),
     .q      (reg2hw.data_out[2].q),
+    .ds     (),
     .qs     (data_out_2_qs)
   );
 
@@ -882,6 +911,7 @@ module aes_reg_top (
     .qre    (reg2hw.data_out[3].re),
     .qe     (),
     .q      (reg2hw.data_out[3].q),
+    .ds     (),
     .qs     (data_out_3_qs)
   );
 
@@ -901,6 +931,7 @@ module aes_reg_top (
     .qre    (reg2hw.ctrl_shadowed.operation.re),
     .qe     (ctrl_shadowed_flds_we[0]),
     .q      (reg2hw.ctrl_shadowed.operation.q),
+    .ds     (),
     .qs     (ctrl_shadowed_operation_qs)
   );
   assign reg2hw.ctrl_shadowed.operation.qe = ctrl_shadowed_qe;
@@ -916,6 +947,7 @@ module aes_reg_top (
     .qre    (reg2hw.ctrl_shadowed.mode.re),
     .qe     (ctrl_shadowed_flds_we[1]),
     .q      (reg2hw.ctrl_shadowed.mode.q),
+    .ds     (),
     .qs     (ctrl_shadowed_mode_qs)
   );
   assign reg2hw.ctrl_shadowed.mode.qe = ctrl_shadowed_qe;
@@ -931,6 +963,7 @@ module aes_reg_top (
     .qre    (reg2hw.ctrl_shadowed.key_len.re),
     .qe     (ctrl_shadowed_flds_we[2]),
     .q      (reg2hw.ctrl_shadowed.key_len.q),
+    .ds     (),
     .qs     (ctrl_shadowed_key_len_qs)
   );
   assign reg2hw.ctrl_shadowed.key_len.qe = ctrl_shadowed_qe;
@@ -946,6 +979,7 @@ module aes_reg_top (
     .qre    (reg2hw.ctrl_shadowed.sideload.re),
     .qe     (ctrl_shadowed_flds_we[3]),
     .q      (reg2hw.ctrl_shadowed.sideload.q),
+    .ds     (),
     .qs     (ctrl_shadowed_sideload_qs)
   );
   assign reg2hw.ctrl_shadowed.sideload.qe = ctrl_shadowed_qe;
@@ -961,6 +995,7 @@ module aes_reg_top (
     .qre    (reg2hw.ctrl_shadowed.prng_reseed_rate.re),
     .qe     (ctrl_shadowed_flds_we[4]),
     .q      (reg2hw.ctrl_shadowed.prng_reseed_rate.q),
+    .ds     (),
     .qs     (ctrl_shadowed_prng_reseed_rate_qs)
   );
   assign reg2hw.ctrl_shadowed.prng_reseed_rate.qe = ctrl_shadowed_qe;
@@ -976,6 +1011,7 @@ module aes_reg_top (
     .qre    (reg2hw.ctrl_shadowed.manual_operation.re),
     .qe     (ctrl_shadowed_flds_we[5]),
     .q      (reg2hw.ctrl_shadowed.manual_operation.q),
+    .ds     (),
     .qs     (ctrl_shadowed_manual_operation_qs)
   );
   assign reg2hw.ctrl_shadowed.manual_operation.qe = ctrl_shadowed_qe;
@@ -991,6 +1027,7 @@ module aes_reg_top (
     .qre    (reg2hw.ctrl_shadowed.force_zero_masks.re),
     .qe     (ctrl_shadowed_flds_we[6]),
     .q      (reg2hw.ctrl_shadowed.force_zero_masks.q),
+    .ds     (),
     .qs     (ctrl_shadowed_force_zero_masks_qs)
   );
   assign reg2hw.ctrl_shadowed.force_zero_masks.qe = ctrl_shadowed_qe;
@@ -1021,6 +1058,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl_aux_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_aux_shadowed_qs),
@@ -1054,6 +1092,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_aux_regwen_qs)
@@ -1081,6 +1120,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.trigger.start.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1106,6 +1146,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.trigger.key_iv_data_in_clear.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1131,6 +1172,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.trigger.data_out_clear.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1156,6 +1198,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.trigger.prng_reseed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1183,6 +1226,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.status.idle.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_idle_qs)
@@ -1208,6 +1252,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_stall_qs)
@@ -1233,6 +1278,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.status.output_lost.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_output_lost_qs)
@@ -1258,6 +1304,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_output_valid_qs)
@@ -1283,6 +1330,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_input_ready_qs)
@@ -1308,6 +1356,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_alert_recov_ctrl_update_err_qs)
@@ -1333,6 +1382,7 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_alert_fatal_fault_qs)

--- a/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
@@ -156,6 +156,7 @@ module clkmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.clk_enables.clk_fixed_peri_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (clk_enables_clk_fixed_peri_en_qs)
@@ -181,6 +182,7 @@ module clkmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.clk_enables.clk_usb_48mhz_peri_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (clk_enables_clk_usb_48mhz_peri_en_qs)
@@ -208,6 +210,7 @@ module clkmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.clk_hints.clk_main_aes_hint.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (clk_hints_clk_main_aes_hint_qs)
@@ -233,6 +236,7 @@ module clkmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.clk_hints.clk_main_hmac_hint.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (clk_hints_clk_main_hmac_hint_qs)
@@ -260,6 +264,7 @@ module clkmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (clk_hints_status_clk_main_aes_val_qs)
@@ -285,6 +290,7 @@ module clkmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (clk_hints_status_clk_main_hmac_val_qs)

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -236,6 +236,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.cs_cmd_req_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_cs_cmd_req_done_qs)
@@ -261,6 +262,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.cs_entropy_req.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_cs_entropy_req_qs)
@@ -286,6 +288,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.cs_hw_inst_exc.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_cs_hw_inst_exc_qs)
@@ -311,6 +314,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.cs_fatal_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_cs_fatal_err_qs)
@@ -338,6 +342,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.cs_cmd_req_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_cs_cmd_req_done_qs)
@@ -363,6 +368,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.cs_entropy_req.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_cs_entropy_req_qs)
@@ -388,6 +394,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.cs_hw_inst_exc.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_cs_hw_inst_exc_qs)
@@ -413,6 +420,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.cs_fatal_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_cs_fatal_err_qs)
@@ -434,6 +442,7 @@ module csrng_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.cs_cmd_req_done.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.cs_cmd_req_done.qe = intr_test_qe;
@@ -449,6 +458,7 @@ module csrng_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.cs_entropy_req.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.cs_entropy_req.qe = intr_test_qe;
@@ -464,6 +474,7 @@ module csrng_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.cs_hw_inst_exc.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.cs_hw_inst_exc.qe = intr_test_qe;
@@ -479,6 +490,7 @@ module csrng_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.cs_fatal_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.cs_fatal_err.qe = intr_test_qe;
@@ -499,6 +511,7 @@ module csrng_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_alert.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_alert.qe = alert_test_qe;
@@ -514,6 +527,7 @@ module csrng_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_alert.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
@@ -539,6 +553,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (regwen_qs)
@@ -569,6 +584,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_enable_qs)
@@ -594,6 +610,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.sw_app_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_sw_app_enable_qs)
@@ -619,6 +636,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.read_int_state.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_read_int_state_qs)
@@ -656,6 +674,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (cmd_req_flds_we[0]),
     .q      (reg2hw.cmd_req.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -684,6 +703,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_cmd_sts_cmd_rdy_qs)
@@ -709,6 +729,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_cmd_sts_cmd_sts_qs)
@@ -727,6 +748,7 @@ module csrng_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (genbits_vld_genbits_vld_qs)
   );
 
@@ -741,6 +763,7 @@ module csrng_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (genbits_vld_genbits_fips_qs)
   );
 
@@ -756,6 +779,7 @@ module csrng_reg_top (
     .qre    (reg2hw.genbits.re),
     .qe     (),
     .q      (reg2hw.genbits.q),
+    .ds     (),
     .qs     (genbits_qs)
   );
 
@@ -791,6 +815,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (int_state_num_flds_we[0]),
     .q      (reg2hw.int_state_num.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (int_state_num_qs)
@@ -809,6 +834,7 @@ module csrng_reg_top (
     .qre    (reg2hw.int_state_val.re),
     .qe     (),
     .q      (reg2hw.int_state_val.q),
+    .ds     (),
     .qs     (int_state_val_qs)
   );
 
@@ -833,6 +859,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (hw_exc_sts_qs)
@@ -860,6 +887,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_enable_field_alert_qs)
@@ -885,6 +913,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_sw_app_enable_field_alert_qs)
@@ -910,6 +939,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_read_int_state_field_alert_qs)
@@ -935,6 +965,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_cs_bus_cmp_alert_qs)
@@ -962,6 +993,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_cmd_err_qs)
@@ -987,6 +1019,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_genbits_err_qs)
@@ -1012,6 +1045,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_cmdreq_err_qs)
@@ -1037,6 +1071,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_rcstage_err_qs)
@@ -1062,6 +1097,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_keyvrc_err_qs)
@@ -1087,6 +1123,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_updreq_err_qs)
@@ -1112,6 +1149,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_bencreq_err_qs)
@@ -1137,6 +1175,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_bencack_err_qs)
@@ -1162,6 +1201,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_pdata_err_qs)
@@ -1187,6 +1227,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_final_err_qs)
@@ -1212,6 +1253,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_gbencack_err_qs)
@@ -1237,6 +1279,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_grcstage_err_qs)
@@ -1262,6 +1305,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_ggenreq_err_qs)
@@ -1287,6 +1331,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_gadstage_err_qs)
@@ -1312,6 +1357,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_ggenbits_err_qs)
@@ -1337,6 +1383,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_blkenc_err_qs)
@@ -1362,6 +1409,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_cmd_stage_sm_err_qs)
@@ -1387,6 +1435,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_main_sm_err_qs)
@@ -1412,6 +1461,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_drbg_gen_sm_err_qs)
@@ -1437,6 +1487,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_drbg_updbe_sm_err_qs)
@@ -1462,6 +1513,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_drbg_updob_sm_err_qs)
@@ -1487,6 +1539,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_aes_cipher_sm_err_qs)
@@ -1512,6 +1565,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_cmd_gen_cnt_err_qs)
@@ -1537,6 +1591,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_fifo_write_err_qs)
@@ -1562,6 +1617,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_fifo_read_err_qs)
@@ -1587,6 +1643,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_fifo_state_err_qs)
@@ -1627,6 +1684,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (err_code_test_flds_we[0]),
     .q      (reg2hw.err_code_test.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_test_qs)
@@ -1654,6 +1712,7 @@ module csrng_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (main_sm_state_qs)

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -212,6 +212,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.edn_cmd_req_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_edn_cmd_req_done_qs)
@@ -237,6 +238,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.edn_fatal_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_edn_fatal_err_qs)
@@ -264,6 +266,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.edn_cmd_req_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_edn_cmd_req_done_qs)
@@ -289,6 +292,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.edn_fatal_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_edn_fatal_err_qs)
@@ -310,6 +314,7 @@ module edn_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.edn_cmd_req_done.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.edn_cmd_req_done.qe = intr_test_qe;
@@ -325,6 +330,7 @@ module edn_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.edn_fatal_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.edn_fatal_err.qe = intr_test_qe;
@@ -345,6 +351,7 @@ module edn_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_alert.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_alert.qe = alert_test_qe;
@@ -360,6 +367,7 @@ module edn_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_alert.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
@@ -385,6 +393,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (regwen_qs)
@@ -415,6 +424,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.edn_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_edn_enable_qs)
@@ -440,6 +450,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.boot_req_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_boot_req_mode_qs)
@@ -465,6 +476,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.auto_req_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_auto_req_mode_qs)
@@ -490,6 +502,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.cmd_fifo_rst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_cmd_fifo_rst_qs)
@@ -516,6 +529,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.boot_ins_cmd.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (boot_ins_cmd_qs)
@@ -542,6 +556,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.boot_gen_cmd.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (boot_gen_cmd_qs)
@@ -562,6 +577,7 @@ module edn_reg_top (
     .qre    (),
     .qe     (sw_cmd_req_flds_we[0]),
     .q      (reg2hw.sw_cmd_req.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.sw_cmd_req.qe = sw_cmd_req_qe;
@@ -588,6 +604,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_cmd_sts_cmd_rdy_qs)
@@ -613,6 +630,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_cmd_sts_cmd_sts_qs)
@@ -633,6 +651,7 @@ module edn_reg_top (
     .qre    (),
     .qe     (reseed_cmd_flds_we[0]),
     .q      (reg2hw.reseed_cmd.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.reseed_cmd.qe = reseed_cmd_qe;
@@ -652,6 +671,7 @@ module edn_reg_top (
     .qre    (),
     .qe     (generate_cmd_flds_we[0]),
     .q      (reg2hw.generate_cmd.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.generate_cmd.qe = generate_cmd_qe;
@@ -688,6 +708,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (max_num_reqs_between_reseeds_flds_we[0]),
     .q      (reg2hw.max_num_reqs_between_reseeds.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (max_num_reqs_between_reseeds_qs)
@@ -716,6 +737,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_edn_enable_field_alert_qs)
@@ -741,6 +763,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_boot_req_mode_field_alert_qs)
@@ -766,6 +789,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_auto_req_mode_field_alert_qs)
@@ -791,6 +815,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_cmd_fifo_rst_field_alert_qs)
@@ -816,6 +841,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_edn_bus_cmp_alert_qs)
@@ -843,6 +869,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_rescmd_err_qs)
@@ -868,6 +895,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_gencmd_err_qs)
@@ -893,6 +921,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_edn_ack_sm_err_qs)
@@ -918,6 +947,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_edn_main_sm_err_qs)
@@ -943,6 +973,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_edn_cntr_err_qs)
@@ -968,6 +999,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_fifo_write_err_qs)
@@ -993,6 +1025,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_fifo_read_err_qs)
@@ -1018,6 +1051,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_fifo_state_err_qs)
@@ -1055,6 +1089,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (err_code_test_flds_we[0]),
     .q      (reg2hw.err_code_test.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_test_qs)
@@ -1082,6 +1117,7 @@ module edn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (main_sm_state_qs)

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -394,6 +394,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.es_entropy_valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_es_entropy_valid_qs)
@@ -419,6 +420,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.es_health_test_failed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_es_health_test_failed_qs)
@@ -444,6 +446,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.es_observe_fifo_ready.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_es_observe_fifo_ready_qs)
@@ -469,6 +472,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.es_fatal_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_es_fatal_err_qs)
@@ -496,6 +500,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.es_entropy_valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_es_entropy_valid_qs)
@@ -521,6 +526,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.es_health_test_failed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_es_health_test_failed_qs)
@@ -546,6 +552,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.es_observe_fifo_ready.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_es_observe_fifo_ready_qs)
@@ -571,6 +578,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.es_fatal_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_es_fatal_err_qs)
@@ -592,6 +600,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.es_entropy_valid.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.es_entropy_valid.qe = intr_test_qe;
@@ -607,6 +616,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.es_health_test_failed.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.es_health_test_failed.qe = intr_test_qe;
@@ -622,6 +632,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.es_observe_fifo_ready.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.es_observe_fifo_ready.qe = intr_test_qe;
@@ -637,6 +648,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.es_fatal_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.es_fatal_err.qe = intr_test_qe;
@@ -657,6 +669,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_alert.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_alert.qe = alert_test_qe;
@@ -672,6 +685,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_alert.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
@@ -697,6 +711,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (me_regwen_qs)
@@ -723,6 +738,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_regupd.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_regupd_qs)
@@ -749,6 +765,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (regwen_qs)
@@ -792,6 +809,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.module_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (module_enable_qs)
@@ -822,6 +840,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.conf.fips_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (conf_fips_enable_qs)
@@ -847,6 +866,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.conf.entropy_data_reg_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (conf_entropy_data_reg_enable_qs)
@@ -872,6 +892,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.conf.threshold_scope.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (conf_threshold_scope_qs)
@@ -897,6 +918,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.conf.rng_bit_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (conf_rng_bit_enable_qs)
@@ -922,6 +944,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.conf.rng_bit_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (conf_rng_bit_sel_qs)
@@ -952,6 +975,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.entropy_control.es_route.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (entropy_control_es_route_qs)
@@ -977,6 +1001,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.entropy_control.es_type.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (entropy_control_es_type_qs)
@@ -994,6 +1019,7 @@ module entropy_src_reg_top (
     .qre    (reg2hw.entropy_data.re),
     .qe     (),
     .q      (reg2hw.entropy_data.q),
+    .ds     (),
     .qs     (entropy_data_qs)
   );
 
@@ -1022,6 +1048,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.health_test_windows.fips_window.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (health_test_windows_fips_window_qs)
@@ -1047,6 +1074,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.health_test_windows.bypass_window.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (health_test_windows_bypass_window_qs)
@@ -1071,6 +1099,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (repcnt_thresholds_flds_we[0]),
     .q      (reg2hw.repcnt_thresholds.fips_thresh.q),
+    .ds     (),
     .qs     (repcnt_thresholds_fips_thresh_qs)
   );
   assign reg2hw.repcnt_thresholds.fips_thresh.qe = repcnt_thresholds_qe;
@@ -1086,6 +1115,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (repcnt_thresholds_flds_we[1]),
     .q      (reg2hw.repcnt_thresholds.bypass_thresh.q),
+    .ds     (),
     .qs     (repcnt_thresholds_bypass_thresh_qs)
   );
   assign reg2hw.repcnt_thresholds.bypass_thresh.qe = repcnt_thresholds_qe;
@@ -1109,6 +1139,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (repcnts_thresholds_flds_we[0]),
     .q      (reg2hw.repcnts_thresholds.fips_thresh.q),
+    .ds     (),
     .qs     (repcnts_thresholds_fips_thresh_qs)
   );
   assign reg2hw.repcnts_thresholds.fips_thresh.qe = repcnts_thresholds_qe;
@@ -1124,6 +1155,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (repcnts_thresholds_flds_we[1]),
     .q      (reg2hw.repcnts_thresholds.bypass_thresh.q),
+    .ds     (),
     .qs     (repcnts_thresholds_bypass_thresh_qs)
   );
   assign reg2hw.repcnts_thresholds.bypass_thresh.qe = repcnts_thresholds_qe;
@@ -1147,6 +1179,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (adaptp_hi_thresholds_flds_we[0]),
     .q      (reg2hw.adaptp_hi_thresholds.fips_thresh.q),
+    .ds     (),
     .qs     (adaptp_hi_thresholds_fips_thresh_qs)
   );
   assign reg2hw.adaptp_hi_thresholds.fips_thresh.qe = adaptp_hi_thresholds_qe;
@@ -1162,6 +1195,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (adaptp_hi_thresholds_flds_we[1]),
     .q      (reg2hw.adaptp_hi_thresholds.bypass_thresh.q),
+    .ds     (),
     .qs     (adaptp_hi_thresholds_bypass_thresh_qs)
   );
   assign reg2hw.adaptp_hi_thresholds.bypass_thresh.qe = adaptp_hi_thresholds_qe;
@@ -1185,6 +1219,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (adaptp_lo_thresholds_flds_we[0]),
     .q      (reg2hw.adaptp_lo_thresholds.fips_thresh.q),
+    .ds     (),
     .qs     (adaptp_lo_thresholds_fips_thresh_qs)
   );
   assign reg2hw.adaptp_lo_thresholds.fips_thresh.qe = adaptp_lo_thresholds_qe;
@@ -1200,6 +1235,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (adaptp_lo_thresholds_flds_we[1]),
     .q      (reg2hw.adaptp_lo_thresholds.bypass_thresh.q),
+    .ds     (),
     .qs     (adaptp_lo_thresholds_bypass_thresh_qs)
   );
   assign reg2hw.adaptp_lo_thresholds.bypass_thresh.qe = adaptp_lo_thresholds_qe;
@@ -1223,6 +1259,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (bucket_thresholds_flds_we[0]),
     .q      (reg2hw.bucket_thresholds.fips_thresh.q),
+    .ds     (),
     .qs     (bucket_thresholds_fips_thresh_qs)
   );
   assign reg2hw.bucket_thresholds.fips_thresh.qe = bucket_thresholds_qe;
@@ -1238,6 +1275,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (bucket_thresholds_flds_we[1]),
     .q      (reg2hw.bucket_thresholds.bypass_thresh.q),
+    .ds     (),
     .qs     (bucket_thresholds_bypass_thresh_qs)
   );
   assign reg2hw.bucket_thresholds.bypass_thresh.qe = bucket_thresholds_qe;
@@ -1261,6 +1299,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (markov_hi_thresholds_flds_we[0]),
     .q      (reg2hw.markov_hi_thresholds.fips_thresh.q),
+    .ds     (),
     .qs     (markov_hi_thresholds_fips_thresh_qs)
   );
   assign reg2hw.markov_hi_thresholds.fips_thresh.qe = markov_hi_thresholds_qe;
@@ -1276,6 +1315,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (markov_hi_thresholds_flds_we[1]),
     .q      (reg2hw.markov_hi_thresholds.bypass_thresh.q),
+    .ds     (),
     .qs     (markov_hi_thresholds_bypass_thresh_qs)
   );
   assign reg2hw.markov_hi_thresholds.bypass_thresh.qe = markov_hi_thresholds_qe;
@@ -1299,6 +1339,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (markov_lo_thresholds_flds_we[0]),
     .q      (reg2hw.markov_lo_thresholds.fips_thresh.q),
+    .ds     (),
     .qs     (markov_lo_thresholds_fips_thresh_qs)
   );
   assign reg2hw.markov_lo_thresholds.fips_thresh.qe = markov_lo_thresholds_qe;
@@ -1314,6 +1355,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (markov_lo_thresholds_flds_we[1]),
     .q      (reg2hw.markov_lo_thresholds.bypass_thresh.q),
+    .ds     (),
     .qs     (markov_lo_thresholds_bypass_thresh_qs)
   );
   assign reg2hw.markov_lo_thresholds.bypass_thresh.qe = markov_lo_thresholds_qe;
@@ -1337,6 +1379,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (extht_hi_thresholds_flds_we[0]),
     .q      (reg2hw.extht_hi_thresholds.fips_thresh.q),
+    .ds     (),
     .qs     (extht_hi_thresholds_fips_thresh_qs)
   );
   assign reg2hw.extht_hi_thresholds.fips_thresh.qe = extht_hi_thresholds_qe;
@@ -1352,6 +1395,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (extht_hi_thresholds_flds_we[1]),
     .q      (reg2hw.extht_hi_thresholds.bypass_thresh.q),
+    .ds     (),
     .qs     (extht_hi_thresholds_bypass_thresh_qs)
   );
   assign reg2hw.extht_hi_thresholds.bypass_thresh.qe = extht_hi_thresholds_qe;
@@ -1375,6 +1419,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (extht_lo_thresholds_flds_we[0]),
     .q      (reg2hw.extht_lo_thresholds.fips_thresh.q),
+    .ds     (),
     .qs     (extht_lo_thresholds_fips_thresh_qs)
   );
   assign reg2hw.extht_lo_thresholds.fips_thresh.qe = extht_lo_thresholds_qe;
@@ -1390,6 +1435,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (extht_lo_thresholds_flds_we[1]),
     .q      (reg2hw.extht_lo_thresholds.bypass_thresh.q),
+    .ds     (),
     .qs     (extht_lo_thresholds_bypass_thresh_qs)
   );
   assign reg2hw.extht_lo_thresholds.bypass_thresh.qe = extht_lo_thresholds_qe;
@@ -1407,6 +1453,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (repcnt_hi_watermarks_fips_watermark_qs)
   );
 
@@ -1421,6 +1468,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (repcnt_hi_watermarks_bypass_watermark_qs)
   );
 
@@ -1437,6 +1485,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (repcnts_hi_watermarks_fips_watermark_qs)
   );
 
@@ -1451,6 +1500,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (repcnts_hi_watermarks_bypass_watermark_qs)
   );
 
@@ -1467,6 +1517,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (adaptp_hi_watermarks_fips_watermark_qs)
   );
 
@@ -1481,6 +1532,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (adaptp_hi_watermarks_bypass_watermark_qs)
   );
 
@@ -1497,6 +1549,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (adaptp_lo_watermarks_fips_watermark_qs)
   );
 
@@ -1511,6 +1564,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (adaptp_lo_watermarks_bypass_watermark_qs)
   );
 
@@ -1527,6 +1581,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (extht_hi_watermarks_fips_watermark_qs)
   );
 
@@ -1541,6 +1596,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (extht_hi_watermarks_bypass_watermark_qs)
   );
 
@@ -1557,6 +1613,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (extht_lo_watermarks_fips_watermark_qs)
   );
 
@@ -1571,6 +1628,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (extht_lo_watermarks_bypass_watermark_qs)
   );
 
@@ -1587,6 +1645,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (bucket_hi_watermarks_fips_watermark_qs)
   );
 
@@ -1601,6 +1660,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (bucket_hi_watermarks_bypass_watermark_qs)
   );
 
@@ -1617,6 +1677,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (markov_hi_watermarks_fips_watermark_qs)
   );
 
@@ -1631,6 +1692,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (markov_hi_watermarks_bypass_watermark_qs)
   );
 
@@ -1647,6 +1709,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (markov_lo_watermarks_fips_watermark_qs)
   );
 
@@ -1661,6 +1724,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (markov_lo_watermarks_bypass_watermark_qs)
   );
 
@@ -1676,6 +1740,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (repcnt_total_fails_qs)
   );
 
@@ -1691,6 +1756,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (repcnts_total_fails_qs)
   );
 
@@ -1706,6 +1772,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (adaptp_hi_total_fails_qs)
   );
 
@@ -1721,6 +1788,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (adaptp_lo_total_fails_qs)
   );
 
@@ -1736,6 +1804,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (bucket_total_fails_qs)
   );
 
@@ -1751,6 +1820,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (markov_hi_total_fails_qs)
   );
 
@@ -1766,6 +1836,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (markov_lo_total_fails_qs)
   );
 
@@ -1781,6 +1852,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (extht_hi_total_fails_qs)
   );
 
@@ -1796,6 +1868,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (extht_lo_total_fails_qs)
   );
 
@@ -1824,6 +1897,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_threshold.alert_threshold.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_threshold_alert_threshold_qs)
@@ -1849,6 +1923,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_threshold.alert_threshold_inv.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_threshold_alert_threshold_inv_qs)
@@ -1866,6 +1941,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_summary_fail_counts_qs)
   );
 
@@ -1882,6 +1958,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_fail_counts_repcnt_fail_count_qs)
   );
 
@@ -1896,6 +1973,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_fail_counts_adaptp_hi_fail_count_qs)
   );
 
@@ -1910,6 +1988,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_fail_counts_adaptp_lo_fail_count_qs)
   );
 
@@ -1924,6 +2003,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_fail_counts_bucket_fail_count_qs)
   );
 
@@ -1938,6 +2018,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_fail_counts_markov_hi_fail_count_qs)
   );
 
@@ -1952,6 +2033,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_fail_counts_markov_lo_fail_count_qs)
   );
 
@@ -1966,6 +2048,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_fail_counts_repcnts_fail_count_qs)
   );
 
@@ -1982,6 +2065,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (extht_fail_counts_extht_hi_fail_count_qs)
   );
 
@@ -1996,6 +2080,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (extht_fail_counts_extht_lo_fail_count_qs)
   );
 
@@ -2024,6 +2109,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fw_ov_control.fw_ov_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fw_ov_control_fw_ov_mode_qs)
@@ -2049,6 +2135,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fw_ov_control.fw_ov_entropy_insert.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fw_ov_control_fw_ov_entropy_insert_qs)
@@ -2075,6 +2162,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fw_ov_sha3_start.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fw_ov_sha3_start_qs)
@@ -2092,6 +2180,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (fw_ov_wr_fifo_full_qs)
   );
 
@@ -2116,6 +2205,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fw_ov_rd_fifo_overflow_qs)
@@ -2133,6 +2223,7 @@ module entropy_src_reg_top (
     .qre    (reg2hw.fw_ov_rd_data.re),
     .qe     (),
     .q      (reg2hw.fw_ov_rd_data.q),
+    .ds     (),
     .qs     (fw_ov_rd_data_qs)
   );
 
@@ -2151,6 +2242,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (fw_ov_wr_data_flds_we[0]),
     .q      (reg2hw.fw_ov_wr_data.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.fw_ov_wr_data.qe = fw_ov_wr_data_qe;
@@ -2179,6 +2271,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.observe_fifo_thresh.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (observe_fifo_thresh_qs)
@@ -2196,6 +2289,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (observe_fifo_depth_qs)
   );
 
@@ -2212,6 +2306,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (debug_status_entropy_fifo_depth_qs)
   );
 
@@ -2226,6 +2321,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (debug_status_sha3_fsm_qs)
   );
 
@@ -2240,6 +2336,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (debug_status_sha3_block_pr_qs)
   );
 
@@ -2254,6 +2351,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (debug_status_sha3_squeezing_qs)
   );
 
@@ -2268,6 +2366,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (debug_status_sha3_absorbed_qs)
   );
 
@@ -2282,6 +2381,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (debug_status_sha3_err_qs)
   );
 
@@ -2296,6 +2396,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (debug_status_main_sm_idle_qs)
   );
 
@@ -2310,6 +2411,7 @@ module entropy_src_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (debug_status_main_sm_boot_done_qs)
   );
 
@@ -2335,6 +2437,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_fips_enable_field_alert_qs)
@@ -2360,6 +2463,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_entropy_data_reg_en_field_alert_qs)
@@ -2385,6 +2489,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_module_enable_field_alert_qs)
@@ -2410,6 +2515,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_threshold_scope_field_alert_qs)
@@ -2435,6 +2541,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_rng_bit_enable_field_alert_qs)
@@ -2460,6 +2567,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_fw_ov_sha3_start_field_alert_qs)
@@ -2485,6 +2593,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_fw_ov_mode_field_alert_qs)
@@ -2510,6 +2619,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_fw_ov_entropy_insert_field_alert_qs)
@@ -2535,6 +2645,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_es_route_field_alert_qs)
@@ -2560,6 +2671,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_es_type_field_alert_qs)
@@ -2585,6 +2697,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_es_main_sm_alert_qs)
@@ -2610,6 +2723,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_es_bus_cmp_alert_qs)
@@ -2635,6 +2749,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_sts_es_thresh_cfg_alert_qs)
@@ -2662,6 +2777,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_esrng_err_qs)
@@ -2687,6 +2803,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_observe_err_qs)
@@ -2712,6 +2829,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_sfifo_esfinal_err_qs)
@@ -2737,6 +2855,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_es_ack_sm_err_qs)
@@ -2762,6 +2881,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_es_main_sm_err_qs)
@@ -2787,6 +2907,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_es_cntr_err_qs)
@@ -2812,6 +2933,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_fifo_write_err_qs)
@@ -2837,6 +2959,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_fifo_read_err_qs)
@@ -2862,6 +2985,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_fifo_state_err_qs)
@@ -2902,6 +3026,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (err_code_test_flds_we[0]),
     .q      (reg2hw.err_code_test.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_test_qs)
@@ -2929,6 +3054,7 @@ module entropy_src_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (main_sm_state_qs)

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -1040,6 +1040,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.prog_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_prog_empty_qs)
@@ -1065,6 +1066,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.prog_lvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_prog_lvl_qs)
@@ -1090,6 +1092,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rd_full.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rd_full_qs)
@@ -1115,6 +1118,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rd_lvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rd_lvl_qs)
@@ -1140,6 +1144,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.op_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_op_done_qs)
@@ -1165,6 +1170,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.corr_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_corr_err_qs)
@@ -1192,6 +1198,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.prog_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_prog_empty_qs)
@@ -1217,6 +1224,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.prog_lvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_prog_lvl_qs)
@@ -1242,6 +1250,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rd_full.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rd_full_qs)
@@ -1267,6 +1276,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rd_lvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rd_lvl_qs)
@@ -1292,6 +1302,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.op_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_op_done_qs)
@@ -1317,6 +1328,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.corr_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_corr_err_qs)
@@ -1338,6 +1350,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.prog_empty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.prog_empty.qe = intr_test_qe;
@@ -1353,6 +1366,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.prog_lvl.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.prog_lvl.qe = intr_test_qe;
@@ -1368,6 +1382,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.rd_full.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rd_full.qe = intr_test_qe;
@@ -1383,6 +1398,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.rd_lvl.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rd_lvl.qe = intr_test_qe;
@@ -1398,6 +1414,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.op_done.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.op_done.qe = intr_test_qe;
@@ -1413,6 +1430,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.corr_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.corr_err.qe = intr_test_qe;
@@ -1433,6 +1451,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_err.qe = alert_test_qe;
@@ -1448,6 +1467,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_std_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_std_err.qe = alert_test_qe;
@@ -1463,6 +1483,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[2]),
     .q      (reg2hw.alert_test.fatal_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_err.qe = alert_test_qe;
@@ -1488,6 +1509,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dis.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dis_qs)
@@ -1514,6 +1536,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exec.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exec_qs)
@@ -1540,6 +1563,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.init.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (init_qs)
@@ -1557,6 +1581,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (ctrl_regwen_qs)
   );
 
@@ -1585,6 +1610,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.start.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_start_qs)
@@ -1610,6 +1636,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.op.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_op_qs)
@@ -1635,6 +1662,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.prog_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_prog_sel_qs)
@@ -1660,6 +1688,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.erase_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_erase_sel_qs)
@@ -1685,6 +1714,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.partition_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_partition_sel_qs)
@@ -1710,6 +1740,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.info_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_info_sel_qs)
@@ -1735,6 +1766,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.num.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_num_qs)
@@ -1761,6 +1793,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.addr.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (addr_qs)
@@ -1788,6 +1821,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prog_type_en.normal.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prog_type_en_normal_qs)
@@ -1813,6 +1847,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prog_type_en.repair.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prog_type_en_repair_qs)
@@ -1839,6 +1874,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.erase_suspend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (erase_suspend_qs)
@@ -1866,6 +1902,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_0_qs)
@@ -1893,6 +1930,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_1_qs)
@@ -1920,6 +1958,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_2_qs)
@@ -1947,6 +1986,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_3_qs)
@@ -1974,6 +2014,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_4_qs)
@@ -2001,6 +2042,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_5_qs)
@@ -2028,6 +2070,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_6_qs)
@@ -2055,6 +2098,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_7_qs)
@@ -2086,6 +2130,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_en_0_qs)
@@ -2111,6 +2156,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_rd_en_0_qs)
@@ -2136,6 +2182,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_prog_en_0_qs)
@@ -2161,6 +2208,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_erase_en_0_qs)
@@ -2186,6 +2234,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_scramble_en_0_qs)
@@ -2211,6 +2260,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_ecc_en_0_qs)
@@ -2236,6 +2286,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_he_en_0_qs)
@@ -2267,6 +2318,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_en_1_qs)
@@ -2292,6 +2344,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_rd_en_1_qs)
@@ -2317,6 +2370,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_prog_en_1_qs)
@@ -2342,6 +2396,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_erase_en_1_qs)
@@ -2367,6 +2422,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_scramble_en_1_qs)
@@ -2392,6 +2448,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_ecc_en_1_qs)
@@ -2417,6 +2474,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_he_en_1_qs)
@@ -2448,6 +2506,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_en_2_qs)
@@ -2473,6 +2532,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_rd_en_2_qs)
@@ -2498,6 +2558,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_prog_en_2_qs)
@@ -2523,6 +2584,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_erase_en_2_qs)
@@ -2548,6 +2610,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_scramble_en_2_qs)
@@ -2573,6 +2636,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_ecc_en_2_qs)
@@ -2598,6 +2662,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_he_en_2_qs)
@@ -2629,6 +2694,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_en_3_qs)
@@ -2654,6 +2720,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_rd_en_3_qs)
@@ -2679,6 +2746,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_prog_en_3_qs)
@@ -2704,6 +2772,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_erase_en_3_qs)
@@ -2729,6 +2798,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_scramble_en_3_qs)
@@ -2754,6 +2824,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_ecc_en_3_qs)
@@ -2779,6 +2850,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_he_en_3_qs)
@@ -2810,6 +2882,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_en_4_qs)
@@ -2835,6 +2908,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_rd_en_4_qs)
@@ -2860,6 +2934,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_prog_en_4_qs)
@@ -2885,6 +2960,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_erase_en_4_qs)
@@ -2910,6 +2986,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_scramble_en_4_qs)
@@ -2935,6 +3012,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_ecc_en_4_qs)
@@ -2960,6 +3038,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_he_en_4_qs)
@@ -2991,6 +3070,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_en_5_qs)
@@ -3016,6 +3096,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_rd_en_5_qs)
@@ -3041,6 +3122,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_prog_en_5_qs)
@@ -3066,6 +3148,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_erase_en_5_qs)
@@ -3091,6 +3174,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_scramble_en_5_qs)
@@ -3116,6 +3200,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_ecc_en_5_qs)
@@ -3141,6 +3226,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_he_en_5_qs)
@@ -3172,6 +3258,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_en_6_qs)
@@ -3197,6 +3284,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_rd_en_6_qs)
@@ -3222,6 +3310,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_prog_en_6_qs)
@@ -3247,6 +3336,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_erase_en_6_qs)
@@ -3272,6 +3362,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_scramble_en_6_qs)
@@ -3297,6 +3388,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_ecc_en_6_qs)
@@ -3322,6 +3414,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_he_en_6_qs)
@@ -3353,6 +3446,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_en_7_qs)
@@ -3378,6 +3472,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_rd_en_7_qs)
@@ -3403,6 +3498,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_prog_en_7_qs)
@@ -3428,6 +3524,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_erase_en_7_qs)
@@ -3453,6 +3550,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_scramble_en_7_qs)
@@ -3478,6 +3576,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_ecc_en_7_qs)
@@ -3503,6 +3602,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_he_en_7_qs)
@@ -3534,6 +3634,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[0].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_0_base_0_qs)
@@ -3559,6 +3660,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[0].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_0_size_0_qs)
@@ -3590,6 +3692,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[1].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_1_base_1_qs)
@@ -3615,6 +3718,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[1].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_1_size_1_qs)
@@ -3646,6 +3750,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[2].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_2_base_2_qs)
@@ -3671,6 +3776,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[2].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_2_size_2_qs)
@@ -3702,6 +3808,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[3].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_3_base_3_qs)
@@ -3727,6 +3834,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[3].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_3_size_3_qs)
@@ -3758,6 +3866,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[4].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_4_base_4_qs)
@@ -3783,6 +3892,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[4].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_4_size_4_qs)
@@ -3814,6 +3924,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[5].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_5_base_5_qs)
@@ -3839,6 +3950,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[5].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_5_size_5_qs)
@@ -3870,6 +3982,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[6].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_6_base_6_qs)
@@ -3895,6 +4008,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[6].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_6_size_6_qs)
@@ -3926,6 +4040,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[7].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_7_base_7_qs)
@@ -3951,6 +4066,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[7].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_7_size_7_qs)
@@ -3978,6 +4094,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_rd_en_qs)
@@ -4003,6 +4120,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_prog_en_qs)
@@ -4028,6 +4146,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_erase_en_qs)
@@ -4053,6 +4172,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_scramble_en_qs)
@@ -4078,6 +4198,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_ecc_en_qs)
@@ -4103,6 +4224,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_he_en_qs)
@@ -4130,6 +4252,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_0_qs)
@@ -4157,6 +4280,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_1_qs)
@@ -4184,6 +4308,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_2_qs)
@@ -4211,6 +4336,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_3_qs)
@@ -4238,6 +4364,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_4_qs)
@@ -4265,6 +4392,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_5_qs)
@@ -4292,6 +4420,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_6_qs)
@@ -4319,6 +4448,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_7_qs)
@@ -4346,6 +4476,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_8_qs)
@@ -4373,6 +4504,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_9_qs)
@@ -4404,6 +4536,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_en_0_qs)
@@ -4429,6 +4562,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_rd_en_0_qs)
@@ -4454,6 +4588,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_prog_en_0_qs)
@@ -4479,6 +4614,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_erase_en_0_qs)
@@ -4504,6 +4640,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_scramble_en_0_qs)
@@ -4529,6 +4666,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_ecc_en_0_qs)
@@ -4554,6 +4692,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_he_en_0_qs)
@@ -4585,6 +4724,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_en_1_qs)
@@ -4610,6 +4750,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_rd_en_1_qs)
@@ -4635,6 +4776,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_prog_en_1_qs)
@@ -4660,6 +4802,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_erase_en_1_qs)
@@ -4685,6 +4828,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_scramble_en_1_qs)
@@ -4710,6 +4854,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_ecc_en_1_qs)
@@ -4735,6 +4880,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_he_en_1_qs)
@@ -4766,6 +4912,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_en_2_qs)
@@ -4791,6 +4938,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_rd_en_2_qs)
@@ -4816,6 +4964,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_prog_en_2_qs)
@@ -4841,6 +4990,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_erase_en_2_qs)
@@ -4866,6 +5016,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_scramble_en_2_qs)
@@ -4891,6 +5042,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_ecc_en_2_qs)
@@ -4916,6 +5068,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_he_en_2_qs)
@@ -4947,6 +5100,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_en_3_qs)
@@ -4972,6 +5126,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_rd_en_3_qs)
@@ -4997,6 +5152,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_prog_en_3_qs)
@@ -5022,6 +5178,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_erase_en_3_qs)
@@ -5047,6 +5204,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_scramble_en_3_qs)
@@ -5072,6 +5230,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_ecc_en_3_qs)
@@ -5097,6 +5256,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_he_en_3_qs)
@@ -5128,6 +5288,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_en_4_qs)
@@ -5153,6 +5314,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_rd_en_4_qs)
@@ -5178,6 +5340,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_prog_en_4_qs)
@@ -5203,6 +5366,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_erase_en_4_qs)
@@ -5228,6 +5392,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_scramble_en_4_qs)
@@ -5253,6 +5418,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_ecc_en_4_qs)
@@ -5278,6 +5444,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_he_en_4_qs)
@@ -5309,6 +5476,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_en_5_qs)
@@ -5334,6 +5502,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_rd_en_5_qs)
@@ -5359,6 +5528,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_prog_en_5_qs)
@@ -5384,6 +5554,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_erase_en_5_qs)
@@ -5409,6 +5580,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_scramble_en_5_qs)
@@ -5434,6 +5606,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_ecc_en_5_qs)
@@ -5459,6 +5632,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_he_en_5_qs)
@@ -5490,6 +5664,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_en_6_qs)
@@ -5515,6 +5690,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_rd_en_6_qs)
@@ -5540,6 +5716,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_prog_en_6_qs)
@@ -5565,6 +5742,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_erase_en_6_qs)
@@ -5590,6 +5768,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_scramble_en_6_qs)
@@ -5615,6 +5794,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_ecc_en_6_qs)
@@ -5640,6 +5820,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_he_en_6_qs)
@@ -5671,6 +5852,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_en_7_qs)
@@ -5696,6 +5878,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_rd_en_7_qs)
@@ -5721,6 +5904,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_prog_en_7_qs)
@@ -5746,6 +5930,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_erase_en_7_qs)
@@ -5771,6 +5956,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_scramble_en_7_qs)
@@ -5796,6 +5982,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_ecc_en_7_qs)
@@ -5821,6 +6008,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_he_en_7_qs)
@@ -5852,6 +6040,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_en_8_qs)
@@ -5877,6 +6066,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_rd_en_8_qs)
@@ -5902,6 +6092,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_prog_en_8_qs)
@@ -5927,6 +6118,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_erase_en_8_qs)
@@ -5952,6 +6144,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_scramble_en_8_qs)
@@ -5977,6 +6170,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_ecc_en_8_qs)
@@ -6002,6 +6196,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_he_en_8_qs)
@@ -6033,6 +6228,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_en_9_qs)
@@ -6058,6 +6254,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_rd_en_9_qs)
@@ -6083,6 +6280,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_prog_en_9_qs)
@@ -6108,6 +6306,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_erase_en_9_qs)
@@ -6133,6 +6332,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_scramble_en_9_qs)
@@ -6158,6 +6358,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_ecc_en_9_qs)
@@ -6183,6 +6384,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_he_en_9_qs)
@@ -6210,6 +6412,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_regwen_qs)
@@ -6241,6 +6444,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_en_0_qs)
@@ -6266,6 +6470,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_rd_en_0_qs)
@@ -6291,6 +6496,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_prog_en_0_qs)
@@ -6316,6 +6522,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_erase_en_0_qs)
@@ -6341,6 +6548,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_scramble_en_0_qs)
@@ -6366,6 +6574,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_ecc_en_0_qs)
@@ -6391,6 +6600,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_he_en_0_qs)
@@ -6418,6 +6628,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_regwen_0_qs)
@@ -6445,6 +6656,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_regwen_1_qs)
@@ -6476,6 +6688,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_en_0_qs)
@@ -6501,6 +6714,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_rd_en_0_qs)
@@ -6526,6 +6740,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_prog_en_0_qs)
@@ -6551,6 +6766,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_erase_en_0_qs)
@@ -6576,6 +6792,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_scramble_en_0_qs)
@@ -6601,6 +6818,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_ecc_en_0_qs)
@@ -6626,6 +6844,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_he_en_0_qs)
@@ -6657,6 +6876,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_en_1_qs)
@@ -6682,6 +6902,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_rd_en_1_qs)
@@ -6707,6 +6928,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_prog_en_1_qs)
@@ -6732,6 +6954,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_erase_en_1_qs)
@@ -6757,6 +6980,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_scramble_en_1_qs)
@@ -6782,6 +7006,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_ecc_en_1_qs)
@@ -6807,6 +7032,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_he_en_1_qs)
@@ -6834,6 +7060,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_0_qs)
@@ -6861,6 +7088,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_1_qs)
@@ -6888,6 +7116,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_2_qs)
@@ -6915,6 +7144,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_3_qs)
@@ -6942,6 +7172,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_4_qs)
@@ -6969,6 +7200,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_5_qs)
@@ -6996,6 +7228,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_6_qs)
@@ -7023,6 +7256,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_7_qs)
@@ -7050,6 +7284,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_8_qs)
@@ -7077,6 +7312,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_9_qs)
@@ -7108,6 +7344,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_en_0_qs)
@@ -7133,6 +7370,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_rd_en_0_qs)
@@ -7158,6 +7396,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_prog_en_0_qs)
@@ -7183,6 +7422,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_erase_en_0_qs)
@@ -7208,6 +7448,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_scramble_en_0_qs)
@@ -7233,6 +7474,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_ecc_en_0_qs)
@@ -7258,6 +7500,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_he_en_0_qs)
@@ -7289,6 +7532,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_en_1_qs)
@@ -7314,6 +7558,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_rd_en_1_qs)
@@ -7339,6 +7584,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_prog_en_1_qs)
@@ -7364,6 +7610,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_erase_en_1_qs)
@@ -7389,6 +7636,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_scramble_en_1_qs)
@@ -7414,6 +7662,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_ecc_en_1_qs)
@@ -7439,6 +7688,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_he_en_1_qs)
@@ -7470,6 +7720,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_en_2_qs)
@@ -7495,6 +7746,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_rd_en_2_qs)
@@ -7520,6 +7772,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_prog_en_2_qs)
@@ -7545,6 +7798,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_erase_en_2_qs)
@@ -7570,6 +7824,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_scramble_en_2_qs)
@@ -7595,6 +7850,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_ecc_en_2_qs)
@@ -7620,6 +7876,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_he_en_2_qs)
@@ -7651,6 +7908,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_en_3_qs)
@@ -7676,6 +7934,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_rd_en_3_qs)
@@ -7701,6 +7960,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_prog_en_3_qs)
@@ -7726,6 +7986,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_erase_en_3_qs)
@@ -7751,6 +8012,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_scramble_en_3_qs)
@@ -7776,6 +8038,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_ecc_en_3_qs)
@@ -7801,6 +8064,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_he_en_3_qs)
@@ -7832,6 +8096,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_en_4_qs)
@@ -7857,6 +8122,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_rd_en_4_qs)
@@ -7882,6 +8148,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_prog_en_4_qs)
@@ -7907,6 +8174,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_erase_en_4_qs)
@@ -7932,6 +8200,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_scramble_en_4_qs)
@@ -7957,6 +8226,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_ecc_en_4_qs)
@@ -7982,6 +8252,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_he_en_4_qs)
@@ -8013,6 +8284,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_en_5_qs)
@@ -8038,6 +8310,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_rd_en_5_qs)
@@ -8063,6 +8336,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_prog_en_5_qs)
@@ -8088,6 +8362,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_erase_en_5_qs)
@@ -8113,6 +8388,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_scramble_en_5_qs)
@@ -8138,6 +8414,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_ecc_en_5_qs)
@@ -8163,6 +8440,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_he_en_5_qs)
@@ -8194,6 +8472,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_en_6_qs)
@@ -8219,6 +8498,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_rd_en_6_qs)
@@ -8244,6 +8524,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_prog_en_6_qs)
@@ -8269,6 +8550,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_erase_en_6_qs)
@@ -8294,6 +8576,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_scramble_en_6_qs)
@@ -8319,6 +8602,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_ecc_en_6_qs)
@@ -8344,6 +8628,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_he_en_6_qs)
@@ -8375,6 +8660,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_en_7_qs)
@@ -8400,6 +8686,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_rd_en_7_qs)
@@ -8425,6 +8712,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_prog_en_7_qs)
@@ -8450,6 +8738,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_erase_en_7_qs)
@@ -8475,6 +8764,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_scramble_en_7_qs)
@@ -8500,6 +8790,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_ecc_en_7_qs)
@@ -8525,6 +8816,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_he_en_7_qs)
@@ -8556,6 +8848,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_en_8_qs)
@@ -8581,6 +8874,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_rd_en_8_qs)
@@ -8606,6 +8900,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_prog_en_8_qs)
@@ -8631,6 +8926,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_erase_en_8_qs)
@@ -8656,6 +8952,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_scramble_en_8_qs)
@@ -8681,6 +8978,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_ecc_en_8_qs)
@@ -8706,6 +9004,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_he_en_8_qs)
@@ -8737,6 +9036,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_en_9_qs)
@@ -8762,6 +9062,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_rd_en_9_qs)
@@ -8787,6 +9088,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_prog_en_9_qs)
@@ -8812,6 +9114,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_erase_en_9_qs)
@@ -8837,6 +9140,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_scramble_en_9_qs)
@@ -8862,6 +9166,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_ecc_en_9_qs)
@@ -8887,6 +9192,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_he_en_9_qs)
@@ -8914,6 +9220,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_regwen_qs)
@@ -8945,6 +9252,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_en_0_qs)
@@ -8970,6 +9278,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_rd_en_0_qs)
@@ -8995,6 +9304,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_prog_en_0_qs)
@@ -9020,6 +9330,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_erase_en_0_qs)
@@ -9045,6 +9356,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_scramble_en_0_qs)
@@ -9070,6 +9382,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_ecc_en_0_qs)
@@ -9095,6 +9408,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_he_en_0_qs)
@@ -9122,6 +9436,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_regwen_0_qs)
@@ -9149,6 +9464,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_regwen_1_qs)
@@ -9180,6 +9496,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_en_0_qs)
@@ -9205,6 +9522,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_rd_en_0_qs)
@@ -9230,6 +9548,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_prog_en_0_qs)
@@ -9255,6 +9574,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_erase_en_0_qs)
@@ -9280,6 +9600,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_scramble_en_0_qs)
@@ -9305,6 +9626,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_ecc_en_0_qs)
@@ -9330,6 +9652,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_he_en_0_qs)
@@ -9361,6 +9684,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_en_1_qs)
@@ -9386,6 +9710,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_rd_en_1_qs)
@@ -9411,6 +9736,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_prog_en_1_qs)
@@ -9436,6 +9762,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_erase_en_1_qs)
@@ -9461,6 +9788,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_scramble_en_1_qs)
@@ -9486,6 +9814,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_ecc_en_1_qs)
@@ -9511,6 +9840,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_he_en_1_qs)
@@ -9537,6 +9867,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank_cfg_regwen_qs)
@@ -9570,6 +9901,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_bank_cfg_shadowed[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_bank_cfg_shadowed_erase_en_0_qs),
@@ -9604,6 +9936,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_bank_cfg_shadowed[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_bank_cfg_shadowed_erase_en_1_qs),
@@ -9638,6 +9971,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (op_status_done_qs)
@@ -9663,6 +9997,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (op_status_err_qs)
@@ -9690,6 +10025,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_rd_full_qs)
@@ -9715,6 +10051,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_rd_empty_qs)
@@ -9740,6 +10077,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_prog_full_qs)
@@ -9765,6 +10103,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_prog_empty_qs)
@@ -9790,6 +10129,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_init_wip_qs)
@@ -9807,6 +10147,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (debug_state_qs)
   );
 
@@ -9832,6 +10173,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_op_err_qs)
@@ -9857,6 +10199,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_mp_err_qs)
@@ -9882,6 +10225,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_rd_err_qs)
@@ -9907,6 +10251,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_prog_err_qs)
@@ -9932,6 +10277,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_prog_win_err_qs)
@@ -9957,6 +10303,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_prog_type_err_qs)
@@ -9982,6 +10329,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_flash_macro_err_qs)
@@ -10007,6 +10355,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_update_err_qs)
@@ -10034,6 +10383,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.reg_intg_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_reg_intg_err_qs)
@@ -10059,6 +10409,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.prog_intg_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_prog_intg_err_qs)
@@ -10084,6 +10435,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.lcmgr_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_lcmgr_err_qs)
@@ -10109,6 +10461,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.lcmgr_intg_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_lcmgr_intg_err_qs)
@@ -10134,6 +10487,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.arb_fsm_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_arb_fsm_err_qs)
@@ -10159,6 +10513,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.storage_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_storage_err_qs)
@@ -10184,6 +10539,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.phy_fsm_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_phy_fsm_err_qs)
@@ -10209,6 +10565,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.ctrl_cnt_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_ctrl_cnt_err_qs)
@@ -10234,6 +10591,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.fifo_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_fifo_err_qs)
@@ -10261,6 +10619,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.op_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_op_err_qs)
@@ -10286,6 +10645,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.mp_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_mp_err_qs)
@@ -10311,6 +10671,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.rd_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_rd_err_qs)
@@ -10336,6 +10697,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.prog_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_prog_err_qs)
@@ -10361,6 +10723,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.prog_win_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_prog_win_err_qs)
@@ -10386,6 +10749,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.prog_type_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_prog_type_err_qs)
@@ -10411,6 +10775,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.flash_macro_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_flash_macro_err_qs)
@@ -10436,6 +10801,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.seed_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_seed_err_qs)
@@ -10461,6 +10827,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.phy_relbl_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_phy_relbl_err_qs)
@@ -10486,6 +10853,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.phy_storage_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_phy_storage_err_qs)
@@ -10511,6 +10879,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.spurious_ack.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_spurious_ack_qs)
@@ -10536,6 +10905,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.arb_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_arb_err_qs)
@@ -10561,6 +10931,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.host_gnt_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_host_gnt_err_qs)
@@ -10587,6 +10958,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_addr_qs)
@@ -10615,6 +10987,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ecc_single_err_cnt[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ecc_single_err_cnt_ecc_single_err_cnt_0_qs)
@@ -10640,6 +11013,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ecc_single_err_cnt[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ecc_single_err_cnt_ecc_single_err_cnt_1_qs)
@@ -10667,6 +11041,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ecc_single_err_addr_0_qs)
@@ -10694,6 +11069,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ecc_single_err_addr_1_qs)
@@ -10721,6 +11097,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_alert_cfg.alert_ack.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_alert_cfg_alert_ack_qs)
@@ -10746,6 +11123,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_alert_cfg.alert_trig.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_alert_cfg_alert_trig_qs)
@@ -10773,6 +11151,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_status_init_wip_qs)
@@ -10798,6 +11177,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_status_prog_normal_avail_qs)
@@ -10823,6 +11203,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_status_prog_repair_avail_qs)
@@ -10849,6 +11230,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.scratch.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (scratch_qs)
@@ -10876,6 +11258,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fifo_lvl.prog.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_lvl_prog_qs)
@@ -10901,6 +11284,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fifo_lvl.rd.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_lvl_rd_qs)
@@ -10927,6 +11311,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fifo_rst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_rst_qs)
@@ -10945,6 +11330,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (curr_fifo_lvl_prog_qs)
   );
 
@@ -10959,6 +11345,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (curr_fifo_lvl_rd_qs)
   );
 

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -199,6 +199,7 @@ module gpio_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_qs)
@@ -225,6 +226,7 @@ module gpio_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_qs)
@@ -245,6 +247,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.qe = intr_test_qe;
@@ -264,6 +267,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -289,6 +293,7 @@ module gpio_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (data_in_qs)
@@ -309,6 +314,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (direct_out_flds_we[0]),
     .q      (reg2hw.direct_out.q),
+    .ds     (),
     .qs     (direct_out_qs)
   );
   assign reg2hw.direct_out.qe = direct_out_qe;
@@ -329,6 +335,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (masked_out_lower_flds_we[0]),
     .q      (reg2hw.masked_out_lower.data.q),
+    .ds     (),
     .qs     (masked_out_lower_data_qs)
   );
   assign reg2hw.masked_out_lower.data.qe = masked_out_lower_qe;
@@ -344,6 +351,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (masked_out_lower_flds_we[1]),
     .q      (reg2hw.masked_out_lower.mask.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.masked_out_lower.mask.qe = masked_out_lower_qe;
@@ -364,6 +372,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (masked_out_upper_flds_we[0]),
     .q      (reg2hw.masked_out_upper.data.q),
+    .ds     (),
     .qs     (masked_out_upper_data_qs)
   );
   assign reg2hw.masked_out_upper.data.qe = masked_out_upper_qe;
@@ -379,6 +388,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (masked_out_upper_flds_we[1]),
     .q      (reg2hw.masked_out_upper.mask.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.masked_out_upper.mask.qe = masked_out_upper_qe;
@@ -398,6 +408,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (direct_oe_flds_we[0]),
     .q      (reg2hw.direct_oe.q),
+    .ds     (),
     .qs     (direct_oe_qs)
   );
   assign reg2hw.direct_oe.qe = direct_oe_qe;
@@ -418,6 +429,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (masked_oe_lower_flds_we[0]),
     .q      (reg2hw.masked_oe_lower.data.q),
+    .ds     (),
     .qs     (masked_oe_lower_data_qs)
   );
   assign reg2hw.masked_oe_lower.data.qe = masked_oe_lower_qe;
@@ -433,6 +445,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (masked_oe_lower_flds_we[1]),
     .q      (reg2hw.masked_oe_lower.mask.q),
+    .ds     (),
     .qs     (masked_oe_lower_mask_qs)
   );
   assign reg2hw.masked_oe_lower.mask.qe = masked_oe_lower_qe;
@@ -453,6 +466,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (masked_oe_upper_flds_we[0]),
     .q      (reg2hw.masked_oe_upper.data.q),
+    .ds     (),
     .qs     (masked_oe_upper_data_qs)
   );
   assign reg2hw.masked_oe_upper.data.qe = masked_oe_upper_qe;
@@ -468,6 +482,7 @@ module gpio_reg_top (
     .qre    (),
     .qe     (masked_oe_upper_flds_we[1]),
     .q      (reg2hw.masked_oe_upper.mask.q),
+    .ds     (),
     .qs     (masked_oe_upper_mask_qs)
   );
   assign reg2hw.masked_oe_upper.mask.qe = masked_oe_upper_qe;
@@ -493,6 +508,7 @@ module gpio_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_ctrl_en_rising.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_ctrl_en_rising_qs)
@@ -519,6 +535,7 @@ module gpio_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_ctrl_en_falling.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_ctrl_en_falling_qs)
@@ -545,6 +562,7 @@ module gpio_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_ctrl_en_lvlhigh.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_ctrl_en_lvlhigh_qs)
@@ -571,6 +589,7 @@ module gpio_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_ctrl_en_lvllow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_ctrl_en_lvllow_qs)
@@ -597,6 +616,7 @@ module gpio_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl_en_input_filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_en_input_filter_qs)

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -272,6 +272,7 @@ module hmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.hmac_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_hmac_done_qs)
@@ -297,6 +298,7 @@ module hmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.fifo_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_fifo_empty_qs)
@@ -322,6 +324,7 @@ module hmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.hmac_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_hmac_err_qs)
@@ -349,6 +352,7 @@ module hmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.hmac_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_hmac_done_qs)
@@ -374,6 +378,7 @@ module hmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.fifo_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_fifo_empty_qs)
@@ -399,6 +404,7 @@ module hmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.hmac_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_hmac_err_qs)
@@ -420,6 +426,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.hmac_done.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.hmac_done.qe = intr_test_qe;
@@ -435,6 +442,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.fifo_empty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.fifo_empty.qe = intr_test_qe;
@@ -450,6 +458,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.hmac_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.hmac_err.qe = intr_test_qe;
@@ -469,6 +478,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -489,6 +499,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (cfg_flds_we[0]),
     .q      (reg2hw.cfg.hmac_en.q),
+    .ds     (),
     .qs     (cfg_hmac_en_qs)
   );
   assign reg2hw.cfg.hmac_en.qe = cfg_qe;
@@ -504,6 +515,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (cfg_flds_we[1]),
     .q      (reg2hw.cfg.sha_en.q),
+    .ds     (),
     .qs     (cfg_sha_en_qs)
   );
   assign reg2hw.cfg.sha_en.qe = cfg_qe;
@@ -519,6 +531,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (cfg_flds_we[2]),
     .q      (reg2hw.cfg.endian_swap.q),
+    .ds     (),
     .qs     (cfg_endian_swap_qs)
   );
   assign reg2hw.cfg.endian_swap.qe = cfg_qe;
@@ -534,6 +547,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (cfg_flds_we[3]),
     .q      (reg2hw.cfg.digest_swap.q),
+    .ds     (),
     .qs     (cfg_digest_swap_qs)
   );
   assign reg2hw.cfg.digest_swap.qe = cfg_qe;
@@ -554,6 +568,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (cmd_flds_we[0]),
     .q      (reg2hw.cmd.hash_start.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.cmd.hash_start.qe = cmd_qe;
@@ -569,6 +584,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (cmd_flds_we[1]),
     .q      (reg2hw.cmd.hash_process.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.cmd.hash_process.qe = cmd_qe;
@@ -586,6 +602,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_fifo_empty_qs)
   );
 
@@ -600,6 +617,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_fifo_full_qs)
   );
 
@@ -614,6 +632,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_fifo_depth_qs)
   );
 
@@ -638,6 +657,7 @@ module hmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_qs)
@@ -658,6 +678,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (wipe_secret_flds_we[0]),
     .q      (reg2hw.wipe_secret.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.wipe_secret.qe = wipe_secret_qe;
@@ -678,6 +699,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (key_0_flds_we[0]),
     .q      (reg2hw.key[0].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key[0].qe = key_0_qe;
@@ -698,6 +720,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (key_1_flds_we[0]),
     .q      (reg2hw.key[1].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key[1].qe = key_1_qe;
@@ -718,6 +741,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (key_2_flds_we[0]),
     .q      (reg2hw.key[2].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key[2].qe = key_2_qe;
@@ -738,6 +762,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (key_3_flds_we[0]),
     .q      (reg2hw.key[3].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key[3].qe = key_3_qe;
@@ -758,6 +783,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (key_4_flds_we[0]),
     .q      (reg2hw.key[4].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key[4].qe = key_4_qe;
@@ -778,6 +804,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (key_5_flds_we[0]),
     .q      (reg2hw.key[5].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key[5].qe = key_5_qe;
@@ -798,6 +825,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (key_6_flds_we[0]),
     .q      (reg2hw.key[6].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key[6].qe = key_6_qe;
@@ -818,6 +846,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (key_7_flds_we[0]),
     .q      (reg2hw.key[7].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key[7].qe = key_7_qe;
@@ -835,6 +864,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (digest_0_qs)
   );
 
@@ -851,6 +881,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (digest_1_qs)
   );
 
@@ -867,6 +898,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (digest_2_qs)
   );
 
@@ -883,6 +915,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (digest_3_qs)
   );
 
@@ -899,6 +932,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (digest_4_qs)
   );
 
@@ -915,6 +949,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (digest_5_qs)
   );
 
@@ -931,6 +966,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (digest_6_qs)
   );
 
@@ -947,6 +983,7 @@ module hmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (digest_7_qs)
   );
 
@@ -971,6 +1008,7 @@ module hmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (msg_length_lower_qs)
@@ -997,6 +1035,7 @@ module hmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (msg_length_upper_qs)

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -336,6 +336,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.fmt_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_fmt_watermark_qs)
@@ -361,6 +362,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_watermark_qs)
@@ -386,6 +388,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.fmt_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_fmt_overflow_qs)
@@ -411,6 +414,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_overflow_qs)
@@ -436,6 +440,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.nak.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_nak_qs)
@@ -461,6 +466,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.scl_interference.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_scl_interference_qs)
@@ -486,6 +492,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.sda_interference.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_sda_interference_qs)
@@ -511,6 +518,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.stretch_timeout.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_stretch_timeout_qs)
@@ -536,6 +544,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.sda_unstable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_sda_unstable_qs)
@@ -561,6 +570,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.trans_complete.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_trans_complete_qs)
@@ -586,6 +596,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.tx_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_tx_empty_qs)
@@ -611,6 +622,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.tx_nonempty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_tx_nonempty_qs)
@@ -636,6 +648,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.tx_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_tx_overflow_qs)
@@ -661,6 +674,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.acq_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_acq_overflow_qs)
@@ -686,6 +700,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.ack_stop.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_ack_stop_qs)
@@ -711,6 +726,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.host_timeout.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_host_timeout_qs)
@@ -738,6 +754,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.fmt_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_fmt_watermark_qs)
@@ -763,6 +780,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_watermark_qs)
@@ -788,6 +806,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.fmt_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_fmt_overflow_qs)
@@ -813,6 +832,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_overflow_qs)
@@ -838,6 +858,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.nak.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_nak_qs)
@@ -863,6 +884,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.scl_interference.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_scl_interference_qs)
@@ -888,6 +910,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.sda_interference.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_sda_interference_qs)
@@ -913,6 +936,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.stretch_timeout.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_stretch_timeout_qs)
@@ -938,6 +962,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.sda_unstable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_sda_unstable_qs)
@@ -963,6 +988,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.trans_complete.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_trans_complete_qs)
@@ -988,6 +1014,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.tx_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_tx_empty_qs)
@@ -1013,6 +1040,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.tx_nonempty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_tx_nonempty_qs)
@@ -1038,6 +1066,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.tx_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_tx_overflow_qs)
@@ -1063,6 +1092,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.acq_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_acq_overflow_qs)
@@ -1088,6 +1118,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.ack_stop.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_ack_stop_qs)
@@ -1113,6 +1144,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.host_timeout.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_host_timeout_qs)
@@ -1134,6 +1166,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.fmt_watermark.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.fmt_watermark.qe = intr_test_qe;
@@ -1149,6 +1182,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.rx_watermark.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_watermark.qe = intr_test_qe;
@@ -1164,6 +1198,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.fmt_overflow.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.fmt_overflow.qe = intr_test_qe;
@@ -1179,6 +1214,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.rx_overflow.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_overflow.qe = intr_test_qe;
@@ -1194,6 +1230,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.nak.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.nak.qe = intr_test_qe;
@@ -1209,6 +1246,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.scl_interference.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.scl_interference.qe = intr_test_qe;
@@ -1224,6 +1262,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[6]),
     .q      (reg2hw.intr_test.sda_interference.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.sda_interference.qe = intr_test_qe;
@@ -1239,6 +1278,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[7]),
     .q      (reg2hw.intr_test.stretch_timeout.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.stretch_timeout.qe = intr_test_qe;
@@ -1254,6 +1294,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[8]),
     .q      (reg2hw.intr_test.sda_unstable.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.sda_unstable.qe = intr_test_qe;
@@ -1269,6 +1310,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[9]),
     .q      (reg2hw.intr_test.trans_complete.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.trans_complete.qe = intr_test_qe;
@@ -1284,6 +1326,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[10]),
     .q      (reg2hw.intr_test.tx_empty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.tx_empty.qe = intr_test_qe;
@@ -1299,6 +1342,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[11]),
     .q      (reg2hw.intr_test.tx_nonempty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.tx_nonempty.qe = intr_test_qe;
@@ -1314,6 +1358,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[12]),
     .q      (reg2hw.intr_test.tx_overflow.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.tx_overflow.qe = intr_test_qe;
@@ -1329,6 +1374,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[13]),
     .q      (reg2hw.intr_test.acq_overflow.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.acq_overflow.qe = intr_test_qe;
@@ -1344,6 +1390,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[14]),
     .q      (reg2hw.intr_test.ack_stop.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.ack_stop.qe = intr_test_qe;
@@ -1359,6 +1406,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[15]),
     .q      (reg2hw.intr_test.host_timeout.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.host_timeout.qe = intr_test_qe;
@@ -1378,6 +1426,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -1404,6 +1453,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.enablehost.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_enablehost_qs)
@@ -1429,6 +1479,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.enabletarget.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_enabletarget_qs)
@@ -1454,6 +1505,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.llpbk.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_llpbk_qs)
@@ -1472,6 +1524,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_fmtfull_qs)
   );
 
@@ -1486,6 +1539,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_rxfull_qs)
   );
 
@@ -1500,6 +1554,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_fmtempty_qs)
   );
 
@@ -1514,6 +1569,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_hostidle_qs)
   );
 
@@ -1528,6 +1584,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_targetidle_qs)
   );
 
@@ -1542,6 +1599,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_rxempty_qs)
   );
 
@@ -1556,6 +1614,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_txfull_qs)
   );
 
@@ -1570,6 +1629,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_acqfull_qs)
   );
 
@@ -1584,6 +1644,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_txempty_qs)
   );
 
@@ -1598,6 +1659,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_acqempty_qs)
   );
 
@@ -1613,6 +1675,7 @@ module i2c_reg_top (
     .qre    (reg2hw.rdata.re),
     .qe     (),
     .q      (reg2hw.rdata.q),
+    .ds     (),
     .qs     (rdata_qs)
   );
 
@@ -1649,6 +1712,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fdata_flds_we[0]),
     .q      (reg2hw.fdata.fbyte.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1675,6 +1739,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fdata_flds_we[1]),
     .q      (reg2hw.fdata.start.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1701,6 +1766,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fdata_flds_we[2]),
     .q      (reg2hw.fdata.stop.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1727,6 +1793,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fdata_flds_we[3]),
     .q      (reg2hw.fdata.read.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1753,6 +1820,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fdata_flds_we[4]),
     .q      (reg2hw.fdata.rcont.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1779,6 +1847,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fdata_flds_we[5]),
     .q      (reg2hw.fdata.nakok.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1818,6 +1887,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fifo_ctrl_flds_we[0]),
     .q      (reg2hw.fifo_ctrl.rxrst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1844,6 +1914,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fifo_ctrl_flds_we[1]),
     .q      (reg2hw.fifo_ctrl.fmtrst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1870,6 +1941,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fifo_ctrl_flds_we[2]),
     .q      (reg2hw.fifo_ctrl.rxilvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_ctrl_rxilvl_qs)
@@ -1896,6 +1968,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fifo_ctrl_flds_we[3]),
     .q      (reg2hw.fifo_ctrl.fmtilvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_ctrl_fmtilvl_qs)
@@ -1922,6 +1995,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fifo_ctrl_flds_we[4]),
     .q      (reg2hw.fifo_ctrl.acqrst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1948,6 +2022,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (fifo_ctrl_flds_we[5]),
     .q      (reg2hw.fifo_ctrl.txrst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1967,6 +2042,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (fifo_status_fmtlvl_qs)
   );
 
@@ -1981,6 +2057,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (fifo_status_txlvl_qs)
   );
 
@@ -1995,6 +2072,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (fifo_status_rxlvl_qs)
   );
 
@@ -2009,6 +2087,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (fifo_status_acqlvl_qs)
   );
 
@@ -2034,6 +2113,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ovrd.txovrden.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ovrd_txovrden_qs)
@@ -2059,6 +2139,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ovrd.sclval.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ovrd_sclval_qs)
@@ -2084,6 +2165,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ovrd.sdaval.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ovrd_sdaval_qs)
@@ -2102,6 +2184,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (val_scl_rx_qs)
   );
 
@@ -2116,6 +2199,7 @@ module i2c_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (val_sda_rx_qs)
   );
 
@@ -2141,6 +2225,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timing0.thigh.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timing0_thigh_qs)
@@ -2166,6 +2251,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timing0.tlow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timing0_tlow_qs)
@@ -2193,6 +2279,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timing1.t_r.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timing1_t_r_qs)
@@ -2218,6 +2305,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timing1.t_f.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timing1_t_f_qs)
@@ -2245,6 +2333,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timing2.tsu_sta.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timing2_tsu_sta_qs)
@@ -2270,6 +2359,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timing2.thd_sta.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timing2_thd_sta_qs)
@@ -2297,6 +2387,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timing3.tsu_dat.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timing3_tsu_dat_qs)
@@ -2322,6 +2413,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timing3.thd_dat.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timing3_thd_dat_qs)
@@ -2349,6 +2441,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timing4.tsu_sto.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timing4_tsu_sto_qs)
@@ -2374,6 +2467,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timing4.t_buf.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timing4_t_buf_qs)
@@ -2401,6 +2495,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timeout_ctrl.val.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timeout_ctrl_val_qs)
@@ -2426,6 +2521,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timeout_ctrl.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timeout_ctrl_en_qs)
@@ -2453,6 +2549,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.target_id.address0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (target_id_address0_qs)
@@ -2478,6 +2575,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.target_id.mask0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (target_id_mask0_qs)
@@ -2503,6 +2601,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.target_id.address1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (target_id_address1_qs)
@@ -2528,6 +2627,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.target_id.mask1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (target_id_mask1_qs)
@@ -2546,6 +2646,7 @@ module i2c_reg_top (
     .qre    (reg2hw.acqdata.abyte.re),
     .qe     (),
     .q      (reg2hw.acqdata.abyte.q),
+    .ds     (),
     .qs     (acqdata_abyte_qs)
   );
 
@@ -2560,6 +2661,7 @@ module i2c_reg_top (
     .qre    (reg2hw.acqdata.signal.re),
     .qe     (),
     .q      (reg2hw.acqdata.signal.q),
+    .ds     (),
     .qs     (acqdata_signal_qs)
   );
 
@@ -2595,6 +2697,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (txdata_flds_we[0]),
     .q      (reg2hw.txdata.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -2623,6 +2726,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.stretch_ctrl.en_addr_tx.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (stretch_ctrl_en_addr_tx_qs)
@@ -2648,6 +2752,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.stretch_ctrl.en_addr_acq.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (stretch_ctrl_en_addr_acq_qs)
@@ -2673,6 +2778,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.stretch_ctrl.stop_tx.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (stretch_ctrl_stop_tx_qs)
@@ -2698,6 +2804,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.stretch_ctrl.stop_acq.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (stretch_ctrl_stop_acq_qs)
@@ -2724,6 +2831,7 @@ module i2c_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.host_timeout_ctrl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (host_timeout_ctrl_qs)

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -383,6 +383,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_qs)
@@ -409,6 +410,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_qs)
@@ -429,6 +431,7 @@ module keymgr_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.qe = intr_test_qe;
@@ -449,6 +452,7 @@ module keymgr_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_operation_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_operation_err.qe = alert_test_qe;
@@ -464,6 +468,7 @@ module keymgr_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_fault_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault_err.qe = alert_test_qe;
@@ -480,6 +485,7 @@ module keymgr_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (cfg_regwen_qs)
   );
 
@@ -507,6 +513,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.start.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (start_qs)
@@ -539,6 +546,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control_shadowed.operation.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_shadowed_operation_qs),
@@ -573,6 +581,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control_shadowed.cdi_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_shadowed_cdi_sel_qs),
@@ -607,6 +616,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control_shadowed.dest_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_shadowed_dest_sel_qs),
@@ -643,6 +653,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sideload_clear.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sideload_clear_qs)
@@ -669,6 +680,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reseed_interval_regwen_qs)
@@ -701,6 +713,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.reseed_interval_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reseed_interval_shadowed_qs),
@@ -728,6 +741,7 @@ module keymgr_reg_top (
     .qre    (),
     .qe     (sw_binding_regwen_flds_we[0]),
     .q      (reg2hw.sw_binding_regwen.q),
+    .ds     (),
     .qs     (sw_binding_regwen_qs)
   );
   assign reg2hw.sw_binding_regwen.qe = sw_binding_regwen_qe;
@@ -757,6 +771,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sealing_sw_binding[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sealing_sw_binding_0_qs)
@@ -787,6 +802,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sealing_sw_binding[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sealing_sw_binding_1_qs)
@@ -817,6 +833,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sealing_sw_binding[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sealing_sw_binding_2_qs)
@@ -847,6 +864,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sealing_sw_binding[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sealing_sw_binding_3_qs)
@@ -877,6 +895,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sealing_sw_binding[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sealing_sw_binding_4_qs)
@@ -907,6 +926,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sealing_sw_binding[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sealing_sw_binding_5_qs)
@@ -937,6 +957,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sealing_sw_binding[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sealing_sw_binding_6_qs)
@@ -967,6 +988,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sealing_sw_binding[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sealing_sw_binding_7_qs)
@@ -997,6 +1019,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.attest_sw_binding[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (attest_sw_binding_0_qs)
@@ -1027,6 +1050,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.attest_sw_binding[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (attest_sw_binding_1_qs)
@@ -1057,6 +1081,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.attest_sw_binding[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (attest_sw_binding_2_qs)
@@ -1087,6 +1112,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.attest_sw_binding[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (attest_sw_binding_3_qs)
@@ -1117,6 +1143,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.attest_sw_binding[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (attest_sw_binding_4_qs)
@@ -1147,6 +1174,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.attest_sw_binding[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (attest_sw_binding_5_qs)
@@ -1177,6 +1205,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.attest_sw_binding[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (attest_sw_binding_6_qs)
@@ -1207,6 +1236,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.attest_sw_binding[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (attest_sw_binding_7_qs)
@@ -1237,6 +1267,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.salt[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (salt_0_qs)
@@ -1267,6 +1298,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.salt[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (salt_1_qs)
@@ -1297,6 +1329,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.salt[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (salt_2_qs)
@@ -1327,6 +1360,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.salt[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (salt_3_qs)
@@ -1357,6 +1391,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.salt[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (salt_4_qs)
@@ -1387,6 +1422,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.salt[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (salt_5_qs)
@@ -1417,6 +1453,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.salt[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (salt_6_qs)
@@ -1447,6 +1484,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.salt[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (salt_7_qs)
@@ -1477,6 +1515,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_version[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (key_version_qs)
@@ -1503,6 +1542,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (max_creator_key_ver_regwen_qs)
@@ -1535,6 +1575,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.max_creator_key_ver_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (max_creator_key_ver_shadowed_qs),
@@ -1568,6 +1609,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (max_owner_int_key_ver_regwen_qs)
@@ -1600,6 +1642,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.max_owner_int_key_ver_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (max_owner_int_key_ver_shadowed_qs),
@@ -1633,6 +1676,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (max_owner_key_ver_regwen_qs)
@@ -1665,6 +1709,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.max_owner_key_ver_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (max_owner_key_ver_shadowed_qs),
@@ -1699,6 +1744,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share0_output_0_qs)
@@ -1726,6 +1772,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share0_output_1_qs)
@@ -1753,6 +1800,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share0_output_2_qs)
@@ -1780,6 +1828,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share0_output_3_qs)
@@ -1807,6 +1856,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share0_output_4_qs)
@@ -1834,6 +1884,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share0_output_5_qs)
@@ -1861,6 +1912,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share0_output_6_qs)
@@ -1888,6 +1940,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share0_output_7_qs)
@@ -1915,6 +1968,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share1_output_0_qs)
@@ -1942,6 +1996,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share1_output_1_qs)
@@ -1969,6 +2024,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share1_output_2_qs)
@@ -1996,6 +2052,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share1_output_3_qs)
@@ -2023,6 +2080,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share1_output_4_qs)
@@ -2050,6 +2108,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share1_output_5_qs)
@@ -2077,6 +2136,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share1_output_6_qs)
@@ -2104,6 +2164,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_share1_output_7_qs)
@@ -2130,6 +2191,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (working_state_qs)
@@ -2156,6 +2218,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (op_status_qs)
@@ -2183,6 +2246,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_invalid_op_qs)
@@ -2208,6 +2272,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_invalid_kmac_input_qs)
@@ -2233,6 +2298,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_invalid_shadow_update_qs)
@@ -2260,6 +2326,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.cmd.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_cmd_qs)
@@ -2285,6 +2352,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.kmac_fsm.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_kmac_fsm_qs)
@@ -2310,6 +2378,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.kmac_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_kmac_done_qs)
@@ -2335,6 +2404,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.kmac_op.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_kmac_op_qs)
@@ -2360,6 +2430,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.kmac_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_kmac_out_qs)
@@ -2385,6 +2456,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.regfile_intg.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_regfile_intg_qs)
@@ -2410,6 +2482,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.shadow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_shadow_qs)
@@ -2435,6 +2508,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.ctrl_fsm_intg.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_ctrl_fsm_intg_qs)
@@ -2460,6 +2534,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.ctrl_fsm_chk.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_ctrl_fsm_chk_qs)
@@ -2485,6 +2560,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.ctrl_fsm_cnt.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_ctrl_fsm_cnt_qs)
@@ -2510,6 +2586,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.reseed_cnt.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_reseed_cnt_qs)
@@ -2535,6 +2612,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.side_ctrl_fsm.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_side_ctrl_fsm_qs)
@@ -2560,6 +2638,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.side_ctrl_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_side_ctrl_sel_qs)
@@ -2585,6 +2664,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.key_ecc.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_key_ecc_qs)
@@ -2612,6 +2692,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (debug_invalid_creator_seed_qs)
@@ -2637,6 +2718,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (debug_invalid_owner_seed_qs)
@@ -2662,6 +2744,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (debug_invalid_dev_id_qs)
@@ -2687,6 +2770,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (debug_invalid_health_state_qs)
@@ -2712,6 +2796,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (debug_invalid_key_version_qs)
@@ -2737,6 +2822,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (debug_invalid_key_qs)
@@ -2762,6 +2848,7 @@ module keymgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (debug_invalid_digest_qs)

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -415,6 +415,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.kmac_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_kmac_done_qs)
@@ -440,6 +441,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.fifo_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_fifo_empty_qs)
@@ -465,6 +467,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.kmac_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_kmac_err_qs)
@@ -492,6 +495,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.kmac_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_kmac_done_qs)
@@ -517,6 +521,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.fifo_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_fifo_empty_qs)
@@ -542,6 +547,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.kmac_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_kmac_err_qs)
@@ -563,6 +569,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.kmac_done.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.kmac_done.qe = intr_test_qe;
@@ -578,6 +585,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.fifo_empty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.fifo_empty.qe = intr_test_qe;
@@ -593,6 +601,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.kmac_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.kmac_err.qe = intr_test_qe;
@@ -613,6 +622,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_operation_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_operation_err.qe = alert_test_qe;
@@ -628,6 +638,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_fault_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault_err.qe = alert_test_qe;
@@ -644,6 +655,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (cfg_regwen_qs)
   );
 
@@ -685,6 +697,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[0]),
     .q      (reg2hw.cfg_shadowed.kmac_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_kmac_en_qs),
@@ -720,6 +733,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[1]),
     .q      (reg2hw.cfg_shadowed.kstrength.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_kstrength_qs),
@@ -755,6 +769,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[2]),
     .q      (reg2hw.cfg_shadowed.mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_mode_qs),
@@ -790,6 +805,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[3]),
     .q      (reg2hw.cfg_shadowed.msg_endianness.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_msg_endianness_qs),
@@ -825,6 +841,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[4]),
     .q      (reg2hw.cfg_shadowed.state_endianness.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_state_endianness_qs),
@@ -860,6 +877,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[5]),
     .q      (reg2hw.cfg_shadowed.sideload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_sideload_qs),
@@ -895,6 +913,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[6]),
     .q      (reg2hw.cfg_shadowed.entropy_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_entropy_mode_qs),
@@ -930,6 +949,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[7]),
     .q      (reg2hw.cfg_shadowed.entropy_fast_process.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_entropy_fast_process_qs),
@@ -965,6 +985,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[8]),
     .q      (reg2hw.cfg_shadowed.msg_mask.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_msg_mask_qs),
@@ -1000,6 +1021,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[9]),
     .q      (reg2hw.cfg_shadowed.entropy_ready.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_entropy_ready_qs),
@@ -1035,6 +1057,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[10]),
     .q      (reg2hw.cfg_shadowed.err_processed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_err_processed_qs),
@@ -1070,6 +1093,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (cfg_shadowed_flds_we[11]),
     .q      (reg2hw.cfg_shadowed.en_unsupported_modestrength.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_shadowed_en_unsupported_modestrength_qs),
@@ -1099,6 +1123,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (cmd_flds_we[0]),
     .q      (reg2hw.cmd.cmd.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.cmd.cmd.qe = cmd_qe;
@@ -1114,6 +1139,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (cmd_flds_we[1]),
     .q      (reg2hw.cmd.entropy_req.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.cmd.entropy_req.qe = cmd_qe;
@@ -1129,6 +1155,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (cmd_flds_we[2]),
     .q      (reg2hw.cmd.hash_cnt_clr.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.cmd.hash_cnt_clr.qe = cmd_qe;
@@ -1146,6 +1173,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_sha3_idle_qs)
   );
 
@@ -1160,6 +1188,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_sha3_absorb_qs)
   );
 
@@ -1174,6 +1203,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_sha3_squeeze_qs)
   );
 
@@ -1188,6 +1218,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_fifo_depth_qs)
   );
 
@@ -1202,6 +1233,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_fifo_empty_qs)
   );
 
@@ -1216,6 +1248,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_fifo_full_qs)
   );
 
@@ -1230,6 +1263,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_alert_fatal_fault_qs)
   );
 
@@ -1244,6 +1278,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_alert_recov_ctrl_update_err_qs)
   );
 
@@ -1272,6 +1307,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.entropy_period.prescaler.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (entropy_period_prescaler_qs)
@@ -1297,6 +1333,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.entropy_period.wait_timer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (entropy_period_wait_timer_qs)
@@ -1323,6 +1360,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (entropy_refresh_hash_cnt_qs)
@@ -1355,6 +1393,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.entropy_refresh_threshold_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (entropy_refresh_threshold_shadowed_qs),
@@ -1386,6 +1425,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (entropy_seed_0_flds_we[0]),
     .q      (reg2hw.entropy_seed[0].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.entropy_seed[0].qe = entropy_seed_0_qe;
@@ -1409,6 +1449,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (entropy_seed_1_flds_we[0]),
     .q      (reg2hw.entropy_seed[1].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.entropy_seed[1].qe = entropy_seed_1_qe;
@@ -1432,6 +1473,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (entropy_seed_2_flds_we[0]),
     .q      (reg2hw.entropy_seed[2].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.entropy_seed[2].qe = entropy_seed_2_qe;
@@ -1455,6 +1497,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (entropy_seed_3_flds_we[0]),
     .q      (reg2hw.entropy_seed[3].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.entropy_seed[3].qe = entropy_seed_3_qe;
@@ -1478,6 +1521,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (entropy_seed_4_flds_we[0]),
     .q      (reg2hw.entropy_seed[4].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.entropy_seed[4].qe = entropy_seed_4_qe;
@@ -1501,6 +1545,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_0_flds_we[0]),
     .q      (reg2hw.key_share0[0].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[0].qe = key_share0_0_qe;
@@ -1524,6 +1569,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_1_flds_we[0]),
     .q      (reg2hw.key_share0[1].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[1].qe = key_share0_1_qe;
@@ -1547,6 +1593,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_2_flds_we[0]),
     .q      (reg2hw.key_share0[2].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[2].qe = key_share0_2_qe;
@@ -1570,6 +1617,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_3_flds_we[0]),
     .q      (reg2hw.key_share0[3].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[3].qe = key_share0_3_qe;
@@ -1593,6 +1641,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_4_flds_we[0]),
     .q      (reg2hw.key_share0[4].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[4].qe = key_share0_4_qe;
@@ -1616,6 +1665,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_5_flds_we[0]),
     .q      (reg2hw.key_share0[5].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[5].qe = key_share0_5_qe;
@@ -1639,6 +1689,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_6_flds_we[0]),
     .q      (reg2hw.key_share0[6].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[6].qe = key_share0_6_qe;
@@ -1662,6 +1713,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_7_flds_we[0]),
     .q      (reg2hw.key_share0[7].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[7].qe = key_share0_7_qe;
@@ -1685,6 +1737,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_8_flds_we[0]),
     .q      (reg2hw.key_share0[8].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[8].qe = key_share0_8_qe;
@@ -1708,6 +1761,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_9_flds_we[0]),
     .q      (reg2hw.key_share0[9].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[9].qe = key_share0_9_qe;
@@ -1731,6 +1785,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_10_flds_we[0]),
     .q      (reg2hw.key_share0[10].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[10].qe = key_share0_10_qe;
@@ -1754,6 +1809,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_11_flds_we[0]),
     .q      (reg2hw.key_share0[11].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[11].qe = key_share0_11_qe;
@@ -1777,6 +1833,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_12_flds_we[0]),
     .q      (reg2hw.key_share0[12].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[12].qe = key_share0_12_qe;
@@ -1800,6 +1857,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_13_flds_we[0]),
     .q      (reg2hw.key_share0[13].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[13].qe = key_share0_13_qe;
@@ -1823,6 +1881,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_14_flds_we[0]),
     .q      (reg2hw.key_share0[14].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[14].qe = key_share0_14_qe;
@@ -1846,6 +1905,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share0_15_flds_we[0]),
     .q      (reg2hw.key_share0[15].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share0[15].qe = key_share0_15_qe;
@@ -1869,6 +1929,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_0_flds_we[0]),
     .q      (reg2hw.key_share1[0].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[0].qe = key_share1_0_qe;
@@ -1892,6 +1953,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_1_flds_we[0]),
     .q      (reg2hw.key_share1[1].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[1].qe = key_share1_1_qe;
@@ -1915,6 +1977,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_2_flds_we[0]),
     .q      (reg2hw.key_share1[2].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[2].qe = key_share1_2_qe;
@@ -1938,6 +2001,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_3_flds_we[0]),
     .q      (reg2hw.key_share1[3].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[3].qe = key_share1_3_qe;
@@ -1961,6 +2025,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_4_flds_we[0]),
     .q      (reg2hw.key_share1[4].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[4].qe = key_share1_4_qe;
@@ -1984,6 +2049,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_5_flds_we[0]),
     .q      (reg2hw.key_share1[5].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[5].qe = key_share1_5_qe;
@@ -2007,6 +2073,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_6_flds_we[0]),
     .q      (reg2hw.key_share1[6].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[6].qe = key_share1_6_qe;
@@ -2030,6 +2097,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_7_flds_we[0]),
     .q      (reg2hw.key_share1[7].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[7].qe = key_share1_7_qe;
@@ -2053,6 +2121,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_8_flds_we[0]),
     .q      (reg2hw.key_share1[8].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[8].qe = key_share1_8_qe;
@@ -2076,6 +2145,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_9_flds_we[0]),
     .q      (reg2hw.key_share1[9].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[9].qe = key_share1_9_qe;
@@ -2099,6 +2169,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_10_flds_we[0]),
     .q      (reg2hw.key_share1[10].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[10].qe = key_share1_10_qe;
@@ -2122,6 +2193,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_11_flds_we[0]),
     .q      (reg2hw.key_share1[11].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[11].qe = key_share1_11_qe;
@@ -2145,6 +2217,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_12_flds_we[0]),
     .q      (reg2hw.key_share1[12].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[12].qe = key_share1_12_qe;
@@ -2168,6 +2241,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_13_flds_we[0]),
     .q      (reg2hw.key_share1[13].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[13].qe = key_share1_13_qe;
@@ -2191,6 +2265,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_14_flds_we[0]),
     .q      (reg2hw.key_share1[14].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[14].qe = key_share1_14_qe;
@@ -2214,6 +2289,7 @@ module kmac_reg_top (
     .qre    (),
     .qe     (key_share1_15_flds_we[0]),
     .q      (reg2hw.key_share1[15].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.key_share1[15].qe = key_share1_15_qe;
@@ -2242,6 +2318,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_len.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -2272,6 +2349,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_0_qs)
@@ -2302,6 +2380,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_1_qs)
@@ -2332,6 +2411,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_2_qs)
@@ -2362,6 +2442,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_3_qs)
@@ -2392,6 +2473,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_4_qs)
@@ -2422,6 +2504,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_5_qs)
@@ -2452,6 +2535,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_6_qs)
@@ -2482,6 +2566,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_7_qs)
@@ -2512,6 +2597,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_8_qs)
@@ -2542,6 +2628,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_9_qs)
@@ -2572,6 +2659,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prefix[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prefix_10_qs)
@@ -2598,6 +2686,7 @@ module kmac_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_qs)

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -232,6 +232,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal_prog_error.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_prog_error.qe = alert_test_qe;
@@ -247,6 +248,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_state_error.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_state_error.qe = alert_test_qe;
@@ -262,6 +264,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[2]),
     .q      (reg2hw.alert_test.fatal_bus_integ_error.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_bus_integ_error.qe = alert_test_qe;
@@ -279,6 +282,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_ready_qs)
   );
 
@@ -293,6 +297,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_transition_successful_qs)
   );
 
@@ -307,6 +312,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_transition_count_error_qs)
   );
 
@@ -321,6 +327,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_transition_error_qs)
   );
 
@@ -335,6 +342,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_token_error_qs)
   );
 
@@ -349,6 +357,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_flash_rma_error_qs)
   );
 
@@ -363,6 +372,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_otp_error_qs)
   );
 
@@ -377,6 +387,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_state_error_qs)
   );
 
@@ -391,6 +402,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_bus_integ_error_qs)
   );
 
@@ -405,6 +417,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_otp_partition_error_qs)
   );
 
@@ -423,6 +436,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (claim_transition_if_flds_we[0]),
     .q      (reg2hw.claim_transition_if.q),
+    .ds     (),
     .qs     (claim_transition_if_qs)
   );
   assign reg2hw.claim_transition_if.qe = claim_transition_if_qe;
@@ -439,6 +453,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (transition_regwen_qs)
   );
 
@@ -460,6 +475,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (transition_cmd_flds_we[0]),
     .q      (reg2hw.transition_cmd.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.transition_cmd.qe = transition_cmd_qe;
@@ -482,6 +498,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (transition_ctrl_flds_we[0]),
     .q      (reg2hw.transition_ctrl.q),
+    .ds     (),
     .qs     (transition_ctrl_qs)
   );
   assign reg2hw.transition_ctrl.qe = transition_ctrl_qe;
@@ -505,6 +522,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (transition_token_0_flds_we[0]),
     .q      (reg2hw.transition_token[0].q),
+    .ds     (),
     .qs     (transition_token_0_qs)
   );
   assign reg2hw.transition_token[0].qe = transition_token_0_qe;
@@ -528,6 +546,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (transition_token_1_flds_we[0]),
     .q      (reg2hw.transition_token[1].q),
+    .ds     (),
     .qs     (transition_token_1_qs)
   );
   assign reg2hw.transition_token[1].qe = transition_token_1_qe;
@@ -551,6 +570,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (transition_token_2_flds_we[0]),
     .q      (reg2hw.transition_token[2].q),
+    .ds     (),
     .qs     (transition_token_2_qs)
   );
   assign reg2hw.transition_token[2].qe = transition_token_2_qe;
@@ -574,6 +594,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (transition_token_3_flds_we[0]),
     .q      (reg2hw.transition_token[3].q),
+    .ds     (),
     .qs     (transition_token_3_qs)
   );
   assign reg2hw.transition_token[3].qe = transition_token_3_qe;
@@ -596,6 +617,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (transition_target_flds_we[0]),
     .q      (reg2hw.transition_target.q),
+    .ds     (),
     .qs     (transition_target_qs)
   );
   assign reg2hw.transition_target.qe = transition_target_qe;
@@ -618,6 +640,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (otp_vendor_test_ctrl_flds_we[0]),
     .q      (reg2hw.otp_vendor_test_ctrl.q),
+    .ds     (),
     .qs     (otp_vendor_test_ctrl_qs)
   );
   assign reg2hw.otp_vendor_test_ctrl.qe = otp_vendor_test_ctrl_qe;
@@ -634,6 +657,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (otp_vendor_test_status_qs)
   );
 
@@ -649,6 +673,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (lc_state_qs)
   );
 
@@ -664,6 +689,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (lc_transition_cnt_qs)
   );
 
@@ -679,6 +705,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (lc_id_state_qs)
   );
 
@@ -695,6 +722,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (hw_rev_chip_rev_qs)
   );
 
@@ -709,6 +737,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (hw_rev_chip_gen_qs)
   );
 
@@ -725,6 +754,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (device_id_0_qs)
   );
 
@@ -741,6 +771,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (device_id_1_qs)
   );
 
@@ -757,6 +788,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (device_id_2_qs)
   );
 
@@ -773,6 +805,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (device_id_3_qs)
   );
 
@@ -789,6 +822,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (device_id_4_qs)
   );
 
@@ -805,6 +839,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (device_id_5_qs)
   );
 
@@ -821,6 +856,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (device_id_6_qs)
   );
 
@@ -837,6 +873,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (device_id_7_qs)
   );
 
@@ -853,6 +890,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (manuf_state_0_qs)
   );
 
@@ -869,6 +907,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (manuf_state_1_qs)
   );
 
@@ -885,6 +924,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (manuf_state_2_qs)
   );
 
@@ -901,6 +941,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (manuf_state_3_qs)
   );
 
@@ -917,6 +958,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (manuf_state_4_qs)
   );
 
@@ -933,6 +975,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (manuf_state_5_qs)
   );
 
@@ -949,6 +992,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (manuf_state_6_qs)
   );
 
@@ -965,6 +1009,7 @@ module lc_ctrl_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (manuf_state_7_qs)
   );
 

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -270,6 +270,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_qs)
@@ -296,6 +297,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_qs)
@@ -316,6 +318,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.qe = intr_test_qe;
@@ -336,6 +339,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal.qe = alert_test_qe;
@@ -351,6 +355,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.recov.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov.qe = alert_test_qe;
@@ -370,6 +375,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (cmd_flds_we[0]),
     .q      (reg2hw.cmd.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.cmd.qe = cmd_qe;
@@ -389,6 +395,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (ctrl_flds_we[0]),
     .q      (reg2hw.ctrl.q),
+    .ds     (),
     .qs     (ctrl_qs)
   );
   assign reg2hw.ctrl.qe = ctrl_qe;
@@ -414,6 +421,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_qs)
@@ -435,6 +443,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[0]),
     .q      (reg2hw.err_bits.bad_data_addr.q),
+    .ds     (),
     .qs     (err_bits_bad_data_addr_qs)
   );
   assign reg2hw.err_bits.bad_data_addr.qe = err_bits_qe;
@@ -450,6 +459,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[1]),
     .q      (reg2hw.err_bits.bad_insn_addr.q),
+    .ds     (),
     .qs     (err_bits_bad_insn_addr_qs)
   );
   assign reg2hw.err_bits.bad_insn_addr.qe = err_bits_qe;
@@ -465,6 +475,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[2]),
     .q      (reg2hw.err_bits.call_stack.q),
+    .ds     (),
     .qs     (err_bits_call_stack_qs)
   );
   assign reg2hw.err_bits.call_stack.qe = err_bits_qe;
@@ -480,6 +491,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[3]),
     .q      (reg2hw.err_bits.illegal_insn.q),
+    .ds     (),
     .qs     (err_bits_illegal_insn_qs)
   );
   assign reg2hw.err_bits.illegal_insn.qe = err_bits_qe;
@@ -495,6 +507,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[4]),
     .q      (reg2hw.err_bits.loop.q),
+    .ds     (),
     .qs     (err_bits_loop_qs)
   );
   assign reg2hw.err_bits.loop.qe = err_bits_qe;
@@ -510,6 +523,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[5]),
     .q      (reg2hw.err_bits.key_invalid.q),
+    .ds     (),
     .qs     (err_bits_key_invalid_qs)
   );
   assign reg2hw.err_bits.key_invalid.qe = err_bits_qe;
@@ -525,6 +539,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[6]),
     .q      (reg2hw.err_bits.rnd_rep_chk_fail.q),
+    .ds     (),
     .qs     (err_bits_rnd_rep_chk_fail_qs)
   );
   assign reg2hw.err_bits.rnd_rep_chk_fail.qe = err_bits_qe;
@@ -540,6 +555,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[7]),
     .q      (reg2hw.err_bits.rnd_fips_chk_fail.q),
+    .ds     (),
     .qs     (err_bits_rnd_fips_chk_fail_qs)
   );
   assign reg2hw.err_bits.rnd_fips_chk_fail.qe = err_bits_qe;
@@ -555,6 +571,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[8]),
     .q      (reg2hw.err_bits.imem_intg_violation.q),
+    .ds     (),
     .qs     (err_bits_imem_intg_violation_qs)
   );
   assign reg2hw.err_bits.imem_intg_violation.qe = err_bits_qe;
@@ -570,6 +587,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[9]),
     .q      (reg2hw.err_bits.dmem_intg_violation.q),
+    .ds     (),
     .qs     (err_bits_dmem_intg_violation_qs)
   );
   assign reg2hw.err_bits.dmem_intg_violation.qe = err_bits_qe;
@@ -585,6 +603,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[10]),
     .q      (reg2hw.err_bits.reg_intg_violation.q),
+    .ds     (),
     .qs     (err_bits_reg_intg_violation_qs)
   );
   assign reg2hw.err_bits.reg_intg_violation.qe = err_bits_qe;
@@ -600,6 +619,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[11]),
     .q      (reg2hw.err_bits.bus_intg_violation.q),
+    .ds     (),
     .qs     (err_bits_bus_intg_violation_qs)
   );
   assign reg2hw.err_bits.bus_intg_violation.qe = err_bits_qe;
@@ -615,6 +635,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[12]),
     .q      (reg2hw.err_bits.bad_internal_state.q),
+    .ds     (),
     .qs     (err_bits_bad_internal_state_qs)
   );
   assign reg2hw.err_bits.bad_internal_state.qe = err_bits_qe;
@@ -630,6 +651,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[13]),
     .q      (reg2hw.err_bits.illegal_bus_access.q),
+    .ds     (),
     .qs     (err_bits_illegal_bus_access_qs)
   );
   assign reg2hw.err_bits.illegal_bus_access.qe = err_bits_qe;
@@ -645,6 +667,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[14]),
     .q      (reg2hw.err_bits.lifecycle_escalation.q),
+    .ds     (),
     .qs     (err_bits_lifecycle_escalation_qs)
   );
   assign reg2hw.err_bits.lifecycle_escalation.qe = err_bits_qe;
@@ -660,6 +683,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (err_bits_flds_we[15]),
     .q      (reg2hw.err_bits.fatal_software.q),
+    .ds     (),
     .qs     (err_bits_fatal_software_qs)
   );
   assign reg2hw.err_bits.fatal_software.qe = err_bits_qe;
@@ -686,6 +710,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_cause_imem_intg_violation_qs)
@@ -711,6 +736,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_cause_dmem_intg_violation_qs)
@@ -736,6 +762,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_cause_reg_intg_violation_qs)
@@ -761,6 +788,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_cause_bus_intg_violation_qs)
@@ -786,6 +814,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_cause_bad_internal_state_qs)
@@ -811,6 +840,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_cause_illegal_bus_access_qs)
@@ -836,6 +866,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_cause_lifecycle_escalation_qs)
@@ -861,6 +892,7 @@ module otbn_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_cause_fatal_software_qs)
@@ -881,6 +913,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (insn_cnt_flds_we[0]),
     .q      (reg2hw.insn_cnt.q),
+    .ds     (),
     .qs     (insn_cnt_qs)
   );
   assign reg2hw.insn_cnt.qe = insn_cnt_qe;
@@ -900,6 +933,7 @@ module otbn_reg_top (
     .qre    (),
     .qe     (load_checksum_flds_we[0]),
     .q      (reg2hw.load_checksum.q),
+    .ds     (),
     .qs     (load_checksum_qs)
   );
   assign reg2hw.load_checksum.qe = load_checksum_qe;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -318,6 +318,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.otp_operation_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_otp_operation_done_qs)
@@ -343,6 +344,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.otp_error.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_otp_error_qs)
@@ -370,6 +372,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.otp_operation_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_otp_operation_done_qs)
@@ -395,6 +398,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.otp_error.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_otp_error_qs)
@@ -416,6 +420,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.otp_operation_done.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.otp_operation_done.qe = intr_test_qe;
@@ -431,6 +436,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.otp_error.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.otp_error.qe = intr_test_qe;
@@ -451,6 +457,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal_macro_error.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_macro_error.qe = alert_test_qe;
@@ -466,6 +473,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_check_error.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_check_error.qe = alert_test_qe;
@@ -481,6 +489,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[2]),
     .q      (reg2hw.alert_test.fatal_bus_integ_error.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_bus_integ_error.qe = alert_test_qe;
@@ -498,6 +507,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_vendor_test_error_qs)
   );
 
@@ -512,6 +522,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_creator_sw_cfg_error_qs)
   );
 
@@ -526,6 +537,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_owner_sw_cfg_error_qs)
   );
 
@@ -540,6 +552,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_hw_cfg_error_qs)
   );
 
@@ -554,6 +567,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_secret0_error_qs)
   );
 
@@ -568,6 +582,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_secret1_error_qs)
   );
 
@@ -582,6 +597,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_secret2_error_qs)
   );
 
@@ -596,6 +612,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_life_cycle_error_qs)
   );
 
@@ -610,6 +627,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_dai_error_qs)
   );
 
@@ -624,6 +642,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_lci_error_qs)
   );
 
@@ -638,6 +657,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_timeout_error_qs)
   );
 
@@ -652,6 +672,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_lfsr_fsm_error_qs)
   );
 
@@ -666,6 +687,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_scrambling_fsm_error_qs)
   );
 
@@ -680,6 +702,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_key_deriv_fsm_error_qs)
   );
 
@@ -694,6 +717,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_bus_integ_error_qs)
   );
 
@@ -708,6 +732,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_dai_idle_qs)
   );
 
@@ -722,6 +747,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_check_pending_qs)
   );
 
@@ -739,6 +765,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (err_code_err_code_0_qs)
   );
 
@@ -753,6 +780,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (err_code_err_code_1_qs)
   );
 
@@ -767,6 +795,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (err_code_err_code_2_qs)
   );
 
@@ -781,6 +810,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (err_code_err_code_3_qs)
   );
 
@@ -795,6 +825,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (err_code_err_code_4_qs)
   );
 
@@ -809,6 +840,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (err_code_err_code_5_qs)
   );
 
@@ -823,6 +855,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (err_code_err_code_6_qs)
   );
 
@@ -837,6 +870,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (err_code_err_code_7_qs)
   );
 
@@ -851,6 +885,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (err_code_err_code_8_qs)
   );
 
@@ -865,6 +900,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (err_code_err_code_9_qs)
   );
 
@@ -880,6 +916,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (direct_access_regwen_qs)
   );
 
@@ -902,6 +939,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (direct_access_cmd_flds_we[0]),
     .q      (reg2hw.direct_access_cmd.rd.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.direct_access_cmd.rd.qe = direct_access_cmd_qe;
@@ -917,6 +955,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (direct_access_cmd_flds_we[1]),
     .q      (reg2hw.direct_access_cmd.wr.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.direct_access_cmd.wr.qe = direct_access_cmd_qe;
@@ -932,6 +971,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (direct_access_cmd_flds_we[2]),
     .q      (reg2hw.direct_access_cmd.digest.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.direct_access_cmd.digest.qe = direct_access_cmd_qe;
@@ -960,6 +1000,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.direct_access_address.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (direct_access_address_qs)
@@ -990,6 +1031,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.direct_access_wdata[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (direct_access_wdata_0_qs)
@@ -1020,6 +1062,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.direct_access_wdata[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (direct_access_wdata_1_qs)
@@ -1038,6 +1081,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (direct_access_rdata_0_qs)
   );
 
@@ -1054,6 +1098,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (direct_access_rdata_1_qs)
   );
 
@@ -1078,6 +1123,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (check_trigger_regwen_qs)
@@ -1102,6 +1148,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (check_trigger_flds_we[0]),
     .q      (reg2hw.check_trigger.integrity.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.check_trigger.integrity.qe = check_trigger_qe;
@@ -1117,6 +1164,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (check_trigger_flds_we[1]),
     .q      (reg2hw.check_trigger.consistency.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.check_trigger.consistency.qe = check_trigger_qe;
@@ -1142,6 +1190,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (check_regwen_qs)
@@ -1171,6 +1220,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.check_timeout.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (check_timeout_qs)
@@ -1200,6 +1250,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.integrity_check_period.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (integrity_check_period_qs)
@@ -1229,6 +1280,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.consistency_check_period.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (consistency_check_period_qs)
@@ -1258,6 +1310,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.vendor_test_read_lock.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (vendor_test_read_lock_qs)
@@ -1287,6 +1340,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.creator_sw_cfg_read_lock.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (creator_sw_cfg_read_lock_qs)
@@ -1316,6 +1370,7 @@ module otp_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.owner_sw_cfg_read_lock.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (owner_sw_cfg_read_lock_qs)
@@ -1334,6 +1389,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (vendor_test_digest_0_qs)
   );
 
@@ -1350,6 +1406,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (vendor_test_digest_1_qs)
   );
 
@@ -1366,6 +1423,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (creator_sw_cfg_digest_0_qs)
   );
 
@@ -1382,6 +1440,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (creator_sw_cfg_digest_1_qs)
   );
 
@@ -1398,6 +1457,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (owner_sw_cfg_digest_0_qs)
   );
 
@@ -1414,6 +1474,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (owner_sw_cfg_digest_1_qs)
   );
 
@@ -1430,6 +1491,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (hw_cfg_digest_0_qs)
   );
 
@@ -1446,6 +1508,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (hw_cfg_digest_1_qs)
   );
 
@@ -1462,6 +1525,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (secret0_digest_0_qs)
   );
 
@@ -1478,6 +1542,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (secret0_digest_1_qs)
   );
 
@@ -1494,6 +1559,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (secret1_digest_0_qs)
   );
 
@@ -1510,6 +1576,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (secret1_digest_1_qs)
   );
 
@@ -1526,6 +1593,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (secret2_digest_0_qs)
   );
 
@@ -1542,6 +1610,7 @@ module otp_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (secret2_digest_1_qs)
   );
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
@@ -211,6 +211,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr0.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr0_field0_qs)
@@ -236,6 +237,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr0.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr0_field1_qs)
@@ -261,6 +263,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr0.field2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr0_field2_qs)
@@ -286,6 +289,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr0.field3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr0_field3_qs)
@@ -311,6 +315,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr0.field4.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr0_field4_qs)
@@ -338,6 +343,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr1.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr1_field0_qs)
@@ -363,6 +369,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr1.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr1_field1_qs)
@@ -388,6 +395,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr1.field2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr1_field2_qs)
@@ -413,6 +421,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr1.field3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr1_field3_qs)
@@ -438,6 +447,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr1.field4.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr1_field4_qs)
@@ -464,6 +474,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr2_qs)
@@ -491,6 +502,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr3.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr3_field0_qs)
@@ -516,6 +528,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr3.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr3_field1_qs)
@@ -541,6 +554,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr3.field2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr3_field2_qs)
@@ -566,6 +580,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr3.field3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr3_field3_qs)
@@ -593,6 +608,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr4.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr4_field0_qs)
@@ -618,6 +634,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr4.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr4_field1_qs)
@@ -643,6 +660,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr4.field2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr4_field2_qs)
@@ -668,6 +686,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr4.field3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr4_field3_qs)
@@ -695,6 +714,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr5.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr5_field0_qs)
@@ -720,6 +740,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr5.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr5_field1_qs)
@@ -745,6 +766,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr5.field2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr5_field2_qs)
@@ -770,6 +792,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr5.field3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr5_field3_qs)
@@ -795,6 +818,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr5.field4.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr5_field4_qs)
@@ -820,6 +844,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr5.field5.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr5_field5_qs)
@@ -845,6 +870,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr5.field6.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr5_field6_qs)
@@ -872,6 +898,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr6.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr6_field0_qs)
@@ -897,6 +924,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr6.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr6_field1_qs)
@@ -922,6 +950,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr6.field2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr6_field2_qs)
@@ -947,6 +976,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr6.field3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr6_field3_qs)
@@ -974,6 +1004,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr7.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr7_field0_qs)
@@ -999,6 +1030,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr7.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr7_field1_qs)
@@ -1024,6 +1056,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr7.field2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr7_field2_qs)
@@ -1049,6 +1082,7 @@ module otp_ctrl_prim_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csr7.field3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csr7_field3_qs)

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -195,6 +195,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.done_ch0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_done_ch0_qs)
@@ -220,6 +221,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.done_ch1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_done_ch1_qs)
@@ -247,6 +249,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.done_ch0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_done_ch0_qs)
@@ -272,6 +275,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.done_ch1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_done_ch1_qs)
@@ -293,6 +297,7 @@ module pattgen_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.done_ch0.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.done_ch0.qe = intr_test_qe;
@@ -308,6 +313,7 @@ module pattgen_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.done_ch1.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.done_ch1.qe = intr_test_qe;
@@ -327,6 +333,7 @@ module pattgen_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -353,6 +360,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.enable_ch0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_enable_ch0_qs)
@@ -378,6 +386,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.enable_ch1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_enable_ch1_qs)
@@ -403,6 +412,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.polarity_ch0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_polarity_ch0_qs)
@@ -428,6 +438,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.polarity_ch1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_polarity_ch1_qs)
@@ -454,6 +465,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prediv_ch0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prediv_ch0_qs)
@@ -480,6 +492,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prediv_ch1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prediv_ch1_qs)
@@ -507,6 +520,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.data_ch0[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (data_ch0_0_qs)
@@ -534,6 +548,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.data_ch0[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (data_ch0_1_qs)
@@ -561,6 +576,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.data_ch1[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (data_ch1_0_qs)
@@ -588,6 +604,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.data_ch1[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (data_ch1_1_qs)
@@ -615,6 +632,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.size.len_ch0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (size_len_ch0_qs)
@@ -640,6 +658,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.size.reps_ch0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (size_reps_ch0_qs)
@@ -665,6 +684,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.size.len_ch1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (size_len_ch1_qs)
@@ -690,6 +710,7 @@ module pattgen_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.size.reps_ch1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (size_reps_ch1_qs)

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -116,18 +116,6 @@ module pinmux_reg_top (
   );
 
   // cdc oversampling signals
-    logic sync_aon_update;
-  prim_sync_reqack u_aon_tgl (
-    .clk_src_i(clk_aon_i),
-    .rst_src_ni(rst_aon_ni),
-    .clk_dst_i(clk_i),
-    .rst_dst_ni(rst_ni),
-    .req_chk_i(1'b1),
-    .src_req_i(1'b1),
-    .src_ack_o(),
-    .dst_req_o(sync_aon_update),
-    .dst_ack_i(sync_aon_update)
-  );
 
   assign reg_rdata = reg_rdata_next ;
   assign reg_error = (devmode_i & addrmiss) | wr_err | intg_err;
@@ -2288,34 +2276,36 @@ module pinmux_reg_top (
   // CDC handling is done on a per-reg instead of per-field boundary.
 
   logic  aon_wkup_detector_en_0_qs_int;
-  logic [0:0] aon_wkup_detector_en_0_d;
+  logic [0:0] aon_wkup_detector_en_0_qs;
   logic [0:0] aon_wkup_detector_en_0_wdata;
   logic aon_wkup_detector_en_0_we;
   logic unused_aon_wkup_detector_en_0_wdata;
   logic aon_wkup_detector_en_0_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_0_d = '0;
-    aon_wkup_detector_en_0_d = aon_wkup_detector_en_0_qs_int;
+    aon_wkup_detector_en_0_qs = 1'h0;
+    aon_wkup_detector_en_0_qs = aon_wkup_detector_en_0_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_0_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_0_qs),
     .src_we_i     (wkup_detector_en_0_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_0_busy),
     .src_qs_o     (wkup_detector_en_0_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_0_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_0_qs),
     .dst_we_o     (aon_wkup_detector_en_0_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_0_regwen),
@@ -2325,34 +2315,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_0_wdata;
 
   logic  aon_wkup_detector_en_1_qs_int;
-  logic [0:0] aon_wkup_detector_en_1_d;
+  logic [0:0] aon_wkup_detector_en_1_qs;
   logic [0:0] aon_wkup_detector_en_1_wdata;
   logic aon_wkup_detector_en_1_we;
   logic unused_aon_wkup_detector_en_1_wdata;
   logic aon_wkup_detector_en_1_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_1_d = '0;
-    aon_wkup_detector_en_1_d = aon_wkup_detector_en_1_qs_int;
+    aon_wkup_detector_en_1_qs = 1'h0;
+    aon_wkup_detector_en_1_qs = aon_wkup_detector_en_1_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_1_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_1_qs),
     .src_we_i     (wkup_detector_en_1_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_1_busy),
     .src_qs_o     (wkup_detector_en_1_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_1_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_1_qs),
     .dst_we_o     (aon_wkup_detector_en_1_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_1_regwen),
@@ -2362,34 +2354,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_1_wdata;
 
   logic  aon_wkup_detector_en_2_qs_int;
-  logic [0:0] aon_wkup_detector_en_2_d;
+  logic [0:0] aon_wkup_detector_en_2_qs;
   logic [0:0] aon_wkup_detector_en_2_wdata;
   logic aon_wkup_detector_en_2_we;
   logic unused_aon_wkup_detector_en_2_wdata;
   logic aon_wkup_detector_en_2_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_2_d = '0;
-    aon_wkup_detector_en_2_d = aon_wkup_detector_en_2_qs_int;
+    aon_wkup_detector_en_2_qs = 1'h0;
+    aon_wkup_detector_en_2_qs = aon_wkup_detector_en_2_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_2_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_2_qs),
     .src_we_i     (wkup_detector_en_2_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_2_busy),
     .src_qs_o     (wkup_detector_en_2_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_2_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_2_qs),
     .dst_we_o     (aon_wkup_detector_en_2_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_2_regwen),
@@ -2399,34 +2393,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_2_wdata;
 
   logic  aon_wkup_detector_en_3_qs_int;
-  logic [0:0] aon_wkup_detector_en_3_d;
+  logic [0:0] aon_wkup_detector_en_3_qs;
   logic [0:0] aon_wkup_detector_en_3_wdata;
   logic aon_wkup_detector_en_3_we;
   logic unused_aon_wkup_detector_en_3_wdata;
   logic aon_wkup_detector_en_3_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_3_d = '0;
-    aon_wkup_detector_en_3_d = aon_wkup_detector_en_3_qs_int;
+    aon_wkup_detector_en_3_qs = 1'h0;
+    aon_wkup_detector_en_3_qs = aon_wkup_detector_en_3_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_3_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_3_qs),
     .src_we_i     (wkup_detector_en_3_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_3_busy),
     .src_qs_o     (wkup_detector_en_3_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_3_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_3_qs),
     .dst_we_o     (aon_wkup_detector_en_3_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_3_regwen),
@@ -2436,34 +2432,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_3_wdata;
 
   logic  aon_wkup_detector_en_4_qs_int;
-  logic [0:0] aon_wkup_detector_en_4_d;
+  logic [0:0] aon_wkup_detector_en_4_qs;
   logic [0:0] aon_wkup_detector_en_4_wdata;
   logic aon_wkup_detector_en_4_we;
   logic unused_aon_wkup_detector_en_4_wdata;
   logic aon_wkup_detector_en_4_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_4_d = '0;
-    aon_wkup_detector_en_4_d = aon_wkup_detector_en_4_qs_int;
+    aon_wkup_detector_en_4_qs = 1'h0;
+    aon_wkup_detector_en_4_qs = aon_wkup_detector_en_4_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_4_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_4_qs),
     .src_we_i     (wkup_detector_en_4_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_4_busy),
     .src_qs_o     (wkup_detector_en_4_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_4_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_4_qs),
     .dst_we_o     (aon_wkup_detector_en_4_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_4_regwen),
@@ -2473,34 +2471,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_4_wdata;
 
   logic  aon_wkup_detector_en_5_qs_int;
-  logic [0:0] aon_wkup_detector_en_5_d;
+  logic [0:0] aon_wkup_detector_en_5_qs;
   logic [0:0] aon_wkup_detector_en_5_wdata;
   logic aon_wkup_detector_en_5_we;
   logic unused_aon_wkup_detector_en_5_wdata;
   logic aon_wkup_detector_en_5_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_5_d = '0;
-    aon_wkup_detector_en_5_d = aon_wkup_detector_en_5_qs_int;
+    aon_wkup_detector_en_5_qs = 1'h0;
+    aon_wkup_detector_en_5_qs = aon_wkup_detector_en_5_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_5_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_5_qs),
     .src_we_i     (wkup_detector_en_5_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_5_busy),
     .src_qs_o     (wkup_detector_en_5_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_5_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_5_qs),
     .dst_we_o     (aon_wkup_detector_en_5_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_5_regwen),
@@ -2510,34 +2510,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_5_wdata;
 
   logic  aon_wkup_detector_en_6_qs_int;
-  logic [0:0] aon_wkup_detector_en_6_d;
+  logic [0:0] aon_wkup_detector_en_6_qs;
   logic [0:0] aon_wkup_detector_en_6_wdata;
   logic aon_wkup_detector_en_6_we;
   logic unused_aon_wkup_detector_en_6_wdata;
   logic aon_wkup_detector_en_6_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_6_d = '0;
-    aon_wkup_detector_en_6_d = aon_wkup_detector_en_6_qs_int;
+    aon_wkup_detector_en_6_qs = 1'h0;
+    aon_wkup_detector_en_6_qs = aon_wkup_detector_en_6_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_6_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_6_qs),
     .src_we_i     (wkup_detector_en_6_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_6_busy),
     .src_qs_o     (wkup_detector_en_6_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_6_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_6_qs),
     .dst_we_o     (aon_wkup_detector_en_6_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_6_regwen),
@@ -2547,34 +2549,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_6_wdata;
 
   logic  aon_wkup_detector_en_7_qs_int;
-  logic [0:0] aon_wkup_detector_en_7_d;
+  logic [0:0] aon_wkup_detector_en_7_qs;
   logic [0:0] aon_wkup_detector_en_7_wdata;
   logic aon_wkup_detector_en_7_we;
   logic unused_aon_wkup_detector_en_7_wdata;
   logic aon_wkup_detector_en_7_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_7_d = '0;
-    aon_wkup_detector_en_7_d = aon_wkup_detector_en_7_qs_int;
+    aon_wkup_detector_en_7_qs = 1'h0;
+    aon_wkup_detector_en_7_qs = aon_wkup_detector_en_7_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_7_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_7_qs),
     .src_we_i     (wkup_detector_en_7_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_7_busy),
     .src_qs_o     (wkup_detector_en_7_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_7_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_7_qs),
     .dst_we_o     (aon_wkup_detector_en_7_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_7_regwen),
@@ -2586,36 +2590,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_0_mode_0_qs_int;
   logic  aon_wkup_detector_0_filter_0_qs_int;
   logic  aon_wkup_detector_0_miodio_0_qs_int;
-  logic [4:0] aon_wkup_detector_0_d;
+  logic [4:0] aon_wkup_detector_0_qs;
   logic [4:0] aon_wkup_detector_0_wdata;
   logic aon_wkup_detector_0_we;
   logic unused_aon_wkup_detector_0_wdata;
   logic aon_wkup_detector_0_regwen;
 
   always_comb begin
-    aon_wkup_detector_0_d = '0;
-    aon_wkup_detector_0_d[2:0] = aon_wkup_detector_0_mode_0_qs_int;
-    aon_wkup_detector_0_d[3] = aon_wkup_detector_0_filter_0_qs_int;
-    aon_wkup_detector_0_d[4] = aon_wkup_detector_0_miodio_0_qs_int;
+    aon_wkup_detector_0_qs = 5'h0;
+    aon_wkup_detector_0_qs[2:0] = aon_wkup_detector_0_mode_0_qs_int;
+    aon_wkup_detector_0_qs[3] = aon_wkup_detector_0_filter_0_qs_int;
+    aon_wkup_detector_0_qs[4] = aon_wkup_detector_0_miodio_0_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_0_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_0_qs),
     .src_we_i     (wkup_detector_0_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_0_busy),
     .src_qs_o     (wkup_detector_0_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_0_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_0_qs),
     .dst_we_o     (aon_wkup_detector_0_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_0_regwen),
@@ -2627,36 +2633,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_1_mode_1_qs_int;
   logic  aon_wkup_detector_1_filter_1_qs_int;
   logic  aon_wkup_detector_1_miodio_1_qs_int;
-  logic [4:0] aon_wkup_detector_1_d;
+  logic [4:0] aon_wkup_detector_1_qs;
   logic [4:0] aon_wkup_detector_1_wdata;
   logic aon_wkup_detector_1_we;
   logic unused_aon_wkup_detector_1_wdata;
   logic aon_wkup_detector_1_regwen;
 
   always_comb begin
-    aon_wkup_detector_1_d = '0;
-    aon_wkup_detector_1_d[2:0] = aon_wkup_detector_1_mode_1_qs_int;
-    aon_wkup_detector_1_d[3] = aon_wkup_detector_1_filter_1_qs_int;
-    aon_wkup_detector_1_d[4] = aon_wkup_detector_1_miodio_1_qs_int;
+    aon_wkup_detector_1_qs = 5'h0;
+    aon_wkup_detector_1_qs[2:0] = aon_wkup_detector_1_mode_1_qs_int;
+    aon_wkup_detector_1_qs[3] = aon_wkup_detector_1_filter_1_qs_int;
+    aon_wkup_detector_1_qs[4] = aon_wkup_detector_1_miodio_1_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_1_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_1_qs),
     .src_we_i     (wkup_detector_1_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_1_busy),
     .src_qs_o     (wkup_detector_1_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_1_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_1_qs),
     .dst_we_o     (aon_wkup_detector_1_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_1_regwen),
@@ -2668,36 +2676,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_2_mode_2_qs_int;
   logic  aon_wkup_detector_2_filter_2_qs_int;
   logic  aon_wkup_detector_2_miodio_2_qs_int;
-  logic [4:0] aon_wkup_detector_2_d;
+  logic [4:0] aon_wkup_detector_2_qs;
   logic [4:0] aon_wkup_detector_2_wdata;
   logic aon_wkup_detector_2_we;
   logic unused_aon_wkup_detector_2_wdata;
   logic aon_wkup_detector_2_regwen;
 
   always_comb begin
-    aon_wkup_detector_2_d = '0;
-    aon_wkup_detector_2_d[2:0] = aon_wkup_detector_2_mode_2_qs_int;
-    aon_wkup_detector_2_d[3] = aon_wkup_detector_2_filter_2_qs_int;
-    aon_wkup_detector_2_d[4] = aon_wkup_detector_2_miodio_2_qs_int;
+    aon_wkup_detector_2_qs = 5'h0;
+    aon_wkup_detector_2_qs[2:0] = aon_wkup_detector_2_mode_2_qs_int;
+    aon_wkup_detector_2_qs[3] = aon_wkup_detector_2_filter_2_qs_int;
+    aon_wkup_detector_2_qs[4] = aon_wkup_detector_2_miodio_2_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_2_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_2_qs),
     .src_we_i     (wkup_detector_2_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_2_busy),
     .src_qs_o     (wkup_detector_2_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_2_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_2_qs),
     .dst_we_o     (aon_wkup_detector_2_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_2_regwen),
@@ -2709,36 +2719,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_3_mode_3_qs_int;
   logic  aon_wkup_detector_3_filter_3_qs_int;
   logic  aon_wkup_detector_3_miodio_3_qs_int;
-  logic [4:0] aon_wkup_detector_3_d;
+  logic [4:0] aon_wkup_detector_3_qs;
   logic [4:0] aon_wkup_detector_3_wdata;
   logic aon_wkup_detector_3_we;
   logic unused_aon_wkup_detector_3_wdata;
   logic aon_wkup_detector_3_regwen;
 
   always_comb begin
-    aon_wkup_detector_3_d = '0;
-    aon_wkup_detector_3_d[2:0] = aon_wkup_detector_3_mode_3_qs_int;
-    aon_wkup_detector_3_d[3] = aon_wkup_detector_3_filter_3_qs_int;
-    aon_wkup_detector_3_d[4] = aon_wkup_detector_3_miodio_3_qs_int;
+    aon_wkup_detector_3_qs = 5'h0;
+    aon_wkup_detector_3_qs[2:0] = aon_wkup_detector_3_mode_3_qs_int;
+    aon_wkup_detector_3_qs[3] = aon_wkup_detector_3_filter_3_qs_int;
+    aon_wkup_detector_3_qs[4] = aon_wkup_detector_3_miodio_3_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_3_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_3_qs),
     .src_we_i     (wkup_detector_3_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_3_busy),
     .src_qs_o     (wkup_detector_3_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_3_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_3_qs),
     .dst_we_o     (aon_wkup_detector_3_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_3_regwen),
@@ -2750,36 +2762,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_4_mode_4_qs_int;
   logic  aon_wkup_detector_4_filter_4_qs_int;
   logic  aon_wkup_detector_4_miodio_4_qs_int;
-  logic [4:0] aon_wkup_detector_4_d;
+  logic [4:0] aon_wkup_detector_4_qs;
   logic [4:0] aon_wkup_detector_4_wdata;
   logic aon_wkup_detector_4_we;
   logic unused_aon_wkup_detector_4_wdata;
   logic aon_wkup_detector_4_regwen;
 
   always_comb begin
-    aon_wkup_detector_4_d = '0;
-    aon_wkup_detector_4_d[2:0] = aon_wkup_detector_4_mode_4_qs_int;
-    aon_wkup_detector_4_d[3] = aon_wkup_detector_4_filter_4_qs_int;
-    aon_wkup_detector_4_d[4] = aon_wkup_detector_4_miodio_4_qs_int;
+    aon_wkup_detector_4_qs = 5'h0;
+    aon_wkup_detector_4_qs[2:0] = aon_wkup_detector_4_mode_4_qs_int;
+    aon_wkup_detector_4_qs[3] = aon_wkup_detector_4_filter_4_qs_int;
+    aon_wkup_detector_4_qs[4] = aon_wkup_detector_4_miodio_4_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_4_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_4_qs),
     .src_we_i     (wkup_detector_4_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_4_busy),
     .src_qs_o     (wkup_detector_4_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_4_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_4_qs),
     .dst_we_o     (aon_wkup_detector_4_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_4_regwen),
@@ -2791,36 +2805,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_5_mode_5_qs_int;
   logic  aon_wkup_detector_5_filter_5_qs_int;
   logic  aon_wkup_detector_5_miodio_5_qs_int;
-  logic [4:0] aon_wkup_detector_5_d;
+  logic [4:0] aon_wkup_detector_5_qs;
   logic [4:0] aon_wkup_detector_5_wdata;
   logic aon_wkup_detector_5_we;
   logic unused_aon_wkup_detector_5_wdata;
   logic aon_wkup_detector_5_regwen;
 
   always_comb begin
-    aon_wkup_detector_5_d = '0;
-    aon_wkup_detector_5_d[2:0] = aon_wkup_detector_5_mode_5_qs_int;
-    aon_wkup_detector_5_d[3] = aon_wkup_detector_5_filter_5_qs_int;
-    aon_wkup_detector_5_d[4] = aon_wkup_detector_5_miodio_5_qs_int;
+    aon_wkup_detector_5_qs = 5'h0;
+    aon_wkup_detector_5_qs[2:0] = aon_wkup_detector_5_mode_5_qs_int;
+    aon_wkup_detector_5_qs[3] = aon_wkup_detector_5_filter_5_qs_int;
+    aon_wkup_detector_5_qs[4] = aon_wkup_detector_5_miodio_5_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_5_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_5_qs),
     .src_we_i     (wkup_detector_5_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_5_busy),
     .src_qs_o     (wkup_detector_5_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_5_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_5_qs),
     .dst_we_o     (aon_wkup_detector_5_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_5_regwen),
@@ -2832,36 +2848,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_6_mode_6_qs_int;
   logic  aon_wkup_detector_6_filter_6_qs_int;
   logic  aon_wkup_detector_6_miodio_6_qs_int;
-  logic [4:0] aon_wkup_detector_6_d;
+  logic [4:0] aon_wkup_detector_6_qs;
   logic [4:0] aon_wkup_detector_6_wdata;
   logic aon_wkup_detector_6_we;
   logic unused_aon_wkup_detector_6_wdata;
   logic aon_wkup_detector_6_regwen;
 
   always_comb begin
-    aon_wkup_detector_6_d = '0;
-    aon_wkup_detector_6_d[2:0] = aon_wkup_detector_6_mode_6_qs_int;
-    aon_wkup_detector_6_d[3] = aon_wkup_detector_6_filter_6_qs_int;
-    aon_wkup_detector_6_d[4] = aon_wkup_detector_6_miodio_6_qs_int;
+    aon_wkup_detector_6_qs = 5'h0;
+    aon_wkup_detector_6_qs[2:0] = aon_wkup_detector_6_mode_6_qs_int;
+    aon_wkup_detector_6_qs[3] = aon_wkup_detector_6_filter_6_qs_int;
+    aon_wkup_detector_6_qs[4] = aon_wkup_detector_6_miodio_6_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_6_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_6_qs),
     .src_we_i     (wkup_detector_6_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_6_busy),
     .src_qs_o     (wkup_detector_6_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_6_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_6_qs),
     .dst_we_o     (aon_wkup_detector_6_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_6_regwen),
@@ -2873,36 +2891,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_7_mode_7_qs_int;
   logic  aon_wkup_detector_7_filter_7_qs_int;
   logic  aon_wkup_detector_7_miodio_7_qs_int;
-  logic [4:0] aon_wkup_detector_7_d;
+  logic [4:0] aon_wkup_detector_7_qs;
   logic [4:0] aon_wkup_detector_7_wdata;
   logic aon_wkup_detector_7_we;
   logic unused_aon_wkup_detector_7_wdata;
   logic aon_wkup_detector_7_regwen;
 
   always_comb begin
-    aon_wkup_detector_7_d = '0;
-    aon_wkup_detector_7_d[2:0] = aon_wkup_detector_7_mode_7_qs_int;
-    aon_wkup_detector_7_d[3] = aon_wkup_detector_7_filter_7_qs_int;
-    aon_wkup_detector_7_d[4] = aon_wkup_detector_7_miodio_7_qs_int;
+    aon_wkup_detector_7_qs = 5'h0;
+    aon_wkup_detector_7_qs[2:0] = aon_wkup_detector_7_mode_7_qs_int;
+    aon_wkup_detector_7_qs[3] = aon_wkup_detector_7_filter_7_qs_int;
+    aon_wkup_detector_7_qs[4] = aon_wkup_detector_7_miodio_7_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_7_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_7_qs),
     .src_we_i     (wkup_detector_7_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_7_busy),
     .src_qs_o     (wkup_detector_7_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_7_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_7_qs),
     .dst_we_o     (aon_wkup_detector_7_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_7_regwen),
@@ -2912,34 +2932,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_7_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_0_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_0_d;
+  logic [7:0] aon_wkup_detector_cnt_th_0_qs;
   logic [7:0] aon_wkup_detector_cnt_th_0_wdata;
   logic aon_wkup_detector_cnt_th_0_we;
   logic unused_aon_wkup_detector_cnt_th_0_wdata;
   logic aon_wkup_detector_cnt_th_0_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_0_d = '0;
-    aon_wkup_detector_cnt_th_0_d = aon_wkup_detector_cnt_th_0_qs_int;
+    aon_wkup_detector_cnt_th_0_qs = 8'h0;
+    aon_wkup_detector_cnt_th_0_qs = aon_wkup_detector_cnt_th_0_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_0_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_0_qs),
     .src_we_i     (wkup_detector_cnt_th_0_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_0_busy),
     .src_qs_o     (wkup_detector_cnt_th_0_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_0_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_0_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_0_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_0_regwen),
@@ -2949,34 +2971,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_0_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_1_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_1_d;
+  logic [7:0] aon_wkup_detector_cnt_th_1_qs;
   logic [7:0] aon_wkup_detector_cnt_th_1_wdata;
   logic aon_wkup_detector_cnt_th_1_we;
   logic unused_aon_wkup_detector_cnt_th_1_wdata;
   logic aon_wkup_detector_cnt_th_1_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_1_d = '0;
-    aon_wkup_detector_cnt_th_1_d = aon_wkup_detector_cnt_th_1_qs_int;
+    aon_wkup_detector_cnt_th_1_qs = 8'h0;
+    aon_wkup_detector_cnt_th_1_qs = aon_wkup_detector_cnt_th_1_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_1_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_1_qs),
     .src_we_i     (wkup_detector_cnt_th_1_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_1_busy),
     .src_qs_o     (wkup_detector_cnt_th_1_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_1_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_1_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_1_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_1_regwen),
@@ -2986,34 +3010,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_1_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_2_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_2_d;
+  logic [7:0] aon_wkup_detector_cnt_th_2_qs;
   logic [7:0] aon_wkup_detector_cnt_th_2_wdata;
   logic aon_wkup_detector_cnt_th_2_we;
   logic unused_aon_wkup_detector_cnt_th_2_wdata;
   logic aon_wkup_detector_cnt_th_2_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_2_d = '0;
-    aon_wkup_detector_cnt_th_2_d = aon_wkup_detector_cnt_th_2_qs_int;
+    aon_wkup_detector_cnt_th_2_qs = 8'h0;
+    aon_wkup_detector_cnt_th_2_qs = aon_wkup_detector_cnt_th_2_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_2_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_2_qs),
     .src_we_i     (wkup_detector_cnt_th_2_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_2_busy),
     .src_qs_o     (wkup_detector_cnt_th_2_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_2_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_2_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_2_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_2_regwen),
@@ -3023,34 +3049,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_2_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_3_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_3_d;
+  logic [7:0] aon_wkup_detector_cnt_th_3_qs;
   logic [7:0] aon_wkup_detector_cnt_th_3_wdata;
   logic aon_wkup_detector_cnt_th_3_we;
   logic unused_aon_wkup_detector_cnt_th_3_wdata;
   logic aon_wkup_detector_cnt_th_3_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_3_d = '0;
-    aon_wkup_detector_cnt_th_3_d = aon_wkup_detector_cnt_th_3_qs_int;
+    aon_wkup_detector_cnt_th_3_qs = 8'h0;
+    aon_wkup_detector_cnt_th_3_qs = aon_wkup_detector_cnt_th_3_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_3_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_3_qs),
     .src_we_i     (wkup_detector_cnt_th_3_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_3_busy),
     .src_qs_o     (wkup_detector_cnt_th_3_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_3_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_3_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_3_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_3_regwen),
@@ -3060,34 +3088,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_3_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_4_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_4_d;
+  logic [7:0] aon_wkup_detector_cnt_th_4_qs;
   logic [7:0] aon_wkup_detector_cnt_th_4_wdata;
   logic aon_wkup_detector_cnt_th_4_we;
   logic unused_aon_wkup_detector_cnt_th_4_wdata;
   logic aon_wkup_detector_cnt_th_4_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_4_d = '0;
-    aon_wkup_detector_cnt_th_4_d = aon_wkup_detector_cnt_th_4_qs_int;
+    aon_wkup_detector_cnt_th_4_qs = 8'h0;
+    aon_wkup_detector_cnt_th_4_qs = aon_wkup_detector_cnt_th_4_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_4_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_4_qs),
     .src_we_i     (wkup_detector_cnt_th_4_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_4_busy),
     .src_qs_o     (wkup_detector_cnt_th_4_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_4_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_4_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_4_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_4_regwen),
@@ -3097,34 +3127,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_4_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_5_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_5_d;
+  logic [7:0] aon_wkup_detector_cnt_th_5_qs;
   logic [7:0] aon_wkup_detector_cnt_th_5_wdata;
   logic aon_wkup_detector_cnt_th_5_we;
   logic unused_aon_wkup_detector_cnt_th_5_wdata;
   logic aon_wkup_detector_cnt_th_5_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_5_d = '0;
-    aon_wkup_detector_cnt_th_5_d = aon_wkup_detector_cnt_th_5_qs_int;
+    aon_wkup_detector_cnt_th_5_qs = 8'h0;
+    aon_wkup_detector_cnt_th_5_qs = aon_wkup_detector_cnt_th_5_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_5_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_5_qs),
     .src_we_i     (wkup_detector_cnt_th_5_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_5_busy),
     .src_qs_o     (wkup_detector_cnt_th_5_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_5_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_5_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_5_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_5_regwen),
@@ -3134,34 +3166,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_5_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_6_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_6_d;
+  logic [7:0] aon_wkup_detector_cnt_th_6_qs;
   logic [7:0] aon_wkup_detector_cnt_th_6_wdata;
   logic aon_wkup_detector_cnt_th_6_we;
   logic unused_aon_wkup_detector_cnt_th_6_wdata;
   logic aon_wkup_detector_cnt_th_6_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_6_d = '0;
-    aon_wkup_detector_cnt_th_6_d = aon_wkup_detector_cnt_th_6_qs_int;
+    aon_wkup_detector_cnt_th_6_qs = 8'h0;
+    aon_wkup_detector_cnt_th_6_qs = aon_wkup_detector_cnt_th_6_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_6_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_6_qs),
     .src_we_i     (wkup_detector_cnt_th_6_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_6_busy),
     .src_qs_o     (wkup_detector_cnt_th_6_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_6_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_6_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_6_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_6_regwen),
@@ -3171,34 +3205,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_6_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_7_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_7_d;
+  logic [7:0] aon_wkup_detector_cnt_th_7_qs;
   logic [7:0] aon_wkup_detector_cnt_th_7_wdata;
   logic aon_wkup_detector_cnt_th_7_we;
   logic unused_aon_wkup_detector_cnt_th_7_wdata;
   logic aon_wkup_detector_cnt_th_7_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_7_d = '0;
-    aon_wkup_detector_cnt_th_7_d = aon_wkup_detector_cnt_th_7_qs_int;
+    aon_wkup_detector_cnt_th_7_qs = 8'h0;
+    aon_wkup_detector_cnt_th_7_qs = aon_wkup_detector_cnt_th_7_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_7_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_7_qs),
     .src_we_i     (wkup_detector_cnt_th_7_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_7_busy),
     .src_qs_o     (wkup_detector_cnt_th_7_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_7_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_7_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_7_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_7_regwen),
@@ -3207,48 +3243,69 @@ module pinmux_reg_top (
   assign unused_aon_wkup_detector_cnt_th_7_wdata =
       ^aon_wkup_detector_cnt_th_7_wdata;
 
+  logic  aon_wkup_cause_cause_0_ds_int;
   logic  aon_wkup_cause_cause_0_qs_int;
+  logic  aon_wkup_cause_cause_1_ds_int;
   logic  aon_wkup_cause_cause_1_qs_int;
+  logic  aon_wkup_cause_cause_2_ds_int;
   logic  aon_wkup_cause_cause_2_qs_int;
+  logic  aon_wkup_cause_cause_3_ds_int;
   logic  aon_wkup_cause_cause_3_qs_int;
+  logic  aon_wkup_cause_cause_4_ds_int;
   logic  aon_wkup_cause_cause_4_qs_int;
+  logic  aon_wkup_cause_cause_5_ds_int;
   logic  aon_wkup_cause_cause_5_qs_int;
+  logic  aon_wkup_cause_cause_6_ds_int;
   logic  aon_wkup_cause_cause_6_qs_int;
+  logic  aon_wkup_cause_cause_7_ds_int;
   logic  aon_wkup_cause_cause_7_qs_int;
-  logic [7:0] aon_wkup_cause_d;
+  logic [7:0] aon_wkup_cause_ds;
+  logic aon_wkup_cause_qe;
+  logic [7:0] aon_wkup_cause_qs;
   logic [7:0] aon_wkup_cause_wdata;
   logic aon_wkup_cause_we;
   logic unused_aon_wkup_cause_wdata;
 
   always_comb begin
-    aon_wkup_cause_d = '0;
-    aon_wkup_cause_d[0] = aon_wkup_cause_cause_0_qs_int;
-    aon_wkup_cause_d[1] = aon_wkup_cause_cause_1_qs_int;
-    aon_wkup_cause_d[2] = aon_wkup_cause_cause_2_qs_int;
-    aon_wkup_cause_d[3] = aon_wkup_cause_cause_3_qs_int;
-    aon_wkup_cause_d[4] = aon_wkup_cause_cause_4_qs_int;
-    aon_wkup_cause_d[5] = aon_wkup_cause_cause_5_qs_int;
-    aon_wkup_cause_d[6] = aon_wkup_cause_cause_6_qs_int;
-    aon_wkup_cause_d[7] = aon_wkup_cause_cause_7_qs_int;
+    aon_wkup_cause_qs = 8'h0;
+    aon_wkup_cause_ds = 8'h0;
+    aon_wkup_cause_ds[0] = aon_wkup_cause_cause_0_ds_int;
+    aon_wkup_cause_qs[0] = aon_wkup_cause_cause_0_qs_int;
+    aon_wkup_cause_ds[1] = aon_wkup_cause_cause_1_ds_int;
+    aon_wkup_cause_qs[1] = aon_wkup_cause_cause_1_qs_int;
+    aon_wkup_cause_ds[2] = aon_wkup_cause_cause_2_ds_int;
+    aon_wkup_cause_qs[2] = aon_wkup_cause_cause_2_qs_int;
+    aon_wkup_cause_ds[3] = aon_wkup_cause_cause_3_ds_int;
+    aon_wkup_cause_qs[3] = aon_wkup_cause_cause_3_qs_int;
+    aon_wkup_cause_ds[4] = aon_wkup_cause_cause_4_ds_int;
+    aon_wkup_cause_qs[4] = aon_wkup_cause_cause_4_qs_int;
+    aon_wkup_cause_ds[5] = aon_wkup_cause_cause_5_ds_int;
+    aon_wkup_cause_qs[5] = aon_wkup_cause_cause_5_qs_int;
+    aon_wkup_cause_ds[6] = aon_wkup_cause_cause_6_ds_int;
+    aon_wkup_cause_qs[6] = aon_wkup_cause_cause_6_qs_int;
+    aon_wkup_cause_ds[7] = aon_wkup_cause_cause_7_ds_int;
+    aon_wkup_cause_qs[7] = aon_wkup_cause_cause_7_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(1)
   ) u_wkup_cause_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     (wkup_cause_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_cause_busy),
     .src_qs_o     (wkup_cause_qs), // for software read back
-    .dst_d_i      (aon_wkup_cause_d),
+    .dst_update_i (aon_wkup_cause_qe),
+    .dst_ds_i     (aon_wkup_cause_ds),
+    .dst_qs_i     (aon_wkup_cause_qs),
     .dst_we_o     (aon_wkup_cause_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -3272,6 +3329,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -3298,6 +3356,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_0_qs)
@@ -3325,6 +3384,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_1_qs)
@@ -3352,6 +3412,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_2_qs)
@@ -3379,6 +3440,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_3_qs)
@@ -3406,6 +3468,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_4_qs)
@@ -3433,6 +3496,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_5_qs)
@@ -3460,6 +3524,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_6_qs)
@@ -3487,6 +3552,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_7_qs)
@@ -3514,6 +3580,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_8_qs)
@@ -3541,6 +3608,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_9_qs)
@@ -3568,6 +3636,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_10_qs)
@@ -3595,6 +3664,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_11_qs)
@@ -3622,6 +3692,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_12_qs)
@@ -3649,6 +3720,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_13_qs)
@@ -3676,6 +3748,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_14_qs)
@@ -3703,6 +3776,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_15_qs)
@@ -3730,6 +3804,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_16_qs)
@@ -3757,6 +3832,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_17_qs)
@@ -3784,6 +3860,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_18_qs)
@@ -3811,6 +3888,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_19_qs)
@@ -3838,6 +3916,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_20_qs)
@@ -3865,6 +3944,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_21_qs)
@@ -3892,6 +3972,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_22_qs)
@@ -3919,6 +4000,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_23_qs)
@@ -3946,6 +4028,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_24_qs)
@@ -3973,6 +4056,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_25_qs)
@@ -4000,6 +4084,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_26_qs)
@@ -4027,6 +4112,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_27_qs)
@@ -4054,6 +4140,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_28_qs)
@@ -4081,6 +4168,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_29_qs)
@@ -4108,6 +4196,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_30_qs)
@@ -4135,6 +4224,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_31_qs)
@@ -4162,6 +4252,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_32_qs)
@@ -4192,6 +4283,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_0_qs)
@@ -4222,6 +4314,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_1_qs)
@@ -4252,6 +4345,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_2_qs)
@@ -4282,6 +4376,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_3_qs)
@@ -4312,6 +4407,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_4_qs)
@@ -4342,6 +4438,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_5_qs)
@@ -4372,6 +4469,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_6_qs)
@@ -4402,6 +4500,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_7_qs)
@@ -4432,6 +4531,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_8_qs)
@@ -4462,6 +4562,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_9_qs)
@@ -4492,6 +4593,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_10_qs)
@@ -4522,6 +4624,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_11_qs)
@@ -4552,6 +4655,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_12_qs)
@@ -4582,6 +4686,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_13_qs)
@@ -4612,6 +4717,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_14_qs)
@@ -4642,6 +4748,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_15_qs)
@@ -4672,6 +4779,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_16_qs)
@@ -4702,6 +4810,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_17_qs)
@@ -4732,6 +4841,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_18_qs)
@@ -4762,6 +4872,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_19_qs)
@@ -4792,6 +4903,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_20_qs)
@@ -4822,6 +4934,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_21_qs)
@@ -4852,6 +4965,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_22_qs)
@@ -4882,6 +4996,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_23_qs)
@@ -4912,6 +5027,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_24_qs)
@@ -4942,6 +5058,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_25_qs)
@@ -4972,6 +5089,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_26_qs)
@@ -5002,6 +5120,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_27_qs)
@@ -5032,6 +5151,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_28_qs)
@@ -5062,6 +5182,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_29_qs)
@@ -5092,6 +5213,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_30_qs)
@@ -5122,6 +5244,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_31_qs)
@@ -5152,6 +5275,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_32_qs)
@@ -5179,6 +5303,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_0_qs)
@@ -5206,6 +5331,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_1_qs)
@@ -5233,6 +5359,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_2_qs)
@@ -5260,6 +5387,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_3_qs)
@@ -5287,6 +5415,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_4_qs)
@@ -5314,6 +5443,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_5_qs)
@@ -5341,6 +5471,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_6_qs)
@@ -5368,6 +5499,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_7_qs)
@@ -5395,6 +5527,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_8_qs)
@@ -5422,6 +5555,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_9_qs)
@@ -5449,6 +5583,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_10_qs)
@@ -5476,6 +5611,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_11_qs)
@@ -5503,6 +5639,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_12_qs)
@@ -5530,6 +5667,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_13_qs)
@@ -5557,6 +5695,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_14_qs)
@@ -5584,6 +5723,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_15_qs)
@@ -5611,6 +5751,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_16_qs)
@@ -5638,6 +5779,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_17_qs)
@@ -5665,6 +5807,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_18_qs)
@@ -5692,6 +5835,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_19_qs)
@@ -5719,6 +5863,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_20_qs)
@@ -5746,6 +5891,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_21_qs)
@@ -5773,6 +5919,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_22_qs)
@@ -5800,6 +5947,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_23_qs)
@@ -5827,6 +5975,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_24_qs)
@@ -5854,6 +6003,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_25_qs)
@@ -5881,6 +6031,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_26_qs)
@@ -5908,6 +6059,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_27_qs)
@@ -5935,6 +6087,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_28_qs)
@@ -5962,6 +6115,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_29_qs)
@@ -5989,6 +6143,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_30_qs)
@@ -6016,6 +6171,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_31_qs)
@@ -6046,6 +6202,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_0_qs)
@@ -6076,6 +6233,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_1_qs)
@@ -6106,6 +6264,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_2_qs)
@@ -6136,6 +6295,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_3_qs)
@@ -6166,6 +6326,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_4_qs)
@@ -6196,6 +6357,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_5_qs)
@@ -6226,6 +6388,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_6_qs)
@@ -6256,6 +6419,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_7_qs)
@@ -6286,6 +6450,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_8_qs)
@@ -6316,6 +6481,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_9_qs)
@@ -6346,6 +6512,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_10_qs)
@@ -6376,6 +6543,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_11_qs)
@@ -6406,6 +6574,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_12_qs)
@@ -6436,6 +6605,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_13_qs)
@@ -6466,6 +6636,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_14_qs)
@@ -6496,6 +6667,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_15_qs)
@@ -6526,6 +6698,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_16_qs)
@@ -6556,6 +6729,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_17_qs)
@@ -6586,6 +6760,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_18_qs)
@@ -6616,6 +6791,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_19_qs)
@@ -6646,6 +6822,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_20_qs)
@@ -6676,6 +6853,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_21_qs)
@@ -6706,6 +6884,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_22_qs)
@@ -6736,6 +6915,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_23_qs)
@@ -6766,6 +6946,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_24_qs)
@@ -6796,6 +6977,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_25_qs)
@@ -6826,6 +7008,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_26_qs)
@@ -6856,6 +7039,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_27_qs)
@@ -6886,6 +7070,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_28_qs)
@@ -6916,6 +7101,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_29_qs)
@@ -6946,6 +7132,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_30_qs)
@@ -6976,6 +7163,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_31_qs)
@@ -7003,6 +7191,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_0_qs)
@@ -7030,6 +7219,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_1_qs)
@@ -7057,6 +7247,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_2_qs)
@@ -7084,6 +7275,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_3_qs)
@@ -7111,6 +7303,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_4_qs)
@@ -7138,6 +7331,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_5_qs)
@@ -7165,6 +7359,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_6_qs)
@@ -7192,6 +7387,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_7_qs)
@@ -7219,6 +7415,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_8_qs)
@@ -7246,6 +7443,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_9_qs)
@@ -7273,6 +7471,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_10_qs)
@@ -7300,6 +7499,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_11_qs)
@@ -7327,6 +7527,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_12_qs)
@@ -7354,6 +7555,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_13_qs)
@@ -7381,6 +7583,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_14_qs)
@@ -7408,6 +7611,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_15_qs)
@@ -7435,6 +7639,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_16_qs)
@@ -7462,6 +7667,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_17_qs)
@@ -7489,6 +7695,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_18_qs)
@@ -7516,6 +7723,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_19_qs)
@@ -7543,6 +7751,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_20_qs)
@@ -7570,6 +7779,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_21_qs)
@@ -7597,6 +7807,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_22_qs)
@@ -7624,6 +7835,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_23_qs)
@@ -7651,6 +7863,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_24_qs)
@@ -7678,6 +7891,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_25_qs)
@@ -7705,6 +7919,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_26_qs)
@@ -7732,6 +7947,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_27_qs)
@@ -7759,6 +7975,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_28_qs)
@@ -7786,6 +8003,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_29_qs)
@@ -7813,6 +8031,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_30_qs)
@@ -7840,6 +8059,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_31_qs)
@@ -7865,6 +8085,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[0].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_invert_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].invert.qe = mio_pad_attr_0_qe;
@@ -7880,6 +8101,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[0].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_virtual_od_en_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].virtual_od_en.qe = mio_pad_attr_0_qe;
@@ -7895,6 +8117,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[0].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_pull_en_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].pull_en.qe = mio_pad_attr_0_qe;
@@ -7910,6 +8133,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[0].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_pull_select_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].pull_select.qe = mio_pad_attr_0_qe;
@@ -7925,6 +8149,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[0].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_keeper_en_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].keeper_en.qe = mio_pad_attr_0_qe;
@@ -7940,6 +8165,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[0].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_schmitt_en_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].schmitt_en.qe = mio_pad_attr_0_qe;
@@ -7955,6 +8181,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[0].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_od_en_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].od_en.qe = mio_pad_attr_0_qe;
@@ -7970,6 +8197,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[0].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_slew_rate_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].slew_rate.qe = mio_pad_attr_0_qe;
@@ -7985,6 +8213,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[0].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_drive_strength_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].drive_strength.qe = mio_pad_attr_0_qe;
@@ -8009,6 +8238,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[1].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_invert_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].invert.qe = mio_pad_attr_1_qe;
@@ -8024,6 +8254,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[1].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_virtual_od_en_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].virtual_od_en.qe = mio_pad_attr_1_qe;
@@ -8039,6 +8270,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[1].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_pull_en_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].pull_en.qe = mio_pad_attr_1_qe;
@@ -8054,6 +8286,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[1].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_pull_select_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].pull_select.qe = mio_pad_attr_1_qe;
@@ -8069,6 +8302,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[1].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_keeper_en_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].keeper_en.qe = mio_pad_attr_1_qe;
@@ -8084,6 +8318,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[1].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_schmitt_en_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].schmitt_en.qe = mio_pad_attr_1_qe;
@@ -8099,6 +8334,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[1].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_od_en_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].od_en.qe = mio_pad_attr_1_qe;
@@ -8114,6 +8350,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[1].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_slew_rate_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].slew_rate.qe = mio_pad_attr_1_qe;
@@ -8129,6 +8366,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[1].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_drive_strength_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].drive_strength.qe = mio_pad_attr_1_qe;
@@ -8153,6 +8391,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[2].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_invert_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].invert.qe = mio_pad_attr_2_qe;
@@ -8168,6 +8407,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[2].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_virtual_od_en_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].virtual_od_en.qe = mio_pad_attr_2_qe;
@@ -8183,6 +8423,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[2].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_pull_en_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].pull_en.qe = mio_pad_attr_2_qe;
@@ -8198,6 +8439,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[2].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_pull_select_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].pull_select.qe = mio_pad_attr_2_qe;
@@ -8213,6 +8455,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[2].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_keeper_en_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].keeper_en.qe = mio_pad_attr_2_qe;
@@ -8228,6 +8471,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[2].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_schmitt_en_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].schmitt_en.qe = mio_pad_attr_2_qe;
@@ -8243,6 +8487,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[2].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_od_en_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].od_en.qe = mio_pad_attr_2_qe;
@@ -8258,6 +8503,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[2].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_slew_rate_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].slew_rate.qe = mio_pad_attr_2_qe;
@@ -8273,6 +8519,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[2].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_drive_strength_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].drive_strength.qe = mio_pad_attr_2_qe;
@@ -8297,6 +8544,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[3].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_invert_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].invert.qe = mio_pad_attr_3_qe;
@@ -8312,6 +8560,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[3].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_virtual_od_en_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].virtual_od_en.qe = mio_pad_attr_3_qe;
@@ -8327,6 +8576,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[3].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_pull_en_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].pull_en.qe = mio_pad_attr_3_qe;
@@ -8342,6 +8592,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[3].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_pull_select_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].pull_select.qe = mio_pad_attr_3_qe;
@@ -8357,6 +8608,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[3].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_keeper_en_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].keeper_en.qe = mio_pad_attr_3_qe;
@@ -8372,6 +8624,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[3].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_schmitt_en_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].schmitt_en.qe = mio_pad_attr_3_qe;
@@ -8387,6 +8640,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[3].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_od_en_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].od_en.qe = mio_pad_attr_3_qe;
@@ -8402,6 +8656,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[3].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_slew_rate_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].slew_rate.qe = mio_pad_attr_3_qe;
@@ -8417,6 +8672,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[3].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_drive_strength_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].drive_strength.qe = mio_pad_attr_3_qe;
@@ -8441,6 +8697,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[4].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_invert_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].invert.qe = mio_pad_attr_4_qe;
@@ -8456,6 +8713,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[4].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_virtual_od_en_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].virtual_od_en.qe = mio_pad_attr_4_qe;
@@ -8471,6 +8729,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[4].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_pull_en_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].pull_en.qe = mio_pad_attr_4_qe;
@@ -8486,6 +8745,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[4].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_pull_select_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].pull_select.qe = mio_pad_attr_4_qe;
@@ -8501,6 +8761,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[4].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_keeper_en_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].keeper_en.qe = mio_pad_attr_4_qe;
@@ -8516,6 +8777,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[4].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_schmitt_en_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].schmitt_en.qe = mio_pad_attr_4_qe;
@@ -8531,6 +8793,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[4].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_od_en_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].od_en.qe = mio_pad_attr_4_qe;
@@ -8546,6 +8809,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[4].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_slew_rate_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].slew_rate.qe = mio_pad_attr_4_qe;
@@ -8561,6 +8825,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[4].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_drive_strength_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].drive_strength.qe = mio_pad_attr_4_qe;
@@ -8585,6 +8850,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[5].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_invert_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].invert.qe = mio_pad_attr_5_qe;
@@ -8600,6 +8866,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[5].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_virtual_od_en_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].virtual_od_en.qe = mio_pad_attr_5_qe;
@@ -8615,6 +8882,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[5].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_pull_en_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].pull_en.qe = mio_pad_attr_5_qe;
@@ -8630,6 +8898,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[5].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_pull_select_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].pull_select.qe = mio_pad_attr_5_qe;
@@ -8645,6 +8914,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[5].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_keeper_en_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].keeper_en.qe = mio_pad_attr_5_qe;
@@ -8660,6 +8930,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[5].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_schmitt_en_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].schmitt_en.qe = mio_pad_attr_5_qe;
@@ -8675,6 +8946,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[5].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_od_en_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].od_en.qe = mio_pad_attr_5_qe;
@@ -8690,6 +8962,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[5].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_slew_rate_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].slew_rate.qe = mio_pad_attr_5_qe;
@@ -8705,6 +8978,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[5].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_drive_strength_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].drive_strength.qe = mio_pad_attr_5_qe;
@@ -8729,6 +9003,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[6].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_invert_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].invert.qe = mio_pad_attr_6_qe;
@@ -8744,6 +9019,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[6].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_virtual_od_en_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].virtual_od_en.qe = mio_pad_attr_6_qe;
@@ -8759,6 +9035,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[6].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_pull_en_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].pull_en.qe = mio_pad_attr_6_qe;
@@ -8774,6 +9051,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[6].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_pull_select_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].pull_select.qe = mio_pad_attr_6_qe;
@@ -8789,6 +9067,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[6].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_keeper_en_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].keeper_en.qe = mio_pad_attr_6_qe;
@@ -8804,6 +9083,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[6].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_schmitt_en_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].schmitt_en.qe = mio_pad_attr_6_qe;
@@ -8819,6 +9099,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[6].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_od_en_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].od_en.qe = mio_pad_attr_6_qe;
@@ -8834,6 +9115,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[6].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_slew_rate_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].slew_rate.qe = mio_pad_attr_6_qe;
@@ -8849,6 +9131,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[6].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_drive_strength_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].drive_strength.qe = mio_pad_attr_6_qe;
@@ -8873,6 +9156,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[7].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_invert_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].invert.qe = mio_pad_attr_7_qe;
@@ -8888,6 +9172,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[7].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_virtual_od_en_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].virtual_od_en.qe = mio_pad_attr_7_qe;
@@ -8903,6 +9188,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[7].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_pull_en_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].pull_en.qe = mio_pad_attr_7_qe;
@@ -8918,6 +9204,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[7].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_pull_select_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].pull_select.qe = mio_pad_attr_7_qe;
@@ -8933,6 +9220,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[7].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_keeper_en_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].keeper_en.qe = mio_pad_attr_7_qe;
@@ -8948,6 +9236,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[7].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_schmitt_en_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].schmitt_en.qe = mio_pad_attr_7_qe;
@@ -8963,6 +9252,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[7].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_od_en_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].od_en.qe = mio_pad_attr_7_qe;
@@ -8978,6 +9268,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[7].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_slew_rate_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].slew_rate.qe = mio_pad_attr_7_qe;
@@ -8993,6 +9284,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[7].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_drive_strength_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].drive_strength.qe = mio_pad_attr_7_qe;
@@ -9017,6 +9309,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[8].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_invert_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].invert.qe = mio_pad_attr_8_qe;
@@ -9032,6 +9325,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[8].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_virtual_od_en_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].virtual_od_en.qe = mio_pad_attr_8_qe;
@@ -9047,6 +9341,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[8].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_pull_en_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].pull_en.qe = mio_pad_attr_8_qe;
@@ -9062,6 +9357,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[8].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_pull_select_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].pull_select.qe = mio_pad_attr_8_qe;
@@ -9077,6 +9373,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[8].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_keeper_en_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].keeper_en.qe = mio_pad_attr_8_qe;
@@ -9092,6 +9389,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[8].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_schmitt_en_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].schmitt_en.qe = mio_pad_attr_8_qe;
@@ -9107,6 +9405,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[8].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_od_en_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].od_en.qe = mio_pad_attr_8_qe;
@@ -9122,6 +9421,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[8].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_slew_rate_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].slew_rate.qe = mio_pad_attr_8_qe;
@@ -9137,6 +9437,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[8].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_drive_strength_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].drive_strength.qe = mio_pad_attr_8_qe;
@@ -9161,6 +9462,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[9].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_invert_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].invert.qe = mio_pad_attr_9_qe;
@@ -9176,6 +9478,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[9].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_virtual_od_en_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].virtual_od_en.qe = mio_pad_attr_9_qe;
@@ -9191,6 +9494,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[9].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_pull_en_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].pull_en.qe = mio_pad_attr_9_qe;
@@ -9206,6 +9510,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[9].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_pull_select_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].pull_select.qe = mio_pad_attr_9_qe;
@@ -9221,6 +9526,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[9].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_keeper_en_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].keeper_en.qe = mio_pad_attr_9_qe;
@@ -9236,6 +9542,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[9].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_schmitt_en_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].schmitt_en.qe = mio_pad_attr_9_qe;
@@ -9251,6 +9558,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[9].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_od_en_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].od_en.qe = mio_pad_attr_9_qe;
@@ -9266,6 +9574,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[9].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_slew_rate_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].slew_rate.qe = mio_pad_attr_9_qe;
@@ -9281,6 +9590,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[9].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_drive_strength_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].drive_strength.qe = mio_pad_attr_9_qe;
@@ -9305,6 +9615,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[10].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_invert_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].invert.qe = mio_pad_attr_10_qe;
@@ -9320,6 +9631,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[10].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_virtual_od_en_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].virtual_od_en.qe = mio_pad_attr_10_qe;
@@ -9335,6 +9647,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[10].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_pull_en_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].pull_en.qe = mio_pad_attr_10_qe;
@@ -9350,6 +9663,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[10].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_pull_select_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].pull_select.qe = mio_pad_attr_10_qe;
@@ -9365,6 +9679,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[10].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_keeper_en_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].keeper_en.qe = mio_pad_attr_10_qe;
@@ -9380,6 +9695,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[10].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_schmitt_en_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].schmitt_en.qe = mio_pad_attr_10_qe;
@@ -9395,6 +9711,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[10].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_od_en_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].od_en.qe = mio_pad_attr_10_qe;
@@ -9410,6 +9727,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[10].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_slew_rate_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].slew_rate.qe = mio_pad_attr_10_qe;
@@ -9425,6 +9743,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[10].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_drive_strength_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].drive_strength.qe = mio_pad_attr_10_qe;
@@ -9449,6 +9768,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[11].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_invert_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].invert.qe = mio_pad_attr_11_qe;
@@ -9464,6 +9784,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[11].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_virtual_od_en_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].virtual_od_en.qe = mio_pad_attr_11_qe;
@@ -9479,6 +9800,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[11].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_pull_en_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].pull_en.qe = mio_pad_attr_11_qe;
@@ -9494,6 +9816,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[11].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_pull_select_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].pull_select.qe = mio_pad_attr_11_qe;
@@ -9509,6 +9832,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[11].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_keeper_en_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].keeper_en.qe = mio_pad_attr_11_qe;
@@ -9524,6 +9848,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[11].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_schmitt_en_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].schmitt_en.qe = mio_pad_attr_11_qe;
@@ -9539,6 +9864,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[11].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_od_en_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].od_en.qe = mio_pad_attr_11_qe;
@@ -9554,6 +9880,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[11].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_slew_rate_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].slew_rate.qe = mio_pad_attr_11_qe;
@@ -9569,6 +9896,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[11].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_drive_strength_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].drive_strength.qe = mio_pad_attr_11_qe;
@@ -9593,6 +9921,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[12].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_invert_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].invert.qe = mio_pad_attr_12_qe;
@@ -9608,6 +9937,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[12].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_virtual_od_en_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].virtual_od_en.qe = mio_pad_attr_12_qe;
@@ -9623,6 +9953,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[12].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_pull_en_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].pull_en.qe = mio_pad_attr_12_qe;
@@ -9638,6 +9969,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[12].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_pull_select_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].pull_select.qe = mio_pad_attr_12_qe;
@@ -9653,6 +9985,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[12].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_keeper_en_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].keeper_en.qe = mio_pad_attr_12_qe;
@@ -9668,6 +10001,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[12].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_schmitt_en_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].schmitt_en.qe = mio_pad_attr_12_qe;
@@ -9683,6 +10017,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[12].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_od_en_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].od_en.qe = mio_pad_attr_12_qe;
@@ -9698,6 +10033,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[12].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_slew_rate_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].slew_rate.qe = mio_pad_attr_12_qe;
@@ -9713,6 +10049,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[12].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_drive_strength_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].drive_strength.qe = mio_pad_attr_12_qe;
@@ -9737,6 +10074,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[13].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_invert_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].invert.qe = mio_pad_attr_13_qe;
@@ -9752,6 +10090,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[13].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_virtual_od_en_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].virtual_od_en.qe = mio_pad_attr_13_qe;
@@ -9767,6 +10106,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[13].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_pull_en_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].pull_en.qe = mio_pad_attr_13_qe;
@@ -9782,6 +10122,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[13].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_pull_select_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].pull_select.qe = mio_pad_attr_13_qe;
@@ -9797,6 +10138,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[13].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_keeper_en_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].keeper_en.qe = mio_pad_attr_13_qe;
@@ -9812,6 +10154,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[13].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_schmitt_en_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].schmitt_en.qe = mio_pad_attr_13_qe;
@@ -9827,6 +10170,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[13].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_od_en_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].od_en.qe = mio_pad_attr_13_qe;
@@ -9842,6 +10186,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[13].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_slew_rate_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].slew_rate.qe = mio_pad_attr_13_qe;
@@ -9857,6 +10202,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[13].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_drive_strength_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].drive_strength.qe = mio_pad_attr_13_qe;
@@ -9881,6 +10227,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[14].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_invert_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].invert.qe = mio_pad_attr_14_qe;
@@ -9896,6 +10243,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[14].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_virtual_od_en_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].virtual_od_en.qe = mio_pad_attr_14_qe;
@@ -9911,6 +10259,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[14].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_pull_en_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].pull_en.qe = mio_pad_attr_14_qe;
@@ -9926,6 +10275,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[14].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_pull_select_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].pull_select.qe = mio_pad_attr_14_qe;
@@ -9941,6 +10291,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[14].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_keeper_en_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].keeper_en.qe = mio_pad_attr_14_qe;
@@ -9956,6 +10307,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[14].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_schmitt_en_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].schmitt_en.qe = mio_pad_attr_14_qe;
@@ -9971,6 +10323,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[14].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_od_en_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].od_en.qe = mio_pad_attr_14_qe;
@@ -9986,6 +10339,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[14].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_slew_rate_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].slew_rate.qe = mio_pad_attr_14_qe;
@@ -10001,6 +10355,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[14].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_drive_strength_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].drive_strength.qe = mio_pad_attr_14_qe;
@@ -10025,6 +10380,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[15].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_invert_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].invert.qe = mio_pad_attr_15_qe;
@@ -10040,6 +10396,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[15].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_virtual_od_en_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].virtual_od_en.qe = mio_pad_attr_15_qe;
@@ -10055,6 +10412,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[15].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_pull_en_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].pull_en.qe = mio_pad_attr_15_qe;
@@ -10070,6 +10428,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[15].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_pull_select_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].pull_select.qe = mio_pad_attr_15_qe;
@@ -10085,6 +10444,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[15].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_keeper_en_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].keeper_en.qe = mio_pad_attr_15_qe;
@@ -10100,6 +10460,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[15].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_schmitt_en_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].schmitt_en.qe = mio_pad_attr_15_qe;
@@ -10115,6 +10476,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[15].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_od_en_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].od_en.qe = mio_pad_attr_15_qe;
@@ -10130,6 +10492,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[15].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_slew_rate_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].slew_rate.qe = mio_pad_attr_15_qe;
@@ -10145,6 +10508,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[15].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_drive_strength_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].drive_strength.qe = mio_pad_attr_15_qe;
@@ -10169,6 +10533,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[16].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_invert_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].invert.qe = mio_pad_attr_16_qe;
@@ -10184,6 +10549,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[16].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_virtual_od_en_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].virtual_od_en.qe = mio_pad_attr_16_qe;
@@ -10199,6 +10565,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[16].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_pull_en_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].pull_en.qe = mio_pad_attr_16_qe;
@@ -10214,6 +10581,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[16].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_pull_select_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].pull_select.qe = mio_pad_attr_16_qe;
@@ -10229,6 +10597,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[16].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_keeper_en_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].keeper_en.qe = mio_pad_attr_16_qe;
@@ -10244,6 +10613,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[16].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_schmitt_en_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].schmitt_en.qe = mio_pad_attr_16_qe;
@@ -10259,6 +10629,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[16].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_od_en_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].od_en.qe = mio_pad_attr_16_qe;
@@ -10274,6 +10645,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[16].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_slew_rate_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].slew_rate.qe = mio_pad_attr_16_qe;
@@ -10289,6 +10661,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[16].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_drive_strength_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].drive_strength.qe = mio_pad_attr_16_qe;
@@ -10313,6 +10686,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[17].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_invert_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].invert.qe = mio_pad_attr_17_qe;
@@ -10328,6 +10702,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[17].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_virtual_od_en_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].virtual_od_en.qe = mio_pad_attr_17_qe;
@@ -10343,6 +10718,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[17].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_pull_en_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].pull_en.qe = mio_pad_attr_17_qe;
@@ -10358,6 +10734,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[17].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_pull_select_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].pull_select.qe = mio_pad_attr_17_qe;
@@ -10373,6 +10750,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[17].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_keeper_en_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].keeper_en.qe = mio_pad_attr_17_qe;
@@ -10388,6 +10766,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[17].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_schmitt_en_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].schmitt_en.qe = mio_pad_attr_17_qe;
@@ -10403,6 +10782,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[17].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_od_en_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].od_en.qe = mio_pad_attr_17_qe;
@@ -10418,6 +10798,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[17].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_slew_rate_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].slew_rate.qe = mio_pad_attr_17_qe;
@@ -10433,6 +10814,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[17].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_drive_strength_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].drive_strength.qe = mio_pad_attr_17_qe;
@@ -10457,6 +10839,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[18].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_invert_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].invert.qe = mio_pad_attr_18_qe;
@@ -10472,6 +10855,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[18].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_virtual_od_en_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].virtual_od_en.qe = mio_pad_attr_18_qe;
@@ -10487,6 +10871,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[18].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_pull_en_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].pull_en.qe = mio_pad_attr_18_qe;
@@ -10502,6 +10887,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[18].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_pull_select_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].pull_select.qe = mio_pad_attr_18_qe;
@@ -10517,6 +10903,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[18].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_keeper_en_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].keeper_en.qe = mio_pad_attr_18_qe;
@@ -10532,6 +10919,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[18].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_schmitt_en_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].schmitt_en.qe = mio_pad_attr_18_qe;
@@ -10547,6 +10935,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[18].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_od_en_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].od_en.qe = mio_pad_attr_18_qe;
@@ -10562,6 +10951,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[18].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_slew_rate_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].slew_rate.qe = mio_pad_attr_18_qe;
@@ -10577,6 +10967,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[18].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_drive_strength_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].drive_strength.qe = mio_pad_attr_18_qe;
@@ -10601,6 +10992,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[19].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_invert_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].invert.qe = mio_pad_attr_19_qe;
@@ -10616,6 +11008,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[19].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_virtual_od_en_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].virtual_od_en.qe = mio_pad_attr_19_qe;
@@ -10631,6 +11024,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[19].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_pull_en_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].pull_en.qe = mio_pad_attr_19_qe;
@@ -10646,6 +11040,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[19].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_pull_select_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].pull_select.qe = mio_pad_attr_19_qe;
@@ -10661,6 +11056,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[19].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_keeper_en_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].keeper_en.qe = mio_pad_attr_19_qe;
@@ -10676,6 +11072,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[19].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_schmitt_en_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].schmitt_en.qe = mio_pad_attr_19_qe;
@@ -10691,6 +11088,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[19].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_od_en_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].od_en.qe = mio_pad_attr_19_qe;
@@ -10706,6 +11104,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[19].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_slew_rate_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].slew_rate.qe = mio_pad_attr_19_qe;
@@ -10721,6 +11120,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[19].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_drive_strength_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].drive_strength.qe = mio_pad_attr_19_qe;
@@ -10745,6 +11145,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[20].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_invert_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].invert.qe = mio_pad_attr_20_qe;
@@ -10760,6 +11161,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[20].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_virtual_od_en_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].virtual_od_en.qe = mio_pad_attr_20_qe;
@@ -10775,6 +11177,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[20].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_pull_en_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].pull_en.qe = mio_pad_attr_20_qe;
@@ -10790,6 +11193,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[20].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_pull_select_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].pull_select.qe = mio_pad_attr_20_qe;
@@ -10805,6 +11209,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[20].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_keeper_en_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].keeper_en.qe = mio_pad_attr_20_qe;
@@ -10820,6 +11225,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[20].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_schmitt_en_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].schmitt_en.qe = mio_pad_attr_20_qe;
@@ -10835,6 +11241,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[20].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_od_en_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].od_en.qe = mio_pad_attr_20_qe;
@@ -10850,6 +11257,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[20].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_slew_rate_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].slew_rate.qe = mio_pad_attr_20_qe;
@@ -10865,6 +11273,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[20].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_drive_strength_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].drive_strength.qe = mio_pad_attr_20_qe;
@@ -10889,6 +11298,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[21].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_invert_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].invert.qe = mio_pad_attr_21_qe;
@@ -10904,6 +11314,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[21].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_virtual_od_en_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].virtual_od_en.qe = mio_pad_attr_21_qe;
@@ -10919,6 +11330,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[21].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_pull_en_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].pull_en.qe = mio_pad_attr_21_qe;
@@ -10934,6 +11346,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[21].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_pull_select_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].pull_select.qe = mio_pad_attr_21_qe;
@@ -10949,6 +11362,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[21].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_keeper_en_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].keeper_en.qe = mio_pad_attr_21_qe;
@@ -10964,6 +11378,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[21].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_schmitt_en_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].schmitt_en.qe = mio_pad_attr_21_qe;
@@ -10979,6 +11394,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[21].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_od_en_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].od_en.qe = mio_pad_attr_21_qe;
@@ -10994,6 +11410,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[21].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_slew_rate_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].slew_rate.qe = mio_pad_attr_21_qe;
@@ -11009,6 +11426,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[21].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_drive_strength_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].drive_strength.qe = mio_pad_attr_21_qe;
@@ -11033,6 +11451,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[22].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_invert_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].invert.qe = mio_pad_attr_22_qe;
@@ -11048,6 +11467,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[22].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_virtual_od_en_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].virtual_od_en.qe = mio_pad_attr_22_qe;
@@ -11063,6 +11483,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[22].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_pull_en_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].pull_en.qe = mio_pad_attr_22_qe;
@@ -11078,6 +11499,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[22].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_pull_select_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].pull_select.qe = mio_pad_attr_22_qe;
@@ -11093,6 +11515,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[22].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_keeper_en_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].keeper_en.qe = mio_pad_attr_22_qe;
@@ -11108,6 +11531,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[22].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_schmitt_en_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].schmitt_en.qe = mio_pad_attr_22_qe;
@@ -11123,6 +11547,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[22].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_od_en_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].od_en.qe = mio_pad_attr_22_qe;
@@ -11138,6 +11563,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[22].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_slew_rate_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].slew_rate.qe = mio_pad_attr_22_qe;
@@ -11153,6 +11579,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[22].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_drive_strength_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].drive_strength.qe = mio_pad_attr_22_qe;
@@ -11177,6 +11604,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[23].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_invert_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].invert.qe = mio_pad_attr_23_qe;
@@ -11192,6 +11620,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[23].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_virtual_od_en_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].virtual_od_en.qe = mio_pad_attr_23_qe;
@@ -11207,6 +11636,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[23].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_pull_en_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].pull_en.qe = mio_pad_attr_23_qe;
@@ -11222,6 +11652,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[23].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_pull_select_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].pull_select.qe = mio_pad_attr_23_qe;
@@ -11237,6 +11668,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[23].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_keeper_en_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].keeper_en.qe = mio_pad_attr_23_qe;
@@ -11252,6 +11684,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[23].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_schmitt_en_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].schmitt_en.qe = mio_pad_attr_23_qe;
@@ -11267,6 +11700,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[23].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_od_en_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].od_en.qe = mio_pad_attr_23_qe;
@@ -11282,6 +11716,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[23].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_slew_rate_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].slew_rate.qe = mio_pad_attr_23_qe;
@@ -11297,6 +11732,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[23].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_drive_strength_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].drive_strength.qe = mio_pad_attr_23_qe;
@@ -11321,6 +11757,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[24].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_invert_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].invert.qe = mio_pad_attr_24_qe;
@@ -11336,6 +11773,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[24].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_virtual_od_en_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].virtual_od_en.qe = mio_pad_attr_24_qe;
@@ -11351,6 +11789,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[24].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_pull_en_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].pull_en.qe = mio_pad_attr_24_qe;
@@ -11366,6 +11805,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[24].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_pull_select_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].pull_select.qe = mio_pad_attr_24_qe;
@@ -11381,6 +11821,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[24].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_keeper_en_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].keeper_en.qe = mio_pad_attr_24_qe;
@@ -11396,6 +11837,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[24].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_schmitt_en_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].schmitt_en.qe = mio_pad_attr_24_qe;
@@ -11411,6 +11853,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[24].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_od_en_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].od_en.qe = mio_pad_attr_24_qe;
@@ -11426,6 +11869,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[24].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_slew_rate_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].slew_rate.qe = mio_pad_attr_24_qe;
@@ -11441,6 +11885,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[24].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_drive_strength_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].drive_strength.qe = mio_pad_attr_24_qe;
@@ -11465,6 +11910,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[25].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_invert_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].invert.qe = mio_pad_attr_25_qe;
@@ -11480,6 +11926,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[25].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_virtual_od_en_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].virtual_od_en.qe = mio_pad_attr_25_qe;
@@ -11495,6 +11942,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[25].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_pull_en_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].pull_en.qe = mio_pad_attr_25_qe;
@@ -11510,6 +11958,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[25].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_pull_select_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].pull_select.qe = mio_pad_attr_25_qe;
@@ -11525,6 +11974,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[25].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_keeper_en_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].keeper_en.qe = mio_pad_attr_25_qe;
@@ -11540,6 +11990,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[25].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_schmitt_en_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].schmitt_en.qe = mio_pad_attr_25_qe;
@@ -11555,6 +12006,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[25].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_od_en_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].od_en.qe = mio_pad_attr_25_qe;
@@ -11570,6 +12022,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[25].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_slew_rate_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].slew_rate.qe = mio_pad_attr_25_qe;
@@ -11585,6 +12038,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[25].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_drive_strength_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].drive_strength.qe = mio_pad_attr_25_qe;
@@ -11609,6 +12063,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[26].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_invert_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].invert.qe = mio_pad_attr_26_qe;
@@ -11624,6 +12079,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[26].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_virtual_od_en_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].virtual_od_en.qe = mio_pad_attr_26_qe;
@@ -11639,6 +12095,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[26].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_pull_en_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].pull_en.qe = mio_pad_attr_26_qe;
@@ -11654,6 +12111,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[26].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_pull_select_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].pull_select.qe = mio_pad_attr_26_qe;
@@ -11669,6 +12127,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[26].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_keeper_en_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].keeper_en.qe = mio_pad_attr_26_qe;
@@ -11684,6 +12143,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[26].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_schmitt_en_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].schmitt_en.qe = mio_pad_attr_26_qe;
@@ -11699,6 +12159,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[26].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_od_en_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].od_en.qe = mio_pad_attr_26_qe;
@@ -11714,6 +12175,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[26].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_slew_rate_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].slew_rate.qe = mio_pad_attr_26_qe;
@@ -11729,6 +12191,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[26].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_drive_strength_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].drive_strength.qe = mio_pad_attr_26_qe;
@@ -11753,6 +12216,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[27].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_invert_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].invert.qe = mio_pad_attr_27_qe;
@@ -11768,6 +12232,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[27].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_virtual_od_en_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].virtual_od_en.qe = mio_pad_attr_27_qe;
@@ -11783,6 +12248,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[27].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_pull_en_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].pull_en.qe = mio_pad_attr_27_qe;
@@ -11798,6 +12264,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[27].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_pull_select_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].pull_select.qe = mio_pad_attr_27_qe;
@@ -11813,6 +12280,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[27].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_keeper_en_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].keeper_en.qe = mio_pad_attr_27_qe;
@@ -11828,6 +12296,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[27].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_schmitt_en_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].schmitt_en.qe = mio_pad_attr_27_qe;
@@ -11843,6 +12312,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[27].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_od_en_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].od_en.qe = mio_pad_attr_27_qe;
@@ -11858,6 +12328,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[27].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_slew_rate_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].slew_rate.qe = mio_pad_attr_27_qe;
@@ -11873,6 +12344,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[27].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_drive_strength_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].drive_strength.qe = mio_pad_attr_27_qe;
@@ -11897,6 +12369,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[28].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_invert_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].invert.qe = mio_pad_attr_28_qe;
@@ -11912,6 +12385,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[28].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_virtual_od_en_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].virtual_od_en.qe = mio_pad_attr_28_qe;
@@ -11927,6 +12401,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[28].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_pull_en_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].pull_en.qe = mio_pad_attr_28_qe;
@@ -11942,6 +12417,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[28].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_pull_select_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].pull_select.qe = mio_pad_attr_28_qe;
@@ -11957,6 +12433,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[28].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_keeper_en_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].keeper_en.qe = mio_pad_attr_28_qe;
@@ -11972,6 +12449,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[28].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_schmitt_en_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].schmitt_en.qe = mio_pad_attr_28_qe;
@@ -11987,6 +12465,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[28].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_od_en_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].od_en.qe = mio_pad_attr_28_qe;
@@ -12002,6 +12481,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[28].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_slew_rate_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].slew_rate.qe = mio_pad_attr_28_qe;
@@ -12017,6 +12497,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[28].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_drive_strength_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].drive_strength.qe = mio_pad_attr_28_qe;
@@ -12041,6 +12522,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[29].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_invert_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].invert.qe = mio_pad_attr_29_qe;
@@ -12056,6 +12538,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[29].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_virtual_od_en_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].virtual_od_en.qe = mio_pad_attr_29_qe;
@@ -12071,6 +12554,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[29].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_pull_en_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].pull_en.qe = mio_pad_attr_29_qe;
@@ -12086,6 +12570,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[29].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_pull_select_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].pull_select.qe = mio_pad_attr_29_qe;
@@ -12101,6 +12586,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[29].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_keeper_en_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].keeper_en.qe = mio_pad_attr_29_qe;
@@ -12116,6 +12602,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[29].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_schmitt_en_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].schmitt_en.qe = mio_pad_attr_29_qe;
@@ -12131,6 +12618,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[29].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_od_en_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].od_en.qe = mio_pad_attr_29_qe;
@@ -12146,6 +12634,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[29].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_slew_rate_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].slew_rate.qe = mio_pad_attr_29_qe;
@@ -12161,6 +12650,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[29].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_drive_strength_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].drive_strength.qe = mio_pad_attr_29_qe;
@@ -12185,6 +12675,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[30].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_invert_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].invert.qe = mio_pad_attr_30_qe;
@@ -12200,6 +12691,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[30].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_virtual_od_en_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].virtual_od_en.qe = mio_pad_attr_30_qe;
@@ -12215,6 +12707,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[30].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_pull_en_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].pull_en.qe = mio_pad_attr_30_qe;
@@ -12230,6 +12723,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[30].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_pull_select_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].pull_select.qe = mio_pad_attr_30_qe;
@@ -12245,6 +12739,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[30].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_keeper_en_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].keeper_en.qe = mio_pad_attr_30_qe;
@@ -12260,6 +12755,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[30].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_schmitt_en_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].schmitt_en.qe = mio_pad_attr_30_qe;
@@ -12275,6 +12771,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[30].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_od_en_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].od_en.qe = mio_pad_attr_30_qe;
@@ -12290,6 +12787,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[30].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_slew_rate_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].slew_rate.qe = mio_pad_attr_30_qe;
@@ -12305,6 +12803,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[30].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_drive_strength_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].drive_strength.qe = mio_pad_attr_30_qe;
@@ -12329,6 +12828,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[31].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_invert_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].invert.qe = mio_pad_attr_31_qe;
@@ -12344,6 +12844,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[31].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_virtual_od_en_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].virtual_od_en.qe = mio_pad_attr_31_qe;
@@ -12359,6 +12860,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[31].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_pull_en_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].pull_en.qe = mio_pad_attr_31_qe;
@@ -12374,6 +12876,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[31].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_pull_select_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].pull_select.qe = mio_pad_attr_31_qe;
@@ -12389,6 +12892,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[31].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_keeper_en_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].keeper_en.qe = mio_pad_attr_31_qe;
@@ -12404,6 +12908,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[31].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_schmitt_en_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].schmitt_en.qe = mio_pad_attr_31_qe;
@@ -12419,6 +12924,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[31].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_od_en_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].od_en.qe = mio_pad_attr_31_qe;
@@ -12434,6 +12940,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[31].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_slew_rate_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].slew_rate.qe = mio_pad_attr_31_qe;
@@ -12449,6 +12956,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[31].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_drive_strength_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].drive_strength.qe = mio_pad_attr_31_qe;
@@ -12475,6 +12983,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_0_qs)
@@ -12502,6 +13011,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_1_qs)
@@ -12529,6 +13039,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_2_qs)
@@ -12556,6 +13067,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_3_qs)
@@ -12583,6 +13095,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_4_qs)
@@ -12610,6 +13123,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_5_qs)
@@ -12637,6 +13151,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_6_qs)
@@ -12664,6 +13179,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_7_qs)
@@ -12691,6 +13207,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_8_qs)
@@ -12718,6 +13235,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_9_qs)
@@ -12745,6 +13263,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_10_qs)
@@ -12772,6 +13291,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_11_qs)
@@ -12799,6 +13319,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_12_qs)
@@ -12826,6 +13347,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_13_qs)
@@ -12853,6 +13375,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_14_qs)
@@ -12880,6 +13403,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_15_qs)
@@ -12905,6 +13429,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[0].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_invert_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].invert.qe = dio_pad_attr_0_qe;
@@ -12920,6 +13445,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[0].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_virtual_od_en_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].virtual_od_en.qe = dio_pad_attr_0_qe;
@@ -12935,6 +13461,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[0].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_pull_en_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].pull_en.qe = dio_pad_attr_0_qe;
@@ -12950,6 +13477,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[0].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_pull_select_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].pull_select.qe = dio_pad_attr_0_qe;
@@ -12965,6 +13493,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[0].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_keeper_en_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].keeper_en.qe = dio_pad_attr_0_qe;
@@ -12980,6 +13509,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[0].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_schmitt_en_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].schmitt_en.qe = dio_pad_attr_0_qe;
@@ -12995,6 +13525,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[0].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_od_en_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].od_en.qe = dio_pad_attr_0_qe;
@@ -13010,6 +13541,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[0].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_slew_rate_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].slew_rate.qe = dio_pad_attr_0_qe;
@@ -13025,6 +13557,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[0].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_drive_strength_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].drive_strength.qe = dio_pad_attr_0_qe;
@@ -13049,6 +13582,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[1].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_invert_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].invert.qe = dio_pad_attr_1_qe;
@@ -13064,6 +13598,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[1].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_virtual_od_en_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].virtual_od_en.qe = dio_pad_attr_1_qe;
@@ -13079,6 +13614,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[1].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_pull_en_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].pull_en.qe = dio_pad_attr_1_qe;
@@ -13094,6 +13630,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[1].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_pull_select_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].pull_select.qe = dio_pad_attr_1_qe;
@@ -13109,6 +13646,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[1].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_keeper_en_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].keeper_en.qe = dio_pad_attr_1_qe;
@@ -13124,6 +13662,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[1].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_schmitt_en_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].schmitt_en.qe = dio_pad_attr_1_qe;
@@ -13139,6 +13678,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[1].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_od_en_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].od_en.qe = dio_pad_attr_1_qe;
@@ -13154,6 +13694,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[1].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_slew_rate_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].slew_rate.qe = dio_pad_attr_1_qe;
@@ -13169,6 +13710,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[1].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_drive_strength_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].drive_strength.qe = dio_pad_attr_1_qe;
@@ -13193,6 +13735,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[2].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_invert_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].invert.qe = dio_pad_attr_2_qe;
@@ -13208,6 +13751,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[2].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_virtual_od_en_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].virtual_od_en.qe = dio_pad_attr_2_qe;
@@ -13223,6 +13767,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[2].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_pull_en_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].pull_en.qe = dio_pad_attr_2_qe;
@@ -13238,6 +13783,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[2].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_pull_select_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].pull_select.qe = dio_pad_attr_2_qe;
@@ -13253,6 +13799,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[2].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_keeper_en_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].keeper_en.qe = dio_pad_attr_2_qe;
@@ -13268,6 +13815,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[2].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_schmitt_en_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].schmitt_en.qe = dio_pad_attr_2_qe;
@@ -13283,6 +13831,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[2].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_od_en_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].od_en.qe = dio_pad_attr_2_qe;
@@ -13298,6 +13847,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[2].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_slew_rate_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].slew_rate.qe = dio_pad_attr_2_qe;
@@ -13313,6 +13863,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[2].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_drive_strength_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].drive_strength.qe = dio_pad_attr_2_qe;
@@ -13337,6 +13888,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[3].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_invert_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].invert.qe = dio_pad_attr_3_qe;
@@ -13352,6 +13904,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[3].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_virtual_od_en_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].virtual_od_en.qe = dio_pad_attr_3_qe;
@@ -13367,6 +13920,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[3].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_pull_en_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].pull_en.qe = dio_pad_attr_3_qe;
@@ -13382,6 +13936,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[3].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_pull_select_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].pull_select.qe = dio_pad_attr_3_qe;
@@ -13397,6 +13952,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[3].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_keeper_en_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].keeper_en.qe = dio_pad_attr_3_qe;
@@ -13412,6 +13968,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[3].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_schmitt_en_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].schmitt_en.qe = dio_pad_attr_3_qe;
@@ -13427,6 +13984,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[3].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_od_en_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].od_en.qe = dio_pad_attr_3_qe;
@@ -13442,6 +14000,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[3].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_slew_rate_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].slew_rate.qe = dio_pad_attr_3_qe;
@@ -13457,6 +14016,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[3].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_drive_strength_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].drive_strength.qe = dio_pad_attr_3_qe;
@@ -13481,6 +14041,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[4].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_invert_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].invert.qe = dio_pad_attr_4_qe;
@@ -13496,6 +14057,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[4].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_virtual_od_en_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].virtual_od_en.qe = dio_pad_attr_4_qe;
@@ -13511,6 +14073,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[4].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_pull_en_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].pull_en.qe = dio_pad_attr_4_qe;
@@ -13526,6 +14089,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[4].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_pull_select_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].pull_select.qe = dio_pad_attr_4_qe;
@@ -13541,6 +14105,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[4].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_keeper_en_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].keeper_en.qe = dio_pad_attr_4_qe;
@@ -13556,6 +14121,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[4].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_schmitt_en_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].schmitt_en.qe = dio_pad_attr_4_qe;
@@ -13571,6 +14137,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[4].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_od_en_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].od_en.qe = dio_pad_attr_4_qe;
@@ -13586,6 +14153,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[4].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_slew_rate_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].slew_rate.qe = dio_pad_attr_4_qe;
@@ -13601,6 +14169,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[4].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_drive_strength_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].drive_strength.qe = dio_pad_attr_4_qe;
@@ -13625,6 +14194,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[5].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_invert_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].invert.qe = dio_pad_attr_5_qe;
@@ -13640,6 +14210,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[5].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_virtual_od_en_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].virtual_od_en.qe = dio_pad_attr_5_qe;
@@ -13655,6 +14226,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[5].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_pull_en_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].pull_en.qe = dio_pad_attr_5_qe;
@@ -13670,6 +14242,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[5].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_pull_select_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].pull_select.qe = dio_pad_attr_5_qe;
@@ -13685,6 +14258,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[5].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_keeper_en_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].keeper_en.qe = dio_pad_attr_5_qe;
@@ -13700,6 +14274,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[5].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_schmitt_en_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].schmitt_en.qe = dio_pad_attr_5_qe;
@@ -13715,6 +14290,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[5].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_od_en_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].od_en.qe = dio_pad_attr_5_qe;
@@ -13730,6 +14306,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[5].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_slew_rate_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].slew_rate.qe = dio_pad_attr_5_qe;
@@ -13745,6 +14322,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[5].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_drive_strength_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].drive_strength.qe = dio_pad_attr_5_qe;
@@ -13769,6 +14347,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[6].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_invert_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].invert.qe = dio_pad_attr_6_qe;
@@ -13784,6 +14363,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[6].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_virtual_od_en_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].virtual_od_en.qe = dio_pad_attr_6_qe;
@@ -13799,6 +14379,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[6].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_pull_en_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].pull_en.qe = dio_pad_attr_6_qe;
@@ -13814,6 +14395,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[6].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_pull_select_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].pull_select.qe = dio_pad_attr_6_qe;
@@ -13829,6 +14411,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[6].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_keeper_en_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].keeper_en.qe = dio_pad_attr_6_qe;
@@ -13844,6 +14427,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[6].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_schmitt_en_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].schmitt_en.qe = dio_pad_attr_6_qe;
@@ -13859,6 +14443,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[6].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_od_en_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].od_en.qe = dio_pad_attr_6_qe;
@@ -13874,6 +14459,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[6].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_slew_rate_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].slew_rate.qe = dio_pad_attr_6_qe;
@@ -13889,6 +14475,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[6].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_drive_strength_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].drive_strength.qe = dio_pad_attr_6_qe;
@@ -13913,6 +14500,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[7].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_invert_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].invert.qe = dio_pad_attr_7_qe;
@@ -13928,6 +14516,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[7].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_virtual_od_en_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].virtual_od_en.qe = dio_pad_attr_7_qe;
@@ -13943,6 +14532,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[7].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_pull_en_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].pull_en.qe = dio_pad_attr_7_qe;
@@ -13958,6 +14548,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[7].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_pull_select_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].pull_select.qe = dio_pad_attr_7_qe;
@@ -13973,6 +14564,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[7].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_keeper_en_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].keeper_en.qe = dio_pad_attr_7_qe;
@@ -13988,6 +14580,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[7].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_schmitt_en_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].schmitt_en.qe = dio_pad_attr_7_qe;
@@ -14003,6 +14596,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[7].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_od_en_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].od_en.qe = dio_pad_attr_7_qe;
@@ -14018,6 +14612,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[7].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_slew_rate_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].slew_rate.qe = dio_pad_attr_7_qe;
@@ -14033,6 +14628,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[7].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_drive_strength_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].drive_strength.qe = dio_pad_attr_7_qe;
@@ -14057,6 +14653,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[8].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_invert_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].invert.qe = dio_pad_attr_8_qe;
@@ -14072,6 +14669,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[8].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_virtual_od_en_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].virtual_od_en.qe = dio_pad_attr_8_qe;
@@ -14087,6 +14685,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[8].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_pull_en_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].pull_en.qe = dio_pad_attr_8_qe;
@@ -14102,6 +14701,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[8].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_pull_select_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].pull_select.qe = dio_pad_attr_8_qe;
@@ -14117,6 +14717,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[8].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_keeper_en_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].keeper_en.qe = dio_pad_attr_8_qe;
@@ -14132,6 +14733,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[8].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_schmitt_en_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].schmitt_en.qe = dio_pad_attr_8_qe;
@@ -14147,6 +14749,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[8].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_od_en_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].od_en.qe = dio_pad_attr_8_qe;
@@ -14162,6 +14765,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[8].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_slew_rate_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].slew_rate.qe = dio_pad_attr_8_qe;
@@ -14177,6 +14781,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[8].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_drive_strength_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].drive_strength.qe = dio_pad_attr_8_qe;
@@ -14201,6 +14806,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[9].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_invert_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].invert.qe = dio_pad_attr_9_qe;
@@ -14216,6 +14822,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[9].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_virtual_od_en_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].virtual_od_en.qe = dio_pad_attr_9_qe;
@@ -14231,6 +14838,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[9].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_pull_en_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].pull_en.qe = dio_pad_attr_9_qe;
@@ -14246,6 +14854,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[9].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_pull_select_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].pull_select.qe = dio_pad_attr_9_qe;
@@ -14261,6 +14870,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[9].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_keeper_en_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].keeper_en.qe = dio_pad_attr_9_qe;
@@ -14276,6 +14886,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[9].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_schmitt_en_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].schmitt_en.qe = dio_pad_attr_9_qe;
@@ -14291,6 +14902,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[9].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_od_en_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].od_en.qe = dio_pad_attr_9_qe;
@@ -14306,6 +14918,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[9].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_slew_rate_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].slew_rate.qe = dio_pad_attr_9_qe;
@@ -14321,6 +14934,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[9].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_drive_strength_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].drive_strength.qe = dio_pad_attr_9_qe;
@@ -14345,6 +14959,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[10].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_invert_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].invert.qe = dio_pad_attr_10_qe;
@@ -14360,6 +14975,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[10].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_virtual_od_en_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].virtual_od_en.qe = dio_pad_attr_10_qe;
@@ -14375,6 +14991,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[10].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_pull_en_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].pull_en.qe = dio_pad_attr_10_qe;
@@ -14390,6 +15007,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[10].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_pull_select_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].pull_select.qe = dio_pad_attr_10_qe;
@@ -14405,6 +15023,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[10].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_keeper_en_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].keeper_en.qe = dio_pad_attr_10_qe;
@@ -14420,6 +15039,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[10].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_schmitt_en_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].schmitt_en.qe = dio_pad_attr_10_qe;
@@ -14435,6 +15055,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[10].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_od_en_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].od_en.qe = dio_pad_attr_10_qe;
@@ -14450,6 +15071,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[10].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_slew_rate_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].slew_rate.qe = dio_pad_attr_10_qe;
@@ -14465,6 +15087,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[10].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_drive_strength_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].drive_strength.qe = dio_pad_attr_10_qe;
@@ -14489,6 +15112,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[11].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_invert_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].invert.qe = dio_pad_attr_11_qe;
@@ -14504,6 +15128,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[11].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_virtual_od_en_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].virtual_od_en.qe = dio_pad_attr_11_qe;
@@ -14519,6 +15144,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[11].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_pull_en_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].pull_en.qe = dio_pad_attr_11_qe;
@@ -14534,6 +15160,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[11].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_pull_select_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].pull_select.qe = dio_pad_attr_11_qe;
@@ -14549,6 +15176,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[11].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_keeper_en_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].keeper_en.qe = dio_pad_attr_11_qe;
@@ -14564,6 +15192,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[11].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_schmitt_en_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].schmitt_en.qe = dio_pad_attr_11_qe;
@@ -14579,6 +15208,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[11].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_od_en_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].od_en.qe = dio_pad_attr_11_qe;
@@ -14594,6 +15224,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[11].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_slew_rate_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].slew_rate.qe = dio_pad_attr_11_qe;
@@ -14609,6 +15240,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[11].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_drive_strength_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].drive_strength.qe = dio_pad_attr_11_qe;
@@ -14633,6 +15265,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[12].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_invert_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].invert.qe = dio_pad_attr_12_qe;
@@ -14648,6 +15281,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[12].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_virtual_od_en_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].virtual_od_en.qe = dio_pad_attr_12_qe;
@@ -14663,6 +15297,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[12].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_pull_en_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].pull_en.qe = dio_pad_attr_12_qe;
@@ -14678,6 +15313,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[12].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_pull_select_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].pull_select.qe = dio_pad_attr_12_qe;
@@ -14693,6 +15329,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[12].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_keeper_en_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].keeper_en.qe = dio_pad_attr_12_qe;
@@ -14708,6 +15345,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[12].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_schmitt_en_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].schmitt_en.qe = dio_pad_attr_12_qe;
@@ -14723,6 +15361,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[12].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_od_en_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].od_en.qe = dio_pad_attr_12_qe;
@@ -14738,6 +15377,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[12].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_slew_rate_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].slew_rate.qe = dio_pad_attr_12_qe;
@@ -14753,6 +15393,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[12].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_drive_strength_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].drive_strength.qe = dio_pad_attr_12_qe;
@@ -14777,6 +15418,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[13].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_invert_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].invert.qe = dio_pad_attr_13_qe;
@@ -14792,6 +15434,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[13].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_virtual_od_en_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].virtual_od_en.qe = dio_pad_attr_13_qe;
@@ -14807,6 +15450,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[13].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_pull_en_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].pull_en.qe = dio_pad_attr_13_qe;
@@ -14822,6 +15466,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[13].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_pull_select_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].pull_select.qe = dio_pad_attr_13_qe;
@@ -14837,6 +15482,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[13].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_keeper_en_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].keeper_en.qe = dio_pad_attr_13_qe;
@@ -14852,6 +15498,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[13].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_schmitt_en_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].schmitt_en.qe = dio_pad_attr_13_qe;
@@ -14867,6 +15514,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[13].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_od_en_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].od_en.qe = dio_pad_attr_13_qe;
@@ -14882,6 +15530,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[13].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_slew_rate_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].slew_rate.qe = dio_pad_attr_13_qe;
@@ -14897,6 +15546,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[13].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_drive_strength_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].drive_strength.qe = dio_pad_attr_13_qe;
@@ -14921,6 +15571,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[14].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_invert_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].invert.qe = dio_pad_attr_14_qe;
@@ -14936,6 +15587,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[14].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_virtual_od_en_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].virtual_od_en.qe = dio_pad_attr_14_qe;
@@ -14951,6 +15603,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[14].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_pull_en_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].pull_en.qe = dio_pad_attr_14_qe;
@@ -14966,6 +15619,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[14].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_pull_select_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].pull_select.qe = dio_pad_attr_14_qe;
@@ -14981,6 +15635,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[14].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_keeper_en_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].keeper_en.qe = dio_pad_attr_14_qe;
@@ -14996,6 +15651,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[14].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_schmitt_en_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].schmitt_en.qe = dio_pad_attr_14_qe;
@@ -15011,6 +15667,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[14].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_od_en_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].od_en.qe = dio_pad_attr_14_qe;
@@ -15026,6 +15683,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[14].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_slew_rate_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].slew_rate.qe = dio_pad_attr_14_qe;
@@ -15041,6 +15699,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[14].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_drive_strength_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].drive_strength.qe = dio_pad_attr_14_qe;
@@ -15065,6 +15724,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[15].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_invert_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].invert.qe = dio_pad_attr_15_qe;
@@ -15080,6 +15740,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[15].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_virtual_od_en_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].virtual_od_en.qe = dio_pad_attr_15_qe;
@@ -15095,6 +15756,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[15].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_pull_en_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].pull_en.qe = dio_pad_attr_15_qe;
@@ -15110,6 +15772,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[15].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_pull_select_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].pull_select.qe = dio_pad_attr_15_qe;
@@ -15125,6 +15788,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[15].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_keeper_en_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].keeper_en.qe = dio_pad_attr_15_qe;
@@ -15140,6 +15804,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[15].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_schmitt_en_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].schmitt_en.qe = dio_pad_attr_15_qe;
@@ -15155,6 +15820,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[15].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_od_en_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].od_en.qe = dio_pad_attr_15_qe;
@@ -15170,6 +15836,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[15].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_slew_rate_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].slew_rate.qe = dio_pad_attr_15_qe;
@@ -15185,6 +15852,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[15].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_drive_strength_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].drive_strength.qe = dio_pad_attr_15_qe;
@@ -15212,6 +15880,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_0_qs)
@@ -15237,6 +15906,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_1_qs)
@@ -15262,6 +15932,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_2_qs)
@@ -15287,6 +15958,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_3_qs)
@@ -15312,6 +15984,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_4_qs)
@@ -15337,6 +16010,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_5_qs)
@@ -15362,6 +16036,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_6_qs)
@@ -15387,6 +16062,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_7_qs)
@@ -15412,6 +16088,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_8_qs)
@@ -15437,6 +16114,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_9_qs)
@@ -15462,6 +16140,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_10_qs)
@@ -15487,6 +16166,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_11_qs)
@@ -15512,6 +16192,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_12_qs)
@@ -15537,6 +16218,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_13_qs)
@@ -15562,6 +16244,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_14_qs)
@@ -15587,6 +16270,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_15_qs)
@@ -15612,6 +16296,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_16_qs)
@@ -15637,6 +16322,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_17_qs)
@@ -15662,6 +16348,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_18_qs)
@@ -15687,6 +16374,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_19_qs)
@@ -15712,6 +16400,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_20_qs)
@@ -15737,6 +16426,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_21_qs)
@@ -15762,6 +16452,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_22_qs)
@@ -15787,6 +16478,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_23_qs)
@@ -15812,6 +16504,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_24_qs)
@@ -15837,6 +16530,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_25_qs)
@@ -15862,6 +16556,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_26_qs)
@@ -15887,6 +16582,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_27_qs)
@@ -15912,6 +16608,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_28_qs)
@@ -15937,6 +16634,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_29_qs)
@@ -15962,6 +16660,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_30_qs)
@@ -15987,6 +16686,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_en_31_qs)
@@ -16014,6 +16714,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_0_qs)
@@ -16041,6 +16742,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_1_qs)
@@ -16068,6 +16770,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_2_qs)
@@ -16095,6 +16798,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_3_qs)
@@ -16122,6 +16826,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_4_qs)
@@ -16149,6 +16854,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_5_qs)
@@ -16176,6 +16882,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_6_qs)
@@ -16203,6 +16910,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_7_qs)
@@ -16230,6 +16938,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_8_qs)
@@ -16257,6 +16966,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_9_qs)
@@ -16284,6 +16994,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_10_qs)
@@ -16311,6 +17022,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_11_qs)
@@ -16338,6 +17050,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_12_qs)
@@ -16365,6 +17078,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_13_qs)
@@ -16392,6 +17106,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_14_qs)
@@ -16419,6 +17134,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_15_qs)
@@ -16446,6 +17162,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_16_qs)
@@ -16473,6 +17190,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_17_qs)
@@ -16500,6 +17218,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_18_qs)
@@ -16527,6 +17246,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_19_qs)
@@ -16554,6 +17274,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_20_qs)
@@ -16581,6 +17302,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_21_qs)
@@ -16608,6 +17330,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_22_qs)
@@ -16635,6 +17358,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_23_qs)
@@ -16662,6 +17386,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_24_qs)
@@ -16689,6 +17414,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_25_qs)
@@ -16716,6 +17442,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_26_qs)
@@ -16743,6 +17470,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_27_qs)
@@ -16770,6 +17498,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_28_qs)
@@ -16797,6 +17526,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_29_qs)
@@ -16824,6 +17554,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_30_qs)
@@ -16851,6 +17582,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_31_qs)
@@ -16881,6 +17613,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_0_qs)
@@ -16911,6 +17644,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_1_qs)
@@ -16941,6 +17675,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_2_qs)
@@ -16971,6 +17706,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_3_qs)
@@ -17001,6 +17737,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_4_qs)
@@ -17031,6 +17768,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_5_qs)
@@ -17061,6 +17799,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_6_qs)
@@ -17091,6 +17830,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_7_qs)
@@ -17121,6 +17861,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_8_qs)
@@ -17151,6 +17892,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_9_qs)
@@ -17181,6 +17923,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_10_qs)
@@ -17211,6 +17954,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_11_qs)
@@ -17241,6 +17985,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_12_qs)
@@ -17271,6 +18016,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_13_qs)
@@ -17301,6 +18047,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_14_qs)
@@ -17331,6 +18078,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_15_qs)
@@ -17361,6 +18109,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_16_qs)
@@ -17391,6 +18140,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_17_qs)
@@ -17421,6 +18171,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_18_qs)
@@ -17451,6 +18202,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_19_qs)
@@ -17481,6 +18233,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_20_qs)
@@ -17511,6 +18264,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_21_qs)
@@ -17541,6 +18295,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_22_qs)
@@ -17571,6 +18326,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_23_qs)
@@ -17601,6 +18357,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_24_qs)
@@ -17631,6 +18388,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_25_qs)
@@ -17661,6 +18419,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_26_qs)
@@ -17691,6 +18450,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_27_qs)
@@ -17721,6 +18481,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_28_qs)
@@ -17751,6 +18512,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_29_qs)
@@ -17781,6 +18543,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_30_qs)
@@ -17811,6 +18574,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_31_qs)
@@ -17841,6 +18605,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_0_qs)
@@ -17871,6 +18636,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_1_qs)
@@ -17901,6 +18667,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_2_qs)
@@ -17931,6 +18698,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_3_qs)
@@ -17961,6 +18729,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_4_qs)
@@ -17991,6 +18760,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_5_qs)
@@ -18021,6 +18791,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_6_qs)
@@ -18051,6 +18822,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_7_qs)
@@ -18081,6 +18853,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_8_qs)
@@ -18111,6 +18884,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_9_qs)
@@ -18141,6 +18915,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_10_qs)
@@ -18171,6 +18946,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_11_qs)
@@ -18201,6 +18977,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_12_qs)
@@ -18231,6 +19008,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_13_qs)
@@ -18261,6 +19039,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_14_qs)
@@ -18291,6 +19070,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_15_qs)
@@ -18321,6 +19101,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_16_qs)
@@ -18351,6 +19132,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_17_qs)
@@ -18381,6 +19163,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_18_qs)
@@ -18411,6 +19194,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_19_qs)
@@ -18441,6 +19225,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_20_qs)
@@ -18471,6 +19256,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_21_qs)
@@ -18501,6 +19287,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_22_qs)
@@ -18531,6 +19318,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_23_qs)
@@ -18561,6 +19349,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_24_qs)
@@ -18591,6 +19380,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_25_qs)
@@ -18621,6 +19411,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_26_qs)
@@ -18651,6 +19442,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_27_qs)
@@ -18681,6 +19473,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_28_qs)
@@ -18711,6 +19504,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_29_qs)
@@ -18741,6 +19535,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_30_qs)
@@ -18771,6 +19566,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_31_qs)
@@ -18799,6 +19595,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_0_qs)
@@ -18824,6 +19621,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_1_qs)
@@ -18849,6 +19647,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_2_qs)
@@ -18874,6 +19673,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_3_qs)
@@ -18899,6 +19699,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_4_qs)
@@ -18924,6 +19725,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_5_qs)
@@ -18949,6 +19751,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_6_qs)
@@ -18974,6 +19777,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_7_qs)
@@ -18999,6 +19803,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_8_qs)
@@ -19024,6 +19829,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_9_qs)
@@ -19049,6 +19855,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_10_qs)
@@ -19074,6 +19881,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_11_qs)
@@ -19099,6 +19907,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_12_qs)
@@ -19124,6 +19933,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_13_qs)
@@ -19149,6 +19959,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_14_qs)
@@ -19174,6 +19985,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_15_qs)
@@ -19201,6 +20013,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_0_qs)
@@ -19228,6 +20041,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_1_qs)
@@ -19255,6 +20069,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_2_qs)
@@ -19282,6 +20097,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_3_qs)
@@ -19309,6 +20125,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_4_qs)
@@ -19336,6 +20153,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_5_qs)
@@ -19363,6 +20181,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_6_qs)
@@ -19390,6 +20209,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_7_qs)
@@ -19417,6 +20237,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_8_qs)
@@ -19444,6 +20265,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_9_qs)
@@ -19471,6 +20293,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_10_qs)
@@ -19498,6 +20321,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_11_qs)
@@ -19525,6 +20349,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_12_qs)
@@ -19552,6 +20377,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_13_qs)
@@ -19579,6 +20405,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_14_qs)
@@ -19606,6 +20433,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_15_qs)
@@ -19636,6 +20464,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_0_qs)
@@ -19666,6 +20495,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_1_qs)
@@ -19696,6 +20526,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_2_qs)
@@ -19726,6 +20557,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_3_qs)
@@ -19756,6 +20588,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_4_qs)
@@ -19786,6 +20619,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_5_qs)
@@ -19816,6 +20650,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_6_qs)
@@ -19846,6 +20681,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_7_qs)
@@ -19876,6 +20712,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_8_qs)
@@ -19906,6 +20743,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_9_qs)
@@ -19936,6 +20774,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_10_qs)
@@ -19966,6 +20805,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_11_qs)
@@ -19996,6 +20836,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_12_qs)
@@ -20026,6 +20867,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_13_qs)
@@ -20056,6 +20898,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_14_qs)
@@ -20086,6 +20929,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_15_qs)
@@ -20116,6 +20960,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_0_qs)
@@ -20146,6 +20991,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_1_qs)
@@ -20176,6 +21022,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_2_qs)
@@ -20206,6 +21053,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_3_qs)
@@ -20236,6 +21084,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_4_qs)
@@ -20266,6 +21115,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_5_qs)
@@ -20296,6 +21146,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_6_qs)
@@ -20326,6 +21177,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_7_qs)
@@ -20356,6 +21208,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_8_qs)
@@ -20386,6 +21239,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_9_qs)
@@ -20416,6 +21270,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_10_qs)
@@ -20446,6 +21301,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_11_qs)
@@ -20476,6 +21332,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_12_qs)
@@ -20506,6 +21363,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_13_qs)
@@ -20536,6 +21394,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_14_qs)
@@ -20566,6 +21425,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_15_qs)
@@ -20593,6 +21453,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_0_qs)
@@ -20620,6 +21481,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_1_qs)
@@ -20647,6 +21509,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_2_qs)
@@ -20674,6 +21537,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_3_qs)
@@ -20701,6 +21565,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_4_qs)
@@ -20728,6 +21593,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_5_qs)
@@ -20755,6 +21621,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_6_qs)
@@ -20782,6 +21649,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_7_qs)
@@ -20813,6 +21681,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_0_qs_int)
@@ -20844,6 +21713,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_1_qs_int)
@@ -20875,6 +21745,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_2_qs_int)
@@ -20906,6 +21777,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_3_qs_int)
@@ -20937,6 +21809,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_4_qs_int)
@@ -20968,6 +21841,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_5_qs_int)
@@ -20999,6 +21873,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_6_qs_int)
@@ -21030,6 +21905,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_7_qs_int)
@@ -21061,6 +21937,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[0].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_0_mode_0_qs_int)
@@ -21086,6 +21963,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[0].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_0_filter_0_qs_int)
@@ -21111,6 +21989,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[0].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_0_miodio_0_qs_int)
@@ -21142,6 +22021,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[1].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_1_mode_1_qs_int)
@@ -21167,6 +22047,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[1].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_1_filter_1_qs_int)
@@ -21192,6 +22073,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[1].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_1_miodio_1_qs_int)
@@ -21223,6 +22105,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[2].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_2_mode_2_qs_int)
@@ -21248,6 +22131,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[2].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_2_filter_2_qs_int)
@@ -21273,6 +22157,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[2].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_2_miodio_2_qs_int)
@@ -21304,6 +22189,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[3].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_3_mode_3_qs_int)
@@ -21329,6 +22215,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[3].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_3_filter_3_qs_int)
@@ -21354,6 +22241,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[3].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_3_miodio_3_qs_int)
@@ -21385,6 +22273,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[4].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_4_mode_4_qs_int)
@@ -21410,6 +22299,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[4].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_4_filter_4_qs_int)
@@ -21435,6 +22325,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[4].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_4_miodio_4_qs_int)
@@ -21466,6 +22357,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[5].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_5_mode_5_qs_int)
@@ -21491,6 +22383,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[5].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_5_filter_5_qs_int)
@@ -21516,6 +22409,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[5].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_5_miodio_5_qs_int)
@@ -21547,6 +22441,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[6].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_6_mode_6_qs_int)
@@ -21572,6 +22467,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[6].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_6_filter_6_qs_int)
@@ -21597,6 +22493,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[6].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_6_miodio_6_qs_int)
@@ -21628,6 +22525,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[7].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_7_mode_7_qs_int)
@@ -21653,6 +22551,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[7].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_7_filter_7_qs_int)
@@ -21678,6 +22577,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[7].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_7_miodio_7_qs_int)
@@ -21709,6 +22609,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_0_qs_int)
@@ -21740,6 +22641,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_1_qs_int)
@@ -21771,6 +22673,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_2_qs_int)
@@ -21802,6 +22705,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_3_qs_int)
@@ -21833,6 +22737,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_4_qs_int)
@@ -21864,6 +22769,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_5_qs_int)
@@ -21895,6 +22801,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_6_qs_int)
@@ -21926,6 +22833,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_7_qs_int)
@@ -21956,6 +22864,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_0_qs)
@@ -21986,6 +22895,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_1_qs)
@@ -22016,6 +22926,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_2_qs)
@@ -22046,6 +22957,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_3_qs)
@@ -22076,6 +22988,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_4_qs)
@@ -22106,6 +23019,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_5_qs)
@@ -22136,6 +23050,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_6_qs)
@@ -22166,6 +23081,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_7_qs)
@@ -22174,6 +23090,8 @@ module pinmux_reg_top (
 
   // Subregister 0 of Multireg wkup_cause
   // R[wkup_cause]: V(False)
+  logic [7:0] wkup_cause_flds_we;
+  assign aon_wkup_cause_qe = |wkup_cause_flds_we;
   //   F[cause_0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -22192,8 +23110,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[0].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[0]),
     .q      (reg2hw.wkup_cause[0].q),
+    .ds     (aon_wkup_cause_cause_0_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_0_qs_int)
@@ -22217,8 +23136,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[1].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[1]),
     .q      (reg2hw.wkup_cause[1].q),
+    .ds     (aon_wkup_cause_cause_1_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_1_qs_int)
@@ -22242,8 +23162,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[2].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[2]),
     .q      (reg2hw.wkup_cause[2].q),
+    .ds     (aon_wkup_cause_cause_2_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_2_qs_int)
@@ -22267,8 +23188,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[3].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[3]),
     .q      (reg2hw.wkup_cause[3].q),
+    .ds     (aon_wkup_cause_cause_3_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_3_qs_int)
@@ -22292,8 +23214,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[4].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[4]),
     .q      (reg2hw.wkup_cause[4].q),
+    .ds     (aon_wkup_cause_cause_4_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_4_qs_int)
@@ -22317,8 +23240,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[5].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[5]),
     .q      (reg2hw.wkup_cause[5].q),
+    .ds     (aon_wkup_cause_cause_5_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_5_qs_int)
@@ -22342,8 +23266,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[6].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[6]),
     .q      (reg2hw.wkup_cause[6].q),
+    .ds     (aon_wkup_cause_cause_6_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_6_qs_int)
@@ -22367,8 +23292,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[7].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[7]),
     .q      (reg2hw.wkup_cause[7].q),
+    .ds     (aon_wkup_cause_cause_7_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_7_qs_int)

--- a/hw/ip/prim/prim_subreg.core
+++ b/hw/ip/prim/prim_subreg.core
@@ -9,9 +9,10 @@ filesets:
   files_rtl:
     files:
       - rtl/prim_subreg_pkg.sv
-      - rtl/prim_subreg_arb.sv
       - rtl/prim_reg_cdc.sv
+      - rtl/prim_reg_cdc_arb.sv
       - rtl/prim_subreg.sv
+      - rtl/prim_subreg_arb.sv
       - rtl/prim_subreg_ext.sv
       - rtl/prim_subreg_shadow.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim/rtl/prim_reg_cdc.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc.sv
@@ -9,21 +9,23 @@
 module prim_reg_cdc #(
   parameter int DataWidth = 32,
   parameter logic [DataWidth-1:0] ResetVal = 32'h0,
-  parameter logic [DataWidth-1:0] BitMask = 32'hFFFFFFFF
+  parameter logic [DataWidth-1:0] BitMask = 32'hFFFFFFFF,
+  // whether this instance needs to support independent hardware writes
+  parameter bit DstWrReq = 0
 ) (
   input clk_src_i,
   input rst_src_ni,
   input clk_dst_i,
   input rst_dst_ni,
-
-  input src_update_i,
   input src_regwen_i,
   input src_we_i,
   input src_re_i,
   input [DataWidth-1:0] src_wd_i,
   output logic src_busy_o,
   output logic [DataWidth-1:0] src_qs_o,
-  input  [DataWidth-1:0] dst_d_i,
+  input  [DataWidth-1:0] dst_ds_i,
+  input  [DataWidth-1:0] dst_qs_i,
+  input  dst_update_i,
   output logic dst_we_o,
   output logic dst_re_o,
   output logic dst_regwen_o,
@@ -61,12 +63,16 @@ module prim_reg_cdc #(
   // src_q acts as both the write holding register and the software read back
   // register.
   // When software performs a write, the write data is captured in src_q for
-  // CDC purposes.  When not performing a write, the src_q periodically
-  // samples the destination domain using the src_update_i indication.
+  // CDC purposes.  When not performing a write, the src_q reflects the most recent
+  // hardware value. For registes with no hardware access, this is simply the
+  // the value programmed by software (or in the case R1C, W1C etc) the value after
+  // the operation. For registers with hardware access, this reflects a potentially
+  // delayed version of the real value, as the software facing updates lag real
+  // time updates.
   //
   // To resolve software and hardware conflicts, the process is as follows:
   // When software issues a write, this module asserts "busy".  While busy,
-  // src_q does not sample the destination value.  Since the
+  // src_q does not take on destination value updates.  Since the
   // logic has committed to updating based on software command, there is an irreversible
   // window from which hardware writes are ignored.  Once the busy window completes,
   // the cdc portion then begins sampling once more.
@@ -78,14 +84,20 @@ module prim_reg_cdc #(
   logic busy;
   assign busy = src_busy_q & !src_ack;
 
+  // This is the current destination value
+  logic [DataWidth-1:0] dst_qs;
+  logic src_update;
   always_ff @(posedge clk_src_i or negedge rst_src_ni) begin
     if (!rst_src_ni) begin
       src_q <= ResetVal;
       txn_bits_q <= '0;
     end else if (src_req && !busy) begin
+      // At the beginning of a software initiated transaction, the following
+      // values are captured in the src_q/txn_bits_q flops to ensure they cannot
+      // change for the duration of the synchronization operation.
       src_q <= src_wd_i & BitMask;
       txn_bits_q <= {src_we_i, src_re_i, src_regwen_i};
-    end else if (src_busy_q && src_ack || src_update_i && !busy) begin
+    end else if (src_busy_q && src_ack || src_update && !busy) begin
       // sample data whenever a busy transaction finishes OR
       // when an update pulse is seen.
       // TODO: We should add a cover group to test different sync timings
@@ -94,7 +106,7 @@ module prim_reg_cdc #(
       // 2. ack one cycle before update
       // 3. update / ack on the same cycle
       // During all 3 cases the read data should be correct
-      src_q <= dst_d_i;
+      src_q <= dst_qs;
       txn_bits_q <= '0;
     end
   end
@@ -112,21 +124,41 @@ module prim_reg_cdc #(
   ////////////////////////////
   // CDC handling
   ////////////////////////////
+
+  logic dst_req_from_src;
   logic dst_req;
-  prim_sync_reqack u_prim_sync (
+
+
+  // the software transaction is pulse synced across the domain.
+  // the prim_reg_cdc_arb module handles conflicts with ongoing hardware updates.
+  prim_pulse_sync u_src_to_dst_req (
     .clk_src_i,
     .rst_src_ni,
     .clk_dst_i,
     .rst_dst_ni,
-    .req_chk_i(1'b0),
-    // prim_sync_reqack does not natively handle single
-    // pulse requests, so use src_busy to even it out.
-    .src_req_i(src_req | src_busy_q),
-    .src_ack_o(src_ack),
-    .dst_req_o(dst_req),
-    // immediately ack on destination once request is seen
-    .dst_ack_i(dst_req)
+    .src_pulse_i(src_req),
+    .dst_pulse_o(dst_req_from_src)
   );
+
+  prim_reg_cdc_arb #(
+    .DataWidth(DataWidth),
+    .ResetVal(ResetVal),
+    .DstWrReq(DstWrReq)
+  ) u_arb (
+    .clk_src_i,
+    .rst_src_ni,
+    .clk_dst_i,
+    .rst_dst_ni,
+    .src_ack_o(src_ack),
+    .src_update_o(src_update),
+    .dst_req_i(dst_req_from_src),
+    .dst_req_o(dst_req),
+    .dst_update_i,
+    .dst_ds_i,
+    .dst_qs_i,
+    .dst_qs_o(dst_qs)
+  );
+
 
   // Each is valid only when destination request pulse is high
   assign {dst_we_o, dst_re_o, dst_regwen_o} = txn_bits_q & {TxnWidth{dst_req}};
@@ -135,21 +167,22 @@ module prim_reg_cdc #(
   `ASSERT_KNOWN(DstReqKnown_A, dst_req, clk_dst_i, !rst_dst_ni)
 
   // If busy goes high, we must eventually see an ack
-  `ASSERT(HungHandShake_A, $rose(src_busy_o) |-> strong(##[0:$] src_ack), clk_src_i, !rst_src_ni)
+  `ASSERT(HungHandShake_A, $rose(src_req) |-> strong(##[0:$] src_ack), clk_src_i, !rst_src_ni)
 
   `ifdef INC_ASSERT
     logic async_flag;
-    always_ff @(posedge clk_src_i or negedge rst_src_ni) begin
+    always_ff @(posedge clk_dst_i or negedge rst_dst_ni or posedge src_update) begin
       if (!rst_src_ni) begin
         async_flag <= '0;
-      end else if (src_req) begin
-        async_flag <= 1'b1;
-      end else if (dst_req) begin
+      end else if (src_update) begin
         async_flag <= '0;
+      end else if (dst_update_i) begin
+        async_flag <= 1'b1;
       end
     end
 
-    `ASSERT(ReqTimeout_A, $rose(async_flag) |-> strong(##[0:3] dst_req), clk_dst_i, !rst_dst_ni)
+   // once hardware makes an update request, we must eventually see an update pulse
+   `ASSERT(ReqTimeout_A, $rose(async_flag) |-> strong(##[0:$] src_update), clk_src_i, !rst_src_ni)
   `endif
 
 

--- a/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
@@ -1,0 +1,253 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Component handling register CDC
+
+`include "prim_assert.sv"
+
+// There are three handling scenarios.
+// 1. The register can only be updated by software.
+// 2. The register can be updated by both software and hardware.
+// 3. The register can only be updated by hardware.
+//
+// For the first scenario, hardware updates are completely ignored.
+// The software facing register (`src_q` in prim_reg_cdc) simply reflects
+// the value affected by software.  Since there is no possibility the
+// register value can change otherwise, there is no need to sample or
+// do any other coordination between the two domains. In this case,
+// we use the gen_passthru block below.
+//
+// For the second scenario, one of 4 things can happen:
+// 1. A software update without conflict
+// 2. A hardware update without conflict
+// 3. A software update is initiated when a hardware update is in-flight
+// 4. A hardware update is initiated when a software update is in-flight
+//
+// For the first case, it behaves similarly to the gen_passthru scenario.
+//
+// For the second case, the hardware update indication and update value are
+// captured, and the intent to change is synchronized back to the software
+// domain. While this happens, other hardware updates are ignored. Any hardware
+// change during the update is then detected as a difference between the
+// transit register `dst_qs_o` and the current hardware register value `dst_qs_i`.
+// When this change is observed after the current handshake completes, another
+// handshake event is generated to bring the latest hardware value over to the
+// software domain.
+//
+// For the third case, if a hardware update event is already in progress, the
+// software event is held and not acknowledged.  Once the hardware event completes,
+// then the software event proceeds through its normal updating process.
+//
+// For the forth case, if a hardware update event is received while a software
+// update is in progress, the hardware update is ignored, and the logic behaves
+// similarly to the second case. Specifically, after the software update completes,
+// a delta is observed between the transit register and the current hardware value,
+// and a new handshake event is generated.
+//
+// The thrid scenario can be folded into the second scenario. The only difference
+// is that of the 4 cases identified, only case 2 can happen since there is never a
+// software initiated update.
+
+module prim_reg_cdc_arb #(
+  parameter int DataWidth = 32,
+  parameter logic [DataWidth-1:0] ResetVal = 32'h0,
+  parameter bit DstWrReq = 0
+) (
+  input clk_src_i,
+  input rst_src_ni,
+  input clk_dst_i,
+  input rst_dst_ni,
+  // destination side acknowledging a software transaction
+  output logic src_ack_o,
+  // destination side requesting a source side update after
+  // after hw update
+  output logic src_update_o,
+  // input request from prim_reg_cdc
+  input dst_req_i,
+  // output request to prim_subreg
+  output logic dst_req_o,
+  input dst_update_i,
+  // ds allows us to sample the destination domain register
+  // one cycle earlier instead of waiting for it to be reflected
+  // in the qs.
+  // This is important because a genearl use case is that interrupts
+  // are captured alongside payloads from the destination domain into
+  // the source domain. If we rely on `qs` only, then it is very likely
+  // that the software observed value will be behind the interrupt
+  // assertion.  If the destination clock is very slow, this can seem
+  // an error on the part of the hardware.
+  input [DataWidth-1:0] dst_ds_i,
+  input [DataWidth-1:0] dst_qs_i,
+  output logic [DataWidth-1:0] dst_qs_o
+);
+
+  typedef enum logic {
+    SelSwReq,
+    SelHwReq
+  } req_sel_e;
+
+  typedef enum logic [1:0] {
+    StIdle,
+    StWait
+  } state_e;
+
+  if (DstWrReq) begin : gen_wr_req
+    logic dst_lat_q;
+    logic dst_lat_d;
+    logic dst_update_req;
+    logic dst_update_ack;
+    req_sel_e id_q;
+
+    state_e state_q, state_d;
+    // Make sure to indent the following later
+    always_ff @(posedge clk_dst_i or negedge rst_dst_ni) begin
+      if (!rst_dst_ni) begin
+        state_q <= StIdle;
+      end else begin
+        state_q <= state_d;
+      end
+    end
+
+    logic busy;
+    logic dst_req_q, dst_req;
+    always_ff @(posedge clk_dst_i or negedge rst_dst_ni) begin
+      if (!rst_dst_ni) begin
+        dst_req_q <= '0;
+      end else if (dst_req_q && dst_lat_d) begin
+        // if request is held, when the transaction starts,
+        // automatically clear.
+        // dst_lat_d is safe to used here because dst_req_q, if set,
+        // always has priority over other hardware based events.
+        dst_req_q <= '0;
+      end else if (dst_req_i && !dst_req_q && busy) begin
+        // if destination request arrives when a handshake event
+        // is already ongoing, hold on to request and send later
+        dst_req_q <= 1'b1;
+      end
+    end
+    assign dst_req = dst_req_q | dst_req_i;
+
+    // Hold data at the beginning of a transaction
+    always_ff @(posedge clk_dst_i or negedge rst_dst_ni) begin
+      if (!rst_dst_ni) begin
+        dst_qs_o <= ResetVal;
+      end else if (dst_lat_d) begin
+        dst_qs_o <= dst_ds_i;
+      end else if (dst_lat_q) begin
+        dst_qs_o <= dst_qs_i;
+      end
+    end
+
+    // Which type of transaction is being ack'd back?
+    // 0 - software initiated request
+    // 1 - hardware initiated request
+    // The id information is used by prim_reg_cdc to disambiguate
+    // simultaneous updates from software and hardware.
+    // See scenario 2 case 3 for an example of how this is handled.
+    always_ff @(posedge clk_dst_i or negedge rst_dst_ni) begin
+      if (!rst_dst_ni) begin
+        id_q <= SelSwReq;
+      end else if (dst_update_req && dst_update_ack) begin
+        id_q <= SelSwReq;
+      end else if (dst_req && dst_lat_d) begin
+        id_q <= SelSwReq;
+      end else if (dst_update_i && dst_lat_d) begin
+        id_q <= SelHwReq;
+      end else if (dst_lat_q) begin
+        id_q <= SelHwReq;
+      end
+    end
+
+    // send out prim_subreg request only when proceeding
+    // with software request
+    assign dst_req_o = ~busy & dst_req;
+
+    logic dst_hold_req;
+    always_comb begin
+      state_d = state_q;
+      dst_hold_req = '0;
+
+      // depending on when the request is received, we
+      // may latch d or q.
+      dst_lat_q = '0;
+      dst_lat_d = '0;
+
+      busy = 1'b1;
+
+      unique case (state_q)
+        StIdle: begin
+          busy = '0;
+          if (dst_req) begin
+            // there's a software issued request for change
+            state_d = StWait;
+            dst_lat_d = 1'b1;
+          end else if (dst_update_i) begin
+            state_d = StWait;
+            dst_lat_d = 1'b1;
+          end else if (dst_qs_o != dst_qs_i) begin
+            // there's a direct destination update
+            // that was blocked by an ongoing transaction
+            state_d = StWait;
+            dst_lat_q = 1'b1;
+          end
+        end
+
+        StWait: begin
+          dst_hold_req = 1'b1;
+          if (dst_update_ack) begin
+            state_d = StIdle;
+          end
+        end
+
+        default: begin
+          state_d = StIdle;
+        end
+      endcase // unique case (state_q)
+    end // always_comb
+
+    assign dst_update_req = dst_hold_req | dst_lat_d | dst_lat_q;
+    logic src_req;
+    prim_sync_reqack u_dst_update_sync (
+      .clk_src_i(clk_dst_i),
+      .rst_src_ni(rst_dst_ni),
+      .clk_dst_i(clk_src_i),
+      .rst_dst_ni(rst_src_ni),
+      .req_chk_i(1'b1),
+      .src_req_i(dst_update_req),
+      .src_ack_o(dst_update_ack),
+      .dst_req_o(src_req),
+      // immediate ack
+      .dst_ack_i(src_req)
+    );
+
+    assign src_ack_o = src_req & (id_q == SelSwReq);
+    assign src_update_o = src_req & (id_q == SelHwReq);
+
+  end else begin : gen_passthru
+    // when there is no possibility of conflicting HW transactions,
+    // we can assume that dst_qs_i will only ever take on the value
+    // that is directly related to the transaction. As a result,
+    // there is no need to latch further, and the end destination
+    // can in fact be used as the holding register.
+    assign dst_qs_o = dst_qs_i;
+    assign dst_req_o = dst_req_i;
+
+    // since there are no hw transactions, src_update_o is always '0
+    assign src_update_o = '0;
+
+    prim_pulse_sync u_dst_to_src_ack (
+      .clk_src_i(clk_dst_i),
+      .rst_src_ni(rst_dst_ni),
+      .clk_dst_i(clk_src_i),
+      .rst_dst_ni(rst_src_ni),
+      .src_pulse_i(dst_req_i),
+      .dst_pulse_o(src_ack_o)
+    );
+
+    logic unused_sigs;
+    assign unused_sigs = |{dst_ds_i, dst_update_i};
+  end
+
+
+endmodule

--- a/hw/ip/prim/rtl/prim_subreg.sv
+++ b/hw/ip/prim/rtl/prim_subreg.sv
@@ -26,6 +26,11 @@ module prim_subreg
   // output to HW and Reg Read
   output logic          qe,
   output logic [DW-1:0] q,
+
+  // ds and qs have slightly different timing.
+  // ds is the data that will be written into the flop,
+  // while qs is the current flop value exposed to software.
+  output logic [DW-1:0] ds,
   output logic [DW-1:0] qs
 );
 
@@ -54,6 +59,7 @@ module prim_subreg
   end
 
   // feed back out for consolidation
+  assign ds = wr_en ? wr_data : qs;
   assign qe = wr_en;
   assign qs = q;
 

--- a/hw/ip/prim/rtl/prim_subreg_ext.sv
+++ b/hw/ip/prim/rtl/prim_subreg_ext.sv
@@ -17,9 +17,13 @@ module prim_subreg_ext #(
   output logic          qe,
   output logic          qre,
   output logic [DW-1:0] q,
+  output logic [DW-1:0] ds,
   output logic [DW-1:0] qs
 );
 
+  // for external registers, there is no difference
+  // between qs and ds
+  assign ds = d;
   assign qs = d;
   assign q = wd;
   assign qe = we;

--- a/hw/ip/prim/rtl/prim_subreg_shadow.sv
+++ b/hw/ip/prim/rtl/prim_subreg_shadow.sv
@@ -31,6 +31,7 @@ module prim_subreg_shadow
   // Output to HW and Reg Read
   output logic          qe,
   output logic [DW-1:0] q,
+  output logic [DW-1:0] ds,
   output logic [DW-1:0] qs,
 
   // Phase output to HW
@@ -123,6 +124,7 @@ module prim_subreg_shadow
     .d        ( ~d        ),
     .qe       (           ),
     .q        ( staged_q  ),
+    .ds       (           ),
     .qs       (           )
   );
 
@@ -147,6 +149,7 @@ module prim_subreg_shadow
     .d        ( staged_q        ),
     .qe       (                 ),
     .q        ( shadow_q        ),
+    .ds       (                 ),
     .qs       (                 )
   );
 
@@ -168,6 +171,7 @@ module prim_subreg_shadow
     .d        ( d            ),
     .qe       ( committed_qe ),
     .q        ( committed_q  ),
+    .ds       ( ds           ),
     .qs       ( committed_qs )
   );
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -194,6 +194,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_qs)
@@ -220,6 +221,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_qs)
@@ -240,6 +242,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.qe = intr_test_qe;
@@ -256,6 +259,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (ctrl_cfg_regwen_qs)
   );
 
@@ -284,6 +288,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.low_power_hint.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_low_power_hint_qs)
@@ -309,6 +314,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.core_clk_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_core_clk_en_qs)
@@ -334,6 +340,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.io_clk_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_io_clk_en_qs)
@@ -359,6 +366,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.usb_clk_en_lp.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_usb_clk_en_lp_qs)
@@ -384,6 +392,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.usb_clk_en_active.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_usb_clk_en_active_qs)
@@ -409,6 +418,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.main_pd_n.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_main_pd_n_qs)
@@ -446,6 +456,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (cfg_cdc_sync_flds_we[0]),
     .q      (reg2hw.cfg_cdc_sync.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_cdc_sync_qs)
@@ -473,6 +484,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wakeup_en_regwen_qs)
@@ -503,6 +515,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wakeup_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wakeup_en_qs)
@@ -530,6 +543,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wake_status_qs)
@@ -556,6 +570,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_en_regwen_qs)
@@ -586,6 +601,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.reset_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_en_qs)
@@ -613,6 +629,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_status_qs)
@@ -639,6 +656,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wake_info_capture_dis.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wake_info_capture_dis_qs)
@@ -660,6 +678,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (wake_info_flds_we[0]),
     .q      (reg2hw.wake_info.reasons.q),
+    .ds     (),
     .qs     (wake_info_reasons_qs)
   );
   assign reg2hw.wake_info.reasons.qe = wake_info_qe;
@@ -675,6 +694,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (wake_info_flds_we[1]),
     .q      (reg2hw.wake_info.fall_through.q),
+    .ds     (),
     .qs     (wake_info_fall_through_qs)
   );
   assign reg2hw.wake_info.fall_through.qe = wake_info_qe;
@@ -690,6 +710,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (wake_info_flds_we[2]),
     .q      (reg2hw.wake_info.abort.q),
+    .ds     (),
     .qs     (wake_info_abort_qs)
   );
   assign reg2hw.wake_info.abort.qe = wake_info_qe;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -157,6 +157,7 @@ module rom_ctrl_regs_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -183,6 +184,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_cause_checker_error_qs)
@@ -208,6 +210,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_cause_integrity_error_qs)
@@ -235,6 +238,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.digest[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (digest_0_qs)
@@ -262,6 +266,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.digest[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (digest_1_qs)
@@ -289,6 +294,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.digest[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (digest_2_qs)
@@ -316,6 +322,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.digest[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (digest_3_qs)
@@ -343,6 +350,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.digest[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (digest_4_qs)
@@ -370,6 +378,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.digest[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (digest_5_qs)
@@ -397,6 +406,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.digest[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (digest_6_qs)
@@ -424,6 +434,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.digest[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (digest_7_qs)
@@ -451,6 +462,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exp_digest[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exp_digest_0_qs)
@@ -478,6 +490,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exp_digest[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exp_digest_1_qs)
@@ -505,6 +518,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exp_digest[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exp_digest_2_qs)
@@ -532,6 +546,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exp_digest[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exp_digest_3_qs)
@@ -559,6 +574,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exp_digest[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exp_digest_4_qs)
@@ -586,6 +602,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exp_digest[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exp_digest_5_qs)
@@ -613,6 +630,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exp_digest[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exp_digest_6_qs)
@@ -640,6 +658,7 @@ module rom_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exp_digest[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exp_digest_7_qs)

--- a/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
@@ -173,6 +173,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_info_por_qs)
@@ -198,6 +199,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_info_low_power_exit_qs)
@@ -223,6 +225,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_info_ndm_reset_qs)
@@ -248,6 +251,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.reset_info.hw_req.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_info_hw_req_qs)
@@ -275,6 +279,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_info_ctrl.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_info_ctrl_en_qs)
@@ -300,6 +305,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_info_ctrl.index.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_info_ctrl_index_qs)
@@ -317,6 +323,7 @@ module rstmgr_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_info_attr_qs)
   );
 
@@ -332,6 +339,7 @@ module rstmgr_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_info_qs)
   );
 
@@ -358,6 +366,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_regwen[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_en_0_qs)
@@ -383,6 +392,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_regwen[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_en_1_qs)
@@ -405,6 +415,7 @@ module rstmgr_reg_top (
     .qre    (),
     .qe     (sw_rst_ctrl_n_flds_we[0]),
     .q      (reg2hw.sw_rst_ctrl_n[0].q),
+    .ds     (),
     .qs     (sw_rst_ctrl_n_val_0_qs)
   );
   assign reg2hw.sw_rst_ctrl_n[0].qe = sw_rst_ctrl_n_qe;
@@ -420,6 +431,7 @@ module rstmgr_reg_top (
     .qre    (),
     .qe     (sw_rst_ctrl_n_flds_we[1]),
     .q      (reg2hw.sw_rst_ctrl_n[1].q),
+    .ds     (),
     .qs     (sw_rst_ctrl_n_val_1_qs)
   );
   assign reg2hw.sw_rst_ctrl_n[1].qe = sw_rst_ctrl_n_qe;

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -277,6 +277,7 @@ module rv_core_ibex_cfg_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal_sw_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_sw_err.qe = alert_test_qe;
@@ -292,6 +293,7 @@ module rv_core_ibex_cfg_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.recov_sw_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_sw_err.qe = alert_test_qe;
@@ -307,6 +309,7 @@ module rv_core_ibex_cfg_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[2]),
     .q      (reg2hw.alert_test.fatal_hw_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_hw_err.qe = alert_test_qe;
@@ -322,6 +325,7 @@ module rv_core_ibex_cfg_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[3]),
     .q      (reg2hw.alert_test.recov_hw_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_hw_err.qe = alert_test_qe;
@@ -347,6 +351,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_recov_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_recov_err_qs)
@@ -373,6 +378,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_fatal_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_fatal_err_qs)
@@ -400,6 +406,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ibus_regwen_0_qs)
@@ -427,6 +434,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ibus_regwen_1_qs)
@@ -457,6 +465,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ibus_addr_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ibus_addr_en_0_qs)
@@ -487,6 +496,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ibus_addr_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ibus_addr_en_1_qs)
@@ -517,6 +527,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ibus_addr_matching[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ibus_addr_matching_0_qs)
@@ -547,6 +558,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ibus_addr_matching[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ibus_addr_matching_1_qs)
@@ -577,6 +589,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ibus_remap_addr[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ibus_remap_addr_0_qs)
@@ -607,6 +620,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ibus_remap_addr[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ibus_remap_addr_1_qs)
@@ -634,6 +648,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dbus_regwen_0_qs)
@@ -661,6 +676,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dbus_regwen_1_qs)
@@ -691,6 +707,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dbus_addr_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dbus_addr_en_0_qs)
@@ -721,6 +738,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dbus_addr_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dbus_addr_en_1_qs)
@@ -751,6 +769,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dbus_addr_matching[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dbus_addr_matching_0_qs)
@@ -781,6 +800,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dbus_addr_matching[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dbus_addr_matching_1_qs)
@@ -811,6 +831,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dbus_remap_addr[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dbus_remap_addr_0_qs)
@@ -841,6 +862,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dbus_remap_addr[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dbus_remap_addr_1_qs)
@@ -868,6 +890,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.nmi_enable.alert_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (nmi_enable_alert_en_qs)
@@ -893,6 +916,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.nmi_enable.wdog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (nmi_enable_wdog_en_qs)
@@ -920,6 +944,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.nmi_state.alert.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (nmi_state_alert_qs)
@@ -945,6 +970,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.nmi_state.wdog.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (nmi_state_wdog_qs)
@@ -972,6 +998,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_status_reg_intg_err_qs)
@@ -997,6 +1024,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_status_fatal_intg_err_qs)
@@ -1022,6 +1050,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_status_fatal_core_err_qs)
@@ -1047,6 +1076,7 @@ module rv_core_ibex_cfg_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_status_recov_core_err_qs)
@@ -1064,6 +1094,7 @@ module rv_core_ibex_cfg_reg_top (
     .qre    (reg2hw.rnd_data.re),
     .qe     (),
     .q      (reg2hw.rnd_data.q),
+    .ds     (),
     .qs     (rnd_data_qs)
   );
 
@@ -1080,6 +1111,7 @@ module rv_core_ibex_cfg_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (rnd_status_rnd_data_valid_qs)
   );
 
@@ -1094,6 +1126,7 @@ module rv_core_ibex_cfg_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (rnd_status_rnd_data_fips_qs)
   );
 
@@ -1109,6 +1142,7 @@ module rv_core_ibex_cfg_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (fpga_info_qs)
   );
 

--- a/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
@@ -138,6 +138,7 @@ module rv_dm_regs_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -167,6 +167,7 @@ module rv_timer_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -193,6 +194,7 @@ module rv_timer_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_qs)
@@ -220,6 +222,7 @@ module rv_timer_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cfg0.prescale.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg0_prescale_qs)
@@ -245,6 +248,7 @@ module rv_timer_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cfg0.step.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg0_step_qs)
@@ -271,6 +275,7 @@ module rv_timer_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timer_v_lower0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timer_v_lower0_qs)
@@ -297,6 +302,7 @@ module rv_timer_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timer_v_upper0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timer_v_upper0_qs)
@@ -334,6 +340,7 @@ module rv_timer_reg_top (
     // to internal hardware
     .qe     (compare_lower0_0_flds_we[0]),
     .q      (reg2hw.compare_lower0_0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (compare_lower0_0_qs)
@@ -372,6 +379,7 @@ module rv_timer_reg_top (
     // to internal hardware
     .qe     (compare_upper0_0_flds_we[0]),
     .q      (reg2hw.compare_upper0_0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (compare_upper0_0_qs)
@@ -400,6 +408,7 @@ module rv_timer_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable0[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable0_qs)
@@ -427,6 +436,7 @@ module rv_timer_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state0[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state0_qs)
@@ -448,6 +458,7 @@ module rv_timer_reg_top (
     .qre    (),
     .qe     (intr_test0_flds_we[0]),
     .q      (reg2hw.intr_test0[0].q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test0[0].qe = intr_test0_qe;

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1577,6 +1577,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.generic_rx_full.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_generic_rx_full_qs)
@@ -1602,6 +1603,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.generic_rx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_generic_rx_watermark_qs)
@@ -1627,6 +1629,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.generic_tx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_generic_tx_watermark_qs)
@@ -1652,6 +1655,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.generic_rx_error.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_generic_rx_error_qs)
@@ -1677,6 +1681,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.generic_rx_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_generic_rx_overflow_qs)
@@ -1702,6 +1707,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.generic_tx_underflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_generic_tx_underflow_qs)
@@ -1727,6 +1733,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.upload_cmdfifo_not_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_upload_cmdfifo_not_empty_qs)
@@ -1752,6 +1759,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.upload_payload_not_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_upload_payload_not_empty_qs)
@@ -1777,6 +1785,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.upload_payload_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_upload_payload_overflow_qs)
@@ -1802,6 +1811,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.readbuf_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_readbuf_watermark_qs)
@@ -1827,6 +1837,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.readbuf_flip.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_readbuf_flip_qs)
@@ -1852,6 +1863,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.tpm_header_not_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_tpm_header_not_empty_qs)
@@ -1879,6 +1891,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.generic_rx_full.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_generic_rx_full_qs)
@@ -1904,6 +1917,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.generic_rx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_generic_rx_watermark_qs)
@@ -1929,6 +1943,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.generic_tx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_generic_tx_watermark_qs)
@@ -1954,6 +1969,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.generic_rx_error.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_generic_rx_error_qs)
@@ -1979,6 +1995,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.generic_rx_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_generic_rx_overflow_qs)
@@ -2004,6 +2021,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.generic_tx_underflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_generic_tx_underflow_qs)
@@ -2029,6 +2047,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.upload_cmdfifo_not_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_upload_cmdfifo_not_empty_qs)
@@ -2054,6 +2073,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.upload_payload_not_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_upload_payload_not_empty_qs)
@@ -2079,6 +2099,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.upload_payload_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_upload_payload_overflow_qs)
@@ -2104,6 +2125,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.readbuf_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_readbuf_watermark_qs)
@@ -2129,6 +2151,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.readbuf_flip.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_readbuf_flip_qs)
@@ -2154,6 +2177,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.tpm_header_not_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_tpm_header_not_empty_qs)
@@ -2175,6 +2199,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.generic_rx_full.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.generic_rx_full.qe = intr_test_qe;
@@ -2190,6 +2215,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.generic_rx_watermark.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.generic_rx_watermark.qe = intr_test_qe;
@@ -2205,6 +2231,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.generic_tx_watermark.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.generic_tx_watermark.qe = intr_test_qe;
@@ -2220,6 +2247,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.generic_rx_error.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.generic_rx_error.qe = intr_test_qe;
@@ -2235,6 +2263,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.generic_rx_overflow.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.generic_rx_overflow.qe = intr_test_qe;
@@ -2250,6 +2279,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.generic_tx_underflow.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.generic_tx_underflow.qe = intr_test_qe;
@@ -2265,6 +2295,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[6]),
     .q      (reg2hw.intr_test.upload_cmdfifo_not_empty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.upload_cmdfifo_not_empty.qe = intr_test_qe;
@@ -2280,6 +2311,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[7]),
     .q      (reg2hw.intr_test.upload_payload_not_empty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.upload_payload_not_empty.qe = intr_test_qe;
@@ -2295,6 +2327,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[8]),
     .q      (reg2hw.intr_test.upload_payload_overflow.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.upload_payload_overflow.qe = intr_test_qe;
@@ -2310,6 +2343,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[9]),
     .q      (reg2hw.intr_test.readbuf_watermark.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.readbuf_watermark.qe = intr_test_qe;
@@ -2325,6 +2359,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[10]),
     .q      (reg2hw.intr_test.readbuf_flip.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.readbuf_flip.qe = intr_test_qe;
@@ -2340,6 +2375,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[11]),
     .q      (reg2hw.intr_test.tpm_header_not_empty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.tpm_header_not_empty.qe = intr_test_qe;
@@ -2359,6 +2395,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -2385,6 +2422,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.abort.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_abort_qs)
@@ -2410,6 +2448,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_mode_qs)
@@ -2435,6 +2474,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.rst_txfifo.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_rst_txfifo_qs)
@@ -2460,6 +2500,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.rst_rxfifo.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_rst_rxfifo_qs)
@@ -2485,6 +2526,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.sram_clk_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_sram_clk_en_qs)
@@ -2512,6 +2554,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cfg.cpol.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_cpol_qs)
@@ -2537,6 +2580,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cfg.cpha.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_cpha_qs)
@@ -2562,6 +2606,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cfg.tx_order.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_tx_order_qs)
@@ -2587,6 +2632,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cfg.rx_order.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_rx_order_qs)
@@ -2612,6 +2658,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cfg.timer_v.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_timer_v_qs)
@@ -2637,6 +2684,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cfg.addr_4b_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_addr_4b_en_qs)
@@ -2662,6 +2710,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cfg.mailbox_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_mailbox_en_qs)
@@ -2689,6 +2738,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fifo_level.rxlvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_level_rxlvl_qs)
@@ -2714,6 +2764,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fifo_level.txlvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_level_txlvl_qs)
@@ -2732,6 +2783,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (async_fifo_level_rxlvl_qs)
   );
 
@@ -2746,6 +2798,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (async_fifo_level_txlvl_qs)
   );
 
@@ -2762,6 +2815,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_rxf_full_qs)
   );
 
@@ -2776,6 +2830,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_rxf_empty_qs)
   );
 
@@ -2790,6 +2845,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_txf_full_qs)
   );
 
@@ -2804,6 +2860,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_txf_empty_qs)
   );
 
@@ -2818,6 +2875,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_abort_done_qs)
   );
 
@@ -2832,6 +2890,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (status_csb_qs)
   );
 
@@ -2857,6 +2916,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxf_ptr.rptr.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxf_ptr_rptr_qs)
@@ -2882,6 +2942,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxf_ptr_wptr_qs)
@@ -2909,6 +2970,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (txf_ptr_rptr_qs)
@@ -2934,6 +2996,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.txf_ptr.wptr.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (txf_ptr_wptr_qs)
@@ -2961,6 +3024,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxf_addr.base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxf_addr_base_qs)
@@ -2986,6 +3050,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxf_addr.limit.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxf_addr_limit_qs)
@@ -3013,6 +3078,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.txf_addr.base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (txf_addr_base_qs)
@@ -3038,6 +3104,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.txf_addr.limit.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (txf_addr_limit_qs)
@@ -3065,6 +3132,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intercept_en.status.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intercept_en_status_qs)
@@ -3090,6 +3158,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intercept_en.jedec.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intercept_en_jedec_qs)
@@ -3115,6 +3184,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intercept_en.sfdp.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intercept_en_sfdp_qs)
@@ -3140,6 +3210,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intercept_en.mbx.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intercept_en_mbx_qs)
@@ -3157,6 +3228,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (last_read_addr_qs)
   );
 
@@ -3176,6 +3248,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (flash_status_flds_we[0]),
     .q      (reg2hw.flash_status.busy.q),
+    .ds     (),
     .qs     (flash_status_busy_qs)
   );
   assign reg2hw.flash_status.busy.qe = flash_status_qe;
@@ -3191,6 +3264,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (flash_status_flds_we[1]),
     .q      (reg2hw.flash_status.status.q),
+    .ds     (),
     .qs     (flash_status_status_qs)
   );
   assign reg2hw.flash_status.status.qe = flash_status_qe;
@@ -3217,6 +3291,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.jedec_cc.cc.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (jedec_cc_cc_qs)
@@ -3242,6 +3317,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.jedec_cc.num_cc.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (jedec_cc_num_cc_qs)
@@ -3269,6 +3345,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.jedec_id.id.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (jedec_id_id_qs)
@@ -3294,6 +3371,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.jedec_id.mf.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (jedec_id_mf_qs)
@@ -3320,6 +3398,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.read_threshold.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (read_threshold_qs)
@@ -3346,6 +3425,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mailbox_addr.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mailbox_addr_qs)
@@ -3373,6 +3453,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (upload_status_cmdfifo_depth_qs)
@@ -3398,6 +3479,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (upload_status_cmdfifo_notempty_qs)
@@ -3423,6 +3505,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (upload_status_addrfifo_depth_qs)
@@ -3448,6 +3531,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (upload_status_addrfifo_notempty_qs)
@@ -3475,6 +3559,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (upload_status2_payload_depth_qs)
@@ -3500,6 +3585,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (upload_status2_payload_start_idx_qs)
@@ -3517,6 +3603,7 @@ module spi_device_reg_top (
     .qre    (reg2hw.upload_cmdfifo.re),
     .qe     (),
     .q      (reg2hw.upload_cmdfifo.q),
+    .ds     (),
     .qs     (upload_cmdfifo_qs)
   );
 
@@ -3532,6 +3619,7 @@ module spi_device_reg_top (
     .qre    (reg2hw.upload_addrfifo.re),
     .qe     (),
     .q      (reg2hw.upload_addrfifo.q),
+    .ds     (),
     .qs     (upload_addrfifo_qs)
   );
 
@@ -3558,6 +3646,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_0_qs)
@@ -3583,6 +3672,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_1_qs)
@@ -3608,6 +3698,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_2_qs)
@@ -3633,6 +3724,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_3_qs)
@@ -3658,6 +3750,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_4_qs)
@@ -3683,6 +3776,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_5_qs)
@@ -3708,6 +3802,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_6_qs)
@@ -3733,6 +3828,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_7_qs)
@@ -3758,6 +3854,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_8_qs)
@@ -3783,6 +3880,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_9_qs)
@@ -3808,6 +3906,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_10_qs)
@@ -3833,6 +3932,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_11_qs)
@@ -3858,6 +3958,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_12_qs)
@@ -3883,6 +3984,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_13_qs)
@@ -3908,6 +4010,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_14_qs)
@@ -3933,6 +4036,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_15_qs)
@@ -3958,6 +4062,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_16_qs)
@@ -3983,6 +4088,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_17_qs)
@@ -4008,6 +4114,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_18_qs)
@@ -4033,6 +4140,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_19_qs)
@@ -4058,6 +4166,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_20_qs)
@@ -4083,6 +4192,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_21_qs)
@@ -4108,6 +4218,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_22_qs)
@@ -4133,6 +4244,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_23_qs)
@@ -4158,6 +4270,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_24_qs)
@@ -4183,6 +4296,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_25_qs)
@@ -4208,6 +4322,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_26_qs)
@@ -4233,6 +4348,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_27_qs)
@@ -4258,6 +4374,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_28_qs)
@@ -4283,6 +4400,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_29_qs)
@@ -4308,6 +4426,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_30_qs)
@@ -4333,6 +4452,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_0_filter_31_qs)
@@ -4361,6 +4481,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_32_qs)
@@ -4386,6 +4507,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_33_qs)
@@ -4411,6 +4533,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_34_qs)
@@ -4436,6 +4559,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_35_qs)
@@ -4461,6 +4585,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_36_qs)
@@ -4486,6 +4611,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_37_qs)
@@ -4511,6 +4637,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_38_qs)
@@ -4536,6 +4663,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_39_qs)
@@ -4561,6 +4689,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_40_qs)
@@ -4586,6 +4715,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_41_qs)
@@ -4611,6 +4741,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_42_qs)
@@ -4636,6 +4767,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_43_qs)
@@ -4661,6 +4793,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_44_qs)
@@ -4686,6 +4819,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_45_qs)
@@ -4711,6 +4845,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_46_qs)
@@ -4736,6 +4871,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[47].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_47_qs)
@@ -4761,6 +4897,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[48].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_48_qs)
@@ -4786,6 +4923,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[49].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_49_qs)
@@ -4811,6 +4949,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[50].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_50_qs)
@@ -4836,6 +4975,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[51].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_51_qs)
@@ -4861,6 +5001,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[52].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_52_qs)
@@ -4886,6 +5027,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[53].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_53_qs)
@@ -4911,6 +5053,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[54].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_54_qs)
@@ -4936,6 +5079,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[55].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_55_qs)
@@ -4961,6 +5105,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[56].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_56_qs)
@@ -4986,6 +5131,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[57].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_57_qs)
@@ -5011,6 +5157,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[58].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_58_qs)
@@ -5036,6 +5183,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[59].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_59_qs)
@@ -5061,6 +5209,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[60].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_60_qs)
@@ -5086,6 +5235,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[61].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_61_qs)
@@ -5111,6 +5261,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[62].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_62_qs)
@@ -5136,6 +5287,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[63].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_1_filter_63_qs)
@@ -5164,6 +5316,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[64].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_64_qs)
@@ -5189,6 +5342,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[65].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_65_qs)
@@ -5214,6 +5368,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[66].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_66_qs)
@@ -5239,6 +5394,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[67].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_67_qs)
@@ -5264,6 +5420,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[68].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_68_qs)
@@ -5289,6 +5446,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[69].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_69_qs)
@@ -5314,6 +5472,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[70].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_70_qs)
@@ -5339,6 +5498,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[71].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_71_qs)
@@ -5364,6 +5524,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[72].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_72_qs)
@@ -5389,6 +5550,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[73].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_73_qs)
@@ -5414,6 +5576,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[74].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_74_qs)
@@ -5439,6 +5602,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[75].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_75_qs)
@@ -5464,6 +5628,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[76].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_76_qs)
@@ -5489,6 +5654,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[77].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_77_qs)
@@ -5514,6 +5680,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[78].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_78_qs)
@@ -5539,6 +5706,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[79].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_79_qs)
@@ -5564,6 +5732,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[80].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_80_qs)
@@ -5589,6 +5758,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[81].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_81_qs)
@@ -5614,6 +5784,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[82].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_82_qs)
@@ -5639,6 +5810,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[83].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_83_qs)
@@ -5664,6 +5836,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[84].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_84_qs)
@@ -5689,6 +5862,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[85].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_85_qs)
@@ -5714,6 +5888,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[86].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_86_qs)
@@ -5739,6 +5914,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[87].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_87_qs)
@@ -5764,6 +5940,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[88].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_88_qs)
@@ -5789,6 +5966,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[89].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_89_qs)
@@ -5814,6 +5992,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[90].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_90_qs)
@@ -5839,6 +6018,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[91].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_91_qs)
@@ -5864,6 +6044,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[92].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_92_qs)
@@ -5889,6 +6070,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[93].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_93_qs)
@@ -5914,6 +6096,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[94].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_94_qs)
@@ -5939,6 +6122,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[95].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_2_filter_95_qs)
@@ -5967,6 +6151,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[96].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_96_qs)
@@ -5992,6 +6177,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[97].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_97_qs)
@@ -6017,6 +6203,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[98].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_98_qs)
@@ -6042,6 +6229,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[99].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_99_qs)
@@ -6067,6 +6255,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[100].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_100_qs)
@@ -6092,6 +6281,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[101].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_101_qs)
@@ -6117,6 +6307,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[102].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_102_qs)
@@ -6142,6 +6333,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[103].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_103_qs)
@@ -6167,6 +6359,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[104].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_104_qs)
@@ -6192,6 +6385,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[105].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_105_qs)
@@ -6217,6 +6411,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[106].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_106_qs)
@@ -6242,6 +6437,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[107].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_107_qs)
@@ -6267,6 +6463,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[108].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_108_qs)
@@ -6292,6 +6489,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[109].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_109_qs)
@@ -6317,6 +6515,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[110].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_110_qs)
@@ -6342,6 +6541,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[111].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_111_qs)
@@ -6367,6 +6567,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[112].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_112_qs)
@@ -6392,6 +6593,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[113].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_113_qs)
@@ -6417,6 +6619,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[114].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_114_qs)
@@ -6442,6 +6645,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[115].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_115_qs)
@@ -6467,6 +6671,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[116].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_116_qs)
@@ -6492,6 +6697,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[117].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_117_qs)
@@ -6517,6 +6723,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[118].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_118_qs)
@@ -6542,6 +6749,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[119].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_119_qs)
@@ -6567,6 +6775,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[120].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_120_qs)
@@ -6592,6 +6801,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[121].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_121_qs)
@@ -6617,6 +6827,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[122].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_122_qs)
@@ -6642,6 +6853,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[123].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_123_qs)
@@ -6667,6 +6879,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[124].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_124_qs)
@@ -6692,6 +6905,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[125].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_125_qs)
@@ -6717,6 +6931,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[126].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_126_qs)
@@ -6742,6 +6957,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[127].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_3_filter_127_qs)
@@ -6770,6 +6986,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[128].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_128_qs)
@@ -6795,6 +7012,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[129].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_129_qs)
@@ -6820,6 +7038,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[130].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_130_qs)
@@ -6845,6 +7064,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[131].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_131_qs)
@@ -6870,6 +7090,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[132].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_132_qs)
@@ -6895,6 +7116,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[133].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_133_qs)
@@ -6920,6 +7142,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[134].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_134_qs)
@@ -6945,6 +7168,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[135].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_135_qs)
@@ -6970,6 +7194,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[136].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_136_qs)
@@ -6995,6 +7220,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[137].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_137_qs)
@@ -7020,6 +7246,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[138].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_138_qs)
@@ -7045,6 +7272,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[139].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_139_qs)
@@ -7070,6 +7298,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[140].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_140_qs)
@@ -7095,6 +7324,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[141].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_141_qs)
@@ -7120,6 +7350,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[142].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_142_qs)
@@ -7145,6 +7376,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[143].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_143_qs)
@@ -7170,6 +7402,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[144].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_144_qs)
@@ -7195,6 +7428,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[145].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_145_qs)
@@ -7220,6 +7454,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[146].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_146_qs)
@@ -7245,6 +7480,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[147].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_147_qs)
@@ -7270,6 +7506,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[148].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_148_qs)
@@ -7295,6 +7532,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[149].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_149_qs)
@@ -7320,6 +7558,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[150].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_150_qs)
@@ -7345,6 +7584,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[151].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_151_qs)
@@ -7370,6 +7610,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[152].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_152_qs)
@@ -7395,6 +7636,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[153].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_153_qs)
@@ -7420,6 +7662,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[154].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_154_qs)
@@ -7445,6 +7688,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[155].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_155_qs)
@@ -7470,6 +7714,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[156].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_156_qs)
@@ -7495,6 +7740,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[157].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_157_qs)
@@ -7520,6 +7766,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[158].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_158_qs)
@@ -7545,6 +7792,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[159].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_4_filter_159_qs)
@@ -7573,6 +7821,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[160].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_160_qs)
@@ -7598,6 +7847,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[161].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_161_qs)
@@ -7623,6 +7873,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[162].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_162_qs)
@@ -7648,6 +7899,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[163].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_163_qs)
@@ -7673,6 +7925,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[164].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_164_qs)
@@ -7698,6 +7951,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[165].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_165_qs)
@@ -7723,6 +7977,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[166].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_166_qs)
@@ -7748,6 +8003,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[167].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_167_qs)
@@ -7773,6 +8029,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[168].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_168_qs)
@@ -7798,6 +8055,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[169].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_169_qs)
@@ -7823,6 +8081,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[170].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_170_qs)
@@ -7848,6 +8107,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[171].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_171_qs)
@@ -7873,6 +8133,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[172].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_172_qs)
@@ -7898,6 +8159,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[173].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_173_qs)
@@ -7923,6 +8185,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[174].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_174_qs)
@@ -7948,6 +8211,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[175].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_175_qs)
@@ -7973,6 +8237,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[176].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_176_qs)
@@ -7998,6 +8263,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[177].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_177_qs)
@@ -8023,6 +8289,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[178].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_178_qs)
@@ -8048,6 +8315,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[179].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_179_qs)
@@ -8073,6 +8341,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[180].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_180_qs)
@@ -8098,6 +8367,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[181].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_181_qs)
@@ -8123,6 +8393,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[182].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_182_qs)
@@ -8148,6 +8419,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[183].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_183_qs)
@@ -8173,6 +8445,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[184].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_184_qs)
@@ -8198,6 +8471,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[185].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_185_qs)
@@ -8223,6 +8497,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[186].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_186_qs)
@@ -8248,6 +8523,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[187].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_187_qs)
@@ -8273,6 +8549,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[188].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_188_qs)
@@ -8298,6 +8575,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[189].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_189_qs)
@@ -8323,6 +8601,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[190].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_190_qs)
@@ -8348,6 +8627,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[191].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_5_filter_191_qs)
@@ -8376,6 +8656,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[192].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_192_qs)
@@ -8401,6 +8682,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[193].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_193_qs)
@@ -8426,6 +8708,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[194].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_194_qs)
@@ -8451,6 +8734,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[195].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_195_qs)
@@ -8476,6 +8760,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[196].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_196_qs)
@@ -8501,6 +8786,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[197].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_197_qs)
@@ -8526,6 +8812,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[198].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_198_qs)
@@ -8551,6 +8838,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[199].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_199_qs)
@@ -8576,6 +8864,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[200].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_200_qs)
@@ -8601,6 +8890,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[201].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_201_qs)
@@ -8626,6 +8916,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[202].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_202_qs)
@@ -8651,6 +8942,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[203].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_203_qs)
@@ -8676,6 +8968,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[204].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_204_qs)
@@ -8701,6 +8994,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[205].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_205_qs)
@@ -8726,6 +9020,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[206].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_206_qs)
@@ -8751,6 +9046,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[207].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_207_qs)
@@ -8776,6 +9072,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[208].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_208_qs)
@@ -8801,6 +9098,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[209].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_209_qs)
@@ -8826,6 +9124,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[210].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_210_qs)
@@ -8851,6 +9150,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[211].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_211_qs)
@@ -8876,6 +9176,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[212].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_212_qs)
@@ -8901,6 +9202,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[213].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_213_qs)
@@ -8926,6 +9228,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[214].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_214_qs)
@@ -8951,6 +9254,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[215].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_215_qs)
@@ -8976,6 +9280,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[216].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_216_qs)
@@ -9001,6 +9306,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[217].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_217_qs)
@@ -9026,6 +9332,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[218].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_218_qs)
@@ -9051,6 +9358,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[219].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_219_qs)
@@ -9076,6 +9384,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[220].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_220_qs)
@@ -9101,6 +9410,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[221].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_221_qs)
@@ -9126,6 +9436,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[222].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_222_qs)
@@ -9151,6 +9462,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[223].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_6_filter_223_qs)
@@ -9179,6 +9491,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[224].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_224_qs)
@@ -9204,6 +9517,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[225].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_225_qs)
@@ -9229,6 +9543,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[226].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_226_qs)
@@ -9254,6 +9569,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[227].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_227_qs)
@@ -9279,6 +9595,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[228].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_228_qs)
@@ -9304,6 +9621,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[229].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_229_qs)
@@ -9329,6 +9647,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[230].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_230_qs)
@@ -9354,6 +9673,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[231].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_231_qs)
@@ -9379,6 +9699,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[232].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_232_qs)
@@ -9404,6 +9725,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[233].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_233_qs)
@@ -9429,6 +9751,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[234].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_234_qs)
@@ -9454,6 +9777,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[235].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_235_qs)
@@ -9479,6 +9803,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[236].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_236_qs)
@@ -9504,6 +9829,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[237].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_237_qs)
@@ -9529,6 +9855,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[238].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_238_qs)
@@ -9554,6 +9881,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[239].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_239_qs)
@@ -9579,6 +9907,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[240].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_240_qs)
@@ -9604,6 +9933,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[241].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_241_qs)
@@ -9629,6 +9959,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[242].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_242_qs)
@@ -9654,6 +9985,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[243].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_243_qs)
@@ -9679,6 +10011,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[244].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_244_qs)
@@ -9704,6 +10037,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[245].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_245_qs)
@@ -9729,6 +10063,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[246].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_246_qs)
@@ -9754,6 +10089,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[247].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_247_qs)
@@ -9779,6 +10115,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[248].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_248_qs)
@@ -9804,6 +10141,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[249].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_249_qs)
@@ -9829,6 +10167,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[250].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_250_qs)
@@ -9854,6 +10193,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[251].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_251_qs)
@@ -9879,6 +10219,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[252].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_252_qs)
@@ -9904,6 +10245,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[253].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_253_qs)
@@ -9929,6 +10271,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[254].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_254_qs)
@@ -9954,6 +10297,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_filter[255].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_filter_7_filter_255_qs)
@@ -9980,6 +10324,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.addr_swap_mask.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (addr_swap_mask_qs)
@@ -10006,6 +10351,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.addr_swap_data.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (addr_swap_data_qs)
@@ -10032,6 +10378,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.payload_swap_mask.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (payload_swap_mask_qs)
@@ -10058,6 +10405,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.payload_swap_data.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (payload_swap_data_qs)
@@ -10086,6 +10434,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_opcode_0_qs)
@@ -10111,6 +10460,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_addr_mode_0_qs)
@@ -10136,6 +10486,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_addr_swap_en_0_qs)
@@ -10161,6 +10512,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_mbyte_en_0_qs)
@@ -10186,6 +10538,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_dummy_size_0_qs)
@@ -10211,6 +10564,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_dummy_en_0_qs)
@@ -10236,6 +10590,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_payload_en_0_qs)
@@ -10261,6 +10616,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_payload_dir_0_qs)
@@ -10286,6 +10642,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_payload_swap_en_0_qs)
@@ -10311,6 +10668,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_upload_0_qs)
@@ -10336,6 +10694,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_busy_0_qs)
@@ -10361,6 +10720,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[0].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_0_valid_0_qs)
@@ -10389,6 +10749,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_opcode_1_qs)
@@ -10414,6 +10775,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_addr_mode_1_qs)
@@ -10439,6 +10801,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_addr_swap_en_1_qs)
@@ -10464,6 +10827,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_mbyte_en_1_qs)
@@ -10489,6 +10853,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_dummy_size_1_qs)
@@ -10514,6 +10879,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_dummy_en_1_qs)
@@ -10539,6 +10905,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_payload_en_1_qs)
@@ -10564,6 +10931,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_payload_dir_1_qs)
@@ -10589,6 +10957,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_payload_swap_en_1_qs)
@@ -10614,6 +10983,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_upload_1_qs)
@@ -10639,6 +11009,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_busy_1_qs)
@@ -10664,6 +11035,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[1].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_1_valid_1_qs)
@@ -10692,6 +11064,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_opcode_2_qs)
@@ -10717,6 +11090,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_addr_mode_2_qs)
@@ -10742,6 +11116,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_addr_swap_en_2_qs)
@@ -10767,6 +11142,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_mbyte_en_2_qs)
@@ -10792,6 +11168,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_dummy_size_2_qs)
@@ -10817,6 +11194,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_dummy_en_2_qs)
@@ -10842,6 +11220,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_payload_en_2_qs)
@@ -10867,6 +11246,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_payload_dir_2_qs)
@@ -10892,6 +11272,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_payload_swap_en_2_qs)
@@ -10917,6 +11298,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_upload_2_qs)
@@ -10942,6 +11324,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_busy_2_qs)
@@ -10967,6 +11350,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[2].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_2_valid_2_qs)
@@ -10995,6 +11379,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_opcode_3_qs)
@@ -11020,6 +11405,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_addr_mode_3_qs)
@@ -11045,6 +11431,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_addr_swap_en_3_qs)
@@ -11070,6 +11457,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_mbyte_en_3_qs)
@@ -11095,6 +11483,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_dummy_size_3_qs)
@@ -11120,6 +11509,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_dummy_en_3_qs)
@@ -11145,6 +11535,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_payload_en_3_qs)
@@ -11170,6 +11561,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_payload_dir_3_qs)
@@ -11195,6 +11587,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_payload_swap_en_3_qs)
@@ -11220,6 +11613,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_upload_3_qs)
@@ -11245,6 +11639,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_busy_3_qs)
@@ -11270,6 +11665,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[3].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_3_valid_3_qs)
@@ -11298,6 +11694,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_opcode_4_qs)
@@ -11323,6 +11720,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_addr_mode_4_qs)
@@ -11348,6 +11746,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_addr_swap_en_4_qs)
@@ -11373,6 +11772,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_mbyte_en_4_qs)
@@ -11398,6 +11798,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_dummy_size_4_qs)
@@ -11423,6 +11824,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_dummy_en_4_qs)
@@ -11448,6 +11850,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_payload_en_4_qs)
@@ -11473,6 +11876,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_payload_dir_4_qs)
@@ -11498,6 +11902,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_payload_swap_en_4_qs)
@@ -11523,6 +11928,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_upload_4_qs)
@@ -11548,6 +11954,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_busy_4_qs)
@@ -11573,6 +11980,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[4].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_4_valid_4_qs)
@@ -11601,6 +12009,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_opcode_5_qs)
@@ -11626,6 +12035,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_addr_mode_5_qs)
@@ -11651,6 +12061,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_addr_swap_en_5_qs)
@@ -11676,6 +12087,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_mbyte_en_5_qs)
@@ -11701,6 +12113,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_dummy_size_5_qs)
@@ -11726,6 +12139,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_dummy_en_5_qs)
@@ -11751,6 +12165,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_payload_en_5_qs)
@@ -11776,6 +12191,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_payload_dir_5_qs)
@@ -11801,6 +12217,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_payload_swap_en_5_qs)
@@ -11826,6 +12243,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_upload_5_qs)
@@ -11851,6 +12269,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_busy_5_qs)
@@ -11876,6 +12295,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[5].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_5_valid_5_qs)
@@ -11904,6 +12324,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_opcode_6_qs)
@@ -11929,6 +12350,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_addr_mode_6_qs)
@@ -11954,6 +12376,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_addr_swap_en_6_qs)
@@ -11979,6 +12402,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_mbyte_en_6_qs)
@@ -12004,6 +12428,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_dummy_size_6_qs)
@@ -12029,6 +12454,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_dummy_en_6_qs)
@@ -12054,6 +12480,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_payload_en_6_qs)
@@ -12079,6 +12506,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_payload_dir_6_qs)
@@ -12104,6 +12532,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_payload_swap_en_6_qs)
@@ -12129,6 +12558,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_upload_6_qs)
@@ -12154,6 +12584,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_busy_6_qs)
@@ -12179,6 +12610,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[6].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_6_valid_6_qs)
@@ -12207,6 +12639,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_opcode_7_qs)
@@ -12232,6 +12665,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_addr_mode_7_qs)
@@ -12257,6 +12691,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_addr_swap_en_7_qs)
@@ -12282,6 +12717,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_mbyte_en_7_qs)
@@ -12307,6 +12743,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_dummy_size_7_qs)
@@ -12332,6 +12769,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_dummy_en_7_qs)
@@ -12357,6 +12795,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_payload_en_7_qs)
@@ -12382,6 +12821,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_payload_dir_7_qs)
@@ -12407,6 +12847,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_payload_swap_en_7_qs)
@@ -12432,6 +12873,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_upload_7_qs)
@@ -12457,6 +12899,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_busy_7_qs)
@@ -12482,6 +12925,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[7].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_7_valid_7_qs)
@@ -12510,6 +12954,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_opcode_8_qs)
@@ -12535,6 +12980,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_addr_mode_8_qs)
@@ -12560,6 +13006,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_addr_swap_en_8_qs)
@@ -12585,6 +13032,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_mbyte_en_8_qs)
@@ -12610,6 +13058,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_dummy_size_8_qs)
@@ -12635,6 +13084,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_dummy_en_8_qs)
@@ -12660,6 +13110,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_payload_en_8_qs)
@@ -12685,6 +13136,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_payload_dir_8_qs)
@@ -12710,6 +13162,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_payload_swap_en_8_qs)
@@ -12735,6 +13188,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_upload_8_qs)
@@ -12760,6 +13214,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_busy_8_qs)
@@ -12785,6 +13240,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[8].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_8_valid_8_qs)
@@ -12813,6 +13269,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_opcode_9_qs)
@@ -12838,6 +13295,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_addr_mode_9_qs)
@@ -12863,6 +13321,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_addr_swap_en_9_qs)
@@ -12888,6 +13347,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_mbyte_en_9_qs)
@@ -12913,6 +13373,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_dummy_size_9_qs)
@@ -12938,6 +13399,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_dummy_en_9_qs)
@@ -12963,6 +13425,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_payload_en_9_qs)
@@ -12988,6 +13451,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_payload_dir_9_qs)
@@ -13013,6 +13477,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_payload_swap_en_9_qs)
@@ -13038,6 +13503,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_upload_9_qs)
@@ -13063,6 +13529,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_busy_9_qs)
@@ -13088,6 +13555,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[9].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_9_valid_9_qs)
@@ -13116,6 +13584,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_opcode_10_qs)
@@ -13141,6 +13610,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_addr_mode_10_qs)
@@ -13166,6 +13636,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_addr_swap_en_10_qs)
@@ -13191,6 +13662,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_mbyte_en_10_qs)
@@ -13216,6 +13688,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_dummy_size_10_qs)
@@ -13241,6 +13714,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_dummy_en_10_qs)
@@ -13266,6 +13740,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_payload_en_10_qs)
@@ -13291,6 +13766,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_payload_dir_10_qs)
@@ -13316,6 +13792,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_payload_swap_en_10_qs)
@@ -13341,6 +13818,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_upload_10_qs)
@@ -13366,6 +13844,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_busy_10_qs)
@@ -13391,6 +13870,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[10].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_10_valid_10_qs)
@@ -13419,6 +13899,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_opcode_11_qs)
@@ -13444,6 +13925,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_addr_mode_11_qs)
@@ -13469,6 +13951,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_addr_swap_en_11_qs)
@@ -13494,6 +13977,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_mbyte_en_11_qs)
@@ -13519,6 +14003,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_dummy_size_11_qs)
@@ -13544,6 +14029,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_dummy_en_11_qs)
@@ -13569,6 +14055,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_payload_en_11_qs)
@@ -13594,6 +14081,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_payload_dir_11_qs)
@@ -13619,6 +14107,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_payload_swap_en_11_qs)
@@ -13644,6 +14133,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_upload_11_qs)
@@ -13669,6 +14159,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_busy_11_qs)
@@ -13694,6 +14185,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[11].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_11_valid_11_qs)
@@ -13722,6 +14214,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_opcode_12_qs)
@@ -13747,6 +14240,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_addr_mode_12_qs)
@@ -13772,6 +14266,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_addr_swap_en_12_qs)
@@ -13797,6 +14292,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_mbyte_en_12_qs)
@@ -13822,6 +14318,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_dummy_size_12_qs)
@@ -13847,6 +14344,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_dummy_en_12_qs)
@@ -13872,6 +14370,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_payload_en_12_qs)
@@ -13897,6 +14396,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_payload_dir_12_qs)
@@ -13922,6 +14422,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_payload_swap_en_12_qs)
@@ -13947,6 +14448,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_upload_12_qs)
@@ -13972,6 +14474,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_busy_12_qs)
@@ -13997,6 +14500,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[12].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_12_valid_12_qs)
@@ -14025,6 +14529,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_opcode_13_qs)
@@ -14050,6 +14555,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_addr_mode_13_qs)
@@ -14075,6 +14581,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_addr_swap_en_13_qs)
@@ -14100,6 +14607,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_mbyte_en_13_qs)
@@ -14125,6 +14633,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_dummy_size_13_qs)
@@ -14150,6 +14659,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_dummy_en_13_qs)
@@ -14175,6 +14685,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_payload_en_13_qs)
@@ -14200,6 +14711,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_payload_dir_13_qs)
@@ -14225,6 +14737,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_payload_swap_en_13_qs)
@@ -14250,6 +14763,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_upload_13_qs)
@@ -14275,6 +14789,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_busy_13_qs)
@@ -14300,6 +14815,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[13].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_13_valid_13_qs)
@@ -14328,6 +14844,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_opcode_14_qs)
@@ -14353,6 +14870,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_addr_mode_14_qs)
@@ -14378,6 +14896,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_addr_swap_en_14_qs)
@@ -14403,6 +14922,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_mbyte_en_14_qs)
@@ -14428,6 +14948,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_dummy_size_14_qs)
@@ -14453,6 +14974,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_dummy_en_14_qs)
@@ -14478,6 +15000,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_payload_en_14_qs)
@@ -14503,6 +15026,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_payload_dir_14_qs)
@@ -14528,6 +15052,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_payload_swap_en_14_qs)
@@ -14553,6 +15078,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_upload_14_qs)
@@ -14578,6 +15104,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_busy_14_qs)
@@ -14603,6 +15130,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[14].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_14_valid_14_qs)
@@ -14631,6 +15159,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_opcode_15_qs)
@@ -14656,6 +15185,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_addr_mode_15_qs)
@@ -14681,6 +15211,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_addr_swap_en_15_qs)
@@ -14706,6 +15237,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_mbyte_en_15_qs)
@@ -14731,6 +15263,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_dummy_size_15_qs)
@@ -14756,6 +15289,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_dummy_en_15_qs)
@@ -14781,6 +15315,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_payload_en_15_qs)
@@ -14806,6 +15341,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_payload_dir_15_qs)
@@ -14831,6 +15367,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_payload_swap_en_15_qs)
@@ -14856,6 +15393,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_upload_15_qs)
@@ -14881,6 +15419,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_busy_15_qs)
@@ -14906,6 +15445,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[15].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_15_valid_15_qs)
@@ -14934,6 +15474,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_opcode_16_qs)
@@ -14959,6 +15500,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_addr_mode_16_qs)
@@ -14984,6 +15526,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_addr_swap_en_16_qs)
@@ -15009,6 +15552,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_mbyte_en_16_qs)
@@ -15034,6 +15578,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_dummy_size_16_qs)
@@ -15059,6 +15604,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_dummy_en_16_qs)
@@ -15084,6 +15630,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_payload_en_16_qs)
@@ -15109,6 +15656,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_payload_dir_16_qs)
@@ -15134,6 +15682,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_payload_swap_en_16_qs)
@@ -15159,6 +15708,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_upload_16_qs)
@@ -15184,6 +15734,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_busy_16_qs)
@@ -15209,6 +15760,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[16].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_16_valid_16_qs)
@@ -15237,6 +15789,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_opcode_17_qs)
@@ -15262,6 +15815,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_addr_mode_17_qs)
@@ -15287,6 +15841,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_addr_swap_en_17_qs)
@@ -15312,6 +15867,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_mbyte_en_17_qs)
@@ -15337,6 +15893,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_dummy_size_17_qs)
@@ -15362,6 +15919,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_dummy_en_17_qs)
@@ -15387,6 +15945,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_payload_en_17_qs)
@@ -15412,6 +15971,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_payload_dir_17_qs)
@@ -15437,6 +15997,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_payload_swap_en_17_qs)
@@ -15462,6 +16023,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_upload_17_qs)
@@ -15487,6 +16049,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_busy_17_qs)
@@ -15512,6 +16075,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[17].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_17_valid_17_qs)
@@ -15540,6 +16104,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_opcode_18_qs)
@@ -15565,6 +16130,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_addr_mode_18_qs)
@@ -15590,6 +16156,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_addr_swap_en_18_qs)
@@ -15615,6 +16182,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_mbyte_en_18_qs)
@@ -15640,6 +16208,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_dummy_size_18_qs)
@@ -15665,6 +16234,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_dummy_en_18_qs)
@@ -15690,6 +16260,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_payload_en_18_qs)
@@ -15715,6 +16286,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_payload_dir_18_qs)
@@ -15740,6 +16312,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_payload_swap_en_18_qs)
@@ -15765,6 +16338,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_upload_18_qs)
@@ -15790,6 +16364,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_busy_18_qs)
@@ -15815,6 +16390,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[18].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_18_valid_18_qs)
@@ -15843,6 +16419,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_opcode_19_qs)
@@ -15868,6 +16445,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_addr_mode_19_qs)
@@ -15893,6 +16471,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_addr_swap_en_19_qs)
@@ -15918,6 +16497,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_mbyte_en_19_qs)
@@ -15943,6 +16523,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_dummy_size_19_qs)
@@ -15968,6 +16549,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_dummy_en_19_qs)
@@ -15993,6 +16575,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_payload_en_19_qs)
@@ -16018,6 +16601,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_payload_dir_19_qs)
@@ -16043,6 +16627,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_payload_swap_en_19_qs)
@@ -16068,6 +16653,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_upload_19_qs)
@@ -16093,6 +16679,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_busy_19_qs)
@@ -16118,6 +16705,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[19].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_19_valid_19_qs)
@@ -16146,6 +16734,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_opcode_20_qs)
@@ -16171,6 +16760,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_addr_mode_20_qs)
@@ -16196,6 +16786,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_addr_swap_en_20_qs)
@@ -16221,6 +16812,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_mbyte_en_20_qs)
@@ -16246,6 +16838,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_dummy_size_20_qs)
@@ -16271,6 +16864,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_dummy_en_20_qs)
@@ -16296,6 +16890,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_payload_en_20_qs)
@@ -16321,6 +16916,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_payload_dir_20_qs)
@@ -16346,6 +16942,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_payload_swap_en_20_qs)
@@ -16371,6 +16968,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_upload_20_qs)
@@ -16396,6 +16994,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_busy_20_qs)
@@ -16421,6 +17020,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[20].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_20_valid_20_qs)
@@ -16449,6 +17049,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_opcode_21_qs)
@@ -16474,6 +17075,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_addr_mode_21_qs)
@@ -16499,6 +17101,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_addr_swap_en_21_qs)
@@ -16524,6 +17127,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_mbyte_en_21_qs)
@@ -16549,6 +17153,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_dummy_size_21_qs)
@@ -16574,6 +17179,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_dummy_en_21_qs)
@@ -16599,6 +17205,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_payload_en_21_qs)
@@ -16624,6 +17231,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_payload_dir_21_qs)
@@ -16649,6 +17257,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_payload_swap_en_21_qs)
@@ -16674,6 +17283,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_upload_21_qs)
@@ -16699,6 +17309,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_busy_21_qs)
@@ -16724,6 +17335,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[21].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_21_valid_21_qs)
@@ -16752,6 +17364,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_opcode_22_qs)
@@ -16777,6 +17390,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_addr_mode_22_qs)
@@ -16802,6 +17416,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_addr_swap_en_22_qs)
@@ -16827,6 +17442,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_mbyte_en_22_qs)
@@ -16852,6 +17468,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_dummy_size_22_qs)
@@ -16877,6 +17494,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_dummy_en_22_qs)
@@ -16902,6 +17520,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_payload_en_22_qs)
@@ -16927,6 +17546,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_payload_dir_22_qs)
@@ -16952,6 +17572,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_payload_swap_en_22_qs)
@@ -16977,6 +17598,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_upload_22_qs)
@@ -17002,6 +17624,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_busy_22_qs)
@@ -17027,6 +17650,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[22].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_22_valid_22_qs)
@@ -17055,6 +17679,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_opcode_23_qs)
@@ -17080,6 +17705,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].addr_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_addr_mode_23_qs)
@@ -17105,6 +17731,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].addr_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_addr_swap_en_23_qs)
@@ -17130,6 +17757,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].mbyte_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_mbyte_en_23_qs)
@@ -17155,6 +17783,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].dummy_size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_dummy_size_23_qs)
@@ -17180,6 +17809,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].dummy_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_dummy_en_23_qs)
@@ -17205,6 +17835,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].payload_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_payload_en_23_qs)
@@ -17230,6 +17861,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].payload_dir.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_payload_dir_23_qs)
@@ -17255,6 +17887,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].payload_swap_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_payload_swap_en_23_qs)
@@ -17280,6 +17913,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].upload.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_upload_23_qs)
@@ -17305,6 +17939,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].busy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_busy_23_qs)
@@ -17330,6 +17965,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info[23].valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_23_valid_23_qs)
@@ -17357,6 +17993,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info_en4b.opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_en4b_opcode_qs)
@@ -17382,6 +18019,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info_en4b.valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_en4b_valid_qs)
@@ -17409,6 +18047,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info_ex4b.opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_ex4b_opcode_qs)
@@ -17434,6 +18073,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info_ex4b.valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_ex4b_valid_qs)
@@ -17461,6 +18101,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info_wren.opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_wren_opcode_qs)
@@ -17486,6 +18127,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info_wren.valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_wren_valid_qs)
@@ -17513,6 +18155,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info_wrdi.opcode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_wrdi_opcode_qs)
@@ -17538,6 +18181,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cmd_info_wrdi.valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cmd_info_wrdi_valid_qs)
@@ -17565,6 +18209,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_cap_rev_qs)
@@ -17590,6 +18235,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_cap_locality_qs)
@@ -17615,6 +18261,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_cap_max_xfer_size_qs)
@@ -17642,6 +18289,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_cfg.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_cfg_en_qs)
@@ -17667,6 +18315,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_cfg.tpm_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_cfg_tpm_mode_qs)
@@ -17692,6 +18341,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_cfg.hw_reg_dis.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_cfg_hw_reg_dis_qs)
@@ -17717,6 +18367,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_cfg.tpm_reg_chk_dis.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_cfg_tpm_reg_chk_dis_qs)
@@ -17742,6 +18393,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_cfg.invalid_locality.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_cfg_invalid_locality_qs)
@@ -17769,6 +18421,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_status_cmdaddr_notempty_qs)
@@ -17794,6 +18447,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_status_rdfifo_notempty_qs)
@@ -17819,6 +18473,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_status_rdfifo_depth_qs)
@@ -17844,6 +18499,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_status_wrfifo_depth_qs)
@@ -17872,6 +18528,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_access[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_access_0_access_0_qs)
@@ -17897,6 +18554,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_access[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_access_0_access_1_qs)
@@ -17922,6 +18580,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_access[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_access_0_access_2_qs)
@@ -17947,6 +18606,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_access[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_access_0_access_3_qs)
@@ -17974,6 +18634,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_access[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_access_1_qs)
@@ -18000,6 +18661,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_sts.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_sts_qs)
@@ -18026,6 +18688,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_intf_capability.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_intf_capability_qs)
@@ -18052,6 +18715,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_int_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_int_enable_qs)
@@ -18078,6 +18742,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_int_vector.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_int_vector_qs)
@@ -18104,6 +18769,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_int_status.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_int_status_qs)
@@ -18131,6 +18797,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_did_vid.vid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_did_vid_vid_qs)
@@ -18156,6 +18823,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_did_vid.did.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_did_vid_did_qs)
@@ -18182,6 +18850,7 @@ module spi_device_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.tpm_rid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (tpm_rid_qs)
@@ -18203,6 +18872,7 @@ module spi_device_reg_top (
     .qre    (reg2hw.tpm_cmd_addr.addr.re),
     .qe     (tpm_cmd_addr_flds_we[0]),
     .q      (reg2hw.tpm_cmd_addr.addr.q),
+    .ds     (),
     .qs     (tpm_cmd_addr_addr_qs)
   );
   assign reg2hw.tpm_cmd_addr.addr.qe = tpm_cmd_addr_qe;
@@ -18218,6 +18888,7 @@ module spi_device_reg_top (
     .qre    (reg2hw.tpm_cmd_addr.cmd.re),
     .qe     (tpm_cmd_addr_flds_we[1]),
     .q      (reg2hw.tpm_cmd_addr.cmd.q),
+    .ds     (),
     .qs     (tpm_cmd_addr_cmd_qs)
   );
   assign reg2hw.tpm_cmd_addr.cmd.qe = tpm_cmd_addr_qe;
@@ -18237,6 +18908,7 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (tpm_read_fifo_flds_we[0]),
     .q      (reg2hw.tpm_read_fifo.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.tpm_read_fifo.qe = tpm_read_fifo_qe;
@@ -18256,6 +18928,7 @@ module spi_device_reg_top (
     .qre    (reg2hw.tpm_write_fifo.re),
     .qe     (tpm_write_fifo_flds_we[0]),
     .q      (reg2hw.tpm_write_fifo.q),
+    .ds     (),
     .qs     (tpm_write_fifo_qs)
   );
   assign reg2hw.tpm_write_fifo.qe = tpm_write_fifo_qe;

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -303,6 +303,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.error.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_error_qs)
@@ -328,6 +329,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.spi_event.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_spi_event_qs)
@@ -355,6 +357,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.error.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_error_qs)
@@ -380,6 +383,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.spi_event.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_spi_event_qs)
@@ -401,6 +405,7 @@ module spi_host_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.error.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.error.qe = intr_test_qe;
@@ -416,6 +421,7 @@ module spi_host_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.spi_event.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.spi_event.qe = intr_test_qe;
@@ -435,6 +441,7 @@ module spi_host_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -461,6 +468,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.rx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_rx_watermark_qs)
@@ -486,6 +494,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.tx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_tx_watermark_qs)
@@ -511,6 +520,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.output_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_output_en_qs)
@@ -536,6 +546,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.sw_rst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_sw_rst_qs)
@@ -561,6 +572,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.spien.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_spien_qs)
@@ -588,6 +600,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_txqd_qs)
@@ -613,6 +626,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_rxqd_qs)
@@ -638,6 +652,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_cmdqd_qs)
@@ -663,6 +678,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_rxwm_qs)
@@ -688,6 +704,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_byteorder_qs)
@@ -713,6 +730,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_rxstall_qs)
@@ -738,6 +756,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_rxempty_qs)
@@ -763,6 +782,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_rxfull_qs)
@@ -788,6 +808,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_txwm_qs)
@@ -813,6 +834,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_txstall_qs)
@@ -838,6 +860,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_txempty_qs)
@@ -863,6 +886,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_txfull_qs)
@@ -888,6 +912,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_active_qs)
@@ -913,6 +938,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_ready_qs)
@@ -941,6 +967,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configopts[0].clkdiv.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configopts_clkdiv_0_qs)
@@ -966,6 +993,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configopts[0].csnidle.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configopts_csnidle_0_qs)
@@ -991,6 +1019,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configopts[0].csntrail.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configopts_csntrail_0_qs)
@@ -1016,6 +1045,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configopts[0].csnlead.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configopts_csnlead_0_qs)
@@ -1041,6 +1071,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configopts[0].fullcyc.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configopts_fullcyc_0_qs)
@@ -1066,6 +1097,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configopts[0].cpha.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configopts_cpha_0_qs)
@@ -1091,6 +1123,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configopts[0].cpol.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configopts_cpol_0_qs)
@@ -1117,6 +1150,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.csid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (csid_qs)
@@ -1138,6 +1172,7 @@ module spi_host_reg_top (
     .qre    (),
     .qe     (command_flds_we[0]),
     .q      (reg2hw.command.len.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.command.len.qe = command_qe;
@@ -1153,6 +1188,7 @@ module spi_host_reg_top (
     .qre    (),
     .qe     (command_flds_we[1]),
     .q      (reg2hw.command.csaat.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.command.csaat.qe = command_qe;
@@ -1168,6 +1204,7 @@ module spi_host_reg_top (
     .qre    (),
     .qe     (command_flds_we[2]),
     .q      (reg2hw.command.speed.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.command.speed.qe = command_qe;
@@ -1183,6 +1220,7 @@ module spi_host_reg_top (
     .qre    (),
     .qe     (command_flds_we[3]),
     .q      (reg2hw.command.direction.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.command.direction.qe = command_qe;
@@ -1209,6 +1247,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_enable.cmdbusy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_enable_cmdbusy_qs)
@@ -1234,6 +1273,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_enable.overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_enable_overflow_qs)
@@ -1259,6 +1299,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_enable.underflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_enable_underflow_qs)
@@ -1284,6 +1325,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_enable.cmdinval.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_enable_cmdinval_qs)
@@ -1309,6 +1351,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_enable.csidinval.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_enable_csidinval_qs)
@@ -1336,6 +1379,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_status.cmdbusy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_status_cmdbusy_qs)
@@ -1361,6 +1405,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_status.overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_status_overflow_qs)
@@ -1386,6 +1431,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_status.underflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_status_underflow_qs)
@@ -1411,6 +1457,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_status.cmdinval.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_status_cmdinval_qs)
@@ -1436,6 +1483,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_status.csidinval.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_status_csidinval_qs)
@@ -1461,6 +1509,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.error_status.accessinval.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (error_status_accessinval_qs)
@@ -1488,6 +1537,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.event_enable.rxfull.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (event_enable_rxfull_qs)
@@ -1513,6 +1563,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.event_enable.txempty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (event_enable_txempty_qs)
@@ -1538,6 +1589,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.event_enable.rxwm.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (event_enable_rxwm_qs)
@@ -1563,6 +1615,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.event_enable.txwm.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (event_enable_txwm_qs)
@@ -1588,6 +1641,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.event_enable.ready.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (event_enable_ready_qs)
@@ -1613,6 +1667,7 @@ module spi_host_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.event_enable.idle.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (event_enable_idle_qs)

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -157,6 +157,7 @@ module sram_ctrl_regs_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -183,6 +184,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.status.bus_integ_error.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_bus_integ_error_qs)
@@ -208,6 +210,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.status.init_error.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_init_error_qs)
@@ -233,6 +236,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.status.escalated.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_escalated_qs)
@@ -258,6 +262,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_scr_key_valid_qs)
@@ -283,6 +288,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.status.scr_key_seed_valid.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_scr_key_seed_valid_qs)
@@ -308,6 +314,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.status.init_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_init_done_qs)
@@ -334,6 +341,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exec_regwen_qs)
@@ -363,6 +371,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exec.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exec_qs)
@@ -389,6 +398,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_regwen_qs)
@@ -430,6 +440,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (ctrl_flds_we[0]),
     .q      (reg2hw.ctrl.renew_scr_key.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -456,6 +467,7 @@ module sram_ctrl_regs_reg_top (
     // to internal hardware
     .qe     (ctrl_flds_we[1]),
     .q      (reg2hw.ctrl.init.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -116,18 +116,6 @@ module sysrst_ctrl_reg_top (
   );
 
   // cdc oversampling signals
-    logic sync_aon_update;
-  prim_sync_reqack u_aon_tgl (
-    .clk_src_i(clk_aon_i),
-    .rst_src_ni(rst_aon_ni),
-    .clk_dst_i(clk_i),
-    .rst_dst_ni(rst_ni),
-    .req_chk_i(1'b1),
-    .src_req_i(1'b1),
-    .src_ack_o(),
-    .dst_req_o(sync_aon_update),
-    .dst_ack_i(sync_aon_update)
-  );
 
   assign reg_rdata = reg_rdata_next ;
   assign reg_error = (devmode_i & addrmiss) | wr_err | intg_err;
@@ -247,34 +235,36 @@ module sysrst_ctrl_reg_top (
   // CDC handling is done on a per-reg instead of per-field boundary.
 
   logic [15:0]  aon_ec_rst_ctl_qs_int;
-  logic [15:0] aon_ec_rst_ctl_d;
+  logic [15:0] aon_ec_rst_ctl_qs;
   logic [15:0] aon_ec_rst_ctl_wdata;
   logic aon_ec_rst_ctl_we;
   logic unused_aon_ec_rst_ctl_wdata;
   logic aon_ec_rst_ctl_regwen;
 
   always_comb begin
-    aon_ec_rst_ctl_d = '0;
-    aon_ec_rst_ctl_d = aon_ec_rst_ctl_qs_int;
+    aon_ec_rst_ctl_qs = 16'h7d0;
+    aon_ec_rst_ctl_qs = aon_ec_rst_ctl_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(16),
     .ResetVal(16'h7d0),
-    .BitMask(16'hffff)
+    .BitMask(16'hffff),
+    .DstWrReq(0)
   ) u_ec_rst_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (ec_rst_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[15:0]),
     .src_busy_o   (ec_rst_ctl_busy),
     .src_qs_o     (ec_rst_ctl_qs), // for software read back
-    .dst_d_i      (aon_ec_rst_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_ec_rst_ctl_qs),
     .dst_we_o     (aon_ec_rst_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_ec_rst_ctl_regwen),
@@ -284,34 +274,36 @@ module sysrst_ctrl_reg_top (
       ^aon_ec_rst_ctl_wdata;
 
   logic [15:0]  aon_ulp_ac_debounce_ctl_qs_int;
-  logic [15:0] aon_ulp_ac_debounce_ctl_d;
+  logic [15:0] aon_ulp_ac_debounce_ctl_qs;
   logic [15:0] aon_ulp_ac_debounce_ctl_wdata;
   logic aon_ulp_ac_debounce_ctl_we;
   logic unused_aon_ulp_ac_debounce_ctl_wdata;
   logic aon_ulp_ac_debounce_ctl_regwen;
 
   always_comb begin
-    aon_ulp_ac_debounce_ctl_d = '0;
-    aon_ulp_ac_debounce_ctl_d = aon_ulp_ac_debounce_ctl_qs_int;
+    aon_ulp_ac_debounce_ctl_qs = 16'h1f40;
+    aon_ulp_ac_debounce_ctl_qs = aon_ulp_ac_debounce_ctl_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(16),
     .ResetVal(16'h1f40),
-    .BitMask(16'hffff)
+    .BitMask(16'hffff),
+    .DstWrReq(0)
   ) u_ulp_ac_debounce_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (ulp_ac_debounce_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[15:0]),
     .src_busy_o   (ulp_ac_debounce_ctl_busy),
     .src_qs_o     (ulp_ac_debounce_ctl_qs), // for software read back
-    .dst_d_i      (aon_ulp_ac_debounce_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_ulp_ac_debounce_ctl_qs),
     .dst_we_o     (aon_ulp_ac_debounce_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_ulp_ac_debounce_ctl_regwen),
@@ -321,34 +313,36 @@ module sysrst_ctrl_reg_top (
       ^aon_ulp_ac_debounce_ctl_wdata;
 
   logic [15:0]  aon_ulp_lid_debounce_ctl_qs_int;
-  logic [15:0] aon_ulp_lid_debounce_ctl_d;
+  logic [15:0] aon_ulp_lid_debounce_ctl_qs;
   logic [15:0] aon_ulp_lid_debounce_ctl_wdata;
   logic aon_ulp_lid_debounce_ctl_we;
   logic unused_aon_ulp_lid_debounce_ctl_wdata;
   logic aon_ulp_lid_debounce_ctl_regwen;
 
   always_comb begin
-    aon_ulp_lid_debounce_ctl_d = '0;
-    aon_ulp_lid_debounce_ctl_d = aon_ulp_lid_debounce_ctl_qs_int;
+    aon_ulp_lid_debounce_ctl_qs = 16'h1f40;
+    aon_ulp_lid_debounce_ctl_qs = aon_ulp_lid_debounce_ctl_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(16),
     .ResetVal(16'h1f40),
-    .BitMask(16'hffff)
+    .BitMask(16'hffff),
+    .DstWrReq(0)
   ) u_ulp_lid_debounce_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (ulp_lid_debounce_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[15:0]),
     .src_busy_o   (ulp_lid_debounce_ctl_busy),
     .src_qs_o     (ulp_lid_debounce_ctl_qs), // for software read back
-    .dst_d_i      (aon_ulp_lid_debounce_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_ulp_lid_debounce_ctl_qs),
     .dst_we_o     (aon_ulp_lid_debounce_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_ulp_lid_debounce_ctl_regwen),
@@ -358,34 +352,36 @@ module sysrst_ctrl_reg_top (
       ^aon_ulp_lid_debounce_ctl_wdata;
 
   logic [15:0]  aon_ulp_pwrb_debounce_ctl_qs_int;
-  logic [15:0] aon_ulp_pwrb_debounce_ctl_d;
+  logic [15:0] aon_ulp_pwrb_debounce_ctl_qs;
   logic [15:0] aon_ulp_pwrb_debounce_ctl_wdata;
   logic aon_ulp_pwrb_debounce_ctl_we;
   logic unused_aon_ulp_pwrb_debounce_ctl_wdata;
   logic aon_ulp_pwrb_debounce_ctl_regwen;
 
   always_comb begin
-    aon_ulp_pwrb_debounce_ctl_d = '0;
-    aon_ulp_pwrb_debounce_ctl_d = aon_ulp_pwrb_debounce_ctl_qs_int;
+    aon_ulp_pwrb_debounce_ctl_qs = 16'h1f40;
+    aon_ulp_pwrb_debounce_ctl_qs = aon_ulp_pwrb_debounce_ctl_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(16),
     .ResetVal(16'h1f40),
-    .BitMask(16'hffff)
+    .BitMask(16'hffff),
+    .DstWrReq(0)
   ) u_ulp_pwrb_debounce_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (ulp_pwrb_debounce_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[15:0]),
     .src_busy_o   (ulp_pwrb_debounce_ctl_busy),
     .src_qs_o     (ulp_pwrb_debounce_ctl_qs), // for software read back
-    .dst_d_i      (aon_ulp_pwrb_debounce_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_ulp_pwrb_debounce_ctl_qs),
     .dst_we_o     (aon_ulp_pwrb_debounce_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_ulp_pwrb_debounce_ctl_regwen),
@@ -395,33 +391,35 @@ module sysrst_ctrl_reg_top (
       ^aon_ulp_pwrb_debounce_ctl_wdata;
 
   logic  aon_ulp_ctl_qs_int;
-  logic [0:0] aon_ulp_ctl_d;
+  logic [0:0] aon_ulp_ctl_qs;
   logic [0:0] aon_ulp_ctl_wdata;
   logic aon_ulp_ctl_we;
   logic unused_aon_ulp_ctl_wdata;
 
   always_comb begin
-    aon_ulp_ctl_d = '0;
-    aon_ulp_ctl_d = aon_ulp_ctl_qs_int;
+    aon_ulp_ctl_qs = 1'h0;
+    aon_ulp_ctl_qs = aon_ulp_ctl_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_ulp_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     (ulp_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (ulp_ctl_busy),
     .src_qs_o     (ulp_ctl_qs), // for software read back
-    .dst_d_i      (aon_ulp_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_ulp_ctl_qs),
     .dst_we_o     (aon_ulp_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -430,34 +428,41 @@ module sysrst_ctrl_reg_top (
   assign unused_aon_ulp_ctl_wdata =
       ^aon_ulp_ctl_wdata;
 
+  logic  aon_ulp_status_ds_int;
   logic  aon_ulp_status_qs_int;
-  logic [0:0] aon_ulp_status_d;
+  logic [0:0] aon_ulp_status_ds;
+  logic aon_ulp_status_qe;
+  logic [0:0] aon_ulp_status_qs;
   logic [0:0] aon_ulp_status_wdata;
   logic aon_ulp_status_we;
   logic unused_aon_ulp_status_wdata;
 
   always_comb begin
-    aon_ulp_status_d = '0;
-    aon_ulp_status_d = aon_ulp_status_qs_int;
+    aon_ulp_status_qs = 1'h0;
+    aon_ulp_status_ds = 1'h0;
+    aon_ulp_status_ds = aon_ulp_status_ds_int;
+    aon_ulp_status_qs = aon_ulp_status_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(1)
   ) u_ulp_status_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     (ulp_status_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (ulp_status_busy),
     .src_qs_o     (ulp_status_qs), // for software read back
-    .dst_d_i      (aon_ulp_status_d),
+    .dst_update_i (aon_ulp_status_qe),
+    .dst_ds_i     (aon_ulp_status_ds),
+    .dst_qs_i     (aon_ulp_status_qs),
     .dst_we_o     (aon_ulp_status_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -466,34 +471,41 @@ module sysrst_ctrl_reg_top (
   assign unused_aon_ulp_status_wdata =
       ^aon_ulp_status_wdata;
 
+  logic  aon_wkup_status_ds_int;
   logic  aon_wkup_status_qs_int;
-  logic [0:0] aon_wkup_status_d;
+  logic [0:0] aon_wkup_status_ds;
+  logic aon_wkup_status_qe;
+  logic [0:0] aon_wkup_status_qs;
   logic [0:0] aon_wkup_status_wdata;
   logic aon_wkup_status_we;
   logic unused_aon_wkup_status_wdata;
 
   always_comb begin
-    aon_wkup_status_d = '0;
-    aon_wkup_status_d = aon_wkup_status_qs_int;
+    aon_wkup_status_qs = 1'h0;
+    aon_wkup_status_ds = 1'h0;
+    aon_wkup_status_ds = aon_wkup_status_ds_int;
+    aon_wkup_status_qs = aon_wkup_status_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(1)
   ) u_wkup_status_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     (wkup_status_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_status_busy),
     .src_qs_o     (wkup_status_qs), // for software read back
-    .dst_d_i      (aon_wkup_status_d),
+    .dst_update_i (aon_wkup_status_qe),
+    .dst_ds_i     (aon_wkup_status_ds),
+    .dst_qs_i     (aon_wkup_status_qs),
     .dst_we_o     (aon_wkup_status_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -514,45 +526,47 @@ module sysrst_ctrl_reg_top (
   logic  aon_key_invert_ctl_bat_disable_qs_int;
   logic  aon_key_invert_ctl_lid_open_qs_int;
   logic  aon_key_invert_ctl_z3_wakeup_qs_int;
-  logic [11:0] aon_key_invert_ctl_d;
+  logic [11:0] aon_key_invert_ctl_qs;
   logic [11:0] aon_key_invert_ctl_wdata;
   logic aon_key_invert_ctl_we;
   logic unused_aon_key_invert_ctl_wdata;
   logic aon_key_invert_ctl_regwen;
 
   always_comb begin
-    aon_key_invert_ctl_d = '0;
-    aon_key_invert_ctl_d[0] = aon_key_invert_ctl_key0_in_qs_int;
-    aon_key_invert_ctl_d[1] = aon_key_invert_ctl_key0_out_qs_int;
-    aon_key_invert_ctl_d[2] = aon_key_invert_ctl_key1_in_qs_int;
-    aon_key_invert_ctl_d[3] = aon_key_invert_ctl_key1_out_qs_int;
-    aon_key_invert_ctl_d[4] = aon_key_invert_ctl_key2_in_qs_int;
-    aon_key_invert_ctl_d[5] = aon_key_invert_ctl_key2_out_qs_int;
-    aon_key_invert_ctl_d[6] = aon_key_invert_ctl_pwrb_in_qs_int;
-    aon_key_invert_ctl_d[7] = aon_key_invert_ctl_pwrb_out_qs_int;
-    aon_key_invert_ctl_d[8] = aon_key_invert_ctl_ac_present_qs_int;
-    aon_key_invert_ctl_d[9] = aon_key_invert_ctl_bat_disable_qs_int;
-    aon_key_invert_ctl_d[10] = aon_key_invert_ctl_lid_open_qs_int;
-    aon_key_invert_ctl_d[11] = aon_key_invert_ctl_z3_wakeup_qs_int;
+    aon_key_invert_ctl_qs = 12'h0;
+    aon_key_invert_ctl_qs[0] = aon_key_invert_ctl_key0_in_qs_int;
+    aon_key_invert_ctl_qs[1] = aon_key_invert_ctl_key0_out_qs_int;
+    aon_key_invert_ctl_qs[2] = aon_key_invert_ctl_key1_in_qs_int;
+    aon_key_invert_ctl_qs[3] = aon_key_invert_ctl_key1_out_qs_int;
+    aon_key_invert_ctl_qs[4] = aon_key_invert_ctl_key2_in_qs_int;
+    aon_key_invert_ctl_qs[5] = aon_key_invert_ctl_key2_out_qs_int;
+    aon_key_invert_ctl_qs[6] = aon_key_invert_ctl_pwrb_in_qs_int;
+    aon_key_invert_ctl_qs[7] = aon_key_invert_ctl_pwrb_out_qs_int;
+    aon_key_invert_ctl_qs[8] = aon_key_invert_ctl_ac_present_qs_int;
+    aon_key_invert_ctl_qs[9] = aon_key_invert_ctl_bat_disable_qs_int;
+    aon_key_invert_ctl_qs[10] = aon_key_invert_ctl_lid_open_qs_int;
+    aon_key_invert_ctl_qs[11] = aon_key_invert_ctl_z3_wakeup_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(12),
     .ResetVal(12'h0),
-    .BitMask(12'hfff)
+    .BitMask(12'hfff),
+    .DstWrReq(0)
   ) u_key_invert_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (key_invert_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[11:0]),
     .src_busy_o   (key_invert_ctl_busy),
     .src_qs_o     (key_invert_ctl_qs), // for software read back
-    .dst_d_i      (aon_key_invert_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_key_invert_ctl_qs),
     .dst_we_o     (aon_key_invert_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_key_invert_ctl_regwen),
@@ -577,49 +591,51 @@ module sysrst_ctrl_reg_top (
   logic  aon_pin_allowed_ctl_key2_out_1_qs_int;
   logic  aon_pin_allowed_ctl_z3_wakeup_1_qs_int;
   logic  aon_pin_allowed_ctl_flash_wp_l_1_qs_int;
-  logic [15:0] aon_pin_allowed_ctl_d;
+  logic [15:0] aon_pin_allowed_ctl_qs;
   logic [15:0] aon_pin_allowed_ctl_wdata;
   logic aon_pin_allowed_ctl_we;
   logic unused_aon_pin_allowed_ctl_wdata;
   logic aon_pin_allowed_ctl_regwen;
 
   always_comb begin
-    aon_pin_allowed_ctl_d = '0;
-    aon_pin_allowed_ctl_d[0] = aon_pin_allowed_ctl_bat_disable_0_qs_int;
-    aon_pin_allowed_ctl_d[1] = aon_pin_allowed_ctl_ec_rst_l_0_qs_int;
-    aon_pin_allowed_ctl_d[2] = aon_pin_allowed_ctl_pwrb_out_0_qs_int;
-    aon_pin_allowed_ctl_d[3] = aon_pin_allowed_ctl_key0_out_0_qs_int;
-    aon_pin_allowed_ctl_d[4] = aon_pin_allowed_ctl_key1_out_0_qs_int;
-    aon_pin_allowed_ctl_d[5] = aon_pin_allowed_ctl_key2_out_0_qs_int;
-    aon_pin_allowed_ctl_d[6] = aon_pin_allowed_ctl_z3_wakeup_0_qs_int;
-    aon_pin_allowed_ctl_d[7] = aon_pin_allowed_ctl_flash_wp_l_0_qs_int;
-    aon_pin_allowed_ctl_d[8] = aon_pin_allowed_ctl_bat_disable_1_qs_int;
-    aon_pin_allowed_ctl_d[9] = aon_pin_allowed_ctl_ec_rst_l_1_qs_int;
-    aon_pin_allowed_ctl_d[10] = aon_pin_allowed_ctl_pwrb_out_1_qs_int;
-    aon_pin_allowed_ctl_d[11] = aon_pin_allowed_ctl_key0_out_1_qs_int;
-    aon_pin_allowed_ctl_d[12] = aon_pin_allowed_ctl_key1_out_1_qs_int;
-    aon_pin_allowed_ctl_d[13] = aon_pin_allowed_ctl_key2_out_1_qs_int;
-    aon_pin_allowed_ctl_d[14] = aon_pin_allowed_ctl_z3_wakeup_1_qs_int;
-    aon_pin_allowed_ctl_d[15] = aon_pin_allowed_ctl_flash_wp_l_1_qs_int;
+    aon_pin_allowed_ctl_qs = 16'h82;
+    aon_pin_allowed_ctl_qs[0] = aon_pin_allowed_ctl_bat_disable_0_qs_int;
+    aon_pin_allowed_ctl_qs[1] = aon_pin_allowed_ctl_ec_rst_l_0_qs_int;
+    aon_pin_allowed_ctl_qs[2] = aon_pin_allowed_ctl_pwrb_out_0_qs_int;
+    aon_pin_allowed_ctl_qs[3] = aon_pin_allowed_ctl_key0_out_0_qs_int;
+    aon_pin_allowed_ctl_qs[4] = aon_pin_allowed_ctl_key1_out_0_qs_int;
+    aon_pin_allowed_ctl_qs[5] = aon_pin_allowed_ctl_key2_out_0_qs_int;
+    aon_pin_allowed_ctl_qs[6] = aon_pin_allowed_ctl_z3_wakeup_0_qs_int;
+    aon_pin_allowed_ctl_qs[7] = aon_pin_allowed_ctl_flash_wp_l_0_qs_int;
+    aon_pin_allowed_ctl_qs[8] = aon_pin_allowed_ctl_bat_disable_1_qs_int;
+    aon_pin_allowed_ctl_qs[9] = aon_pin_allowed_ctl_ec_rst_l_1_qs_int;
+    aon_pin_allowed_ctl_qs[10] = aon_pin_allowed_ctl_pwrb_out_1_qs_int;
+    aon_pin_allowed_ctl_qs[11] = aon_pin_allowed_ctl_key0_out_1_qs_int;
+    aon_pin_allowed_ctl_qs[12] = aon_pin_allowed_ctl_key1_out_1_qs_int;
+    aon_pin_allowed_ctl_qs[13] = aon_pin_allowed_ctl_key2_out_1_qs_int;
+    aon_pin_allowed_ctl_qs[14] = aon_pin_allowed_ctl_z3_wakeup_1_qs_int;
+    aon_pin_allowed_ctl_qs[15] = aon_pin_allowed_ctl_flash_wp_l_1_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(16),
     .ResetVal(16'h82),
-    .BitMask(16'hffff)
+    .BitMask(16'hffff),
+    .DstWrReq(0)
   ) u_pin_allowed_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (pin_allowed_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[15:0]),
     .src_busy_o   (pin_allowed_ctl_busy),
     .src_qs_o     (pin_allowed_ctl_qs), // for software read back
-    .dst_d_i      (aon_pin_allowed_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_pin_allowed_ctl_qs),
     .dst_we_o     (aon_pin_allowed_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_pin_allowed_ctl_regwen),
@@ -636,40 +652,42 @@ module sysrst_ctrl_reg_top (
   logic  aon_pin_out_ctl_key2_out_qs_int;
   logic  aon_pin_out_ctl_z3_wakeup_qs_int;
   logic  aon_pin_out_ctl_flash_wp_l_qs_int;
-  logic [7:0] aon_pin_out_ctl_d;
+  logic [7:0] aon_pin_out_ctl_qs;
   logic [7:0] aon_pin_out_ctl_wdata;
   logic aon_pin_out_ctl_we;
   logic unused_aon_pin_out_ctl_wdata;
 
   always_comb begin
-    aon_pin_out_ctl_d = '0;
-    aon_pin_out_ctl_d[0] = aon_pin_out_ctl_bat_disable_qs_int;
-    aon_pin_out_ctl_d[1] = aon_pin_out_ctl_ec_rst_l_qs_int;
-    aon_pin_out_ctl_d[2] = aon_pin_out_ctl_pwrb_out_qs_int;
-    aon_pin_out_ctl_d[3] = aon_pin_out_ctl_key0_out_qs_int;
-    aon_pin_out_ctl_d[4] = aon_pin_out_ctl_key1_out_qs_int;
-    aon_pin_out_ctl_d[5] = aon_pin_out_ctl_key2_out_qs_int;
-    aon_pin_out_ctl_d[6] = aon_pin_out_ctl_z3_wakeup_qs_int;
-    aon_pin_out_ctl_d[7] = aon_pin_out_ctl_flash_wp_l_qs_int;
+    aon_pin_out_ctl_qs = 8'h82;
+    aon_pin_out_ctl_qs[0] = aon_pin_out_ctl_bat_disable_qs_int;
+    aon_pin_out_ctl_qs[1] = aon_pin_out_ctl_ec_rst_l_qs_int;
+    aon_pin_out_ctl_qs[2] = aon_pin_out_ctl_pwrb_out_qs_int;
+    aon_pin_out_ctl_qs[3] = aon_pin_out_ctl_key0_out_qs_int;
+    aon_pin_out_ctl_qs[4] = aon_pin_out_ctl_key1_out_qs_int;
+    aon_pin_out_ctl_qs[5] = aon_pin_out_ctl_key2_out_qs_int;
+    aon_pin_out_ctl_qs[6] = aon_pin_out_ctl_z3_wakeup_qs_int;
+    aon_pin_out_ctl_qs[7] = aon_pin_out_ctl_flash_wp_l_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h82),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_pin_out_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     (pin_out_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (pin_out_ctl_busy),
     .src_qs_o     (pin_out_ctl_qs), // for software read back
-    .dst_d_i      (aon_pin_out_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_pin_out_ctl_qs),
     .dst_we_o     (aon_pin_out_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -686,40 +704,42 @@ module sysrst_ctrl_reg_top (
   logic  aon_pin_out_value_key2_out_qs_int;
   logic  aon_pin_out_value_z3_wakeup_qs_int;
   logic  aon_pin_out_value_flash_wp_l_qs_int;
-  logic [7:0] aon_pin_out_value_d;
+  logic [7:0] aon_pin_out_value_qs;
   logic [7:0] aon_pin_out_value_wdata;
   logic aon_pin_out_value_we;
   logic unused_aon_pin_out_value_wdata;
 
   always_comb begin
-    aon_pin_out_value_d = '0;
-    aon_pin_out_value_d[0] = aon_pin_out_value_bat_disable_qs_int;
-    aon_pin_out_value_d[1] = aon_pin_out_value_ec_rst_l_qs_int;
-    aon_pin_out_value_d[2] = aon_pin_out_value_pwrb_out_qs_int;
-    aon_pin_out_value_d[3] = aon_pin_out_value_key0_out_qs_int;
-    aon_pin_out_value_d[4] = aon_pin_out_value_key1_out_qs_int;
-    aon_pin_out_value_d[5] = aon_pin_out_value_key2_out_qs_int;
-    aon_pin_out_value_d[6] = aon_pin_out_value_z3_wakeup_qs_int;
-    aon_pin_out_value_d[7] = aon_pin_out_value_flash_wp_l_qs_int;
+    aon_pin_out_value_qs = 8'h0;
+    aon_pin_out_value_qs[0] = aon_pin_out_value_bat_disable_qs_int;
+    aon_pin_out_value_qs[1] = aon_pin_out_value_ec_rst_l_qs_int;
+    aon_pin_out_value_qs[2] = aon_pin_out_value_pwrb_out_qs_int;
+    aon_pin_out_value_qs[3] = aon_pin_out_value_key0_out_qs_int;
+    aon_pin_out_value_qs[4] = aon_pin_out_value_key1_out_qs_int;
+    aon_pin_out_value_qs[5] = aon_pin_out_value_key2_out_qs_int;
+    aon_pin_out_value_qs[6] = aon_pin_out_value_z3_wakeup_qs_int;
+    aon_pin_out_value_qs[7] = aon_pin_out_value_flash_wp_l_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_pin_out_value_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     (pin_out_value_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (pin_out_value_busy),
     .src_qs_o     (pin_out_value_qs), // for software read back
-    .dst_d_i      (aon_pin_out_value_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_pin_out_value_qs),
     .dst_we_o     (aon_pin_out_value_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -742,47 +762,49 @@ module sysrst_ctrl_reg_top (
   logic  aon_key_intr_ctl_ac_present_l2h_qs_int;
   logic  aon_key_intr_ctl_ec_rst_l_l2h_qs_int;
   logic  aon_key_intr_ctl_flash_wp_l_l2h_qs_int;
-  logic [14:0] aon_key_intr_ctl_d;
+  logic [14:0] aon_key_intr_ctl_qs;
   logic [14:0] aon_key_intr_ctl_wdata;
   logic aon_key_intr_ctl_we;
   logic unused_aon_key_intr_ctl_wdata;
   logic aon_key_intr_ctl_regwen;
 
   always_comb begin
-    aon_key_intr_ctl_d = '0;
-    aon_key_intr_ctl_d[0] = aon_key_intr_ctl_pwrb_in_h2l_qs_int;
-    aon_key_intr_ctl_d[1] = aon_key_intr_ctl_key0_in_h2l_qs_int;
-    aon_key_intr_ctl_d[2] = aon_key_intr_ctl_key1_in_h2l_qs_int;
-    aon_key_intr_ctl_d[3] = aon_key_intr_ctl_key2_in_h2l_qs_int;
-    aon_key_intr_ctl_d[4] = aon_key_intr_ctl_ac_present_h2l_qs_int;
-    aon_key_intr_ctl_d[5] = aon_key_intr_ctl_ec_rst_l_h2l_qs_int;
-    aon_key_intr_ctl_d[6] = aon_key_intr_ctl_flash_wp_l_h2l_qs_int;
-    aon_key_intr_ctl_d[8] = aon_key_intr_ctl_pwrb_in_l2h_qs_int;
-    aon_key_intr_ctl_d[9] = aon_key_intr_ctl_key0_in_l2h_qs_int;
-    aon_key_intr_ctl_d[10] = aon_key_intr_ctl_key1_in_l2h_qs_int;
-    aon_key_intr_ctl_d[11] = aon_key_intr_ctl_key2_in_l2h_qs_int;
-    aon_key_intr_ctl_d[12] = aon_key_intr_ctl_ac_present_l2h_qs_int;
-    aon_key_intr_ctl_d[13] = aon_key_intr_ctl_ec_rst_l_l2h_qs_int;
-    aon_key_intr_ctl_d[14] = aon_key_intr_ctl_flash_wp_l_l2h_qs_int;
+    aon_key_intr_ctl_qs = 15'h0;
+    aon_key_intr_ctl_qs[0] = aon_key_intr_ctl_pwrb_in_h2l_qs_int;
+    aon_key_intr_ctl_qs[1] = aon_key_intr_ctl_key0_in_h2l_qs_int;
+    aon_key_intr_ctl_qs[2] = aon_key_intr_ctl_key1_in_h2l_qs_int;
+    aon_key_intr_ctl_qs[3] = aon_key_intr_ctl_key2_in_h2l_qs_int;
+    aon_key_intr_ctl_qs[4] = aon_key_intr_ctl_ac_present_h2l_qs_int;
+    aon_key_intr_ctl_qs[5] = aon_key_intr_ctl_ec_rst_l_h2l_qs_int;
+    aon_key_intr_ctl_qs[6] = aon_key_intr_ctl_flash_wp_l_h2l_qs_int;
+    aon_key_intr_ctl_qs[8] = aon_key_intr_ctl_pwrb_in_l2h_qs_int;
+    aon_key_intr_ctl_qs[9] = aon_key_intr_ctl_key0_in_l2h_qs_int;
+    aon_key_intr_ctl_qs[10] = aon_key_intr_ctl_key1_in_l2h_qs_int;
+    aon_key_intr_ctl_qs[11] = aon_key_intr_ctl_key2_in_l2h_qs_int;
+    aon_key_intr_ctl_qs[12] = aon_key_intr_ctl_ac_present_l2h_qs_int;
+    aon_key_intr_ctl_qs[13] = aon_key_intr_ctl_ec_rst_l_l2h_qs_int;
+    aon_key_intr_ctl_qs[14] = aon_key_intr_ctl_flash_wp_l_l2h_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(15),
     .ResetVal(15'h0),
-    .BitMask(15'h7f7f)
+    .BitMask(15'h7f7f),
+    .DstWrReq(0)
   ) u_key_intr_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (key_intr_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[14:0]),
     .src_busy_o   (key_intr_ctl_busy),
     .src_qs_o     (key_intr_ctl_qs), // for software read back
-    .dst_d_i      (aon_key_intr_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_key_intr_ctl_qs),
     .dst_we_o     (aon_key_intr_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_key_intr_ctl_regwen),
@@ -792,34 +814,36 @@ module sysrst_ctrl_reg_top (
       ^aon_key_intr_ctl_wdata;
 
   logic [15:0]  aon_key_intr_debounce_ctl_qs_int;
-  logic [15:0] aon_key_intr_debounce_ctl_d;
+  logic [15:0] aon_key_intr_debounce_ctl_qs;
   logic [15:0] aon_key_intr_debounce_ctl_wdata;
   logic aon_key_intr_debounce_ctl_we;
   logic unused_aon_key_intr_debounce_ctl_wdata;
   logic aon_key_intr_debounce_ctl_regwen;
 
   always_comb begin
-    aon_key_intr_debounce_ctl_d = '0;
-    aon_key_intr_debounce_ctl_d = aon_key_intr_debounce_ctl_qs_int;
+    aon_key_intr_debounce_ctl_qs = 16'h7d0;
+    aon_key_intr_debounce_ctl_qs = aon_key_intr_debounce_ctl_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(16),
     .ResetVal(16'h7d0),
-    .BitMask(16'hffff)
+    .BitMask(16'hffff),
+    .DstWrReq(0)
   ) u_key_intr_debounce_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (key_intr_debounce_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[15:0]),
     .src_busy_o   (key_intr_debounce_ctl_busy),
     .src_qs_o     (key_intr_debounce_ctl_qs), // for software read back
-    .dst_d_i      (aon_key_intr_debounce_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_key_intr_debounce_ctl_qs),
     .dst_we_o     (aon_key_intr_debounce_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_key_intr_debounce_ctl_regwen),
@@ -830,35 +854,37 @@ module sysrst_ctrl_reg_top (
 
   logic [15:0]  aon_auto_block_debounce_ctl_debounce_timer_qs_int;
   logic  aon_auto_block_debounce_ctl_auto_block_enable_qs_int;
-  logic [16:0] aon_auto_block_debounce_ctl_d;
+  logic [16:0] aon_auto_block_debounce_ctl_qs;
   logic [16:0] aon_auto_block_debounce_ctl_wdata;
   logic aon_auto_block_debounce_ctl_we;
   logic unused_aon_auto_block_debounce_ctl_wdata;
   logic aon_auto_block_debounce_ctl_regwen;
 
   always_comb begin
-    aon_auto_block_debounce_ctl_d = '0;
-    aon_auto_block_debounce_ctl_d[15:0] = aon_auto_block_debounce_ctl_debounce_timer_qs_int;
-    aon_auto_block_debounce_ctl_d[16] = aon_auto_block_debounce_ctl_auto_block_enable_qs_int;
+    aon_auto_block_debounce_ctl_qs = 17'h7d0;
+    aon_auto_block_debounce_ctl_qs[15:0] = aon_auto_block_debounce_ctl_debounce_timer_qs_int;
+    aon_auto_block_debounce_ctl_qs[16] = aon_auto_block_debounce_ctl_auto_block_enable_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(17),
     .ResetVal(17'h7d0),
-    .BitMask(17'h1ffff)
+    .BitMask(17'h1ffff),
+    .DstWrReq(0)
   ) u_auto_block_debounce_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (auto_block_debounce_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[16:0]),
     .src_busy_o   (auto_block_debounce_ctl_busy),
     .src_qs_o     (auto_block_debounce_ctl_qs), // for software read back
-    .dst_d_i      (aon_auto_block_debounce_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_auto_block_debounce_ctl_qs),
     .dst_we_o     (aon_auto_block_debounce_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_auto_block_debounce_ctl_regwen),
@@ -873,39 +899,41 @@ module sysrst_ctrl_reg_top (
   logic  aon_auto_block_out_ctl_key0_out_value_qs_int;
   logic  aon_auto_block_out_ctl_key1_out_value_qs_int;
   logic  aon_auto_block_out_ctl_key2_out_value_qs_int;
-  logic [6:0] aon_auto_block_out_ctl_d;
+  logic [6:0] aon_auto_block_out_ctl_qs;
   logic [6:0] aon_auto_block_out_ctl_wdata;
   logic aon_auto_block_out_ctl_we;
   logic unused_aon_auto_block_out_ctl_wdata;
   logic aon_auto_block_out_ctl_regwen;
 
   always_comb begin
-    aon_auto_block_out_ctl_d = '0;
-    aon_auto_block_out_ctl_d[0] = aon_auto_block_out_ctl_key0_out_sel_qs_int;
-    aon_auto_block_out_ctl_d[1] = aon_auto_block_out_ctl_key1_out_sel_qs_int;
-    aon_auto_block_out_ctl_d[2] = aon_auto_block_out_ctl_key2_out_sel_qs_int;
-    aon_auto_block_out_ctl_d[4] = aon_auto_block_out_ctl_key0_out_value_qs_int;
-    aon_auto_block_out_ctl_d[5] = aon_auto_block_out_ctl_key1_out_value_qs_int;
-    aon_auto_block_out_ctl_d[6] = aon_auto_block_out_ctl_key2_out_value_qs_int;
+    aon_auto_block_out_ctl_qs = 7'h0;
+    aon_auto_block_out_ctl_qs[0] = aon_auto_block_out_ctl_key0_out_sel_qs_int;
+    aon_auto_block_out_ctl_qs[1] = aon_auto_block_out_ctl_key1_out_sel_qs_int;
+    aon_auto_block_out_ctl_qs[2] = aon_auto_block_out_ctl_key2_out_sel_qs_int;
+    aon_auto_block_out_ctl_qs[4] = aon_auto_block_out_ctl_key0_out_value_qs_int;
+    aon_auto_block_out_ctl_qs[5] = aon_auto_block_out_ctl_key1_out_value_qs_int;
+    aon_auto_block_out_ctl_qs[6] = aon_auto_block_out_ctl_key2_out_value_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(7),
     .ResetVal(7'h0),
-    .BitMask(7'h77)
+    .BitMask(7'h77),
+    .DstWrReq(0)
   ) u_auto_block_out_ctl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (auto_block_out_ctl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[6:0]),
     .src_busy_o   (auto_block_out_ctl_busy),
     .src_qs_o     (auto_block_out_ctl_qs), // for software read back
-    .dst_d_i      (aon_auto_block_out_ctl_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_auto_block_out_ctl_qs),
     .dst_we_o     (aon_auto_block_out_ctl_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_auto_block_out_ctl_regwen),
@@ -919,38 +947,40 @@ module sysrst_ctrl_reg_top (
   logic  aon_com_sel_ctl_0_key2_in_sel_0_qs_int;
   logic  aon_com_sel_ctl_0_pwrb_in_sel_0_qs_int;
   logic  aon_com_sel_ctl_0_ac_present_sel_0_qs_int;
-  logic [4:0] aon_com_sel_ctl_0_d;
+  logic [4:0] aon_com_sel_ctl_0_qs;
   logic [4:0] aon_com_sel_ctl_0_wdata;
   logic aon_com_sel_ctl_0_we;
   logic unused_aon_com_sel_ctl_0_wdata;
   logic aon_com_sel_ctl_0_regwen;
 
   always_comb begin
-    aon_com_sel_ctl_0_d = '0;
-    aon_com_sel_ctl_0_d[0] = aon_com_sel_ctl_0_key0_in_sel_0_qs_int;
-    aon_com_sel_ctl_0_d[1] = aon_com_sel_ctl_0_key1_in_sel_0_qs_int;
-    aon_com_sel_ctl_0_d[2] = aon_com_sel_ctl_0_key2_in_sel_0_qs_int;
-    aon_com_sel_ctl_0_d[3] = aon_com_sel_ctl_0_pwrb_in_sel_0_qs_int;
-    aon_com_sel_ctl_0_d[4] = aon_com_sel_ctl_0_ac_present_sel_0_qs_int;
+    aon_com_sel_ctl_0_qs = 5'h0;
+    aon_com_sel_ctl_0_qs[0] = aon_com_sel_ctl_0_key0_in_sel_0_qs_int;
+    aon_com_sel_ctl_0_qs[1] = aon_com_sel_ctl_0_key1_in_sel_0_qs_int;
+    aon_com_sel_ctl_0_qs[2] = aon_com_sel_ctl_0_key2_in_sel_0_qs_int;
+    aon_com_sel_ctl_0_qs[3] = aon_com_sel_ctl_0_pwrb_in_sel_0_qs_int;
+    aon_com_sel_ctl_0_qs[4] = aon_com_sel_ctl_0_ac_present_sel_0_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_com_sel_ctl_0_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_sel_ctl_0_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (com_sel_ctl_0_busy),
     .src_qs_o     (com_sel_ctl_0_qs), // for software read back
-    .dst_d_i      (aon_com_sel_ctl_0_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_sel_ctl_0_qs),
     .dst_we_o     (aon_com_sel_ctl_0_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_sel_ctl_0_regwen),
@@ -964,38 +994,40 @@ module sysrst_ctrl_reg_top (
   logic  aon_com_sel_ctl_1_key2_in_sel_1_qs_int;
   logic  aon_com_sel_ctl_1_pwrb_in_sel_1_qs_int;
   logic  aon_com_sel_ctl_1_ac_present_sel_1_qs_int;
-  logic [4:0] aon_com_sel_ctl_1_d;
+  logic [4:0] aon_com_sel_ctl_1_qs;
   logic [4:0] aon_com_sel_ctl_1_wdata;
   logic aon_com_sel_ctl_1_we;
   logic unused_aon_com_sel_ctl_1_wdata;
   logic aon_com_sel_ctl_1_regwen;
 
   always_comb begin
-    aon_com_sel_ctl_1_d = '0;
-    aon_com_sel_ctl_1_d[0] = aon_com_sel_ctl_1_key0_in_sel_1_qs_int;
-    aon_com_sel_ctl_1_d[1] = aon_com_sel_ctl_1_key1_in_sel_1_qs_int;
-    aon_com_sel_ctl_1_d[2] = aon_com_sel_ctl_1_key2_in_sel_1_qs_int;
-    aon_com_sel_ctl_1_d[3] = aon_com_sel_ctl_1_pwrb_in_sel_1_qs_int;
-    aon_com_sel_ctl_1_d[4] = aon_com_sel_ctl_1_ac_present_sel_1_qs_int;
+    aon_com_sel_ctl_1_qs = 5'h0;
+    aon_com_sel_ctl_1_qs[0] = aon_com_sel_ctl_1_key0_in_sel_1_qs_int;
+    aon_com_sel_ctl_1_qs[1] = aon_com_sel_ctl_1_key1_in_sel_1_qs_int;
+    aon_com_sel_ctl_1_qs[2] = aon_com_sel_ctl_1_key2_in_sel_1_qs_int;
+    aon_com_sel_ctl_1_qs[3] = aon_com_sel_ctl_1_pwrb_in_sel_1_qs_int;
+    aon_com_sel_ctl_1_qs[4] = aon_com_sel_ctl_1_ac_present_sel_1_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_com_sel_ctl_1_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_sel_ctl_1_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (com_sel_ctl_1_busy),
     .src_qs_o     (com_sel_ctl_1_qs), // for software read back
-    .dst_d_i      (aon_com_sel_ctl_1_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_sel_ctl_1_qs),
     .dst_we_o     (aon_com_sel_ctl_1_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_sel_ctl_1_regwen),
@@ -1009,38 +1041,40 @@ module sysrst_ctrl_reg_top (
   logic  aon_com_sel_ctl_2_key2_in_sel_2_qs_int;
   logic  aon_com_sel_ctl_2_pwrb_in_sel_2_qs_int;
   logic  aon_com_sel_ctl_2_ac_present_sel_2_qs_int;
-  logic [4:0] aon_com_sel_ctl_2_d;
+  logic [4:0] aon_com_sel_ctl_2_qs;
   logic [4:0] aon_com_sel_ctl_2_wdata;
   logic aon_com_sel_ctl_2_we;
   logic unused_aon_com_sel_ctl_2_wdata;
   logic aon_com_sel_ctl_2_regwen;
 
   always_comb begin
-    aon_com_sel_ctl_2_d = '0;
-    aon_com_sel_ctl_2_d[0] = aon_com_sel_ctl_2_key0_in_sel_2_qs_int;
-    aon_com_sel_ctl_2_d[1] = aon_com_sel_ctl_2_key1_in_sel_2_qs_int;
-    aon_com_sel_ctl_2_d[2] = aon_com_sel_ctl_2_key2_in_sel_2_qs_int;
-    aon_com_sel_ctl_2_d[3] = aon_com_sel_ctl_2_pwrb_in_sel_2_qs_int;
-    aon_com_sel_ctl_2_d[4] = aon_com_sel_ctl_2_ac_present_sel_2_qs_int;
+    aon_com_sel_ctl_2_qs = 5'h0;
+    aon_com_sel_ctl_2_qs[0] = aon_com_sel_ctl_2_key0_in_sel_2_qs_int;
+    aon_com_sel_ctl_2_qs[1] = aon_com_sel_ctl_2_key1_in_sel_2_qs_int;
+    aon_com_sel_ctl_2_qs[2] = aon_com_sel_ctl_2_key2_in_sel_2_qs_int;
+    aon_com_sel_ctl_2_qs[3] = aon_com_sel_ctl_2_pwrb_in_sel_2_qs_int;
+    aon_com_sel_ctl_2_qs[4] = aon_com_sel_ctl_2_ac_present_sel_2_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_com_sel_ctl_2_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_sel_ctl_2_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (com_sel_ctl_2_busy),
     .src_qs_o     (com_sel_ctl_2_qs), // for software read back
-    .dst_d_i      (aon_com_sel_ctl_2_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_sel_ctl_2_qs),
     .dst_we_o     (aon_com_sel_ctl_2_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_sel_ctl_2_regwen),
@@ -1054,38 +1088,40 @@ module sysrst_ctrl_reg_top (
   logic  aon_com_sel_ctl_3_key2_in_sel_3_qs_int;
   logic  aon_com_sel_ctl_3_pwrb_in_sel_3_qs_int;
   logic  aon_com_sel_ctl_3_ac_present_sel_3_qs_int;
-  logic [4:0] aon_com_sel_ctl_3_d;
+  logic [4:0] aon_com_sel_ctl_3_qs;
   logic [4:0] aon_com_sel_ctl_3_wdata;
   logic aon_com_sel_ctl_3_we;
   logic unused_aon_com_sel_ctl_3_wdata;
   logic aon_com_sel_ctl_3_regwen;
 
   always_comb begin
-    aon_com_sel_ctl_3_d = '0;
-    aon_com_sel_ctl_3_d[0] = aon_com_sel_ctl_3_key0_in_sel_3_qs_int;
-    aon_com_sel_ctl_3_d[1] = aon_com_sel_ctl_3_key1_in_sel_3_qs_int;
-    aon_com_sel_ctl_3_d[2] = aon_com_sel_ctl_3_key2_in_sel_3_qs_int;
-    aon_com_sel_ctl_3_d[3] = aon_com_sel_ctl_3_pwrb_in_sel_3_qs_int;
-    aon_com_sel_ctl_3_d[4] = aon_com_sel_ctl_3_ac_present_sel_3_qs_int;
+    aon_com_sel_ctl_3_qs = 5'h0;
+    aon_com_sel_ctl_3_qs[0] = aon_com_sel_ctl_3_key0_in_sel_3_qs_int;
+    aon_com_sel_ctl_3_qs[1] = aon_com_sel_ctl_3_key1_in_sel_3_qs_int;
+    aon_com_sel_ctl_3_qs[2] = aon_com_sel_ctl_3_key2_in_sel_3_qs_int;
+    aon_com_sel_ctl_3_qs[3] = aon_com_sel_ctl_3_pwrb_in_sel_3_qs_int;
+    aon_com_sel_ctl_3_qs[4] = aon_com_sel_ctl_3_ac_present_sel_3_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_com_sel_ctl_3_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_sel_ctl_3_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (com_sel_ctl_3_busy),
     .src_qs_o     (com_sel_ctl_3_qs), // for software read back
-    .dst_d_i      (aon_com_sel_ctl_3_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_sel_ctl_3_qs),
     .dst_we_o     (aon_com_sel_ctl_3_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_sel_ctl_3_regwen),
@@ -1095,34 +1131,36 @@ module sysrst_ctrl_reg_top (
       ^aon_com_sel_ctl_3_wdata;
 
   logic [31:0]  aon_com_det_ctl_0_qs_int;
-  logic [31:0] aon_com_det_ctl_0_d;
+  logic [31:0] aon_com_det_ctl_0_qs;
   logic [31:0] aon_com_det_ctl_0_wdata;
   logic aon_com_det_ctl_0_we;
   logic unused_aon_com_det_ctl_0_wdata;
   logic aon_com_det_ctl_0_regwen;
 
   always_comb begin
-    aon_com_det_ctl_0_d = '0;
-    aon_com_det_ctl_0_d = aon_com_det_ctl_0_qs_int;
+    aon_com_det_ctl_0_qs = 32'h0;
+    aon_com_det_ctl_0_qs = aon_com_det_ctl_0_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(32),
     .ResetVal(32'h0),
-    .BitMask(32'hffffffff)
+    .BitMask(32'hffffffff),
+    .DstWrReq(0)
   ) u_com_det_ctl_0_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_det_ctl_0_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[31:0]),
     .src_busy_o   (com_det_ctl_0_busy),
     .src_qs_o     (com_det_ctl_0_qs), // for software read back
-    .dst_d_i      (aon_com_det_ctl_0_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_det_ctl_0_qs),
     .dst_we_o     (aon_com_det_ctl_0_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_det_ctl_0_regwen),
@@ -1132,34 +1170,36 @@ module sysrst_ctrl_reg_top (
       ^aon_com_det_ctl_0_wdata;
 
   logic [31:0]  aon_com_det_ctl_1_qs_int;
-  logic [31:0] aon_com_det_ctl_1_d;
+  logic [31:0] aon_com_det_ctl_1_qs;
   logic [31:0] aon_com_det_ctl_1_wdata;
   logic aon_com_det_ctl_1_we;
   logic unused_aon_com_det_ctl_1_wdata;
   logic aon_com_det_ctl_1_regwen;
 
   always_comb begin
-    aon_com_det_ctl_1_d = '0;
-    aon_com_det_ctl_1_d = aon_com_det_ctl_1_qs_int;
+    aon_com_det_ctl_1_qs = 32'h0;
+    aon_com_det_ctl_1_qs = aon_com_det_ctl_1_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(32),
     .ResetVal(32'h0),
-    .BitMask(32'hffffffff)
+    .BitMask(32'hffffffff),
+    .DstWrReq(0)
   ) u_com_det_ctl_1_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_det_ctl_1_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[31:0]),
     .src_busy_o   (com_det_ctl_1_busy),
     .src_qs_o     (com_det_ctl_1_qs), // for software read back
-    .dst_d_i      (aon_com_det_ctl_1_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_det_ctl_1_qs),
     .dst_we_o     (aon_com_det_ctl_1_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_det_ctl_1_regwen),
@@ -1169,34 +1209,36 @@ module sysrst_ctrl_reg_top (
       ^aon_com_det_ctl_1_wdata;
 
   logic [31:0]  aon_com_det_ctl_2_qs_int;
-  logic [31:0] aon_com_det_ctl_2_d;
+  logic [31:0] aon_com_det_ctl_2_qs;
   logic [31:0] aon_com_det_ctl_2_wdata;
   logic aon_com_det_ctl_2_we;
   logic unused_aon_com_det_ctl_2_wdata;
   logic aon_com_det_ctl_2_regwen;
 
   always_comb begin
-    aon_com_det_ctl_2_d = '0;
-    aon_com_det_ctl_2_d = aon_com_det_ctl_2_qs_int;
+    aon_com_det_ctl_2_qs = 32'h0;
+    aon_com_det_ctl_2_qs = aon_com_det_ctl_2_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(32),
     .ResetVal(32'h0),
-    .BitMask(32'hffffffff)
+    .BitMask(32'hffffffff),
+    .DstWrReq(0)
   ) u_com_det_ctl_2_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_det_ctl_2_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[31:0]),
     .src_busy_o   (com_det_ctl_2_busy),
     .src_qs_o     (com_det_ctl_2_qs), // for software read back
-    .dst_d_i      (aon_com_det_ctl_2_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_det_ctl_2_qs),
     .dst_we_o     (aon_com_det_ctl_2_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_det_ctl_2_regwen),
@@ -1206,34 +1248,36 @@ module sysrst_ctrl_reg_top (
       ^aon_com_det_ctl_2_wdata;
 
   logic [31:0]  aon_com_det_ctl_3_qs_int;
-  logic [31:0] aon_com_det_ctl_3_d;
+  logic [31:0] aon_com_det_ctl_3_qs;
   logic [31:0] aon_com_det_ctl_3_wdata;
   logic aon_com_det_ctl_3_we;
   logic unused_aon_com_det_ctl_3_wdata;
   logic aon_com_det_ctl_3_regwen;
 
   always_comb begin
-    aon_com_det_ctl_3_d = '0;
-    aon_com_det_ctl_3_d = aon_com_det_ctl_3_qs_int;
+    aon_com_det_ctl_3_qs = 32'h0;
+    aon_com_det_ctl_3_qs = aon_com_det_ctl_3_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(32),
     .ResetVal(32'h0),
-    .BitMask(32'hffffffff)
+    .BitMask(32'hffffffff),
+    .DstWrReq(0)
   ) u_com_det_ctl_3_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_det_ctl_3_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[31:0]),
     .src_busy_o   (com_det_ctl_3_busy),
     .src_qs_o     (com_det_ctl_3_qs), // for software read back
-    .dst_d_i      (aon_com_det_ctl_3_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_det_ctl_3_qs),
     .dst_we_o     (aon_com_det_ctl_3_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_det_ctl_3_regwen),
@@ -1246,37 +1290,39 @@ module sysrst_ctrl_reg_top (
   logic  aon_com_out_ctl_0_interrupt_0_qs_int;
   logic  aon_com_out_ctl_0_ec_rst_0_qs_int;
   logic  aon_com_out_ctl_0_rst_req_0_qs_int;
-  logic [3:0] aon_com_out_ctl_0_d;
+  logic [3:0] aon_com_out_ctl_0_qs;
   logic [3:0] aon_com_out_ctl_0_wdata;
   logic aon_com_out_ctl_0_we;
   logic unused_aon_com_out_ctl_0_wdata;
   logic aon_com_out_ctl_0_regwen;
 
   always_comb begin
-    aon_com_out_ctl_0_d = '0;
-    aon_com_out_ctl_0_d[0] = aon_com_out_ctl_0_bat_disable_0_qs_int;
-    aon_com_out_ctl_0_d[1] = aon_com_out_ctl_0_interrupt_0_qs_int;
-    aon_com_out_ctl_0_d[2] = aon_com_out_ctl_0_ec_rst_0_qs_int;
-    aon_com_out_ctl_0_d[3] = aon_com_out_ctl_0_rst_req_0_qs_int;
+    aon_com_out_ctl_0_qs = 4'h0;
+    aon_com_out_ctl_0_qs[0] = aon_com_out_ctl_0_bat_disable_0_qs_int;
+    aon_com_out_ctl_0_qs[1] = aon_com_out_ctl_0_interrupt_0_qs_int;
+    aon_com_out_ctl_0_qs[2] = aon_com_out_ctl_0_ec_rst_0_qs_int;
+    aon_com_out_ctl_0_qs[3] = aon_com_out_ctl_0_rst_req_0_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(4),
     .ResetVal(4'h0),
-    .BitMask(4'hf)
+    .BitMask(4'hf),
+    .DstWrReq(0)
   ) u_com_out_ctl_0_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_out_ctl_0_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[3:0]),
     .src_busy_o   (com_out_ctl_0_busy),
     .src_qs_o     (com_out_ctl_0_qs), // for software read back
-    .dst_d_i      (aon_com_out_ctl_0_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_out_ctl_0_qs),
     .dst_we_o     (aon_com_out_ctl_0_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_out_ctl_0_regwen),
@@ -1289,37 +1335,39 @@ module sysrst_ctrl_reg_top (
   logic  aon_com_out_ctl_1_interrupt_1_qs_int;
   logic  aon_com_out_ctl_1_ec_rst_1_qs_int;
   logic  aon_com_out_ctl_1_rst_req_1_qs_int;
-  logic [3:0] aon_com_out_ctl_1_d;
+  logic [3:0] aon_com_out_ctl_1_qs;
   logic [3:0] aon_com_out_ctl_1_wdata;
   logic aon_com_out_ctl_1_we;
   logic unused_aon_com_out_ctl_1_wdata;
   logic aon_com_out_ctl_1_regwen;
 
   always_comb begin
-    aon_com_out_ctl_1_d = '0;
-    aon_com_out_ctl_1_d[0] = aon_com_out_ctl_1_bat_disable_1_qs_int;
-    aon_com_out_ctl_1_d[1] = aon_com_out_ctl_1_interrupt_1_qs_int;
-    aon_com_out_ctl_1_d[2] = aon_com_out_ctl_1_ec_rst_1_qs_int;
-    aon_com_out_ctl_1_d[3] = aon_com_out_ctl_1_rst_req_1_qs_int;
+    aon_com_out_ctl_1_qs = 4'h0;
+    aon_com_out_ctl_1_qs[0] = aon_com_out_ctl_1_bat_disable_1_qs_int;
+    aon_com_out_ctl_1_qs[1] = aon_com_out_ctl_1_interrupt_1_qs_int;
+    aon_com_out_ctl_1_qs[2] = aon_com_out_ctl_1_ec_rst_1_qs_int;
+    aon_com_out_ctl_1_qs[3] = aon_com_out_ctl_1_rst_req_1_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(4),
     .ResetVal(4'h0),
-    .BitMask(4'hf)
+    .BitMask(4'hf),
+    .DstWrReq(0)
   ) u_com_out_ctl_1_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_out_ctl_1_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[3:0]),
     .src_busy_o   (com_out_ctl_1_busy),
     .src_qs_o     (com_out_ctl_1_qs), // for software read back
-    .dst_d_i      (aon_com_out_ctl_1_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_out_ctl_1_qs),
     .dst_we_o     (aon_com_out_ctl_1_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_out_ctl_1_regwen),
@@ -1332,37 +1380,39 @@ module sysrst_ctrl_reg_top (
   logic  aon_com_out_ctl_2_interrupt_2_qs_int;
   logic  aon_com_out_ctl_2_ec_rst_2_qs_int;
   logic  aon_com_out_ctl_2_rst_req_2_qs_int;
-  logic [3:0] aon_com_out_ctl_2_d;
+  logic [3:0] aon_com_out_ctl_2_qs;
   logic [3:0] aon_com_out_ctl_2_wdata;
   logic aon_com_out_ctl_2_we;
   logic unused_aon_com_out_ctl_2_wdata;
   logic aon_com_out_ctl_2_regwen;
 
   always_comb begin
-    aon_com_out_ctl_2_d = '0;
-    aon_com_out_ctl_2_d[0] = aon_com_out_ctl_2_bat_disable_2_qs_int;
-    aon_com_out_ctl_2_d[1] = aon_com_out_ctl_2_interrupt_2_qs_int;
-    aon_com_out_ctl_2_d[2] = aon_com_out_ctl_2_ec_rst_2_qs_int;
-    aon_com_out_ctl_2_d[3] = aon_com_out_ctl_2_rst_req_2_qs_int;
+    aon_com_out_ctl_2_qs = 4'h0;
+    aon_com_out_ctl_2_qs[0] = aon_com_out_ctl_2_bat_disable_2_qs_int;
+    aon_com_out_ctl_2_qs[1] = aon_com_out_ctl_2_interrupt_2_qs_int;
+    aon_com_out_ctl_2_qs[2] = aon_com_out_ctl_2_ec_rst_2_qs_int;
+    aon_com_out_ctl_2_qs[3] = aon_com_out_ctl_2_rst_req_2_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(4),
     .ResetVal(4'h0),
-    .BitMask(4'hf)
+    .BitMask(4'hf),
+    .DstWrReq(0)
   ) u_com_out_ctl_2_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_out_ctl_2_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[3:0]),
     .src_busy_o   (com_out_ctl_2_busy),
     .src_qs_o     (com_out_ctl_2_qs), // for software read back
-    .dst_d_i      (aon_com_out_ctl_2_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_out_ctl_2_qs),
     .dst_we_o     (aon_com_out_ctl_2_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_out_ctl_2_regwen),
@@ -1375,37 +1425,39 @@ module sysrst_ctrl_reg_top (
   logic  aon_com_out_ctl_3_interrupt_3_qs_int;
   logic  aon_com_out_ctl_3_ec_rst_3_qs_int;
   logic  aon_com_out_ctl_3_rst_req_3_qs_int;
-  logic [3:0] aon_com_out_ctl_3_d;
+  logic [3:0] aon_com_out_ctl_3_qs;
   logic [3:0] aon_com_out_ctl_3_wdata;
   logic aon_com_out_ctl_3_we;
   logic unused_aon_com_out_ctl_3_wdata;
   logic aon_com_out_ctl_3_regwen;
 
   always_comb begin
-    aon_com_out_ctl_3_d = '0;
-    aon_com_out_ctl_3_d[0] = aon_com_out_ctl_3_bat_disable_3_qs_int;
-    aon_com_out_ctl_3_d[1] = aon_com_out_ctl_3_interrupt_3_qs_int;
-    aon_com_out_ctl_3_d[2] = aon_com_out_ctl_3_ec_rst_3_qs_int;
-    aon_com_out_ctl_3_d[3] = aon_com_out_ctl_3_rst_req_3_qs_int;
+    aon_com_out_ctl_3_qs = 4'h0;
+    aon_com_out_ctl_3_qs[0] = aon_com_out_ctl_3_bat_disable_3_qs_int;
+    aon_com_out_ctl_3_qs[1] = aon_com_out_ctl_3_interrupt_3_qs_int;
+    aon_com_out_ctl_3_qs[2] = aon_com_out_ctl_3_ec_rst_3_qs_int;
+    aon_com_out_ctl_3_qs[3] = aon_com_out_ctl_3_rst_req_3_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(4),
     .ResetVal(4'h0),
-    .BitMask(4'hf)
+    .BitMask(4'hf),
+    .DstWrReq(0)
   ) u_com_out_ctl_3_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (regwen_qs),
     .src_we_i     (com_out_ctl_3_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[3:0]),
     .src_busy_o   (com_out_ctl_3_busy),
     .src_qs_o     (com_out_ctl_3_qs), // for software read back
-    .dst_d_i      (aon_com_out_ctl_3_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_out_ctl_3_qs),
     .dst_we_o     (aon_com_out_ctl_3_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_com_out_ctl_3_regwen),
@@ -1414,40 +1466,53 @@ module sysrst_ctrl_reg_top (
   assign unused_aon_com_out_ctl_3_wdata =
       ^aon_com_out_ctl_3_wdata;
 
+  logic  aon_combo_intr_status_combo0_h2l_ds_int;
   logic  aon_combo_intr_status_combo0_h2l_qs_int;
+  logic  aon_combo_intr_status_combo1_h2l_ds_int;
   logic  aon_combo_intr_status_combo1_h2l_qs_int;
+  logic  aon_combo_intr_status_combo2_h2l_ds_int;
   logic  aon_combo_intr_status_combo2_h2l_qs_int;
+  logic  aon_combo_intr_status_combo3_h2l_ds_int;
   logic  aon_combo_intr_status_combo3_h2l_qs_int;
-  logic [3:0] aon_combo_intr_status_d;
+  logic [3:0] aon_combo_intr_status_ds;
+  logic aon_combo_intr_status_qe;
+  logic [3:0] aon_combo_intr_status_qs;
   logic [3:0] aon_combo_intr_status_wdata;
   logic aon_combo_intr_status_we;
   logic unused_aon_combo_intr_status_wdata;
 
   always_comb begin
-    aon_combo_intr_status_d = '0;
-    aon_combo_intr_status_d[0] = aon_combo_intr_status_combo0_h2l_qs_int;
-    aon_combo_intr_status_d[1] = aon_combo_intr_status_combo1_h2l_qs_int;
-    aon_combo_intr_status_d[2] = aon_combo_intr_status_combo2_h2l_qs_int;
-    aon_combo_intr_status_d[3] = aon_combo_intr_status_combo3_h2l_qs_int;
+    aon_combo_intr_status_qs = 4'h0;
+    aon_combo_intr_status_ds = 4'h0;
+    aon_combo_intr_status_ds[0] = aon_combo_intr_status_combo0_h2l_ds_int;
+    aon_combo_intr_status_qs[0] = aon_combo_intr_status_combo0_h2l_qs_int;
+    aon_combo_intr_status_ds[1] = aon_combo_intr_status_combo1_h2l_ds_int;
+    aon_combo_intr_status_qs[1] = aon_combo_intr_status_combo1_h2l_qs_int;
+    aon_combo_intr_status_ds[2] = aon_combo_intr_status_combo2_h2l_ds_int;
+    aon_combo_intr_status_qs[2] = aon_combo_intr_status_combo2_h2l_qs_int;
+    aon_combo_intr_status_ds[3] = aon_combo_intr_status_combo3_h2l_ds_int;
+    aon_combo_intr_status_qs[3] = aon_combo_intr_status_combo3_h2l_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(4),
     .ResetVal(4'h0),
-    .BitMask(4'hf)
+    .BitMask(4'hf),
+    .DstWrReq(1)
   ) u_combo_intr_status_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     (combo_intr_status_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[3:0]),
     .src_busy_o   (combo_intr_status_busy),
     .src_qs_o     (combo_intr_status_qs), // for software read back
-    .dst_d_i      (aon_combo_intr_status_d),
+    .dst_update_i (aon_combo_intr_status_qe),
+    .dst_ds_i     (aon_combo_intr_status_ds),
+    .dst_qs_i     (aon_combo_intr_status_qs),
     .dst_we_o     (aon_combo_intr_status_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -1456,60 +1521,93 @@ module sysrst_ctrl_reg_top (
   assign unused_aon_combo_intr_status_wdata =
       ^aon_combo_intr_status_wdata;
 
+  logic  aon_key_intr_status_pwrb_h2l_ds_int;
   logic  aon_key_intr_status_pwrb_h2l_qs_int;
+  logic  aon_key_intr_status_key0_in_h2l_ds_int;
   logic  aon_key_intr_status_key0_in_h2l_qs_int;
+  logic  aon_key_intr_status_key1_in_h2l_ds_int;
   logic  aon_key_intr_status_key1_in_h2l_qs_int;
+  logic  aon_key_intr_status_key2_in_h2l_ds_int;
   logic  aon_key_intr_status_key2_in_h2l_qs_int;
+  logic  aon_key_intr_status_ac_present_h2l_ds_int;
   logic  aon_key_intr_status_ac_present_h2l_qs_int;
+  logic  aon_key_intr_status_ec_rst_l_h2l_ds_int;
   logic  aon_key_intr_status_ec_rst_l_h2l_qs_int;
+  logic  aon_key_intr_status_flash_wp_l_h2l_ds_int;
   logic  aon_key_intr_status_flash_wp_l_h2l_qs_int;
+  logic  aon_key_intr_status_pwrb_l2h_ds_int;
   logic  aon_key_intr_status_pwrb_l2h_qs_int;
+  logic  aon_key_intr_status_key0_in_l2h_ds_int;
   logic  aon_key_intr_status_key0_in_l2h_qs_int;
+  logic  aon_key_intr_status_key1_in_l2h_ds_int;
   logic  aon_key_intr_status_key1_in_l2h_qs_int;
+  logic  aon_key_intr_status_key2_in_l2h_ds_int;
   logic  aon_key_intr_status_key2_in_l2h_qs_int;
+  logic  aon_key_intr_status_ac_present_l2h_ds_int;
   logic  aon_key_intr_status_ac_present_l2h_qs_int;
+  logic  aon_key_intr_status_ec_rst_l_l2h_ds_int;
   logic  aon_key_intr_status_ec_rst_l_l2h_qs_int;
+  logic  aon_key_intr_status_flash_wp_l_l2h_ds_int;
   logic  aon_key_intr_status_flash_wp_l_l2h_qs_int;
-  logic [13:0] aon_key_intr_status_d;
+  logic [13:0] aon_key_intr_status_ds;
+  logic aon_key_intr_status_qe;
+  logic [13:0] aon_key_intr_status_qs;
   logic [13:0] aon_key_intr_status_wdata;
   logic aon_key_intr_status_we;
   logic unused_aon_key_intr_status_wdata;
 
   always_comb begin
-    aon_key_intr_status_d = '0;
-    aon_key_intr_status_d[0] = aon_key_intr_status_pwrb_h2l_qs_int;
-    aon_key_intr_status_d[1] = aon_key_intr_status_key0_in_h2l_qs_int;
-    aon_key_intr_status_d[2] = aon_key_intr_status_key1_in_h2l_qs_int;
-    aon_key_intr_status_d[3] = aon_key_intr_status_key2_in_h2l_qs_int;
-    aon_key_intr_status_d[4] = aon_key_intr_status_ac_present_h2l_qs_int;
-    aon_key_intr_status_d[5] = aon_key_intr_status_ec_rst_l_h2l_qs_int;
-    aon_key_intr_status_d[6] = aon_key_intr_status_flash_wp_l_h2l_qs_int;
-    aon_key_intr_status_d[7] = aon_key_intr_status_pwrb_l2h_qs_int;
-    aon_key_intr_status_d[8] = aon_key_intr_status_key0_in_l2h_qs_int;
-    aon_key_intr_status_d[9] = aon_key_intr_status_key1_in_l2h_qs_int;
-    aon_key_intr_status_d[10] = aon_key_intr_status_key2_in_l2h_qs_int;
-    aon_key_intr_status_d[11] = aon_key_intr_status_ac_present_l2h_qs_int;
-    aon_key_intr_status_d[12] = aon_key_intr_status_ec_rst_l_l2h_qs_int;
-    aon_key_intr_status_d[13] = aon_key_intr_status_flash_wp_l_l2h_qs_int;
+    aon_key_intr_status_qs = 14'h0;
+    aon_key_intr_status_ds = 14'h0;
+    aon_key_intr_status_ds[0] = aon_key_intr_status_pwrb_h2l_ds_int;
+    aon_key_intr_status_qs[0] = aon_key_intr_status_pwrb_h2l_qs_int;
+    aon_key_intr_status_ds[1] = aon_key_intr_status_key0_in_h2l_ds_int;
+    aon_key_intr_status_qs[1] = aon_key_intr_status_key0_in_h2l_qs_int;
+    aon_key_intr_status_ds[2] = aon_key_intr_status_key1_in_h2l_ds_int;
+    aon_key_intr_status_qs[2] = aon_key_intr_status_key1_in_h2l_qs_int;
+    aon_key_intr_status_ds[3] = aon_key_intr_status_key2_in_h2l_ds_int;
+    aon_key_intr_status_qs[3] = aon_key_intr_status_key2_in_h2l_qs_int;
+    aon_key_intr_status_ds[4] = aon_key_intr_status_ac_present_h2l_ds_int;
+    aon_key_intr_status_qs[4] = aon_key_intr_status_ac_present_h2l_qs_int;
+    aon_key_intr_status_ds[5] = aon_key_intr_status_ec_rst_l_h2l_ds_int;
+    aon_key_intr_status_qs[5] = aon_key_intr_status_ec_rst_l_h2l_qs_int;
+    aon_key_intr_status_ds[6] = aon_key_intr_status_flash_wp_l_h2l_ds_int;
+    aon_key_intr_status_qs[6] = aon_key_intr_status_flash_wp_l_h2l_qs_int;
+    aon_key_intr_status_ds[7] = aon_key_intr_status_pwrb_l2h_ds_int;
+    aon_key_intr_status_qs[7] = aon_key_intr_status_pwrb_l2h_qs_int;
+    aon_key_intr_status_ds[8] = aon_key_intr_status_key0_in_l2h_ds_int;
+    aon_key_intr_status_qs[8] = aon_key_intr_status_key0_in_l2h_qs_int;
+    aon_key_intr_status_ds[9] = aon_key_intr_status_key1_in_l2h_ds_int;
+    aon_key_intr_status_qs[9] = aon_key_intr_status_key1_in_l2h_qs_int;
+    aon_key_intr_status_ds[10] = aon_key_intr_status_key2_in_l2h_ds_int;
+    aon_key_intr_status_qs[10] = aon_key_intr_status_key2_in_l2h_qs_int;
+    aon_key_intr_status_ds[11] = aon_key_intr_status_ac_present_l2h_ds_int;
+    aon_key_intr_status_qs[11] = aon_key_intr_status_ac_present_l2h_qs_int;
+    aon_key_intr_status_ds[12] = aon_key_intr_status_ec_rst_l_l2h_ds_int;
+    aon_key_intr_status_qs[12] = aon_key_intr_status_ec_rst_l_l2h_qs_int;
+    aon_key_intr_status_ds[13] = aon_key_intr_status_flash_wp_l_l2h_ds_int;
+    aon_key_intr_status_qs[13] = aon_key_intr_status_flash_wp_l_l2h_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(14),
     .ResetVal(14'h0),
-    .BitMask(14'h3fff)
+    .BitMask(14'h3fff),
+    .DstWrReq(1)
   ) u_key_intr_status_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     (key_intr_status_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[13:0]),
     .src_busy_o   (key_intr_status_busy),
     .src_qs_o     (key_intr_status_qs), // for software read back
-    .dst_d_i      (aon_key_intr_status_d),
+    .dst_update_i (aon_key_intr_status_qe),
+    .dst_ds_i     (aon_key_intr_status_ds),
+    .dst_qs_i     (aon_key_intr_status_qs),
     .dst_we_o     (aon_key_intr_status_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -1539,6 +1637,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_qs)
@@ -1565,6 +1664,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_qs)
@@ -1585,6 +1685,7 @@ module sysrst_ctrl_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.qe = intr_test_qe;
@@ -1604,6 +1705,7 @@ module sysrst_ctrl_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -1629,6 +1731,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (regwen_qs)
@@ -1658,6 +1761,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ec_rst_ctl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_ec_rst_ctl_qs_int)
@@ -1688,6 +1792,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ulp_ac_debounce_ctl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_ulp_ac_debounce_ctl_qs_int)
@@ -1718,6 +1823,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ulp_lid_debounce_ctl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_ulp_lid_debounce_ctl_qs_int)
@@ -1748,6 +1854,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ulp_pwrb_debounce_ctl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_ulp_pwrb_debounce_ctl_qs_int)
@@ -1774,6 +1881,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ulp_ctl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_ulp_ctl_qs_int)
@@ -1781,6 +1889,8 @@ module sysrst_ctrl_reg_top (
 
 
   // R[ulp_status]: V(False)
+  logic [0:0] ulp_status_flds_we;
+  assign aon_ulp_status_qe = |ulp_status_flds_we;
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1798,8 +1908,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.ulp_status.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (ulp_status_flds_we[0]),
     .q      (),
+    .ds     (aon_ulp_status_ds_int),
 
     // to register interface (read)
     .qs     (aon_ulp_status_qs_int)
@@ -1807,6 +1918,8 @@ module sysrst_ctrl_reg_top (
 
 
   // R[wkup_status]: V(False)
+  logic [0:0] wkup_status_flds_we;
+  assign aon_wkup_status_qe = |wkup_status_flds_we;
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1824,8 +1937,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.wkup_status.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_status_flds_we[0]),
     .q      (reg2hw.wkup_status.q),
+    .ds     (aon_wkup_status_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_status_qs_int)
@@ -1856,6 +1970,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.key0_in.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_key0_in_qs_int)
@@ -1881,6 +1996,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.key0_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_key0_out_qs_int)
@@ -1906,6 +2022,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.key1_in.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_key1_in_qs_int)
@@ -1931,6 +2048,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.key1_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_key1_out_qs_int)
@@ -1956,6 +2074,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.key2_in.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_key2_in_qs_int)
@@ -1981,6 +2100,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.key2_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_key2_out_qs_int)
@@ -2006,6 +2126,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.pwrb_in.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_pwrb_in_qs_int)
@@ -2031,6 +2152,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.pwrb_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_pwrb_out_qs_int)
@@ -2056,6 +2178,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.ac_present.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_ac_present_qs_int)
@@ -2081,6 +2204,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.bat_disable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_bat_disable_qs_int)
@@ -2106,6 +2230,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.lid_open.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_lid_open_qs_int)
@@ -2131,6 +2256,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_invert_ctl.z3_wakeup.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_invert_ctl_z3_wakeup_qs_int)
@@ -2161,6 +2287,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.bat_disable_0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_bat_disable_0_qs_int)
@@ -2186,6 +2313,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.ec_rst_l_0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_ec_rst_l_0_qs_int)
@@ -2211,6 +2339,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.pwrb_out_0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_pwrb_out_0_qs_int)
@@ -2236,6 +2365,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.key0_out_0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_key0_out_0_qs_int)
@@ -2261,6 +2391,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.key1_out_0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_key1_out_0_qs_int)
@@ -2286,6 +2417,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.key2_out_0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_key2_out_0_qs_int)
@@ -2311,6 +2443,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.z3_wakeup_0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_z3_wakeup_0_qs_int)
@@ -2336,6 +2469,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.flash_wp_l_0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_flash_wp_l_0_qs_int)
@@ -2361,6 +2495,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.bat_disable_1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_bat_disable_1_qs_int)
@@ -2386,6 +2521,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.ec_rst_l_1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_ec_rst_l_1_qs_int)
@@ -2411,6 +2547,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.pwrb_out_1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_pwrb_out_1_qs_int)
@@ -2436,6 +2573,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.key0_out_1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_key0_out_1_qs_int)
@@ -2461,6 +2599,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.key1_out_1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_key1_out_1_qs_int)
@@ -2486,6 +2625,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.key2_out_1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_key2_out_1_qs_int)
@@ -2511,6 +2651,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.z3_wakeup_1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_z3_wakeup_1_qs_int)
@@ -2536,6 +2677,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_allowed_ctl.flash_wp_l_1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_flash_wp_l_1_qs_int)
@@ -2563,6 +2705,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_ctl.bat_disable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_ctl_bat_disable_qs_int)
@@ -2588,6 +2731,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_ctl.ec_rst_l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_ctl_ec_rst_l_qs_int)
@@ -2613,6 +2757,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_ctl.pwrb_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_ctl_pwrb_out_qs_int)
@@ -2638,6 +2783,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_ctl.key0_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_ctl_key0_out_qs_int)
@@ -2663,6 +2809,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_ctl.key1_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_ctl_key1_out_qs_int)
@@ -2688,6 +2835,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_ctl.key2_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_ctl_key2_out_qs_int)
@@ -2713,6 +2861,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_ctl.z3_wakeup.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_ctl_z3_wakeup_qs_int)
@@ -2738,6 +2887,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_ctl.flash_wp_l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_ctl_flash_wp_l_qs_int)
@@ -2765,6 +2915,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_value.bat_disable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_value_bat_disable_qs_int)
@@ -2790,6 +2941,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_value.ec_rst_l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_value_ec_rst_l_qs_int)
@@ -2815,6 +2967,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_value.pwrb_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_value_pwrb_out_qs_int)
@@ -2840,6 +2993,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_value.key0_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_value_key0_out_qs_int)
@@ -2865,6 +3019,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_value.key1_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_value_key1_out_qs_int)
@@ -2890,6 +3045,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_value.key2_out.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_value_key2_out_qs_int)
@@ -2915,6 +3071,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_value.z3_wakeup.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_value_z3_wakeup_qs_int)
@@ -2940,6 +3097,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.pin_out_value.flash_wp_l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_pin_out_value_flash_wp_l_qs_int)
@@ -2967,6 +3125,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (pin_in_value_pwrb_in_qs)
@@ -2992,6 +3151,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (pin_in_value_key0_in_qs)
@@ -3017,6 +3177,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (pin_in_value_key1_in_qs)
@@ -3042,6 +3203,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (pin_in_value_key2_in_qs)
@@ -3067,6 +3229,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (pin_in_value_lid_open_qs)
@@ -3092,6 +3255,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (pin_in_value_ac_present_qs)
@@ -3117,6 +3281,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (pin_in_value_ec_rst_l_qs)
@@ -3142,6 +3307,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (pin_in_value_flash_wp_l_qs)
@@ -3172,6 +3338,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.pwrb_in_h2l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_pwrb_in_h2l_qs_int)
@@ -3197,6 +3364,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.key0_in_h2l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_key0_in_h2l_qs_int)
@@ -3222,6 +3390,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.key1_in_h2l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_key1_in_h2l_qs_int)
@@ -3247,6 +3416,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.key2_in_h2l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_key2_in_h2l_qs_int)
@@ -3272,6 +3442,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.ac_present_h2l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_ac_present_h2l_qs_int)
@@ -3297,6 +3468,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.ec_rst_l_h2l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_ec_rst_l_h2l_qs_int)
@@ -3322,6 +3494,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.flash_wp_l_h2l.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_flash_wp_l_h2l_qs_int)
@@ -3347,6 +3520,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.pwrb_in_l2h.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_pwrb_in_l2h_qs_int)
@@ -3372,6 +3546,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.key0_in_l2h.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_key0_in_l2h_qs_int)
@@ -3397,6 +3572,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.key1_in_l2h.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_key1_in_l2h_qs_int)
@@ -3422,6 +3598,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.key2_in_l2h.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_key2_in_l2h_qs_int)
@@ -3447,6 +3624,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.ac_present_l2h.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_ac_present_l2h_qs_int)
@@ -3472,6 +3650,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.ec_rst_l_l2h.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_ec_rst_l_l2h_qs_int)
@@ -3497,6 +3676,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_ctl.flash_wp_l_l2h.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_ctl_flash_wp_l_l2h_qs_int)
@@ -3527,6 +3707,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.key_intr_debounce_ctl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_key_intr_debounce_ctl_qs_int)
@@ -3558,6 +3739,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.auto_block_debounce_ctl.debounce_timer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_auto_block_debounce_ctl_debounce_timer_qs_int)
@@ -3583,6 +3765,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.auto_block_debounce_ctl.auto_block_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_auto_block_debounce_ctl_auto_block_enable_qs_int)
@@ -3614,6 +3797,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.auto_block_out_ctl.key0_out_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_auto_block_out_ctl_key0_out_sel_qs_int)
@@ -3639,6 +3823,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.auto_block_out_ctl.key1_out_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_auto_block_out_ctl_key1_out_sel_qs_int)
@@ -3664,6 +3849,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.auto_block_out_ctl.key2_out_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_auto_block_out_ctl_key2_out_sel_qs_int)
@@ -3689,6 +3875,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.auto_block_out_ctl.key0_out_value.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_auto_block_out_ctl_key0_out_value_qs_int)
@@ -3714,6 +3901,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.auto_block_out_ctl.key1_out_value.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_auto_block_out_ctl_key1_out_value_qs_int)
@@ -3739,6 +3927,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.auto_block_out_ctl.key2_out_value.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_auto_block_out_ctl_key2_out_value_qs_int)
@@ -3770,6 +3959,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[0].key0_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_0_key0_in_sel_0_qs_int)
@@ -3795,6 +3985,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[0].key1_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_0_key1_in_sel_0_qs_int)
@@ -3820,6 +4011,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[0].key2_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_0_key2_in_sel_0_qs_int)
@@ -3845,6 +4037,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[0].pwrb_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_0_pwrb_in_sel_0_qs_int)
@@ -3870,6 +4063,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[0].ac_present_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_0_ac_present_sel_0_qs_int)
@@ -3901,6 +4095,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[1].key0_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_1_key0_in_sel_1_qs_int)
@@ -3926,6 +4121,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[1].key1_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_1_key1_in_sel_1_qs_int)
@@ -3951,6 +4147,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[1].key2_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_1_key2_in_sel_1_qs_int)
@@ -3976,6 +4173,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[1].pwrb_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_1_pwrb_in_sel_1_qs_int)
@@ -4001,6 +4199,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[1].ac_present_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_1_ac_present_sel_1_qs_int)
@@ -4032,6 +4231,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[2].key0_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_2_key0_in_sel_2_qs_int)
@@ -4057,6 +4257,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[2].key1_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_2_key1_in_sel_2_qs_int)
@@ -4082,6 +4283,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[2].key2_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_2_key2_in_sel_2_qs_int)
@@ -4107,6 +4309,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[2].pwrb_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_2_pwrb_in_sel_2_qs_int)
@@ -4132,6 +4335,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[2].ac_present_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_2_ac_present_sel_2_qs_int)
@@ -4163,6 +4367,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[3].key0_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_3_key0_in_sel_3_qs_int)
@@ -4188,6 +4393,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[3].key1_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_3_key1_in_sel_3_qs_int)
@@ -4213,6 +4419,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[3].key2_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_3_key2_in_sel_3_qs_int)
@@ -4238,6 +4445,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[3].pwrb_in_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_3_pwrb_in_sel_3_qs_int)
@@ -4263,6 +4471,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_sel_ctl[3].ac_present_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_sel_ctl_3_ac_present_sel_3_qs_int)
@@ -4293,6 +4502,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_det_ctl[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_det_ctl_0_qs_int)
@@ -4323,6 +4533,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_det_ctl[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_det_ctl_1_qs_int)
@@ -4353,6 +4564,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_det_ctl[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_det_ctl_2_qs_int)
@@ -4383,6 +4595,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_det_ctl[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_det_ctl_3_qs_int)
@@ -4414,6 +4627,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[0].bat_disable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_0_bat_disable_0_qs_int)
@@ -4439,6 +4653,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[0].interrupt.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_0_interrupt_0_qs_int)
@@ -4464,6 +4679,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[0].ec_rst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_0_ec_rst_0_qs_int)
@@ -4489,6 +4705,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[0].rst_req.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_0_rst_req_0_qs_int)
@@ -4520,6 +4737,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[1].bat_disable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_1_bat_disable_1_qs_int)
@@ -4545,6 +4763,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[1].interrupt.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_1_interrupt_1_qs_int)
@@ -4570,6 +4789,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[1].ec_rst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_1_ec_rst_1_qs_int)
@@ -4595,6 +4815,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[1].rst_req.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_1_rst_req_1_qs_int)
@@ -4626,6 +4847,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[2].bat_disable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_2_bat_disable_2_qs_int)
@@ -4651,6 +4873,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[2].interrupt.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_2_interrupt_2_qs_int)
@@ -4676,6 +4899,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[2].ec_rst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_2_ec_rst_2_qs_int)
@@ -4701,6 +4925,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[2].rst_req.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_2_rst_req_2_qs_int)
@@ -4732,6 +4957,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[3].bat_disable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_3_bat_disable_3_qs_int)
@@ -4757,6 +4983,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[3].interrupt.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_3_interrupt_3_qs_int)
@@ -4782,6 +5009,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[3].ec_rst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_3_ec_rst_3_qs_int)
@@ -4807,6 +5035,7 @@ module sysrst_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.com_out_ctl[3].rst_req.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_com_out_ctl_3_rst_req_3_qs_int)
@@ -4814,6 +5043,8 @@ module sysrst_ctrl_reg_top (
 
 
   // R[combo_intr_status]: V(False)
+  logic [3:0] combo_intr_status_flds_we;
+  assign aon_combo_intr_status_qe = |combo_intr_status_flds_we;
   //   F[combo0_h2l]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -4832,8 +5063,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.combo_intr_status.combo0_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (combo_intr_status_flds_we[0]),
     .q      (),
+    .ds     (aon_combo_intr_status_combo0_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_combo_intr_status_combo0_h2l_qs_int)
@@ -4857,8 +5089,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.combo_intr_status.combo1_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (combo_intr_status_flds_we[1]),
     .q      (),
+    .ds     (aon_combo_intr_status_combo1_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_combo_intr_status_combo1_h2l_qs_int)
@@ -4882,8 +5115,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.combo_intr_status.combo2_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (combo_intr_status_flds_we[2]),
     .q      (),
+    .ds     (aon_combo_intr_status_combo2_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_combo_intr_status_combo2_h2l_qs_int)
@@ -4907,8 +5141,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.combo_intr_status.combo3_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (combo_intr_status_flds_we[3]),
     .q      (),
+    .ds     (aon_combo_intr_status_combo3_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_combo_intr_status_combo3_h2l_qs_int)
@@ -4916,6 +5151,8 @@ module sysrst_ctrl_reg_top (
 
 
   // R[key_intr_status]: V(False)
+  logic [13:0] key_intr_status_flds_we;
+  assign aon_key_intr_status_qe = |key_intr_status_flds_we;
   //   F[pwrb_h2l]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -4934,8 +5171,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.pwrb_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[0]),
     .q      (),
+    .ds     (aon_key_intr_status_pwrb_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_pwrb_h2l_qs_int)
@@ -4959,8 +5197,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.key0_in_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[1]),
     .q      (),
+    .ds     (aon_key_intr_status_key0_in_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_key0_in_h2l_qs_int)
@@ -4984,8 +5223,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.key1_in_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[2]),
     .q      (),
+    .ds     (aon_key_intr_status_key1_in_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_key1_in_h2l_qs_int)
@@ -5009,8 +5249,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.key2_in_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[3]),
     .q      (),
+    .ds     (aon_key_intr_status_key2_in_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_key2_in_h2l_qs_int)
@@ -5034,8 +5275,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.ac_present_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[4]),
     .q      (),
+    .ds     (aon_key_intr_status_ac_present_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_ac_present_h2l_qs_int)
@@ -5059,8 +5301,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.ec_rst_l_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[5]),
     .q      (),
+    .ds     (aon_key_intr_status_ec_rst_l_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_ec_rst_l_h2l_qs_int)
@@ -5084,8 +5327,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.flash_wp_l_h2l.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[6]),
     .q      (),
+    .ds     (aon_key_intr_status_flash_wp_l_h2l_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_flash_wp_l_h2l_qs_int)
@@ -5109,8 +5353,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.pwrb_l2h.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[7]),
     .q      (),
+    .ds     (aon_key_intr_status_pwrb_l2h_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_pwrb_l2h_qs_int)
@@ -5134,8 +5379,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.key0_in_l2h.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[8]),
     .q      (),
+    .ds     (aon_key_intr_status_key0_in_l2h_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_key0_in_l2h_qs_int)
@@ -5159,8 +5405,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.key1_in_l2h.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[9]),
     .q      (),
+    .ds     (aon_key_intr_status_key1_in_l2h_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_key1_in_l2h_qs_int)
@@ -5184,8 +5431,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.key2_in_l2h.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[10]),
     .q      (),
+    .ds     (aon_key_intr_status_key2_in_l2h_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_key2_in_l2h_qs_int)
@@ -5209,8 +5457,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.ac_present_l2h.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[11]),
     .q      (),
+    .ds     (aon_key_intr_status_ac_present_l2h_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_ac_present_l2h_qs_int)
@@ -5234,8 +5483,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.ec_rst_l_l2h.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[12]),
     .q      (),
+    .ds     (aon_key_intr_status_ec_rst_l_l2h_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_ec_rst_l_l2h_qs_int)
@@ -5259,8 +5509,9 @@ module sysrst_ctrl_reg_top (
     .d      (hw2reg.key_intr_status.flash_wp_l_l2h.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (key_intr_status_flds_we[13]),
     .q      (),
+    .ds     (aon_key_intr_status_flash_wp_l_l2h_ds_int),
 
     // to register interface (read)
     .qs     (aon_key_intr_status_flash_wp_l_l2h_qs_int)

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -222,6 +222,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rwtype0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype0_qs)
@@ -249,6 +250,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rwtype1.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype1_field0_qs)
@@ -274,6 +276,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rwtype1.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype1_field1_qs)
@@ -299,6 +302,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rwtype1.field4.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype1_field4_qs)
@@ -324,6 +328,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rwtype1.field15_8.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype1_field15_8_qs)
@@ -350,6 +355,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rwtype2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype2_qs)
@@ -377,6 +383,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rwtype3.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype3_field0_qs)
@@ -402,6 +409,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rwtype3.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype3_field1_qs)
@@ -429,6 +437,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rwtype4.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype4_field0_qs)
@@ -454,6 +463,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rwtype4.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype4_field1_qs)
@@ -480,6 +490,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rotype0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rotype0_qs)
@@ -506,6 +517,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.w1ctype0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (w1ctype0_qs)
@@ -533,6 +545,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.w1ctype1.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (w1ctype1_field0_qs)
@@ -558,6 +571,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.w1ctype1.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (w1ctype1_field1_qs)
@@ -584,6 +598,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.w1ctype2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (w1ctype2_qs)
@@ -610,6 +625,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.w1stype2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (w1stype2_qs)
@@ -636,6 +652,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.w0ctype2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (w0ctype2_qs)
@@ -662,6 +679,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.r0w1ctype2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -688,6 +706,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rctype0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rctype0_qs)
@@ -714,6 +733,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wotype0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -741,6 +761,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mixtype0.field0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mixtype0_field0_qs)
@@ -766,6 +787,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mixtype0.field1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mixtype0_field1_qs)
@@ -791,6 +813,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mixtype0.field2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mixtype0_field2_qs)
@@ -816,6 +839,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mixtype0.field3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mixtype0_field3_qs)
@@ -841,6 +865,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mixtype0.field4.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mixtype0_field4_qs)
@@ -866,6 +891,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mixtype0.field5.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mixtype0_field5_qs)
@@ -891,6 +917,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mixtype0.field6.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mixtype0_field6_qs)
@@ -916,6 +943,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mixtype0.field7.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -953,6 +981,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (rwtype5_flds_we[0]),
     .q      (reg2hw.rwtype5.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype5_qs)
@@ -974,6 +1003,7 @@ module trial1_reg_top (
     .qre    (),
     .qe     (rwtype6_flds_we[0]),
     .q      (reg2hw.rwtype6.q),
+    .ds     (),
     .qs     (rwtype6_qs)
   );
   assign reg2hw.rwtype6.qe = rwtype6_qe;
@@ -990,6 +1020,7 @@ module trial1_reg_top (
     .qre    (),
     .qe     (),
     .q      (reg2hw.rotype1.q),
+    .ds     (),
     .qs     (rotype1_qs)
   );
 
@@ -1028,6 +1059,7 @@ module trial1_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rwtype7_qs)

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -241,6 +241,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.tx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_tx_watermark_qs)
@@ -266,6 +267,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_watermark_qs)
@@ -291,6 +293,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.tx_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_tx_empty_qs)
@@ -316,6 +319,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_overflow_qs)
@@ -341,6 +345,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_frame_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_frame_err_qs)
@@ -366,6 +371,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_break_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_break_err_qs)
@@ -391,6 +397,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_timeout.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_timeout_qs)
@@ -416,6 +423,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_parity_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_parity_err_qs)
@@ -443,6 +451,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.tx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_tx_watermark_qs)
@@ -468,6 +477,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_watermark.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_watermark_qs)
@@ -493,6 +503,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.tx_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_tx_empty_qs)
@@ -518,6 +529,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_overflow_qs)
@@ -543,6 +555,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_frame_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_frame_err_qs)
@@ -568,6 +581,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_break_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_break_err_qs)
@@ -593,6 +607,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_timeout.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_timeout_qs)
@@ -618,6 +633,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_parity_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_parity_err_qs)
@@ -639,6 +655,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.tx_watermark.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.tx_watermark.qe = intr_test_qe;
@@ -654,6 +671,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.rx_watermark.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_watermark.qe = intr_test_qe;
@@ -669,6 +687,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.tx_empty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.tx_empty.qe = intr_test_qe;
@@ -684,6 +703,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.rx_overflow.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_overflow.qe = intr_test_qe;
@@ -699,6 +719,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.rx_frame_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_frame_err.qe = intr_test_qe;
@@ -714,6 +735,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.rx_break_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_break_err.qe = intr_test_qe;
@@ -729,6 +751,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[6]),
     .q      (reg2hw.intr_test.rx_timeout.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_timeout.qe = intr_test_qe;
@@ -744,6 +767,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[7]),
     .q      (reg2hw.intr_test.rx_parity_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_parity_err.qe = intr_test_qe;
@@ -763,6 +787,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -789,6 +814,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.tx.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_tx_qs)
@@ -814,6 +840,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.rx.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_rx_qs)
@@ -839,6 +866,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.nf.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_nf_qs)
@@ -864,6 +892,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.slpbk.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_slpbk_qs)
@@ -889,6 +918,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.llpbk.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_llpbk_qs)
@@ -914,6 +944,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.parity_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_parity_en_qs)
@@ -939,6 +970,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.parity_odd.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_parity_odd_qs)
@@ -964,6 +996,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.rxblvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_rxblvl_qs)
@@ -989,6 +1022,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ctrl.nco.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ctrl_nco_qs)
@@ -1007,6 +1041,7 @@ module uart_reg_top (
     .qre    (reg2hw.status.txfull.re),
     .qe     (),
     .q      (reg2hw.status.txfull.q),
+    .ds     (),
     .qs     (status_txfull_qs)
   );
 
@@ -1021,6 +1056,7 @@ module uart_reg_top (
     .qre    (reg2hw.status.rxfull.re),
     .qe     (),
     .q      (reg2hw.status.rxfull.q),
+    .ds     (),
     .qs     (status_rxfull_qs)
   );
 
@@ -1035,6 +1071,7 @@ module uart_reg_top (
     .qre    (reg2hw.status.txempty.re),
     .qe     (),
     .q      (reg2hw.status.txempty.q),
+    .ds     (),
     .qs     (status_txempty_qs)
   );
 
@@ -1049,6 +1086,7 @@ module uart_reg_top (
     .qre    (reg2hw.status.txidle.re),
     .qe     (),
     .q      (reg2hw.status.txidle.q),
+    .ds     (),
     .qs     (status_txidle_qs)
   );
 
@@ -1063,6 +1101,7 @@ module uart_reg_top (
     .qre    (reg2hw.status.rxidle.re),
     .qe     (),
     .q      (reg2hw.status.rxidle.q),
+    .ds     (),
     .qs     (status_rxidle_qs)
   );
 
@@ -1077,6 +1116,7 @@ module uart_reg_top (
     .qre    (reg2hw.status.rxempty.re),
     .qe     (),
     .q      (reg2hw.status.rxempty.q),
+    .ds     (),
     .qs     (status_rxempty_qs)
   );
 
@@ -1092,6 +1132,7 @@ module uart_reg_top (
     .qre    (reg2hw.rdata.re),
     .qe     (),
     .q      (reg2hw.rdata.q),
+    .ds     (),
     .qs     (rdata_qs)
   );
 
@@ -1127,6 +1168,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (wdata_flds_we[0]),
     .q      (reg2hw.wdata.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1166,6 +1208,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (fifo_ctrl_flds_we[0]),
     .q      (reg2hw.fifo_ctrl.rxrst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1192,6 +1235,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (fifo_ctrl_flds_we[1]),
     .q      (reg2hw.fifo_ctrl.txrst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -1218,6 +1262,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (fifo_ctrl_flds_we[2]),
     .q      (reg2hw.fifo_ctrl.rxilvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_ctrl_rxilvl_qs)
@@ -1244,6 +1289,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (fifo_ctrl_flds_we[3]),
     .q      (reg2hw.fifo_ctrl.txilvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_ctrl_txilvl_qs)
@@ -1263,6 +1309,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (fifo_status_txlvl_qs)
   );
 
@@ -1277,6 +1324,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (fifo_status_rxlvl_qs)
   );
 
@@ -1302,6 +1350,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ovrd.txen.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ovrd_txen_qs)
@@ -1327,6 +1376,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ovrd.txval.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ovrd_txval_qs)
@@ -1344,6 +1394,7 @@ module uart_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (val_qs)
   );
 
@@ -1369,6 +1420,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timeout_ctrl.val.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timeout_ctrl_val_qs)
@@ -1394,6 +1446,7 @@ module uart_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.timeout_ctrl.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (timeout_ctrl_en_qs)

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -172,30 +172,6 @@ module usbdev_reg_top (
   );
 
   // cdc oversampling signals
-    logic sync_usb_48mhz_update;
-  prim_sync_reqack u_usb_48mhz_tgl (
-    .clk_src_i(clk_usb_48mhz_i),
-    .rst_src_ni(rst_usb_48mhz_ni),
-    .clk_dst_i(clk_i),
-    .rst_dst_ni(rst_ni),
-    .req_chk_i(1'b1),
-    .src_req_i(1'b1),
-    .src_ack_o(),
-    .dst_req_o(sync_usb_48mhz_update),
-    .dst_ack_i(sync_usb_48mhz_update)
-  );
-    logic sync_aon_update;
-  prim_sync_reqack u_aon_tgl (
-    .clk_src_i(clk_aon_i),
-    .rst_src_ni(rst_aon_ni),
-    .clk_dst_i(clk_i),
-    .rst_dst_ni(rst_ni),
-    .req_chk_i(1'b1),
-    .src_req_i(1'b1),
-    .src_ack_o(),
-    .dst_req_o(sync_aon_update),
-    .dst_ack_i(sync_aon_update)
-  );
 
   assign reg_rdata = reg_rdata_next ;
   assign reg_error = (devmode_i & addrmiss) | wr_err | intg_err;
@@ -711,36 +687,46 @@ module usbdev_reg_top (
   // Define register CDC handling.
   // CDC handling is done on a per-reg instead of per-field boundary.
 
+  logic  usb_48mhz_usbctrl_enable_ds_int;
   logic  usb_48mhz_usbctrl_enable_qs_int;
+  logic  usb_48mhz_usbctrl_resume_link_active_ds_int;
+  logic [6:0]  usb_48mhz_usbctrl_device_address_ds_int;
   logic [6:0]  usb_48mhz_usbctrl_device_address_qs_int;
-  logic [22:0] usb_48mhz_usbctrl_d;
+  logic [22:0] usb_48mhz_usbctrl_ds;
+  logic usb_48mhz_usbctrl_qe;
+  logic [22:0] usb_48mhz_usbctrl_qs;
   logic [22:0] usb_48mhz_usbctrl_wdata;
   logic usb_48mhz_usbctrl_we;
   logic unused_usb_48mhz_usbctrl_wdata;
 
   always_comb begin
-    usb_48mhz_usbctrl_d = '0;
-    usb_48mhz_usbctrl_d[0] = usb_48mhz_usbctrl_enable_qs_int;
-    usb_48mhz_usbctrl_d[22:16] = usb_48mhz_usbctrl_device_address_qs_int;
+    usb_48mhz_usbctrl_qs = 23'h0;
+    usb_48mhz_usbctrl_ds = 23'h0;
+    usb_48mhz_usbctrl_ds[0] = usb_48mhz_usbctrl_enable_ds_int;
+    usb_48mhz_usbctrl_qs[0] = usb_48mhz_usbctrl_enable_qs_int;
+    usb_48mhz_usbctrl_ds[22:16] = usb_48mhz_usbctrl_device_address_ds_int;
+    usb_48mhz_usbctrl_qs[22:16] = usb_48mhz_usbctrl_device_address_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(23),
     .ResetVal(23'h0),
-    .BitMask(23'h7f0003)
+    .BitMask(23'h7f0003),
+    .DstWrReq(1)
   ) u_usbctrl_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_usb_48mhz_i),
     .rst_dst_ni   (rst_usb_48mhz_ni),
-    .src_update_i (sync_usb_48mhz_update),
     .src_regwen_i ('0),
     .src_we_i     (usbctrl_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[22:0]),
     .src_busy_o   (usbctrl_busy),
     .src_qs_o     (usbctrl_qs), // for software read back
-    .dst_d_i      (usb_48mhz_usbctrl_d),
+    .dst_update_i (usb_48mhz_usbctrl_qe),
+    .dst_ds_i     (usb_48mhz_usbctrl_ds),
+    .dst_qs_i     (usb_48mhz_usbctrl_qs),
     .dst_we_o     (usb_48mhz_usbctrl_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -749,56 +735,85 @@ module usbdev_reg_top (
   assign unused_usb_48mhz_usbctrl_wdata =
       ^usb_48mhz_usbctrl_wdata;
 
+  logic  usb_48mhz_rxenable_out_out_0_ds_int;
   logic  usb_48mhz_rxenable_out_out_0_qs_int;
+  logic  usb_48mhz_rxenable_out_out_1_ds_int;
   logic  usb_48mhz_rxenable_out_out_1_qs_int;
+  logic  usb_48mhz_rxenable_out_out_2_ds_int;
   logic  usb_48mhz_rxenable_out_out_2_qs_int;
+  logic  usb_48mhz_rxenable_out_out_3_ds_int;
   logic  usb_48mhz_rxenable_out_out_3_qs_int;
+  logic  usb_48mhz_rxenable_out_out_4_ds_int;
   logic  usb_48mhz_rxenable_out_out_4_qs_int;
+  logic  usb_48mhz_rxenable_out_out_5_ds_int;
   logic  usb_48mhz_rxenable_out_out_5_qs_int;
+  logic  usb_48mhz_rxenable_out_out_6_ds_int;
   logic  usb_48mhz_rxenable_out_out_6_qs_int;
+  logic  usb_48mhz_rxenable_out_out_7_ds_int;
   logic  usb_48mhz_rxenable_out_out_7_qs_int;
+  logic  usb_48mhz_rxenable_out_out_8_ds_int;
   logic  usb_48mhz_rxenable_out_out_8_qs_int;
+  logic  usb_48mhz_rxenable_out_out_9_ds_int;
   logic  usb_48mhz_rxenable_out_out_9_qs_int;
+  logic  usb_48mhz_rxenable_out_out_10_ds_int;
   logic  usb_48mhz_rxenable_out_out_10_qs_int;
+  logic  usb_48mhz_rxenable_out_out_11_ds_int;
   logic  usb_48mhz_rxenable_out_out_11_qs_int;
-  logic [11:0] usb_48mhz_rxenable_out_d;
+  logic [11:0] usb_48mhz_rxenable_out_ds;
+  logic usb_48mhz_rxenable_out_qe;
+  logic [11:0] usb_48mhz_rxenable_out_qs;
   logic [11:0] usb_48mhz_rxenable_out_wdata;
   logic usb_48mhz_rxenable_out_we;
   logic unused_usb_48mhz_rxenable_out_wdata;
 
   always_comb begin
-    usb_48mhz_rxenable_out_d = '0;
-    usb_48mhz_rxenable_out_d[0] = usb_48mhz_rxenable_out_out_0_qs_int;
-    usb_48mhz_rxenable_out_d[1] = usb_48mhz_rxenable_out_out_1_qs_int;
-    usb_48mhz_rxenable_out_d[2] = usb_48mhz_rxenable_out_out_2_qs_int;
-    usb_48mhz_rxenable_out_d[3] = usb_48mhz_rxenable_out_out_3_qs_int;
-    usb_48mhz_rxenable_out_d[4] = usb_48mhz_rxenable_out_out_4_qs_int;
-    usb_48mhz_rxenable_out_d[5] = usb_48mhz_rxenable_out_out_5_qs_int;
-    usb_48mhz_rxenable_out_d[6] = usb_48mhz_rxenable_out_out_6_qs_int;
-    usb_48mhz_rxenable_out_d[7] = usb_48mhz_rxenable_out_out_7_qs_int;
-    usb_48mhz_rxenable_out_d[8] = usb_48mhz_rxenable_out_out_8_qs_int;
-    usb_48mhz_rxenable_out_d[9] = usb_48mhz_rxenable_out_out_9_qs_int;
-    usb_48mhz_rxenable_out_d[10] = usb_48mhz_rxenable_out_out_10_qs_int;
-    usb_48mhz_rxenable_out_d[11] = usb_48mhz_rxenable_out_out_11_qs_int;
+    usb_48mhz_rxenable_out_qs = 12'h0;
+    usb_48mhz_rxenable_out_ds = 12'h0;
+    usb_48mhz_rxenable_out_ds[0] = usb_48mhz_rxenable_out_out_0_ds_int;
+    usb_48mhz_rxenable_out_qs[0] = usb_48mhz_rxenable_out_out_0_qs_int;
+    usb_48mhz_rxenable_out_ds[1] = usb_48mhz_rxenable_out_out_1_ds_int;
+    usb_48mhz_rxenable_out_qs[1] = usb_48mhz_rxenable_out_out_1_qs_int;
+    usb_48mhz_rxenable_out_ds[2] = usb_48mhz_rxenable_out_out_2_ds_int;
+    usb_48mhz_rxenable_out_qs[2] = usb_48mhz_rxenable_out_out_2_qs_int;
+    usb_48mhz_rxenable_out_ds[3] = usb_48mhz_rxenable_out_out_3_ds_int;
+    usb_48mhz_rxenable_out_qs[3] = usb_48mhz_rxenable_out_out_3_qs_int;
+    usb_48mhz_rxenable_out_ds[4] = usb_48mhz_rxenable_out_out_4_ds_int;
+    usb_48mhz_rxenable_out_qs[4] = usb_48mhz_rxenable_out_out_4_qs_int;
+    usb_48mhz_rxenable_out_ds[5] = usb_48mhz_rxenable_out_out_5_ds_int;
+    usb_48mhz_rxenable_out_qs[5] = usb_48mhz_rxenable_out_out_5_qs_int;
+    usb_48mhz_rxenable_out_ds[6] = usb_48mhz_rxenable_out_out_6_ds_int;
+    usb_48mhz_rxenable_out_qs[6] = usb_48mhz_rxenable_out_out_6_qs_int;
+    usb_48mhz_rxenable_out_ds[7] = usb_48mhz_rxenable_out_out_7_ds_int;
+    usb_48mhz_rxenable_out_qs[7] = usb_48mhz_rxenable_out_out_7_qs_int;
+    usb_48mhz_rxenable_out_ds[8] = usb_48mhz_rxenable_out_out_8_ds_int;
+    usb_48mhz_rxenable_out_qs[8] = usb_48mhz_rxenable_out_out_8_qs_int;
+    usb_48mhz_rxenable_out_ds[9] = usb_48mhz_rxenable_out_out_9_ds_int;
+    usb_48mhz_rxenable_out_qs[9] = usb_48mhz_rxenable_out_out_9_qs_int;
+    usb_48mhz_rxenable_out_ds[10] = usb_48mhz_rxenable_out_out_10_ds_int;
+    usb_48mhz_rxenable_out_qs[10] = usb_48mhz_rxenable_out_out_10_qs_int;
+    usb_48mhz_rxenable_out_ds[11] = usb_48mhz_rxenable_out_out_11_ds_int;
+    usb_48mhz_rxenable_out_qs[11] = usb_48mhz_rxenable_out_out_11_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(12),
     .ResetVal(12'h0),
-    .BitMask(12'hfff)
+    .BitMask(12'hfff),
+    .DstWrReq(1)
   ) u_rxenable_out_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_usb_48mhz_i),
     .rst_dst_ni   (rst_usb_48mhz_ni),
-    .src_update_i (sync_usb_48mhz_update),
     .src_regwen_i ('0),
     .src_we_i     (rxenable_out_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[11:0]),
     .src_busy_o   (rxenable_out_busy),
     .src_qs_o     (rxenable_out_qs), // for software read back
-    .dst_d_i      (usb_48mhz_rxenable_out_d),
+    .dst_update_i (usb_48mhz_rxenable_out_qe),
+    .dst_ds_i     (usb_48mhz_rxenable_out_ds),
+    .dst_qs_i     (usb_48mhz_rxenable_out_qs),
     .dst_we_o     (usb_48mhz_rxenable_out_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -807,32 +822,34 @@ module usbdev_reg_top (
   assign unused_usb_48mhz_rxenable_out_wdata =
       ^usb_48mhz_rxenable_out_wdata;
 
-  logic [1:0] aon_wake_control_d;
+  logic [1:0] aon_wake_control_qs;
   logic [1:0] aon_wake_control_wdata;
   logic aon_wake_control_we;
   logic unused_aon_wake_control_wdata;
 
   always_comb begin
-    aon_wake_control_d = '0;
+    aon_wake_control_qs = 2'h0;
   end
 
   prim_reg_cdc #(
     .DataWidth(2),
     .ResetVal(2'h0),
-    .BitMask(2'h3)
+    .BitMask(2'h3),
+    .DstWrReq(0)
   ) u_wake_control_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     (wake_control_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[1:0]),
     .src_busy_o   (wake_control_busy),
     .src_qs_o     (wake_control_qs), // for software read back
-    .dst_d_i      (aon_wake_control_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wake_control_qs),
     .dst_we_o     (aon_wake_control_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -841,35 +858,46 @@ module usbdev_reg_top (
   assign unused_aon_wake_control_wdata =
       ^aon_wake_control_wdata;
 
+  logic  aon_wake_events_module_active_ds_int;
   logic  aon_wake_events_module_active_qs_int;
+  logic  aon_wake_events_disconnected_ds_int;
   logic  aon_wake_events_disconnected_qs_int;
+  logic  aon_wake_events_bus_reset_ds_int;
   logic  aon_wake_events_bus_reset_qs_int;
-  logic [9:0] aon_wake_events_d;
+  logic [9:0] aon_wake_events_ds;
+  logic aon_wake_events_qe;
+  logic [9:0] aon_wake_events_qs;
 
   always_comb begin
-    aon_wake_events_d = '0;
-    aon_wake_events_d[0] = aon_wake_events_module_active_qs_int;
-    aon_wake_events_d[8] = aon_wake_events_disconnected_qs_int;
-    aon_wake_events_d[9] = aon_wake_events_bus_reset_qs_int;
+    aon_wake_events_qs = 10'h0;
+    aon_wake_events_ds = 10'h0;
+    aon_wake_events_ds[0] = aon_wake_events_module_active_ds_int;
+    aon_wake_events_qs[0] = aon_wake_events_module_active_qs_int;
+    aon_wake_events_ds[8] = aon_wake_events_disconnected_ds_int;
+    aon_wake_events_qs[8] = aon_wake_events_disconnected_qs_int;
+    aon_wake_events_ds[9] = aon_wake_events_bus_reset_ds_int;
+    aon_wake_events_qs[9] = aon_wake_events_bus_reset_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(10),
     .ResetVal(10'h0),
-    .BitMask(10'h301)
+    .BitMask(10'h301),
+    .DstWrReq(1)
   ) u_wake_events_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     ('0),
     .src_re_i     ('0),
     .src_wd_i     ('0),
     .src_busy_o   (wake_events_busy),
     .src_qs_o     (wake_events_qs), // for software read back
-    .dst_d_i      (aon_wake_events_d),
+    .dst_update_i (aon_wake_events_qe),
+    .dst_ds_i     (aon_wake_events_ds),
+    .dst_qs_i     (aon_wake_events_qs),
     .dst_we_o     (),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -898,6 +926,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.pkt_received.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_pkt_received_qs)
@@ -923,6 +952,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.pkt_sent.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_pkt_sent_qs)
@@ -948,6 +978,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.disconnected.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_disconnected_qs)
@@ -973,6 +1004,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.host_lost.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_host_lost_qs)
@@ -998,6 +1030,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.link_reset.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_link_reset_qs)
@@ -1023,6 +1056,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.link_suspend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_link_suspend_qs)
@@ -1048,6 +1082,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.link_resume.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_link_resume_qs)
@@ -1073,6 +1108,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.av_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_av_empty_qs)
@@ -1098,6 +1134,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_full.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_full_qs)
@@ -1123,6 +1160,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.av_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_av_overflow_qs)
@@ -1148,6 +1186,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.link_in_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_link_in_err_qs)
@@ -1173,6 +1212,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_crc_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_crc_err_qs)
@@ -1198,6 +1238,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_pid_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_pid_err_qs)
@@ -1223,6 +1264,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rx_bitstuff_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rx_bitstuff_err_qs)
@@ -1248,6 +1290,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.frame.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_frame_qs)
@@ -1273,6 +1316,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.powered.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_powered_qs)
@@ -1298,6 +1342,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.link_out_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_link_out_err_qs)
@@ -1325,6 +1370,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.pkt_received.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_pkt_received_qs)
@@ -1350,6 +1396,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.pkt_sent.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_pkt_sent_qs)
@@ -1375,6 +1422,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.disconnected.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_disconnected_qs)
@@ -1400,6 +1448,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.host_lost.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_host_lost_qs)
@@ -1425,6 +1474,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.link_reset.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_link_reset_qs)
@@ -1450,6 +1500,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.link_suspend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_link_suspend_qs)
@@ -1475,6 +1526,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.link_resume.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_link_resume_qs)
@@ -1500,6 +1552,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.av_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_av_empty_qs)
@@ -1525,6 +1578,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_full.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_full_qs)
@@ -1550,6 +1604,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.av_overflow.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_av_overflow_qs)
@@ -1575,6 +1630,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.link_in_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_link_in_err_qs)
@@ -1600,6 +1656,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_crc_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_crc_err_qs)
@@ -1625,6 +1682,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_pid_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_pid_err_qs)
@@ -1650,6 +1708,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rx_bitstuff_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rx_bitstuff_err_qs)
@@ -1675,6 +1734,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.frame.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_frame_qs)
@@ -1700,6 +1760,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.powered.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_powered_qs)
@@ -1725,6 +1786,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.link_out_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_link_out_err_qs)
@@ -1746,6 +1808,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.pkt_received.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.pkt_received.qe = intr_test_qe;
@@ -1761,6 +1824,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.pkt_sent.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.pkt_sent.qe = intr_test_qe;
@@ -1776,6 +1840,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.disconnected.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.disconnected.qe = intr_test_qe;
@@ -1791,6 +1856,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.host_lost.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.host_lost.qe = intr_test_qe;
@@ -1806,6 +1872,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.link_reset.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.link_reset.qe = intr_test_qe;
@@ -1821,6 +1888,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.link_suspend.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.link_suspend.qe = intr_test_qe;
@@ -1836,6 +1904,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[6]),
     .q      (reg2hw.intr_test.link_resume.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.link_resume.qe = intr_test_qe;
@@ -1851,6 +1920,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[7]),
     .q      (reg2hw.intr_test.av_empty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.av_empty.qe = intr_test_qe;
@@ -1866,6 +1936,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[8]),
     .q      (reg2hw.intr_test.rx_full.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_full.qe = intr_test_qe;
@@ -1881,6 +1952,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[9]),
     .q      (reg2hw.intr_test.av_overflow.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.av_overflow.qe = intr_test_qe;
@@ -1896,6 +1968,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[10]),
     .q      (reg2hw.intr_test.link_in_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.link_in_err.qe = intr_test_qe;
@@ -1911,6 +1984,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[11]),
     .q      (reg2hw.intr_test.rx_crc_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_crc_err.qe = intr_test_qe;
@@ -1926,6 +2000,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[12]),
     .q      (reg2hw.intr_test.rx_pid_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_pid_err.qe = intr_test_qe;
@@ -1941,6 +2016,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[13]),
     .q      (reg2hw.intr_test.rx_bitstuff_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rx_bitstuff_err.qe = intr_test_qe;
@@ -1956,6 +2032,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[14]),
     .q      (reg2hw.intr_test.frame.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.frame.qe = intr_test_qe;
@@ -1971,6 +2048,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[15]),
     .q      (reg2hw.intr_test.powered.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.powered.qe = intr_test_qe;
@@ -1986,6 +2064,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[16]),
     .q      (reg2hw.intr_test.link_out_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.link_out_err.qe = intr_test_qe;
@@ -2005,6 +2084,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -2022,6 +2102,7 @@ module usbdev_reg_top (
     .d_i(&usbctrl_flds_we),
     .q_o(usbctrl_qe)
   );
+  assign usb_48mhz_usbctrl_qe = |usbctrl_flds_we;
   //   F[enable]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -2042,6 +2123,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (usbctrl_flds_we[0]),
     .q      (reg2hw.usbctrl.enable.q),
+    .ds     (usb_48mhz_usbctrl_enable_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_usbctrl_enable_qs_int)
@@ -2067,6 +2149,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (usbctrl_flds_we[1]),
     .q      (reg2hw.usbctrl.resume_link_active.q),
+    .ds     (usb_48mhz_usbctrl_resume_link_active_ds_int),
 
     // to register interface (read)
     .qs     ()
@@ -2093,6 +2176,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (usbctrl_flds_we[2]),
     .q      (reg2hw.usbctrl.device_address.q),
+    .ds     (usb_48mhz_usbctrl_device_address_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_usbctrl_device_address_qs_int)
@@ -2121,6 +2205,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_0_qs)
@@ -2146,6 +2231,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_1_qs)
@@ -2171,6 +2257,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_2_qs)
@@ -2196,6 +2283,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_3_qs)
@@ -2221,6 +2309,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_4_qs)
@@ -2246,6 +2335,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_5_qs)
@@ -2271,6 +2361,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_6_qs)
@@ -2296,6 +2387,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_7_qs)
@@ -2321,6 +2413,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_8_qs)
@@ -2346,6 +2439,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_9_qs)
@@ -2371,6 +2465,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_10_qs)
@@ -2396,6 +2491,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_out_enable[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_out_enable_enable_11_qs)
@@ -2424,6 +2520,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_0_qs)
@@ -2449,6 +2546,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_1_qs)
@@ -2474,6 +2572,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_2_qs)
@@ -2499,6 +2598,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_3_qs)
@@ -2524,6 +2624,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_4_qs)
@@ -2549,6 +2650,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_5_qs)
@@ -2574,6 +2676,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_6_qs)
@@ -2599,6 +2702,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_7_qs)
@@ -2624,6 +2728,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_8_qs)
@@ -2649,6 +2754,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_9_qs)
@@ -2674,6 +2780,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_10_qs)
@@ -2699,6 +2806,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ep_in_enable[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ep_in_enable_enable_11_qs)
@@ -2717,6 +2825,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (usbstat_frame_qs)
   );
 
@@ -2731,6 +2840,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (usbstat_host_lost_qs)
   );
 
@@ -2745,6 +2855,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (usbstat_link_state_qs)
   );
 
@@ -2759,6 +2870,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (usbstat_sense_qs)
   );
 
@@ -2773,6 +2885,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (usbstat_av_depth_qs)
   );
 
@@ -2787,6 +2900,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (usbstat_av_full_qs)
   );
 
@@ -2801,6 +2915,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (usbstat_rx_depth_qs)
   );
 
@@ -2815,6 +2930,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (usbstat_rx_empty_qs)
   );
 
@@ -2850,6 +2966,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (avbuffer_flds_we[0]),
     .q      (reg2hw.avbuffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -2869,6 +2986,7 @@ module usbdev_reg_top (
     .qre    (reg2hw.rxfifo.buffer.re),
     .qe     (),
     .q      (reg2hw.rxfifo.buffer.q),
+    .ds     (),
     .qs     (rxfifo_buffer_qs)
   );
 
@@ -2883,6 +3001,7 @@ module usbdev_reg_top (
     .qre    (reg2hw.rxfifo.size.re),
     .qe     (),
     .q      (reg2hw.rxfifo.size.q),
+    .ds     (),
     .qs     (rxfifo_size_qs)
   );
 
@@ -2897,6 +3016,7 @@ module usbdev_reg_top (
     .qre    (reg2hw.rxfifo.setup.re),
     .qe     (),
     .q      (reg2hw.rxfifo.setup.q),
+    .ds     (),
     .qs     (rxfifo_setup_qs)
   );
 
@@ -2911,6 +3031,7 @@ module usbdev_reg_top (
     .qre    (reg2hw.rxfifo.ep.re),
     .qe     (),
     .q      (reg2hw.rxfifo.ep.q),
+    .ds     (),
     .qs     (rxfifo_ep_qs)
   );
 
@@ -2937,6 +3058,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_0_qs)
@@ -2962,6 +3084,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_1_qs)
@@ -2987,6 +3110,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_2_qs)
@@ -3012,6 +3136,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_3_qs)
@@ -3037,6 +3162,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_4_qs)
@@ -3062,6 +3188,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_5_qs)
@@ -3087,6 +3214,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_6_qs)
@@ -3112,6 +3240,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_7_qs)
@@ -3137,6 +3266,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_8_qs)
@@ -3162,6 +3292,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_9_qs)
@@ -3187,6 +3318,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_10_qs)
@@ -3212,6 +3344,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rxenable_setup[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rxenable_setup_setup_11_qs)
@@ -3220,6 +3353,8 @@ module usbdev_reg_top (
 
   // Subregister 0 of Multireg rxenable_out
   // R[rxenable_out]: V(False)
+  logic [11:0] rxenable_out_flds_we;
+  assign usb_48mhz_rxenable_out_qe = |rxenable_out_flds_we;
   //   F[out_0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -3238,8 +3373,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[0].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[0]),
     .q      (reg2hw.rxenable_out[0].q),
+    .ds     (usb_48mhz_rxenable_out_out_0_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_0_qs_int)
@@ -3263,8 +3399,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[1].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[1]),
     .q      (reg2hw.rxenable_out[1].q),
+    .ds     (usb_48mhz_rxenable_out_out_1_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_1_qs_int)
@@ -3288,8 +3425,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[2].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[2]),
     .q      (reg2hw.rxenable_out[2].q),
+    .ds     (usb_48mhz_rxenable_out_out_2_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_2_qs_int)
@@ -3313,8 +3451,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[3].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[3]),
     .q      (reg2hw.rxenable_out[3].q),
+    .ds     (usb_48mhz_rxenable_out_out_3_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_3_qs_int)
@@ -3338,8 +3477,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[4].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[4]),
     .q      (reg2hw.rxenable_out[4].q),
+    .ds     (usb_48mhz_rxenable_out_out_4_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_4_qs_int)
@@ -3363,8 +3503,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[5].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[5]),
     .q      (reg2hw.rxenable_out[5].q),
+    .ds     (usb_48mhz_rxenable_out_out_5_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_5_qs_int)
@@ -3388,8 +3529,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[6].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[6]),
     .q      (reg2hw.rxenable_out[6].q),
+    .ds     (usb_48mhz_rxenable_out_out_6_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_6_qs_int)
@@ -3413,8 +3555,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[7].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[7]),
     .q      (reg2hw.rxenable_out[7].q),
+    .ds     (usb_48mhz_rxenable_out_out_7_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_7_qs_int)
@@ -3438,8 +3581,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[8].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[8]),
     .q      (reg2hw.rxenable_out[8].q),
+    .ds     (usb_48mhz_rxenable_out_out_8_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_8_qs_int)
@@ -3463,8 +3607,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[9].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[9]),
     .q      (reg2hw.rxenable_out[9].q),
+    .ds     (usb_48mhz_rxenable_out_out_9_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_9_qs_int)
@@ -3488,8 +3633,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[10].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[10]),
     .q      (reg2hw.rxenable_out[10].q),
+    .ds     (usb_48mhz_rxenable_out_out_10_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_10_qs_int)
@@ -3513,8 +3659,9 @@ module usbdev_reg_top (
     .d      (hw2reg.rxenable_out[11].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (rxenable_out_flds_we[11]),
     .q      (reg2hw.rxenable_out[11].q),
+    .ds     (usb_48mhz_rxenable_out_out_11_ds_int),
 
     // to register interface (read)
     .qs     (usb_48mhz_rxenable_out_out_11_qs_int)
@@ -3543,6 +3690,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_0_qs)
@@ -3568,6 +3716,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_1_qs)
@@ -3593,6 +3742,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_2_qs)
@@ -3618,6 +3768,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_3_qs)
@@ -3643,6 +3794,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_4_qs)
@@ -3668,6 +3820,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_5_qs)
@@ -3693,6 +3846,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_6_qs)
@@ -3718,6 +3872,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_7_qs)
@@ -3743,6 +3898,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_8_qs)
@@ -3768,6 +3924,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_9_qs)
@@ -3793,6 +3950,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_10_qs)
@@ -3818,6 +3976,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.set_nak_out[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (set_nak_out_enable_11_qs)
@@ -3846,6 +4005,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_0_qs)
@@ -3871,6 +4031,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_1_qs)
@@ -3896,6 +4057,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_2_qs)
@@ -3921,6 +4083,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_3_qs)
@@ -3946,6 +4109,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_4_qs)
@@ -3971,6 +4135,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_5_qs)
@@ -3996,6 +4161,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_6_qs)
@@ -4021,6 +4187,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_7_qs)
@@ -4046,6 +4213,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_8_qs)
@@ -4071,6 +4239,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_9_qs)
@@ -4096,6 +4265,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_10_qs)
@@ -4121,6 +4291,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_sent_sent_11_qs)
@@ -4149,6 +4320,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_0_qs)
@@ -4174,6 +4346,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_1_qs)
@@ -4199,6 +4372,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_2_qs)
@@ -4224,6 +4398,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_3_qs)
@@ -4249,6 +4424,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_4_qs)
@@ -4274,6 +4450,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_5_qs)
@@ -4299,6 +4476,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_6_qs)
@@ -4324,6 +4502,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_7_qs)
@@ -4349,6 +4528,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_8_qs)
@@ -4374,6 +4554,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_9_qs)
@@ -4399,6 +4580,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_10_qs)
@@ -4424,6 +4606,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_stall[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_stall_endpoint_11_qs)
@@ -4452,6 +4635,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_0_qs)
@@ -4477,6 +4661,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_1_qs)
@@ -4502,6 +4687,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_2_qs)
@@ -4527,6 +4713,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_3_qs)
@@ -4552,6 +4739,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_4_qs)
@@ -4577,6 +4765,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_5_qs)
@@ -4602,6 +4791,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_6_qs)
@@ -4627,6 +4817,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_7_qs)
@@ -4652,6 +4843,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_8_qs)
@@ -4677,6 +4869,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_9_qs)
@@ -4702,6 +4895,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_10_qs)
@@ -4727,6 +4921,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_stall[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_stall_endpoint_11_qs)
@@ -4755,6 +4950,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[0].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_0_buffer_0_qs)
@@ -4780,6 +4976,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[0].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_0_size_0_qs)
@@ -4805,6 +5002,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[0].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_0_pend_0_qs)
@@ -4830,6 +5028,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[0].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_0_rdy_0_qs)
@@ -4858,6 +5057,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[1].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_1_buffer_1_qs)
@@ -4883,6 +5083,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[1].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_1_size_1_qs)
@@ -4908,6 +5109,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[1].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_1_pend_1_qs)
@@ -4933,6 +5135,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[1].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_1_rdy_1_qs)
@@ -4961,6 +5164,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[2].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_2_buffer_2_qs)
@@ -4986,6 +5190,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[2].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_2_size_2_qs)
@@ -5011,6 +5216,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[2].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_2_pend_2_qs)
@@ -5036,6 +5242,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[2].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_2_rdy_2_qs)
@@ -5064,6 +5271,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[3].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_3_buffer_3_qs)
@@ -5089,6 +5297,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[3].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_3_size_3_qs)
@@ -5114,6 +5323,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[3].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_3_pend_3_qs)
@@ -5139,6 +5349,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[3].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_3_rdy_3_qs)
@@ -5167,6 +5378,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[4].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_4_buffer_4_qs)
@@ -5192,6 +5404,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[4].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_4_size_4_qs)
@@ -5217,6 +5430,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[4].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_4_pend_4_qs)
@@ -5242,6 +5456,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[4].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_4_rdy_4_qs)
@@ -5270,6 +5485,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[5].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_5_buffer_5_qs)
@@ -5295,6 +5511,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[5].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_5_size_5_qs)
@@ -5320,6 +5537,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[5].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_5_pend_5_qs)
@@ -5345,6 +5563,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[5].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_5_rdy_5_qs)
@@ -5373,6 +5592,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[6].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_6_buffer_6_qs)
@@ -5398,6 +5618,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[6].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_6_size_6_qs)
@@ -5423,6 +5644,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[6].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_6_pend_6_qs)
@@ -5448,6 +5670,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[6].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_6_rdy_6_qs)
@@ -5476,6 +5699,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[7].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_7_buffer_7_qs)
@@ -5501,6 +5725,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[7].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_7_size_7_qs)
@@ -5526,6 +5751,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[7].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_7_pend_7_qs)
@@ -5551,6 +5777,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[7].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_7_rdy_7_qs)
@@ -5579,6 +5806,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[8].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_8_buffer_8_qs)
@@ -5604,6 +5832,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[8].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_8_size_8_qs)
@@ -5629,6 +5858,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[8].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_8_pend_8_qs)
@@ -5654,6 +5884,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[8].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_8_rdy_8_qs)
@@ -5682,6 +5913,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[9].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_9_buffer_9_qs)
@@ -5707,6 +5939,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[9].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_9_size_9_qs)
@@ -5732,6 +5965,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[9].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_9_pend_9_qs)
@@ -5757,6 +5991,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[9].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_9_rdy_9_qs)
@@ -5785,6 +6020,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[10].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_10_buffer_10_qs)
@@ -5810,6 +6046,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[10].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_10_size_10_qs)
@@ -5835,6 +6072,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[10].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_10_pend_10_qs)
@@ -5860,6 +6098,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[10].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_10_rdy_10_qs)
@@ -5888,6 +6127,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[11].buffer.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_11_buffer_11_qs)
@@ -5913,6 +6153,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[11].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_11_size_11_qs)
@@ -5938,6 +6179,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[11].pend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_11_pend_11_qs)
@@ -5963,6 +6205,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.configin[11].rdy.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (configin_11_rdy_11_qs)
@@ -5991,6 +6234,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_0_qs)
@@ -6016,6 +6260,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_1_qs)
@@ -6041,6 +6286,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_2_qs)
@@ -6066,6 +6312,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_3_qs)
@@ -6091,6 +6338,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_4_qs)
@@ -6116,6 +6364,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_5_qs)
@@ -6141,6 +6390,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_6_qs)
@@ -6166,6 +6416,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_7_qs)
@@ -6191,6 +6442,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_8_qs)
@@ -6216,6 +6468,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_9_qs)
@@ -6241,6 +6494,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_10_qs)
@@ -6266,6 +6520,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.out_iso[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (out_iso_iso_11_qs)
@@ -6294,6 +6549,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_0_qs)
@@ -6319,6 +6575,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_1_qs)
@@ -6344,6 +6601,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_2_qs)
@@ -6369,6 +6627,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_3_qs)
@@ -6394,6 +6653,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_4_qs)
@@ -6419,6 +6679,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_5_qs)
@@ -6444,6 +6705,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_6_qs)
@@ -6469,6 +6731,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_7_qs)
@@ -6494,6 +6757,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_8_qs)
@@ -6519,6 +6783,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_9_qs)
@@ -6544,6 +6809,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_10_qs)
@@ -6569,6 +6835,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.in_iso[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (in_iso_iso_11_qs)
@@ -6608,6 +6875,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[0]),
     .q      (reg2hw.data_toggle_clear[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6634,6 +6902,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[1]),
     .q      (reg2hw.data_toggle_clear[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6660,6 +6929,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[2]),
     .q      (reg2hw.data_toggle_clear[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6686,6 +6956,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[3]),
     .q      (reg2hw.data_toggle_clear[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6712,6 +6983,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[4]),
     .q      (reg2hw.data_toggle_clear[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6738,6 +7010,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[5]),
     .q      (reg2hw.data_toggle_clear[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6764,6 +7037,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[6]),
     .q      (reg2hw.data_toggle_clear[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6790,6 +7064,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[7]),
     .q      (reg2hw.data_toggle_clear[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6816,6 +7091,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[8]),
     .q      (reg2hw.data_toggle_clear[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6842,6 +7118,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[9]),
     .q      (reg2hw.data_toggle_clear[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6868,6 +7145,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[10]),
     .q      (reg2hw.data_toggle_clear[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6894,6 +7172,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (data_toggle_clear_flds_we[11]),
     .q      (reg2hw.data_toggle_clear[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     ()
@@ -6913,6 +7192,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (phy_pins_sense_rx_dp_i_qs)
   );
 
@@ -6927,6 +7207,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (phy_pins_sense_rx_dn_i_qs)
   );
 
@@ -6941,6 +7222,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (phy_pins_sense_rx_d_i_qs)
   );
 
@@ -6955,6 +7237,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (phy_pins_sense_tx_dp_o_qs)
   );
 
@@ -6969,6 +7252,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (phy_pins_sense_tx_dn_o_qs)
   );
 
@@ -6983,6 +7267,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (phy_pins_sense_tx_d_o_qs)
   );
 
@@ -6997,6 +7282,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (phy_pins_sense_tx_se0_o_qs)
   );
 
@@ -7011,6 +7297,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (phy_pins_sense_tx_oe_o_qs)
   );
 
@@ -7025,6 +7312,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (phy_pins_sense_pwr_sense_qs)
   );
 
@@ -7050,6 +7338,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_pins_drive.dp_o.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_pins_drive_dp_o_qs)
@@ -7075,6 +7364,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_pins_drive.dn_o.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_pins_drive_dn_o_qs)
@@ -7100,6 +7390,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_pins_drive.d_o.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_pins_drive_d_o_qs)
@@ -7125,6 +7416,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_pins_drive.se0_o.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_pins_drive_se0_o_qs)
@@ -7150,6 +7442,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_pins_drive.oe_o.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_pins_drive_oe_o_qs)
@@ -7175,6 +7468,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_pins_drive.rx_enable_o.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_pins_drive_rx_enable_o_qs)
@@ -7200,6 +7494,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_pins_drive.dp_pullup_en_o.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_pins_drive_dp_pullup_en_o_qs)
@@ -7225,6 +7520,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_pins_drive.dn_pullup_en_o.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_pins_drive_dn_pullup_en_o_qs)
@@ -7250,6 +7546,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_pins_drive.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_pins_drive_en_qs)
@@ -7277,6 +7574,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_config.use_diff_rcvr.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_config_use_diff_rcvr_qs)
@@ -7302,6 +7600,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_config.tx_use_d_se0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_config_tx_use_d_se0_qs)
@@ -7327,6 +7626,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_config.eop_single_bit.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_config_eop_single_bit_qs)
@@ -7352,6 +7652,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_config.pinflip.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_config_pinflip_qs)
@@ -7377,6 +7678,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_config.usb_ref_disable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_config_usb_ref_disable_qs)
@@ -7402,6 +7704,7 @@ module usbdev_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_config.tx_osc_test_mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_config_tx_osc_test_mode_qs)
@@ -7423,6 +7726,7 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (wake_control_flds_we[0]),
     .q      (reg2hw.wake_control.suspend_req.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.wake_control.suspend_req.qe = wake_control_qe;
@@ -7438,12 +7742,15 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (wake_control_flds_we[1]),
     .q      (reg2hw.wake_control.wake_ack.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.wake_control.wake_ack.qe = wake_control_qe;
 
 
   // R[wake_events]: V(False)
+  logic [2:0] wake_events_flds_we;
+  assign aon_wake_events_qe = |wake_events_flds_we;
   //   F[module_active]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -7462,8 +7769,9 @@ module usbdev_reg_top (
     .d      (hw2reg.wake_events.module_active.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wake_events_flds_we[0]),
     .q      (),
+    .ds     (aon_wake_events_module_active_ds_int),
 
     // to register interface (read)
     .qs     (aon_wake_events_module_active_qs_int)
@@ -7487,8 +7795,9 @@ module usbdev_reg_top (
     .d      (hw2reg.wake_events.disconnected.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wake_events_flds_we[1]),
     .q      (),
+    .ds     (aon_wake_events_disconnected_ds_int),
 
     // to register interface (read)
     .qs     (aon_wake_events_disconnected_qs_int)
@@ -7512,8 +7821,9 @@ module usbdev_reg_top (
     .d      (hw2reg.wake_events.bus_reset.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wake_events_flds_we[2]),
     .q      (),
+    .ds     (aon_wake_events_bus_reset_ds_int),
 
     // to register interface (read)
     .qs     (aon_wake_events_bus_reset_qs_int)

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -268,6 +268,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega0_qs)
@@ -294,6 +295,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega1_qs)
@@ -320,6 +322,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega2_qs)
@@ -346,6 +349,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega3_qs)
@@ -372,6 +376,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega4.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega4_qs)
@@ -398,6 +403,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega5.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega5_qs)
@@ -424,6 +430,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega6.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega6_qs)
@@ -450,6 +457,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega7.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega7_qs)
@@ -476,6 +484,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega8.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega8_qs)
@@ -502,6 +511,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega9.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega9_qs)
@@ -528,6 +538,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega10.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega10_qs)
@@ -554,6 +565,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega11.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega11_qs)
@@ -580,6 +592,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega12.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega12_qs)
@@ -606,6 +619,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega13.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega13_qs)
@@ -632,6 +646,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega14.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega14_qs)
@@ -658,6 +673,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega15.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega15_qs)
@@ -684,6 +700,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega16.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega16_qs)
@@ -710,6 +727,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega17.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega17_qs)
@@ -736,6 +754,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega18.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega18_qs)
@@ -762,6 +781,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega19.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega19_qs)
@@ -788,6 +808,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega20.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega20_qs)
@@ -814,6 +835,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega21.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega21_qs)
@@ -840,6 +862,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega22.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega22_qs)
@@ -866,6 +889,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega23.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega23_qs)
@@ -892,6 +916,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega24.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega24_qs)
@@ -918,6 +943,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega25.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega25_qs)
@@ -944,6 +970,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega26.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega26_qs)
@@ -970,6 +997,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega27.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega27_qs)
@@ -996,6 +1024,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega28.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega28_qs)
@@ -1022,6 +1051,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega29.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega29_qs)
@@ -1048,6 +1078,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega30.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega30_qs)
@@ -1074,6 +1105,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega31.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega31_qs)
@@ -1100,6 +1132,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega32.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega32_qs)
@@ -1126,6 +1159,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega33.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega33_qs)
@@ -1152,6 +1186,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega34.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega34_qs)
@@ -1178,6 +1213,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega35.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega35_qs)
@@ -1204,6 +1240,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega36.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega36_qs)
@@ -1230,6 +1267,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.rega37.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (rega37_qs)
@@ -1250,6 +1288,7 @@ module ast_reg_top (
     .qre    (),
     .qe     (regal_flds_we[0]),
     .q      (reg2hw.regal.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.regal.qe = regal_qe;
@@ -1276,6 +1315,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.regb[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (regb_0_qs)
@@ -1303,6 +1343,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.regb[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (regb_1_qs)
@@ -1330,6 +1371,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.regb[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (regb_2_qs)
@@ -1357,6 +1399,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.regb[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (regb_3_qs)
@@ -1384,6 +1427,7 @@ module ast_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.regb[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (regb_4_qs)

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -1040,6 +1040,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.prog_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_prog_empty_qs)
@@ -1065,6 +1066,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.prog_lvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_prog_lvl_qs)
@@ -1090,6 +1092,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rd_full.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rd_full_qs)
@@ -1115,6 +1118,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.rd_lvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_rd_lvl_qs)
@@ -1140,6 +1144,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.op_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_op_done_qs)
@@ -1165,6 +1170,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.corr_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_corr_err_qs)
@@ -1192,6 +1198,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.prog_empty.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_prog_empty_qs)
@@ -1217,6 +1224,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.prog_lvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_prog_lvl_qs)
@@ -1242,6 +1250,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rd_full.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rd_full_qs)
@@ -1267,6 +1276,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.rd_lvl.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_rd_lvl_qs)
@@ -1292,6 +1302,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.op_done.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_op_done_qs)
@@ -1317,6 +1328,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.corr_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_corr_err_qs)
@@ -1338,6 +1350,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.prog_empty.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.prog_empty.qe = intr_test_qe;
@@ -1353,6 +1366,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.prog_lvl.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.prog_lvl.qe = intr_test_qe;
@@ -1368,6 +1382,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.rd_full.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rd_full.qe = intr_test_qe;
@@ -1383,6 +1398,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.rd_lvl.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.rd_lvl.qe = intr_test_qe;
@@ -1398,6 +1414,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.op_done.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.op_done.qe = intr_test_qe;
@@ -1413,6 +1430,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.corr_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.corr_err.qe = intr_test_qe;
@@ -1433,6 +1451,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_err.qe = alert_test_qe;
@@ -1448,6 +1467,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_std_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_std_err.qe = alert_test_qe;
@@ -1463,6 +1483,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[2]),
     .q      (reg2hw.alert_test.fatal_err.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_err.qe = alert_test_qe;
@@ -1488,6 +1509,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dis.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dis_qs)
@@ -1514,6 +1536,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.exec.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (exec_qs)
@@ -1540,6 +1563,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.init.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (init_qs)
@@ -1557,6 +1581,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (ctrl_regwen_qs)
   );
 
@@ -1585,6 +1610,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.start.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_start_qs)
@@ -1610,6 +1636,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.op.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_op_qs)
@@ -1635,6 +1662,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.prog_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_prog_sel_qs)
@@ -1660,6 +1688,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.erase_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_erase_sel_qs)
@@ -1685,6 +1714,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.partition_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_partition_sel_qs)
@@ -1710,6 +1740,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.info_sel.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_info_sel_qs)
@@ -1735,6 +1766,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.num.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_num_qs)
@@ -1761,6 +1793,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.addr.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (addr_qs)
@@ -1788,6 +1821,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prog_type_en.normal.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prog_type_en_normal_qs)
@@ -1813,6 +1847,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prog_type_en.repair.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prog_type_en_repair_qs)
@@ -1839,6 +1874,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.erase_suspend.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (erase_suspend_qs)
@@ -1866,6 +1902,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_0_qs)
@@ -1893,6 +1930,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_1_qs)
@@ -1920,6 +1958,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_2_qs)
@@ -1947,6 +1986,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_3_qs)
@@ -1974,6 +2014,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_4_qs)
@@ -2001,6 +2042,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_5_qs)
@@ -2028,6 +2070,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_6_qs)
@@ -2055,6 +2098,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (region_cfg_regwen_7_qs)
@@ -2086,6 +2130,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_en_0_qs)
@@ -2111,6 +2156,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_rd_en_0_qs)
@@ -2136,6 +2182,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_prog_en_0_qs)
@@ -2161,6 +2208,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_erase_en_0_qs)
@@ -2186,6 +2234,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_scramble_en_0_qs)
@@ -2211,6 +2260,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_ecc_en_0_qs)
@@ -2236,6 +2286,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_0_he_en_0_qs)
@@ -2267,6 +2318,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_en_1_qs)
@@ -2292,6 +2344,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_rd_en_1_qs)
@@ -2317,6 +2370,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_prog_en_1_qs)
@@ -2342,6 +2396,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_erase_en_1_qs)
@@ -2367,6 +2422,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_scramble_en_1_qs)
@@ -2392,6 +2448,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_ecc_en_1_qs)
@@ -2417,6 +2474,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[1].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_he_en_1_qs)
@@ -2448,6 +2506,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_en_2_qs)
@@ -2473,6 +2532,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_rd_en_2_qs)
@@ -2498,6 +2558,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_prog_en_2_qs)
@@ -2523,6 +2584,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_erase_en_2_qs)
@@ -2548,6 +2610,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_scramble_en_2_qs)
@@ -2573,6 +2636,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_ecc_en_2_qs)
@@ -2598,6 +2662,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[2].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_2_he_en_2_qs)
@@ -2629,6 +2694,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_en_3_qs)
@@ -2654,6 +2720,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_rd_en_3_qs)
@@ -2679,6 +2746,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_prog_en_3_qs)
@@ -2704,6 +2772,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_erase_en_3_qs)
@@ -2729,6 +2798,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_scramble_en_3_qs)
@@ -2754,6 +2824,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_ecc_en_3_qs)
@@ -2779,6 +2850,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[3].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_he_en_3_qs)
@@ -2810,6 +2882,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_en_4_qs)
@@ -2835,6 +2908,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_rd_en_4_qs)
@@ -2860,6 +2934,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_prog_en_4_qs)
@@ -2885,6 +2960,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_erase_en_4_qs)
@@ -2910,6 +2986,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_scramble_en_4_qs)
@@ -2935,6 +3012,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_ecc_en_4_qs)
@@ -2960,6 +3038,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[4].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_4_he_en_4_qs)
@@ -2991,6 +3070,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_en_5_qs)
@@ -3016,6 +3096,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_rd_en_5_qs)
@@ -3041,6 +3122,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_prog_en_5_qs)
@@ -3066,6 +3148,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_erase_en_5_qs)
@@ -3091,6 +3174,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_scramble_en_5_qs)
@@ -3116,6 +3200,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_ecc_en_5_qs)
@@ -3141,6 +3226,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[5].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_he_en_5_qs)
@@ -3172,6 +3258,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_en_6_qs)
@@ -3197,6 +3284,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_rd_en_6_qs)
@@ -3222,6 +3310,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_prog_en_6_qs)
@@ -3247,6 +3336,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_erase_en_6_qs)
@@ -3272,6 +3362,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_scramble_en_6_qs)
@@ -3297,6 +3388,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_ecc_en_6_qs)
@@ -3322,6 +3414,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[6].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_6_he_en_6_qs)
@@ -3353,6 +3446,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_en_7_qs)
@@ -3378,6 +3472,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_rd_en_7_qs)
@@ -3403,6 +3498,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_prog_en_7_qs)
@@ -3428,6 +3524,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_erase_en_7_qs)
@@ -3453,6 +3550,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_scramble_en_7_qs)
@@ -3478,6 +3576,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_ecc_en_7_qs)
@@ -3503,6 +3602,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region_cfg[7].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_cfg_7_he_en_7_qs)
@@ -3534,6 +3634,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[0].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_0_base_0_qs)
@@ -3559,6 +3660,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[0].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_0_size_0_qs)
@@ -3590,6 +3692,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[1].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_1_base_1_qs)
@@ -3615,6 +3718,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[1].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_1_size_1_qs)
@@ -3646,6 +3750,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[2].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_2_base_2_qs)
@@ -3671,6 +3776,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[2].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_2_size_2_qs)
@@ -3702,6 +3808,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[3].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_3_base_3_qs)
@@ -3727,6 +3834,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[3].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_3_size_3_qs)
@@ -3758,6 +3866,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[4].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_4_base_4_qs)
@@ -3783,6 +3892,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[4].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_4_size_4_qs)
@@ -3814,6 +3924,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[5].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_5_base_5_qs)
@@ -3839,6 +3950,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[5].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_5_size_5_qs)
@@ -3870,6 +3982,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[6].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_6_base_6_qs)
@@ -3895,6 +4008,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[6].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_6_size_6_qs)
@@ -3926,6 +4040,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[7].base.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_7_base_7_qs)
@@ -3951,6 +4066,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_region[7].size.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_region_7_size_7_qs)
@@ -3978,6 +4094,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_rd_en_qs)
@@ -4003,6 +4120,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_prog_en_qs)
@@ -4028,6 +4146,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_erase_en_qs)
@@ -4053,6 +4172,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_scramble_en_qs)
@@ -4078,6 +4198,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_ecc_en_qs)
@@ -4103,6 +4224,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.default_region.he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (default_region_he_en_qs)
@@ -4130,6 +4252,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_0_qs)
@@ -4157,6 +4280,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_1_qs)
@@ -4184,6 +4308,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_2_qs)
@@ -4211,6 +4336,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_3_qs)
@@ -4238,6 +4364,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_4_qs)
@@ -4265,6 +4392,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_5_qs)
@@ -4292,6 +4420,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_6_qs)
@@ -4319,6 +4448,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_7_qs)
@@ -4346,6 +4476,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_8_qs)
@@ -4373,6 +4504,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_regwen_9_qs)
@@ -4404,6 +4536,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_en_0_qs)
@@ -4429,6 +4562,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_rd_en_0_qs)
@@ -4454,6 +4588,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_prog_en_0_qs)
@@ -4479,6 +4614,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_erase_en_0_qs)
@@ -4504,6 +4640,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_scramble_en_0_qs)
@@ -4529,6 +4666,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_ecc_en_0_qs)
@@ -4554,6 +4692,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_0_he_en_0_qs)
@@ -4585,6 +4724,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_en_1_qs)
@@ -4610,6 +4750,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_rd_en_1_qs)
@@ -4635,6 +4776,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_prog_en_1_qs)
@@ -4660,6 +4802,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_erase_en_1_qs)
@@ -4685,6 +4828,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_scramble_en_1_qs)
@@ -4710,6 +4854,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_ecc_en_1_qs)
@@ -4735,6 +4880,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[1].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_he_en_1_qs)
@@ -4766,6 +4912,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_en_2_qs)
@@ -4791,6 +4938,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_rd_en_2_qs)
@@ -4816,6 +4964,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_prog_en_2_qs)
@@ -4841,6 +4990,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_erase_en_2_qs)
@@ -4866,6 +5016,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_scramble_en_2_qs)
@@ -4891,6 +5042,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_ecc_en_2_qs)
@@ -4916,6 +5068,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[2].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_2_he_en_2_qs)
@@ -4947,6 +5100,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_en_3_qs)
@@ -4972,6 +5126,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_rd_en_3_qs)
@@ -4997,6 +5152,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_prog_en_3_qs)
@@ -5022,6 +5178,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_erase_en_3_qs)
@@ -5047,6 +5204,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_scramble_en_3_qs)
@@ -5072,6 +5230,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_ecc_en_3_qs)
@@ -5097,6 +5256,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[3].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_he_en_3_qs)
@@ -5128,6 +5288,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_en_4_qs)
@@ -5153,6 +5314,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_rd_en_4_qs)
@@ -5178,6 +5340,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_prog_en_4_qs)
@@ -5203,6 +5366,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_erase_en_4_qs)
@@ -5228,6 +5392,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_scramble_en_4_qs)
@@ -5253,6 +5418,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_ecc_en_4_qs)
@@ -5278,6 +5444,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[4].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_4_he_en_4_qs)
@@ -5309,6 +5476,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_en_5_qs)
@@ -5334,6 +5502,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_rd_en_5_qs)
@@ -5359,6 +5528,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_prog_en_5_qs)
@@ -5384,6 +5554,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_erase_en_5_qs)
@@ -5409,6 +5580,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_scramble_en_5_qs)
@@ -5434,6 +5606,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_ecc_en_5_qs)
@@ -5459,6 +5632,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[5].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_5_he_en_5_qs)
@@ -5490,6 +5664,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_en_6_qs)
@@ -5515,6 +5690,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_rd_en_6_qs)
@@ -5540,6 +5716,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_prog_en_6_qs)
@@ -5565,6 +5742,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_erase_en_6_qs)
@@ -5590,6 +5768,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_scramble_en_6_qs)
@@ -5615,6 +5794,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_ecc_en_6_qs)
@@ -5640,6 +5820,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[6].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_6_he_en_6_qs)
@@ -5671,6 +5852,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_en_7_qs)
@@ -5696,6 +5878,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_rd_en_7_qs)
@@ -5721,6 +5904,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_prog_en_7_qs)
@@ -5746,6 +5930,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_erase_en_7_qs)
@@ -5771,6 +5956,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_scramble_en_7_qs)
@@ -5796,6 +5982,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_ecc_en_7_qs)
@@ -5821,6 +6008,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[7].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_7_he_en_7_qs)
@@ -5852,6 +6040,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_en_8_qs)
@@ -5877,6 +6066,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_rd_en_8_qs)
@@ -5902,6 +6092,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_prog_en_8_qs)
@@ -5927,6 +6118,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_erase_en_8_qs)
@@ -5952,6 +6144,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_scramble_en_8_qs)
@@ -5977,6 +6170,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_ecc_en_8_qs)
@@ -6002,6 +6196,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[8].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_8_he_en_8_qs)
@@ -6033,6 +6228,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_en_9_qs)
@@ -6058,6 +6254,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_rd_en_9_qs)
@@ -6083,6 +6280,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_prog_en_9_qs)
@@ -6108,6 +6306,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_erase_en_9_qs)
@@ -6133,6 +6332,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_scramble_en_9_qs)
@@ -6158,6 +6358,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_ecc_en_9_qs)
@@ -6183,6 +6384,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info0_page_cfg[9].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_9_he_en_9_qs)
@@ -6210,6 +6412,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_regwen_qs)
@@ -6241,6 +6444,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_en_0_qs)
@@ -6266,6 +6470,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_rd_en_0_qs)
@@ -6291,6 +6496,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_prog_en_0_qs)
@@ -6316,6 +6522,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_erase_en_0_qs)
@@ -6341,6 +6548,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_scramble_en_0_qs)
@@ -6366,6 +6574,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_ecc_en_0_qs)
@@ -6391,6 +6600,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info1_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_he_en_0_qs)
@@ -6418,6 +6628,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_regwen_0_qs)
@@ -6445,6 +6656,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_regwen_1_qs)
@@ -6476,6 +6688,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_en_0_qs)
@@ -6501,6 +6714,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_rd_en_0_qs)
@@ -6526,6 +6740,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_prog_en_0_qs)
@@ -6551,6 +6766,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_erase_en_0_qs)
@@ -6576,6 +6792,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_scramble_en_0_qs)
@@ -6601,6 +6818,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_ecc_en_0_qs)
@@ -6626,6 +6844,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_0_he_en_0_qs)
@@ -6657,6 +6876,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_en_1_qs)
@@ -6682,6 +6902,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_rd_en_1_qs)
@@ -6707,6 +6928,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_prog_en_1_qs)
@@ -6732,6 +6954,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_erase_en_1_qs)
@@ -6757,6 +6980,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_scramble_en_1_qs)
@@ -6782,6 +7006,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_ecc_en_1_qs)
@@ -6807,6 +7032,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank0_info2_page_cfg[1].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_1_he_en_1_qs)
@@ -6834,6 +7060,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_0_qs)
@@ -6861,6 +7088,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_1_qs)
@@ -6888,6 +7116,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_2_qs)
@@ -6915,6 +7144,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_3_qs)
@@ -6942,6 +7172,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_4_qs)
@@ -6969,6 +7200,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_5_qs)
@@ -6996,6 +7228,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_6_qs)
@@ -7023,6 +7256,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_7_qs)
@@ -7050,6 +7284,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_8_qs)
@@ -7077,6 +7312,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_regwen_9_qs)
@@ -7108,6 +7344,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_en_0_qs)
@@ -7133,6 +7370,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_rd_en_0_qs)
@@ -7158,6 +7396,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_prog_en_0_qs)
@@ -7183,6 +7422,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_erase_en_0_qs)
@@ -7208,6 +7448,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_scramble_en_0_qs)
@@ -7233,6 +7474,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_ecc_en_0_qs)
@@ -7258,6 +7500,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_0_he_en_0_qs)
@@ -7289,6 +7532,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_en_1_qs)
@@ -7314,6 +7558,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_rd_en_1_qs)
@@ -7339,6 +7584,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_prog_en_1_qs)
@@ -7364,6 +7610,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_erase_en_1_qs)
@@ -7389,6 +7636,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_scramble_en_1_qs)
@@ -7414,6 +7662,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_ecc_en_1_qs)
@@ -7439,6 +7688,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[1].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_he_en_1_qs)
@@ -7470,6 +7720,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_en_2_qs)
@@ -7495,6 +7746,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_rd_en_2_qs)
@@ -7520,6 +7772,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_prog_en_2_qs)
@@ -7545,6 +7798,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_erase_en_2_qs)
@@ -7570,6 +7824,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_scramble_en_2_qs)
@@ -7595,6 +7850,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_ecc_en_2_qs)
@@ -7620,6 +7876,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[2].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_2_he_en_2_qs)
@@ -7651,6 +7908,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_en_3_qs)
@@ -7676,6 +7934,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_rd_en_3_qs)
@@ -7701,6 +7960,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_prog_en_3_qs)
@@ -7726,6 +7986,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_erase_en_3_qs)
@@ -7751,6 +8012,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_scramble_en_3_qs)
@@ -7776,6 +8038,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_ecc_en_3_qs)
@@ -7801,6 +8064,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[3].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_he_en_3_qs)
@@ -7832,6 +8096,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_en_4_qs)
@@ -7857,6 +8122,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_rd_en_4_qs)
@@ -7882,6 +8148,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_prog_en_4_qs)
@@ -7907,6 +8174,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_erase_en_4_qs)
@@ -7932,6 +8200,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_scramble_en_4_qs)
@@ -7957,6 +8226,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_ecc_en_4_qs)
@@ -7982,6 +8252,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[4].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_4_he_en_4_qs)
@@ -8013,6 +8284,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_en_5_qs)
@@ -8038,6 +8310,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_rd_en_5_qs)
@@ -8063,6 +8336,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_prog_en_5_qs)
@@ -8088,6 +8362,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_erase_en_5_qs)
@@ -8113,6 +8388,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_scramble_en_5_qs)
@@ -8138,6 +8414,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_ecc_en_5_qs)
@@ -8163,6 +8440,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[5].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_5_he_en_5_qs)
@@ -8194,6 +8472,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_en_6_qs)
@@ -8219,6 +8498,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_rd_en_6_qs)
@@ -8244,6 +8524,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_prog_en_6_qs)
@@ -8269,6 +8550,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_erase_en_6_qs)
@@ -8294,6 +8576,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_scramble_en_6_qs)
@@ -8319,6 +8602,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_ecc_en_6_qs)
@@ -8344,6 +8628,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[6].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_6_he_en_6_qs)
@@ -8375,6 +8660,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_en_7_qs)
@@ -8400,6 +8686,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_rd_en_7_qs)
@@ -8425,6 +8712,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_prog_en_7_qs)
@@ -8450,6 +8738,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_erase_en_7_qs)
@@ -8475,6 +8764,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_scramble_en_7_qs)
@@ -8500,6 +8790,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_ecc_en_7_qs)
@@ -8525,6 +8816,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[7].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_7_he_en_7_qs)
@@ -8556,6 +8848,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_en_8_qs)
@@ -8581,6 +8874,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_rd_en_8_qs)
@@ -8606,6 +8900,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_prog_en_8_qs)
@@ -8631,6 +8926,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_erase_en_8_qs)
@@ -8656,6 +8952,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_scramble_en_8_qs)
@@ -8681,6 +8978,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_ecc_en_8_qs)
@@ -8706,6 +9004,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[8].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_8_he_en_8_qs)
@@ -8737,6 +9036,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_en_9_qs)
@@ -8762,6 +9062,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_rd_en_9_qs)
@@ -8787,6 +9088,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_prog_en_9_qs)
@@ -8812,6 +9114,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_erase_en_9_qs)
@@ -8837,6 +9140,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_scramble_en_9_qs)
@@ -8862,6 +9166,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_ecc_en_9_qs)
@@ -8887,6 +9192,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info0_page_cfg[9].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_9_he_en_9_qs)
@@ -8914,6 +9220,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_regwen_qs)
@@ -8945,6 +9252,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_en_0_qs)
@@ -8970,6 +9278,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_rd_en_0_qs)
@@ -8995,6 +9304,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_prog_en_0_qs)
@@ -9020,6 +9330,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_erase_en_0_qs)
@@ -9045,6 +9356,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_scramble_en_0_qs)
@@ -9070,6 +9382,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_ecc_en_0_qs)
@@ -9095,6 +9408,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info1_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_he_en_0_qs)
@@ -9122,6 +9436,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_regwen_0_qs)
@@ -9149,6 +9464,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_regwen_1_qs)
@@ -9180,6 +9496,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_en_0_qs)
@@ -9205,6 +9522,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_rd_en_0_qs)
@@ -9230,6 +9548,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_prog_en_0_qs)
@@ -9255,6 +9574,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_erase_en_0_qs)
@@ -9280,6 +9600,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_scramble_en_0_qs)
@@ -9305,6 +9626,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_ecc_en_0_qs)
@@ -9330,6 +9652,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[0].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_0_he_en_0_qs)
@@ -9361,6 +9684,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_en_1_qs)
@@ -9386,6 +9710,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].rd_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_rd_en_1_qs)
@@ -9411,6 +9736,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].prog_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_prog_en_1_qs)
@@ -9436,6 +9762,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].erase_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_erase_en_1_qs)
@@ -9461,6 +9788,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].scramble_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_scramble_en_1_qs)
@@ -9486,6 +9814,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].ecc_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_ecc_en_1_qs)
@@ -9511,6 +9840,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.bank1_info2_page_cfg[1].he_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_1_he_en_1_qs)
@@ -9537,6 +9867,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (bank_cfg_regwen_qs)
@@ -9570,6 +9901,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_bank_cfg_shadowed[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_bank_cfg_shadowed_erase_en_0_qs),
@@ -9604,6 +9936,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mp_bank_cfg_shadowed[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mp_bank_cfg_shadowed_erase_en_1_qs),
@@ -9638,6 +9971,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (op_status_done_qs)
@@ -9663,6 +9997,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (op_status_err_qs)
@@ -9690,6 +10025,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_rd_full_qs)
@@ -9715,6 +10051,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_rd_empty_qs)
@@ -9740,6 +10077,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_prog_full_qs)
@@ -9765,6 +10103,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_prog_empty_qs)
@@ -9790,6 +10129,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_init_wip_qs)
@@ -9807,6 +10147,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (debug_state_qs)
   );
 
@@ -9832,6 +10173,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_op_err_qs)
@@ -9857,6 +10199,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_mp_err_qs)
@@ -9882,6 +10225,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_rd_err_qs)
@@ -9907,6 +10251,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_prog_err_qs)
@@ -9932,6 +10277,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_prog_win_err_qs)
@@ -9957,6 +10303,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_prog_type_err_qs)
@@ -9982,6 +10329,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_flash_macro_err_qs)
@@ -10007,6 +10355,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_update_err_qs)
@@ -10034,6 +10383,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.reg_intg_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_reg_intg_err_qs)
@@ -10059,6 +10409,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.prog_intg_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_prog_intg_err_qs)
@@ -10084,6 +10435,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.lcmgr_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_lcmgr_err_qs)
@@ -10109,6 +10461,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.lcmgr_intg_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_lcmgr_intg_err_qs)
@@ -10134,6 +10487,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.arb_fsm_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_arb_fsm_err_qs)
@@ -10159,6 +10513,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.storage_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_storage_err_qs)
@@ -10184,6 +10539,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.phy_fsm_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_phy_fsm_err_qs)
@@ -10209,6 +10565,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.ctrl_cnt_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_ctrl_cnt_err_qs)
@@ -10234,6 +10591,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.std_fault_status.fifo_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (std_fault_status_fifo_err_qs)
@@ -10261,6 +10619,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.op_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_op_err_qs)
@@ -10286,6 +10645,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.mp_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_mp_err_qs)
@@ -10311,6 +10671,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.rd_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_rd_err_qs)
@@ -10336,6 +10697,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.prog_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_prog_err_qs)
@@ -10361,6 +10723,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.prog_win_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_prog_win_err_qs)
@@ -10386,6 +10749,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.prog_type_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_prog_type_err_qs)
@@ -10411,6 +10775,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.flash_macro_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_flash_macro_err_qs)
@@ -10436,6 +10801,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.seed_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_seed_err_qs)
@@ -10461,6 +10827,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.phy_relbl_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_phy_relbl_err_qs)
@@ -10486,6 +10853,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.phy_storage_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_phy_storage_err_qs)
@@ -10511,6 +10879,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.spurious_ack.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_spurious_ack_qs)
@@ -10536,6 +10905,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.arb_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_arb_err_qs)
@@ -10561,6 +10931,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.host_gnt_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_host_gnt_err_qs)
@@ -10587,6 +10958,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_addr_qs)
@@ -10615,6 +10987,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ecc_single_err_cnt[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ecc_single_err_cnt_ecc_single_err_cnt_0_qs)
@@ -10640,6 +11013,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ecc_single_err_cnt[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ecc_single_err_cnt_ecc_single_err_cnt_1_qs)
@@ -10667,6 +11041,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ecc_single_err_addr_0_qs)
@@ -10694,6 +11069,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ecc_single_err_addr_1_qs)
@@ -10721,6 +11097,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_alert_cfg.alert_ack.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_alert_cfg_alert_ack_qs)
@@ -10746,6 +11123,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.phy_alert_cfg.alert_trig.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_alert_cfg_alert_trig_qs)
@@ -10773,6 +11151,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_status_init_wip_qs)
@@ -10798,6 +11177,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_status_prog_normal_avail_qs)
@@ -10823,6 +11203,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (phy_status_prog_repair_avail_qs)
@@ -10849,6 +11230,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.scratch.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (scratch_qs)
@@ -10876,6 +11258,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fifo_lvl.prog.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_lvl_prog_qs)
@@ -10901,6 +11284,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fifo_lvl.rd.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_lvl_rd_qs)
@@ -10927,6 +11311,7 @@ module flash_ctrl_core_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fifo_rst.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fifo_rst_qs)
@@ -10945,6 +11330,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (curr_fifo_lvl_prog_qs)
   );
 
@@ -10959,6 +11345,7 @@ module flash_ctrl_core_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (curr_fifo_lvl_rd_qs)
   );
 

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -116,18 +116,6 @@ module pinmux_reg_top (
   );
 
   // cdc oversampling signals
-    logic sync_aon_update;
-  prim_sync_reqack u_aon_tgl (
-    .clk_src_i(clk_aon_i),
-    .rst_src_ni(rst_aon_ni),
-    .clk_dst_i(clk_i),
-    .rst_dst_ni(rst_ni),
-    .req_chk_i(1'b1),
-    .src_req_i(1'b1),
-    .src_ack_o(),
-    .dst_req_o(sync_aon_update),
-    .dst_ack_i(sync_aon_update)
-  );
 
   assign reg_rdata = reg_rdata_next ;
   assign reg_error = (devmode_i & addrmiss) | wr_err | intg_err;
@@ -3033,34 +3021,36 @@ module pinmux_reg_top (
   // CDC handling is done on a per-reg instead of per-field boundary.
 
   logic  aon_wkup_detector_en_0_qs_int;
-  logic [0:0] aon_wkup_detector_en_0_d;
+  logic [0:0] aon_wkup_detector_en_0_qs;
   logic [0:0] aon_wkup_detector_en_0_wdata;
   logic aon_wkup_detector_en_0_we;
   logic unused_aon_wkup_detector_en_0_wdata;
   logic aon_wkup_detector_en_0_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_0_d = '0;
-    aon_wkup_detector_en_0_d = aon_wkup_detector_en_0_qs_int;
+    aon_wkup_detector_en_0_qs = 1'h0;
+    aon_wkup_detector_en_0_qs = aon_wkup_detector_en_0_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_0_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_0_qs),
     .src_we_i     (wkup_detector_en_0_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_0_busy),
     .src_qs_o     (wkup_detector_en_0_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_0_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_0_qs),
     .dst_we_o     (aon_wkup_detector_en_0_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_0_regwen),
@@ -3070,34 +3060,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_0_wdata;
 
   logic  aon_wkup_detector_en_1_qs_int;
-  logic [0:0] aon_wkup_detector_en_1_d;
+  logic [0:0] aon_wkup_detector_en_1_qs;
   logic [0:0] aon_wkup_detector_en_1_wdata;
   logic aon_wkup_detector_en_1_we;
   logic unused_aon_wkup_detector_en_1_wdata;
   logic aon_wkup_detector_en_1_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_1_d = '0;
-    aon_wkup_detector_en_1_d = aon_wkup_detector_en_1_qs_int;
+    aon_wkup_detector_en_1_qs = 1'h0;
+    aon_wkup_detector_en_1_qs = aon_wkup_detector_en_1_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_1_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_1_qs),
     .src_we_i     (wkup_detector_en_1_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_1_busy),
     .src_qs_o     (wkup_detector_en_1_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_1_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_1_qs),
     .dst_we_o     (aon_wkup_detector_en_1_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_1_regwen),
@@ -3107,34 +3099,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_1_wdata;
 
   logic  aon_wkup_detector_en_2_qs_int;
-  logic [0:0] aon_wkup_detector_en_2_d;
+  logic [0:0] aon_wkup_detector_en_2_qs;
   logic [0:0] aon_wkup_detector_en_2_wdata;
   logic aon_wkup_detector_en_2_we;
   logic unused_aon_wkup_detector_en_2_wdata;
   logic aon_wkup_detector_en_2_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_2_d = '0;
-    aon_wkup_detector_en_2_d = aon_wkup_detector_en_2_qs_int;
+    aon_wkup_detector_en_2_qs = 1'h0;
+    aon_wkup_detector_en_2_qs = aon_wkup_detector_en_2_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_2_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_2_qs),
     .src_we_i     (wkup_detector_en_2_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_2_busy),
     .src_qs_o     (wkup_detector_en_2_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_2_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_2_qs),
     .dst_we_o     (aon_wkup_detector_en_2_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_2_regwen),
@@ -3144,34 +3138,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_2_wdata;
 
   logic  aon_wkup_detector_en_3_qs_int;
-  logic [0:0] aon_wkup_detector_en_3_d;
+  logic [0:0] aon_wkup_detector_en_3_qs;
   logic [0:0] aon_wkup_detector_en_3_wdata;
   logic aon_wkup_detector_en_3_we;
   logic unused_aon_wkup_detector_en_3_wdata;
   logic aon_wkup_detector_en_3_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_3_d = '0;
-    aon_wkup_detector_en_3_d = aon_wkup_detector_en_3_qs_int;
+    aon_wkup_detector_en_3_qs = 1'h0;
+    aon_wkup_detector_en_3_qs = aon_wkup_detector_en_3_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_3_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_3_qs),
     .src_we_i     (wkup_detector_en_3_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_3_busy),
     .src_qs_o     (wkup_detector_en_3_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_3_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_3_qs),
     .dst_we_o     (aon_wkup_detector_en_3_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_3_regwen),
@@ -3181,34 +3177,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_3_wdata;
 
   logic  aon_wkup_detector_en_4_qs_int;
-  logic [0:0] aon_wkup_detector_en_4_d;
+  logic [0:0] aon_wkup_detector_en_4_qs;
   logic [0:0] aon_wkup_detector_en_4_wdata;
   logic aon_wkup_detector_en_4_we;
   logic unused_aon_wkup_detector_en_4_wdata;
   logic aon_wkup_detector_en_4_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_4_d = '0;
-    aon_wkup_detector_en_4_d = aon_wkup_detector_en_4_qs_int;
+    aon_wkup_detector_en_4_qs = 1'h0;
+    aon_wkup_detector_en_4_qs = aon_wkup_detector_en_4_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_4_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_4_qs),
     .src_we_i     (wkup_detector_en_4_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_4_busy),
     .src_qs_o     (wkup_detector_en_4_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_4_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_4_qs),
     .dst_we_o     (aon_wkup_detector_en_4_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_4_regwen),
@@ -3218,34 +3216,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_4_wdata;
 
   logic  aon_wkup_detector_en_5_qs_int;
-  logic [0:0] aon_wkup_detector_en_5_d;
+  logic [0:0] aon_wkup_detector_en_5_qs;
   logic [0:0] aon_wkup_detector_en_5_wdata;
   logic aon_wkup_detector_en_5_we;
   logic unused_aon_wkup_detector_en_5_wdata;
   logic aon_wkup_detector_en_5_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_5_d = '0;
-    aon_wkup_detector_en_5_d = aon_wkup_detector_en_5_qs_int;
+    aon_wkup_detector_en_5_qs = 1'h0;
+    aon_wkup_detector_en_5_qs = aon_wkup_detector_en_5_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_5_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_5_qs),
     .src_we_i     (wkup_detector_en_5_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_5_busy),
     .src_qs_o     (wkup_detector_en_5_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_5_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_5_qs),
     .dst_we_o     (aon_wkup_detector_en_5_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_5_regwen),
@@ -3255,34 +3255,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_5_wdata;
 
   logic  aon_wkup_detector_en_6_qs_int;
-  logic [0:0] aon_wkup_detector_en_6_d;
+  logic [0:0] aon_wkup_detector_en_6_qs;
   logic [0:0] aon_wkup_detector_en_6_wdata;
   logic aon_wkup_detector_en_6_we;
   logic unused_aon_wkup_detector_en_6_wdata;
   logic aon_wkup_detector_en_6_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_6_d = '0;
-    aon_wkup_detector_en_6_d = aon_wkup_detector_en_6_qs_int;
+    aon_wkup_detector_en_6_qs = 1'h0;
+    aon_wkup_detector_en_6_qs = aon_wkup_detector_en_6_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_6_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_6_qs),
     .src_we_i     (wkup_detector_en_6_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_6_busy),
     .src_qs_o     (wkup_detector_en_6_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_6_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_6_qs),
     .dst_we_o     (aon_wkup_detector_en_6_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_6_regwen),
@@ -3292,34 +3294,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_en_6_wdata;
 
   logic  aon_wkup_detector_en_7_qs_int;
-  logic [0:0] aon_wkup_detector_en_7_d;
+  logic [0:0] aon_wkup_detector_en_7_qs;
   logic [0:0] aon_wkup_detector_en_7_wdata;
   logic aon_wkup_detector_en_7_we;
   logic unused_aon_wkup_detector_en_7_wdata;
   logic aon_wkup_detector_en_7_regwen;
 
   always_comb begin
-    aon_wkup_detector_en_7_d = '0;
-    aon_wkup_detector_en_7_d = aon_wkup_detector_en_7_qs_int;
+    aon_wkup_detector_en_7_qs = 1'h0;
+    aon_wkup_detector_en_7_qs = aon_wkup_detector_en_7_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(1),
     .ResetVal(1'h0),
-    .BitMask(1'h1)
+    .BitMask(1'h1),
+    .DstWrReq(0)
   ) u_wkup_detector_en_7_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_7_qs),
     .src_we_i     (wkup_detector_en_7_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[0:0]),
     .src_busy_o   (wkup_detector_en_7_busy),
     .src_qs_o     (wkup_detector_en_7_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_en_7_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_en_7_qs),
     .dst_we_o     (aon_wkup_detector_en_7_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_en_7_regwen),
@@ -3331,36 +3335,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_0_mode_0_qs_int;
   logic  aon_wkup_detector_0_filter_0_qs_int;
   logic  aon_wkup_detector_0_miodio_0_qs_int;
-  logic [4:0] aon_wkup_detector_0_d;
+  logic [4:0] aon_wkup_detector_0_qs;
   logic [4:0] aon_wkup_detector_0_wdata;
   logic aon_wkup_detector_0_we;
   logic unused_aon_wkup_detector_0_wdata;
   logic aon_wkup_detector_0_regwen;
 
   always_comb begin
-    aon_wkup_detector_0_d = '0;
-    aon_wkup_detector_0_d[2:0] = aon_wkup_detector_0_mode_0_qs_int;
-    aon_wkup_detector_0_d[3] = aon_wkup_detector_0_filter_0_qs_int;
-    aon_wkup_detector_0_d[4] = aon_wkup_detector_0_miodio_0_qs_int;
+    aon_wkup_detector_0_qs = 5'h0;
+    aon_wkup_detector_0_qs[2:0] = aon_wkup_detector_0_mode_0_qs_int;
+    aon_wkup_detector_0_qs[3] = aon_wkup_detector_0_filter_0_qs_int;
+    aon_wkup_detector_0_qs[4] = aon_wkup_detector_0_miodio_0_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_0_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_0_qs),
     .src_we_i     (wkup_detector_0_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_0_busy),
     .src_qs_o     (wkup_detector_0_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_0_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_0_qs),
     .dst_we_o     (aon_wkup_detector_0_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_0_regwen),
@@ -3372,36 +3378,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_1_mode_1_qs_int;
   logic  aon_wkup_detector_1_filter_1_qs_int;
   logic  aon_wkup_detector_1_miodio_1_qs_int;
-  logic [4:0] aon_wkup_detector_1_d;
+  logic [4:0] aon_wkup_detector_1_qs;
   logic [4:0] aon_wkup_detector_1_wdata;
   logic aon_wkup_detector_1_we;
   logic unused_aon_wkup_detector_1_wdata;
   logic aon_wkup_detector_1_regwen;
 
   always_comb begin
-    aon_wkup_detector_1_d = '0;
-    aon_wkup_detector_1_d[2:0] = aon_wkup_detector_1_mode_1_qs_int;
-    aon_wkup_detector_1_d[3] = aon_wkup_detector_1_filter_1_qs_int;
-    aon_wkup_detector_1_d[4] = aon_wkup_detector_1_miodio_1_qs_int;
+    aon_wkup_detector_1_qs = 5'h0;
+    aon_wkup_detector_1_qs[2:0] = aon_wkup_detector_1_mode_1_qs_int;
+    aon_wkup_detector_1_qs[3] = aon_wkup_detector_1_filter_1_qs_int;
+    aon_wkup_detector_1_qs[4] = aon_wkup_detector_1_miodio_1_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_1_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_1_qs),
     .src_we_i     (wkup_detector_1_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_1_busy),
     .src_qs_o     (wkup_detector_1_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_1_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_1_qs),
     .dst_we_o     (aon_wkup_detector_1_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_1_regwen),
@@ -3413,36 +3421,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_2_mode_2_qs_int;
   logic  aon_wkup_detector_2_filter_2_qs_int;
   logic  aon_wkup_detector_2_miodio_2_qs_int;
-  logic [4:0] aon_wkup_detector_2_d;
+  logic [4:0] aon_wkup_detector_2_qs;
   logic [4:0] aon_wkup_detector_2_wdata;
   logic aon_wkup_detector_2_we;
   logic unused_aon_wkup_detector_2_wdata;
   logic aon_wkup_detector_2_regwen;
 
   always_comb begin
-    aon_wkup_detector_2_d = '0;
-    aon_wkup_detector_2_d[2:0] = aon_wkup_detector_2_mode_2_qs_int;
-    aon_wkup_detector_2_d[3] = aon_wkup_detector_2_filter_2_qs_int;
-    aon_wkup_detector_2_d[4] = aon_wkup_detector_2_miodio_2_qs_int;
+    aon_wkup_detector_2_qs = 5'h0;
+    aon_wkup_detector_2_qs[2:0] = aon_wkup_detector_2_mode_2_qs_int;
+    aon_wkup_detector_2_qs[3] = aon_wkup_detector_2_filter_2_qs_int;
+    aon_wkup_detector_2_qs[4] = aon_wkup_detector_2_miodio_2_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_2_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_2_qs),
     .src_we_i     (wkup_detector_2_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_2_busy),
     .src_qs_o     (wkup_detector_2_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_2_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_2_qs),
     .dst_we_o     (aon_wkup_detector_2_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_2_regwen),
@@ -3454,36 +3464,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_3_mode_3_qs_int;
   logic  aon_wkup_detector_3_filter_3_qs_int;
   logic  aon_wkup_detector_3_miodio_3_qs_int;
-  logic [4:0] aon_wkup_detector_3_d;
+  logic [4:0] aon_wkup_detector_3_qs;
   logic [4:0] aon_wkup_detector_3_wdata;
   logic aon_wkup_detector_3_we;
   logic unused_aon_wkup_detector_3_wdata;
   logic aon_wkup_detector_3_regwen;
 
   always_comb begin
-    aon_wkup_detector_3_d = '0;
-    aon_wkup_detector_3_d[2:0] = aon_wkup_detector_3_mode_3_qs_int;
-    aon_wkup_detector_3_d[3] = aon_wkup_detector_3_filter_3_qs_int;
-    aon_wkup_detector_3_d[4] = aon_wkup_detector_3_miodio_3_qs_int;
+    aon_wkup_detector_3_qs = 5'h0;
+    aon_wkup_detector_3_qs[2:0] = aon_wkup_detector_3_mode_3_qs_int;
+    aon_wkup_detector_3_qs[3] = aon_wkup_detector_3_filter_3_qs_int;
+    aon_wkup_detector_3_qs[4] = aon_wkup_detector_3_miodio_3_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_3_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_3_qs),
     .src_we_i     (wkup_detector_3_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_3_busy),
     .src_qs_o     (wkup_detector_3_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_3_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_3_qs),
     .dst_we_o     (aon_wkup_detector_3_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_3_regwen),
@@ -3495,36 +3507,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_4_mode_4_qs_int;
   logic  aon_wkup_detector_4_filter_4_qs_int;
   logic  aon_wkup_detector_4_miodio_4_qs_int;
-  logic [4:0] aon_wkup_detector_4_d;
+  logic [4:0] aon_wkup_detector_4_qs;
   logic [4:0] aon_wkup_detector_4_wdata;
   logic aon_wkup_detector_4_we;
   logic unused_aon_wkup_detector_4_wdata;
   logic aon_wkup_detector_4_regwen;
 
   always_comb begin
-    aon_wkup_detector_4_d = '0;
-    aon_wkup_detector_4_d[2:0] = aon_wkup_detector_4_mode_4_qs_int;
-    aon_wkup_detector_4_d[3] = aon_wkup_detector_4_filter_4_qs_int;
-    aon_wkup_detector_4_d[4] = aon_wkup_detector_4_miodio_4_qs_int;
+    aon_wkup_detector_4_qs = 5'h0;
+    aon_wkup_detector_4_qs[2:0] = aon_wkup_detector_4_mode_4_qs_int;
+    aon_wkup_detector_4_qs[3] = aon_wkup_detector_4_filter_4_qs_int;
+    aon_wkup_detector_4_qs[4] = aon_wkup_detector_4_miodio_4_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_4_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_4_qs),
     .src_we_i     (wkup_detector_4_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_4_busy),
     .src_qs_o     (wkup_detector_4_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_4_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_4_qs),
     .dst_we_o     (aon_wkup_detector_4_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_4_regwen),
@@ -3536,36 +3550,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_5_mode_5_qs_int;
   logic  aon_wkup_detector_5_filter_5_qs_int;
   logic  aon_wkup_detector_5_miodio_5_qs_int;
-  logic [4:0] aon_wkup_detector_5_d;
+  logic [4:0] aon_wkup_detector_5_qs;
   logic [4:0] aon_wkup_detector_5_wdata;
   logic aon_wkup_detector_5_we;
   logic unused_aon_wkup_detector_5_wdata;
   logic aon_wkup_detector_5_regwen;
 
   always_comb begin
-    aon_wkup_detector_5_d = '0;
-    aon_wkup_detector_5_d[2:0] = aon_wkup_detector_5_mode_5_qs_int;
-    aon_wkup_detector_5_d[3] = aon_wkup_detector_5_filter_5_qs_int;
-    aon_wkup_detector_5_d[4] = aon_wkup_detector_5_miodio_5_qs_int;
+    aon_wkup_detector_5_qs = 5'h0;
+    aon_wkup_detector_5_qs[2:0] = aon_wkup_detector_5_mode_5_qs_int;
+    aon_wkup_detector_5_qs[3] = aon_wkup_detector_5_filter_5_qs_int;
+    aon_wkup_detector_5_qs[4] = aon_wkup_detector_5_miodio_5_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_5_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_5_qs),
     .src_we_i     (wkup_detector_5_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_5_busy),
     .src_qs_o     (wkup_detector_5_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_5_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_5_qs),
     .dst_we_o     (aon_wkup_detector_5_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_5_regwen),
@@ -3577,36 +3593,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_6_mode_6_qs_int;
   logic  aon_wkup_detector_6_filter_6_qs_int;
   logic  aon_wkup_detector_6_miodio_6_qs_int;
-  logic [4:0] aon_wkup_detector_6_d;
+  logic [4:0] aon_wkup_detector_6_qs;
   logic [4:0] aon_wkup_detector_6_wdata;
   logic aon_wkup_detector_6_we;
   logic unused_aon_wkup_detector_6_wdata;
   logic aon_wkup_detector_6_regwen;
 
   always_comb begin
-    aon_wkup_detector_6_d = '0;
-    aon_wkup_detector_6_d[2:0] = aon_wkup_detector_6_mode_6_qs_int;
-    aon_wkup_detector_6_d[3] = aon_wkup_detector_6_filter_6_qs_int;
-    aon_wkup_detector_6_d[4] = aon_wkup_detector_6_miodio_6_qs_int;
+    aon_wkup_detector_6_qs = 5'h0;
+    aon_wkup_detector_6_qs[2:0] = aon_wkup_detector_6_mode_6_qs_int;
+    aon_wkup_detector_6_qs[3] = aon_wkup_detector_6_filter_6_qs_int;
+    aon_wkup_detector_6_qs[4] = aon_wkup_detector_6_miodio_6_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_6_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_6_qs),
     .src_we_i     (wkup_detector_6_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_6_busy),
     .src_qs_o     (wkup_detector_6_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_6_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_6_qs),
     .dst_we_o     (aon_wkup_detector_6_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_6_regwen),
@@ -3618,36 +3636,38 @@ module pinmux_reg_top (
   logic [2:0]  aon_wkup_detector_7_mode_7_qs_int;
   logic  aon_wkup_detector_7_filter_7_qs_int;
   logic  aon_wkup_detector_7_miodio_7_qs_int;
-  logic [4:0] aon_wkup_detector_7_d;
+  logic [4:0] aon_wkup_detector_7_qs;
   logic [4:0] aon_wkup_detector_7_wdata;
   logic aon_wkup_detector_7_we;
   logic unused_aon_wkup_detector_7_wdata;
   logic aon_wkup_detector_7_regwen;
 
   always_comb begin
-    aon_wkup_detector_7_d = '0;
-    aon_wkup_detector_7_d[2:0] = aon_wkup_detector_7_mode_7_qs_int;
-    aon_wkup_detector_7_d[3] = aon_wkup_detector_7_filter_7_qs_int;
-    aon_wkup_detector_7_d[4] = aon_wkup_detector_7_miodio_7_qs_int;
+    aon_wkup_detector_7_qs = 5'h0;
+    aon_wkup_detector_7_qs[2:0] = aon_wkup_detector_7_mode_7_qs_int;
+    aon_wkup_detector_7_qs[3] = aon_wkup_detector_7_filter_7_qs_int;
+    aon_wkup_detector_7_qs[4] = aon_wkup_detector_7_miodio_7_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(5),
     .ResetVal(5'h0),
-    .BitMask(5'h1f)
+    .BitMask(5'h1f),
+    .DstWrReq(0)
   ) u_wkup_detector_7_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_7_qs),
     .src_we_i     (wkup_detector_7_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[4:0]),
     .src_busy_o   (wkup_detector_7_busy),
     .src_qs_o     (wkup_detector_7_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_7_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_7_qs),
     .dst_we_o     (aon_wkup_detector_7_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_7_regwen),
@@ -3657,34 +3677,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_7_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_0_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_0_d;
+  logic [7:0] aon_wkup_detector_cnt_th_0_qs;
   logic [7:0] aon_wkup_detector_cnt_th_0_wdata;
   logic aon_wkup_detector_cnt_th_0_we;
   logic unused_aon_wkup_detector_cnt_th_0_wdata;
   logic aon_wkup_detector_cnt_th_0_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_0_d = '0;
-    aon_wkup_detector_cnt_th_0_d = aon_wkup_detector_cnt_th_0_qs_int;
+    aon_wkup_detector_cnt_th_0_qs = 8'h0;
+    aon_wkup_detector_cnt_th_0_qs = aon_wkup_detector_cnt_th_0_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_0_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_0_qs),
     .src_we_i     (wkup_detector_cnt_th_0_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_0_busy),
     .src_qs_o     (wkup_detector_cnt_th_0_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_0_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_0_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_0_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_0_regwen),
@@ -3694,34 +3716,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_0_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_1_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_1_d;
+  logic [7:0] aon_wkup_detector_cnt_th_1_qs;
   logic [7:0] aon_wkup_detector_cnt_th_1_wdata;
   logic aon_wkup_detector_cnt_th_1_we;
   logic unused_aon_wkup_detector_cnt_th_1_wdata;
   logic aon_wkup_detector_cnt_th_1_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_1_d = '0;
-    aon_wkup_detector_cnt_th_1_d = aon_wkup_detector_cnt_th_1_qs_int;
+    aon_wkup_detector_cnt_th_1_qs = 8'h0;
+    aon_wkup_detector_cnt_th_1_qs = aon_wkup_detector_cnt_th_1_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_1_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_1_qs),
     .src_we_i     (wkup_detector_cnt_th_1_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_1_busy),
     .src_qs_o     (wkup_detector_cnt_th_1_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_1_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_1_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_1_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_1_regwen),
@@ -3731,34 +3755,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_1_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_2_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_2_d;
+  logic [7:0] aon_wkup_detector_cnt_th_2_qs;
   logic [7:0] aon_wkup_detector_cnt_th_2_wdata;
   logic aon_wkup_detector_cnt_th_2_we;
   logic unused_aon_wkup_detector_cnt_th_2_wdata;
   logic aon_wkup_detector_cnt_th_2_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_2_d = '0;
-    aon_wkup_detector_cnt_th_2_d = aon_wkup_detector_cnt_th_2_qs_int;
+    aon_wkup_detector_cnt_th_2_qs = 8'h0;
+    aon_wkup_detector_cnt_th_2_qs = aon_wkup_detector_cnt_th_2_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_2_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_2_qs),
     .src_we_i     (wkup_detector_cnt_th_2_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_2_busy),
     .src_qs_o     (wkup_detector_cnt_th_2_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_2_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_2_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_2_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_2_regwen),
@@ -3768,34 +3794,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_2_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_3_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_3_d;
+  logic [7:0] aon_wkup_detector_cnt_th_3_qs;
   logic [7:0] aon_wkup_detector_cnt_th_3_wdata;
   logic aon_wkup_detector_cnt_th_3_we;
   logic unused_aon_wkup_detector_cnt_th_3_wdata;
   logic aon_wkup_detector_cnt_th_3_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_3_d = '0;
-    aon_wkup_detector_cnt_th_3_d = aon_wkup_detector_cnt_th_3_qs_int;
+    aon_wkup_detector_cnt_th_3_qs = 8'h0;
+    aon_wkup_detector_cnt_th_3_qs = aon_wkup_detector_cnt_th_3_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_3_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_3_qs),
     .src_we_i     (wkup_detector_cnt_th_3_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_3_busy),
     .src_qs_o     (wkup_detector_cnt_th_3_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_3_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_3_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_3_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_3_regwen),
@@ -3805,34 +3833,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_3_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_4_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_4_d;
+  logic [7:0] aon_wkup_detector_cnt_th_4_qs;
   logic [7:0] aon_wkup_detector_cnt_th_4_wdata;
   logic aon_wkup_detector_cnt_th_4_we;
   logic unused_aon_wkup_detector_cnt_th_4_wdata;
   logic aon_wkup_detector_cnt_th_4_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_4_d = '0;
-    aon_wkup_detector_cnt_th_4_d = aon_wkup_detector_cnt_th_4_qs_int;
+    aon_wkup_detector_cnt_th_4_qs = 8'h0;
+    aon_wkup_detector_cnt_th_4_qs = aon_wkup_detector_cnt_th_4_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_4_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_4_qs),
     .src_we_i     (wkup_detector_cnt_th_4_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_4_busy),
     .src_qs_o     (wkup_detector_cnt_th_4_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_4_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_4_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_4_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_4_regwen),
@@ -3842,34 +3872,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_4_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_5_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_5_d;
+  logic [7:0] aon_wkup_detector_cnt_th_5_qs;
   logic [7:0] aon_wkup_detector_cnt_th_5_wdata;
   logic aon_wkup_detector_cnt_th_5_we;
   logic unused_aon_wkup_detector_cnt_th_5_wdata;
   logic aon_wkup_detector_cnt_th_5_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_5_d = '0;
-    aon_wkup_detector_cnt_th_5_d = aon_wkup_detector_cnt_th_5_qs_int;
+    aon_wkup_detector_cnt_th_5_qs = 8'h0;
+    aon_wkup_detector_cnt_th_5_qs = aon_wkup_detector_cnt_th_5_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_5_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_5_qs),
     .src_we_i     (wkup_detector_cnt_th_5_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_5_busy),
     .src_qs_o     (wkup_detector_cnt_th_5_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_5_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_5_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_5_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_5_regwen),
@@ -3879,34 +3911,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_5_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_6_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_6_d;
+  logic [7:0] aon_wkup_detector_cnt_th_6_qs;
   logic [7:0] aon_wkup_detector_cnt_th_6_wdata;
   logic aon_wkup_detector_cnt_th_6_we;
   logic unused_aon_wkup_detector_cnt_th_6_wdata;
   logic aon_wkup_detector_cnt_th_6_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_6_d = '0;
-    aon_wkup_detector_cnt_th_6_d = aon_wkup_detector_cnt_th_6_qs_int;
+    aon_wkup_detector_cnt_th_6_qs = 8'h0;
+    aon_wkup_detector_cnt_th_6_qs = aon_wkup_detector_cnt_th_6_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_6_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_6_qs),
     .src_we_i     (wkup_detector_cnt_th_6_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_6_busy),
     .src_qs_o     (wkup_detector_cnt_th_6_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_6_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_6_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_6_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_6_regwen),
@@ -3916,34 +3950,36 @@ module pinmux_reg_top (
       ^aon_wkup_detector_cnt_th_6_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_7_qs_int;
-  logic [7:0] aon_wkup_detector_cnt_th_7_d;
+  logic [7:0] aon_wkup_detector_cnt_th_7_qs;
   logic [7:0] aon_wkup_detector_cnt_th_7_wdata;
   logic aon_wkup_detector_cnt_th_7_we;
   logic unused_aon_wkup_detector_cnt_th_7_wdata;
   logic aon_wkup_detector_cnt_th_7_regwen;
 
   always_comb begin
-    aon_wkup_detector_cnt_th_7_d = '0;
-    aon_wkup_detector_cnt_th_7_d = aon_wkup_detector_cnt_th_7_qs_int;
+    aon_wkup_detector_cnt_th_7_qs = 8'h0;
+    aon_wkup_detector_cnt_th_7_qs = aon_wkup_detector_cnt_th_7_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(0)
   ) u_wkup_detector_cnt_th_7_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i (wkup_detector_regwen_7_qs),
     .src_we_i     (wkup_detector_cnt_th_7_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_detector_cnt_th_7_busy),
     .src_qs_o     (wkup_detector_cnt_th_7_qs), // for software read back
-    .dst_d_i      (aon_wkup_detector_cnt_th_7_d),
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_detector_cnt_th_7_qs),
     .dst_we_o     (aon_wkup_detector_cnt_th_7_we),
     .dst_re_o     (),
     .dst_regwen_o (aon_wkup_detector_cnt_th_7_regwen),
@@ -3952,48 +3988,69 @@ module pinmux_reg_top (
   assign unused_aon_wkup_detector_cnt_th_7_wdata =
       ^aon_wkup_detector_cnt_th_7_wdata;
 
+  logic  aon_wkup_cause_cause_0_ds_int;
   logic  aon_wkup_cause_cause_0_qs_int;
+  logic  aon_wkup_cause_cause_1_ds_int;
   logic  aon_wkup_cause_cause_1_qs_int;
+  logic  aon_wkup_cause_cause_2_ds_int;
   logic  aon_wkup_cause_cause_2_qs_int;
+  logic  aon_wkup_cause_cause_3_ds_int;
   logic  aon_wkup_cause_cause_3_qs_int;
+  logic  aon_wkup_cause_cause_4_ds_int;
   logic  aon_wkup_cause_cause_4_qs_int;
+  logic  aon_wkup_cause_cause_5_ds_int;
   logic  aon_wkup_cause_cause_5_qs_int;
+  logic  aon_wkup_cause_cause_6_ds_int;
   logic  aon_wkup_cause_cause_6_qs_int;
+  logic  aon_wkup_cause_cause_7_ds_int;
   logic  aon_wkup_cause_cause_7_qs_int;
-  logic [7:0] aon_wkup_cause_d;
+  logic [7:0] aon_wkup_cause_ds;
+  logic aon_wkup_cause_qe;
+  logic [7:0] aon_wkup_cause_qs;
   logic [7:0] aon_wkup_cause_wdata;
   logic aon_wkup_cause_we;
   logic unused_aon_wkup_cause_wdata;
 
   always_comb begin
-    aon_wkup_cause_d = '0;
-    aon_wkup_cause_d[0] = aon_wkup_cause_cause_0_qs_int;
-    aon_wkup_cause_d[1] = aon_wkup_cause_cause_1_qs_int;
-    aon_wkup_cause_d[2] = aon_wkup_cause_cause_2_qs_int;
-    aon_wkup_cause_d[3] = aon_wkup_cause_cause_3_qs_int;
-    aon_wkup_cause_d[4] = aon_wkup_cause_cause_4_qs_int;
-    aon_wkup_cause_d[5] = aon_wkup_cause_cause_5_qs_int;
-    aon_wkup_cause_d[6] = aon_wkup_cause_cause_6_qs_int;
-    aon_wkup_cause_d[7] = aon_wkup_cause_cause_7_qs_int;
+    aon_wkup_cause_qs = 8'h0;
+    aon_wkup_cause_ds = 8'h0;
+    aon_wkup_cause_ds[0] = aon_wkup_cause_cause_0_ds_int;
+    aon_wkup_cause_qs[0] = aon_wkup_cause_cause_0_qs_int;
+    aon_wkup_cause_ds[1] = aon_wkup_cause_cause_1_ds_int;
+    aon_wkup_cause_qs[1] = aon_wkup_cause_cause_1_qs_int;
+    aon_wkup_cause_ds[2] = aon_wkup_cause_cause_2_ds_int;
+    aon_wkup_cause_qs[2] = aon_wkup_cause_cause_2_qs_int;
+    aon_wkup_cause_ds[3] = aon_wkup_cause_cause_3_ds_int;
+    aon_wkup_cause_qs[3] = aon_wkup_cause_cause_3_qs_int;
+    aon_wkup_cause_ds[4] = aon_wkup_cause_cause_4_ds_int;
+    aon_wkup_cause_qs[4] = aon_wkup_cause_cause_4_qs_int;
+    aon_wkup_cause_ds[5] = aon_wkup_cause_cause_5_ds_int;
+    aon_wkup_cause_qs[5] = aon_wkup_cause_cause_5_qs_int;
+    aon_wkup_cause_ds[6] = aon_wkup_cause_cause_6_ds_int;
+    aon_wkup_cause_qs[6] = aon_wkup_cause_cause_6_qs_int;
+    aon_wkup_cause_ds[7] = aon_wkup_cause_cause_7_ds_int;
+    aon_wkup_cause_qs[7] = aon_wkup_cause_cause_7_qs_int;
   end
 
   prim_reg_cdc #(
     .DataWidth(8),
     .ResetVal(8'h0),
-    .BitMask(8'hff)
+    .BitMask(8'hff),
+    .DstWrReq(1)
   ) u_wkup_cause_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
     .src_regwen_i ('0),
     .src_we_i     (wkup_cause_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (wkup_cause_busy),
     .src_qs_o     (wkup_cause_qs), // for software read back
-    .dst_d_i      (aon_wkup_cause_d),
+    .dst_update_i (aon_wkup_cause_qe),
+    .dst_ds_i     (aon_wkup_cause_ds),
+    .dst_qs_i     (aon_wkup_cause_qs),
     .dst_we_o     (aon_wkup_cause_we),
     .dst_re_o     (),
     .dst_regwen_o (),
@@ -4017,6 +4074,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -4043,6 +4101,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_0_qs)
@@ -4070,6 +4129,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_1_qs)
@@ -4097,6 +4157,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_2_qs)
@@ -4124,6 +4185,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_3_qs)
@@ -4151,6 +4213,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_4_qs)
@@ -4178,6 +4241,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_5_qs)
@@ -4205,6 +4269,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_6_qs)
@@ -4232,6 +4297,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_7_qs)
@@ -4259,6 +4325,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_8_qs)
@@ -4286,6 +4353,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_9_qs)
@@ -4313,6 +4381,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_10_qs)
@@ -4340,6 +4409,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_11_qs)
@@ -4367,6 +4437,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_12_qs)
@@ -4394,6 +4465,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_13_qs)
@@ -4421,6 +4493,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_14_qs)
@@ -4448,6 +4521,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_15_qs)
@@ -4475,6 +4549,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_16_qs)
@@ -4502,6 +4577,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_17_qs)
@@ -4529,6 +4605,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_18_qs)
@@ -4556,6 +4633,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_19_qs)
@@ -4583,6 +4661,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_20_qs)
@@ -4610,6 +4689,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_21_qs)
@@ -4637,6 +4717,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_22_qs)
@@ -4664,6 +4745,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_23_qs)
@@ -4691,6 +4773,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_24_qs)
@@ -4718,6 +4801,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_25_qs)
@@ -4745,6 +4829,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_26_qs)
@@ -4772,6 +4857,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_27_qs)
@@ -4799,6 +4885,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_28_qs)
@@ -4826,6 +4913,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_29_qs)
@@ -4853,6 +4941,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_30_qs)
@@ -4880,6 +4969,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_31_qs)
@@ -4907,6 +4997,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_32_qs)
@@ -4934,6 +5025,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_33_qs)
@@ -4961,6 +5053,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_34_qs)
@@ -4988,6 +5081,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_35_qs)
@@ -5015,6 +5109,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_36_qs)
@@ -5042,6 +5137,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_37_qs)
@@ -5069,6 +5165,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_38_qs)
@@ -5096,6 +5193,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_39_qs)
@@ -5123,6 +5221,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_40_qs)
@@ -5150,6 +5249,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_41_qs)
@@ -5177,6 +5277,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_42_qs)
@@ -5204,6 +5305,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_43_qs)
@@ -5231,6 +5333,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_44_qs)
@@ -5258,6 +5361,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_45_qs)
@@ -5285,6 +5389,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_46_qs)
@@ -5312,6 +5417,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_47_qs)
@@ -5339,6 +5445,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_48_qs)
@@ -5366,6 +5473,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_49_qs)
@@ -5393,6 +5501,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_50_qs)
@@ -5420,6 +5529,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_51_qs)
@@ -5447,6 +5557,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_52_qs)
@@ -5474,6 +5585,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_53_qs)
@@ -5501,6 +5613,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_54_qs)
@@ -5528,6 +5641,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_55_qs)
@@ -5555,6 +5669,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_regwen_56_qs)
@@ -5585,6 +5700,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_0_qs)
@@ -5615,6 +5731,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_1_qs)
@@ -5645,6 +5762,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_2_qs)
@@ -5675,6 +5793,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_3_qs)
@@ -5705,6 +5824,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_4_qs)
@@ -5735,6 +5855,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_5_qs)
@@ -5765,6 +5886,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_6_qs)
@@ -5795,6 +5917,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_7_qs)
@@ -5825,6 +5948,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_8_qs)
@@ -5855,6 +5979,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_9_qs)
@@ -5885,6 +6010,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_10_qs)
@@ -5915,6 +6041,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_11_qs)
@@ -5945,6 +6072,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_12_qs)
@@ -5975,6 +6103,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_13_qs)
@@ -6005,6 +6134,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_14_qs)
@@ -6035,6 +6165,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_15_qs)
@@ -6065,6 +6196,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_16_qs)
@@ -6095,6 +6227,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_17_qs)
@@ -6125,6 +6258,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_18_qs)
@@ -6155,6 +6289,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_19_qs)
@@ -6185,6 +6320,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_20_qs)
@@ -6215,6 +6351,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_21_qs)
@@ -6245,6 +6382,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_22_qs)
@@ -6275,6 +6413,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_23_qs)
@@ -6305,6 +6444,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_24_qs)
@@ -6335,6 +6475,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_25_qs)
@@ -6365,6 +6506,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_26_qs)
@@ -6395,6 +6537,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_27_qs)
@@ -6425,6 +6568,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_28_qs)
@@ -6455,6 +6599,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_29_qs)
@@ -6485,6 +6630,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_30_qs)
@@ -6515,6 +6661,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_31_qs)
@@ -6545,6 +6692,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_32_qs)
@@ -6575,6 +6723,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_33_qs)
@@ -6605,6 +6754,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_34_qs)
@@ -6635,6 +6785,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_35_qs)
@@ -6665,6 +6816,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_36_qs)
@@ -6695,6 +6847,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_37_qs)
@@ -6725,6 +6878,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_38_qs)
@@ -6755,6 +6909,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_39_qs)
@@ -6785,6 +6940,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_40_qs)
@@ -6815,6 +6971,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_41_qs)
@@ -6845,6 +7002,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_42_qs)
@@ -6875,6 +7033,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_43_qs)
@@ -6905,6 +7064,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_44_qs)
@@ -6935,6 +7095,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_45_qs)
@@ -6965,6 +7126,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_46_qs)
@@ -6995,6 +7157,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[47].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_47_qs)
@@ -7025,6 +7188,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[48].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_48_qs)
@@ -7055,6 +7219,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[49].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_49_qs)
@@ -7085,6 +7250,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[50].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_50_qs)
@@ -7115,6 +7281,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[51].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_51_qs)
@@ -7145,6 +7312,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[52].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_52_qs)
@@ -7175,6 +7343,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[53].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_53_qs)
@@ -7205,6 +7374,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[54].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_54_qs)
@@ -7235,6 +7405,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[55].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_55_qs)
@@ -7265,6 +7436,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_periph_insel[56].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_periph_insel_56_qs)
@@ -7292,6 +7464,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_0_qs)
@@ -7319,6 +7492,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_1_qs)
@@ -7346,6 +7520,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_2_qs)
@@ -7373,6 +7548,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_3_qs)
@@ -7400,6 +7576,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_4_qs)
@@ -7427,6 +7604,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_5_qs)
@@ -7454,6 +7632,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_6_qs)
@@ -7481,6 +7660,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_7_qs)
@@ -7508,6 +7688,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_8_qs)
@@ -7535,6 +7716,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_9_qs)
@@ -7562,6 +7744,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_10_qs)
@@ -7589,6 +7772,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_11_qs)
@@ -7616,6 +7800,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_12_qs)
@@ -7643,6 +7828,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_13_qs)
@@ -7670,6 +7856,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_14_qs)
@@ -7697,6 +7884,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_15_qs)
@@ -7724,6 +7912,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_16_qs)
@@ -7751,6 +7940,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_17_qs)
@@ -7778,6 +7968,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_18_qs)
@@ -7805,6 +7996,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_19_qs)
@@ -7832,6 +8024,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_20_qs)
@@ -7859,6 +8052,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_21_qs)
@@ -7886,6 +8080,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_22_qs)
@@ -7913,6 +8108,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_23_qs)
@@ -7940,6 +8136,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_24_qs)
@@ -7967,6 +8164,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_25_qs)
@@ -7994,6 +8192,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_26_qs)
@@ -8021,6 +8220,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_27_qs)
@@ -8048,6 +8248,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_28_qs)
@@ -8075,6 +8276,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_29_qs)
@@ -8102,6 +8304,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_30_qs)
@@ -8129,6 +8332,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_31_qs)
@@ -8156,6 +8360,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_32_qs)
@@ -8183,6 +8388,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_33_qs)
@@ -8210,6 +8416,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_34_qs)
@@ -8237,6 +8444,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_35_qs)
@@ -8264,6 +8472,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_36_qs)
@@ -8291,6 +8500,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_37_qs)
@@ -8318,6 +8528,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_38_qs)
@@ -8345,6 +8556,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_39_qs)
@@ -8372,6 +8584,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_40_qs)
@@ -8399,6 +8612,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_41_qs)
@@ -8426,6 +8640,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_42_qs)
@@ -8453,6 +8668,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_43_qs)
@@ -8480,6 +8696,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_44_qs)
@@ -8507,6 +8724,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_45_qs)
@@ -8534,6 +8752,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_regwen_46_qs)
@@ -8564,6 +8783,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_0_qs)
@@ -8594,6 +8814,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_1_qs)
@@ -8624,6 +8845,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_2_qs)
@@ -8654,6 +8876,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_3_qs)
@@ -8684,6 +8907,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_4_qs)
@@ -8714,6 +8938,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_5_qs)
@@ -8744,6 +8969,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_6_qs)
@@ -8774,6 +9000,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_7_qs)
@@ -8804,6 +9031,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_8_qs)
@@ -8834,6 +9062,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_9_qs)
@@ -8864,6 +9093,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_10_qs)
@@ -8894,6 +9124,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_11_qs)
@@ -8924,6 +9155,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_12_qs)
@@ -8954,6 +9186,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_13_qs)
@@ -8984,6 +9217,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_14_qs)
@@ -9014,6 +9248,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_15_qs)
@@ -9044,6 +9279,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_16_qs)
@@ -9074,6 +9310,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_17_qs)
@@ -9104,6 +9341,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_18_qs)
@@ -9134,6 +9372,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_19_qs)
@@ -9164,6 +9403,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_20_qs)
@@ -9194,6 +9434,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_21_qs)
@@ -9224,6 +9465,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_22_qs)
@@ -9254,6 +9496,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_23_qs)
@@ -9284,6 +9527,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_24_qs)
@@ -9314,6 +9558,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_25_qs)
@@ -9344,6 +9589,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_26_qs)
@@ -9374,6 +9620,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_27_qs)
@@ -9404,6 +9651,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_28_qs)
@@ -9434,6 +9682,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_29_qs)
@@ -9464,6 +9713,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_30_qs)
@@ -9494,6 +9744,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_31_qs)
@@ -9524,6 +9775,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_32_qs)
@@ -9554,6 +9806,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_33_qs)
@@ -9584,6 +9837,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_34_qs)
@@ -9614,6 +9868,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_35_qs)
@@ -9644,6 +9899,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_36_qs)
@@ -9674,6 +9930,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_37_qs)
@@ -9704,6 +9961,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_38_qs)
@@ -9734,6 +9992,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_39_qs)
@@ -9764,6 +10023,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_40_qs)
@@ -9794,6 +10054,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_41_qs)
@@ -9824,6 +10085,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_42_qs)
@@ -9854,6 +10116,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_43_qs)
@@ -9884,6 +10147,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_44_qs)
@@ -9914,6 +10178,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_45_qs)
@@ -9944,6 +10209,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_outsel[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_outsel_46_qs)
@@ -9971,6 +10237,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_0_qs)
@@ -9998,6 +10265,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_1_qs)
@@ -10025,6 +10293,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_2_qs)
@@ -10052,6 +10321,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_3_qs)
@@ -10079,6 +10349,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_4_qs)
@@ -10106,6 +10377,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_5_qs)
@@ -10133,6 +10405,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_6_qs)
@@ -10160,6 +10433,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_7_qs)
@@ -10187,6 +10461,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_8_qs)
@@ -10214,6 +10489,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_9_qs)
@@ -10241,6 +10517,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_10_qs)
@@ -10268,6 +10545,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_11_qs)
@@ -10295,6 +10573,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_12_qs)
@@ -10322,6 +10601,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_13_qs)
@@ -10349,6 +10629,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_14_qs)
@@ -10376,6 +10657,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_15_qs)
@@ -10403,6 +10685,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_16_qs)
@@ -10430,6 +10713,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_17_qs)
@@ -10457,6 +10741,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_18_qs)
@@ -10484,6 +10769,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_19_qs)
@@ -10511,6 +10797,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_20_qs)
@@ -10538,6 +10825,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_21_qs)
@@ -10565,6 +10853,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_22_qs)
@@ -10592,6 +10881,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_23_qs)
@@ -10619,6 +10909,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_24_qs)
@@ -10646,6 +10937,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_25_qs)
@@ -10673,6 +10965,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_26_qs)
@@ -10700,6 +10993,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_27_qs)
@@ -10727,6 +11021,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_28_qs)
@@ -10754,6 +11049,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_29_qs)
@@ -10781,6 +11077,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_30_qs)
@@ -10808,6 +11105,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_31_qs)
@@ -10835,6 +11133,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_32_qs)
@@ -10862,6 +11161,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_33_qs)
@@ -10889,6 +11189,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_34_qs)
@@ -10916,6 +11217,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_35_qs)
@@ -10943,6 +11245,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_36_qs)
@@ -10970,6 +11273,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_37_qs)
@@ -10997,6 +11301,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_38_qs)
@@ -11024,6 +11329,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_39_qs)
@@ -11051,6 +11357,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_40_qs)
@@ -11078,6 +11385,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_41_qs)
@@ -11105,6 +11413,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_42_qs)
@@ -11132,6 +11441,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_43_qs)
@@ -11159,6 +11469,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_44_qs)
@@ -11186,6 +11497,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_45_qs)
@@ -11213,6 +11525,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_attr_regwen_46_qs)
@@ -11238,6 +11551,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[0].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_invert_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].invert.qe = mio_pad_attr_0_qe;
@@ -11253,6 +11567,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[0].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_virtual_od_en_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].virtual_od_en.qe = mio_pad_attr_0_qe;
@@ -11268,6 +11583,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[0].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_pull_en_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].pull_en.qe = mio_pad_attr_0_qe;
@@ -11283,6 +11599,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[0].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_pull_select_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].pull_select.qe = mio_pad_attr_0_qe;
@@ -11298,6 +11615,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[0].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_keeper_en_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].keeper_en.qe = mio_pad_attr_0_qe;
@@ -11313,6 +11631,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[0].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_schmitt_en_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].schmitt_en.qe = mio_pad_attr_0_qe;
@@ -11328,6 +11647,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[0].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_od_en_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].od_en.qe = mio_pad_attr_0_qe;
@@ -11343,6 +11663,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[0].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_slew_rate_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].slew_rate.qe = mio_pad_attr_0_qe;
@@ -11358,6 +11679,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_0_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[0].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_0_drive_strength_0_qs)
   );
   assign reg2hw.mio_pad_attr[0].drive_strength.qe = mio_pad_attr_0_qe;
@@ -11382,6 +11704,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[1].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_invert_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].invert.qe = mio_pad_attr_1_qe;
@@ -11397,6 +11720,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[1].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_virtual_od_en_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].virtual_od_en.qe = mio_pad_attr_1_qe;
@@ -11412,6 +11736,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[1].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_pull_en_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].pull_en.qe = mio_pad_attr_1_qe;
@@ -11427,6 +11752,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[1].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_pull_select_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].pull_select.qe = mio_pad_attr_1_qe;
@@ -11442,6 +11768,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[1].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_keeper_en_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].keeper_en.qe = mio_pad_attr_1_qe;
@@ -11457,6 +11784,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[1].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_schmitt_en_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].schmitt_en.qe = mio_pad_attr_1_qe;
@@ -11472,6 +11800,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[1].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_od_en_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].od_en.qe = mio_pad_attr_1_qe;
@@ -11487,6 +11816,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[1].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_slew_rate_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].slew_rate.qe = mio_pad_attr_1_qe;
@@ -11502,6 +11832,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_1_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[1].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_1_drive_strength_1_qs)
   );
   assign reg2hw.mio_pad_attr[1].drive_strength.qe = mio_pad_attr_1_qe;
@@ -11526,6 +11857,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[2].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_invert_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].invert.qe = mio_pad_attr_2_qe;
@@ -11541,6 +11873,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[2].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_virtual_od_en_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].virtual_od_en.qe = mio_pad_attr_2_qe;
@@ -11556,6 +11889,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[2].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_pull_en_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].pull_en.qe = mio_pad_attr_2_qe;
@@ -11571,6 +11905,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[2].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_pull_select_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].pull_select.qe = mio_pad_attr_2_qe;
@@ -11586,6 +11921,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[2].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_keeper_en_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].keeper_en.qe = mio_pad_attr_2_qe;
@@ -11601,6 +11937,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[2].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_schmitt_en_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].schmitt_en.qe = mio_pad_attr_2_qe;
@@ -11616,6 +11953,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[2].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_od_en_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].od_en.qe = mio_pad_attr_2_qe;
@@ -11631,6 +11969,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[2].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_slew_rate_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].slew_rate.qe = mio_pad_attr_2_qe;
@@ -11646,6 +11985,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_2_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[2].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_2_drive_strength_2_qs)
   );
   assign reg2hw.mio_pad_attr[2].drive_strength.qe = mio_pad_attr_2_qe;
@@ -11670,6 +12010,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[3].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_invert_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].invert.qe = mio_pad_attr_3_qe;
@@ -11685,6 +12026,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[3].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_virtual_od_en_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].virtual_od_en.qe = mio_pad_attr_3_qe;
@@ -11700,6 +12042,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[3].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_pull_en_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].pull_en.qe = mio_pad_attr_3_qe;
@@ -11715,6 +12058,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[3].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_pull_select_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].pull_select.qe = mio_pad_attr_3_qe;
@@ -11730,6 +12074,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[3].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_keeper_en_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].keeper_en.qe = mio_pad_attr_3_qe;
@@ -11745,6 +12090,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[3].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_schmitt_en_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].schmitt_en.qe = mio_pad_attr_3_qe;
@@ -11760,6 +12106,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[3].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_od_en_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].od_en.qe = mio_pad_attr_3_qe;
@@ -11775,6 +12122,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[3].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_slew_rate_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].slew_rate.qe = mio_pad_attr_3_qe;
@@ -11790,6 +12138,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_3_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[3].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_3_drive_strength_3_qs)
   );
   assign reg2hw.mio_pad_attr[3].drive_strength.qe = mio_pad_attr_3_qe;
@@ -11814,6 +12163,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[4].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_invert_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].invert.qe = mio_pad_attr_4_qe;
@@ -11829,6 +12179,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[4].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_virtual_od_en_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].virtual_od_en.qe = mio_pad_attr_4_qe;
@@ -11844,6 +12195,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[4].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_pull_en_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].pull_en.qe = mio_pad_attr_4_qe;
@@ -11859,6 +12211,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[4].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_pull_select_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].pull_select.qe = mio_pad_attr_4_qe;
@@ -11874,6 +12227,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[4].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_keeper_en_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].keeper_en.qe = mio_pad_attr_4_qe;
@@ -11889,6 +12243,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[4].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_schmitt_en_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].schmitt_en.qe = mio_pad_attr_4_qe;
@@ -11904,6 +12259,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[4].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_od_en_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].od_en.qe = mio_pad_attr_4_qe;
@@ -11919,6 +12275,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[4].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_slew_rate_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].slew_rate.qe = mio_pad_attr_4_qe;
@@ -11934,6 +12291,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_4_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[4].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_4_drive_strength_4_qs)
   );
   assign reg2hw.mio_pad_attr[4].drive_strength.qe = mio_pad_attr_4_qe;
@@ -11958,6 +12316,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[5].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_invert_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].invert.qe = mio_pad_attr_5_qe;
@@ -11973,6 +12332,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[5].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_virtual_od_en_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].virtual_od_en.qe = mio_pad_attr_5_qe;
@@ -11988,6 +12348,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[5].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_pull_en_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].pull_en.qe = mio_pad_attr_5_qe;
@@ -12003,6 +12364,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[5].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_pull_select_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].pull_select.qe = mio_pad_attr_5_qe;
@@ -12018,6 +12380,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[5].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_keeper_en_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].keeper_en.qe = mio_pad_attr_5_qe;
@@ -12033,6 +12396,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[5].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_schmitt_en_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].schmitt_en.qe = mio_pad_attr_5_qe;
@@ -12048,6 +12412,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[5].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_od_en_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].od_en.qe = mio_pad_attr_5_qe;
@@ -12063,6 +12428,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[5].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_slew_rate_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].slew_rate.qe = mio_pad_attr_5_qe;
@@ -12078,6 +12444,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_5_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[5].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_5_drive_strength_5_qs)
   );
   assign reg2hw.mio_pad_attr[5].drive_strength.qe = mio_pad_attr_5_qe;
@@ -12102,6 +12469,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[6].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_invert_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].invert.qe = mio_pad_attr_6_qe;
@@ -12117,6 +12485,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[6].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_virtual_od_en_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].virtual_od_en.qe = mio_pad_attr_6_qe;
@@ -12132,6 +12501,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[6].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_pull_en_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].pull_en.qe = mio_pad_attr_6_qe;
@@ -12147,6 +12517,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[6].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_pull_select_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].pull_select.qe = mio_pad_attr_6_qe;
@@ -12162,6 +12533,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[6].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_keeper_en_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].keeper_en.qe = mio_pad_attr_6_qe;
@@ -12177,6 +12549,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[6].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_schmitt_en_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].schmitt_en.qe = mio_pad_attr_6_qe;
@@ -12192,6 +12565,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[6].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_od_en_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].od_en.qe = mio_pad_attr_6_qe;
@@ -12207,6 +12581,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[6].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_slew_rate_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].slew_rate.qe = mio_pad_attr_6_qe;
@@ -12222,6 +12597,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_6_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[6].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_6_drive_strength_6_qs)
   );
   assign reg2hw.mio_pad_attr[6].drive_strength.qe = mio_pad_attr_6_qe;
@@ -12246,6 +12622,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[7].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_invert_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].invert.qe = mio_pad_attr_7_qe;
@@ -12261,6 +12638,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[7].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_virtual_od_en_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].virtual_od_en.qe = mio_pad_attr_7_qe;
@@ -12276,6 +12654,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[7].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_pull_en_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].pull_en.qe = mio_pad_attr_7_qe;
@@ -12291,6 +12670,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[7].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_pull_select_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].pull_select.qe = mio_pad_attr_7_qe;
@@ -12306,6 +12686,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[7].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_keeper_en_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].keeper_en.qe = mio_pad_attr_7_qe;
@@ -12321,6 +12702,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[7].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_schmitt_en_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].schmitt_en.qe = mio_pad_attr_7_qe;
@@ -12336,6 +12718,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[7].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_od_en_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].od_en.qe = mio_pad_attr_7_qe;
@@ -12351,6 +12734,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[7].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_slew_rate_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].slew_rate.qe = mio_pad_attr_7_qe;
@@ -12366,6 +12750,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_7_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[7].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_7_drive_strength_7_qs)
   );
   assign reg2hw.mio_pad_attr[7].drive_strength.qe = mio_pad_attr_7_qe;
@@ -12390,6 +12775,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[8].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_invert_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].invert.qe = mio_pad_attr_8_qe;
@@ -12405,6 +12791,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[8].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_virtual_od_en_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].virtual_od_en.qe = mio_pad_attr_8_qe;
@@ -12420,6 +12807,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[8].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_pull_en_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].pull_en.qe = mio_pad_attr_8_qe;
@@ -12435,6 +12823,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[8].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_pull_select_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].pull_select.qe = mio_pad_attr_8_qe;
@@ -12450,6 +12839,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[8].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_keeper_en_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].keeper_en.qe = mio_pad_attr_8_qe;
@@ -12465,6 +12855,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[8].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_schmitt_en_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].schmitt_en.qe = mio_pad_attr_8_qe;
@@ -12480,6 +12871,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[8].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_od_en_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].od_en.qe = mio_pad_attr_8_qe;
@@ -12495,6 +12887,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[8].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_slew_rate_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].slew_rate.qe = mio_pad_attr_8_qe;
@@ -12510,6 +12903,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_8_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[8].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_8_drive_strength_8_qs)
   );
   assign reg2hw.mio_pad_attr[8].drive_strength.qe = mio_pad_attr_8_qe;
@@ -12534,6 +12928,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[9].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_invert_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].invert.qe = mio_pad_attr_9_qe;
@@ -12549,6 +12944,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[9].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_virtual_od_en_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].virtual_od_en.qe = mio_pad_attr_9_qe;
@@ -12564,6 +12960,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[9].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_pull_en_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].pull_en.qe = mio_pad_attr_9_qe;
@@ -12579,6 +12976,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[9].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_pull_select_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].pull_select.qe = mio_pad_attr_9_qe;
@@ -12594,6 +12992,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[9].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_keeper_en_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].keeper_en.qe = mio_pad_attr_9_qe;
@@ -12609,6 +13008,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[9].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_schmitt_en_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].schmitt_en.qe = mio_pad_attr_9_qe;
@@ -12624,6 +13024,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[9].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_od_en_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].od_en.qe = mio_pad_attr_9_qe;
@@ -12639,6 +13040,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[9].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_slew_rate_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].slew_rate.qe = mio_pad_attr_9_qe;
@@ -12654,6 +13056,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_9_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[9].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_9_drive_strength_9_qs)
   );
   assign reg2hw.mio_pad_attr[9].drive_strength.qe = mio_pad_attr_9_qe;
@@ -12678,6 +13081,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[10].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_invert_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].invert.qe = mio_pad_attr_10_qe;
@@ -12693,6 +13097,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[10].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_virtual_od_en_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].virtual_od_en.qe = mio_pad_attr_10_qe;
@@ -12708,6 +13113,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[10].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_pull_en_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].pull_en.qe = mio_pad_attr_10_qe;
@@ -12723,6 +13129,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[10].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_pull_select_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].pull_select.qe = mio_pad_attr_10_qe;
@@ -12738,6 +13145,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[10].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_keeper_en_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].keeper_en.qe = mio_pad_attr_10_qe;
@@ -12753,6 +13161,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[10].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_schmitt_en_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].schmitt_en.qe = mio_pad_attr_10_qe;
@@ -12768,6 +13177,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[10].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_od_en_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].od_en.qe = mio_pad_attr_10_qe;
@@ -12783,6 +13193,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[10].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_slew_rate_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].slew_rate.qe = mio_pad_attr_10_qe;
@@ -12798,6 +13209,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_10_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[10].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_10_drive_strength_10_qs)
   );
   assign reg2hw.mio_pad_attr[10].drive_strength.qe = mio_pad_attr_10_qe;
@@ -12822,6 +13234,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[11].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_invert_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].invert.qe = mio_pad_attr_11_qe;
@@ -12837,6 +13250,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[11].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_virtual_od_en_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].virtual_od_en.qe = mio_pad_attr_11_qe;
@@ -12852,6 +13266,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[11].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_pull_en_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].pull_en.qe = mio_pad_attr_11_qe;
@@ -12867,6 +13282,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[11].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_pull_select_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].pull_select.qe = mio_pad_attr_11_qe;
@@ -12882,6 +13298,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[11].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_keeper_en_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].keeper_en.qe = mio_pad_attr_11_qe;
@@ -12897,6 +13314,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[11].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_schmitt_en_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].schmitt_en.qe = mio_pad_attr_11_qe;
@@ -12912,6 +13330,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[11].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_od_en_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].od_en.qe = mio_pad_attr_11_qe;
@@ -12927,6 +13346,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[11].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_slew_rate_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].slew_rate.qe = mio_pad_attr_11_qe;
@@ -12942,6 +13362,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_11_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[11].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_11_drive_strength_11_qs)
   );
   assign reg2hw.mio_pad_attr[11].drive_strength.qe = mio_pad_attr_11_qe;
@@ -12966,6 +13387,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[12].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_invert_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].invert.qe = mio_pad_attr_12_qe;
@@ -12981,6 +13403,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[12].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_virtual_od_en_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].virtual_od_en.qe = mio_pad_attr_12_qe;
@@ -12996,6 +13419,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[12].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_pull_en_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].pull_en.qe = mio_pad_attr_12_qe;
@@ -13011,6 +13435,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[12].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_pull_select_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].pull_select.qe = mio_pad_attr_12_qe;
@@ -13026,6 +13451,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[12].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_keeper_en_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].keeper_en.qe = mio_pad_attr_12_qe;
@@ -13041,6 +13467,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[12].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_schmitt_en_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].schmitt_en.qe = mio_pad_attr_12_qe;
@@ -13056,6 +13483,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[12].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_od_en_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].od_en.qe = mio_pad_attr_12_qe;
@@ -13071,6 +13499,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[12].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_slew_rate_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].slew_rate.qe = mio_pad_attr_12_qe;
@@ -13086,6 +13515,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_12_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[12].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_12_drive_strength_12_qs)
   );
   assign reg2hw.mio_pad_attr[12].drive_strength.qe = mio_pad_attr_12_qe;
@@ -13110,6 +13540,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[13].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_invert_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].invert.qe = mio_pad_attr_13_qe;
@@ -13125,6 +13556,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[13].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_virtual_od_en_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].virtual_od_en.qe = mio_pad_attr_13_qe;
@@ -13140,6 +13572,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[13].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_pull_en_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].pull_en.qe = mio_pad_attr_13_qe;
@@ -13155,6 +13588,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[13].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_pull_select_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].pull_select.qe = mio_pad_attr_13_qe;
@@ -13170,6 +13604,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[13].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_keeper_en_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].keeper_en.qe = mio_pad_attr_13_qe;
@@ -13185,6 +13620,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[13].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_schmitt_en_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].schmitt_en.qe = mio_pad_attr_13_qe;
@@ -13200,6 +13636,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[13].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_od_en_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].od_en.qe = mio_pad_attr_13_qe;
@@ -13215,6 +13652,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[13].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_slew_rate_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].slew_rate.qe = mio_pad_attr_13_qe;
@@ -13230,6 +13668,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_13_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[13].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_13_drive_strength_13_qs)
   );
   assign reg2hw.mio_pad_attr[13].drive_strength.qe = mio_pad_attr_13_qe;
@@ -13254,6 +13693,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[14].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_invert_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].invert.qe = mio_pad_attr_14_qe;
@@ -13269,6 +13709,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[14].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_virtual_od_en_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].virtual_od_en.qe = mio_pad_attr_14_qe;
@@ -13284,6 +13725,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[14].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_pull_en_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].pull_en.qe = mio_pad_attr_14_qe;
@@ -13299,6 +13741,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[14].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_pull_select_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].pull_select.qe = mio_pad_attr_14_qe;
@@ -13314,6 +13757,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[14].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_keeper_en_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].keeper_en.qe = mio_pad_attr_14_qe;
@@ -13329,6 +13773,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[14].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_schmitt_en_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].schmitt_en.qe = mio_pad_attr_14_qe;
@@ -13344,6 +13789,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[14].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_od_en_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].od_en.qe = mio_pad_attr_14_qe;
@@ -13359,6 +13805,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[14].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_slew_rate_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].slew_rate.qe = mio_pad_attr_14_qe;
@@ -13374,6 +13821,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_14_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[14].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_14_drive_strength_14_qs)
   );
   assign reg2hw.mio_pad_attr[14].drive_strength.qe = mio_pad_attr_14_qe;
@@ -13398,6 +13846,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[15].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_invert_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].invert.qe = mio_pad_attr_15_qe;
@@ -13413,6 +13862,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[15].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_virtual_od_en_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].virtual_od_en.qe = mio_pad_attr_15_qe;
@@ -13428,6 +13878,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[15].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_pull_en_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].pull_en.qe = mio_pad_attr_15_qe;
@@ -13443,6 +13894,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[15].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_pull_select_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].pull_select.qe = mio_pad_attr_15_qe;
@@ -13458,6 +13910,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[15].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_keeper_en_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].keeper_en.qe = mio_pad_attr_15_qe;
@@ -13473,6 +13926,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[15].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_schmitt_en_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].schmitt_en.qe = mio_pad_attr_15_qe;
@@ -13488,6 +13942,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[15].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_od_en_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].od_en.qe = mio_pad_attr_15_qe;
@@ -13503,6 +13958,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[15].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_slew_rate_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].slew_rate.qe = mio_pad_attr_15_qe;
@@ -13518,6 +13974,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_15_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[15].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_15_drive_strength_15_qs)
   );
   assign reg2hw.mio_pad_attr[15].drive_strength.qe = mio_pad_attr_15_qe;
@@ -13542,6 +13999,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[16].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_invert_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].invert.qe = mio_pad_attr_16_qe;
@@ -13557,6 +14015,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[16].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_virtual_od_en_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].virtual_od_en.qe = mio_pad_attr_16_qe;
@@ -13572,6 +14031,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[16].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_pull_en_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].pull_en.qe = mio_pad_attr_16_qe;
@@ -13587,6 +14047,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[16].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_pull_select_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].pull_select.qe = mio_pad_attr_16_qe;
@@ -13602,6 +14063,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[16].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_keeper_en_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].keeper_en.qe = mio_pad_attr_16_qe;
@@ -13617,6 +14079,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[16].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_schmitt_en_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].schmitt_en.qe = mio_pad_attr_16_qe;
@@ -13632,6 +14095,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[16].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_od_en_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].od_en.qe = mio_pad_attr_16_qe;
@@ -13647,6 +14111,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[16].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_slew_rate_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].slew_rate.qe = mio_pad_attr_16_qe;
@@ -13662,6 +14127,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_16_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[16].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_16_drive_strength_16_qs)
   );
   assign reg2hw.mio_pad_attr[16].drive_strength.qe = mio_pad_attr_16_qe;
@@ -13686,6 +14152,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[17].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_invert_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].invert.qe = mio_pad_attr_17_qe;
@@ -13701,6 +14168,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[17].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_virtual_od_en_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].virtual_od_en.qe = mio_pad_attr_17_qe;
@@ -13716,6 +14184,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[17].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_pull_en_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].pull_en.qe = mio_pad_attr_17_qe;
@@ -13731,6 +14200,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[17].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_pull_select_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].pull_select.qe = mio_pad_attr_17_qe;
@@ -13746,6 +14216,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[17].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_keeper_en_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].keeper_en.qe = mio_pad_attr_17_qe;
@@ -13761,6 +14232,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[17].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_schmitt_en_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].schmitt_en.qe = mio_pad_attr_17_qe;
@@ -13776,6 +14248,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[17].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_od_en_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].od_en.qe = mio_pad_attr_17_qe;
@@ -13791,6 +14264,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[17].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_slew_rate_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].slew_rate.qe = mio_pad_attr_17_qe;
@@ -13806,6 +14280,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_17_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[17].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_17_drive_strength_17_qs)
   );
   assign reg2hw.mio_pad_attr[17].drive_strength.qe = mio_pad_attr_17_qe;
@@ -13830,6 +14305,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[18].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_invert_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].invert.qe = mio_pad_attr_18_qe;
@@ -13845,6 +14321,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[18].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_virtual_od_en_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].virtual_od_en.qe = mio_pad_attr_18_qe;
@@ -13860,6 +14337,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[18].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_pull_en_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].pull_en.qe = mio_pad_attr_18_qe;
@@ -13875,6 +14353,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[18].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_pull_select_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].pull_select.qe = mio_pad_attr_18_qe;
@@ -13890,6 +14369,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[18].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_keeper_en_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].keeper_en.qe = mio_pad_attr_18_qe;
@@ -13905,6 +14385,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[18].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_schmitt_en_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].schmitt_en.qe = mio_pad_attr_18_qe;
@@ -13920,6 +14401,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[18].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_od_en_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].od_en.qe = mio_pad_attr_18_qe;
@@ -13935,6 +14417,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[18].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_slew_rate_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].slew_rate.qe = mio_pad_attr_18_qe;
@@ -13950,6 +14433,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_18_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[18].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_18_drive_strength_18_qs)
   );
   assign reg2hw.mio_pad_attr[18].drive_strength.qe = mio_pad_attr_18_qe;
@@ -13974,6 +14458,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[19].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_invert_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].invert.qe = mio_pad_attr_19_qe;
@@ -13989,6 +14474,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[19].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_virtual_od_en_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].virtual_od_en.qe = mio_pad_attr_19_qe;
@@ -14004,6 +14490,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[19].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_pull_en_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].pull_en.qe = mio_pad_attr_19_qe;
@@ -14019,6 +14506,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[19].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_pull_select_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].pull_select.qe = mio_pad_attr_19_qe;
@@ -14034,6 +14522,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[19].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_keeper_en_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].keeper_en.qe = mio_pad_attr_19_qe;
@@ -14049,6 +14538,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[19].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_schmitt_en_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].schmitt_en.qe = mio_pad_attr_19_qe;
@@ -14064,6 +14554,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[19].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_od_en_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].od_en.qe = mio_pad_attr_19_qe;
@@ -14079,6 +14570,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[19].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_slew_rate_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].slew_rate.qe = mio_pad_attr_19_qe;
@@ -14094,6 +14586,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_19_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[19].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_19_drive_strength_19_qs)
   );
   assign reg2hw.mio_pad_attr[19].drive_strength.qe = mio_pad_attr_19_qe;
@@ -14118,6 +14611,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[20].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_invert_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].invert.qe = mio_pad_attr_20_qe;
@@ -14133,6 +14627,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[20].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_virtual_od_en_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].virtual_od_en.qe = mio_pad_attr_20_qe;
@@ -14148,6 +14643,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[20].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_pull_en_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].pull_en.qe = mio_pad_attr_20_qe;
@@ -14163,6 +14659,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[20].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_pull_select_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].pull_select.qe = mio_pad_attr_20_qe;
@@ -14178,6 +14675,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[20].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_keeper_en_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].keeper_en.qe = mio_pad_attr_20_qe;
@@ -14193,6 +14691,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[20].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_schmitt_en_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].schmitt_en.qe = mio_pad_attr_20_qe;
@@ -14208,6 +14707,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[20].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_od_en_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].od_en.qe = mio_pad_attr_20_qe;
@@ -14223,6 +14723,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[20].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_slew_rate_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].slew_rate.qe = mio_pad_attr_20_qe;
@@ -14238,6 +14739,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_20_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[20].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_20_drive_strength_20_qs)
   );
   assign reg2hw.mio_pad_attr[20].drive_strength.qe = mio_pad_attr_20_qe;
@@ -14262,6 +14764,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[21].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_invert_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].invert.qe = mio_pad_attr_21_qe;
@@ -14277,6 +14780,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[21].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_virtual_od_en_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].virtual_od_en.qe = mio_pad_attr_21_qe;
@@ -14292,6 +14796,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[21].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_pull_en_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].pull_en.qe = mio_pad_attr_21_qe;
@@ -14307,6 +14812,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[21].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_pull_select_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].pull_select.qe = mio_pad_attr_21_qe;
@@ -14322,6 +14828,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[21].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_keeper_en_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].keeper_en.qe = mio_pad_attr_21_qe;
@@ -14337,6 +14844,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[21].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_schmitt_en_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].schmitt_en.qe = mio_pad_attr_21_qe;
@@ -14352,6 +14860,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[21].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_od_en_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].od_en.qe = mio_pad_attr_21_qe;
@@ -14367,6 +14876,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[21].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_slew_rate_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].slew_rate.qe = mio_pad_attr_21_qe;
@@ -14382,6 +14892,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_21_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[21].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_21_drive_strength_21_qs)
   );
   assign reg2hw.mio_pad_attr[21].drive_strength.qe = mio_pad_attr_21_qe;
@@ -14406,6 +14917,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[22].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_invert_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].invert.qe = mio_pad_attr_22_qe;
@@ -14421,6 +14933,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[22].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_virtual_od_en_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].virtual_od_en.qe = mio_pad_attr_22_qe;
@@ -14436,6 +14949,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[22].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_pull_en_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].pull_en.qe = mio_pad_attr_22_qe;
@@ -14451,6 +14965,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[22].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_pull_select_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].pull_select.qe = mio_pad_attr_22_qe;
@@ -14466,6 +14981,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[22].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_keeper_en_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].keeper_en.qe = mio_pad_attr_22_qe;
@@ -14481,6 +14997,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[22].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_schmitt_en_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].schmitt_en.qe = mio_pad_attr_22_qe;
@@ -14496,6 +15013,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[22].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_od_en_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].od_en.qe = mio_pad_attr_22_qe;
@@ -14511,6 +15029,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[22].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_slew_rate_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].slew_rate.qe = mio_pad_attr_22_qe;
@@ -14526,6 +15045,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_22_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[22].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_22_drive_strength_22_qs)
   );
   assign reg2hw.mio_pad_attr[22].drive_strength.qe = mio_pad_attr_22_qe;
@@ -14550,6 +15070,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[23].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_invert_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].invert.qe = mio_pad_attr_23_qe;
@@ -14565,6 +15086,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[23].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_virtual_od_en_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].virtual_od_en.qe = mio_pad_attr_23_qe;
@@ -14580,6 +15102,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[23].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_pull_en_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].pull_en.qe = mio_pad_attr_23_qe;
@@ -14595,6 +15118,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[23].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_pull_select_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].pull_select.qe = mio_pad_attr_23_qe;
@@ -14610,6 +15134,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[23].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_keeper_en_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].keeper_en.qe = mio_pad_attr_23_qe;
@@ -14625,6 +15150,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[23].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_schmitt_en_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].schmitt_en.qe = mio_pad_attr_23_qe;
@@ -14640,6 +15166,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[23].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_od_en_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].od_en.qe = mio_pad_attr_23_qe;
@@ -14655,6 +15182,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[23].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_slew_rate_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].slew_rate.qe = mio_pad_attr_23_qe;
@@ -14670,6 +15198,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_23_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[23].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_23_drive_strength_23_qs)
   );
   assign reg2hw.mio_pad_attr[23].drive_strength.qe = mio_pad_attr_23_qe;
@@ -14694,6 +15223,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[24].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_invert_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].invert.qe = mio_pad_attr_24_qe;
@@ -14709,6 +15239,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[24].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_virtual_od_en_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].virtual_od_en.qe = mio_pad_attr_24_qe;
@@ -14724,6 +15255,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[24].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_pull_en_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].pull_en.qe = mio_pad_attr_24_qe;
@@ -14739,6 +15271,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[24].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_pull_select_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].pull_select.qe = mio_pad_attr_24_qe;
@@ -14754,6 +15287,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[24].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_keeper_en_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].keeper_en.qe = mio_pad_attr_24_qe;
@@ -14769,6 +15303,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[24].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_schmitt_en_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].schmitt_en.qe = mio_pad_attr_24_qe;
@@ -14784,6 +15319,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[24].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_od_en_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].od_en.qe = mio_pad_attr_24_qe;
@@ -14799,6 +15335,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[24].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_slew_rate_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].slew_rate.qe = mio_pad_attr_24_qe;
@@ -14814,6 +15351,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_24_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[24].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_24_drive_strength_24_qs)
   );
   assign reg2hw.mio_pad_attr[24].drive_strength.qe = mio_pad_attr_24_qe;
@@ -14838,6 +15376,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[25].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_invert_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].invert.qe = mio_pad_attr_25_qe;
@@ -14853,6 +15392,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[25].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_virtual_od_en_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].virtual_od_en.qe = mio_pad_attr_25_qe;
@@ -14868,6 +15408,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[25].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_pull_en_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].pull_en.qe = mio_pad_attr_25_qe;
@@ -14883,6 +15424,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[25].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_pull_select_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].pull_select.qe = mio_pad_attr_25_qe;
@@ -14898,6 +15440,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[25].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_keeper_en_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].keeper_en.qe = mio_pad_attr_25_qe;
@@ -14913,6 +15456,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[25].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_schmitt_en_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].schmitt_en.qe = mio_pad_attr_25_qe;
@@ -14928,6 +15472,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[25].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_od_en_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].od_en.qe = mio_pad_attr_25_qe;
@@ -14943,6 +15488,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[25].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_slew_rate_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].slew_rate.qe = mio_pad_attr_25_qe;
@@ -14958,6 +15504,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_25_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[25].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_25_drive_strength_25_qs)
   );
   assign reg2hw.mio_pad_attr[25].drive_strength.qe = mio_pad_attr_25_qe;
@@ -14982,6 +15529,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[26].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_invert_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].invert.qe = mio_pad_attr_26_qe;
@@ -14997,6 +15545,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[26].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_virtual_od_en_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].virtual_od_en.qe = mio_pad_attr_26_qe;
@@ -15012,6 +15561,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[26].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_pull_en_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].pull_en.qe = mio_pad_attr_26_qe;
@@ -15027,6 +15577,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[26].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_pull_select_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].pull_select.qe = mio_pad_attr_26_qe;
@@ -15042,6 +15593,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[26].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_keeper_en_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].keeper_en.qe = mio_pad_attr_26_qe;
@@ -15057,6 +15609,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[26].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_schmitt_en_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].schmitt_en.qe = mio_pad_attr_26_qe;
@@ -15072,6 +15625,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[26].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_od_en_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].od_en.qe = mio_pad_attr_26_qe;
@@ -15087,6 +15641,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[26].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_slew_rate_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].slew_rate.qe = mio_pad_attr_26_qe;
@@ -15102,6 +15657,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_26_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[26].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_26_drive_strength_26_qs)
   );
   assign reg2hw.mio_pad_attr[26].drive_strength.qe = mio_pad_attr_26_qe;
@@ -15126,6 +15682,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[27].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_invert_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].invert.qe = mio_pad_attr_27_qe;
@@ -15141,6 +15698,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[27].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_virtual_od_en_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].virtual_od_en.qe = mio_pad_attr_27_qe;
@@ -15156,6 +15714,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[27].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_pull_en_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].pull_en.qe = mio_pad_attr_27_qe;
@@ -15171,6 +15730,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[27].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_pull_select_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].pull_select.qe = mio_pad_attr_27_qe;
@@ -15186,6 +15746,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[27].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_keeper_en_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].keeper_en.qe = mio_pad_attr_27_qe;
@@ -15201,6 +15762,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[27].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_schmitt_en_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].schmitt_en.qe = mio_pad_attr_27_qe;
@@ -15216,6 +15778,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[27].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_od_en_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].od_en.qe = mio_pad_attr_27_qe;
@@ -15231,6 +15794,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[27].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_slew_rate_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].slew_rate.qe = mio_pad_attr_27_qe;
@@ -15246,6 +15810,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_27_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[27].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_27_drive_strength_27_qs)
   );
   assign reg2hw.mio_pad_attr[27].drive_strength.qe = mio_pad_attr_27_qe;
@@ -15270,6 +15835,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[28].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_invert_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].invert.qe = mio_pad_attr_28_qe;
@@ -15285,6 +15851,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[28].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_virtual_od_en_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].virtual_od_en.qe = mio_pad_attr_28_qe;
@@ -15300,6 +15867,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[28].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_pull_en_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].pull_en.qe = mio_pad_attr_28_qe;
@@ -15315,6 +15883,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[28].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_pull_select_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].pull_select.qe = mio_pad_attr_28_qe;
@@ -15330,6 +15899,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[28].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_keeper_en_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].keeper_en.qe = mio_pad_attr_28_qe;
@@ -15345,6 +15915,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[28].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_schmitt_en_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].schmitt_en.qe = mio_pad_attr_28_qe;
@@ -15360,6 +15931,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[28].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_od_en_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].od_en.qe = mio_pad_attr_28_qe;
@@ -15375,6 +15947,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[28].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_slew_rate_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].slew_rate.qe = mio_pad_attr_28_qe;
@@ -15390,6 +15963,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_28_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[28].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_28_drive_strength_28_qs)
   );
   assign reg2hw.mio_pad_attr[28].drive_strength.qe = mio_pad_attr_28_qe;
@@ -15414,6 +15988,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[29].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_invert_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].invert.qe = mio_pad_attr_29_qe;
@@ -15429,6 +16004,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[29].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_virtual_od_en_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].virtual_od_en.qe = mio_pad_attr_29_qe;
@@ -15444,6 +16020,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[29].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_pull_en_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].pull_en.qe = mio_pad_attr_29_qe;
@@ -15459,6 +16036,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[29].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_pull_select_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].pull_select.qe = mio_pad_attr_29_qe;
@@ -15474,6 +16052,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[29].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_keeper_en_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].keeper_en.qe = mio_pad_attr_29_qe;
@@ -15489,6 +16068,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[29].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_schmitt_en_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].schmitt_en.qe = mio_pad_attr_29_qe;
@@ -15504,6 +16084,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[29].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_od_en_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].od_en.qe = mio_pad_attr_29_qe;
@@ -15519,6 +16100,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[29].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_slew_rate_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].slew_rate.qe = mio_pad_attr_29_qe;
@@ -15534,6 +16116,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_29_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[29].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_29_drive_strength_29_qs)
   );
   assign reg2hw.mio_pad_attr[29].drive_strength.qe = mio_pad_attr_29_qe;
@@ -15558,6 +16141,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[30].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_invert_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].invert.qe = mio_pad_attr_30_qe;
@@ -15573,6 +16157,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[30].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_virtual_od_en_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].virtual_od_en.qe = mio_pad_attr_30_qe;
@@ -15588,6 +16173,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[30].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_pull_en_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].pull_en.qe = mio_pad_attr_30_qe;
@@ -15603,6 +16189,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[30].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_pull_select_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].pull_select.qe = mio_pad_attr_30_qe;
@@ -15618,6 +16205,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[30].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_keeper_en_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].keeper_en.qe = mio_pad_attr_30_qe;
@@ -15633,6 +16221,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[30].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_schmitt_en_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].schmitt_en.qe = mio_pad_attr_30_qe;
@@ -15648,6 +16237,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[30].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_od_en_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].od_en.qe = mio_pad_attr_30_qe;
@@ -15663,6 +16253,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[30].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_slew_rate_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].slew_rate.qe = mio_pad_attr_30_qe;
@@ -15678,6 +16269,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_30_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[30].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_30_drive_strength_30_qs)
   );
   assign reg2hw.mio_pad_attr[30].drive_strength.qe = mio_pad_attr_30_qe;
@@ -15702,6 +16294,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[31].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_invert_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].invert.qe = mio_pad_attr_31_qe;
@@ -15717,6 +16310,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[31].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_virtual_od_en_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].virtual_od_en.qe = mio_pad_attr_31_qe;
@@ -15732,6 +16326,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[31].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_pull_en_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].pull_en.qe = mio_pad_attr_31_qe;
@@ -15747,6 +16342,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[31].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_pull_select_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].pull_select.qe = mio_pad_attr_31_qe;
@@ -15762,6 +16358,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[31].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_keeper_en_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].keeper_en.qe = mio_pad_attr_31_qe;
@@ -15777,6 +16374,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[31].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_schmitt_en_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].schmitt_en.qe = mio_pad_attr_31_qe;
@@ -15792,6 +16390,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[31].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_od_en_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].od_en.qe = mio_pad_attr_31_qe;
@@ -15807,6 +16406,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[31].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_slew_rate_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].slew_rate.qe = mio_pad_attr_31_qe;
@@ -15822,6 +16422,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_31_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[31].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_31_drive_strength_31_qs)
   );
   assign reg2hw.mio_pad_attr[31].drive_strength.qe = mio_pad_attr_31_qe;
@@ -15846,6 +16447,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_32_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[32].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_32_invert_32_qs)
   );
   assign reg2hw.mio_pad_attr[32].invert.qe = mio_pad_attr_32_qe;
@@ -15861,6 +16463,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_32_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[32].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_32_virtual_od_en_32_qs)
   );
   assign reg2hw.mio_pad_attr[32].virtual_od_en.qe = mio_pad_attr_32_qe;
@@ -15876,6 +16479,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_32_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[32].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_32_pull_en_32_qs)
   );
   assign reg2hw.mio_pad_attr[32].pull_en.qe = mio_pad_attr_32_qe;
@@ -15891,6 +16495,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_32_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[32].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_32_pull_select_32_qs)
   );
   assign reg2hw.mio_pad_attr[32].pull_select.qe = mio_pad_attr_32_qe;
@@ -15906,6 +16511,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_32_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[32].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_32_keeper_en_32_qs)
   );
   assign reg2hw.mio_pad_attr[32].keeper_en.qe = mio_pad_attr_32_qe;
@@ -15921,6 +16527,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_32_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[32].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_32_schmitt_en_32_qs)
   );
   assign reg2hw.mio_pad_attr[32].schmitt_en.qe = mio_pad_attr_32_qe;
@@ -15936,6 +16543,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_32_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[32].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_32_od_en_32_qs)
   );
   assign reg2hw.mio_pad_attr[32].od_en.qe = mio_pad_attr_32_qe;
@@ -15951,6 +16559,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_32_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[32].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_32_slew_rate_32_qs)
   );
   assign reg2hw.mio_pad_attr[32].slew_rate.qe = mio_pad_attr_32_qe;
@@ -15966,6 +16575,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_32_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[32].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_32_drive_strength_32_qs)
   );
   assign reg2hw.mio_pad_attr[32].drive_strength.qe = mio_pad_attr_32_qe;
@@ -15990,6 +16600,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_33_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[33].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_33_invert_33_qs)
   );
   assign reg2hw.mio_pad_attr[33].invert.qe = mio_pad_attr_33_qe;
@@ -16005,6 +16616,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_33_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[33].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_33_virtual_od_en_33_qs)
   );
   assign reg2hw.mio_pad_attr[33].virtual_od_en.qe = mio_pad_attr_33_qe;
@@ -16020,6 +16632,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_33_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[33].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_33_pull_en_33_qs)
   );
   assign reg2hw.mio_pad_attr[33].pull_en.qe = mio_pad_attr_33_qe;
@@ -16035,6 +16648,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_33_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[33].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_33_pull_select_33_qs)
   );
   assign reg2hw.mio_pad_attr[33].pull_select.qe = mio_pad_attr_33_qe;
@@ -16050,6 +16664,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_33_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[33].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_33_keeper_en_33_qs)
   );
   assign reg2hw.mio_pad_attr[33].keeper_en.qe = mio_pad_attr_33_qe;
@@ -16065,6 +16680,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_33_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[33].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_33_schmitt_en_33_qs)
   );
   assign reg2hw.mio_pad_attr[33].schmitt_en.qe = mio_pad_attr_33_qe;
@@ -16080,6 +16696,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_33_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[33].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_33_od_en_33_qs)
   );
   assign reg2hw.mio_pad_attr[33].od_en.qe = mio_pad_attr_33_qe;
@@ -16095,6 +16712,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_33_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[33].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_33_slew_rate_33_qs)
   );
   assign reg2hw.mio_pad_attr[33].slew_rate.qe = mio_pad_attr_33_qe;
@@ -16110,6 +16728,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_33_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[33].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_33_drive_strength_33_qs)
   );
   assign reg2hw.mio_pad_attr[33].drive_strength.qe = mio_pad_attr_33_qe;
@@ -16134,6 +16753,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_34_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[34].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_34_invert_34_qs)
   );
   assign reg2hw.mio_pad_attr[34].invert.qe = mio_pad_attr_34_qe;
@@ -16149,6 +16769,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_34_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[34].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_34_virtual_od_en_34_qs)
   );
   assign reg2hw.mio_pad_attr[34].virtual_od_en.qe = mio_pad_attr_34_qe;
@@ -16164,6 +16785,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_34_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[34].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_34_pull_en_34_qs)
   );
   assign reg2hw.mio_pad_attr[34].pull_en.qe = mio_pad_attr_34_qe;
@@ -16179,6 +16801,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_34_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[34].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_34_pull_select_34_qs)
   );
   assign reg2hw.mio_pad_attr[34].pull_select.qe = mio_pad_attr_34_qe;
@@ -16194,6 +16817,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_34_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[34].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_34_keeper_en_34_qs)
   );
   assign reg2hw.mio_pad_attr[34].keeper_en.qe = mio_pad_attr_34_qe;
@@ -16209,6 +16833,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_34_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[34].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_34_schmitt_en_34_qs)
   );
   assign reg2hw.mio_pad_attr[34].schmitt_en.qe = mio_pad_attr_34_qe;
@@ -16224,6 +16849,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_34_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[34].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_34_od_en_34_qs)
   );
   assign reg2hw.mio_pad_attr[34].od_en.qe = mio_pad_attr_34_qe;
@@ -16239,6 +16865,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_34_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[34].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_34_slew_rate_34_qs)
   );
   assign reg2hw.mio_pad_attr[34].slew_rate.qe = mio_pad_attr_34_qe;
@@ -16254,6 +16881,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_34_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[34].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_34_drive_strength_34_qs)
   );
   assign reg2hw.mio_pad_attr[34].drive_strength.qe = mio_pad_attr_34_qe;
@@ -16278,6 +16906,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_35_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[35].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_35_invert_35_qs)
   );
   assign reg2hw.mio_pad_attr[35].invert.qe = mio_pad_attr_35_qe;
@@ -16293,6 +16922,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_35_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[35].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_35_virtual_od_en_35_qs)
   );
   assign reg2hw.mio_pad_attr[35].virtual_od_en.qe = mio_pad_attr_35_qe;
@@ -16308,6 +16938,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_35_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[35].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_35_pull_en_35_qs)
   );
   assign reg2hw.mio_pad_attr[35].pull_en.qe = mio_pad_attr_35_qe;
@@ -16323,6 +16954,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_35_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[35].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_35_pull_select_35_qs)
   );
   assign reg2hw.mio_pad_attr[35].pull_select.qe = mio_pad_attr_35_qe;
@@ -16338,6 +16970,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_35_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[35].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_35_keeper_en_35_qs)
   );
   assign reg2hw.mio_pad_attr[35].keeper_en.qe = mio_pad_attr_35_qe;
@@ -16353,6 +16986,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_35_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[35].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_35_schmitt_en_35_qs)
   );
   assign reg2hw.mio_pad_attr[35].schmitt_en.qe = mio_pad_attr_35_qe;
@@ -16368,6 +17002,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_35_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[35].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_35_od_en_35_qs)
   );
   assign reg2hw.mio_pad_attr[35].od_en.qe = mio_pad_attr_35_qe;
@@ -16383,6 +17018,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_35_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[35].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_35_slew_rate_35_qs)
   );
   assign reg2hw.mio_pad_attr[35].slew_rate.qe = mio_pad_attr_35_qe;
@@ -16398,6 +17034,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_35_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[35].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_35_drive_strength_35_qs)
   );
   assign reg2hw.mio_pad_attr[35].drive_strength.qe = mio_pad_attr_35_qe;
@@ -16422,6 +17059,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_36_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[36].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_36_invert_36_qs)
   );
   assign reg2hw.mio_pad_attr[36].invert.qe = mio_pad_attr_36_qe;
@@ -16437,6 +17075,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_36_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[36].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_36_virtual_od_en_36_qs)
   );
   assign reg2hw.mio_pad_attr[36].virtual_od_en.qe = mio_pad_attr_36_qe;
@@ -16452,6 +17091,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_36_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[36].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_36_pull_en_36_qs)
   );
   assign reg2hw.mio_pad_attr[36].pull_en.qe = mio_pad_attr_36_qe;
@@ -16467,6 +17107,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_36_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[36].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_36_pull_select_36_qs)
   );
   assign reg2hw.mio_pad_attr[36].pull_select.qe = mio_pad_attr_36_qe;
@@ -16482,6 +17123,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_36_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[36].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_36_keeper_en_36_qs)
   );
   assign reg2hw.mio_pad_attr[36].keeper_en.qe = mio_pad_attr_36_qe;
@@ -16497,6 +17139,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_36_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[36].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_36_schmitt_en_36_qs)
   );
   assign reg2hw.mio_pad_attr[36].schmitt_en.qe = mio_pad_attr_36_qe;
@@ -16512,6 +17155,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_36_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[36].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_36_od_en_36_qs)
   );
   assign reg2hw.mio_pad_attr[36].od_en.qe = mio_pad_attr_36_qe;
@@ -16527,6 +17171,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_36_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[36].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_36_slew_rate_36_qs)
   );
   assign reg2hw.mio_pad_attr[36].slew_rate.qe = mio_pad_attr_36_qe;
@@ -16542,6 +17187,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_36_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[36].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_36_drive_strength_36_qs)
   );
   assign reg2hw.mio_pad_attr[36].drive_strength.qe = mio_pad_attr_36_qe;
@@ -16566,6 +17212,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_37_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[37].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_37_invert_37_qs)
   );
   assign reg2hw.mio_pad_attr[37].invert.qe = mio_pad_attr_37_qe;
@@ -16581,6 +17228,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_37_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[37].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_37_virtual_od_en_37_qs)
   );
   assign reg2hw.mio_pad_attr[37].virtual_od_en.qe = mio_pad_attr_37_qe;
@@ -16596,6 +17244,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_37_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[37].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_37_pull_en_37_qs)
   );
   assign reg2hw.mio_pad_attr[37].pull_en.qe = mio_pad_attr_37_qe;
@@ -16611,6 +17260,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_37_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[37].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_37_pull_select_37_qs)
   );
   assign reg2hw.mio_pad_attr[37].pull_select.qe = mio_pad_attr_37_qe;
@@ -16626,6 +17276,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_37_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[37].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_37_keeper_en_37_qs)
   );
   assign reg2hw.mio_pad_attr[37].keeper_en.qe = mio_pad_attr_37_qe;
@@ -16641,6 +17292,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_37_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[37].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_37_schmitt_en_37_qs)
   );
   assign reg2hw.mio_pad_attr[37].schmitt_en.qe = mio_pad_attr_37_qe;
@@ -16656,6 +17308,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_37_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[37].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_37_od_en_37_qs)
   );
   assign reg2hw.mio_pad_attr[37].od_en.qe = mio_pad_attr_37_qe;
@@ -16671,6 +17324,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_37_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[37].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_37_slew_rate_37_qs)
   );
   assign reg2hw.mio_pad_attr[37].slew_rate.qe = mio_pad_attr_37_qe;
@@ -16686,6 +17340,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_37_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[37].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_37_drive_strength_37_qs)
   );
   assign reg2hw.mio_pad_attr[37].drive_strength.qe = mio_pad_attr_37_qe;
@@ -16710,6 +17365,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_38_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[38].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_38_invert_38_qs)
   );
   assign reg2hw.mio_pad_attr[38].invert.qe = mio_pad_attr_38_qe;
@@ -16725,6 +17381,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_38_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[38].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_38_virtual_od_en_38_qs)
   );
   assign reg2hw.mio_pad_attr[38].virtual_od_en.qe = mio_pad_attr_38_qe;
@@ -16740,6 +17397,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_38_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[38].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_38_pull_en_38_qs)
   );
   assign reg2hw.mio_pad_attr[38].pull_en.qe = mio_pad_attr_38_qe;
@@ -16755,6 +17413,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_38_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[38].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_38_pull_select_38_qs)
   );
   assign reg2hw.mio_pad_attr[38].pull_select.qe = mio_pad_attr_38_qe;
@@ -16770,6 +17429,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_38_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[38].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_38_keeper_en_38_qs)
   );
   assign reg2hw.mio_pad_attr[38].keeper_en.qe = mio_pad_attr_38_qe;
@@ -16785,6 +17445,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_38_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[38].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_38_schmitt_en_38_qs)
   );
   assign reg2hw.mio_pad_attr[38].schmitt_en.qe = mio_pad_attr_38_qe;
@@ -16800,6 +17461,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_38_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[38].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_38_od_en_38_qs)
   );
   assign reg2hw.mio_pad_attr[38].od_en.qe = mio_pad_attr_38_qe;
@@ -16815,6 +17477,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_38_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[38].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_38_slew_rate_38_qs)
   );
   assign reg2hw.mio_pad_attr[38].slew_rate.qe = mio_pad_attr_38_qe;
@@ -16830,6 +17493,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_38_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[38].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_38_drive_strength_38_qs)
   );
   assign reg2hw.mio_pad_attr[38].drive_strength.qe = mio_pad_attr_38_qe;
@@ -16854,6 +17518,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_39_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[39].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_39_invert_39_qs)
   );
   assign reg2hw.mio_pad_attr[39].invert.qe = mio_pad_attr_39_qe;
@@ -16869,6 +17534,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_39_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[39].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_39_virtual_od_en_39_qs)
   );
   assign reg2hw.mio_pad_attr[39].virtual_od_en.qe = mio_pad_attr_39_qe;
@@ -16884,6 +17550,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_39_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[39].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_39_pull_en_39_qs)
   );
   assign reg2hw.mio_pad_attr[39].pull_en.qe = mio_pad_attr_39_qe;
@@ -16899,6 +17566,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_39_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[39].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_39_pull_select_39_qs)
   );
   assign reg2hw.mio_pad_attr[39].pull_select.qe = mio_pad_attr_39_qe;
@@ -16914,6 +17582,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_39_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[39].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_39_keeper_en_39_qs)
   );
   assign reg2hw.mio_pad_attr[39].keeper_en.qe = mio_pad_attr_39_qe;
@@ -16929,6 +17598,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_39_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[39].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_39_schmitt_en_39_qs)
   );
   assign reg2hw.mio_pad_attr[39].schmitt_en.qe = mio_pad_attr_39_qe;
@@ -16944,6 +17614,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_39_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[39].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_39_od_en_39_qs)
   );
   assign reg2hw.mio_pad_attr[39].od_en.qe = mio_pad_attr_39_qe;
@@ -16959,6 +17630,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_39_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[39].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_39_slew_rate_39_qs)
   );
   assign reg2hw.mio_pad_attr[39].slew_rate.qe = mio_pad_attr_39_qe;
@@ -16974,6 +17646,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_39_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[39].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_39_drive_strength_39_qs)
   );
   assign reg2hw.mio_pad_attr[39].drive_strength.qe = mio_pad_attr_39_qe;
@@ -16998,6 +17671,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_40_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[40].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_40_invert_40_qs)
   );
   assign reg2hw.mio_pad_attr[40].invert.qe = mio_pad_attr_40_qe;
@@ -17013,6 +17687,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_40_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[40].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_40_virtual_od_en_40_qs)
   );
   assign reg2hw.mio_pad_attr[40].virtual_od_en.qe = mio_pad_attr_40_qe;
@@ -17028,6 +17703,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_40_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[40].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_40_pull_en_40_qs)
   );
   assign reg2hw.mio_pad_attr[40].pull_en.qe = mio_pad_attr_40_qe;
@@ -17043,6 +17719,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_40_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[40].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_40_pull_select_40_qs)
   );
   assign reg2hw.mio_pad_attr[40].pull_select.qe = mio_pad_attr_40_qe;
@@ -17058,6 +17735,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_40_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[40].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_40_keeper_en_40_qs)
   );
   assign reg2hw.mio_pad_attr[40].keeper_en.qe = mio_pad_attr_40_qe;
@@ -17073,6 +17751,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_40_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[40].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_40_schmitt_en_40_qs)
   );
   assign reg2hw.mio_pad_attr[40].schmitt_en.qe = mio_pad_attr_40_qe;
@@ -17088,6 +17767,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_40_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[40].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_40_od_en_40_qs)
   );
   assign reg2hw.mio_pad_attr[40].od_en.qe = mio_pad_attr_40_qe;
@@ -17103,6 +17783,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_40_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[40].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_40_slew_rate_40_qs)
   );
   assign reg2hw.mio_pad_attr[40].slew_rate.qe = mio_pad_attr_40_qe;
@@ -17118,6 +17799,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_40_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[40].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_40_drive_strength_40_qs)
   );
   assign reg2hw.mio_pad_attr[40].drive_strength.qe = mio_pad_attr_40_qe;
@@ -17142,6 +17824,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_41_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[41].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_41_invert_41_qs)
   );
   assign reg2hw.mio_pad_attr[41].invert.qe = mio_pad_attr_41_qe;
@@ -17157,6 +17840,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_41_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[41].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_41_virtual_od_en_41_qs)
   );
   assign reg2hw.mio_pad_attr[41].virtual_od_en.qe = mio_pad_attr_41_qe;
@@ -17172,6 +17856,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_41_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[41].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_41_pull_en_41_qs)
   );
   assign reg2hw.mio_pad_attr[41].pull_en.qe = mio_pad_attr_41_qe;
@@ -17187,6 +17872,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_41_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[41].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_41_pull_select_41_qs)
   );
   assign reg2hw.mio_pad_attr[41].pull_select.qe = mio_pad_attr_41_qe;
@@ -17202,6 +17888,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_41_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[41].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_41_keeper_en_41_qs)
   );
   assign reg2hw.mio_pad_attr[41].keeper_en.qe = mio_pad_attr_41_qe;
@@ -17217,6 +17904,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_41_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[41].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_41_schmitt_en_41_qs)
   );
   assign reg2hw.mio_pad_attr[41].schmitt_en.qe = mio_pad_attr_41_qe;
@@ -17232,6 +17920,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_41_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[41].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_41_od_en_41_qs)
   );
   assign reg2hw.mio_pad_attr[41].od_en.qe = mio_pad_attr_41_qe;
@@ -17247,6 +17936,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_41_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[41].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_41_slew_rate_41_qs)
   );
   assign reg2hw.mio_pad_attr[41].slew_rate.qe = mio_pad_attr_41_qe;
@@ -17262,6 +17952,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_41_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[41].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_41_drive_strength_41_qs)
   );
   assign reg2hw.mio_pad_attr[41].drive_strength.qe = mio_pad_attr_41_qe;
@@ -17286,6 +17977,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_42_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[42].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_42_invert_42_qs)
   );
   assign reg2hw.mio_pad_attr[42].invert.qe = mio_pad_attr_42_qe;
@@ -17301,6 +17993,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_42_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[42].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_42_virtual_od_en_42_qs)
   );
   assign reg2hw.mio_pad_attr[42].virtual_od_en.qe = mio_pad_attr_42_qe;
@@ -17316,6 +18009,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_42_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[42].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_42_pull_en_42_qs)
   );
   assign reg2hw.mio_pad_attr[42].pull_en.qe = mio_pad_attr_42_qe;
@@ -17331,6 +18025,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_42_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[42].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_42_pull_select_42_qs)
   );
   assign reg2hw.mio_pad_attr[42].pull_select.qe = mio_pad_attr_42_qe;
@@ -17346,6 +18041,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_42_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[42].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_42_keeper_en_42_qs)
   );
   assign reg2hw.mio_pad_attr[42].keeper_en.qe = mio_pad_attr_42_qe;
@@ -17361,6 +18057,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_42_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[42].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_42_schmitt_en_42_qs)
   );
   assign reg2hw.mio_pad_attr[42].schmitt_en.qe = mio_pad_attr_42_qe;
@@ -17376,6 +18073,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_42_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[42].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_42_od_en_42_qs)
   );
   assign reg2hw.mio_pad_attr[42].od_en.qe = mio_pad_attr_42_qe;
@@ -17391,6 +18089,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_42_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[42].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_42_slew_rate_42_qs)
   );
   assign reg2hw.mio_pad_attr[42].slew_rate.qe = mio_pad_attr_42_qe;
@@ -17406,6 +18105,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_42_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[42].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_42_drive_strength_42_qs)
   );
   assign reg2hw.mio_pad_attr[42].drive_strength.qe = mio_pad_attr_42_qe;
@@ -17430,6 +18130,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_43_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[43].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_43_invert_43_qs)
   );
   assign reg2hw.mio_pad_attr[43].invert.qe = mio_pad_attr_43_qe;
@@ -17445,6 +18146,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_43_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[43].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_43_virtual_od_en_43_qs)
   );
   assign reg2hw.mio_pad_attr[43].virtual_od_en.qe = mio_pad_attr_43_qe;
@@ -17460,6 +18162,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_43_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[43].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_43_pull_en_43_qs)
   );
   assign reg2hw.mio_pad_attr[43].pull_en.qe = mio_pad_attr_43_qe;
@@ -17475,6 +18178,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_43_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[43].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_43_pull_select_43_qs)
   );
   assign reg2hw.mio_pad_attr[43].pull_select.qe = mio_pad_attr_43_qe;
@@ -17490,6 +18194,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_43_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[43].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_43_keeper_en_43_qs)
   );
   assign reg2hw.mio_pad_attr[43].keeper_en.qe = mio_pad_attr_43_qe;
@@ -17505,6 +18210,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_43_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[43].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_43_schmitt_en_43_qs)
   );
   assign reg2hw.mio_pad_attr[43].schmitt_en.qe = mio_pad_attr_43_qe;
@@ -17520,6 +18226,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_43_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[43].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_43_od_en_43_qs)
   );
   assign reg2hw.mio_pad_attr[43].od_en.qe = mio_pad_attr_43_qe;
@@ -17535,6 +18242,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_43_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[43].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_43_slew_rate_43_qs)
   );
   assign reg2hw.mio_pad_attr[43].slew_rate.qe = mio_pad_attr_43_qe;
@@ -17550,6 +18258,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_43_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[43].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_43_drive_strength_43_qs)
   );
   assign reg2hw.mio_pad_attr[43].drive_strength.qe = mio_pad_attr_43_qe;
@@ -17574,6 +18283,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_44_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[44].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_44_invert_44_qs)
   );
   assign reg2hw.mio_pad_attr[44].invert.qe = mio_pad_attr_44_qe;
@@ -17589,6 +18299,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_44_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[44].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_44_virtual_od_en_44_qs)
   );
   assign reg2hw.mio_pad_attr[44].virtual_od_en.qe = mio_pad_attr_44_qe;
@@ -17604,6 +18315,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_44_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[44].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_44_pull_en_44_qs)
   );
   assign reg2hw.mio_pad_attr[44].pull_en.qe = mio_pad_attr_44_qe;
@@ -17619,6 +18331,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_44_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[44].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_44_pull_select_44_qs)
   );
   assign reg2hw.mio_pad_attr[44].pull_select.qe = mio_pad_attr_44_qe;
@@ -17634,6 +18347,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_44_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[44].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_44_keeper_en_44_qs)
   );
   assign reg2hw.mio_pad_attr[44].keeper_en.qe = mio_pad_attr_44_qe;
@@ -17649,6 +18363,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_44_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[44].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_44_schmitt_en_44_qs)
   );
   assign reg2hw.mio_pad_attr[44].schmitt_en.qe = mio_pad_attr_44_qe;
@@ -17664,6 +18379,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_44_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[44].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_44_od_en_44_qs)
   );
   assign reg2hw.mio_pad_attr[44].od_en.qe = mio_pad_attr_44_qe;
@@ -17679,6 +18395,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_44_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[44].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_44_slew_rate_44_qs)
   );
   assign reg2hw.mio_pad_attr[44].slew_rate.qe = mio_pad_attr_44_qe;
@@ -17694,6 +18411,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_44_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[44].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_44_drive_strength_44_qs)
   );
   assign reg2hw.mio_pad_attr[44].drive_strength.qe = mio_pad_attr_44_qe;
@@ -17718,6 +18436,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_45_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[45].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_45_invert_45_qs)
   );
   assign reg2hw.mio_pad_attr[45].invert.qe = mio_pad_attr_45_qe;
@@ -17733,6 +18452,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_45_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[45].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_45_virtual_od_en_45_qs)
   );
   assign reg2hw.mio_pad_attr[45].virtual_od_en.qe = mio_pad_attr_45_qe;
@@ -17748,6 +18468,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_45_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[45].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_45_pull_en_45_qs)
   );
   assign reg2hw.mio_pad_attr[45].pull_en.qe = mio_pad_attr_45_qe;
@@ -17763,6 +18484,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_45_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[45].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_45_pull_select_45_qs)
   );
   assign reg2hw.mio_pad_attr[45].pull_select.qe = mio_pad_attr_45_qe;
@@ -17778,6 +18500,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_45_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[45].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_45_keeper_en_45_qs)
   );
   assign reg2hw.mio_pad_attr[45].keeper_en.qe = mio_pad_attr_45_qe;
@@ -17793,6 +18516,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_45_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[45].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_45_schmitt_en_45_qs)
   );
   assign reg2hw.mio_pad_attr[45].schmitt_en.qe = mio_pad_attr_45_qe;
@@ -17808,6 +18532,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_45_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[45].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_45_od_en_45_qs)
   );
   assign reg2hw.mio_pad_attr[45].od_en.qe = mio_pad_attr_45_qe;
@@ -17823,6 +18548,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_45_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[45].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_45_slew_rate_45_qs)
   );
   assign reg2hw.mio_pad_attr[45].slew_rate.qe = mio_pad_attr_45_qe;
@@ -17838,6 +18564,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_45_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[45].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_45_drive_strength_45_qs)
   );
   assign reg2hw.mio_pad_attr[45].drive_strength.qe = mio_pad_attr_45_qe;
@@ -17862,6 +18589,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_46_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[46].invert.q),
+    .ds     (),
     .qs     (mio_pad_attr_46_invert_46_qs)
   );
   assign reg2hw.mio_pad_attr[46].invert.qe = mio_pad_attr_46_qe;
@@ -17877,6 +18605,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_46_flds_we[1]),
     .q      (reg2hw.mio_pad_attr[46].virtual_od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_46_virtual_od_en_46_qs)
   );
   assign reg2hw.mio_pad_attr[46].virtual_od_en.qe = mio_pad_attr_46_qe;
@@ -17892,6 +18621,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_46_flds_we[2]),
     .q      (reg2hw.mio_pad_attr[46].pull_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_46_pull_en_46_qs)
   );
   assign reg2hw.mio_pad_attr[46].pull_en.qe = mio_pad_attr_46_qe;
@@ -17907,6 +18637,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_46_flds_we[3]),
     .q      (reg2hw.mio_pad_attr[46].pull_select.q),
+    .ds     (),
     .qs     (mio_pad_attr_46_pull_select_46_qs)
   );
   assign reg2hw.mio_pad_attr[46].pull_select.qe = mio_pad_attr_46_qe;
@@ -17922,6 +18653,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_46_flds_we[4]),
     .q      (reg2hw.mio_pad_attr[46].keeper_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_46_keeper_en_46_qs)
   );
   assign reg2hw.mio_pad_attr[46].keeper_en.qe = mio_pad_attr_46_qe;
@@ -17937,6 +18669,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_46_flds_we[5]),
     .q      (reg2hw.mio_pad_attr[46].schmitt_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_46_schmitt_en_46_qs)
   );
   assign reg2hw.mio_pad_attr[46].schmitt_en.qe = mio_pad_attr_46_qe;
@@ -17952,6 +18685,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_46_flds_we[6]),
     .q      (reg2hw.mio_pad_attr[46].od_en.q),
+    .ds     (),
     .qs     (mio_pad_attr_46_od_en_46_qs)
   );
   assign reg2hw.mio_pad_attr[46].od_en.qe = mio_pad_attr_46_qe;
@@ -17967,6 +18701,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_46_flds_we[7]),
     .q      (reg2hw.mio_pad_attr[46].slew_rate.q),
+    .ds     (),
     .qs     (mio_pad_attr_46_slew_rate_46_qs)
   );
   assign reg2hw.mio_pad_attr[46].slew_rate.qe = mio_pad_attr_46_qe;
@@ -17982,6 +18717,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (mio_pad_attr_46_flds_we[8]),
     .q      (reg2hw.mio_pad_attr[46].drive_strength.q),
+    .ds     (),
     .qs     (mio_pad_attr_46_drive_strength_46_qs)
   );
   assign reg2hw.mio_pad_attr[46].drive_strength.qe = mio_pad_attr_46_qe;
@@ -18008,6 +18744,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_0_qs)
@@ -18035,6 +18772,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_1_qs)
@@ -18062,6 +18800,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_2_qs)
@@ -18089,6 +18828,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_3_qs)
@@ -18116,6 +18856,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_4_qs)
@@ -18143,6 +18884,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_5_qs)
@@ -18170,6 +18912,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_6_qs)
@@ -18197,6 +18940,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_7_qs)
@@ -18224,6 +18968,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_8_qs)
@@ -18251,6 +18996,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_9_qs)
@@ -18278,6 +19024,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_10_qs)
@@ -18305,6 +19052,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_11_qs)
@@ -18332,6 +19080,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_12_qs)
@@ -18359,6 +19108,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_13_qs)
@@ -18386,6 +19136,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_14_qs)
@@ -18413,6 +19164,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_attr_regwen_15_qs)
@@ -18438,6 +19190,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[0].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_invert_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].invert.qe = dio_pad_attr_0_qe;
@@ -18453,6 +19206,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[0].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_virtual_od_en_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].virtual_od_en.qe = dio_pad_attr_0_qe;
@@ -18468,6 +19222,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[0].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_pull_en_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].pull_en.qe = dio_pad_attr_0_qe;
@@ -18483,6 +19238,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[0].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_pull_select_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].pull_select.qe = dio_pad_attr_0_qe;
@@ -18498,6 +19254,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[0].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_keeper_en_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].keeper_en.qe = dio_pad_attr_0_qe;
@@ -18513,6 +19270,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[0].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_schmitt_en_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].schmitt_en.qe = dio_pad_attr_0_qe;
@@ -18528,6 +19286,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[0].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_od_en_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].od_en.qe = dio_pad_attr_0_qe;
@@ -18543,6 +19302,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[0].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_slew_rate_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].slew_rate.qe = dio_pad_attr_0_qe;
@@ -18558,6 +19318,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_0_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[0].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_0_drive_strength_0_qs)
   );
   assign reg2hw.dio_pad_attr[0].drive_strength.qe = dio_pad_attr_0_qe;
@@ -18582,6 +19343,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[1].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_invert_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].invert.qe = dio_pad_attr_1_qe;
@@ -18597,6 +19359,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[1].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_virtual_od_en_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].virtual_od_en.qe = dio_pad_attr_1_qe;
@@ -18612,6 +19375,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[1].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_pull_en_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].pull_en.qe = dio_pad_attr_1_qe;
@@ -18627,6 +19391,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[1].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_pull_select_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].pull_select.qe = dio_pad_attr_1_qe;
@@ -18642,6 +19407,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[1].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_keeper_en_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].keeper_en.qe = dio_pad_attr_1_qe;
@@ -18657,6 +19423,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[1].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_schmitt_en_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].schmitt_en.qe = dio_pad_attr_1_qe;
@@ -18672,6 +19439,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[1].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_od_en_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].od_en.qe = dio_pad_attr_1_qe;
@@ -18687,6 +19455,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[1].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_slew_rate_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].slew_rate.qe = dio_pad_attr_1_qe;
@@ -18702,6 +19471,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_1_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[1].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_1_drive_strength_1_qs)
   );
   assign reg2hw.dio_pad_attr[1].drive_strength.qe = dio_pad_attr_1_qe;
@@ -18726,6 +19496,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[2].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_invert_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].invert.qe = dio_pad_attr_2_qe;
@@ -18741,6 +19512,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[2].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_virtual_od_en_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].virtual_od_en.qe = dio_pad_attr_2_qe;
@@ -18756,6 +19528,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[2].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_pull_en_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].pull_en.qe = dio_pad_attr_2_qe;
@@ -18771,6 +19544,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[2].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_pull_select_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].pull_select.qe = dio_pad_attr_2_qe;
@@ -18786,6 +19560,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[2].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_keeper_en_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].keeper_en.qe = dio_pad_attr_2_qe;
@@ -18801,6 +19576,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[2].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_schmitt_en_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].schmitt_en.qe = dio_pad_attr_2_qe;
@@ -18816,6 +19592,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[2].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_od_en_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].od_en.qe = dio_pad_attr_2_qe;
@@ -18831,6 +19608,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[2].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_slew_rate_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].slew_rate.qe = dio_pad_attr_2_qe;
@@ -18846,6 +19624,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_2_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[2].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_2_drive_strength_2_qs)
   );
   assign reg2hw.dio_pad_attr[2].drive_strength.qe = dio_pad_attr_2_qe;
@@ -18870,6 +19649,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[3].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_invert_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].invert.qe = dio_pad_attr_3_qe;
@@ -18885,6 +19665,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[3].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_virtual_od_en_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].virtual_od_en.qe = dio_pad_attr_3_qe;
@@ -18900,6 +19681,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[3].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_pull_en_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].pull_en.qe = dio_pad_attr_3_qe;
@@ -18915,6 +19697,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[3].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_pull_select_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].pull_select.qe = dio_pad_attr_3_qe;
@@ -18930,6 +19713,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[3].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_keeper_en_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].keeper_en.qe = dio_pad_attr_3_qe;
@@ -18945,6 +19729,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[3].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_schmitt_en_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].schmitt_en.qe = dio_pad_attr_3_qe;
@@ -18960,6 +19745,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[3].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_od_en_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].od_en.qe = dio_pad_attr_3_qe;
@@ -18975,6 +19761,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[3].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_slew_rate_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].slew_rate.qe = dio_pad_attr_3_qe;
@@ -18990,6 +19777,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_3_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[3].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_3_drive_strength_3_qs)
   );
   assign reg2hw.dio_pad_attr[3].drive_strength.qe = dio_pad_attr_3_qe;
@@ -19014,6 +19802,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[4].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_invert_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].invert.qe = dio_pad_attr_4_qe;
@@ -19029,6 +19818,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[4].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_virtual_od_en_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].virtual_od_en.qe = dio_pad_attr_4_qe;
@@ -19044,6 +19834,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[4].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_pull_en_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].pull_en.qe = dio_pad_attr_4_qe;
@@ -19059,6 +19850,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[4].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_pull_select_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].pull_select.qe = dio_pad_attr_4_qe;
@@ -19074,6 +19866,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[4].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_keeper_en_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].keeper_en.qe = dio_pad_attr_4_qe;
@@ -19089,6 +19882,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[4].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_schmitt_en_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].schmitt_en.qe = dio_pad_attr_4_qe;
@@ -19104,6 +19898,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[4].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_od_en_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].od_en.qe = dio_pad_attr_4_qe;
@@ -19119,6 +19914,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[4].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_slew_rate_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].slew_rate.qe = dio_pad_attr_4_qe;
@@ -19134,6 +19930,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_4_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[4].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_4_drive_strength_4_qs)
   );
   assign reg2hw.dio_pad_attr[4].drive_strength.qe = dio_pad_attr_4_qe;
@@ -19158,6 +19955,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[5].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_invert_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].invert.qe = dio_pad_attr_5_qe;
@@ -19173,6 +19971,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[5].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_virtual_od_en_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].virtual_od_en.qe = dio_pad_attr_5_qe;
@@ -19188,6 +19987,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[5].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_pull_en_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].pull_en.qe = dio_pad_attr_5_qe;
@@ -19203,6 +20003,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[5].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_pull_select_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].pull_select.qe = dio_pad_attr_5_qe;
@@ -19218,6 +20019,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[5].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_keeper_en_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].keeper_en.qe = dio_pad_attr_5_qe;
@@ -19233,6 +20035,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[5].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_schmitt_en_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].schmitt_en.qe = dio_pad_attr_5_qe;
@@ -19248,6 +20051,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[5].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_od_en_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].od_en.qe = dio_pad_attr_5_qe;
@@ -19263,6 +20067,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[5].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_slew_rate_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].slew_rate.qe = dio_pad_attr_5_qe;
@@ -19278,6 +20083,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_5_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[5].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_5_drive_strength_5_qs)
   );
   assign reg2hw.dio_pad_attr[5].drive_strength.qe = dio_pad_attr_5_qe;
@@ -19302,6 +20108,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[6].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_invert_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].invert.qe = dio_pad_attr_6_qe;
@@ -19317,6 +20124,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[6].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_virtual_od_en_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].virtual_od_en.qe = dio_pad_attr_6_qe;
@@ -19332,6 +20140,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[6].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_pull_en_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].pull_en.qe = dio_pad_attr_6_qe;
@@ -19347,6 +20156,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[6].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_pull_select_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].pull_select.qe = dio_pad_attr_6_qe;
@@ -19362,6 +20172,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[6].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_keeper_en_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].keeper_en.qe = dio_pad_attr_6_qe;
@@ -19377,6 +20188,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[6].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_schmitt_en_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].schmitt_en.qe = dio_pad_attr_6_qe;
@@ -19392,6 +20204,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[6].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_od_en_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].od_en.qe = dio_pad_attr_6_qe;
@@ -19407,6 +20220,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[6].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_slew_rate_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].slew_rate.qe = dio_pad_attr_6_qe;
@@ -19422,6 +20236,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_6_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[6].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_6_drive_strength_6_qs)
   );
   assign reg2hw.dio_pad_attr[6].drive_strength.qe = dio_pad_attr_6_qe;
@@ -19446,6 +20261,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[7].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_invert_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].invert.qe = dio_pad_attr_7_qe;
@@ -19461,6 +20277,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[7].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_virtual_od_en_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].virtual_od_en.qe = dio_pad_attr_7_qe;
@@ -19476,6 +20293,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[7].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_pull_en_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].pull_en.qe = dio_pad_attr_7_qe;
@@ -19491,6 +20309,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[7].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_pull_select_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].pull_select.qe = dio_pad_attr_7_qe;
@@ -19506,6 +20325,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[7].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_keeper_en_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].keeper_en.qe = dio_pad_attr_7_qe;
@@ -19521,6 +20341,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[7].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_schmitt_en_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].schmitt_en.qe = dio_pad_attr_7_qe;
@@ -19536,6 +20357,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[7].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_od_en_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].od_en.qe = dio_pad_attr_7_qe;
@@ -19551,6 +20373,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[7].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_slew_rate_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].slew_rate.qe = dio_pad_attr_7_qe;
@@ -19566,6 +20389,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_7_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[7].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_7_drive_strength_7_qs)
   );
   assign reg2hw.dio_pad_attr[7].drive_strength.qe = dio_pad_attr_7_qe;
@@ -19590,6 +20414,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[8].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_invert_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].invert.qe = dio_pad_attr_8_qe;
@@ -19605,6 +20430,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[8].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_virtual_od_en_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].virtual_od_en.qe = dio_pad_attr_8_qe;
@@ -19620,6 +20446,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[8].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_pull_en_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].pull_en.qe = dio_pad_attr_8_qe;
@@ -19635,6 +20462,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[8].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_pull_select_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].pull_select.qe = dio_pad_attr_8_qe;
@@ -19650,6 +20478,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[8].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_keeper_en_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].keeper_en.qe = dio_pad_attr_8_qe;
@@ -19665,6 +20494,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[8].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_schmitt_en_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].schmitt_en.qe = dio_pad_attr_8_qe;
@@ -19680,6 +20510,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[8].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_od_en_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].od_en.qe = dio_pad_attr_8_qe;
@@ -19695,6 +20526,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[8].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_slew_rate_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].slew_rate.qe = dio_pad_attr_8_qe;
@@ -19710,6 +20542,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_8_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[8].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_8_drive_strength_8_qs)
   );
   assign reg2hw.dio_pad_attr[8].drive_strength.qe = dio_pad_attr_8_qe;
@@ -19734,6 +20567,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[9].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_invert_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].invert.qe = dio_pad_attr_9_qe;
@@ -19749,6 +20583,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[9].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_virtual_od_en_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].virtual_od_en.qe = dio_pad_attr_9_qe;
@@ -19764,6 +20599,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[9].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_pull_en_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].pull_en.qe = dio_pad_attr_9_qe;
@@ -19779,6 +20615,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[9].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_pull_select_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].pull_select.qe = dio_pad_attr_9_qe;
@@ -19794,6 +20631,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[9].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_keeper_en_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].keeper_en.qe = dio_pad_attr_9_qe;
@@ -19809,6 +20647,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[9].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_schmitt_en_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].schmitt_en.qe = dio_pad_attr_9_qe;
@@ -19824,6 +20663,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[9].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_od_en_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].od_en.qe = dio_pad_attr_9_qe;
@@ -19839,6 +20679,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[9].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_slew_rate_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].slew_rate.qe = dio_pad_attr_9_qe;
@@ -19854,6 +20695,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_9_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[9].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_9_drive_strength_9_qs)
   );
   assign reg2hw.dio_pad_attr[9].drive_strength.qe = dio_pad_attr_9_qe;
@@ -19878,6 +20720,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[10].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_invert_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].invert.qe = dio_pad_attr_10_qe;
@@ -19893,6 +20736,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[10].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_virtual_od_en_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].virtual_od_en.qe = dio_pad_attr_10_qe;
@@ -19908,6 +20752,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[10].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_pull_en_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].pull_en.qe = dio_pad_attr_10_qe;
@@ -19923,6 +20768,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[10].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_pull_select_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].pull_select.qe = dio_pad_attr_10_qe;
@@ -19938,6 +20784,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[10].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_keeper_en_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].keeper_en.qe = dio_pad_attr_10_qe;
@@ -19953,6 +20800,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[10].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_schmitt_en_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].schmitt_en.qe = dio_pad_attr_10_qe;
@@ -19968,6 +20816,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[10].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_od_en_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].od_en.qe = dio_pad_attr_10_qe;
@@ -19983,6 +20832,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[10].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_slew_rate_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].slew_rate.qe = dio_pad_attr_10_qe;
@@ -19998,6 +20848,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_10_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[10].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_10_drive_strength_10_qs)
   );
   assign reg2hw.dio_pad_attr[10].drive_strength.qe = dio_pad_attr_10_qe;
@@ -20022,6 +20873,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[11].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_invert_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].invert.qe = dio_pad_attr_11_qe;
@@ -20037,6 +20889,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[11].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_virtual_od_en_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].virtual_od_en.qe = dio_pad_attr_11_qe;
@@ -20052,6 +20905,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[11].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_pull_en_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].pull_en.qe = dio_pad_attr_11_qe;
@@ -20067,6 +20921,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[11].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_pull_select_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].pull_select.qe = dio_pad_attr_11_qe;
@@ -20082,6 +20937,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[11].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_keeper_en_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].keeper_en.qe = dio_pad_attr_11_qe;
@@ -20097,6 +20953,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[11].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_schmitt_en_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].schmitt_en.qe = dio_pad_attr_11_qe;
@@ -20112,6 +20969,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[11].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_od_en_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].od_en.qe = dio_pad_attr_11_qe;
@@ -20127,6 +20985,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[11].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_slew_rate_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].slew_rate.qe = dio_pad_attr_11_qe;
@@ -20142,6 +21001,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_11_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[11].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_11_drive_strength_11_qs)
   );
   assign reg2hw.dio_pad_attr[11].drive_strength.qe = dio_pad_attr_11_qe;
@@ -20166,6 +21026,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[12].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_invert_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].invert.qe = dio_pad_attr_12_qe;
@@ -20181,6 +21042,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[12].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_virtual_od_en_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].virtual_od_en.qe = dio_pad_attr_12_qe;
@@ -20196,6 +21058,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[12].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_pull_en_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].pull_en.qe = dio_pad_attr_12_qe;
@@ -20211,6 +21074,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[12].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_pull_select_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].pull_select.qe = dio_pad_attr_12_qe;
@@ -20226,6 +21090,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[12].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_keeper_en_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].keeper_en.qe = dio_pad_attr_12_qe;
@@ -20241,6 +21106,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[12].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_schmitt_en_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].schmitt_en.qe = dio_pad_attr_12_qe;
@@ -20256,6 +21122,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[12].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_od_en_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].od_en.qe = dio_pad_attr_12_qe;
@@ -20271,6 +21138,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[12].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_slew_rate_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].slew_rate.qe = dio_pad_attr_12_qe;
@@ -20286,6 +21154,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_12_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[12].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_12_drive_strength_12_qs)
   );
   assign reg2hw.dio_pad_attr[12].drive_strength.qe = dio_pad_attr_12_qe;
@@ -20310,6 +21179,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[13].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_invert_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].invert.qe = dio_pad_attr_13_qe;
@@ -20325,6 +21195,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[13].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_virtual_od_en_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].virtual_od_en.qe = dio_pad_attr_13_qe;
@@ -20340,6 +21211,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[13].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_pull_en_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].pull_en.qe = dio_pad_attr_13_qe;
@@ -20355,6 +21227,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[13].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_pull_select_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].pull_select.qe = dio_pad_attr_13_qe;
@@ -20370,6 +21243,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[13].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_keeper_en_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].keeper_en.qe = dio_pad_attr_13_qe;
@@ -20385,6 +21259,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[13].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_schmitt_en_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].schmitt_en.qe = dio_pad_attr_13_qe;
@@ -20400,6 +21275,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[13].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_od_en_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].od_en.qe = dio_pad_attr_13_qe;
@@ -20415,6 +21291,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[13].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_slew_rate_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].slew_rate.qe = dio_pad_attr_13_qe;
@@ -20430,6 +21307,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_13_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[13].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_13_drive_strength_13_qs)
   );
   assign reg2hw.dio_pad_attr[13].drive_strength.qe = dio_pad_attr_13_qe;
@@ -20454,6 +21332,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[14].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_invert_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].invert.qe = dio_pad_attr_14_qe;
@@ -20469,6 +21348,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[14].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_virtual_od_en_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].virtual_od_en.qe = dio_pad_attr_14_qe;
@@ -20484,6 +21364,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[14].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_pull_en_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].pull_en.qe = dio_pad_attr_14_qe;
@@ -20499,6 +21380,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[14].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_pull_select_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].pull_select.qe = dio_pad_attr_14_qe;
@@ -20514,6 +21396,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[14].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_keeper_en_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].keeper_en.qe = dio_pad_attr_14_qe;
@@ -20529,6 +21412,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[14].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_schmitt_en_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].schmitt_en.qe = dio_pad_attr_14_qe;
@@ -20544,6 +21428,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[14].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_od_en_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].od_en.qe = dio_pad_attr_14_qe;
@@ -20559,6 +21444,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[14].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_slew_rate_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].slew_rate.qe = dio_pad_attr_14_qe;
@@ -20574,6 +21460,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_14_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[14].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_14_drive_strength_14_qs)
   );
   assign reg2hw.dio_pad_attr[14].drive_strength.qe = dio_pad_attr_14_qe;
@@ -20598,6 +21485,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[15].invert.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_invert_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].invert.qe = dio_pad_attr_15_qe;
@@ -20613,6 +21501,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[1]),
     .q      (reg2hw.dio_pad_attr[15].virtual_od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_virtual_od_en_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].virtual_od_en.qe = dio_pad_attr_15_qe;
@@ -20628,6 +21517,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[2]),
     .q      (reg2hw.dio_pad_attr[15].pull_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_pull_en_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].pull_en.qe = dio_pad_attr_15_qe;
@@ -20643,6 +21533,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[3]),
     .q      (reg2hw.dio_pad_attr[15].pull_select.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_pull_select_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].pull_select.qe = dio_pad_attr_15_qe;
@@ -20658,6 +21549,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[4]),
     .q      (reg2hw.dio_pad_attr[15].keeper_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_keeper_en_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].keeper_en.qe = dio_pad_attr_15_qe;
@@ -20673,6 +21565,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[5]),
     .q      (reg2hw.dio_pad_attr[15].schmitt_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_schmitt_en_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].schmitt_en.qe = dio_pad_attr_15_qe;
@@ -20688,6 +21581,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[6]),
     .q      (reg2hw.dio_pad_attr[15].od_en.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_od_en_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].od_en.qe = dio_pad_attr_15_qe;
@@ -20703,6 +21597,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[7]),
     .q      (reg2hw.dio_pad_attr[15].slew_rate.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_slew_rate_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].slew_rate.qe = dio_pad_attr_15_qe;
@@ -20718,6 +21613,7 @@ module pinmux_reg_top (
     .qre    (),
     .qe     (dio_pad_attr_15_flds_we[8]),
     .q      (reg2hw.dio_pad_attr[15].drive_strength.q),
+    .ds     (),
     .qs     (dio_pad_attr_15_drive_strength_15_qs)
   );
   assign reg2hw.dio_pad_attr[15].drive_strength.qe = dio_pad_attr_15_qe;
@@ -20745,6 +21641,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_0_qs)
@@ -20770,6 +21667,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_1_qs)
@@ -20795,6 +21693,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_2_qs)
@@ -20820,6 +21719,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_3_qs)
@@ -20845,6 +21745,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_4_qs)
@@ -20870,6 +21771,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_5_qs)
@@ -20895,6 +21797,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_6_qs)
@@ -20920,6 +21823,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_7_qs)
@@ -20945,6 +21849,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_8_qs)
@@ -20970,6 +21875,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_9_qs)
@@ -20995,6 +21901,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_10_qs)
@@ -21020,6 +21927,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_11_qs)
@@ -21045,6 +21953,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_12_qs)
@@ -21070,6 +21979,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_13_qs)
@@ -21095,6 +22005,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_14_qs)
@@ -21120,6 +22031,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_15_qs)
@@ -21145,6 +22057,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_16_qs)
@@ -21170,6 +22083,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_17_qs)
@@ -21195,6 +22109,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_18_qs)
@@ -21220,6 +22135,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_19_qs)
@@ -21245,6 +22161,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_20_qs)
@@ -21270,6 +22187,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_21_qs)
@@ -21295,6 +22213,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_22_qs)
@@ -21320,6 +22239,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_23_qs)
@@ -21345,6 +22265,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_24_qs)
@@ -21370,6 +22291,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_25_qs)
@@ -21395,6 +22317,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_26_qs)
@@ -21420,6 +22343,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_27_qs)
@@ -21445,6 +22369,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_28_qs)
@@ -21470,6 +22395,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_29_qs)
@@ -21495,6 +22421,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_30_qs)
@@ -21520,6 +22447,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_0_en_31_qs)
@@ -21548,6 +22476,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_32_qs)
@@ -21573,6 +22502,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_33_qs)
@@ -21598,6 +22528,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_34_qs)
@@ -21623,6 +22554,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_35_qs)
@@ -21648,6 +22580,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_36_qs)
@@ -21673,6 +22606,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_37_qs)
@@ -21698,6 +22632,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_38_qs)
@@ -21723,6 +22658,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_39_qs)
@@ -21748,6 +22684,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_40_qs)
@@ -21773,6 +22710,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_41_qs)
@@ -21798,6 +22736,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_42_qs)
@@ -21823,6 +22762,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_43_qs)
@@ -21848,6 +22788,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_44_qs)
@@ -21873,6 +22814,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_45_qs)
@@ -21898,6 +22840,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_status[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_status_1_en_46_qs)
@@ -21925,6 +22868,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_0_qs)
@@ -21952,6 +22896,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_1_qs)
@@ -21979,6 +22924,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_2_qs)
@@ -22006,6 +22952,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_3_qs)
@@ -22033,6 +22980,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_4_qs)
@@ -22060,6 +23008,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_5_qs)
@@ -22087,6 +23036,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_6_qs)
@@ -22114,6 +23064,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_7_qs)
@@ -22141,6 +23092,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_8_qs)
@@ -22168,6 +23120,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_9_qs)
@@ -22195,6 +23148,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_10_qs)
@@ -22222,6 +23176,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_11_qs)
@@ -22249,6 +23204,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_12_qs)
@@ -22276,6 +23232,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_13_qs)
@@ -22303,6 +23260,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_14_qs)
@@ -22330,6 +23288,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_15_qs)
@@ -22357,6 +23316,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_16_qs)
@@ -22384,6 +23344,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_17_qs)
@@ -22411,6 +23372,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_18_qs)
@@ -22438,6 +23400,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_19_qs)
@@ -22465,6 +23428,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_20_qs)
@@ -22492,6 +23456,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_21_qs)
@@ -22519,6 +23484,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_22_qs)
@@ -22546,6 +23512,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_23_qs)
@@ -22573,6 +23540,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_24_qs)
@@ -22600,6 +23568,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_25_qs)
@@ -22627,6 +23596,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_26_qs)
@@ -22654,6 +23624,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_27_qs)
@@ -22681,6 +23652,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_28_qs)
@@ -22708,6 +23680,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_29_qs)
@@ -22735,6 +23708,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_30_qs)
@@ -22762,6 +23736,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_31_qs)
@@ -22789,6 +23764,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_32_qs)
@@ -22816,6 +23792,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_33_qs)
@@ -22843,6 +23820,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_34_qs)
@@ -22870,6 +23848,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_35_qs)
@@ -22897,6 +23876,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_36_qs)
@@ -22924,6 +23904,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_37_qs)
@@ -22951,6 +23932,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_38_qs)
@@ -22978,6 +23960,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_39_qs)
@@ -23005,6 +23988,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_40_qs)
@@ -23032,6 +24016,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_41_qs)
@@ -23059,6 +24044,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_42_qs)
@@ -23086,6 +24072,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_43_qs)
@@ -23113,6 +24100,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_44_qs)
@@ -23140,6 +24128,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_45_qs)
@@ -23167,6 +24156,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_regwen_46_qs)
@@ -23197,6 +24187,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_0_qs)
@@ -23227,6 +24218,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_1_qs)
@@ -23257,6 +24249,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_2_qs)
@@ -23287,6 +24280,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_3_qs)
@@ -23317,6 +24311,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_4_qs)
@@ -23347,6 +24342,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_5_qs)
@@ -23377,6 +24373,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_6_qs)
@@ -23407,6 +24404,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_7_qs)
@@ -23437,6 +24435,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_8_qs)
@@ -23467,6 +24466,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_9_qs)
@@ -23497,6 +24497,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_10_qs)
@@ -23527,6 +24528,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_11_qs)
@@ -23557,6 +24559,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_12_qs)
@@ -23587,6 +24590,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_13_qs)
@@ -23617,6 +24621,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_14_qs)
@@ -23647,6 +24652,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_15_qs)
@@ -23677,6 +24683,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_16_qs)
@@ -23707,6 +24714,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_17_qs)
@@ -23737,6 +24745,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_18_qs)
@@ -23767,6 +24776,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_19_qs)
@@ -23797,6 +24807,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_20_qs)
@@ -23827,6 +24838,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_21_qs)
@@ -23857,6 +24869,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_22_qs)
@@ -23887,6 +24900,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_23_qs)
@@ -23917,6 +24931,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_24_qs)
@@ -23947,6 +24962,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_25_qs)
@@ -23977,6 +24993,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_26_qs)
@@ -24007,6 +25024,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_27_qs)
@@ -24037,6 +25055,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_28_qs)
@@ -24067,6 +25086,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_29_qs)
@@ -24097,6 +25117,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_30_qs)
@@ -24127,6 +25148,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_31_qs)
@@ -24157,6 +25179,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_32_qs)
@@ -24187,6 +25210,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_33_qs)
@@ -24217,6 +25241,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_34_qs)
@@ -24247,6 +25272,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_35_qs)
@@ -24277,6 +25303,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_36_qs)
@@ -24307,6 +25334,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_37_qs)
@@ -24337,6 +25365,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_38_qs)
@@ -24367,6 +25396,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_39_qs)
@@ -24397,6 +25427,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_40_qs)
@@ -24427,6 +25458,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_41_qs)
@@ -24457,6 +25489,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_42_qs)
@@ -24487,6 +25520,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_43_qs)
@@ -24517,6 +25551,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_44_qs)
@@ -24547,6 +25582,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_45_qs)
@@ -24577,6 +25613,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_en[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_en_46_qs)
@@ -24607,6 +25644,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_0_qs)
@@ -24637,6 +25675,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_1_qs)
@@ -24667,6 +25706,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_2_qs)
@@ -24697,6 +25737,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_3_qs)
@@ -24727,6 +25768,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_4_qs)
@@ -24757,6 +25799,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_5_qs)
@@ -24787,6 +25830,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_6_qs)
@@ -24817,6 +25861,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_7_qs)
@@ -24847,6 +25892,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_8_qs)
@@ -24877,6 +25923,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_9_qs)
@@ -24907,6 +25954,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_10_qs)
@@ -24937,6 +25985,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_11_qs)
@@ -24967,6 +26016,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_12_qs)
@@ -24997,6 +26047,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_13_qs)
@@ -25027,6 +26078,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_14_qs)
@@ -25057,6 +26109,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_15_qs)
@@ -25087,6 +26140,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_16_qs)
@@ -25117,6 +26171,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_17_qs)
@@ -25147,6 +26202,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_18_qs)
@@ -25177,6 +26233,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_19_qs)
@@ -25207,6 +26264,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_20_qs)
@@ -25237,6 +26295,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_21_qs)
@@ -25267,6 +26326,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_22_qs)
@@ -25297,6 +26357,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_23_qs)
@@ -25327,6 +26388,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_24_qs)
@@ -25357,6 +26419,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_25_qs)
@@ -25387,6 +26450,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_26_qs)
@@ -25417,6 +26481,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_27_qs)
@@ -25447,6 +26512,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_28_qs)
@@ -25477,6 +26543,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_29_qs)
@@ -25507,6 +26574,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_30_qs)
@@ -25537,6 +26605,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_31_qs)
@@ -25567,6 +26636,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_32_qs)
@@ -25597,6 +26667,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_33_qs)
@@ -25627,6 +26698,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_34_qs)
@@ -25657,6 +26729,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_35_qs)
@@ -25687,6 +26760,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_36_qs)
@@ -25717,6 +26791,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_37_qs)
@@ -25747,6 +26822,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_38_qs)
@@ -25777,6 +26853,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_39_qs)
@@ -25807,6 +26884,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_40_qs)
@@ -25837,6 +26915,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_41_qs)
@@ -25867,6 +26946,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_42_qs)
@@ -25897,6 +26977,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_43_qs)
@@ -25927,6 +27008,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_44_qs)
@@ -25957,6 +27039,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_45_qs)
@@ -25987,6 +27070,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.mio_pad_sleep_mode[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (mio_pad_sleep_mode_46_qs)
@@ -26015,6 +27099,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_0_qs)
@@ -26040,6 +27125,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_1_qs)
@@ -26065,6 +27151,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_2_qs)
@@ -26090,6 +27177,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_3_qs)
@@ -26115,6 +27203,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_4_qs)
@@ -26140,6 +27229,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_5_qs)
@@ -26165,6 +27255,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_6_qs)
@@ -26190,6 +27281,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_7_qs)
@@ -26215,6 +27307,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_8_qs)
@@ -26240,6 +27333,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_9_qs)
@@ -26265,6 +27359,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_10_qs)
@@ -26290,6 +27385,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_11_qs)
@@ -26315,6 +27411,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_12_qs)
@@ -26340,6 +27437,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_13_qs)
@@ -26365,6 +27463,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_14_qs)
@@ -26390,6 +27489,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_status[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_status_en_15_qs)
@@ -26417,6 +27517,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_0_qs)
@@ -26444,6 +27545,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_1_qs)
@@ -26471,6 +27573,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_2_qs)
@@ -26498,6 +27601,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_3_qs)
@@ -26525,6 +27629,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_4_qs)
@@ -26552,6 +27657,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_5_qs)
@@ -26579,6 +27685,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_6_qs)
@@ -26606,6 +27713,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_7_qs)
@@ -26633,6 +27741,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_8_qs)
@@ -26660,6 +27769,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_9_qs)
@@ -26687,6 +27797,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_10_qs)
@@ -26714,6 +27825,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_11_qs)
@@ -26741,6 +27853,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_12_qs)
@@ -26768,6 +27881,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_13_qs)
@@ -26795,6 +27909,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_14_qs)
@@ -26822,6 +27937,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_regwen_15_qs)
@@ -26852,6 +27968,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_0_qs)
@@ -26882,6 +27999,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_1_qs)
@@ -26912,6 +28030,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_2_qs)
@@ -26942,6 +28061,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_3_qs)
@@ -26972,6 +28092,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_4_qs)
@@ -27002,6 +28123,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_5_qs)
@@ -27032,6 +28154,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_6_qs)
@@ -27062,6 +28185,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_7_qs)
@@ -27092,6 +28216,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_8_qs)
@@ -27122,6 +28247,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_9_qs)
@@ -27152,6 +28278,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_10_qs)
@@ -27182,6 +28309,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_11_qs)
@@ -27212,6 +28340,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_12_qs)
@@ -27242,6 +28371,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_13_qs)
@@ -27272,6 +28402,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_14_qs)
@@ -27302,6 +28433,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_en[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_en_15_qs)
@@ -27332,6 +28464,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_0_qs)
@@ -27362,6 +28495,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_1_qs)
@@ -27392,6 +28526,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_2_qs)
@@ -27422,6 +28557,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_3_qs)
@@ -27452,6 +28588,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_4_qs)
@@ -27482,6 +28619,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_5_qs)
@@ -27512,6 +28650,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_6_qs)
@@ -27542,6 +28681,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_7_qs)
@@ -27572,6 +28712,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_8_qs)
@@ -27602,6 +28743,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_9_qs)
@@ -27632,6 +28774,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_10_qs)
@@ -27662,6 +28805,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_11_qs)
@@ -27692,6 +28836,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_12_qs)
@@ -27722,6 +28867,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_13_qs)
@@ -27752,6 +28898,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_14_qs)
@@ -27782,6 +28929,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.dio_pad_sleep_mode[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (dio_pad_sleep_mode_15_qs)
@@ -27809,6 +28957,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_0_qs)
@@ -27836,6 +28985,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_1_qs)
@@ -27863,6 +29013,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_2_qs)
@@ -27890,6 +29041,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_3_qs)
@@ -27917,6 +29069,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_4_qs)
@@ -27944,6 +29097,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_5_qs)
@@ -27971,6 +29125,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_6_qs)
@@ -27998,6 +29153,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_regwen_7_qs)
@@ -28029,6 +29185,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_0_qs_int)
@@ -28060,6 +29217,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_1_qs_int)
@@ -28091,6 +29249,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_2_qs_int)
@@ -28122,6 +29281,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_3_qs_int)
@@ -28153,6 +29313,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_4_qs_int)
@@ -28184,6 +29345,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_5_qs_int)
@@ -28215,6 +29377,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_6_qs_int)
@@ -28246,6 +29409,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_en[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_en_7_qs_int)
@@ -28277,6 +29441,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[0].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_0_mode_0_qs_int)
@@ -28302,6 +29467,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[0].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_0_filter_0_qs_int)
@@ -28327,6 +29493,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[0].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_0_miodio_0_qs_int)
@@ -28358,6 +29525,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[1].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_1_mode_1_qs_int)
@@ -28383,6 +29551,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[1].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_1_filter_1_qs_int)
@@ -28408,6 +29577,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[1].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_1_miodio_1_qs_int)
@@ -28439,6 +29609,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[2].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_2_mode_2_qs_int)
@@ -28464,6 +29635,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[2].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_2_filter_2_qs_int)
@@ -28489,6 +29661,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[2].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_2_miodio_2_qs_int)
@@ -28520,6 +29693,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[3].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_3_mode_3_qs_int)
@@ -28545,6 +29719,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[3].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_3_filter_3_qs_int)
@@ -28570,6 +29745,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[3].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_3_miodio_3_qs_int)
@@ -28601,6 +29777,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[4].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_4_mode_4_qs_int)
@@ -28626,6 +29803,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[4].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_4_filter_4_qs_int)
@@ -28651,6 +29829,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[4].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_4_miodio_4_qs_int)
@@ -28682,6 +29861,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[5].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_5_mode_5_qs_int)
@@ -28707,6 +29887,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[5].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_5_filter_5_qs_int)
@@ -28732,6 +29913,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[5].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_5_miodio_5_qs_int)
@@ -28763,6 +29945,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[6].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_6_mode_6_qs_int)
@@ -28788,6 +29971,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[6].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_6_filter_6_qs_int)
@@ -28813,6 +29997,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[6].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_6_miodio_6_qs_int)
@@ -28844,6 +30029,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[7].mode.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_7_mode_7_qs_int)
@@ -28869,6 +30055,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[7].filter.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_7_filter_7_qs_int)
@@ -28894,6 +30081,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector[7].miodio.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_7_miodio_7_qs_int)
@@ -28925,6 +30113,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_0_qs_int)
@@ -28956,6 +30145,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_1_qs_int)
@@ -28987,6 +30177,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_2_qs_int)
@@ -29018,6 +30209,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_3_qs_int)
@@ -29049,6 +30241,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_4_qs_int)
@@ -29080,6 +30273,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_5_qs_int)
@@ -29111,6 +30305,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_6_qs_int)
@@ -29142,6 +30337,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_cnt_th[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_detector_cnt_th_7_qs_int)
@@ -29172,6 +30368,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_0_qs)
@@ -29202,6 +30399,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_1_qs)
@@ -29232,6 +30430,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_2_qs)
@@ -29262,6 +30461,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_3_qs)
@@ -29292,6 +30492,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_4_qs)
@@ -29322,6 +30523,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_5_qs)
@@ -29352,6 +30554,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_6_qs)
@@ -29382,6 +30585,7 @@ module pinmux_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wkup_detector_padsel[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wkup_detector_padsel_7_qs)
@@ -29390,6 +30594,8 @@ module pinmux_reg_top (
 
   // Subregister 0 of Multireg wkup_cause
   // R[wkup_cause]: V(False)
+  logic [7:0] wkup_cause_flds_we;
+  assign aon_wkup_cause_qe = |wkup_cause_flds_we;
   //   F[cause_0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -29408,8 +30614,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[0].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[0]),
     .q      (reg2hw.wkup_cause[0].q),
+    .ds     (aon_wkup_cause_cause_0_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_0_qs_int)
@@ -29433,8 +30640,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[1].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[1]),
     .q      (reg2hw.wkup_cause[1].q),
+    .ds     (aon_wkup_cause_cause_1_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_1_qs_int)
@@ -29458,8 +30666,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[2].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[2]),
     .q      (reg2hw.wkup_cause[2].q),
+    .ds     (aon_wkup_cause_cause_2_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_2_qs_int)
@@ -29483,8 +30692,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[3].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[3]),
     .q      (reg2hw.wkup_cause[3].q),
+    .ds     (aon_wkup_cause_cause_3_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_3_qs_int)
@@ -29508,8 +30718,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[4].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[4]),
     .q      (reg2hw.wkup_cause[4].q),
+    .ds     (aon_wkup_cause_cause_4_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_4_qs_int)
@@ -29533,8 +30744,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[5].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[5]),
     .q      (reg2hw.wkup_cause[5].q),
+    .ds     (aon_wkup_cause_cause_5_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_5_qs_int)
@@ -29558,8 +30770,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[6].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[6]),
     .q      (reg2hw.wkup_cause[6].q),
+    .ds     (aon_wkup_cause_cause_6_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_6_qs_int)
@@ -29583,8 +30796,9 @@ module pinmux_reg_top (
     .d      (hw2reg.wkup_cause[7].d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_cause_flds_we[7]),
     .q      (reg2hw.wkup_cause[7].q),
+    .ds     (aon_wkup_cause_cause_7_ds_int),
 
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_7_qs_int)

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -218,6 +218,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_qs)
@@ -244,6 +245,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_qs)
@@ -264,6 +266,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.qe = intr_test_qe;
@@ -283,6 +286,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
@@ -299,6 +303,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (ctrl_cfg_regwen_qs)
   );
 
@@ -327,6 +332,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.low_power_hint.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_low_power_hint_qs)
@@ -352,6 +358,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.core_clk_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_core_clk_en_qs)
@@ -377,6 +384,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.io_clk_en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_io_clk_en_qs)
@@ -402,6 +410,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.usb_clk_en_lp.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_usb_clk_en_lp_qs)
@@ -427,6 +436,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.usb_clk_en_active.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_usb_clk_en_active_qs)
@@ -452,6 +462,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.control.main_pd_n.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (control_main_pd_n_qs)
@@ -489,6 +500,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (cfg_cdc_sync_flds_we[0]),
     .q      (reg2hw.cfg_cdc_sync.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_cdc_sync_qs)
@@ -516,6 +528,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wakeup_en_regwen_qs)
@@ -547,6 +560,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wakeup_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wakeup_en_en_0_qs)
@@ -572,6 +586,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wakeup_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wakeup_en_en_1_qs)
@@ -597,6 +612,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wakeup_en[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wakeup_en_en_2_qs)
@@ -622,6 +638,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wakeup_en[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wakeup_en_en_3_qs)
@@ -647,6 +664,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wakeup_en[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wakeup_en_en_4_qs)
@@ -672,6 +690,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wakeup_en[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wakeup_en_en_5_qs)
@@ -700,6 +719,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wake_status_val_0_qs)
@@ -725,6 +745,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wake_status_val_1_qs)
@@ -750,6 +771,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wake_status_val_2_qs)
@@ -775,6 +797,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wake_status_val_3_qs)
@@ -800,6 +823,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wake_status_val_4_qs)
@@ -825,6 +849,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wake_status_val_5_qs)
@@ -851,6 +876,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_en_regwen_qs)
@@ -882,6 +908,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.reset_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_en_en_0_qs)
@@ -907,6 +934,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.reset_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_en_en_1_qs)
@@ -935,6 +963,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_status_val_0_qs)
@@ -960,6 +989,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_status_val_1_qs)
@@ -986,6 +1016,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (escalate_reset_status_qs)
@@ -1012,6 +1043,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.wake_info_capture_dis.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (wake_info_capture_dis_qs)
@@ -1033,6 +1065,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (wake_info_flds_we[0]),
     .q      (reg2hw.wake_info.reasons.q),
+    .ds     (),
     .qs     (wake_info_reasons_qs)
   );
   assign reg2hw.wake_info.reasons.qe = wake_info_qe;
@@ -1048,6 +1081,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (wake_info_flds_we[1]),
     .q      (reg2hw.wake_info.fall_through.q),
+    .ds     (),
     .qs     (wake_info_fall_through_qs)
   );
   assign reg2hw.wake_info.fall_through.qe = wake_info_qe;
@@ -1063,6 +1097,7 @@ module pwrmgr_reg_top (
     .qre    (),
     .qe     (wake_info_flds_we[2]),
     .q      (reg2hw.wake_info.abort.q),
+    .ds     (),
     .qs     (wake_info_abort_qs)
   );
   assign reg2hw.wake_info.abort.qe = wake_info_qe;
@@ -1089,6 +1124,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.reg_intg_err.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_reg_intg_err_qs)
@@ -1114,6 +1150,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.esc_timeout.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_esc_timeout_qs)
@@ -1139,6 +1176,7 @@ module pwrmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fault_status.main_pd_glitch.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fault_status_main_pd_glitch_qs)

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -226,6 +226,7 @@ module rstmgr_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal_fault.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault.qe = alert_test_qe;
@@ -241,6 +242,7 @@ module rstmgr_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_cnsty_fault.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_cnsty_fault.qe = alert_test_qe;
@@ -266,6 +268,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.reset_req.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_req_qs)
@@ -293,6 +296,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_info_por_qs)
@@ -318,6 +322,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_info_low_power_exit_qs)
@@ -343,6 +348,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_info_ndm_reset_qs)
@@ -368,6 +374,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.reset_info.sw_reset.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_info_sw_reset_qs)
@@ -393,6 +400,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.reset_info.hw_req.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (reset_info_hw_req_qs)
@@ -419,6 +427,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_qs)
@@ -449,6 +458,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_info_ctrl.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_info_ctrl_en_qs)
@@ -474,6 +484,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_info_ctrl.index.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_info_ctrl_index_qs)
@@ -491,6 +502,7 @@ module rstmgr_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_info_attr_qs)
   );
 
@@ -506,6 +518,7 @@ module rstmgr_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (alert_info_qs)
   );
 
@@ -530,6 +543,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cpu_regwen_qs)
@@ -560,6 +574,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cpu_info_ctrl.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cpu_info_ctrl_en_qs)
@@ -585,6 +600,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.cpu_info_ctrl.index.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cpu_info_ctrl_index_qs)
@@ -602,6 +618,7 @@ module rstmgr_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (cpu_info_attr_qs)
   );
 
@@ -617,6 +634,7 @@ module rstmgr_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (cpu_info_qs)
   );
 
@@ -642,6 +660,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_0_qs)
@@ -669,6 +688,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_1_qs)
@@ -696,6 +716,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_2_qs)
@@ -723,6 +744,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_3_qs)
@@ -750,6 +772,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_4_qs)
@@ -777,6 +800,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_5_qs)
@@ -804,6 +828,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_6_qs)
@@ -834,6 +859,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_ctrl_n_0_qs)
@@ -864,6 +890,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_ctrl_n_1_qs)
@@ -894,6 +921,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_ctrl_n_2_qs)
@@ -924,6 +952,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_ctrl_n_3_qs)
@@ -954,6 +983,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_ctrl_n_4_qs)
@@ -984,6 +1014,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_ctrl_n_5_qs)
@@ -1014,6 +1045,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_ctrl_n_6_qs)
@@ -1041,6 +1073,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_reg_intg_err_qs)
@@ -1066,6 +1099,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (err_code_reset_consistency_err_qs)

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -260,6 +260,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.io_status_change.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_io_status_change_qs)
@@ -285,6 +286,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.init_status_change.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_init_status_change_qs)
@@ -312,6 +314,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.io_status_change.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_io_status_change_qs)
@@ -337,6 +340,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.init_status_change.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_init_status_change_qs)
@@ -358,6 +362,7 @@ module sensor_ctrl_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.io_status_change.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.io_status_change.qe = intr_test_qe;
@@ -373,6 +378,7 @@ module sensor_ctrl_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.init_status_change.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.init_status_change.qe = intr_test_qe;
@@ -393,6 +399,7 @@ module sensor_ctrl_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_alert.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.recov_alert.qe = alert_test_qe;
@@ -408,6 +415,7 @@ module sensor_ctrl_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_alert.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
@@ -433,6 +441,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (cfg_regwen_qs)
@@ -461,6 +470,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_0_qs)
@@ -486,6 +496,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_1_qs)
@@ -511,6 +522,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_2_qs)
@@ -536,6 +548,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_3_qs)
@@ -561,6 +574,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_4_qs)
@@ -586,6 +600,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_5_qs)
@@ -611,6 +626,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_6_qs)
@@ -636,6 +652,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_7_qs)
@@ -661,6 +678,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_8_qs)
@@ -686,6 +704,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_9_qs)
@@ -711,6 +730,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_10_qs)
@@ -736,6 +756,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_11_qs)
@@ -761,6 +782,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_trig[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_trig_val_12_qs)
@@ -792,6 +814,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_0_qs)
@@ -817,6 +840,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_1_qs)
@@ -842,6 +866,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_2_qs)
@@ -867,6 +892,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_3_qs)
@@ -892,6 +918,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_4_qs)
@@ -917,6 +944,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_5_qs)
@@ -942,6 +970,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_6_qs)
@@ -967,6 +996,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_7_qs)
@@ -992,6 +1022,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_8_qs)
@@ -1017,6 +1048,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_9_qs)
@@ -1042,6 +1074,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_10_qs)
@@ -1067,6 +1100,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_11_qs)
@@ -1092,6 +1126,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert_en[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_en_val_12_qs)
@@ -1120,6 +1155,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_0_qs)
@@ -1145,6 +1181,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_1_qs)
@@ -1170,6 +1207,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_2_qs)
@@ -1195,6 +1233,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_3_qs)
@@ -1220,6 +1259,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_4_qs)
@@ -1245,6 +1285,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_5_qs)
@@ -1270,6 +1311,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_6_qs)
@@ -1295,6 +1337,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_7_qs)
@@ -1320,6 +1363,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_8_qs)
@@ -1345,6 +1389,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_9_qs)
@@ -1370,6 +1415,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_10_qs)
@@ -1395,6 +1441,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_11_qs)
@@ -1420,6 +1467,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.recov_alert[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (recov_alert_val_12_qs)
@@ -1448,6 +1496,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_0_qs)
@@ -1473,6 +1522,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_1_qs)
@@ -1498,6 +1548,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_2_qs)
@@ -1523,6 +1574,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_3_qs)
@@ -1548,6 +1600,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_4_qs)
@@ -1573,6 +1626,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_5_qs)
@@ -1598,6 +1652,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_6_qs)
@@ -1623,6 +1678,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_7_qs)
@@ -1648,6 +1704,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_8_qs)
@@ -1673,6 +1730,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_9_qs)
@@ -1698,6 +1756,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_10_qs)
@@ -1723,6 +1782,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_11_qs)
@@ -1748,6 +1808,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_12_qs)
@@ -1773,6 +1834,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.fatal_alert[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (fatal_alert_val_13_qs)
@@ -1800,6 +1862,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_ast_init_done_qs)
@@ -1825,6 +1888,7 @@ module sensor_ctrl_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (status_io_pok_qs)

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
@@ -1818,6 +1818,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.classa.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_classa_qs)
@@ -1843,6 +1844,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.classb.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_classb_qs)
@@ -1868,6 +1870,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.classc.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_classc_qs)
@@ -1893,6 +1896,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_state.classd.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_state_classd_qs)
@@ -1920,6 +1924,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.classa.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_classa_qs)
@@ -1945,6 +1950,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.classb.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_classb_qs)
@@ -1970,6 +1976,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.classc.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_classc_qs)
@@ -1995,6 +2002,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.intr_enable.classd.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (intr_enable_classd_qs)
@@ -2016,6 +2024,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.classa.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.classa.qe = intr_test_qe;
@@ -2031,6 +2040,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.classb.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.classb.qe = intr_test_qe;
@@ -2046,6 +2056,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.classc.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.classc.qe = intr_test_qe;
@@ -2061,6 +2072,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.classd.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.intr_test.classd.qe = intr_test_qe;
@@ -2086,6 +2098,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ping_timer_regwen_qs)
@@ -2117,6 +2130,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ping_timeout_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ping_timeout_cyc_shadowed_qs),
@@ -2155,6 +2169,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ping_timer_en_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ping_timer_en_shadowed_qs),
@@ -2189,6 +2204,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_0_qs)
@@ -2216,6 +2232,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_1_qs)
@@ -2243,6 +2260,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_2_qs)
@@ -2270,6 +2288,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_3_qs)
@@ -2297,6 +2316,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_4_qs)
@@ -2324,6 +2344,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_5_qs)
@@ -2351,6 +2372,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_6_qs)
@@ -2378,6 +2400,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_7_qs)
@@ -2405,6 +2428,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_8_qs)
@@ -2432,6 +2456,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_9_qs)
@@ -2459,6 +2484,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_10_qs)
@@ -2486,6 +2512,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_11_qs)
@@ -2513,6 +2540,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_12_qs)
@@ -2540,6 +2568,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_13_qs)
@@ -2567,6 +2596,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_14_qs)
@@ -2594,6 +2624,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_15_qs)
@@ -2621,6 +2652,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_16_qs)
@@ -2648,6 +2680,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_17_qs)
@@ -2675,6 +2708,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_18_qs)
@@ -2702,6 +2736,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_19_qs)
@@ -2729,6 +2764,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_20_qs)
@@ -2756,6 +2792,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_21_qs)
@@ -2783,6 +2820,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_22_qs)
@@ -2810,6 +2848,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_23_qs)
@@ -2837,6 +2876,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_24_qs)
@@ -2864,6 +2904,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_25_qs)
@@ -2891,6 +2932,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_26_qs)
@@ -2918,6 +2960,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_27_qs)
@@ -2945,6 +2988,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_28_qs)
@@ -2972,6 +3016,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_29_qs)
@@ -2999,6 +3044,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_30_qs)
@@ -3026,6 +3072,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_31_qs)
@@ -3053,6 +3100,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_32_qs)
@@ -3080,6 +3128,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_33_qs)
@@ -3107,6 +3156,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_34_qs)
@@ -3134,6 +3184,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_35_qs)
@@ -3161,6 +3212,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_36_qs)
@@ -3188,6 +3240,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_37_qs)
@@ -3215,6 +3268,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_38_qs)
@@ -3242,6 +3296,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_39_qs)
@@ -3269,6 +3324,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_40_qs)
@@ -3296,6 +3352,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_41_qs)
@@ -3323,6 +3380,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_42_qs)
@@ -3350,6 +3408,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_43_qs)
@@ -3377,6 +3436,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_44_qs)
@@ -3404,6 +3464,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_45_qs)
@@ -3431,6 +3492,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_46_qs)
@@ -3458,6 +3520,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[47].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_47_qs)
@@ -3485,6 +3548,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[48].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_48_qs)
@@ -3512,6 +3576,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[49].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_49_qs)
@@ -3539,6 +3604,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[50].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_50_qs)
@@ -3566,6 +3632,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[51].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_51_qs)
@@ -3593,6 +3660,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[52].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_52_qs)
@@ -3620,6 +3688,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[53].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_53_qs)
@@ -3647,6 +3716,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[54].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_54_qs)
@@ -3674,6 +3744,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[55].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_55_qs)
@@ -3701,6 +3772,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[56].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_56_qs)
@@ -3728,6 +3800,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[57].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_57_qs)
@@ -3755,6 +3828,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[58].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_58_qs)
@@ -3782,6 +3856,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[59].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_59_qs)
@@ -3809,6 +3884,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_regwen[60].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_regwen_60_qs)
@@ -3841,6 +3917,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_0_qs),
@@ -3880,6 +3957,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_1_qs),
@@ -3919,6 +3997,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_2_qs),
@@ -3958,6 +4037,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_3_qs),
@@ -3997,6 +4077,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_4_qs),
@@ -4036,6 +4117,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_5_qs),
@@ -4075,6 +4157,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_6_qs),
@@ -4114,6 +4197,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_7_qs),
@@ -4153,6 +4237,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_8_qs),
@@ -4192,6 +4277,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_9_qs),
@@ -4231,6 +4317,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_10_qs),
@@ -4270,6 +4357,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_11_qs),
@@ -4309,6 +4397,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_12_qs),
@@ -4348,6 +4437,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_13_qs),
@@ -4387,6 +4477,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_14_qs),
@@ -4426,6 +4517,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_15_qs),
@@ -4465,6 +4557,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_16_qs),
@@ -4504,6 +4597,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_17_qs),
@@ -4543,6 +4637,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_18_qs),
@@ -4582,6 +4677,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_19_qs),
@@ -4621,6 +4717,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_20_qs),
@@ -4660,6 +4757,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_21_qs),
@@ -4699,6 +4797,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_22_qs),
@@ -4738,6 +4837,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_23_qs),
@@ -4777,6 +4877,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_24_qs),
@@ -4816,6 +4917,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_25_qs),
@@ -4855,6 +4957,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_26_qs),
@@ -4894,6 +4997,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_27_qs),
@@ -4933,6 +5037,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_28_qs),
@@ -4972,6 +5077,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_29_qs),
@@ -5011,6 +5117,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_30_qs),
@@ -5050,6 +5157,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_31_qs),
@@ -5089,6 +5197,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_32_qs),
@@ -5128,6 +5237,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_33_qs),
@@ -5167,6 +5277,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_34_qs),
@@ -5206,6 +5317,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_35_qs),
@@ -5245,6 +5357,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_36_qs),
@@ -5284,6 +5397,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_37_qs),
@@ -5323,6 +5437,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_38_qs),
@@ -5362,6 +5477,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_39_qs),
@@ -5401,6 +5517,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_40_qs),
@@ -5440,6 +5557,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_41_qs),
@@ -5479,6 +5597,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_42_qs),
@@ -5518,6 +5637,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_43_qs),
@@ -5557,6 +5677,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_44_qs),
@@ -5596,6 +5717,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_45_qs),
@@ -5635,6 +5757,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_46_qs),
@@ -5674,6 +5797,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[47].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_47_qs),
@@ -5713,6 +5837,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[48].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_48_qs),
@@ -5752,6 +5877,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[49].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_49_qs),
@@ -5791,6 +5917,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[50].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_50_qs),
@@ -5830,6 +5957,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[51].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_51_qs),
@@ -5869,6 +5997,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[52].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_52_qs),
@@ -5908,6 +6037,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[53].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_53_qs),
@@ -5947,6 +6077,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[54].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_54_qs),
@@ -5986,6 +6117,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[55].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_55_qs),
@@ -6025,6 +6157,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[56].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_56_qs),
@@ -6064,6 +6197,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[57].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_57_qs),
@@ -6103,6 +6237,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[58].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_58_qs),
@@ -6142,6 +6277,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[59].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_59_qs),
@@ -6181,6 +6317,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_en_shadowed[60].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_en_shadowed_60_qs),
@@ -6220,6 +6357,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_0_qs),
@@ -6259,6 +6397,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_1_qs),
@@ -6298,6 +6437,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_2_qs),
@@ -6337,6 +6477,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_3_qs),
@@ -6376,6 +6517,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_4_qs),
@@ -6415,6 +6557,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_5_qs),
@@ -6454,6 +6597,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_6_qs),
@@ -6493,6 +6637,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_7_qs),
@@ -6532,6 +6677,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_8_qs),
@@ -6571,6 +6717,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_9_qs),
@@ -6610,6 +6757,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_10_qs),
@@ -6649,6 +6797,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_11_qs),
@@ -6688,6 +6837,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_12_qs),
@@ -6727,6 +6877,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_13_qs),
@@ -6766,6 +6917,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_14_qs),
@@ -6805,6 +6957,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_15_qs),
@@ -6844,6 +6997,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_16_qs),
@@ -6883,6 +7037,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_17_qs),
@@ -6922,6 +7077,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_18_qs),
@@ -6961,6 +7117,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_19_qs),
@@ -7000,6 +7157,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_20_qs),
@@ -7039,6 +7197,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_21_qs),
@@ -7078,6 +7237,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_22_qs),
@@ -7117,6 +7277,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_23_qs),
@@ -7156,6 +7317,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_24_qs),
@@ -7195,6 +7357,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_25_qs),
@@ -7234,6 +7397,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_26_qs),
@@ -7273,6 +7437,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_27_qs),
@@ -7312,6 +7477,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_28_qs),
@@ -7351,6 +7517,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_29_qs),
@@ -7390,6 +7557,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_30_qs),
@@ -7429,6 +7597,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_31_qs),
@@ -7468,6 +7637,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_32_qs),
@@ -7507,6 +7677,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_33_qs),
@@ -7546,6 +7717,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_34_qs),
@@ -7585,6 +7757,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_35_qs),
@@ -7624,6 +7797,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_36_qs),
@@ -7663,6 +7837,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_37_qs),
@@ -7702,6 +7877,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_38_qs),
@@ -7741,6 +7917,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_39_qs),
@@ -7780,6 +7957,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_40_qs),
@@ -7819,6 +7997,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_41_qs),
@@ -7858,6 +8037,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_42_qs),
@@ -7897,6 +8077,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_43_qs),
@@ -7936,6 +8117,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_44_qs),
@@ -7975,6 +8157,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_45_qs),
@@ -8014,6 +8197,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_46_qs),
@@ -8053,6 +8237,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[47].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_47_qs),
@@ -8092,6 +8277,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[48].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_48_qs),
@@ -8131,6 +8317,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[49].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_49_qs),
@@ -8170,6 +8357,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[50].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_50_qs),
@@ -8209,6 +8397,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[51].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_51_qs),
@@ -8248,6 +8437,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[52].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_52_qs),
@@ -8287,6 +8477,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[53].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_53_qs),
@@ -8326,6 +8517,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[54].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_54_qs),
@@ -8365,6 +8557,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[55].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_55_qs),
@@ -8404,6 +8597,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[56].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_56_qs),
@@ -8443,6 +8637,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[57].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_57_qs),
@@ -8482,6 +8677,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[58].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_58_qs),
@@ -8521,6 +8717,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[59].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_59_qs),
@@ -8560,6 +8757,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_class_shadowed[60].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_class_shadowed_60_qs),
@@ -8594,6 +8792,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_0_qs)
@@ -8621,6 +8820,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_1_qs)
@@ -8648,6 +8848,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_2_qs)
@@ -8675,6 +8876,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_3_qs)
@@ -8702,6 +8904,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_4_qs)
@@ -8729,6 +8932,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_5_qs)
@@ -8756,6 +8960,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_6_qs)
@@ -8783,6 +8988,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_7_qs)
@@ -8810,6 +9016,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_8_qs)
@@ -8837,6 +9044,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_9_qs)
@@ -8864,6 +9072,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_10_qs)
@@ -8891,6 +9100,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_11_qs)
@@ -8918,6 +9128,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_12_qs)
@@ -8945,6 +9156,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_13_qs)
@@ -8972,6 +9184,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_14_qs)
@@ -8999,6 +9212,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_15_qs)
@@ -9026,6 +9240,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_16_qs)
@@ -9053,6 +9268,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_17_qs)
@@ -9080,6 +9296,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_18_qs)
@@ -9107,6 +9324,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_19_qs)
@@ -9134,6 +9352,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_20_qs)
@@ -9161,6 +9380,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_21_qs)
@@ -9188,6 +9408,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_22_qs)
@@ -9215,6 +9436,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_23_qs)
@@ -9242,6 +9464,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_24_qs)
@@ -9269,6 +9492,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_25_qs)
@@ -9296,6 +9520,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_26_qs)
@@ -9323,6 +9548,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_27_qs)
@@ -9350,6 +9576,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_28_qs)
@@ -9377,6 +9604,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_29_qs)
@@ -9404,6 +9632,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_30_qs)
@@ -9431,6 +9660,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_31_qs)
@@ -9458,6 +9688,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_32_qs)
@@ -9485,6 +9716,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_33_qs)
@@ -9512,6 +9744,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_34_qs)
@@ -9539,6 +9772,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_35_qs)
@@ -9566,6 +9800,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_36_qs)
@@ -9593,6 +9828,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_37_qs)
@@ -9620,6 +9856,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_38_qs)
@@ -9647,6 +9884,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_39_qs)
@@ -9674,6 +9912,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_40_qs)
@@ -9701,6 +9940,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_41_qs)
@@ -9728,6 +9968,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_42_qs)
@@ -9755,6 +9996,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_43_qs)
@@ -9782,6 +10024,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_44_qs)
@@ -9809,6 +10052,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_45_qs)
@@ -9836,6 +10080,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_46_qs)
@@ -9863,6 +10108,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[47].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_47_qs)
@@ -9890,6 +10136,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[48].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_48_qs)
@@ -9917,6 +10164,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[49].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_49_qs)
@@ -9944,6 +10192,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[50].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_50_qs)
@@ -9971,6 +10220,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[51].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_51_qs)
@@ -9998,6 +10248,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[52].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_52_qs)
@@ -10025,6 +10276,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[53].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_53_qs)
@@ -10052,6 +10304,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[54].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_54_qs)
@@ -10079,6 +10332,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[55].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_55_qs)
@@ -10106,6 +10360,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[56].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_56_qs)
@@ -10133,6 +10388,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[57].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_57_qs)
@@ -10160,6 +10416,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[58].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_58_qs)
@@ -10187,6 +10444,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[59].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_59_qs)
@@ -10214,6 +10472,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.alert_cause[60].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (alert_cause_60_qs)
@@ -10241,6 +10500,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_regwen_0_qs)
@@ -10268,6 +10528,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_regwen_1_qs)
@@ -10295,6 +10556,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_regwen_2_qs)
@@ -10322,6 +10584,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_regwen_3_qs)
@@ -10349,6 +10612,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_regwen_4_qs)
@@ -10376,6 +10640,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_regwen_5_qs)
@@ -10403,6 +10668,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_regwen_6_qs)
@@ -10435,6 +10701,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_en_shadowed[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_0_qs),
@@ -10474,6 +10741,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_en_shadowed[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_1_qs),
@@ -10513,6 +10781,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_en_shadowed[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_2_qs),
@@ -10552,6 +10821,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_en_shadowed[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_3_qs),
@@ -10591,6 +10861,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_en_shadowed[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_4_qs),
@@ -10630,6 +10901,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_en_shadowed[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_5_qs),
@@ -10669,6 +10941,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_en_shadowed[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_6_qs),
@@ -10709,6 +10982,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_class_shadowed[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_0_qs),
@@ -10749,6 +11023,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_class_shadowed[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_1_qs),
@@ -10789,6 +11064,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_class_shadowed[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_2_qs),
@@ -10829,6 +11105,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_class_shadowed[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_3_qs),
@@ -10869,6 +11146,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_class_shadowed[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_4_qs),
@@ -10909,6 +11187,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_class_shadowed[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_5_qs),
@@ -10949,6 +11228,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_class_shadowed[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_6_qs),
@@ -10983,6 +11263,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_cause[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_cause_0_qs)
@@ -11010,6 +11291,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_cause[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_cause_1_qs)
@@ -11037,6 +11319,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_cause[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_cause_2_qs)
@@ -11064,6 +11347,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_cause[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_cause_3_qs)
@@ -11091,6 +11375,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_cause[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_cause_4_qs)
@@ -11118,6 +11403,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_cause[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_cause_5_qs)
@@ -11145,6 +11431,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.loc_alert_cause[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (loc_alert_cause_6_qs)
@@ -11171,6 +11458,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_regwen_qs)
@@ -11203,6 +11491,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_ctrl_shadowed.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_en_qs),
@@ -11237,6 +11526,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_ctrl_shadowed.lock.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_lock_qs),
@@ -11271,6 +11561,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_ctrl_shadowed.en_e0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_en_e0_qs),
@@ -11305,6 +11596,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_ctrl_shadowed.en_e1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_en_e1_qs),
@@ -11339,6 +11631,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_ctrl_shadowed.en_e2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_en_e2_qs),
@@ -11373,6 +11666,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_ctrl_shadowed.en_e3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_en_e3_qs),
@@ -11407,6 +11701,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_ctrl_shadowed.map_e0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_map_e0_qs),
@@ -11441,6 +11736,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_ctrl_shadowed.map_e1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_map_e1_qs),
@@ -11475,6 +11771,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_ctrl_shadowed.map_e2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_map_e2_qs),
@@ -11509,6 +11806,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_ctrl_shadowed.map_e3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_map_e3_qs),
@@ -11542,6 +11840,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_clr_regwen_qs)
@@ -11584,6 +11883,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (classa_clr_shadowed_flds_we[0]),
     .q      (reg2hw.classa_clr_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_clr_shadowed_qs),
@@ -11609,6 +11909,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classa_accum_cnt_qs)
   );
 
@@ -11638,6 +11939,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_accum_thresh_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_accum_thresh_shadowed_qs),
@@ -11676,6 +11978,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_timeout_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_timeout_cyc_shadowed_qs),
@@ -11715,6 +12018,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_crashdump_trigger_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_crashdump_trigger_shadowed_qs),
@@ -11753,6 +12057,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_phase0_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_phase0_cyc_shadowed_qs),
@@ -11791,6 +12096,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_phase1_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_phase1_cyc_shadowed_qs),
@@ -11829,6 +12135,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_phase2_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_phase2_cyc_shadowed_qs),
@@ -11867,6 +12174,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classa_phase3_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classa_phase3_cyc_shadowed_qs),
@@ -11891,6 +12199,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classa_esc_cnt_qs)
   );
 
@@ -11906,6 +12215,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classa_state_qs)
   );
 
@@ -11930,6 +12240,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_regwen_qs)
@@ -11962,6 +12273,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_ctrl_shadowed.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_en_qs),
@@ -11996,6 +12308,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_ctrl_shadowed.lock.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_lock_qs),
@@ -12030,6 +12343,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_ctrl_shadowed.en_e0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_en_e0_qs),
@@ -12064,6 +12378,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_ctrl_shadowed.en_e1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_en_e1_qs),
@@ -12098,6 +12413,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_ctrl_shadowed.en_e2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_en_e2_qs),
@@ -12132,6 +12448,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_ctrl_shadowed.en_e3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_en_e3_qs),
@@ -12166,6 +12483,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_ctrl_shadowed.map_e0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_map_e0_qs),
@@ -12200,6 +12518,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_ctrl_shadowed.map_e1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_map_e1_qs),
@@ -12234,6 +12553,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_ctrl_shadowed.map_e2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_map_e2_qs),
@@ -12268,6 +12588,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_ctrl_shadowed.map_e3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_map_e3_qs),
@@ -12301,6 +12622,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_clr_regwen_qs)
@@ -12343,6 +12665,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (classb_clr_shadowed_flds_we[0]),
     .q      (reg2hw.classb_clr_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_clr_shadowed_qs),
@@ -12368,6 +12691,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classb_accum_cnt_qs)
   );
 
@@ -12397,6 +12721,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_accum_thresh_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_accum_thresh_shadowed_qs),
@@ -12435,6 +12760,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_timeout_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_timeout_cyc_shadowed_qs),
@@ -12474,6 +12800,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_crashdump_trigger_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_crashdump_trigger_shadowed_qs),
@@ -12512,6 +12839,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_phase0_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_phase0_cyc_shadowed_qs),
@@ -12550,6 +12878,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_phase1_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_phase1_cyc_shadowed_qs),
@@ -12588,6 +12917,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_phase2_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_phase2_cyc_shadowed_qs),
@@ -12626,6 +12956,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classb_phase3_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classb_phase3_cyc_shadowed_qs),
@@ -12650,6 +12981,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classb_esc_cnt_qs)
   );
 
@@ -12665,6 +12997,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classb_state_qs)
   );
 
@@ -12689,6 +13022,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_regwen_qs)
@@ -12721,6 +13055,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_ctrl_shadowed.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_en_qs),
@@ -12755,6 +13090,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_ctrl_shadowed.lock.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_lock_qs),
@@ -12789,6 +13125,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_ctrl_shadowed.en_e0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_en_e0_qs),
@@ -12823,6 +13160,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_ctrl_shadowed.en_e1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_en_e1_qs),
@@ -12857,6 +13195,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_ctrl_shadowed.en_e2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_en_e2_qs),
@@ -12891,6 +13230,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_ctrl_shadowed.en_e3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_en_e3_qs),
@@ -12925,6 +13265,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_ctrl_shadowed.map_e0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_map_e0_qs),
@@ -12959,6 +13300,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_ctrl_shadowed.map_e1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_map_e1_qs),
@@ -12993,6 +13335,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_ctrl_shadowed.map_e2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_map_e2_qs),
@@ -13027,6 +13370,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_ctrl_shadowed.map_e3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_map_e3_qs),
@@ -13060,6 +13404,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_clr_regwen_qs)
@@ -13102,6 +13447,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (classc_clr_shadowed_flds_we[0]),
     .q      (reg2hw.classc_clr_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_clr_shadowed_qs),
@@ -13127,6 +13473,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classc_accum_cnt_qs)
   );
 
@@ -13156,6 +13503,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_accum_thresh_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_accum_thresh_shadowed_qs),
@@ -13194,6 +13542,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_timeout_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_timeout_cyc_shadowed_qs),
@@ -13233,6 +13582,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_crashdump_trigger_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_crashdump_trigger_shadowed_qs),
@@ -13271,6 +13621,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_phase0_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_phase0_cyc_shadowed_qs),
@@ -13309,6 +13660,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_phase1_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_phase1_cyc_shadowed_qs),
@@ -13347,6 +13699,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_phase2_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_phase2_cyc_shadowed_qs),
@@ -13385,6 +13738,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classc_phase3_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classc_phase3_cyc_shadowed_qs),
@@ -13409,6 +13763,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classc_esc_cnt_qs)
   );
 
@@ -13424,6 +13779,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classc_state_qs)
   );
 
@@ -13448,6 +13804,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_regwen_qs)
@@ -13480,6 +13837,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_ctrl_shadowed.en.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_en_qs),
@@ -13514,6 +13872,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_ctrl_shadowed.lock.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_lock_qs),
@@ -13548,6 +13907,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_ctrl_shadowed.en_e0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_en_e0_qs),
@@ -13582,6 +13942,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_ctrl_shadowed.en_e1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_en_e1_qs),
@@ -13616,6 +13977,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_ctrl_shadowed.en_e2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_en_e2_qs),
@@ -13650,6 +14012,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_ctrl_shadowed.en_e3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_en_e3_qs),
@@ -13684,6 +14047,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_ctrl_shadowed.map_e0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_map_e0_qs),
@@ -13718,6 +14082,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_ctrl_shadowed.map_e1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_map_e1_qs),
@@ -13752,6 +14117,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_ctrl_shadowed.map_e2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_map_e2_qs),
@@ -13786,6 +14152,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_ctrl_shadowed.map_e3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_map_e3_qs),
@@ -13819,6 +14186,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_clr_regwen_qs)
@@ -13861,6 +14229,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (classd_clr_shadowed_flds_we[0]),
     .q      (reg2hw.classd_clr_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_clr_shadowed_qs),
@@ -13886,6 +14255,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classd_accum_cnt_qs)
   );
 
@@ -13915,6 +14285,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_accum_thresh_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_accum_thresh_shadowed_qs),
@@ -13953,6 +14324,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_timeout_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_timeout_cyc_shadowed_qs),
@@ -13992,6 +14364,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_crashdump_trigger_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_crashdump_trigger_shadowed_qs),
@@ -14030,6 +14403,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_phase0_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_phase0_cyc_shadowed_qs),
@@ -14068,6 +14442,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_phase1_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_phase1_cyc_shadowed_qs),
@@ -14106,6 +14481,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_phase2_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_phase2_cyc_shadowed_qs),
@@ -14144,6 +14520,7 @@ module alert_handler_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.classd_phase3_cyc_shadowed.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (classd_phase3_cyc_shadowed_qs),
@@ -14168,6 +14545,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classd_esc_cnt_qs)
   );
 
@@ -14183,6 +14561,7 @@ module alert_handler_reg_top (
     .qre    (),
     .qe     (),
     .q      (),
+    .ds     (),
     .qs     (classd_state_qs)
   );
 

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -1289,6 +1289,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio0_qs)
@@ -1315,6 +1316,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio1.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio1_qs)
@@ -1341,6 +1343,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio2.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio2_qs)
@@ -1367,6 +1370,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio3.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio3_qs)
@@ -1393,6 +1397,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio4.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio4_qs)
@@ -1419,6 +1424,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio5.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio5_qs)
@@ -1445,6 +1451,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio6.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio6_qs)
@@ -1471,6 +1478,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio7.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio7_qs)
@@ -1497,6 +1505,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio8.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio8_qs)
@@ -1523,6 +1532,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio9.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio9_qs)
@@ -1549,6 +1559,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio10.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio10_qs)
@@ -1575,6 +1586,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio11.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio11_qs)
@@ -1601,6 +1613,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio12.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio12_qs)
@@ -1627,6 +1640,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio13.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio13_qs)
@@ -1653,6 +1667,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio14.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio14_qs)
@@ -1679,6 +1694,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio15.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio15_qs)
@@ -1705,6 +1721,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio16.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio16_qs)
@@ -1731,6 +1748,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio17.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio17_qs)
@@ -1757,6 +1775,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio18.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio18_qs)
@@ -1783,6 +1802,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio19.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio19_qs)
@@ -1809,6 +1829,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio20.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio20_qs)
@@ -1835,6 +1856,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio21.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio21_qs)
@@ -1861,6 +1883,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio22.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio22_qs)
@@ -1887,6 +1910,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio23.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio23_qs)
@@ -1913,6 +1937,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio24.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio24_qs)
@@ -1939,6 +1964,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio25.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio25_qs)
@@ -1965,6 +1991,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio26.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio26_qs)
@@ -1991,6 +2018,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio27.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio27_qs)
@@ -2017,6 +2045,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio28.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio28_qs)
@@ -2043,6 +2072,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio29.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio29_qs)
@@ -2069,6 +2099,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio30.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio30_qs)
@@ -2095,6 +2126,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio31.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio31_qs)
@@ -2121,6 +2153,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio32.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio32_qs)
@@ -2147,6 +2180,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio33.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio33_qs)
@@ -2173,6 +2207,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio34.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio34_qs)
@@ -2199,6 +2234,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio35.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio35_qs)
@@ -2225,6 +2261,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio36.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio36_qs)
@@ -2251,6 +2288,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio37.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio37_qs)
@@ -2277,6 +2315,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio38.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio38_qs)
@@ -2303,6 +2342,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio39.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio39_qs)
@@ -2329,6 +2369,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio40.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio40_qs)
@@ -2355,6 +2396,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio41.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio41_qs)
@@ -2381,6 +2423,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio42.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio42_qs)
@@ -2407,6 +2450,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio43.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio43_qs)
@@ -2433,6 +2477,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio44.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio44_qs)
@@ -2459,6 +2504,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio45.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio45_qs)
@@ -2485,6 +2531,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio46.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio46_qs)
@@ -2511,6 +2558,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio47.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio47_qs)
@@ -2537,6 +2585,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio48.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio48_qs)
@@ -2563,6 +2612,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio49.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio49_qs)
@@ -2589,6 +2639,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio50.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio50_qs)
@@ -2615,6 +2666,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio51.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio51_qs)
@@ -2641,6 +2693,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio52.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio52_qs)
@@ -2667,6 +2720,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio53.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio53_qs)
@@ -2693,6 +2747,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio54.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio54_qs)
@@ -2719,6 +2774,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio55.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio55_qs)
@@ -2745,6 +2801,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio56.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio56_qs)
@@ -2771,6 +2828,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio57.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio57_qs)
@@ -2797,6 +2855,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio58.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio58_qs)
@@ -2823,6 +2882,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio59.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio59_qs)
@@ -2849,6 +2909,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio60.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio60_qs)
@@ -2875,6 +2936,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio61.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio61_qs)
@@ -2901,6 +2963,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio62.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio62_qs)
@@ -2927,6 +2990,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio63.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio63_qs)
@@ -2953,6 +3017,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio64.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio64_qs)
@@ -2979,6 +3044,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio65.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio65_qs)
@@ -3005,6 +3071,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio66.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio66_qs)
@@ -3031,6 +3098,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio67.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio67_qs)
@@ -3057,6 +3125,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio68.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio68_qs)
@@ -3083,6 +3152,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio69.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio69_qs)
@@ -3109,6 +3179,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio70.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio70_qs)
@@ -3135,6 +3206,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio71.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio71_qs)
@@ -3161,6 +3233,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio72.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio72_qs)
@@ -3187,6 +3260,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio73.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio73_qs)
@@ -3213,6 +3287,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio74.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio74_qs)
@@ -3239,6 +3314,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio75.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio75_qs)
@@ -3265,6 +3341,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio76.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio76_qs)
@@ -3291,6 +3368,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio77.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio77_qs)
@@ -3317,6 +3395,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio78.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio78_qs)
@@ -3343,6 +3422,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio79.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio79_qs)
@@ -3369,6 +3449,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio80.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio80_qs)
@@ -3395,6 +3476,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio81.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio81_qs)
@@ -3421,6 +3503,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio82.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio82_qs)
@@ -3447,6 +3530,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio83.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio83_qs)
@@ -3473,6 +3557,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio84.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio84_qs)
@@ -3499,6 +3584,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio85.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio85_qs)
@@ -3525,6 +3611,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio86.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio86_qs)
@@ -3551,6 +3638,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio87.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio87_qs)
@@ -3577,6 +3665,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio88.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio88_qs)
@@ -3603,6 +3692,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio89.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio89_qs)
@@ -3629,6 +3719,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio90.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio90_qs)
@@ -3655,6 +3746,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio91.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio91_qs)
@@ -3681,6 +3773,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio92.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio92_qs)
@@ -3707,6 +3800,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio93.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio93_qs)
@@ -3733,6 +3827,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio94.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio94_qs)
@@ -3759,6 +3854,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio95.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio95_qs)
@@ -3785,6 +3881,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio96.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio96_qs)
@@ -3811,6 +3908,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio97.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio97_qs)
@@ -3837,6 +3935,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio98.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio98_qs)
@@ -3863,6 +3962,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio99.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio99_qs)
@@ -3889,6 +3989,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio100.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio100_qs)
@@ -3915,6 +4016,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio101.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio101_qs)
@@ -3941,6 +4043,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio102.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio102_qs)
@@ -3967,6 +4070,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio103.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio103_qs)
@@ -3993,6 +4097,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio104.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio104_qs)
@@ -4019,6 +4124,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio105.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio105_qs)
@@ -4045,6 +4151,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio106.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio106_qs)
@@ -4071,6 +4178,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio107.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio107_qs)
@@ -4097,6 +4205,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio108.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio108_qs)
@@ -4123,6 +4232,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio109.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio109_qs)
@@ -4149,6 +4259,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio110.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio110_qs)
@@ -4175,6 +4286,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio111.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio111_qs)
@@ -4201,6 +4313,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio112.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio112_qs)
@@ -4227,6 +4340,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio113.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio113_qs)
@@ -4253,6 +4367,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio114.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio114_qs)
@@ -4279,6 +4394,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio115.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio115_qs)
@@ -4305,6 +4421,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio116.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio116_qs)
@@ -4331,6 +4448,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio117.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio117_qs)
@@ -4357,6 +4475,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio118.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio118_qs)
@@ -4383,6 +4502,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio119.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio119_qs)
@@ -4409,6 +4529,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio120.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio120_qs)
@@ -4435,6 +4556,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio121.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio121_qs)
@@ -4461,6 +4583,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio122.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio122_qs)
@@ -4487,6 +4610,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio123.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio123_qs)
@@ -4513,6 +4637,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio124.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio124_qs)
@@ -4539,6 +4664,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio125.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio125_qs)
@@ -4565,6 +4691,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio126.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio126_qs)
@@ -4591,6 +4718,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio127.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio127_qs)
@@ -4617,6 +4745,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio128.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio128_qs)
@@ -4643,6 +4772,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio129.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio129_qs)
@@ -4669,6 +4799,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio130.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio130_qs)
@@ -4695,6 +4826,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio131.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio131_qs)
@@ -4721,6 +4853,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio132.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio132_qs)
@@ -4747,6 +4880,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio133.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio133_qs)
@@ -4773,6 +4907,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio134.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio134_qs)
@@ -4799,6 +4934,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio135.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio135_qs)
@@ -4825,6 +4961,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio136.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio136_qs)
@@ -4851,6 +4988,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio137.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio137_qs)
@@ -4877,6 +5015,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio138.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio138_qs)
@@ -4903,6 +5042,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio139.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio139_qs)
@@ -4929,6 +5069,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio140.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio140_qs)
@@ -4955,6 +5096,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio141.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio141_qs)
@@ -4981,6 +5123,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio142.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio142_qs)
@@ -5007,6 +5150,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio143.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio143_qs)
@@ -5033,6 +5177,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio144.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio144_qs)
@@ -5059,6 +5204,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio145.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio145_qs)
@@ -5085,6 +5231,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio146.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio146_qs)
@@ -5111,6 +5258,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio147.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio147_qs)
@@ -5137,6 +5285,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio148.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio148_qs)
@@ -5163,6 +5312,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio149.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio149_qs)
@@ -5189,6 +5339,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio150.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio150_qs)
@@ -5215,6 +5366,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio151.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio151_qs)
@@ -5241,6 +5393,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio152.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio152_qs)
@@ -5267,6 +5420,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio153.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio153_qs)
@@ -5293,6 +5447,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio154.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio154_qs)
@@ -5319,6 +5474,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio155.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio155_qs)
@@ -5345,6 +5501,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio156.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio156_qs)
@@ -5371,6 +5528,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio157.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio157_qs)
@@ -5397,6 +5555,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio158.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio158_qs)
@@ -5423,6 +5582,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio159.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio159_qs)
@@ -5449,6 +5609,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio160.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio160_qs)
@@ -5475,6 +5636,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio161.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio161_qs)
@@ -5501,6 +5663,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio162.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio162_qs)
@@ -5527,6 +5690,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio163.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio163_qs)
@@ -5553,6 +5717,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio164.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio164_qs)
@@ -5579,6 +5744,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio165.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio165_qs)
@@ -5605,6 +5771,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio166.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio166_qs)
@@ -5631,6 +5798,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio167.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio167_qs)
@@ -5657,6 +5825,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio168.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio168_qs)
@@ -5683,6 +5852,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio169.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio169_qs)
@@ -5709,6 +5879,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio170.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio170_qs)
@@ -5735,6 +5906,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio171.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio171_qs)
@@ -5761,6 +5933,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio172.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio172_qs)
@@ -5787,6 +5960,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio173.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio173_qs)
@@ -5813,6 +5987,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio174.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio174_qs)
@@ -5839,6 +6014,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio175.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio175_qs)
@@ -5865,6 +6041,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio176.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio176_qs)
@@ -5891,6 +6068,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio177.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio177_qs)
@@ -5917,6 +6095,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio178.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio178_qs)
@@ -5943,6 +6122,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio179.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio179_qs)
@@ -5969,6 +6149,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio180.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio180_qs)
@@ -5995,6 +6176,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio181.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio181_qs)
@@ -6021,6 +6203,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio182.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio182_qs)
@@ -6047,6 +6230,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio183.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio183_qs)
@@ -6073,6 +6257,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio184.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio184_qs)
@@ -6099,6 +6284,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio185.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio185_qs)
@@ -6125,6 +6311,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio186.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio186_qs)
@@ -6151,6 +6338,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.prio187.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (prio187_qs)
@@ -6179,6 +6367,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_0_qs)
@@ -6204,6 +6393,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_1_qs)
@@ -6229,6 +6419,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_2_qs)
@@ -6254,6 +6445,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_3_qs)
@@ -6279,6 +6471,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_4_qs)
@@ -6304,6 +6497,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_5_qs)
@@ -6329,6 +6523,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_6_qs)
@@ -6354,6 +6549,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_7_qs)
@@ -6379,6 +6575,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_8_qs)
@@ -6404,6 +6601,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_9_qs)
@@ -6429,6 +6627,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_10_qs)
@@ -6454,6 +6653,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_11_qs)
@@ -6479,6 +6679,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_12_qs)
@@ -6504,6 +6705,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_13_qs)
@@ -6529,6 +6731,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_14_qs)
@@ -6554,6 +6757,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_15_qs)
@@ -6579,6 +6783,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_16_qs)
@@ -6604,6 +6809,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_17_qs)
@@ -6629,6 +6835,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_18_qs)
@@ -6654,6 +6861,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_19_qs)
@@ -6679,6 +6887,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_20_qs)
@@ -6704,6 +6913,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_21_qs)
@@ -6729,6 +6939,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_22_qs)
@@ -6754,6 +6965,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_23_qs)
@@ -6779,6 +6991,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_24_qs)
@@ -6804,6 +7017,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_25_qs)
@@ -6829,6 +7043,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_26_qs)
@@ -6854,6 +7069,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_27_qs)
@@ -6879,6 +7095,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_28_qs)
@@ -6904,6 +7121,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_29_qs)
@@ -6929,6 +7147,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_30_qs)
@@ -6954,6 +7173,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_0_p_31_qs)
@@ -6982,6 +7202,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_32_qs)
@@ -7007,6 +7228,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_33_qs)
@@ -7032,6 +7254,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_34_qs)
@@ -7057,6 +7280,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_35_qs)
@@ -7082,6 +7306,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_36_qs)
@@ -7107,6 +7332,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_37_qs)
@@ -7132,6 +7358,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_38_qs)
@@ -7157,6 +7384,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_39_qs)
@@ -7182,6 +7410,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_40_qs)
@@ -7207,6 +7436,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_41_qs)
@@ -7232,6 +7462,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_42_qs)
@@ -7257,6 +7488,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_43_qs)
@@ -7282,6 +7514,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_44_qs)
@@ -7307,6 +7540,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_45_qs)
@@ -7332,6 +7566,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_46_qs)
@@ -7357,6 +7592,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_47_qs)
@@ -7382,6 +7618,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_48_qs)
@@ -7407,6 +7644,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_49_qs)
@@ -7432,6 +7670,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_50_qs)
@@ -7457,6 +7696,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_51_qs)
@@ -7482,6 +7722,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_52_qs)
@@ -7507,6 +7748,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_53_qs)
@@ -7532,6 +7774,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_54_qs)
@@ -7557,6 +7800,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_55_qs)
@@ -7582,6 +7826,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_56_qs)
@@ -7607,6 +7852,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_57_qs)
@@ -7632,6 +7878,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_58_qs)
@@ -7657,6 +7904,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_59_qs)
@@ -7682,6 +7930,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_60_qs)
@@ -7707,6 +7956,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_61_qs)
@@ -7732,6 +7982,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_62_qs)
@@ -7757,6 +8008,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_1_p_63_qs)
@@ -7785,6 +8037,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_64_qs)
@@ -7810,6 +8063,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_65_qs)
@@ -7835,6 +8089,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_66_qs)
@@ -7860,6 +8115,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_67_qs)
@@ -7885,6 +8141,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_68_qs)
@@ -7910,6 +8167,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_69_qs)
@@ -7935,6 +8193,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_70_qs)
@@ -7960,6 +8219,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_71_qs)
@@ -7985,6 +8245,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_72_qs)
@@ -8010,6 +8271,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_73_qs)
@@ -8035,6 +8297,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_74_qs)
@@ -8060,6 +8323,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_75_qs)
@@ -8085,6 +8349,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_76_qs)
@@ -8110,6 +8375,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_77_qs)
@@ -8135,6 +8401,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_78_qs)
@@ -8160,6 +8427,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_79_qs)
@@ -8185,6 +8453,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_80_qs)
@@ -8210,6 +8479,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_81_qs)
@@ -8235,6 +8505,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_82_qs)
@@ -8260,6 +8531,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_83_qs)
@@ -8285,6 +8557,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_84_qs)
@@ -8310,6 +8583,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_85_qs)
@@ -8335,6 +8609,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_86_qs)
@@ -8360,6 +8635,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_87_qs)
@@ -8385,6 +8661,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_88_qs)
@@ -8410,6 +8687,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_89_qs)
@@ -8435,6 +8713,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_90_qs)
@@ -8460,6 +8739,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_91_qs)
@@ -8485,6 +8765,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_92_qs)
@@ -8510,6 +8791,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_93_qs)
@@ -8535,6 +8817,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_94_qs)
@@ -8560,6 +8843,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_2_p_95_qs)
@@ -8588,6 +8872,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_96_qs)
@@ -8613,6 +8898,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_97_qs)
@@ -8638,6 +8924,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_98_qs)
@@ -8663,6 +8950,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_99_qs)
@@ -8688,6 +8976,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_100_qs)
@@ -8713,6 +9002,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_101_qs)
@@ -8738,6 +9028,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_102_qs)
@@ -8763,6 +9054,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_103_qs)
@@ -8788,6 +9080,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_104_qs)
@@ -8813,6 +9106,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_105_qs)
@@ -8838,6 +9132,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_106_qs)
@@ -8863,6 +9158,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_107_qs)
@@ -8888,6 +9184,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_108_qs)
@@ -8913,6 +9210,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_109_qs)
@@ -8938,6 +9236,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_110_qs)
@@ -8963,6 +9262,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_111_qs)
@@ -8988,6 +9288,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_112_qs)
@@ -9013,6 +9314,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_113_qs)
@@ -9038,6 +9340,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_114_qs)
@@ -9063,6 +9366,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_115_qs)
@@ -9088,6 +9392,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_116_qs)
@@ -9113,6 +9418,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_117_qs)
@@ -9138,6 +9444,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_118_qs)
@@ -9163,6 +9470,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_119_qs)
@@ -9188,6 +9496,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_120_qs)
@@ -9213,6 +9522,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_121_qs)
@@ -9238,6 +9548,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_122_qs)
@@ -9263,6 +9574,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_123_qs)
@@ -9288,6 +9600,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_124_qs)
@@ -9313,6 +9626,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_125_qs)
@@ -9338,6 +9652,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_126_qs)
@@ -9363,6 +9678,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_3_p_127_qs)
@@ -9391,6 +9707,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_128_qs)
@@ -9416,6 +9733,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_129_qs)
@@ -9441,6 +9759,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_130_qs)
@@ -9466,6 +9785,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_131_qs)
@@ -9491,6 +9811,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_132_qs)
@@ -9516,6 +9837,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_133_qs)
@@ -9541,6 +9863,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_134_qs)
@@ -9566,6 +9889,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_135_qs)
@@ -9591,6 +9915,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_136_qs)
@@ -9616,6 +9941,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_137_qs)
@@ -9641,6 +9967,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_138_qs)
@@ -9666,6 +9993,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_139_qs)
@@ -9691,6 +10019,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_140_qs)
@@ -9716,6 +10045,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_141_qs)
@@ -9741,6 +10071,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_142_qs)
@@ -9766,6 +10097,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_143_qs)
@@ -9791,6 +10123,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_144_qs)
@@ -9816,6 +10149,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_145_qs)
@@ -9841,6 +10175,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_146_qs)
@@ -9866,6 +10201,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_147_qs)
@@ -9891,6 +10227,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_148_qs)
@@ -9916,6 +10253,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_149_qs)
@@ -9941,6 +10279,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_150_qs)
@@ -9966,6 +10305,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_151_qs)
@@ -9991,6 +10331,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_152_qs)
@@ -10016,6 +10357,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_153_qs)
@@ -10041,6 +10383,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_154_qs)
@@ -10066,6 +10409,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_155_qs)
@@ -10091,6 +10435,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_156_qs)
@@ -10116,6 +10461,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_157_qs)
@@ -10141,6 +10487,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_158_qs)
@@ -10166,6 +10513,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_4_p_159_qs)
@@ -10194,6 +10542,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_160_qs)
@@ -10219,6 +10568,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_161_qs)
@@ -10244,6 +10594,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_162_qs)
@@ -10269,6 +10620,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_163_qs)
@@ -10294,6 +10646,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_164_qs)
@@ -10319,6 +10672,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_165_qs)
@@ -10344,6 +10698,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_166_qs)
@@ -10369,6 +10724,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_167_qs)
@@ -10394,6 +10750,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_168_qs)
@@ -10419,6 +10776,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_169_qs)
@@ -10444,6 +10802,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_170_qs)
@@ -10469,6 +10828,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_171_qs)
@@ -10494,6 +10854,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_172_qs)
@@ -10519,6 +10880,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_173_qs)
@@ -10544,6 +10906,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_174_qs)
@@ -10569,6 +10932,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_175_qs)
@@ -10594,6 +10958,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_176_qs)
@@ -10619,6 +10984,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_177_qs)
@@ -10644,6 +11010,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_178_qs)
@@ -10669,6 +11036,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_179_qs)
@@ -10694,6 +11062,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_180_qs)
@@ -10719,6 +11088,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_181_qs)
@@ -10744,6 +11114,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_182_qs)
@@ -10769,6 +11140,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_183_qs)
@@ -10794,6 +11166,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_184_qs)
@@ -10819,6 +11192,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_185_qs)
@@ -10844,6 +11218,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_186_qs)
@@ -10869,6 +11244,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ip_5_p_187_qs)
@@ -10897,6 +11273,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[0].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_0_qs)
@@ -10922,6 +11299,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[1].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_1_qs)
@@ -10947,6 +11325,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[2].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_2_qs)
@@ -10972,6 +11351,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[3].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_3_qs)
@@ -10997,6 +11377,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[4].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_4_qs)
@@ -11022,6 +11403,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[5].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_5_qs)
@@ -11047,6 +11429,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[6].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_6_qs)
@@ -11072,6 +11455,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_7_qs)
@@ -11097,6 +11481,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[8].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_8_qs)
@@ -11122,6 +11507,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[9].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_9_qs)
@@ -11147,6 +11533,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[10].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_10_qs)
@@ -11172,6 +11559,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[11].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_11_qs)
@@ -11197,6 +11585,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[12].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_12_qs)
@@ -11222,6 +11611,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[13].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_13_qs)
@@ -11247,6 +11637,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[14].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_14_qs)
@@ -11272,6 +11663,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[15].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_15_qs)
@@ -11297,6 +11689,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[16].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_16_qs)
@@ -11322,6 +11715,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[17].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_17_qs)
@@ -11347,6 +11741,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[18].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_18_qs)
@@ -11372,6 +11767,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[19].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_19_qs)
@@ -11397,6 +11793,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[20].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_20_qs)
@@ -11422,6 +11819,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[21].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_21_qs)
@@ -11447,6 +11845,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[22].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_22_qs)
@@ -11472,6 +11871,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[23].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_23_qs)
@@ -11497,6 +11897,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[24].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_24_qs)
@@ -11522,6 +11923,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[25].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_25_qs)
@@ -11547,6 +11949,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[26].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_26_qs)
@@ -11572,6 +11975,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[27].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_27_qs)
@@ -11597,6 +12001,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[28].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_28_qs)
@@ -11622,6 +12027,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[29].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_29_qs)
@@ -11647,6 +12053,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[30].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_30_qs)
@@ -11672,6 +12079,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[31].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_0_e_31_qs)
@@ -11700,6 +12108,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[32].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_32_qs)
@@ -11725,6 +12134,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[33].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_33_qs)
@@ -11750,6 +12160,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[34].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_34_qs)
@@ -11775,6 +12186,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[35].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_35_qs)
@@ -11800,6 +12212,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[36].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_36_qs)
@@ -11825,6 +12238,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[37].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_37_qs)
@@ -11850,6 +12264,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[38].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_38_qs)
@@ -11875,6 +12290,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[39].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_39_qs)
@@ -11900,6 +12316,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[40].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_40_qs)
@@ -11925,6 +12342,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[41].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_41_qs)
@@ -11950,6 +12368,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[42].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_42_qs)
@@ -11975,6 +12394,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[43].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_43_qs)
@@ -12000,6 +12420,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[44].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_44_qs)
@@ -12025,6 +12446,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[45].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_45_qs)
@@ -12050,6 +12472,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[46].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_46_qs)
@@ -12075,6 +12498,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[47].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_47_qs)
@@ -12100,6 +12524,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[48].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_48_qs)
@@ -12125,6 +12550,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[49].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_49_qs)
@@ -12150,6 +12576,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[50].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_50_qs)
@@ -12175,6 +12602,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[51].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_51_qs)
@@ -12200,6 +12628,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[52].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_52_qs)
@@ -12225,6 +12654,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[53].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_53_qs)
@@ -12250,6 +12680,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[54].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_54_qs)
@@ -12275,6 +12706,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[55].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_55_qs)
@@ -12300,6 +12732,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[56].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_56_qs)
@@ -12325,6 +12758,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[57].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_57_qs)
@@ -12350,6 +12784,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[58].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_58_qs)
@@ -12375,6 +12810,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[59].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_59_qs)
@@ -12400,6 +12836,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[60].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_60_qs)
@@ -12425,6 +12862,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[61].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_61_qs)
@@ -12450,6 +12888,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[62].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_62_qs)
@@ -12475,6 +12914,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[63].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_1_e_63_qs)
@@ -12503,6 +12943,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[64].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_64_qs)
@@ -12528,6 +12969,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[65].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_65_qs)
@@ -12553,6 +12995,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[66].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_66_qs)
@@ -12578,6 +13021,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[67].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_67_qs)
@@ -12603,6 +13047,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[68].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_68_qs)
@@ -12628,6 +13073,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[69].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_69_qs)
@@ -12653,6 +13099,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[70].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_70_qs)
@@ -12678,6 +13125,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[71].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_71_qs)
@@ -12703,6 +13151,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[72].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_72_qs)
@@ -12728,6 +13177,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[73].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_73_qs)
@@ -12753,6 +13203,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[74].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_74_qs)
@@ -12778,6 +13229,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[75].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_75_qs)
@@ -12803,6 +13255,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[76].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_76_qs)
@@ -12828,6 +13281,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[77].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_77_qs)
@@ -12853,6 +13307,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[78].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_78_qs)
@@ -12878,6 +13333,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[79].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_79_qs)
@@ -12903,6 +13359,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[80].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_80_qs)
@@ -12928,6 +13385,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[81].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_81_qs)
@@ -12953,6 +13411,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[82].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_82_qs)
@@ -12978,6 +13437,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[83].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_83_qs)
@@ -13003,6 +13463,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[84].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_84_qs)
@@ -13028,6 +13489,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[85].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_85_qs)
@@ -13053,6 +13515,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[86].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_86_qs)
@@ -13078,6 +13541,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[87].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_87_qs)
@@ -13103,6 +13567,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[88].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_88_qs)
@@ -13128,6 +13593,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[89].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_89_qs)
@@ -13153,6 +13619,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[90].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_90_qs)
@@ -13178,6 +13645,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[91].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_91_qs)
@@ -13203,6 +13671,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[92].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_92_qs)
@@ -13228,6 +13697,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[93].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_93_qs)
@@ -13253,6 +13723,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[94].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_94_qs)
@@ -13278,6 +13749,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[95].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_2_e_95_qs)
@@ -13306,6 +13778,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[96].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_96_qs)
@@ -13331,6 +13804,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[97].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_97_qs)
@@ -13356,6 +13830,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[98].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_98_qs)
@@ -13381,6 +13856,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[99].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_99_qs)
@@ -13406,6 +13882,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[100].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_100_qs)
@@ -13431,6 +13908,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[101].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_101_qs)
@@ -13456,6 +13934,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[102].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_102_qs)
@@ -13481,6 +13960,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[103].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_103_qs)
@@ -13506,6 +13986,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[104].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_104_qs)
@@ -13531,6 +14012,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[105].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_105_qs)
@@ -13556,6 +14038,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[106].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_106_qs)
@@ -13581,6 +14064,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[107].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_107_qs)
@@ -13606,6 +14090,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[108].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_108_qs)
@@ -13631,6 +14116,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[109].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_109_qs)
@@ -13656,6 +14142,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[110].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_110_qs)
@@ -13681,6 +14168,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[111].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_111_qs)
@@ -13706,6 +14194,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[112].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_112_qs)
@@ -13731,6 +14220,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[113].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_113_qs)
@@ -13756,6 +14246,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[114].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_114_qs)
@@ -13781,6 +14272,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[115].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_115_qs)
@@ -13806,6 +14298,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[116].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_116_qs)
@@ -13831,6 +14324,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[117].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_117_qs)
@@ -13856,6 +14350,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[118].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_118_qs)
@@ -13881,6 +14376,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[119].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_119_qs)
@@ -13906,6 +14402,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[120].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_120_qs)
@@ -13931,6 +14428,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[121].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_121_qs)
@@ -13956,6 +14454,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[122].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_122_qs)
@@ -13981,6 +14480,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[123].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_123_qs)
@@ -14006,6 +14506,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[124].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_124_qs)
@@ -14031,6 +14532,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[125].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_125_qs)
@@ -14056,6 +14558,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[126].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_126_qs)
@@ -14081,6 +14584,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[127].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_3_e_127_qs)
@@ -14109,6 +14613,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[128].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_128_qs)
@@ -14134,6 +14639,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[129].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_129_qs)
@@ -14159,6 +14665,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[130].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_130_qs)
@@ -14184,6 +14691,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[131].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_131_qs)
@@ -14209,6 +14717,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[132].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_132_qs)
@@ -14234,6 +14743,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[133].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_133_qs)
@@ -14259,6 +14769,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[134].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_134_qs)
@@ -14284,6 +14795,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[135].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_135_qs)
@@ -14309,6 +14821,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[136].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_136_qs)
@@ -14334,6 +14847,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[137].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_137_qs)
@@ -14359,6 +14873,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[138].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_138_qs)
@@ -14384,6 +14899,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[139].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_139_qs)
@@ -14409,6 +14925,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[140].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_140_qs)
@@ -14434,6 +14951,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[141].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_141_qs)
@@ -14459,6 +14977,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[142].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_142_qs)
@@ -14484,6 +15003,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[143].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_143_qs)
@@ -14509,6 +15029,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[144].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_144_qs)
@@ -14534,6 +15055,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[145].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_145_qs)
@@ -14559,6 +15081,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[146].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_146_qs)
@@ -14584,6 +15107,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[147].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_147_qs)
@@ -14609,6 +15133,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[148].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_148_qs)
@@ -14634,6 +15159,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[149].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_149_qs)
@@ -14659,6 +15185,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[150].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_150_qs)
@@ -14684,6 +15211,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[151].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_151_qs)
@@ -14709,6 +15237,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[152].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_152_qs)
@@ -14734,6 +15263,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[153].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_153_qs)
@@ -14759,6 +15289,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[154].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_154_qs)
@@ -14784,6 +15315,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[155].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_155_qs)
@@ -14809,6 +15341,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[156].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_156_qs)
@@ -14834,6 +15367,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[157].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_157_qs)
@@ -14859,6 +15393,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[158].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_158_qs)
@@ -14884,6 +15419,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[159].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_4_e_159_qs)
@@ -14912,6 +15448,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[160].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_160_qs)
@@ -14937,6 +15474,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[161].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_161_qs)
@@ -14962,6 +15500,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[162].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_162_qs)
@@ -14987,6 +15526,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[163].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_163_qs)
@@ -15012,6 +15552,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[164].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_164_qs)
@@ -15037,6 +15578,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[165].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_165_qs)
@@ -15062,6 +15604,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[166].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_166_qs)
@@ -15087,6 +15630,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[167].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_167_qs)
@@ -15112,6 +15656,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[168].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_168_qs)
@@ -15137,6 +15682,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[169].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_169_qs)
@@ -15162,6 +15708,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[170].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_170_qs)
@@ -15187,6 +15734,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[171].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_171_qs)
@@ -15212,6 +15760,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[172].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_172_qs)
@@ -15237,6 +15786,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[173].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_173_qs)
@@ -15262,6 +15812,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[174].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_174_qs)
@@ -15287,6 +15838,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[175].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_175_qs)
@@ -15312,6 +15864,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[176].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_176_qs)
@@ -15337,6 +15890,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[177].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_177_qs)
@@ -15362,6 +15916,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[178].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_178_qs)
@@ -15387,6 +15942,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[179].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_179_qs)
@@ -15412,6 +15968,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[180].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_180_qs)
@@ -15437,6 +15994,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[181].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_181_qs)
@@ -15462,6 +16020,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[182].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_182_qs)
@@ -15487,6 +16046,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[183].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_183_qs)
@@ -15512,6 +16072,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[184].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_184_qs)
@@ -15537,6 +16098,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[185].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_185_qs)
@@ -15562,6 +16124,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[186].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_186_qs)
@@ -15587,6 +16150,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.ie0[187].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (ie0_5_e_187_qs)
@@ -15613,6 +16177,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.threshold0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (threshold0_qs)
@@ -15633,6 +16198,7 @@ module rv_plic_reg_top (
     .qre    (reg2hw.cc0.re),
     .qe     (cc0_flds_we[0]),
     .q      (reg2hw.cc0.q),
+    .ds     (),
     .qs     (cc0_qs)
   );
   assign reg2hw.cc0.qe = cc0_qe;
@@ -15658,6 +16224,7 @@ module rv_plic_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.msip0.q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (msip0_qs)
@@ -15678,6 +16245,7 @@ module rv_plic_reg_top (
     .qre    (),
     .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
+    .ds     (),
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -435,6 +435,16 @@ class Register(RegBase):
                 return True
         return False
 
+    def needs_int_qe(self) -> bool:
+        '''Return true if the register or at least one field needs an
+           internal q-enable.  An internal q-enable means the net
+           may be consumed by other reg logic but will not be exposed
+           in the package file.'''
+        if self.async_clk and self.is_hw_writable():
+            return True
+        else:
+            return self.needs_qe();
+
     def needs_re(self) -> bool:
         '''Return true if at least one field needs a read-enable
 


### PR DESCRIPTION
[updated slides to better illustrate changes](https://docs.google.com/presentation/d/1o-3Kf7DkppXVgwrkHhGP4HnaXTx2emTgb3XxXXgVAOk/edit?usp=sharing)

- fixes https://github.com/lowRISC/opentitan/issues/12718
- Instead of using clock edge sampling to capture hw updates (this
  only works if the sampling clock is at least 4x the sampled domain),
  use proper synchronization to bring the updated values across.
- The new scheme applies only to registers that can be written by
  hardware.  Software update only registers do not need the
  new scheme.
- Added additional logic to handle software / hardware updates that
  arrive at approximately the same time.

Compared to the previous approach, there are 2 main drawbacks

- more overhead. Instead of relying on one edge detection module to
  synchronize all updates, now each register is handled as an independent
  unit.  This is mitigated by the fact that only hw_writable registers
  have this function, but it nonetheless is an increase.

- lack of multi-reg sync. Since each register is treated separately, it
  means if there is an update that spans across multiple registers, while in
  the old scheme they would all update at exactly the same time, the new scheme
  means the registers will have an update uncertainty window of 1 software facing
  clock cycle.  This is something that the software / hardware design needs to be
  cognizant of during the design.  If simultaneous update across multiple registers
  is desired, it is better to handle the async crossing outside.  A good example of
  this would be a 64-bit counter that is updated on an asynchronous clock which
  software is actively polling.  Either the update should be handled outside the
  reg block, or software reads should be done multiple times to ensure value
  consistency.

- Longer term we can propagate more options to indicate which registers need to be
  treated as a unit, but those options do not currently exist.