### PR TITLE
DONOTMERGE: reset loop with random value example

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -852,6 +852,13 @@
                  // test will exit while SW is still running
                  "+disable_assert_final_checks"]
     }
+    {
+      name: chip_sw_pwrmgr_random_sleep
+      uvm_test_seq: "chip_sw_pwrmgr_random_sleep_vseq"
+      sw_images: ["sw/device/tests/pwrmgr_random_sleep:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=18000000"]
+    }
   ]
 
   // List of regressions.

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -65,6 +65,7 @@ filesets:
       - seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_pwrmgr_random_sleep_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - ast_supply_if.sv
       - pwrmgr_low_power_if.sv

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_random_sleep_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_random_sleep_vseq.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_pwrmgr_random_sleep_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_pwrmgr_random_sleep_vseq)
+  `uvm_object_new
+
+  rand bit[7:0] assa[3];
+  constraint assa_c {
+    foreach (assa[i]) assa[i] inside {[0:1]};
+  }
+
+  virtual task cpu_init();
+    super.cpu_init();
+    sw_symbol_backdoor_overwrite("ASSA", assa);
+  endtask // cpu_init
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -33,3 +33,4 @@
 `include "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv"
 `include "chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv"
 `include "chip_tap_straps_vseq.sv"
+`include "chip_sw_pwrmgr_random_sleep_vseq.sv"

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -509,3 +509,28 @@ sw_tests += {
     'library': adc_ctrl_sleep_debug_cable_wakeup_test_lib,
   }
 }
+
+pwrmgr_random_sleep_lib = declare_dependency(
+  link_with: static_library(
+    'pwrmgr_random_sleep_lib',
+    sources: ['pwrmgr_random_sleep.c'],
+    dependencies: [
+      sw_lib_dif_aon_timer,
+      sw_lib_dif_flash_ctrl,
+      sw_lib_dif_pwrmgr,
+      sw_lib_dif_rstmgr,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+      sw_lib_testing_aon_timer_testutils,
+      sw_lib_testing_pwrmgr_testutils,
+      sw_lib_testing_rstmgr_testutils,
+      sw_lib_testing_flash_ctrl_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'pwrmgr_random_sleep': {
+    'library': pwrmgr_random_sleep_lib,
+  }
+}

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep.c
@@ -1,0 +1,128 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static volatile const uint8_t ASSA[3] = { 3, 30, 130};
+static dif_flash_ctrl_state_t flash_ctrl;
+
+__attribute__((section(".non_volatile_scratch")))
+const volatile uint32_t events_vector = UINT32_MAX;
+
+/**
+ *  Extracts current event id from the bit-strike counter.
+ */
+static uint32_t event_to_test(void) {
+  uint32_t addr = (uint32_t)(&events_vector);
+  uint32_t val = abs_mmio_read32(addr);
+
+  for (size_t i = 0; i < 32; ++i) {
+    if (val >> i & 0x1) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+/**
+ *  Increment flash bit-strike counter.
+ */
+static bool incr_flash_cnt(uint32_t tested_idx) {
+  uint32_t addr = (uint32_t)(&events_vector);
+
+  // set the tested bit to 0
+  uint32_t val = abs_mmio_read32(addr) & ~(1 << tested_idx);
+
+  // program the word into flash
+  return flash_ctrl_testutils_write(&flash_ctrl, addr, 0, &val,
+
+                                    kDifFlashCtrlPartitionTypeData, 1);
+};
+
+
+bool test_main(void) {
+  // Issue a wakeup signal in ~150us through the AON timer.
+  uint32_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 300 : 30;
+
+  // Initialize pwrmgr
+  dif_pwrmgr_t pwrmgr;
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+
+  // Initialize rstmgr since this will check some registers.
+
+  dif_rstmgr_t rstmgr;
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  // Initialize flash_ctrl
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash_ctrl,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+
+  // First check the flash stored value
+  uint32_t event_idx = event_to_test();
+
+  // Enable flash access
+  flash_ctrl_testutils_default_region_access(&flash_ctrl,
+                                             /*rd_en*/ true,
+                                             /*prog_en*/ true,
+                                             /*erase_en*/ true,
+                                             /*scramble_en*/ false,
+                                             /*ecc_en*/ false,
+                                             /*he_en*/ false);
+
+  // Increment flash counter to know where we are
+  if (incr_flash_cnt(event_idx)) {
+    LOG_ERROR("Error when incrementing flash counter");
+  }
+
+  dif_aon_timer_t aon_timer;
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+
+  if (event_idx < ARRAYSIZE(ASSA)) {
+    LOG_INFO("ASSA[%d] = %d", event_idx, ASSA[event_idx]);
+  } else {
+    LOG_INFO("Test finish");
+    return true;
+  }
+
+  // Prepare rstmgr for a reset.
+  rstmgr_testutils_pre_reset(&rstmgr);
+
+  // This is mark for sv sequence to prepare to asserting parallel event.
+  LOG_INFO("ready for power down");
+  busy_spin_micros(10);
+  // timer setup in case wake up comes before entering low power mode
+  aon_timer_testutils_wakeup_config(&aon_timer, wakeup_threshold);
+
+  // Deep sleep.
+  pwrmgr_testutils_enable_low_power(
+      &pwrmgr,
+      (kDifPwrmgrWakeupRequestSourceOne | kDifPwrmgrWakeupRequestSourceTwo |
+       kDifPwrmgrWakeupRequestSourceThree | kDifPwrmgrWakeupRequestSourceFour |
+       kDifPwrmgrWakeupRequestSourceFive | kDifPwrmgrWakeupRequestSourceSix),
+      0);
+
+  // Enter low power mode.
+  wait_for_interrupt();
+
+
+  return false;
+}


### PR DESCRIPTION
This is example how to randomize variable (or array) in c file from sv.
Right after cpu_init, sv sequence ("chip_sw_pwrmgr_random_sleep_vseq.sv")
randomize byte array assa[] either 0 or 1 then overwrite C array ASSA[].

Then from the c test("pwrmgr_random_sleep.c"), non-volatile count (event_idx) increment by 1 after reset & wake up event
until count == 3. Each time, test prints array value to the log file.

run command:
./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i chip_sw_pwrmgr_random_sleep -r 1 -v m -w fsdb



Signed-off-by: Jaedon Kim <jdonjdon@google.com>