### PR TITLE
[bazel] Tag test_suites to fix --build_tag_filters=-verilator

### DIFF
--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -392,4 +392,16 @@ def opentitan_functest(
     native.test_suite(
         name = name,
         tests = all_tests,
+        # In test_suites, tags perform a filtering function and will select
+        # matching tags internally instead of allowing filters to select
+        # test_suites.
+        # There are exceptions: "small", "medium", "large", "enourmous", "manual"
+        tags = [
+            # The manual tag is a special case and is applied to the test suite
+            # it prevents it from being included in wildcards so that
+            # --build_tag_filters=-verilator works as expected and excludes
+            # building verilator tests so the verilator build wont be invoked.
+            "manual",
+            # For more see https://bazel.build/reference/be/general#test_suite.tags
+        ],
     )


### PR DESCRIPTION
The test suites are useful for individual invocations like
`bazel build //sw/device/tests:aes_entropy_test`

When using wildcard invocations, disabling the test suite
by tagging it with manual is effective in preventing invocations
like:
`bazel build --build_tag_filters=-verilator //sw/device/tests/...`
from building the test_suite which depends on the verilator image.
`//sw/device/tests/...` includes the verilator tests already so we don't
need the test_suite to make this function properly.

Tested:
`bazel build //sw/device/tests:aes_entropy_test`
works, just as without the tag
`bazel build --build_tag_filters=cw310 //sw/device/tests:aes_entropy_test`
doesn't build anything with or without the tag. the test suite doesn't have the cw310 tag and won't match
`bazel build --build_tag_filters=cw310 //sw/device/tests/...`
builds the cw310 tests without invoking Verilator

Fixes: #9653

Signed-off-by: Drew Macrae <drewmacrae@google.com>