### PR TITLE
[ci] Reintroduce python based cw310 tests in case they don't hang

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -425,6 +425,34 @@ jobs:
 - job: execute_fpga_tests_cw310
   displayName: Execute tests on ChipWhisperer CW310 FPGA board
   pool: FPGA
+  timeoutInMinutes: 8
+  dependsOn:
+    - chip_earlgrey_cw310
+    - sw_build
+  steps:
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_earlgrey_cw310
+        - sw_build
+  - bash: |
+      set -e
+
+      # Install an additional pytest dependency for result upload.
+      pip3 install pytest-azurepipelines
+
+      . util/build_consts.sh
+      pytest --version
+      pytest test/systemtest/earlgrey/test_fpga_cw310.py \
+        --log-cli-level=DEBUG \
+        --test-run-title="Run system tests on ChipWhisperer CW310 FPGA board" \
+        --napoleon-docstrings
+    displayName: Execute tests
+
+- job: execute_fpga_tests_cw310_bazel_ott
+  displayName: Execute tests on ChipWhisperer CW310 FPGA board with bazel and opentitan tool
+  pool: FPGA
   timeoutInMinutes: 24
   dependsOn:
     - chip_earlgrey_cw310
@@ -457,6 +485,7 @@ jobs:
           --define cw310=lowrisc \
           $(./bazelisk.sh query 'rdeps(//sw/...,@bitstreams//:bitstream_test_rom)') \
           # All the tests that depend on the test rom
+    continueOnError: true
     displayName: Execute tests
 
 - job: deploy_release_artifacts

--- a/test/systemtest/earlgrey/config.py
+++ b/test/systemtest/earlgrey/config.py
@@ -20,7 +20,6 @@
 TEST_APPS_SELFCHECKING = [
     {
         "name": "crt_test",
-        "tagets": ["sim_verilator"],
     },
     {
         "name": "otbn_smoketest_rtl",
@@ -35,47 +34,57 @@ TEST_APPS_SELFCHECKING = [
     },
     {
         "name": "otbn_irq_test",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310"],
+    },
+    # The OTBN end-to-end tests can be run in simulation, but take a long time
+    # there. Run them on the CW310 FPGA board only for faster test results.
+    {
+        "name": "otbn_rsa_test",
+        "targets": ["fpga_cw310"],
+    },
+    {
+        "name": "otbn_ecdsa_op_irq_test",
+        "targets": ["fpga_cw310"],
     },
     {
         "name": "aes_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310", "fpga_nexysvideo"],
     },
     {
         "name": "aon_timer_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310"],
     },
     {
         "name": "otp_ctrl_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310"],
     },
     {
         "name": "rv_plic_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310"],
     },
     {
         "name": "pwrmgr_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310"],
     },
     {
         "name": "rstmgr_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310", "fpga_nexysvideo"],
     },
     {
         "name": "rv_timer_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310"],
     },
     {
         "name": "uart_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310", "fpga_nexysvideo"],
     },
     {
         "name": "clkmgr_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310", "fpga_nexysvideo"],
     },
     {
         "name": "sram_ctrl_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310", "fpga_nexysvideo"],
     },
     # TODO(lowrisc/opentitan#7505): Debug CSRNG generate bits mismatch.
     # {
@@ -90,17 +99,17 @@ TEST_APPS_SELFCHECKING = [
     # },
     {
         "name": "kmac_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310"],
     },
     {
-        "name": "kmac_mode_cshake_test",  # Passing on cw310 when coordinated by Bazel
+        "name": "kmac_mode_cshake_test",
     },
     {
-        "name": "kmac_mode_kmac_test",  # Passing on cw310 when coordinated by Bazel
+        "name": "kmac_mode_kmac_test",
     },
     {
         "name": "flash_ctrl_test",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310", "fpga_nexysvideo"],
     },
     {
         "name": "pmp_smoketest_napot",
@@ -114,31 +123,57 @@ TEST_APPS_SELFCHECKING = [
         "name": "usbdev_test",
         "targets": ["sim_verilator"],
     },
-    {  # Passing on cw310 when coordinated by Bazel
+    # Cannot run on sim_verilator due to the differences in the top level.
+    {
+        "name": "gpio_smoketest",
+        "targets": ["fpga_cw310", "fpga_nexysvideo"],
+    },
+    {
         "name": "sw_silicon_creator_lib_driver_hmac_functest",
         "test_dir": "sw/device/silicon_creator/testing",
     },
-    {  # Passing on cw310 when coordinated by Bazel
+    {
         "name": "sw_silicon_creator_lib_driver_uart_functest",
         "test_dir": "sw/device/silicon_creator/testing",
     },
-    {  # Passing on cw310 when coordinated by Bazel
+    {
         "name": "sw_silicon_creator_lib_driver_retention_sram_functest",
         "test_dir": "sw/device/silicon_creator/testing",
     },
-    {  # Passing on cw310 when coordinated by Bazel
+    {
         "name": "sw_silicon_creator_lib_driver_alert_functest",
         "test_dir": "sw/device/silicon_creator/testing",
+        # TODO(lowRISC/opentitan#6965) This test resets the chip and appears to
+        # cause a test failure on FPGA boards.  Restrict this test to
+        # verilator for now.
         "targets": ["sim_verilator"],
+    },
+    {
+        "name": "sw_silicon_creator_lib_sigverify_functest",
+        "test_dir": "sw/device/silicon_creator/testing",
+        # Not running on sim_verilator because this test takes a long time to complete.
+        "targets": ["fpga_cw310", "fpga_nexysvideo"],
     },
     {
         "name": "sw_silicon_creator_lib_driver_watchdog_functest",
         "test_dir": "sw/device/silicon_creator/testing",
+        # TODO(lowRISC/opentitan#6965) This test resets the chip and appears to
+        # cause a test failure on FPGA boards.  Restrict this test to
+        # verilator for now.
         "targets": ["sim_verilator"],
     },
     {
         "name": "sw_silicon_creator_lib_irq_asm_functest",
         "test_dir": "sw/device/silicon_creator/testing",
+        # TODO(lowRISC/opentitan#6965) This test resets the chip and appears to
+        # cause a test failure on FPGA boards.  Restrict this test to
+        # verilator for now.
         "targets": ["sim_verilator"],
+    },
+    {
+        "name": "sw_silicon_creator_lib_boot_data_functest",
+        "test_dir": "sw/device/silicon_creator/testing",
+        # This test takes a long time to run in simulation.
+        "targets": ["fpga_cw310"],
     },
 ]

--- a/test/systemtest/earlgrey/test_fpga_cw310.py
+++ b/test/systemtest/earlgrey/test_fpga_cw310.py
@@ -1,0 +1,103 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import re
+
+import pytest
+
+from . import config
+from .. import utils
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def localconf_board(localconf):
+    assert 'boards' in localconf
+    assert 'cw310' in localconf['boards']
+    boardconf = localconf['boards']['cw310']
+
+    assert 'uart_device' in boardconf
+    assert 'uart_speed' in boardconf
+    return boardconf
+
+
+@pytest.fixture(scope="module")
+def board_earlgrey(tmp_path_factory, topsrcdir, bin_dir, localconf_board):
+    """ A ChipWhispere CW310 board flashed with an Earl Grey bitstream """
+
+    bitstream = bin_dir / "hw/top_earlgrey/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+    assert bitstream.is_file(), ("Bitstream not found at %s." % str(bitstream))
+
+    cmd_pgm = [
+        topsrcdir / 'util/fpga/cw310_loader.py',
+        '--bitstream',
+        bitstream,
+    ]
+
+    log.debug("Flashing ChipWhisperer CW310 board with bitstream {}".format(
+        str(bitstream)))
+    tmp_path = tmp_path_factory.mktemp('cw310_earlgrey')
+    p_pgm = utils.Process(cmd_pgm, logdir=tmp_path, cwd=tmp_path)
+    p_pgm.run()
+    p_pgm.proc.wait(timeout=300)
+    assert p_pgm.proc.returncode == 0
+
+
+@pytest.fixture(params=config.TEST_APPS_SELFCHECKING,
+                ids=lambda param: param['name'])
+def app_selfchecking_bin(request, bin_dir):
+    app_config = request.param
+
+    if 'name' not in app_config:
+        raise RuntimeError("Key 'name' not found in TEST_APPS_SELFCHECKING")
+
+    if 'targets' in app_config and 'fpga_cw310' not in app_config[
+            'targets']:
+        pytest.skip("Test %s skipped on ChipWhisperer CW310 board." % app_config['name'])
+
+    if 'binary_name' in app_config:
+        binary_name = app_config['binary_name']
+    else:
+        binary_name = app_config['name']
+
+    # Allow tests to optionally specify their subdir within the project.
+    test_dir = app_config.get('test_dir', 'sw/device/tests')
+
+    test_filename = binary_name + '_fpga_cw310.bin'
+    bin_path = bin_dir / test_dir / test_filename
+    assert bin_path.is_file()
+    return bin_path
+
+
+def test_apps_selfchecking(tmp_path, localconf_board, board_earlgrey,
+                           app_selfchecking_bin, topsrcdir, bin_dir, uart):
+    """ Load a simple application, and check its output. """
+
+    loader_path = topsrcdir / 'util/fpga/cw310_loader.py'
+    utils.load_sw_over_spi(tmp_path,
+                           loader_path,
+                           app_selfchecking_bin,
+                           timeout=30)
+
+    # We need to wait for this message to ensure we are asserting on the output
+    # of the newly flashed software, not the software which might be already on
+    # the chip (which might get re-executed when running the loading tool).
+    bootstrap_done_exp = b'Bootstrap: DONE!'
+    assert uart.find_in_output(bootstrap_done_exp, timeout=60)
+
+    bootmsg_exp = b'Test ROM complete, jumping to flash!'
+    assert uart.find_in_output(bootmsg_exp,
+                               timeout=10), "End-of-bootrom string not found."
+
+    log.debug("Waiting for pass string from device test")
+
+    result_match = uart.find_in_output(re.compile(br'^(PASS|FAIL)!$'),
+                                       timeout=60)
+    assert result_match is not None, "PASS/FAIL indication not found in test output."
+
+    result_msg = result_match.group(1)
+    log.info("Test ended with {}".format(result_msg))
+    assert result_msg == b'PASS'


### PR DESCRIPTION
I don't know if it's that bazel lets us add more tests for the cw310 or if OTT is failing in a non-specific manner, but if this can pass while opentitantool is stuck we should probably merge it.

Signed-off-by: Drew Macrae <drewmacrae@google.com>