### PR TITLE
fix(ottf): Make SWI asynchronous ISR

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_isrs.S
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.S
@@ -165,9 +165,9 @@ handler_irq_software:
   csrr t0, mstatus
   sw t0, 29 * OTTF_WORD_SIZE(sp)
 
-  // Save MEPC to the stack after updating it to the next instruction (since
-  // this is a synchronous IRQ).
-  jal compute_mepc_on_synchronous_irq
+  // Save MEPC to the stack.
+  // NOTE: this IRQ is asynchronous, therefore, we do not need to modify MEPC.
+  csrr t0, mepc
   sw t0, 0(sp)
 
   // Store stack pointer to current TCB (only if concurrency is enabled, i.e.,


### PR DESCRIPTION
https://github.com/lowRISC/opentitan/issues/12787

SWI in `ottf_isrs.S` was synchronous, where the logic changes MEPC by
adding the instruction size.

However, SWI in Opentitan (and according to Spec) is asynchronous. In
OpenTitan, after setting MSIP (Memory Mapped CSR in RV_PLIC), the
software interrupt occurs two cycles later due to the fabric latency and
the register update in RV_PLIC.

So, `handler_software_isr` is revised to store MEPC directly to the
stack not manipulating it.

