### PR TITLE
[dv/shadow reg] Fix alert checking timing with dut_init

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
@@ -226,6 +226,11 @@ virtual task glitch_shadowed_reset(ref dv_base_reg shadowed_csr[$],
     `DV_SPINWAIT(while (!cfg.m_alert_agent_cfg[alert_name].vif.get_alert())
                  cfg.clk_rst_vif.wait_clks(1);,
                  $sformatf("expect fatal alert:%0s to fire after rst_ni glitched", alert_name))
+
+    // `dut_init` task is used to toggle IP reset pin. If the IP has more than one reset pin, alert
+    // might already fire when the main reset is deasserted. So the below line we wait for a full
+    // alert handshake before check fatal alert.
+    cfg.m_alert_agent_cfg[alert_name].vif.wait_ack_complete();
     check_fatal_alert_nonblocking(alert_name);
   end
 


### PR DESCRIPTION
In reset glitch shadow reg test, we are hoping to capture alert firing
right after reset glitch happens. However, we are using dut_init to
issue IP pin reset. This might cause long delay and we might only catch
the last few cycles of alert handshake.
So to avoid this issue, we wait for a full alert handshake before
issuing check_fatal_alert_nonblocking.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>