### PR TITLE
[sw/silicon_creator] Use the new strap pins for bootstrap

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/pinmux.c
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.c
@@ -13,6 +13,13 @@
 #include "otp_ctrl_regs.h"
 #include "pinmux_regs.h"
 
+enum {
+  /**
+   * Base address of the pinmux registers.
+   */
+  kBase = TOP_EARLGREY_PINMUX_AON_BASE_ADDR,
+};
+
 /**
  * A peripheral input and MIO pad to link it to.
  */
@@ -68,10 +75,34 @@ static const pinmux_input_t kInputSwStrap2 = {
  * @param input A peripheral input and MIO pad to link it to.
  */
 static void configure_input(pinmux_input_t input) {
-  abs_mmio_write32(TOP_EARLGREY_PINMUX_AON_BASE_ADDR +
-                       PINMUX_MIO_PERIPH_INSEL_0_REG_OFFSET +
+  abs_mmio_write32(kBase + PINMUX_MIO_PERIPH_INSEL_0_REG_OFFSET +
                        input.periph * sizeof(uint32_t),
                    input.pad);
+}
+
+/**
+ * Enables pull-down for the specified pad.
+ *
+ * @param pad A MIO pad.
+ */
+static void enable_pull_down(top_earlgrey_pinmux_insel_t pad) {
+  uint32_t reg =
+      bitfield_bit32_write(0, PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, true);
+  abs_mmio_write32(
+      kBase + PINMUX_MIO_PAD_ATTR_0_REG_OFFSET + pad * sizeof(uint32_t), reg);
+}
+
+/**
+ * Configures the given pin as input and enables the internal pull-down.
+ *
+ * We enable internal pull-downs since we expect strong pull-ups on the strap
+ * pins.
+ *
+ * @param input A peripheral input and MIO pad to link it to.
+ */
+static void configure_strap_pin(pinmux_input_t input) {
+  configure_input(input);
+  enable_pull_down(input.pad);
 }
 
 /**
@@ -80,19 +111,18 @@ static void configure_input(pinmux_input_t input) {
  * @param output An MIO pad and a peripheral output to link it to.
  */
 static void configure_output(pinmux_output_t output) {
-  abs_mmio_write32(TOP_EARLGREY_PINMUX_AON_BASE_ADDR +
-                       PINMUX_MIO_OUTSEL_0_REG_OFFSET +
-                       output.pad * sizeof(uint32_t),
-                   output.periph);
+  abs_mmio_write32(
+      kBase + PINMUX_MIO_OUTSEL_0_REG_OFFSET + output.pad * sizeof(uint32_t),
+      output.periph);
 }
 
 void pinmux_init(void) {
   uint32_t bootstrap_en = otp_read32(OTP_CTRL_PARAM_ROM_BOOTSTRAP_EN_OFFSET);
   if (launder32(bootstrap_en) == kHardenedBoolTrue) {
     HARDENED_CHECK_EQ(bootstrap_en, kHardenedBoolTrue);
-    configure_input(kInputSwStrap0);
-    configure_input(kInputSwStrap1);
-    configure_input(kInputSwStrap2);
+    configure_strap_pin(kInputSwStrap0);
+    configure_strap_pin(kInputSwStrap1);
+    configure_strap_pin(kInputSwStrap2);
   }
 
   configure_input(kInputUart0);

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -38,11 +38,16 @@ class InitTest : public PinmuxTest {
    *
    * Triggers a test failure if the input has already been registered.
    */
-  uint32_t RegIn(top_earlgrey_pinmux_peripheral_in_t index) {
+  uint32_t RegInSel(top_earlgrey_pinmux_peripheral_in_t index) {
     EXPECT_TRUE(index >= 0 && index < kTopEarlgreyPinmuxPeripheralInLast);
     EXPECT_TRUE(configured_in_.insert(index).second);
     return base_ + PINMUX_MIO_PERIPH_INSEL_0_REG_OFFSET +
            static_cast<uint32_t>(index) * sizeof(uint32_t);
+  }
+
+  uint32_t RegPadAttr(top_earlgrey_pinmux_insel_t pad) {
+    return base_ + PINMUX_MIO_PAD_ATTR_0_REG_OFFSET +
+           static_cast<uint32_t>(pad) * sizeof(uint32_t);
   }
 
   /**
@@ -56,7 +61,7 @@ class InitTest : public PinmuxTest {
    *
    * Triggers a test failure if the input has already been registered.
    */
-  uint32_t RegOut(top_earlgrey_pinmux_mio_out_t index) {
+  uint32_t RegOutSel(top_earlgrey_pinmux_mio_out_t index) {
     EXPECT_TRUE(index >= 0 && index < kTopEarlgreyPinmuxMioOutLast);
     EXPECT_TRUE(configured_out_.insert(index).second);
     return base_ + PINMUX_MIO_OUTSEL_0_REG_OFFSET +
@@ -68,17 +73,23 @@ TEST_F(InitTest, WithBootstrap) {
   // The inputs that will be configured.
   EXPECT_CALL(otp_, read32(OTP_CTRL_PARAM_ROM_BOOTSTRAP_EN_OFFSET))
       .WillOnce(Return(kHardenedBoolTrue));
-  EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInGpioGpio22),
+  EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInGpioGpio22),
                      kTopEarlgreyPinmuxInselIoc0)
-  EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInGpioGpio23),
+  EXPECT_ABS_WRITE32(RegPadAttr(kTopEarlgreyPinmuxInselIoc0),
+                     {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
+  EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInGpioGpio23),
                      kTopEarlgreyPinmuxInselIoc1)
-  EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInGpioGpio24),
+  EXPECT_ABS_WRITE32(RegPadAttr(kTopEarlgreyPinmuxInselIoc1),
+                     {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
+  EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInGpioGpio24),
                      kTopEarlgreyPinmuxInselIoc2)
-  EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInUart0Rx),
+  EXPECT_ABS_WRITE32(RegPadAttr(kTopEarlgreyPinmuxInselIoc2),
+                     {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
+  EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInUart0Rx),
                      kTopEarlgreyPinmuxInselIoc3);
 
   // The outputs that will be configured.
-  EXPECT_ABS_WRITE32(RegOut(kTopEarlgreyPinmuxMioOutIoc4),
+  EXPECT_ABS_WRITE32(RegOutSel(kTopEarlgreyPinmuxMioOutIoc4),
                      kTopEarlgreyPinmuxOutselUart0Tx);
 
   pinmux_init();
@@ -88,11 +99,11 @@ TEST_F(InitTest, WithoutBootstrap) {
   // The inputs that will be configured.
   EXPECT_CALL(otp_, read32(OTP_CTRL_PARAM_ROM_BOOTSTRAP_EN_OFFSET))
       .WillOnce(Return(kHardenedBoolFalse));
-  EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInUart0Rx),
+  EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInUart0Rx),
                      kTopEarlgreyPinmuxInselIoc3);
 
   // The outputs that will be configured.
-  EXPECT_ABS_WRITE32(RegOut(kTopEarlgreyPinmuxMioOutIoc4),
+  EXPECT_ABS_WRITE32(RegOutSel(kTopEarlgreyPinmuxMioOutIoc4),
                      kTopEarlgreyPinmuxOutselUart0Tx);
 
   pinmux_init();

--- a/sw/device/silicon_creator/mask_rom/bootstrap.c
+++ b/sw/device/silicon_creator/mask_rom/bootstrap.c
@@ -330,6 +330,8 @@ hardened_bool_t bootstrap_requested(void) {
   }
   HARDENED_CHECK_EQ(res, kHardenedBoolTrue);
 
+  // A single read is sufficient since we expect strong pull-ups on the strap
+  // pins.
   res ^= kBootstrapPinMask;
   res ^=
       abs_mmio_read32(TOP_EARLGREY_GPIO_BASE_ADDR + GPIO_DATA_IN_REG_OFFSET) &

--- a/sw/device/silicon_creator/mask_rom/bootstrap.h
+++ b/sw/device/silicon_creator/mask_rom/bootstrap.h
@@ -13,11 +13,11 @@ extern "C" {
 
 enum {
   /**
-   * Mask for the bootstrap pin.
+   * Mask for the bootstrap pins.
    *
-   * TODO(#11934): The actual chip will have 3 strapping pins.
+   * We expect strong pull-ups on GPIO pins 22, 23, and 24.
    */
-  kBootstrapPinMask = 0x00400000,
+  kBootstrapPinMask = (1 << 22) | (1 << 23) | (1 << 24),
 };
 
 /**

--- a/sw/host/opentitantool/config/opentitan.json
+++ b/sw/host/opentitantool/config/opentitan.json
@@ -2,12 +2,36 @@
   "pins": [
     {
       "name": "RESET",
-      "mode": "OpenDrain",
+      "mode": "PushPull",
       "level": true,
-      "pull_mode": "PullUp"
+      "pull_mode": "None"
     },
     {
-      "name": "BOOTSTRAP",
+      "name": "SW_STRAP0",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None"
+    },
+    {
+      "name": "SW_STRAP1",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None"
+    },
+    {
+      "name": "SW_STRAP2",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None"
+    },
+    {
+      "name": "TAP_STRAP0",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None"
+    },
+    {
+      "name": "TAP_STRAP1",
       "mode": "PushPull",
       "level": false,
       "pull_mode": "None"
@@ -15,10 +39,31 @@
   ],
   "strappings": [
     {
-      "name": "RomBootstrap",
+      "name": "ROM_BOOTSTRAP",
       "pins": [
         {
-          "name": "BOOTSTRAP",
+          "name": "SW_STRAP0",
+          "level": true
+        },
+        {
+          "name": "SW_STRAP1",
+          "level": true
+        },
+        {
+          "name": "SW_STRAP2",
+          "level": true
+        }
+      ]
+    },
+    {
+      "name": "RESET",
+      "pins": [
+        {
+          "name": "RESET",
+          "level": false
+        },
+        {
+          "name": "TAP_STRAP1",
           "level": true
         }
       ]

--- a/sw/host/opentitantool/config/opentitan_cw310.json
+++ b/sw/host/opentitantool/config/opentitan_cw310.json
@@ -4,17 +4,27 @@
   "pins": [
     {
       "name": "RESET",
-      "mode": "OpenDrain",
-      "level": true,
-      "pullup": true,
       "alias_of": "USB_A14"
     },
     {
-      "name": "BOOTSTRAP",
-      "mode": "PushPull",
-      "level": false,
-      "pullup": false,
+      "name": "SW_STRAP0",
       "alias_of": "USB_A15"
+    },
+    {
+      "name": "SW_STRAP1",
+      "alias_of": "USB_A16"
+    },
+    {
+      "name": "SW_STRAP2",
+      "alias_of": "USB_A17"
+    },
+    {
+      "name": "TAP_STRAP0",
+      "alias_of": "USB_A18"
+    },
+    {
+      "name": "TAP_STRAP1",
+      "alias_of": "USB_A19"
     }
   ],
   "uarts": [


### PR DESCRIPTION
This PR updates the mask_rom and opentitantool to use the new strap pins from #12633 for bootstrap.