### PR TITLE
[dv/pattgen] Move pattgen to V2S

### DIFF
--- a/hw/ip/pattgen/data/pattgen.prj.hjson
+++ b/hw/ip/pattgen/data/pattgen.prj.hjson
@@ -13,7 +13,7 @@
         version:            "1.0",
         life_stage:         "L1",
         design_stage:       "D2S",
-        verification_stage: "V1",
+        verification_stage: "V2S",
         dif_stage:          "S0",
         notes:              ""
       }

--- a/hw/ip/pattgen/doc/checklist.md
+++ b/hw/ip/pattgen/doc/checklist.md
@@ -182,7 +182,7 @@ Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | N/A         |
 Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | N/A         |
 Tests         | [SIM_FW_SIMULATED][]                    | N/A         |
 Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Done        |
-Coverage      | [SIM_CODE_COVERAGE_V2][]                | Done        |
+Coverage      | [SIM_CODE_COVERAGE_V2][]                | Done        | Waived register reg check module
 Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        |
 Coverage      | [FPV_CODE_COVERAGE_V2][]                | N/A         |
 Coverage      | [FPV_COI_COVERAGE_V2][]                 | N/A         |


### PR DESCRIPTION
1). Waived register check related coverage because we will implement the
  check in common test.
2). Claim pattgen to V2S after passing V2 review because there is no
  special security countermeasure.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>