### PR TITLE
[otbn,dv] Remove unused rnd_req field

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -100,7 +100,6 @@ class OTBNState:
 
         self.rnd_set_flag = False
 
-        self.rnd_req = 0
         self.rnd_cdc_pending = False
         self.urnd_cdc_pending = False
 


### PR DESCRIPTION
This was added in 051133d, but isn't needed: that commit eventually
switched to tracking the EDN request in a RND_REQ external register.
