### PR TITLE
[fpv/pwrmgr] Fix FPV compile error

### DIFF
--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent.core
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
       - lowrisc:ip:pwrmgr_pkg
+      - lowrisc:dv:pwrmgr_clk_ctrl_common_pkg
     files:
       - pwrmgr_clk_ctrl_if.sv
       - pwrmgr_clk_ctrl_agent_pkg.sv

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent_pkg.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent_pkg.sv
@@ -7,16 +7,14 @@ package pwrmgr_clk_ctrl_agent_pkg;
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
+  import pwrmgr_clk_ctrl_common_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
   // parameters
-  parameter uint MAIN_CLK_DELAY_MIN = 15;  // cycle of aon clk
-  parameter uint MAIN_CLK_DELAY_MAX = 258; // cycle of aon clk
-  parameter uint ESC_CLK_DELAY_MIN = 1;    // cycle of aon clk
-  parameter uint ESC_CLK_DELAY_MAX = 10;   // cycle of aon clk
+
   // local types
   // forward declare classes to allow typedefs below
   typedef class pwrmgr_clk_ctrl_item;

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_common_pkg.core
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_common_pkg.core
@@ -2,18 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:pwrmgr_rstmgr_sva_if:0.1"
-description: "PWRMGR to RSTMGR assertion interface."
+name: "lowrisc:dv:pwrmgr_clk_ctrl_common_pkg:0.1"
+description: "A target for common pwrmgr_clk_ctrl package to share among dv and fpv"
 filesets:
   files_dv:
-    depend:
-      - lowrisc:ip:pwrmgr_pkg
-      - lowrisc:dv:pwrmgr_clk_ctrl_common_pkg
     files:
-      - pwrmgr_rstmgr_sva_if.sv
+      - pwrmgr_clk_ctrl_common_pkg.sv
     file_type: systemVerilogSource
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_common_pkg.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_common_pkg.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This package is shared among DV and FPV testbenches.
+package pwrmgr_clk_ctrl_common_pkg;
+
+  // parameters
+  // do not use uint because it is declared in dv_utils_pkg.
+  parameter bit [31:0] MAIN_CLK_DELAY_MIN = 15;  // cycle of aon clk
+  parameter bit [31:0] MAIN_CLK_DELAY_MAX = 258; // cycle of aon clk
+  parameter bit [31:0] ESC_CLK_DELAY_MIN = 1;    // cycle of aon clk
+  parameter bit [31:0] ESC_CLK_DELAY_MAX = 10;   // cycle of aon clk
+
+endpackage: pwrmgr_clk_ctrl_common_pkg

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
@@ -21,6 +21,7 @@ package pwrmgr_env_pkg;
   import prim_mubi_pkg::MuBi4Width;
   import sec_cm_pkg::*;
   import pwrmgr_clk_ctrl_agent_pkg::*;
+  import pwrmgr_clk_ctrl_common_pkg::*;
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
@@ -29,10 +30,10 @@ package pwrmgr_env_pkg;
   parameter int NUM_INTERRUPTS = 1;
 
   // clk enable disable delay
-  parameter uint MAIN_CLK_DELAY_MIN = pwrmgr_clk_ctrl_agent_pkg::MAIN_CLK_DELAY_MIN;
-  parameter uint MAIN_CLK_DELAY_MAX = pwrmgr_clk_ctrl_agent_pkg::MAIN_CLK_DELAY_MAX;
-  parameter uint ESC_CLK_DELAY_MIN = pwrmgr_clk_ctrl_agent_pkg::ESC_CLK_DELAY_MIN;
-  parameter uint ESC_CLK_DELAY_MAX = pwrmgr_clk_ctrl_agent_pkg::ESC_CLK_DELAY_MAX;
+  parameter uint MAIN_CLK_DELAY_MIN = pwrmgr_clk_ctrl_common_pkg::MAIN_CLK_DELAY_MIN;
+  parameter uint MAIN_CLK_DELAY_MAX = pwrmgr_clk_ctrl_common_pkg::MAIN_CLK_DELAY_MAX;
+  parameter uint ESC_CLK_DELAY_MIN = pwrmgr_clk_ctrl_common_pkg::ESC_CLK_DELAY_MIN;
+  parameter uint ESC_CLK_DELAY_MAX = pwrmgr_clk_ctrl_common_pkg::ESC_CLK_DELAY_MAX;
 
   // alerts
   parameter uint NUM_ALERTS = 1;

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
@@ -7,7 +7,7 @@
 // these assertions will also be useful at full chip level.
 interface pwrmgr_rstmgr_sva_if
   import pwrmgr_pkg::*, pwrmgr_reg_pkg::NumRstReqs;
-  import pwrmgr_clk_ctrl_agent_pkg::*;
+  import pwrmgr_clk_ctrl_common_pkg::*;
 (
   input logic                            clk_i,
   input logic                            rst_ni,
@@ -43,11 +43,11 @@ interface pwrmgr_rstmgr_sva_if
 
   // output reset cycle with a clk enalbe disable
   localparam int MIN_MAIN_RST_CYCLES = 0;
-  localparam int MAX_MAIN_RST_CYCLES = pwrmgr_clk_ctrl_agent_pkg::MAIN_CLK_DELAY_MAX;
+  localparam int MAX_MAIN_RST_CYCLES = pwrmgr_clk_ctrl_common_pkg::MAIN_CLK_DELAY_MAX;
   `define MAIN_RST_CYCLES ##[MIN_MAIN_RST_CYCLES:MAX_MAIN_RST_CYCLES]
 
   localparam int MIN_ESC_RST_CYCLES = 0;
-  localparam int MAX_ESC_RST_CYCLES = pwrmgr_clk_ctrl_agent_pkg::ESC_CLK_DELAY_MAX * 8;
+  localparam int MAX_ESC_RST_CYCLES = pwrmgr_clk_ctrl_common_pkg::ESC_CLK_DELAY_MAX * 8;
   `define ESC_RST_CYCLES ##[MIN_ESC_RST_CYCLES:MAX_ESC_RST_CYCLES]
 
   bit disable_sva;

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
@@ -30,12 +30,12 @@ module pwrmgr_sec_cm_checker_assert (
   `ASYNC_ASSERT(RomIntgChkDisTrue_A,
                 rom_intg_chk_dis == prim_mubi_pkg::MuBi4True |->
                 (lc_dft_en_i == lc_ctrl_pkg::On && lc_hw_debug_en_i == lc_ctrl_pkg::On),
-                rom_intg_chk_dis or lc_dft_en_i or lc_hw_debug_en_i, reset_or_disable)
+                (rom_intg_chk_dis | lc_dft_en_i | lc_hw_debug_en_i), reset_or_disable)
 
   `ASYNC_ASSERT(RomIntgChkDisFalse_A,
                 rom_intg_chk_dis == prim_mubi_pkg::MuBi4False |->
                 (lc_dft_en_i != lc_ctrl_pkg::On || lc_hw_debug_en_i != lc_ctrl_pkg::On),
-                rom_intg_chk_dis or lc_dft_en_i or lc_hw_debug_en_i, reset_or_disable)
+                (rom_intg_chk_dis | lc_dft_en_i | lc_hw_debug_en_i), reset_or_disable)
 
   // check rom_intg_chk_ok
   // rom_ctrl_i go through cdc. So use synchronous assertion.
@@ -46,7 +46,7 @@ module pwrmgr_sec_cm_checker_assert (
                  rom_ctrl_done_i == prim_mubi_pkg::MuBi4True) ||
                 (rom_ctrl_done_i == prim_mubi_pkg::MuBi4True &&
                  rom_ctrl_good_i == prim_mubi_pkg::MuBi4True),
-                rom_intg_chk_ok or rom_intg_chk_dis or rom_ctrl_done_i or rom_ctrl_good_i,
+                (rom_intg_chk_ok | rom_intg_chk_dis | rom_ctrl_done_i | rom_ctrl_good_i),
                 reset_or_disable)
 
   `ASYNC_ASSERT(RomIntgChkOkFalse_A,
@@ -55,7 +55,7 @@ module pwrmgr_sec_cm_checker_assert (
                  rom_ctrl_done_i != prim_mubi_pkg::MuBi4True) &&
                 (rom_ctrl_done_i != prim_mubi_pkg::MuBi4True ||
                  rom_ctrl_good_i != prim_mubi_pkg::MuBi4True),
-                rom_intg_chk_ok or rom_intg_chk_dis or rom_ctrl_done_i or rom_ctrl_good_i,
+                (rom_intg_chk_ok | rom_intg_chk_dis | rom_ctrl_done_i | rom_ctrl_good_i),
                 reset_or_disable)
 
 `undef ASYNC_ASSERT


### PR DESCRIPTION
This PR fixes FPV compile error:
1). The pwrmgr_rstmgr imports a UVM agent that needs UVM dependency in
  FPV.
  The solution is to use `ifdef` to remove UVM related components in
  this agent package, and create a separate core file just for FPV to
  use.
2). FPV compile error using keyword `or` for signals. This is not an
  issue for VCS but JasperGold complains that `or` should be used for
  logic sequence instead of individual signal.

Signed-off-by: Cindy Chen chencindy@opentitan.org
