### PR TITLE
[sw/silicon_creator] Update `kBootstrapPinMask` and relax the default case in `bootstrap_handle_program()`

### DIFF
--- a/sw/device/silicon_creator/mask_rom/bootstrap.c
+++ b/sw/device/silicon_creator/mask_rom/bootstrap.c
@@ -312,8 +312,10 @@ static rom_error_t bootstrap_handle_program(bootstrap_state_t *state) {
 #endif
       break;
     default:
-      // We don't expect any other commands.
-      error = kErrorBootstrapInvalidOpcode;
+      // We don't expect any other commands but we can potentially end up
+      // here with a 0x0 opcode due to glitches on SPI or strap lines (see
+      // #11871).
+      error = kErrorOk;
   }
   HARDENED_RETURN_IF_ERROR(error);
 

--- a/sw/device/silicon_creator/mask_rom/bootstrap.h
+++ b/sw/device/silicon_creator/mask_rom/bootstrap.h
@@ -17,7 +17,7 @@ enum {
    *
    * TODO(#11934): The actual chip will have 3 strapping pins.
    */
-  kBootstrapPinMask = 0x00020000,
+  kBootstrapPinMask = 0x00400000,
 };
 
 /**


### PR DESCRIPTION
This commit updates `kBootstrapPinMask` to match the changes in #12633. With this change we can bootstrap the mask ROM using the new SPI Flash based protocol:

```
$ export BIN_FILE="...rom_ext_virtual_addr_fpga_cw310.test_key_0.signed.bin"
$ ./opentitantool bootstrap --protocol eeprom $BIN_FILE
```

UART output:
```
MaskROM:9aad6890
MaskROM:9aad6890
starting rom_ext
BFV:0142500d
LCV:2739ce73
```

This PR also relaxes the default case in `bootstrap_handle_program()` after #11871: SW can potentially get invalid commands (opcode: 0x0) if there are glitches on SPI or strap lines.

Signed-off-by: Alphan Ulusoy <alphan@google.com>