### PR TITLE
[usbdev] Simplify interface to AON wake module

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -104,14 +104,14 @@
       package: "",
       default: "1'b0"
     },
-    { name:    "usb_dppullup_en_upwr",
+    { name:    "usbdev_dppullup_en",
       type:    "uni",
       act:     "rcv",
       package: "",
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_dnpullup_en_upwr",
+    { name:    "usbdev_dnpullup_en",
       type:    "uni",
       act:     "rcv",
       package: "",
@@ -141,35 +141,21 @@
       package: "",
       default: "1'b0"
     },
-    { name:    "usb_out_of_rst",
+    { name:    "usbdev_suspend_req",
       type:    "uni",
       act:     "rcv",
       package: "",
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_aon_wake_en",
+    { name:    "usbdev_wake_ack",
       type:    "uni",
       act:     "rcv",
       package: "",
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_aon_wake_ack",
-      type:    "uni",
-      act:     "rcv",
-      package: "",
-      struct:  "logic",
-      width:   "1"
-    },
-    { name:    "usb_suspend",
-      type:    "uni",
-      act:     "rcv",
-      package: "",
-      struct:  "logic",
-      width:   "1"
-    },
-    { name:    "usb_bus_reset",
+    { name:    "usbdev_bus_reset",
       type:    "uni",
       act:     "req",
       package: "",
@@ -177,7 +163,7 @@
       width:   "1",
       default: "1'b0"
     },
-    { name:    "usb_sense_lost",
+    { name:    "usbdev_sense_lost",
       type:    "uni",
       act:     "req",
       package: "",
@@ -185,11 +171,13 @@
       width:   "1",
       default: "1'b0"
     },
-    { name:    "usb_state_debug",
+    { name:    "usbdev_wake_detect_active",
       type:    "uni",
       act:     "req",
-      package: "usbdev_pkg",
-      struct:  "awk_state",
+      package: "",
+      struct:  "logic",
+      width:   1,
+      default: "1'b0"
     },
   ]
 
@@ -973,4 +961,3 @@
     },
   ],
 }
-

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -116,14 +116,14 @@
       package: "",
       default: "1'b0"
     },
-    { name:    "usb_dppullup_en_upwr",
+    { name:    "usbdev_dppullup_en",
       type:    "uni",
       act:     "rcv",
       package: "",
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_dnpullup_en_upwr",
+    { name:    "usbdev_dnpullup_en",
       type:    "uni",
       act:     "rcv",
       package: "",
@@ -153,35 +153,21 @@
       package: "",
       default: "1'b0"
     },
-    { name:    "usb_out_of_rst",
+    { name:    "usbdev_suspend_req",
       type:    "uni",
       act:     "rcv",
       package: "",
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_aon_wake_en",
+    { name:    "usbdev_wake_ack",
       type:    "uni",
       act:     "rcv",
       package: "",
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_aon_wake_ack",
-      type:    "uni",
-      act:     "rcv",
-      package: "",
-      struct:  "logic",
-      width:   "1"
-    },
-    { name:    "usb_suspend",
-      type:    "uni",
-      act:     "rcv",
-      package: "",
-      struct:  "logic",
-      width:   "1"
-    },
-    { name:    "usb_bus_reset",
+    { name:    "usbdev_bus_reset",
       type:    "uni",
       act:     "req",
       package: "",
@@ -189,7 +175,7 @@
       width:   "1",
       default: "1'b0"
     },
-    { name:    "usb_sense_lost",
+    { name:    "usbdev_sense_lost",
       type:    "uni",
       act:     "req",
       package: "",
@@ -197,11 +183,13 @@
       width:   "1",
       default: "1'b0"
     },
-    { name:    "usb_state_debug",
+    { name:    "usbdev_wake_detect_active",
       type:    "uni",
       act:     "req",
-      package: "usbdev_pkg",
-      struct:  "awk_state",
+      package: "",
+      struct:  "logic",
+      width:   1,
+      default: "1'b0"
     },
   ]
 

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -89,14 +89,7 @@
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_out_of_rst",
-      type:    "uni",
-      act:     "req",
-      package: "",
-      struct:  "logic",
-      width:   "1"
-    },
-    { name:    "usb_aon_wake_en",
+    { name:    "usb_aon_suspend_req",
       type:    "uni",
       act:     "req",
       package: "",
@@ -104,13 +97,6 @@
       width:   "1"
     },
     { name:    "usb_aon_wake_ack",
-      type:    "uni",
-      act:     "req",
-      package: "",
-      struct:  "logic",
-      width:   "1"
-    },
-    { name:    "usb_suspend",
       type:    "uni",
       act:     "req",
       package: "",
@@ -131,11 +117,12 @@
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_state_debug",
+    { name:    "usb_aon_wake_detect_active",
       type:    "uni",
       act:     "rcv",
-      package: "usbdev_pkg",
-      struct:  "awk_state",
+      package: "",
+      struct:  "logic",
+      width:   "1"
     },
     { struct:  "ram_2p_cfg",
       package: "prim_ram_2p_pkg",
@@ -809,11 +796,6 @@
           desc: "USB OE output (readback)."
         }
         {
-          bits: "13",
-          name: "suspend_o",
-          desc: "USB suspend output (readback)."
-        }
-        {
           bits: "16",
           name: "pwr_sense",
           desc: "USB power sense signal."
@@ -871,11 +853,6 @@
           bits: "7",
           name: "dn_pullup_en_o",
           desc: "USB D- pullup enable output."
-        }
-        {
-          bits: "8",
-          name: "suspend_o",
-          desc: "USB suspend output."
         }
         {
           bits: "16",
@@ -959,22 +936,24 @@
       ]
     }
 
-    { name: "wake_config",
-      desc: "USB wake configuration for suspend / resume",
-      swaccess: "rw",
+    { name: "wake_control",
+      desc: "USB wake module control for suspend / resume",
+      swaccess: "wo",
       hwaccess: "hro",
+      hwext: "true",
+      hwqe: "true",
       async: "clk_aon_i",
       fields: [
         {
           bits: "0",
           resval: "0",
-          name: "wake_en",
+          name: "suspend_req",
           desc: '''
-                Enable the usb resume wake function.  When this is set, a resume indication from
-                a usb host can be used to drive a wake from sleep event.
+                Suspend request to the wake detection module.
 
-                Note this function is meant to be set as a mode and not toggled on/off every time
-                usb enters / exit suspend.
+                Trigger the wake detection module to begin monitoring for wake-from-suspend events.
+                When written with a 1, the wake detection module will activate.
+                Activation may not happen immediately, and its status can be verified by checking wake_events.module_active.
                 '''
           tags: [// Prevent usb wake functions from being turned on outside of directed tests
                  "excl:CsrNonInitTests:CsrExclWrite"]
@@ -983,15 +962,14 @@
           bits: "1",
           resval: "0",
           name: "wake_ack",
-          swaccess: "wo",
-          hwaccess: "hro",
-          hwqe: "true",
           desc: '''
-                Wake acknowledgement. Once the usb device resumes from suspend, this acknowledgement is used
-                to transition the module back to normal operation.
+                Wake acknowledgement.
 
-                Note wake acknowledgement is only necessary if wake_en was '1' when the usb device was suspended.
-                However, setting/clearing this bit during other conditions has no side effects.
+                Signal to the wake detection module that it may release control of the pull-ups back to the main block and return to an inactive state.
+                The release back to normal state may not happen immediately.
+                The status can be confirmed via wake_events.module_active.
+
+                Note that this bit can also be used without powering down, such as when usbdev detects resume signaling before transitions to low power states have begun.
                 '''
         },
       ]
@@ -1004,11 +982,11 @@
       async: "clk_aon_i",
       fields: [
         {
-          bits: "2:0",
+          bits: "0",
           resval: "0",
-          name: "state",
+          name: "module_active",
           desc: '''
-                USB aon wake module state read back
+                USB aon wake module is active, monitoring events and controlling the pull-ups.
                 '''
         }
         {

--- a/hw/ip/usbdev/doc/wake_resume.md
+++ b/hw/ip/usbdev/doc/wake_resume.md
@@ -9,28 +9,32 @@ It assumes the design uses the `usbdev_aon_wake` and `pinmux` modules to handle 
 The `pinmux` module ensures the D+ and D- pins are high-Z / input only.
 The `usbdev_aon_wake` module maintains the pull-up state, monitors the D+ and D- pins for events to leave the suspended state, and provides the wake-up signal.
 
+Note that this procedure to hand control over to `usbdev_aon_wake` does not apply if there is no intention to go to a low-power mode.
+
 ## Suspending from Active
 
 ### Configuration
 
-0. Software configures usbdev to enable wake-from-deep-sleep on resume.
-   {{< regref "wake_config.wake_en" "hw/ip/usbdev/doc/_index.md" >}} should be set to `1`.
-1. Software configures the sleep state for usbdev DIOs to be high-Z (input only), in the `pinmux`.
+0. Software configures the sleep state for usbdev DIOs to be high-Z (input only), in the `pinmux`.
 
 ### Suspending
 
 1. The `usbdev_linkstate` module detects the line has been at idle for at least 3 ms, issues `link_suspend_o`, and transitions to the `LinkSuspended` state.
-   - The AON module transitions to the AwkTrigUon state and takes over the pullup enable.
-     It begins monitoring for events that trigger waking / resuming / resetting.
    - The protocol engine begins ignoring transactions.
      Any non-idle signaling kicks off the process to resume.
    - The USB differential receiver is turned off, if it was controlled by the `rx_enable_o` pin.
    - Software receives the event for going into the suspended state in {{< regref "intr_state.link_suspend" "hw/ip/usbdev/doc/_index.md" >}}.
-2. Software prepares for deep sleep.
+2. Software hands control to the AON module.
+   - Software writes a `1` to {{< regref "wake_control.suspend_req" "hw/ip/usbdev/doc/_index.md" >}}.
+   - The AON module transitions to the active state and takes over the pullup enable.
+     It begins monitoring for events that trigger waking / resuming / resetting.
+3. Software prepares for deep sleep.
    - It saves the current "device state" in the AON retention RAM, including the current configuration and device address (if any).
    - The `usbdev_linkstate` module is still powered and monitoring events, and it can resume at any time.
+     Note that if a resume event does occur before the point of no return, software need only set {{< regref "wake_control.wake_ack" "hw/ip/usbdev/doc/_index.md" >}} to restore control to `usbdev`.
    - Software also does any other tasks for preparing for deep sleep, such as enabling USB events to wake the chip.
-3. Software begins deep sleep.
+4. Software begins deep sleep.
+   - This is the likely the point of no return.
    - It turns off non-AON clocks and power.
    - As it is now unpowered, the `usbdev_linkstate` module is inactive.
      The AON module is now the only device monitoring for USB events.
@@ -45,7 +49,7 @@ The `usbdev_aon_wake` module maintains the pull-up state, monitors the D+ and D-
      It is now monitoring events alongside the AON module.
 4. Software releases the DIOs from sleep mode.
 5. Software checks the AON events and identifies the correct state transition.
-6. Software issues {{< regref "wake_config.wake_ack" "hw/ip/usbdev/doc/_index.md" >}} to the AON module.
+6. Software issues {{< regref "wake_control.wake_ack" "hw/ip/usbdev/doc/_index.md" >}} to the AON module.
    - The AON module stops monitoring events and controlling the pull-ups, restoring control to the full-power `usbdev` module.
    - The AON module also clears the stored events.
      Events that occurred between reading the stored values in the AON module and acknowledging the wake-up are captured in the `usbdev_linkstate` module.

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -63,39 +63,37 @@ module tb;
 
     // USB Interface
     // TOOD: need to hook up an interface
-    .cio_usb_dp_i         (1'b1),
-    .cio_usb_dn_i         (1'b0),
-    .usb_rx_d_i           (1'b0),
-    .cio_usb_dp_o         (),
-    .cio_usb_dp_en_o      (),
-    .cio_usb_dn_o         (),
-    .cio_usb_dn_en_o      (),
-    .usb_tx_d_o           (),
-    .usb_tx_se0_o         (),
+    .cio_usb_dp_i           (1'b1),
+    .cio_usb_dn_i           (1'b0),
+    .usb_rx_d_i             (1'b0),
+    .cio_usb_dp_o           (),
+    .cio_usb_dp_en_o        (),
+    .cio_usb_dn_o           (),
+    .cio_usb_dn_en_o        (),
+    .usb_tx_d_o             (),
+    .usb_tx_se0_o           (),
 
-    .cio_sense_i          (1'b0),
-    .usb_dp_pullup_o      (),
-    .usb_dn_pullup_o      (),
-    .usb_rx_enable_o      (),
-    .usb_tx_use_d_se0_o   (),
+    .cio_sense_i            (1'b0),
+    .usb_dp_pullup_o        (),
+    .usb_dn_pullup_o        (),
+    .usb_rx_enable_o        (),
+    .usb_tx_use_d_se0_o     (),
 
     // Direct pinmux aon detect connections
-    .usb_out_of_rst_o     (),
-    .usb_aon_wake_en_o    (),
-    .usb_aon_wake_ack_o   (),
-    .usb_suspend_o        (),
+    .usb_aon_suspend_req_o  (),
+    .usb_aon_wake_ack_o     (),
 
     // Events and debug info from wakeup module
-    .usb_aon_bus_reset_i  ('0),
-    .usb_aon_sense_lost_i ('0),
-    .usb_state_debug_i    (usbdev_pkg::AwkIdle),
+    .usb_aon_bus_reset_i          ('0),
+    .usb_aon_sense_lost_i         ('0),
+    .usb_aon_wake_detect_active_i ('0),
 
     // SOF reference for clock calibration
-    .usb_ref_val_o        (),
-    .usb_ref_pulse_o      (),
+    .usb_ref_val_o          (),
+    .usb_ref_pulse_o        (),
 
     // memory configuration
-    .ram_cfg_i            ('0),
+    .ram_cfg_i              ('0),
 
     // Interrupts
     .intr_pkt_received_o    (intr_pkt_received    ),

--- a/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
+++ b/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
@@ -11,81 +11,47 @@ module usbdev_aon_wake import usbdev_pkg::*;(
   input  logic clk_aon_i,
   input  logic rst_aon_ni,
 
-  // the system to which usb belongs has entered low power
-  input  logic low_power_alw_i,
-
   // These come from the chip pin
-  input  logic usb_dp_async_alw_i,
-  input  logic usb_dn_async_alw_i,
-  input  logic usb_sense_async_alw_i,
+  input  logic usb_dp_i,
+  input  logic usb_dn_i,
+  input  logic usb_sense_i,
 
   // These come from the IP
-  input  logic usb_dppullup_en_upwr_i,
-  input  logic usb_dnpullup_en_upwr_i,
+  input  logic usbdev_dppullup_en_i,
+  input  logic usbdev_dnpullup_en_i,
 
-  // Register signals from IP
-  input  logic usb_out_of_rst_upwr_i,
-  input  logic usb_aon_wake_en_upwr_i,
-  input  logic usb_aon_woken_upwr_i,
-
-  // Status from IP, must be valid for long enough for aon clock to catch (>15us)
-  input  logic usb_suspended_upwr_i,
+  // Register signals from the IP, which must already be synchronized to the AON domain.
+  input  logic wake_ack_aon_i,
+  input  logic suspend_req_aon_i,
 
   // The I/Os that need to be maintained in low-power mode
   output logic usb_dppullup_en_o,
   output logic usb_dnpullup_en_o,
 
   // wake/powerup request
-  output logic wake_req_alw_o,
+  output logic wake_req_aon_o,
 
   // Event signals that indicate what happened while monitoring
-  output logic bus_reset_alw_o,
-  output logic sense_lost_alw_o,
+  output logic bus_reset_aon_o,
+  output logic sense_lost_aon_o,
 
   // state debug information
-  output awk_state_e state_debug_o
+  output logic wake_detect_active_aon_o
 );
 
-  awk_state_e astate_d, astate_q;
+  // Whether this AON wake detector is active and controlling the pull-ups.
+  logic wake_detect_active_d, wake_detect_active_q;
 
-  logic suspend_req_async, suspend_req;
-  logic wake_ack_async, wake_ack;
-  logic low_power_async, low_power;
+  // Detect whether the USB has moved from an idle state.
+  logic not_idle_async;
+  logic event_not_idle;
 
-  // note the _upwr signals are only valid when usb_out_of_rst_upwr_i is set
-  assign suspend_req_async = usb_aon_wake_en_upwr_i & usb_suspended_upwr_i & usb_out_of_rst_upwr_i;
-  assign wake_ack_async = usb_aon_woken_upwr_i & usb_out_of_rst_upwr_i;
-  assign low_power_async = low_power_alw_i;
-
-  // The suspend_req / wake ack / low power construction come from multiple clock domains.
-  // As a result the 2 flop sync could glitch for up to 1 cycle.  Place a filter after
-  // the two flop sync to passthrough the value only when stable.
-  logic [2:0] filter_cdc_in, filter_cdc_out;
-  assign filter_cdc_in = {low_power_async, suspend_req_async, wake_ack_async};
-
-  for (genvar i = 0; i < 3; i++) begin : gen_filters
-    prim_filter #(
-      .AsyncOn(1), // Instantiate 2-stage synchronizer
-      .Cycles(2)
-    ) u_filter (
-      .clk_i(clk_aon_i),
-      .rst_ni(rst_aon_ni),
-      .enable_i(1'b1),
-      .filter_i(filter_cdc_in[i]),
-      .filter_o(filter_cdc_out[i])
-    );
-  end
-
-  assign {low_power, suspend_req, wake_ack} = filter_cdc_out;
-
-  logic notidle_async;
-  logic wake_req;
   // In suspend it is the device pullup that sets the line state
   // so if the input value differs then the host is doing something
   // This covers both host generated wake (J->K) and host generated reset (J->SE0)
   // Use of the pullups takes care of pinflipping
-  assign notidle_async = (usb_dp_async_alw_i != usb_dppullup_en_o) |
-                         (usb_dn_async_alw_i != usb_dnpullup_en_o);
+  assign not_idle_async = (usb_dp_i != usb_dppullup_en_o) |
+                          (usb_dn_i != usb_dnpullup_en_o);
 
   // aon clock is ~200kHz so 4 cycle filter is about 20us
   // as well as noise debounce this gives the main IP time to detect resume if it didn't turn off
@@ -96,22 +62,21 @@ module usbdev_aon_wake import usbdev_pkg::*;(
     .clk_i    (clk_aon_i),
     .rst_ni   (rst_aon_ni),
     .enable_i (1'b1),
-    .filter_i (notidle_async),
-    .filter_o (wake_req)
+    .filter_i (not_idle_async),
+    .filter_o (event_not_idle)
   );
 
   // Detect bus reset and VBUS removal events.
   // Hold the detectors in reset when this module is in the idle state, to
   // avoid sampling / hysteresis issues that carry over when the link is
   // active.
-  logic aon_usb_events_active;
   logic se0_async, sense_lost_async;
   logic event_bus_reset, event_sense_lost;
   logic bus_reset_d, bus_reset_q;
   logic sense_lost_d, sense_lost_q;
 
-  assign se0_async = ~usb_dp_async_alw_i & ~usb_dn_async_alw_i;
-  assign sense_lost_async = ~usb_sense_async_alw_i;
+  assign se0_async = ~usb_dp_i & ~usb_dn_i;
+  assign sense_lost_async = ~usb_sense_i;
 
   prim_filter #(
     .AsyncOn(1),
@@ -135,107 +100,67 @@ module usbdev_aon_wake import usbdev_pkg::*;(
     .filter_o (event_sense_lost)
   );
 
-  assign bus_reset_d = (event_bus_reset | bus_reset_q) & aon_usb_events_active;
-  assign sense_lost_d = (event_sense_lost | sense_lost_q) & aon_usb_events_active;
+  assign bus_reset_d = (event_bus_reset | bus_reset_q) & wake_detect_active_q;
+  assign sense_lost_d = (event_sense_lost | sense_lost_q) & wake_detect_active_q;
 
-  assign bus_reset_alw_o = bus_reset_q;
-  assign sense_lost_alw_o = sense_lost_q;
+  assign bus_reset_aon_o = bus_reset_q;
+  assign sense_lost_aon_o = sense_lost_q;
+
+  logic wake_req_d, wake_req_q;
+  assign wake_req_d = wake_detect_active_q &
+                      (event_not_idle | event_bus_reset | event_sense_lost | wake_req_q);
+  assign wake_req_aon_o = wake_req_q;
 
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin : proc_reg_events
     if (!rst_aon_ni) begin
       bus_reset_q <= 1'b0;
       sense_lost_q <= 1'b0;
+      wake_req_q <= 1'b0;
     end else begin
       bus_reset_q <= bus_reset_d;
       sense_lost_q <= sense_lost_d;
+      wake_req_q <= wake_req_d;
     end
   end
 
   always_comb begin : proc_awk_fsm
-    astate_d  = astate_q;
-    aon_usb_events_active = 1'b1;
+    wake_detect_active_d = wake_detect_active_q;
 
-    unique case (astate_q)
+    unique case (wake_detect_active_q)
       // No aon suspend entry has been requested or detected
-      AwkIdle: begin
-        aon_usb_events_active = 1'b0;
-        if (suspend_req) begin
-          astate_d = AwkTrigUon;
+      1'b0: begin
+        if (suspend_req_aon_i) begin
+          wake_detect_active_d = 1'b1;
         end
       end
 
-      // Suspend has been requested but the USB IP is still alive.
-      // If the system progresses into low power, wait for wakeup request.
-      // If before the system progresses into low power the suspend request is lost,
-      // go manage the interruption
-      AwkTrigUon: begin
-        // We are trying to juggle when the usb is no longer detecting resumes.
-        // This could be when the usb is in reset, or when the system cuts off
-        // clocking to usb.
-        // If low power and the suspend request drop at the same time (race condition),
-        // prioritize low power since the system is already committed to enter low power.
-        if (low_power) begin
-          astate_d = AwkTrigUoff;
-        end else if (!suspend_req) begin
-          astate_d = AwkWokenUon;
+      // The USB IP has passed control to this module for handling the suspend
+      // request. wake_ack_i must be asserted to bring control back to the USB
+      // IP.
+      1'b1: begin
+        if (wake_ack_aon_i) begin
+          wake_detect_active_d = 1'b0;
         end
       end
-
-      // The link went not-idle before the USB IP powered off
-      // It could be about to power down, it could manage the wake, or this was a glitch
-      // If wake_ack is seen, that means software already handled the resume.
-      // If suspend_req is seen again, it means th1e !suspend_req seen was just a glitch
-      // If low power conditions are seen, this means even though there was a glitch / resume,
-      // the system went to low power anyways, we should now follow the normal resume routine.
-      AwkWokenUon: begin
-        if (wake_ack) begin
-          astate_d = AwkIdle;
-        end else if (suspend_req) begin
-          astate_d = AwkTrigUon;
-        end else if (low_power) begin
-          astate_d = AwkTrigUoff;
-        end
-      end
-
-      // Suspend has been entered and the USB IP is in low power
-      AwkTrigUoff: begin
-        // wake_req covers any events on D+/D-, including a bus reset, since
-        // it triggers on anything where D+/D- != J. A bus reset would show an
-        // SE0 symbol.
-        // sense_lost_q covers events on VBUS.
-        if (wake_req | sense_lost_q) begin
-          astate_d = AwkWoken;
-        end
-      end
-
-      // The USB IP was in low power and the link went not-idle, time to wake up
-      AwkWoken: begin
-        if (wake_ack) begin
-          astate_d = AwkIdle;
-        end
-      end
-
-      default : astate_d = AwkIdle;
+      default : wake_detect_active_d = 1'b0;
     endcase
   end
 
-  `ASSERT(StateValid_A, astate_q inside {AwkIdle, AwkTrigUon, AwkWokenUon, AwkTrigUoff, AwkWoken},
+  `ASSERT_KNOWN(WakeDetectActiveAonKnown_A, wake_detect_active_aon_o,
     clk_aon_i, !rst_aon_ni)
 
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin : proc_reg_awk
     if (!rst_aon_ni) begin
-      astate_q <= AwkIdle;
+      wake_detect_active_q <= 1'b0;
     end else begin
-      astate_q <= astate_d;
+      wake_detect_active_q <= wake_detect_active_d;
     end
   end
 
-  assign wake_req_alw_o = (astate_q == AwkWoken);
-
-  assign state_debug_o = astate_q;
+  assign wake_detect_active_aon_o = wake_detect_active_q;
 
   // Control the pullup enable outputs from the AON module when it's active
-  logic usb_dppullup_en_alw, usb_dnpullup_en_alw;
+  logic usbdev_dppullup_en_aon, usbdev_dnpullup_en_aon;
   logic aon_dppullup_en_d, aon_dppullup_en_q;
   logic aon_dnpullup_en_d, aon_dnpullup_en_q;
 
@@ -244,14 +169,14 @@ module usbdev_aon_wake import usbdev_pkg::*;(
   ) u_pullup_en_cdc (
     .clk_i(clk_aon_i),
     .rst_ni(rst_aon_ni),
-    .d_i({usb_dppullup_en_upwr_i, usb_dnpullup_en_upwr_i}),
-    .q_o({usb_dppullup_en_alw, usb_dnpullup_en_alw})
+    .d_i({usbdev_dppullup_en_i, usbdev_dnpullup_en_i}),
+    .q_o({usbdev_dppullup_en_aon, usbdev_dnpullup_en_aon})
   );
 
-  assign aon_dppullup_en_d = aon_usb_events_active ? aon_dppullup_en_q
-                                                   : usb_dppullup_en_alw;
-  assign aon_dnpullup_en_d = aon_usb_events_active ? aon_dnpullup_en_q
-                                                   : usb_dnpullup_en_alw;
+  assign aon_dppullup_en_d = wake_detect_active_q ? aon_dppullup_en_q
+                                                  : usbdev_dppullup_en_aon;
+  assign aon_dnpullup_en_d = wake_detect_active_q ? aon_dnpullup_en_q
+                                                  : usbdev_dnpullup_en_aon;
 
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin : proc_reg_pullup_en
     if (!rst_aon_ni) begin
@@ -263,13 +188,9 @@ module usbdev_aon_wake import usbdev_pkg::*;(
     end
   end
 
-  assign usb_dppullup_en_o = aon_usb_events_active ? aon_dppullup_en_q
-                                                   : usb_dppullup_en_upwr_i;
-  assign usb_dnpullup_en_o = aon_usb_events_active ? aon_dnpullup_en_q
-                                                   : usb_dnpullup_en_upwr_i;
-
-  // The wakeup signal is not latched in the pwrmgr so must be held until acked by software
-  `ASSERT(UsbWkupStable_A, wake_req_alw_o |=> wake_req_alw_o ||
-      $past(wake_ack) && !low_power_alw_i, clk_aon_i, !rst_aon_ni)
+  assign usb_dppullup_en_o = wake_detect_active_q ? aon_dppullup_en_q
+                                                  : usbdev_dppullup_en_i;
+  assign usb_dnpullup_en_o = wake_detect_active_q ? aon_dnpullup_en_q
+                                                  : usbdev_dnpullup_en_i;
 
 endmodule

--- a/hw/ip/usbdev/rtl/usbdev_iomux.sv
+++ b/hw/ip/usbdev/rtl/usbdev_iomux.sv
@@ -34,7 +34,6 @@ module usbdev_iomux
   input  logic                          cio_usb_sense_i,
   output logic                          usb_dp_pullup_en_o,
   output logic                          usb_dn_pullup_en_o,
-  output logic                          usb_suspend_o,
   output logic                          usb_rx_enable_o,
 
   // Internal USB Interface (usb clk)
@@ -48,7 +47,6 @@ module usbdev_iomux
   input  logic                          usb_tx_oe_i,
   input  logic                          usb_dp_pullup_en_i,
   input  logic                          usb_dn_pullup_en_i,
-  input  logic                          usb_suspend_i,
   input  logic                          usb_rx_enable_i,
   output logic                          usb_pwr_sense_o
 );
@@ -60,7 +58,7 @@ module usbdev_iomux
 
   // USB pins sense (to sysclk)
   prim_flop_2sync #(
-    .Width (10)
+    .Width (9)
   ) cdc_io_to_sys (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
@@ -72,7 +70,6 @@ module usbdev_iomux
               usb_tx_d_i,
               usb_tx_se0_i,
               usb_tx_oe_i,
-              usb_suspend_i,
               cio_usb_sense_i}),
     .q_o   ({sys_hw2reg_sense_o.rx_dp_i.d,
               sys_hw2reg_sense_o.rx_dn_i.d,
@@ -82,7 +79,6 @@ module usbdev_iomux
               sys_hw2reg_sense_o.tx_d_o.d,
               sys_hw2reg_sense_o.tx_se0_o.d,
               sys_hw2reg_sense_o.tx_oe_o.d,
-              sys_hw2reg_sense_o.suspend_o.d,
               sys_usb_sense})
   );
 
@@ -113,13 +109,11 @@ module usbdev_iomux
       // Override from registers
       usb_dp_pullup_en_o = sys_reg2hw_drive_i.dp_pullup_en_o.q;
       usb_dn_pullup_en_o = sys_reg2hw_drive_i.dn_pullup_en_o.q;
-      usb_suspend_o      = sys_reg2hw_drive_i.suspend_o.q;
       usb_rx_enable_o    = sys_reg2hw_drive_i.rx_enable_o.q;
     end else begin
       // Signals from the peripheral core
       usb_dp_pullup_en_o = usb_dp_pullup_en_i;
       usb_dn_pullup_en_o = usb_dn_pullup_en_i;
-      usb_suspend_o      = usb_suspend_i;
       usb_rx_enable_o    = usb_rx_enable_i;
     end
   end

--- a/hw/ip/usbdev/rtl/usbdev_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_pkg.sv
@@ -4,16 +4,4 @@
 
 package usbdev_pkg;
 
-  // Code the state values so that the transitions software could poll are single bit
-  // Woken->Idle and WokenUon->Idle (after sw ack) should therefore be single bit changes
-  typedef enum logic [2:0] {
-    AwkIdle     = 3'b000,
-    AwkTrigUon  = 3'b011,  // 2 bit change from Idle but sw not monitoring
-    AwkTrigUoff = 3'b010,  // ok with two bit change out because chip power is off
-    AwkWokenUon = 3'b001,  // one bit change in/out to TrigUon and Idle, chip off to Woken
-    AwkWoken    = 3'b100  // one bit change out to Idle, in has chip power off
-  } awk_state_e;
-
-  typedef awk_state_e awk_state_t;
-
 endpackage : usbdev_pkg

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -321,9 +321,6 @@ package usbdev_reg_pkg;
     } dn_pullup_en_o;
     struct packed {
       logic        q;
-    } suspend_o;
-    struct packed {
-      logic        q;
     } en;
   } usbdev_reg2hw_phy_pins_drive_reg_t;
 
@@ -351,12 +348,13 @@ package usbdev_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
-    } wake_en;
+      logic        qe;
+    } suspend_req;
     struct packed {
       logic        q;
       logic        qe;
     } wake_ack;
-  } usbdev_reg2hw_wake_config_reg_t;
+  } usbdev_reg2hw_wake_control_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -536,17 +534,14 @@ package usbdev_reg_pkg;
     } tx_oe_o;
     struct packed {
       logic        d;
-    } suspend_o;
-    struct packed {
-      logic        d;
     } pwr_sense;
   } usbdev_hw2reg_phy_pins_sense_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [2:0]  d;
+      logic        d;
       logic        de;
-    } state;
+    } module_active;
     struct packed {
       logic        d;
       logic        de;
@@ -577,24 +572,24 @@ package usbdev_reg_pkg;
     usbdev_reg2hw_out_iso_mreg_t [11:0] out_iso; // [66:55]
     usbdev_reg2hw_in_iso_mreg_t [11:0] in_iso; // [54:43]
     usbdev_reg2hw_data_toggle_clear_mreg_t [11:0] data_toggle_clear; // [42:19]
-    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [18:9]
-    usbdev_reg2hw_phy_config_reg_t phy_config; // [8:3]
-    usbdev_reg2hw_wake_config_reg_t wake_config; // [2:0]
+    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [18:10]
+    usbdev_reg2hw_phy_config_reg_t phy_config; // [9:4]
+    usbdev_reg2hw_wake_control_reg_t wake_control; // [3:0]
   } usbdev_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [244:211]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [210:203]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [202:179]
-    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [178:162]
-    usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [161:138]
-    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [137:114]
-    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [113:90]
-    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [89:66]
-    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [65:18]
-    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [17:8]
-    usbdev_hw2reg_wake_events_reg_t wake_events; // [7:0]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [241:208]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [207:200]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [199:176]
+    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [175:159]
+    usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [158:135]
+    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [134:111]
+    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [110:87]
+    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [86:63]
+    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [62:15]
+    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [14:6]
+    usbdev_hw2reg_wake_events_reg_t wake_events; // [5:0]
   } usbdev_hw2reg_t;
 
   // Register offsets
@@ -632,7 +627,7 @@ package usbdev_reg_pkg;
   parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_SENSE_OFFSET = 12'h 7c;
   parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_DRIVE_OFFSET = 12'h 80;
   parameter logic [BlockAw-1:0] USBDEV_PHY_CONFIG_OFFSET = 12'h 84;
-  parameter logic [BlockAw-1:0] USBDEV_WAKE_CONFIG_OFFSET = 12'h 88;
+  parameter logic [BlockAw-1:0] USBDEV_WAKE_CONTROL_OFFSET = 12'h 88;
   parameter logic [BlockAw-1:0] USBDEV_WAKE_EVENTS_OFFSET = 12'h 8c;
 
   // Reset values for hwext registers and their fields
@@ -660,6 +655,9 @@ package usbdev_reg_pkg;
   parameter logic [0:0] USBDEV_USBSTAT_RX_EMPTY_RESVAL = 1'h 1;
   parameter logic [23:0] USBDEV_RXFIFO_RESVAL = 24'h 0;
   parameter logic [16:0] USBDEV_PHY_PINS_SENSE_RESVAL = 17'h 0;
+  parameter logic [1:0] USBDEV_WAKE_CONTROL_RESVAL = 2'h 0;
+  parameter logic [0:0] USBDEV_WAKE_CONTROL_SUSPEND_REQ_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_WAKE_CONTROL_WAKE_ACK_RESVAL = 1'h 0;
 
   // Window parameters
   parameter logic [BlockAw-1:0] USBDEV_BUFFER_OFFSET = 12'h 800;
@@ -701,7 +699,7 @@ package usbdev_reg_pkg;
     USBDEV_PHY_PINS_SENSE,
     USBDEV_PHY_PINS_DRIVE,
     USBDEV_PHY_CONFIG,
-    USBDEV_WAKE_CONFIG,
+    USBDEV_WAKE_CONTROL,
     USBDEV_WAKE_EVENTS
   } usbdev_id_e;
 
@@ -741,7 +739,7 @@ package usbdev_reg_pkg;
     4'b 0111, // index[31] USBDEV_PHY_PINS_SENSE
     4'b 0111, // index[32] USBDEV_PHY_PINS_DRIVE
     4'b 0001, // index[33] USBDEV_PHY_CONFIG
-    4'b 0001, // index[34] USBDEV_WAKE_CONFIG
+    4'b 0001, // index[34] USBDEV_WAKE_CONTROL
     4'b 0011  // index[35] USBDEV_WAKE_EVENTS
   };
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1263,7 +1263,7 @@
           index: -1
         }
         {
-          name: usb_out_of_rst
+          name: usb_aon_suspend_req
           struct: logic
           type: uni
           act: req
@@ -1273,21 +1273,7 @@
           package: ""
           end_idx: -1
           top_type: broadcast
-          top_signame: usbdev_usb_out_of_rst
-          index: -1
-        }
-        {
-          name: usb_aon_wake_en
-          struct: logic
-          type: uni
-          act: req
-          width: 1
-          inst_name: usbdev
-          default: ""
-          package: ""
-          end_idx: -1
-          top_type: broadcast
-          top_signame: usbdev_usb_aon_wake_en
+          top_signame: usbdev_usb_aon_suspend_req
           index: -1
         }
         {
@@ -1303,22 +1289,6 @@
           top_type: broadcast
           top_signame: usbdev_usb_aon_wake_ack
           index: -1
-        }
-        {
-          name: usb_suspend
-          struct: logic
-          type: uni
-          act: req
-          width: 1
-          inst_name: usbdev
-          default: ""
-          package: ""
-          end_idx: -1
-          top_type: broadcast
-          top_signame: usbdev_usb_suspend
-          index: -1
-          external: true
-          conn_type: true
         }
         {
           name: usb_aon_bus_reset
@@ -1349,15 +1319,15 @@
           index: -1
         }
         {
-          name: usb_state_debug
-          struct: awk_state
-          package: usbdev_pkg
+          name: usb_aon_wake_detect_active
+          struct: logic
           type: uni
           act: rcv
           width: 1
           inst_name: usbdev
           default: ""
-          top_signame: pinmux_aon_usb_state_debug
+          package: ""
+          top_signame: pinmux_aon_usbdev_wake_detect_active
           index: -1
         }
         {
@@ -3722,7 +3692,7 @@
           index: 2
         }
         {
-          name: usb_dppullup_en_upwr
+          name: usbdev_dppullup_en
           struct: logic
           type: uni
           act: rcv
@@ -3734,7 +3704,7 @@
           index: -1
         }
         {
-          name: usb_dnpullup_en_upwr
+          name: usbdev_dnpullup_en
           struct: logic
           type: uni
           act: rcv
@@ -3786,7 +3756,7 @@
           index: 3
         }
         {
-          name: usb_out_of_rst
+          name: usbdev_suspend_req
           struct: logic
           type: uni
           act: rcv
@@ -3794,23 +3764,11 @@
           inst_name: pinmux_aon
           default: ""
           package: ""
-          top_signame: usbdev_usb_out_of_rst
+          top_signame: usbdev_usb_aon_suspend_req
           index: -1
         }
         {
-          name: usb_aon_wake_en
-          struct: logic
-          type: uni
-          act: rcv
-          width: 1
-          inst_name: pinmux_aon
-          default: ""
-          package: ""
-          top_signame: usbdev_usb_aon_wake_en
-          index: -1
-        }
-        {
-          name: usb_aon_wake_ack
+          name: usbdev_wake_ack
           struct: logic
           type: uni
           act: rcv
@@ -3822,19 +3780,7 @@
           index: -1
         }
         {
-          name: usb_suspend
-          struct: logic
-          type: uni
-          act: rcv
-          width: 1
-          inst_name: pinmux_aon
-          default: ""
-          package: ""
-          top_signame: usbdev_usb_suspend
-          index: -1
-        }
-        {
-          name: usb_bus_reset
+          name: usbdev_bus_reset
           struct: logic
           type: uni
           act: req
@@ -3846,7 +3792,7 @@
           index: -1
         }
         {
-          name: usb_sense_lost
+          name: usbdev_sense_lost
           struct: logic
           type: uni
           act: req
@@ -3858,17 +3804,17 @@
           index: -1
         }
         {
-          name: usb_state_debug
-          struct: awk_state
-          package: usbdev_pkg
+          name: usbdev_wake_detect_active
+          struct: logic
           type: uni
           act: req
           width: 1
+          default: 1'b0
           inst_name: pinmux_aon
-          default: ""
+          package: ""
           end_idx: -1
           top_type: broadcast
-          top_signame: pinmux_aon_usb_state_debug
+          top_signame: pinmux_aon_usbdev_wake_detect_active
           index: -1
         }
         {
@@ -7763,39 +7709,31 @@
       ]
       usbdev.usb_dp_pullup:
       [
-        pinmux_aon.usb_dppullup_en_upwr
+        pinmux_aon.usbdev_dppullup_en
       ]
       usbdev.usb_dn_pullup:
       [
-        pinmux_aon.usb_dnpullup_en_upwr
+        pinmux_aon.usbdev_dnpullup_en
       ]
-      usbdev.usb_out_of_rst:
+      usbdev.usb_aon_suspend_req:
       [
-        pinmux_aon.usb_out_of_rst
-      ]
-      usbdev.usb_aon_wake_en:
-      [
-        pinmux_aon.usb_aon_wake_en
+        pinmux_aon.usbdev_suspend_req
       ]
       usbdev.usb_aon_wake_ack:
       [
-        pinmux_aon.usb_aon_wake_ack
-      ]
-      usbdev.usb_suspend:
-      [
-        pinmux_aon.usb_suspend
+        pinmux_aon.usbdev_wake_ack
       ]
       usbdev.usb_aon_bus_reset:
       [
-        pinmux_aon.usb_bus_reset
+        pinmux_aon.usbdev_bus_reset
       ]
       usbdev.usb_aon_sense_lost:
       [
-        pinmux_aon.usb_sense_lost
+        pinmux_aon.usbdev_sense_lost
       ]
-      pinmux_aon.usb_state_debug:
+      pinmux_aon.usbdev_wake_detect_active:
       [
-        usbdev.usb_state_debug
+        usbdev.usb_aon_wake_detect_active
       ]
       edn0.edn:
       [
@@ -8273,7 +8211,6 @@
       usbdev.usb_tx_d: ""
       usbdev.usb_tx_se0: ""
       usbdev.usb_tx_use_d_se0: ""
-      usbdev.usb_suspend: ""
       usbdev.usb_rx_enable: ""
       usbdev.usb_ref_val: ""
       usbdev.usb_ref_pulse: ""
@@ -14660,7 +14597,7 @@
         index: -1
       }
       {
-        name: usb_out_of_rst
+        name: usb_aon_suspend_req
         struct: logic
         type: uni
         act: req
@@ -14670,21 +14607,7 @@
         package: ""
         end_idx: -1
         top_type: broadcast
-        top_signame: usbdev_usb_out_of_rst
-        index: -1
-      }
-      {
-        name: usb_aon_wake_en
-        struct: logic
-        type: uni
-        act: req
-        width: 1
-        inst_name: usbdev
-        default: ""
-        package: ""
-        end_idx: -1
-        top_type: broadcast
-        top_signame: usbdev_usb_aon_wake_en
+        top_signame: usbdev_usb_aon_suspend_req
         index: -1
       }
       {
@@ -14700,22 +14623,6 @@
         top_type: broadcast
         top_signame: usbdev_usb_aon_wake_ack
         index: -1
-      }
-      {
-        name: usb_suspend
-        struct: logic
-        type: uni
-        act: req
-        width: 1
-        inst_name: usbdev
-        default: ""
-        package: ""
-        end_idx: -1
-        top_type: broadcast
-        top_signame: usbdev_usb_suspend
-        index: -1
-        external: true
-        conn_type: true
       }
       {
         name: usb_aon_bus_reset
@@ -14746,15 +14653,15 @@
         index: -1
       }
       {
-        name: usb_state_debug
-        struct: awk_state
-        package: usbdev_pkg
+        name: usb_aon_wake_detect_active
+        struct: logic
         type: uni
         act: rcv
         width: 1
         inst_name: usbdev
         default: ""
-        top_signame: pinmux_aon_usb_state_debug
+        package: ""
+        top_signame: pinmux_aon_usbdev_wake_detect_active
         index: -1
       }
       {
@@ -16396,7 +16303,7 @@
         index: 2
       }
       {
-        name: usb_dppullup_en_upwr
+        name: usbdev_dppullup_en
         struct: logic
         type: uni
         act: rcv
@@ -16408,7 +16315,7 @@
         index: -1
       }
       {
-        name: usb_dnpullup_en_upwr
+        name: usbdev_dnpullup_en
         struct: logic
         type: uni
         act: rcv
@@ -16460,7 +16367,7 @@
         index: 3
       }
       {
-        name: usb_out_of_rst
+        name: usbdev_suspend_req
         struct: logic
         type: uni
         act: rcv
@@ -16468,23 +16375,11 @@
         inst_name: pinmux_aon
         default: ""
         package: ""
-        top_signame: usbdev_usb_out_of_rst
+        top_signame: usbdev_usb_aon_suspend_req
         index: -1
       }
       {
-        name: usb_aon_wake_en
-        struct: logic
-        type: uni
-        act: rcv
-        width: 1
-        inst_name: pinmux_aon
-        default: ""
-        package: ""
-        top_signame: usbdev_usb_aon_wake_en
-        index: -1
-      }
-      {
-        name: usb_aon_wake_ack
+        name: usbdev_wake_ack
         struct: logic
         type: uni
         act: rcv
@@ -16496,19 +16391,7 @@
         index: -1
       }
       {
-        name: usb_suspend
-        struct: logic
-        type: uni
-        act: rcv
-        width: 1
-        inst_name: pinmux_aon
-        default: ""
-        package: ""
-        top_signame: usbdev_usb_suspend
-        index: -1
-      }
-      {
-        name: usb_bus_reset
+        name: usbdev_bus_reset
         struct: logic
         type: uni
         act: req
@@ -16520,7 +16403,7 @@
         index: -1
       }
       {
-        name: usb_sense_lost
+        name: usbdev_sense_lost
         struct: logic
         type: uni
         act: req
@@ -16532,17 +16415,17 @@
         index: -1
       }
       {
-        name: usb_state_debug
-        struct: awk_state
-        package: usbdev_pkg
+        name: usbdev_wake_detect_active
+        struct: logic
         type: uni
         act: req
         width: 1
+        default: 1'b0
         inst_name: pinmux_aon
-        default: ""
+        package: ""
         end_idx: -1
         top_type: broadcast
-        top_signame: pinmux_aon_usb_state_debug
+        top_signame: pinmux_aon_usbdev_wake_detect_active
         index: -1
       }
       {
@@ -19797,18 +19680,6 @@
       {
         package: ""
         struct: logic
-        signame: usbdev_usb_suspend_o
-        width: 1
-        type: uni
-        default: ""
-        direction: out
-        conn_type: true
-        index: -1
-        netname: usbdev_usb_suspend
-      }
-      {
-        package: ""
-        struct: logic
         signame: usbdev_usb_rx_enable_o
         width: 1
         type: uni
@@ -20266,18 +20137,7 @@
       {
         package: ""
         struct: logic
-        signame: usbdev_usb_out_of_rst
-        width: 1
-        type: uni
-        end_idx: -1
-        act: req
-        suffix: ""
-        default: "'0"
-      }
-      {
-        package: ""
-        struct: logic
-        signame: usbdev_usb_aon_wake_en
+        signame: usbdev_usb_aon_suspend_req
         width: 1
         type: uni
         end_idx: -1
@@ -20289,17 +20149,6 @@
         package: ""
         struct: logic
         signame: usbdev_usb_aon_wake_ack
-        width: 1
-        type: uni
-        end_idx: -1
-        act: req
-        suffix: ""
-        default: "'0"
-      }
-      {
-        package: ""
-        struct: logic
-        signame: usbdev_usb_suspend
         width: 1
         type: uni
         end_idx: -1
@@ -20330,15 +20179,15 @@
         default: "'0"
       }
       {
-        package: usbdev_pkg
-        struct: awk_state
-        signame: pinmux_aon_usb_state_debug
+        package: ""
+        struct: logic
+        signame: pinmux_aon_usbdev_wake_detect_active
         width: 1
         type: uni
         end_idx: -1
         act: req
         suffix: ""
-        default: usbdev_pkg::AWK_STATE_DEFAULT
+        default: 1'b0
       }
       {
         package: edn_pkg

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -867,15 +867,13 @@
       'csrng.entropy_src_hw_if' : ['entropy_src.entropy_src_hw_if'],
 
       // usbdev connection to pinmux
-      'usbdev.usb_dp_pullup'      : ['pinmux_aon.usb_dppullup_en_upwr'],
-      'usbdev.usb_dn_pullup'      : ['pinmux_aon.usb_dnpullup_en_upwr'],
-      'usbdev.usb_out_of_rst'     : ['pinmux_aon.usb_out_of_rst'],
-      'usbdev.usb_aon_wake_en'    : ['pinmux_aon.usb_aon_wake_en'],
-      'usbdev.usb_aon_wake_ack'   : ['pinmux_aon.usb_aon_wake_ack'],
-      'usbdev.usb_suspend'        : ['pinmux_aon.usb_suspend'],
-      'usbdev.usb_aon_bus_reset'  : ['pinmux_aon.usb_bus_reset'],
-      'usbdev.usb_aon_sense_lost' : ['pinmux_aon.usb_sense_lost'],
-      'pinmux_aon.usb_state_debug' : ['usbdev.usb_state_debug'],
+      'usbdev.usb_dp_pullup'      : ['pinmux_aon.usbdev_dppullup_en'],
+      'usbdev.usb_dn_pullup'      : ['pinmux_aon.usbdev_dnpullup_en'],
+      'usbdev.usb_aon_suspend_req': ['pinmux_aon.usbdev_suspend_req'],
+      'usbdev.usb_aon_wake_ack'   : ['pinmux_aon.usbdev_wake_ack'],
+      'usbdev.usb_aon_bus_reset'  : ['pinmux_aon.usbdev_bus_reset'],
+      'usbdev.usb_aon_sense_lost' : ['pinmux_aon.usbdev_sense_lost'],
+      'pinmux_aon.usbdev_wake_detect_active' : ['usbdev.usb_aon_wake_detect_active'],
 
       // Edn connections
       'edn0.edn'              : ['keymgr.edn', 'otp_ctrl.edn', 'ast.edn', 'kmac.entropy',
@@ -1065,7 +1063,6 @@
         'usbdev.usb_tx_d'                 : '',
         'usbdev.usb_tx_se0'               : '',
         'usbdev.usb_tx_use_d_se0'         : '',
-        'usbdev.usb_suspend'              : '',
         'usbdev.usb_rx_enable'            : '',
         'usbdev.usb_ref_val'              : '',
         'usbdev.usb_ref_pulse'            : '',

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
@@ -19,7 +19,6 @@ module chip_sim_tb (
   logic cio_usbdev_se0_d2p;
   logic cio_usbdev_dp_pullup_d2p;
   logic cio_usbdev_dn_pullup_d2p;
-  logic cio_usbdev_suspend_d2p;
   logic cio_usbdev_rx_enable_d2p;
   logic cio_usbdev_tx_use_d_se0_d2p;
   logic cio_usbdev_d_p2d, cio_usbdev_d_d2p, cio_usbdev_d_en_d2p;
@@ -61,8 +60,7 @@ module chip_sim_tb (
     .cio_usbdev_d_en_d2p_o(cio_usbdev_d_en_d2p),
     .cio_usbdev_se0_d2p_o(cio_usbdev_se0_d2p),
     .cio_usbdev_rx_enable_d2p_o(cio_usbdev_rx_enable_d2p),
-    .cio_usbdev_tx_use_d_se0_d2p_o(cio_usbdev_tx_use_d_se0_d2p),
-    .cio_usbdev_suspend_d2p_o(cio_usbdev_suspend_d2p)
+    .cio_usbdev_tx_use_d_se0_d2p_o(cio_usbdev_tx_use_d_se0_d2p)
   );
 
   // GPIO DPI

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -112,14 +112,14 @@
       package: "",
       default: "1'b0"
     },
-    { name:    "usb_dppullup_en_upwr",
+    { name:    "usbdev_dppullup_en",
       type:    "uni",
       act:     "rcv",
       package: "",
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_dnpullup_en_upwr",
+    { name:    "usbdev_dnpullup_en",
       type:    "uni",
       act:     "rcv",
       package: "",
@@ -149,35 +149,21 @@
       package: "",
       default: "1'b0"
     },
-    { name:    "usb_out_of_rst",
+    { name:    "usbdev_suspend_req",
       type:    "uni",
       act:     "rcv",
       package: "",
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_aon_wake_en",
+    { name:    "usbdev_wake_ack",
       type:    "uni",
       act:     "rcv",
       package: "",
       struct:  "logic",
       width:   "1"
     },
-    { name:    "usb_aon_wake_ack",
-      type:    "uni",
-      act:     "rcv",
-      package: "",
-      struct:  "logic",
-      width:   "1"
-    },
-    { name:    "usb_suspend",
-      type:    "uni",
-      act:     "rcv",
-      package: "",
-      struct:  "logic",
-      width:   "1"
-    },
-    { name:    "usb_bus_reset",
+    { name:    "usbdev_bus_reset",
       type:    "uni",
       act:     "req",
       package: "",
@@ -185,7 +171,7 @@
       width:   "1",
       default: "1'b0"
     },
-    { name:    "usb_sense_lost",
+    { name:    "usbdev_sense_lost",
       type:    "uni",
       act:     "req",
       package: "",
@@ -193,11 +179,13 @@
       width:   "1",
       default: "1'b0"
     },
-    { name:    "usb_state_debug",
+    { name:    "usbdev_wake_detect_active",
       type:    "uni",
       act:     "req",
-      package: "usbdev_pkg",
-      struct:  "awk_state",
+      package: "",
+      struct:  "logic",
+      width:   1,
+      default: "1'b0"
     },
   ]
 

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -1093,7 +1093,6 @@ module chip_earlgrey_asic (
     .usbdev_usb_tx_d_o            (                            ),
     .usbdev_usb_tx_se0_o          (                            ),
     .usbdev_usb_tx_use_d_se0_o    (                            ),
-    .usbdev_usb_suspend_o         (                            ),
     .usbdev_usb_rx_enable_o       ( usb_rx_enable              ),
     .usbdev_usb_ref_val_o         ( usb_ref_val                ),
     .usbdev_usb_ref_pulse_o       ( usb_ref_pulse              ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -581,7 +581,6 @@ module chip_earlgrey_cw310 #(
   logic usb_rx_d;
   logic usb_tx_d;
   logic usb_tx_se0;
-  logic usb_suspend;
   logic usb_rx_enable;
 
   // DioUsbdevUsbDn
@@ -613,7 +612,7 @@ module chip_earlgrey_cw310 #(
   assign manual_oe_io_usb_speed = 1'b1;
 
   // TUSB1106 low-power mode
-  assign manual_out_io_usb_suspend = usb_suspend;
+  assign manual_out_io_usb_suspend = !usb_rx_enable;
   assign manual_oe_io_usb_suspend = 1'b1;
 
   logic unused_usb_sigs;
@@ -621,7 +620,6 @@ module chip_earlgrey_cw310 #(
     usb_dn_pullup_en,
     usb_tx_d,
     usb_tx_se0,
-    usb_rx_enable,
     manual_in_io_usb_connect,
     manual_in_io_usb_oe_n,
     manual_in_io_usb_speed,
@@ -1007,7 +1005,6 @@ module chip_earlgrey_cw310 #(
     .usbdev_usb_tx_d_o            ( usb_tx_d              ),
     .usbdev_usb_tx_se0_o          ( usb_tx_se0            ),
     .usbdev_usb_tx_use_d_se0_o    ( usb_tx_use_d_se0      ),
-    .usbdev_usb_suspend_o         ( usb_suspend           ),
     .usbdev_usb_rx_enable_o       ( usb_rx_enable         ),
     .usbdev_usb_ref_val_o         ( usb_ref_val           ),
     .usbdev_usb_ref_pulse_o       ( usb_ref_pulse         ),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -176,7 +176,6 @@ module top_earlgrey #(
   output logic       usbdev_usb_tx_d_o,
   output logic       usbdev_usb_tx_se0_o,
   output logic       usbdev_usb_tx_use_d_se0_o,
-  output logic       usbdev_usb_suspend_o,
   output logic       usbdev_usb_rx_enable_o,
   output logic       usbdev_usb_ref_val_o,
   output logic       usbdev_usb_ref_pulse_o,
@@ -561,13 +560,11 @@ module top_earlgrey #(
   rom_ctrl_pkg::keymgr_data_t       rom_ctrl_keymgr_data;
   logic       usbdev_usb_dp_pullup;
   logic       usbdev_usb_dn_pullup;
-  logic       usbdev_usb_out_of_rst;
-  logic       usbdev_usb_aon_wake_en;
+  logic       usbdev_usb_aon_suspend_req;
   logic       usbdev_usb_aon_wake_ack;
-  logic       usbdev_usb_suspend;
   logic       usbdev_usb_aon_bus_reset;
   logic       usbdev_usb_aon_sense_lost;
-  usbdev_pkg::awk_state_t       pinmux_aon_usb_state_debug;
+  logic       pinmux_aon_usbdev_wake_detect_active;
   edn_pkg::edn_req_t [7:0] edn0_edn_req;
   edn_pkg::edn_rsp_t [7:0] edn0_edn_rsp;
   edn_pkg::edn_req_t [7:0] edn1_edn_req;
@@ -749,7 +746,6 @@ module top_earlgrey #(
   assign ast_ram_1p_cfg = ram_1p_cfg_i;
   assign ast_ram_2p_cfg = ram_2p_cfg_i;
   assign ast_rom_cfg = rom_cfg_i;
-  assign usbdev_usb_suspend_o = usbdev_usb_suspend;
 
   // define partial inter-module tie-off
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp1;
@@ -1417,13 +1413,11 @@ module top_earlgrey #(
       .usb_rx_enable_o(usbdev_usb_rx_enable_o),
       .usb_ref_val_o(usbdev_usb_ref_val_o),
       .usb_ref_pulse_o(usbdev_usb_ref_pulse_o),
-      .usb_out_of_rst_o(usbdev_usb_out_of_rst),
-      .usb_aon_wake_en_o(usbdev_usb_aon_wake_en),
+      .usb_aon_suspend_req_o(usbdev_usb_aon_suspend_req),
       .usb_aon_wake_ack_o(usbdev_usb_aon_wake_ack),
-      .usb_suspend_o(usbdev_usb_suspend),
       .usb_aon_bus_reset_i(usbdev_usb_aon_bus_reset),
       .usb_aon_sense_lost_i(usbdev_usb_aon_sense_lost),
-      .usb_state_debug_i(pinmux_aon_usb_state_debug),
+      .usb_aon_wake_detect_active_i(pinmux_aon_usbdev_wake_detect_active),
       .ram_cfg_i(ast_ram_2p_cfg),
       .tl_i(usbdev_tl_req),
       .tl_o(usbdev_tl_rsp),
@@ -1903,18 +1897,16 @@ module top_earlgrey #(
       .sleep_en_i(pwrmgr_aon_low_power),
       .strap_en_i(pwrmgr_aon_strap),
       .pin_wkup_req_o(pwrmgr_aon_wakeups[2]),
-      .usb_dppullup_en_upwr_i(usbdev_usb_dp_pullup),
-      .usb_dnpullup_en_upwr_i(usbdev_usb_dn_pullup),
+      .usbdev_dppullup_en_i(usbdev_usb_dp_pullup),
+      .usbdev_dnpullup_en_i(usbdev_usb_dn_pullup),
       .usb_dppullup_en_o(usb_dp_pullup_en_o),
       .usb_dnpullup_en_o(usb_dn_pullup_en_o),
       .usb_wkup_req_o(pwrmgr_aon_wakeups[3]),
-      .usb_out_of_rst_i(usbdev_usb_out_of_rst),
-      .usb_aon_wake_en_i(usbdev_usb_aon_wake_en),
-      .usb_aon_wake_ack_i(usbdev_usb_aon_wake_ack),
-      .usb_suspend_i(usbdev_usb_suspend),
-      .usb_bus_reset_o(usbdev_usb_aon_bus_reset),
-      .usb_sense_lost_o(usbdev_usb_aon_sense_lost),
-      .usb_state_debug_o(pinmux_aon_usb_state_debug),
+      .usbdev_suspend_req_i(usbdev_usb_aon_suspend_req),
+      .usbdev_wake_ack_i(usbdev_usb_aon_wake_ack),
+      .usbdev_bus_reset_o(usbdev_usb_aon_bus_reset),
+      .usbdev_sense_lost_o(usbdev_usb_aon_sense_lost),
+      .usbdev_wake_detect_active_o(pinmux_aon_usbdev_wake_detect_active),
       .tl_i(pinmux_aon_tl_req),
       .tl_o(pinmux_aon_tl_rsp),
 

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -39,8 +39,7 @@ module chip_earlgrey_verilator (
   output logic cio_usbdev_d_en_d2p_o,
   output logic cio_usbdev_se0_d2p_o,
   output logic cio_usbdev_rx_enable_d2p_o,
-  output logic cio_usbdev_tx_use_d_se0_d2p_o,
-  output logic cio_usbdev_suspend_d2p_o
+  output logic cio_usbdev_tx_use_d_se0_d2p_o
 );
 
   import top_earlgrey_pkg::*;
@@ -69,13 +68,11 @@ module chip_earlgrey_verilator (
   logic usb_tx_d;
   logic usb_tx_se0;
   logic usb_tx_use_d_se0;
-  logic usb_suspend;
   logic usb_rx_enable;
 
   assign usb_rx_d = cio_usbdev_d_p2d_i;
   assign cio_usbdev_d_d2p_o  = usb_tx_d;
   assign cio_usbdev_d_en_d2p_o = dio_oe[DioUsbdevUsbDp];
-  assign cio_usbdev_suspend_d2p_o = usb_suspend;
   assign cio_usbdev_dn_pullup_d2p_o = usb_dn_pullup;
   assign cio_usbdev_dp_pullup_d2p_o = usb_dp_pullup;
   assign cio_usbdev_se0_d2p_o = usb_tx_se0;
@@ -474,7 +471,6 @@ module chip_earlgrey_verilator (
     .usbdev_usb_tx_d_o            (usb_tx_d),
     .usbdev_usb_tx_se0_o          (usb_tx_se0),
     .usbdev_usb_tx_use_d_se0_o    (usb_tx_use_d_se0),
-    .usbdev_usb_suspend_o         (usb_suspend),
     .usbdev_usb_rx_enable_o       (usb_rx_enable),
 
     // Flash test mode voltages

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -563,15 +563,13 @@
       'pwrmgr_aon.fetch_en'     : ['rv_core_ibex.pwrmgr_cpu_en'],
 
       // usbdev connection to pinmux
-      'usbdev.usb_dp_pullup'      : ['pinmux_aon.usb_dppullup_en_upwr'],
-      'usbdev.usb_dn_pullup'      : ['pinmux_aon.usb_dnpullup_en_upwr'],
-      'usbdev.usb_out_of_rst'     : ['pinmux_aon.usb_out_of_rst'],
-      'usbdev.usb_aon_wake_en'    : ['pinmux_aon.usb_aon_wake_en'],
-      'usbdev.usb_aon_wake_ack'   : ['pinmux_aon.usb_aon_wake_ack'],
-      'usbdev.usb_suspend'        : ['pinmux_aon.usb_suspend'],
-      'usbdev.usb_aon_bus_reset'  : ['pinmux_aon.usb_bus_reset'],
-      'usbdev.usb_aon_sense_lost' : ['pinmux_aon.usb_sense_lost'],
-      'pinmux_aon.usb_state_debug' : ['usbdev.usb_state_debug'],
+      'usbdev.usb_dp_pullup'      : ['pinmux_aon.usbdev_dppullup_en'],
+      'usbdev.usb_dn_pullup'      : ['pinmux_aon.usbdev_dnpullup_en'],
+      'usbdev.usb_aon_suspend_req': ['pinmux_aon.usbdev_suspend_req'],
+      'usbdev.usb_aon_wake_ack'   : ['pinmux_aon.usbdev_wake_ack'],
+      'usbdev.usb_aon_bus_reset'  : ['pinmux_aon.usbdev_bus_reset'],
+      'usbdev.usb_aon_sense_lost' : ['pinmux_aon.usbdev_sense_lost'],
+      'pinmux_aon.usbdev_wake_detect_active' : ['usbdev.usb_aon_wake_detect_active'],
 
       // The idle connection is automatically connected through topgen.
       // The user does not need to explicitly declare anything other than
@@ -680,7 +678,6 @@
         'usbdev.usb_tx_d'                : '',
         'usbdev.usb_tx_se0'              : '',
         'usbdev.usb_tx_use_d_se0'        : '',
-        'usbdev.usb_suspend'             : '',
         'usbdev.usb_rx_enable'           : '',
         'usbdev.usb_ref_val'             : '',
         'usbdev.usb_ref_pulse'           : '',

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -21,7 +21,6 @@ module chip_englishbreakfast_verilator (
   logic cio_usbdev_se0_d2p;
   logic cio_usbdev_dp_pullup_d2p;
   logic cio_usbdev_dn_pullup_d2p;
-  logic cio_usbdev_suspend_d2p;
   logic cio_usbdev_rx_enable_d2p;
   logic cio_usbdev_tx_use_d_se0_d2p;
   logic cio_usbdev_d_p2d, cio_usbdev_d_d2p, cio_usbdev_d_en_d2p;
@@ -50,14 +49,12 @@ module chip_englishbreakfast_verilator (
   logic usb_tx_d;
   logic usb_tx_se0;
   logic usb_tx_use_d_se0;
-  logic usb_suspend;
   logic usb_rx_enable;
 
   assign usb_rx_d = cio_usbdev_d_p2d;
   assign cio_usbdev_dn_d2p = dio_out[DioUsbdevUsbDn];
   assign cio_usbdev_dp_d2p = dio_out[DioUsbdevUsbDp];
   assign cio_usbdev_d_d2p  = usb_tx_d;
-  assign cio_usbdev_suspend_d2p = usb_suspend;
   assign cio_usbdev_rx_enable_d2p = usb_rx_enable;
   assign cio_usbdev_tx_use_d_se0_d2p = usb_tx_use_d_se0;
   assign cio_usbdev_dn_pullup_d2p = usb_dn_pullup;
@@ -198,7 +195,6 @@ module chip_englishbreakfast_verilator (
     .usbdev_usb_tx_d_o            (usb_tx_d),
     .usbdev_usb_tx_se0_o          (usb_tx_se0),
     .usbdev_usb_tx_use_d_se0_o      (usb_tx_use_d_se0),
-    .usbdev_usb_suspend_o         (usb_suspend),
     .usbdev_usb_rx_enable_o       (usb_rx_enable),
 
     // Multiplexed I/O

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -105,9 +105,9 @@ static void usb_send_str(const char *string, usb_ss_ctx_t *ss_ctx) {
 }
 
 // These GPIO bits control USB PHY configuration
-static const uint32_t kPinflipMask = 1;
-static const uint32_t kDiffXcvrMask = 2;
-static const uint32_t kUPhyMask = 4;
+static const uint32_t kPinflipMask = (1 << 8);
+static const uint32_t kDiffXcvrMask = (1 << 9);
+static const uint32_t kUPhyMask = (1 << 10);
 
 void _ottf_main(void) {
   CHECK_DIF_OK(dif_pinmux_init(
@@ -148,7 +148,7 @@ void _ottf_main(void) {
   CHECK_DIF_OK(
       dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00));
+  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, 0x000ff));
 
   LOG_INFO("Hello, USB!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
@@ -173,7 +173,7 @@ void _ottf_main(void) {
   } else {
     CHECK_DIF_OK(dif_pinmux_input_select(
         &pinmux, kTopEarlgreyPinmuxPeripheralInUsbdevSense,
-        kTopEarlgreyPinmuxInselIor1));
+        kTopEarlgreyPinmuxInselConstantOne));
   }
   CHECK_DIF_OK(dif_spi_device_send(&spi, "SPI!", 4, /*bytes_sent=*/NULL));
 

--- a/sw/device/lib/usbdev.c
+++ b/sw/device/lib/usbdev.c
@@ -365,21 +365,14 @@ void usbdev_force_dx_pullup(line_sel_t line, bool set) {
   REG32(USBDEV_BASE_ADDR + USBDEV_PHY_PINS_DRIVE_REG_OFFSET) = reg_val;
 }
 
-void usbdev_force_suspend() {
-  // Force usb to pretend it is in suspend
-  REG32(USBDEV_BASE_ADDR + USBDEV_PHY_PINS_DRIVE_REG_OFFSET) |=
-      1 << USBDEV_PHY_PINS_DRIVE_SUSPEND_O_BIT |
-      1 << USBDEV_PHY_PINS_DRIVE_EN_BIT;
-}
-
-void usbdev_wake(bool set) {
-  uint32_t reg_val = REG32(USBDEV_BASE_ADDR + USBDEV_WAKE_CONFIG_REG_OFFSET);
+void usbdev_set_wake_module_active(bool set) {
+  uint32_t reg_val = REG32(USBDEV_BASE_ADDR + USBDEV_WAKE_CONTROL_REG_OFFSET);
   if (set) {
-    reg_val = SETBIT(reg_val, USBDEV_WAKE_CONFIG_WAKE_EN_BIT);
+    reg_val = SETBIT(reg_val, USBDEV_WAKE_CONTROL_SUSPEND_REQ_BIT);
   } else {
-    reg_val = CLRBIT(reg_val, USBDEV_WAKE_CONFIG_WAKE_EN_BIT);
+    reg_val = SETBIT(reg_val, USBDEV_WAKE_CONTROL_WAKE_ACK_BIT);
   }
-  REG32(USBDEV_BASE_ADDR + USBDEV_WAKE_CONFIG_REG_OFFSET) = reg_val;
+  REG32(USBDEV_BASE_ADDR + USBDEV_WAKE_CONTROL_REG_OFFSET) = reg_val;
 }
 
 // `extern` declarations to give the inline functions in the

--- a/sw/device/lib/usbdev.h
+++ b/sw/device/lib/usbdev.h
@@ -289,9 +289,9 @@ void usbdev_force_suspend(void);
 void usbdev_force_dx_pullup(line_sel_t line, bool set);
 
 /**
- * Enable usb wake
+ * Enable usb wake module to go active / inactive.
  */
-void usbdev_wake(bool set);
+void usbdev_set_wake_module_active(bool set);
 
 // Used for tracing what is going on. This may impact timing which is critical
 // when simulating with the USB DPI module.

--- a/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
+++ b/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
@@ -65,8 +65,7 @@ bool test_main(void) {
   // Fake low power entry through usb
   // Force usb to output suspend indication
   if (!low_power_exit) {
-    usbdev_wake(true);
-    usbdev_force_suspend();
+    usbdev_set_wake_module_active(true);
     usbdev_force_dx_pullup(kDpSel, true);
     usbdev_force_dx_pullup(kDnSel, false);
 

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -354,7 +354,6 @@ module chip_${top["name"]}_${target["name"]} (
   logic usb_tx_d;
   logic usb_tx_se0;
   logic usb_tx_use_d_se0;
-  logic usb_suspend;
   logic usb_rx_enable;
 
   // Connect the DP pad
@@ -395,7 +394,6 @@ module chip_${top["name"]}_${target["name"]} (
   logic usb_rx_d;
   logic usb_tx_d;
   logic usb_tx_se0;
-  logic usb_suspend;
   logic usb_rx_enable;
 
   // DioUsbdevUsbDn
@@ -427,7 +425,7 @@ module chip_${top["name"]}_${target["name"]} (
   assign manual_oe_io_usb_speed = 1'b1;
 
   // TUSB1106 low-power mode
-  assign manual_out_io_usb_suspend = usb_suspend;
+  assign manual_out_io_usb_suspend = !usb_rx_enable;
   assign manual_oe_io_usb_suspend = 1'b1;
 
   logic unused_usb_sigs;
@@ -435,7 +433,6 @@ module chip_${top["name"]}_${target["name"]} (
     usb_dn_pullup_en,
     usb_tx_d,
     usb_tx_se0,
-    usb_rx_enable,
     manual_in_io_usb_connect,
     manual_in_io_usb_oe_n,
     manual_in_io_usb_speed,
@@ -933,7 +930,6 @@ module chip_${top["name"]}_${target["name"]} (
     .usbdev_usb_tx_d_o            (                            ),
     .usbdev_usb_tx_se0_o          (                            ),
     .usbdev_usb_tx_use_d_se0_o    (                            ),
-    .usbdev_usb_suspend_o         (                            ),
     .usbdev_usb_rx_enable_o       ( usb_rx_enable              ),
     .usbdev_usb_ref_val_o         ( usb_ref_val                ),
     .usbdev_usb_ref_pulse_o       ( usb_ref_pulse              ),
@@ -1103,7 +1099,6 @@ module chip_${top["name"]}_${target["name"]} (
     .usbdev_usb_tx_d_o            ( usb_tx_d              ),
     .usbdev_usb_tx_se0_o          ( usb_tx_se0            ),
     .usbdev_usb_tx_use_d_se0_o    ( usb_tx_use_d_se0      ),
-    .usbdev_usb_suspend_o         ( usb_suspend           ),
     .usbdev_usb_rx_enable_o       ( usb_rx_enable         ),
     .usbdev_usb_ref_val_o         ( usb_ref_val           ),
     .usbdev_usb_ref_pulse_o       ( usb_ref_pulse         ),


### PR DESCRIPTION
Make controls to AON wake module be simpler, with one signal to trigger
entry into the AON module going active and one signal to trigger
returning from the active state back to inactive.

Adjust the documentation to reflect changing from a mode CSR (wake_en)
to a trigger CSR (suspend_req).

Signed-off-by: Alexander Williams <awill@google.com>

--
Resolves #12813 