### PR TITLE
[otbn, dv] Disabling end addr check when zero state error is injected

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
@@ -12,6 +12,10 @@ class otbn_single_vseq extends otbn_base_vseq;
   // bus transactions to load it into the memory properly?
   rand bit do_backdoor_load;
 
+  // This bit dictates if end address check should happen or not. Set it to 0 if the check needs to
+  // be disabled.
+  bit do_end_addr_check = 1;
+
   constraint do_backdoor_load_c {
     do_backdoor_load dist { 1'b1 := cfg.backdoor_load_pct,
                             1'b0 := 100 - cfg.backdoor_load_pct };
@@ -33,7 +37,7 @@ class otbn_single_vseq extends otbn_base_vseq;
         return;
     end
     // We've loaded the binary. Run the processor to see what happens!
-    run_otbn();
+    run_otbn(do_end_addr_check);
   endtask : body
 
 endclass : otbn_single_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
@@ -7,6 +7,7 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
   `uvm_object_new
 
   task body();
+    do_end_addr_check = 0;
     fork
       begin
         super.body();


### PR DESCRIPTION
This commit disables end addr check when zero state error is injected

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>