### PR TITLE
[silicon_creator] Update sigverify test vector header template.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/sigverify_tests/sigverify_testvectors.h.tpl
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify_tests/sigverify_testvectors.h.tpl
@@ -8,7 +8,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SIGVERIFY_TESTS_SIGVERIFY_TESTVECTORS_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SIGVERIFY_TESTS_SIGVERIFY_TESTVECTORS_H_
 
-#include "sw/device/silicon_creator/lib/sigverify/sigverify_rsa_key.h"
+#include "sw/device/silicon_creator/lib/sigverify/rsa_key.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -64,4 +64,4 @@ static const sigverify_test_vector_t sigverify_tests[${len(tests)}] = {
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_TESTS_SIGVERIFY_TESTVECTORS_H_
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SIGVERIFY_TESTS_SIGVERIFY_TESTVECTORS_H_


### PR DESCRIPTION
This template is used for testing alternate test vector sets such as Wycheproof. I recently ran the large test set for the first time in a while to check some recent changes and noticed the template had gotten slightly out of sync with the surrounding code.