### PR TITLE
[top, dv] Add chip_tap_straps_prod

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -218,6 +218,16 @@
       reseed: 20
     }
     {
+      name: strap_tests_mode
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+create_jtag_riscv_map=1",
+                 // select DFT tap
+                 "+uart0_sel=0",
+                 // test will exit while SW is still running
+                 "+disable_assert_final_checks"]
+      reseed: 5
+    }
+    {
       name: xbar_run_mode
       en_run_modes: ["gen_otp_images_mode"]
       run_opts: ["+xbar_mode=1"]
@@ -841,24 +851,20 @@
     {
       name: chip_tap_straps_dev
       uvm_test_seq: chip_tap_straps_vseq
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStDev",
-                 "+create_jtag_riscv_map=1",
-                 // select DFT tap
-                 "+uart0_sel=0",
-                 // test will exit while SW is still running
-                 "+disable_assert_final_checks"]
+      en_run_modes: ["strap_tests_mode"]
+      run_opts: ["+use_otp_image=LcStDev"]
     }
     {
       name: chip_tap_straps_rma
       uvm_test_seq: chip_tap_straps_vseq
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRma",
-                 "+create_jtag_riscv_map=1",
-                 // select DFT tap
-                 "+uart0_sel=0",
-                 // test will exit while SW is still running
-                 "+disable_assert_final_checks"]
+      en_run_modes: ["strap_tests_mode"]
+      run_opts: ["+use_otp_image=LcStRma"]
+    }
+    {
+      name: chip_tap_straps_prod
+      uvm_test_seq: chip_tap_straps_vseq
+      en_run_modes: ["strap_tests_mode"]
+      run_opts: ["+lc_at_prod=1"]
     }
   ]
 

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:ip:kmac_pkg
       - lowrisc:dv:cip_lib
       - lowrisc:dv:digestpp_dpi
+      - lowrisc:ip:jtag_pkg
       - lowrisc:dv:jtag_riscv_agent
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:dv:ralgen

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -18,6 +18,8 @@ package chip_env_pkg;
   import dv_lib_pkg::*;
   import dv_utils_pkg::*;
   import flash_ctrl_pkg::*;
+  import jtag_pkg::*;
+  import jtag_agent_pkg::*;
   import jtag_riscv_agent_pkg::*;
   import kmac_pkg::*;
   import lc_ctrl_state_pkg::*;
@@ -103,7 +105,8 @@ package chip_env_pkg;
   typedef enum bit [1:0] {
     DeselectJtagTap = 2'b00,
     SelectLCJtagTap = 2'b01,
-    SelectRVJtagTap = 2'b10
+    SelectRVJtagTap = 2'b10,
+    SelectDftJtagTap = 2'b11
   } chip_tap_type_e;
 
   // Two status for LC JTAG to identify if LC state transition is successful.

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -107,7 +107,6 @@ module tb;
   bit uart0_sel = 1;
   initial begin
     void'($value$plusargs("uart0_sel=%0b", uart0_sel));
-    $display("wcy uart0_sel %0d",uart0_sel );
   end
   assign ioc3 = (uart0_sel) ? uart_if[0].uart_rx : dft_straps[0];
   assign ioc4 = (uart0_sel) ? 1'bz : dft_straps[1];


### PR DESCRIPTION
1. Test tap straps at LC prod state
2. force tap inputs to test DFT tap is connected correctly. This is to
   do connectivity test for DFT tap as it's just a dummy module in
   open-source.
Signed-off-by: Weicai Yang <weicai@google.com>