### PR TITLE
[fpv/rstmgr] Fix FPV compile error

### DIFF
--- a/hw/ip/rstmgr/dv/cov/rstmgr_cov_bind.sv
+++ b/hw/ip/rstmgr/dv/cov/rstmgr_cov_bind.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description:
+// Reset manager coverage bindings for multi bus input
+module rstmgr_cov_bind;
+  // sec cm coverage bind
+  bind rstmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_scanmode_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (scanmode_i)
+  );
+endmodule

--- a/hw/ip/rstmgr/dv/rstmgr_sim.core
+++ b/hw/ip/rstmgr/dv/rstmgr_sim.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:dv:rstmgr_sva
     files:
       - tb.sv
+      - cov/rstmgr_cov_bind.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -52,7 +52,7 @@
   ]
 
   // Add additional tops for simulation.
-  sim_tops: ["rstmgr_bind",
+  sim_tops: ["rstmgr_bind", "rstmgr_cov_bind",
              "sec_cm_prim_sparse_fsm_flop_bind"]
 
   // Default iterations for all tests - each test entry can override this.

--- a/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
@@ -98,9 +98,4 @@ module rstmgr_bind;
     })
   );
 
-  // sec cm coverage bind
-  bind rstmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_scanmode_mubi_cov_if (
-    .rst_ni (rst_ni),
-    .mubi   (scanmode_i)
-  );
 endmodule


### PR DESCRIPTION
This PR fixes rstmgr FPV sec_cm compile error.
The sva core file cannot include any UVM components, so we moved the
mubi coverage bind to rstmgr/dv/cov/ folder.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>