### PR TITLE
[python-requirements.txt] Switch to chipwhisperer-minimal

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -52,10 +52,7 @@ git+https://github.com/lowRISC/fusesoc.git@ot-0.1
 # Development version with OT-specific changes
 git+https://github.com/lowRISC/edalize.git@ot-0.1
 
-# Development version of ChipWhisperer toolchain
-# Use a development version until support for the CW310 board works in a
-# released version.
-# Prefer the archive download over a git clone to decrease installation time
-# (The chipwhisperer repository is rather large and uses additionally uses
-# submodules, which need to be fetched as well.)
-https://github.com/newaetech/chipwhisperer/archive/9b6825b495f14f85aae8b11007c63c59a1654584.tar.gz
+# Development version of minimal ChipWhisperer toolchain with latest features
+# and bug fixes. We fix the version for improved stability and manually update
+# if necessary.
+git+https://github.com/newaetech/chipwhisperer-minimal.git@ba568261645df7d70a91a8625bb1b38dc0939c09#egg=chipwhisperer


### PR DESCRIPTION
So far, we haven't touched the chipwhisperer version but we will soon have to update in order to re-enable FTDI MPSSE emulation and OpenOCD debugging on the CW310. See lowRISC/OpenTitan#10625. However, this isn't straightforward as more recent ChipWhisperer versions have dependencies that require Python 3.7 or newer (e.g. numpy), whereas OpenTitan requires Python 3.6 or newer.

ChipWhisperer has now prepared a minimal ChipWhisperer version that only supports the CW310 but doesn't have these dependencies. As such chipwhisperer-minimal will allows us to track more recent versions ChipWhisperer while remaining on Python 3.6 for the moment (default for Ubuntu 18.04). This PR switches to using chipwhisperer-minimal.
