### PR TITLE
[CODEOWNERS] Update .github/CODEOWNERS to get mcy some of his time back

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,6 @@ COPYING*            @mundaym
 /util/licence-checker.hjson  @mundaym
 
 # CI and testing
-/ci/                @mcy @milesdai @rswarbrick
-/test/              @mcy
-azure-pipelines.yml @mcy @milesdai @rswarbrick
+/ci/                @milesdai @rswarbrick @drewmacrae
+/test/              @milesdai @rswarbrick @drewmacrae
+azure-pipelines.yml @milesdai @rswarbrick @drewmacrae


### PR DESCRIPTION
Having non-committers as codeowners doesn't do anything by the way, but it seems useful to track the intent anyway.

Signed-off-by: Drew Macrae <drewmacrae@google.com>