### PR TITLE
[dv/top] bypass alert watchdog at the end of test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -375,6 +375,7 @@
       name: chip_sw_flash_ctrl_lc_rw_en
       uvm_test_seq: chip_sw_flash_ctrl_lc_rw_en_vseq
       sw_images: ["sw/device/tests/flash_ctrl_lc_rw_en_test:1"]
+      run_opts: ["+bypass_alert_ready_to_end_check=1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {


### PR DESCRIPTION
flash_lc_rw_en tests move to scrap state at the end of the
test, which causes many alerts to continuously fire.

This run option just tells the test to ignore those continuously
firing alerts.

Signed-off-by: Timothy Chen <timothytim@google.com>