### PR TITLE
[dv] Fix inject_fault for sparse_fsm

### DIFF
--- a/hw/ip/rstmgr/dv/rstmgr_cnsty_chk/tb.sv
+++ b/hw/ip/rstmgr/dv/rstmgr_cnsty_chk/tb.sv
@@ -237,6 +237,10 @@ module tb;
     .fsm_err_o(rstmgr_cnsty_chk_if.fsm_err_o)
   );
 
+  // set this to one to avoid a SVA error
+  // This SVA is to ensure we have a fatal alert check attached to the FSM error, but this is unit
+  // level testbench, no alert will occur.
+  assign dut.u_state_regs.unused_assert_connected = 1;
   initial begin
     automatic dv_utils_pkg::dv_report_server dv_report_server = new();
     $timeformat(-12, 0, " ps", 12);

--- a/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -109,8 +109,7 @@ module rstmgr_cnsty_chk
   state_e state_q, state_d;
 
   // SEC_CM: LEAF.FSM.SPARSE
-  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Reset,
-      clk_i, rst_ni, 0)
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Reset, clk_i, rst_ni)
 
   logic timeout;
   logic cnt_inc;


### PR DESCRIPTION
2 commits:

[rstmgr] Enable SVA check in sparse_fsm
- It shouldn't be disabled.

[dv] Fix inject_fault for sparse_fsm
1. Changed "force and release" to `deposit` value in the flop
Reason: if we do force and release on a net, it's restored to the value
on the original net immeidately, but if it's a flop, it's updated in the
next cycle. We force 2 state_q, we need to keep them in sync.

2. don't restore the value after forcing an invalid state, as FSM may
   need 2 cycles to detect the fault and trigger fatal alert
Signed-off-by: Weicai Yang <weicai@google.com>