### PR TITLE
[fpga] Bring AON clk down to 200 kHz

### DIFF
--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -8,7 +8,7 @@ create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports IO_
 ## Clock Domain Crossings
 set clks_10_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT0]]
 set clks_48_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT1]]
-set clks_aon_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT2]]
+set clks_aon_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT4]]
 
 ## Divided clock
 ## This is not really recommended per Vivado's guidelines, but hopefully these clocks are slow enough and their
@@ -21,9 +21,9 @@ create_generated_clock -name clk_io_div2 -source [get_pin ${u_pll}/CLKOUT0] -div
 set u_div4 top_*/u_clkmgr_aon/u_no_scan_io_div4_div
 create_generated_clock -name clk_io_div4 -source [get_pin ${u_pll}/CLKOUT0] -divide_by 4 [get_pin ${u_div4}/u_clk_div_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.bufg_i/O]
 
-# the step-down mux is implemented with a LUT right now and the mux switches on the falling edge. 
+# the step-down mux is implemented with a LUT right now and the mux switches on the falling edge.
 # therefore, Vivado propagates both clock edges down the clock network.
-# this implementation is not ideal - but we can at least tell Vivado to only honour the rising edge for 
+# this implementation is not ideal - but we can at least tell Vivado to only honour the rising edge for
 # timing analysis.
 set_clock_sense -positive top_*/u_clkmgr_aon/u_no_scan_io_div2_div/gen_div2.u_div2/gen_fpga_buf.bufg_i_i_1__0/O
 

--- a/hw/top_earlgrey/rtl/clkgen_xil7series.sv
+++ b/hw/top_earlgrey/rtl/clkgen_xil7series.sv
@@ -26,31 +26,41 @@ module clkgen_xil7series # (
   logic clk_aon_buf;
   logic clk_aon_unbuf;
 
-  PLLE2_ADV #(
+  MMCME2_ADV #(
     .BANDWIDTH            ("OPTIMIZED"),
     .COMPENSATION         ("ZHOLD"),
     .STARTUP_WAIT         ("FALSE"),
     .DIVCLK_DIVIDE        (1),
-    .CLKFBOUT_MULT        (12),
+    .CLKFBOUT_MULT_F      (12.000),
     .CLKFBOUT_PHASE       (0.000),
-    .CLKOUT0_DIVIDE       (120),
+    .CLKOUT0_DIVIDE_F     (120.0),
     .CLKOUT0_PHASE        (0.000),
     .CLKOUT0_DUTY_CYCLE   (0.500),
     .CLKOUT1_DIVIDE       (25),
     .CLKOUT1_PHASE        (0.000),
     .CLKOUT1_DUTY_CYCLE   (0.500),
-    .CLKOUT2_DIVIDE       (128),
-    .CLKOUT2_PHASE        (0.000),
-    .CLKOUT2_DUTY_CYCLE   (0.500),
+    // With CLKOUT4_CASCADE, CLKOUT6's divider is an input to CLKOUT4's
+    // divider. The effective ratio is a multiplication of the two.
+    .CLKOUT4_DIVIDE       (40),
+    .CLKOUT4_PHASE        (0.000),
+    .CLKOUT4_DUTY_CYCLE   (0.500),
+    .CLKOUT4_CASCADE      ("TRUE"),
+    .CLKOUT6_DIVIDE       (120),
     .CLKIN1_PERIOD        (10.000)
   ) pll (
     .CLKFBOUT            (clk_fb_unbuf),
+    .CLKFBOUTB           (),
     .CLKOUT0             (clk_10_unbuf),
+    .CLKOUT0B            (),
     .CLKOUT1             (clk_48_unbuf),
-    .CLKOUT2             (clk_aon_unbuf),
+    .CLKOUT1B            (),
+    .CLKOUT2             (),
+    .CLKOUT2B            (),
     .CLKOUT3             (),
-    .CLKOUT4             (),
+    .CLKOUT3B            (),
+    .CLKOUT4             (clk_aon_unbuf),
     .CLKOUT5             (),
+    .CLKOUT6             (),
      // Input clock control
     .CLKFBIN             (clk_fb_buf),
     .CLKIN1              (clk_i),
@@ -65,10 +75,17 @@ module clkgen_xil7series # (
     .DO                  (),
     .DRDY                (),
     .DWE                 (1'b0),
+    // Phase shift signals
+    .PSCLK               (1'b0),
+    .PSEN                (1'b0),
+    .PSINCDEC            (1'b0),
+    .PSDONE              (),
     // Other control and status signals
+    .CLKFBSTOPPED        (),
+    .CLKINSTOPPED        (),
     .LOCKED              (locked_pll),
     .PWRDWN              (1'b0),
-    // Do not reset PLL on external reset, otherwise ILA disconnects at a reset
+    // Do not reset MMCM on external reset, otherwise ILA disconnects at a reset
     .RST                 (1'b0));
 
   // output buffering

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -19,7 +19,7 @@ const uint64_t kClockFreqPeripheralHz = 25 * 100 * 1000;  // 2.5MHz
 
 const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
-const uint64_t kClockFreqAonHz = 200 * 1000;  // 200kHz
+const uint64_t kClockFreqAonHz = 250 * 1000;  // 250kHz
 
 const uint64_t kUartBaudrate = 115200;
 


### PR DESCRIPTION
Use the MMCM's cascaded dividers to bring the clock frequency down and
align with the software's constants.

Signed-off-by: Alexander Williams <awill@google.com>

--
Resolves #12837