### PR TITLE
[top, dv] Fix strap selection issues

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -410,7 +410,7 @@
             and RMA, regardless of the value on DFT SW straps.
             '''
       milestone: V2
-      tests: ["chip_tap_straps_dev", "chip_tap_straps_rma"]
+      tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
     }
 
     // PADCTRL tests:
@@ -1259,7 +1259,7 @@
             correctness.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
     }
     {
       name: chip_sw_lc_ctrl_jtag_trst

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -326,7 +326,7 @@
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=80_000_000", "+use_otp_image=LcStRma",
+      run_opts: ["+sw_test_timeout_ns=80_000_000",
                  "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1"]
       reseed: 5
     }
@@ -335,7 +335,7 @@
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=80_000_000", "+use_otp_image=LcStRma",
+      run_opts: ["+sw_test_timeout_ns=80_000_000",
                  "+ext_clk_type=ExtClkLowSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
       reseed: 5
     }
@@ -349,7 +349,7 @@
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=80_000_000", "+use_otp_image=LcStRma",
+      run_opts: ["+sw_test_timeout_ns=80_000_000",
                  "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
       reseed: 5
     }
@@ -889,7 +889,6 @@
       name: chip_tap_straps_rma
       uvm_test_seq: chip_tap_straps_vseq
       en_run_modes: ["strap_tests_mode"]
-      run_opts: ["+use_otp_image=LcStRma"]
     }
     {
       name: chip_tap_straps_prod

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
@@ -63,7 +63,12 @@ class chip_tap_straps_vseq extends chip_sw_base_vseq;
     // If it's not LC tap, effectively, no tap is selected.
     if (cur_lc_state == LcStProd) begin
       cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStProd);
-      if (select_jtag != SelectLCJtagTap) select_jtag = DeselectJtagTap;
+      // In Dev state, only pin0 of select_jtag is sampled. When it's set, select LC tap
+      if (select_jtag[0] == 0) select_jtag = DeselectJtagTap;
+      else                     select_jtag = SelectLCJtagTap;
+    end else if (cur_lc_state == LcStDev) begin
+      // In Dev state, can't select DFT tap. If it's selected, effectively, no tap is enabled
+      if (select_jtag == SelectDftJtagTap) select_jtag = DeselectJtagTap;
     end
   endtask
 
@@ -105,7 +110,6 @@ class chip_tap_straps_vseq extends chip_sw_base_vseq;
     end
   endtask
 
-  // TODO, add DFT tap
   virtual task enable_jtag_tap(chip_tap_type_e tap);
     if (select_jtag != tap) begin
       select_jtag = tap;


### PR DESCRIPTION
Fix strap selection on dev and prod state
1. in prod state, only pin[0] is sampled
2. in dev state, if dft is selected, changed to unselected as dft can't
   be enabled at this state

Also fix unmapped error
Signed-off-by: Weicai Yang <weicai@google.com>