### PR TITLE
Fix aes nightly regression

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -932,7 +932,7 @@
             chip_pwrmgr_sleep_all_reset_reqs, except `control.main_pd_n` is set to 0.
             '''
       milestone: V2
-      tests: ["chip_aon_timer_wdog_bite_reset"]
+      tests: ["chip_sw_aon_timer_wdog_bite_reset"]
     }
     {
       name: chip_sw_pwrmgr_all_reset_reqs

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -605,7 +605,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/aes_idle_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15000000"]
+      run_opts: ["+sw_test_timeout_ns=25000000"]
     }
     {
       name: chip_sw_alert_test

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -428,7 +428,7 @@ TEST_F(DataProcessTest, ThreeBlocksSuccess) {
   dif_aes_data_t out[kBlockCount];
   EXPECT_DIF_OK(dif_aes_process_data(&aes_, kDataIn, out, kBlockCount));
 
-  for (int i = 0; i < kBlockCount; ++i) {
+  for (size_t i = 0; i < kBlockCount; ++i) {
     EXPECT_THAT(out[i].data, ElementsAreArray(kDataOut[i].data));
   }
 }


### PR DESCRIPTION
## Test objective
Start a AES operation, disable the clock hint and check that clock is still on until the encryption has finished.

## Problem
Somehow the AES was faster than the software when running on vcs, so that the AES was finishing it before the software be able to disable the clock hint.

## Solution
Use the manual mode and trigger a reseed together with the start so that the AES will take more time to finish.
 