### PR TITLE
[dvsim] Add `timescale` to the config field

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -58,6 +58,8 @@
   // the 'overrides' directive.
   dut_instance: "{tb}.dut"
 
+  timescale: "1ns/1ps"
+
   // Top level simulation entities.
   sim_tops: ["{tb}"]
 

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -7,7 +7,7 @@
   run_cmd:    "{job_prefix} {build_ex}"
 
   build_opts: ["-sverilog -full64 -licqueue -ntb_opts uvm-1.2",
-               "-timescale=1ns/1ps",
+               "-timescale={timescale}",
                "-Mdir={build_ex}.csrc",
                "-o {build_ex}",
                "-f {sv_flist}",
@@ -183,7 +183,7 @@
   cov_unr_dir:     "{scratch_path}/cov_unr"
 
   cov_unr_common_build_opts: ["-sverilog -full64 -licqueue -ntb_opts uvm-1.2",
-                              "-timescale=1ns/1ps"]
+                              "-timescale={timescale}"]
 
   // Use recommended UUM (Unified usage model) 3 steps flow. The other flow defines macro
   // "SYNTHESIS", which we have used in design

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -12,7 +12,7 @@
                // TODO: duplicate primitives between OT and Ibex #1231
                "-ALLOWREDEFINITION",
                "-messages -errormax 50",
-               "-timescale 1ns/1ps",
+               "-timescale {timescale}",
                "-f {sv_flist}",
                "-uvmhome CDNS-1.2",
                "-xmlibdirname {build_db_dir}",

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -41,6 +41,13 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  //overrides: [
+  //  {
+  //    name: "timescale"
+  //    value: "1ns/1ns"
+  //  }
+  //]
+
   // Default UVM test and seq class name.
   uvm_test: spi_device_base_test
   uvm_test_seq: spi_device_base_vseq


### PR DESCRIPTION
Revise dvsim `CfgJson.py` to overwrite the default field to the leaf most field if exists. Main usecase is to overwrite `timescale` for a specific test.

Rather than raising `RuntimeError`, it warns now.