### PR TITLE
[signing] Offline signing demo

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -1082,6 +1082,7 @@ def opentitan_flash_binary(
         srcs = all_targets,
         testonly = testonly,
     )
+
     # Create a filegroup with all binary targets.
     native.filegroup(
         name = name + "_bin",

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -970,6 +970,7 @@ def opentitan_flash_binary(
     """
     deps = kwargs.pop("deps", [])
     all_targets = []
+    binaries = []
     for device in devices:
         if device not in PER_DEVICE_DEPS:
             fail("invalid device; device must be in {}".format(PER_DEVICE_DEPS.keys()))
@@ -994,6 +995,7 @@ def opentitan_flash_binary(
             **kwargs
         ))
         bin_name = "{}_{}".format(devname, "bin")
+        binaries.append(":" + bin_name)
 
         # Sign BIN (if required) and generate scrambled VMEM images.
         if signed:
@@ -1074,10 +1076,16 @@ def opentitan_flash_binary(
         )
         all_targets.extend(dev_targets)
 
-    # Create a filegroup with just all targets from all devices.
+    # Create a filegroup with all targets from all devices.
     native.filegroup(
         name = name,
         srcs = all_targets,
+        testonly = testonly,
+    )
+    # Create a filegroup with all binary targets.
+    native.filegroup(
+        name = name + "_bin",
+        srcs = binaries,
         testonly = testonly,
     )
 

--- a/rules/signing.bzl
+++ b/rules/signing.bzl
@@ -1,0 +1,152 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+PreSigningBinary = provider(fields = ["files"])
+
+def _offline_presigning_artifacts(ctx):
+    digests = []
+    bins = []
+    for src in ctx.files.srcs:
+        pre = ctx.actions.declare_file(paths.replace_extension(src.basename, ".pre-signing"))
+        bins.append(pre)
+        ctx.actions.run(
+            outputs = [pre],
+            inputs = [src, ctx.file.manifest, ctx.file.key_file, ctx.executable._tool],
+            arguments = [
+                "--rcfile=",
+                "image",
+                "manifest",
+                "update",
+                "--manifest={}".format(ctx.file.manifest.path),
+                "--key-file={}".format(ctx.file.key_file.path),
+                "--output={}".format(pre.path),
+                src.path,
+            ],
+            executable = ctx.executable._tool,
+        )
+
+        out = ctx.actions.declare_file(paths.replace_extension(src.basename, ".digest"))
+        digests.append(out)
+        ctx.actions.run(
+            outputs = [out],
+            inputs = [pre, ctx.executable._tool],
+            arguments = [
+                "--rcfile=",
+                "image",
+                "digest",
+                "--bin={}".format(out.path),
+                pre.path,
+            ],
+            executable = ctx.executable._tool,
+        )
+    return [
+        DefaultInfo(files = depset(digests), data_runfiles = ctx.runfiles(files = digests)),
+        PreSigningBinary(files = depset(bins)),
+        OutputGroupInfo(digest = depset(digests), binary = depset(bins)),
+    ]
+
+offline_presigning_artifacts = rule(
+    implementation = _offline_presigning_artifacts,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True, doc = "Binary files to generate digests for"),
+        "manifest": attr.label(allow_single_file = True, doc = "Manifest for this image"),
+        "key_file": attr.label(allow_single_file = True, doc = "Public key to validate this image"),
+        "_tool": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def _strip_all_extensions(path):
+    path = path.split(".")[0]
+    return path
+
+def _offline_fake_sign(ctx):
+    outputs = []
+    for file in ctx.files.srcs:
+        out = ctx.actions.declare_file(paths.replace_extension(file.basename, ".sig"))
+        ctx.actions.run(
+            outputs = [out],
+            inputs = [file, ctx.file.key_file],
+            arguments = [
+                "--rcfile=",
+                "rsa",
+                "sign",
+                "--input={}".format(file.path),
+                "--output={}".format(out.path),
+                ctx.file.key_file.path,
+            ],
+            executable = ctx.executable._tool,
+        )
+        outputs.append(out)
+    return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
+
+offline_fake_sign = rule(
+    implementation = _offline_fake_sign,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True, doc = "Digest files to sign"),
+        "key_file": attr.label(allow_single_file = True, doc = "Public key to validate this image"),
+        "_tool": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = "Create detached signatures using on-disk private keys via opentitantool.",
+)
+
+def _offline_signature_attach(ctx):
+    inputs = {}
+    for src in ctx.attr.srcs:
+        if PreSigningBinary in src:
+            for file in src[PreSigningBinary].files.to_list():
+                f = _strip_all_extensions(file.basename)
+                inputs[f] = {"bin": file}
+        elif DefaultInfo in src:
+            for file in src[DefaultInfo].files.to_list():
+                f = _strip_all_extensions(file.basename)
+                inputs[f] = {"bin": file}
+    for sig in ctx.files.signatures:
+        f = _strip_all_extensions(sig.basename)
+        if f not in inputs:
+            fail("Signature {} does not have a corresponding entry in srcs".format(sig))
+        inputs[f]["sig"] = sig
+
+    print(inputs)
+
+    outputs = []
+    for f in inputs:
+        out = ctx.actions.declare_file(paths.replace_extension(f, ".signed.bin"))
+        ctx.actions.run(
+            outputs = [out],
+            inputs = [inputs[f]["bin"], inputs[f]["sig"], ctx.executable._tool],
+            arguments = [
+                "--rcfile=",
+                "image",
+                "manifest",
+                "update",
+                "--signature-file={}".format(inputs[f]["sig"].path),
+                "--output={}".format(out.path),
+                inputs[f]["bin"].path,
+            ],
+            executable = ctx.executable._tool,
+        )
+        outputs.append(out)
+    return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
+
+offline_signature_attach = rule(
+    implementation = _offline_signature_attach,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True, providers = [PreSigningBinary], doc = "Binary files to sign"),
+        "signatures": attr.label_list(allow_files = True, doc = "Signed digest files"),
+        "_tool": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/signing/README.md
+++ b/signing/README.md
@@ -1,0 +1,47 @@
+# Demo of offline signing
+
+This demonstration of the offline signing flow does not use an HSM.
+It uses opentitantool to generate the image digests and to create the
+detached signatures.  Finally, it attaches the signatures to the binaries
+and emits signed artifacts.
+
+1. Generate pre-signing artifacts:
+
+   ```
+   bazel build //siging/examples:digests
+   ```
+
+2. Generate the detached signatures.
+
+   Normally, in this step, the pre-signing artifacts would be taken
+   to the secure facility and a signing ceremony would be performed to
+   create the detached signatures.
+
+   ```
+   bazel build //siging/examples:fake
+   ```
+
+3. Copy the signatures into into `signing/examples/signatures`
+
+   Normally, in this step, the signatures created in the signing ceremony
+   would be copied into the target directory.
+
+   ```
+   cp -f bazel-bin/signing/examples/*.sig signing/examples/signatures/
+   ```
+
+4. Attach signatures to the pre-signed binaries, thus generating
+   signed binaries:
+
+   ```
+   bazel build //signing/rom_ext:signed
+   ```
+
+5. Inspect the signed artifacts (optional):
+
+   ```
+   cd $REPO_TOP
+   bazel run //sw/host/opentitantool -- \
+       image manifest show \
+       $PWD/bazel-bin/signing/examples/hello_world_fpga_cw310.signed.bin
+   ```

--- a/signing/examples/BUILD
+++ b/signing/examples/BUILD
@@ -1,0 +1,47 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:signing.bzl", "offline_fake_sign", "offline_presigning_artifacts", "offline_signature_attach")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+package(default_visibility = ["//visibility:public"])
+
+offline_presigning_artifacts(
+    name = "presigning",
+    srcs = [
+        "//sw/device/examples/hello_world:hello_world_bin",
+    ],
+    key_file = "//sw/device/silicon_creator/rom/keys/fake:test_private_key_0",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "digests",
+    srcs = [":presigning"],
+    mode = "0644",
+    tags = ["manual"],
+)
+
+# The `fake_sign` rule uses opentitantool to generate the detached signatures
+# that would normally be created by the offline signing operation.
+# These signatures can be copied into the `signatures` directory and attached
+# to the binaries to test the offline signing flow without an HSM operation.
+offline_fake_sign(
+    name = "fake",
+    srcs = [":presigning"],
+    key_file = "//sw/device/silicon_creator/rom/keys/fake:test_private_key_0",
+    tags = ["manual"],
+)
+
+offline_signature_attach(
+    name = "signed",
+    srcs = [
+        ":presigning",
+    ],
+    signatures = [
+        "//signing/examples/signatures:signatures",
+    ],
+    tags = ["manual"],
+)

--- a/signing/examples/signatures/BUILD
+++ b/signing/examples/signatures/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "signatures",
+    srcs = glob(["*.sig"]),
+)

--- a/signing/rom_ext/BUILD
+++ b/signing/rom_ext/BUILD
@@ -1,0 +1,48 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:signing.bzl", "offline_fake_sign", "offline_presigning_artifacts", "offline_signature_attach")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+package(default_visibility = ["//visibility:public"])
+
+offline_presigning_artifacts(
+    name = "presigning",
+    srcs = [
+        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a_bin",
+        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b_bin",
+    ],
+    key_file = "//sw/device/silicon_creator/rom/keys/fake:test_private_key_0",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "digests",
+    srcs = [":presigning"],
+    mode = "0644",
+    tags = ["manual"],
+)
+
+# The `fake_sign` rule uses opentitantool to generate the detached signatures
+# that would normally be created by the offline signing operation.
+# These signatures can be copied into the `signatures` directory and attached
+# to the binaries to test the offline signing flow without an HSM operation.
+offline_fake_sign(
+    name = "fake",
+    srcs = [":presigning"],
+    key_file = "//sw/device/silicon_creator/rom/keys/fake:test_private_key_0",
+    tags = ["manual"],
+)
+
+offline_signature_attach(
+    name = "signed",
+    srcs = [
+        ":presigning",
+    ],
+    signatures = [
+        "//signing/rom_ext/signatures:signatures",
+    ],
+    tags = ["manual"],
+)

--- a/signing/rom_ext/signatures/BUILD
+++ b/signing/rom_ext/signatures/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "signatures",
+    srcs = glob(["*.sig"]),
+)

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 
 opentitan_flash_binary(
     name = "hello_world",
+    testonly = False,
     srcs = [
         "hello_world.c",
     ],

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -187,6 +187,7 @@ manifest({
 
 opentitan_flash_binary(
     name = "rom_ext_slot_a",
+    testonly = False,
     manifest = ":manifest_standard",
     signed = True,
     deps = [
@@ -199,6 +200,7 @@ opentitan_flash_binary(
 
 opentitan_flash_binary(
     name = "rom_ext_slot_b",
+    testonly = False,
     manifest = ":manifest_standard",
     signed = True,
     deps = [
@@ -211,6 +213,7 @@ opentitan_flash_binary(
 
 opentitan_flash_binary(
     name = "rom_ext_slot_virtual",
+    testonly = False,
     manifest = ":manifest_virtual",
     signed = True,
     deps = [
@@ -229,6 +232,7 @@ manifest({
 
 opentitan_flash_binary(
     name = "rom_ext_slot_a_bad_address_translation",
+    testonly = False,
     manifest = ":manifest_bad_address_translation",
     signed = True,
     deps = [


### PR DESCRIPTION
# Offline Signing Demo with SoftHSM2

This is a demonstration of offline signing using SoftHSM2 as a stand-in for a PKCS#11 HSM.

### The SoftHSM configuration is described in `//signing/softhsm/README.md`

The configuration (such as it is) simply initializes a SoftHSM2 token.

### The offline signing process is described in `//signing/rom_ext/README.md`

The process has three major steps:
- Generate pre-signing artifacts.
- Use the HSM to sign those artifacts.
- Attach the signatures to the pre-signed artifacts.

HSM operations are performed by a simple python script in `//sw/host/hsmtool`.  This script will grow to accommodate real (physical) HSMs.