### PR TITLE
[dvsim] Revert #12761 to build SW with meson

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -5,7 +5,8 @@
 export SHELL  := /bin/bash
 .DEFAULT_GOAL := all
 
-LOCK_ROOT_DIR ?= flock --timeout 3600 ${proj_root} --command
+LOCK_ROOT_DIR     ?= flock --timeout 3600 ${proj_root} --command
+LOCK_SW_BUILD_DIR ?= flock --timeout 3600 ${sw_build_dir} --command
 
 all: build run
 
@@ -56,7 +57,9 @@ endif
 sw_build: pre_run
 	@echo "[make]: sw_build"
 ifneq (${sw_images},)
-	# Loop through the list of sw_images and invoke Bazel on each.
+	# Initialize meson build system.
+	#
+	# Loop through the list of sw_images and invoke meson on each item.
 	# `sw_images` is a space-separated list of tests to be built into an image.
 	# Optionally, each item in the list can have additional metadata / flags using
 	# the delimiter ':'. The format is as follows:
@@ -67,13 +70,12 @@ ifneq (${sw_images},)
 	# test> followed by <index>. The <flag> is considered optional.
 	set -e; \
 	mkdir -p ${sw_build_dir}; \
+	${LOCK_SW_BUILD_DIR} "cd ${proj_root} && \
+		env BUILD_ROOT=${sw_build_dir} ${proj_root}/meson_init.sh"; \
 	for sw_image in ${sw_images}; do \
-		image=`echo $$sw_image | cut -d: -f 1`; \
+		image=`echo $$sw_image | cut -d: -f 1`;  \
 		index=`echo $$sw_image | cut -d: -f 2`; \
 		flags=(`echo $$sw_image | cut -d: -f 3- --output-delimiter " "`); \
-		target_dir=`dirname ${sw_build_dir}/build-bin/$$image`; \
-		mkdir -p $$target_dir; \
-		cd ${proj_root}; \
 		if [[ -z $$image ]]; then \
 			echo "ERROR: SW image \"$$sw_image\" is malformed."; \
 			echo "Expected format: path-to-sw-test:index:optional-flags."; \
@@ -81,26 +83,13 @@ ifneq (${sw_images},)
 		fi; \
 		if [[ $${flags[@]} =~ "prebuilt" ]]; then \
 			echo "SW image \"$$image\" is prebuilt - copying sources."; \
+			target_dir=`dirname ${sw_build_dir}/build-bin/$$image`; \
+			mkdir -p $$target_dir; \
 			cp ${proj_root}/$$image* $$target_dir/.; \
 		else \
 			echo "Building SW image \"$$image\"."; \
-			bazel_label="//`dirname $${image}`:`basename $${image}`"; \
-			if [[ $$index == "1" ]]; then \
-				bazel_label+="_sim_dv"; \
-			fi; \
-			bazel_opts="--define DISABLE_VERILATOR_BUILD=true"; \
-			if [[ -z $${BAZEL_PYTHON_WHEELS_REPO} ]]; then \
-				echo "Building \"$${bazel_label}\" on network connected machine."; \
-				bazel_cmd="./bazelisk.sh"; \
-			else \
-				echo "Building \"$${bazel_label}\" on air-gapped machine."; \
-				bazel_opts+=" --distdir=$${BAZEL_DISTDIR} --repository_cache=$${BAZEL_CACHE}"; \
-				bazel_cmd="bazel"; \
-			fi; \
-			$${bazel_cmd} build $${bazel_opts} $${bazel_label}; \
-			find -L $$($${bazel_cmd} info output_path)/ \
-				-type f -name "$$(basename $${image})*" | \
-				xargs -I % cp % $${target_dir}; \
+			target="$$image""_export_${sw_build_device}"; \
+			${LOCK_SW_BUILD_DIR} "ninja -C ${sw_build_dir}/build-out $$target"; \
 		fi; \
 	done;
 endif

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -277,7 +277,7 @@
     {
       name: chip_sw_uart_tx_rx
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=0"]
       reseed: 5
@@ -285,7 +285,7 @@
     {
       name: chip_sw_uart_tx_rx_idx1
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=1"]
       reseed: 5
@@ -293,7 +293,7 @@
     {
       name: chip_sw_uart_tx_rx_idx2
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=2"]
       reseed: 5
@@ -301,7 +301,7 @@
     {
       name: chip_sw_uart_tx_rx_idx3
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=3"]
       reseed: 5
@@ -309,14 +309,14 @@
     {
       name: chip_sw_uart_tx_rx_bootstrap
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_spi_load_bootstrap=1"]
     }
     {
       name: chip_sw_uart_rand_baudrate
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000"]
       reseed: 20
@@ -324,7 +324,7 @@
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+use_otp_image=LcStRma",
                  "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1"]
@@ -333,7 +333,7 @@
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq_low_speed
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+use_otp_image=LcStRma",
                  "+ext_clk_type=ExtClkLowSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
@@ -347,7 +347,7 @@
     {
       name: chip_sw_uart_tx_rx_alt_clk_fast_ip_clk
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+use_otp_image=LcStRma",
                  "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
@@ -356,13 +356,13 @@
     {
       name: chip_sw_spi_device_tx_rx
       uvm_test_seq: chip_sw_spi_tx_rx_vseq
-      sw_images: ["sw/device/tests/sim_dv/spi_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/spi_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
       name: chip_sw_gpio
       uvm_test_seq: chip_sw_gpio_vseq
-      sw_images: ["sw/device/tests/sim_dv/gpio_test:1"]
+      sw_images: ["sw/device/tests/gpio_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
@@ -382,7 +382,7 @@
     {
       name: chip_sw_flash_ctrl_lc_rw_en
       uvm_test_seq: chip_sw_flash_ctrl_lc_rw_en_vseq
-      sw_images: ["sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test:1"]
+      sw_images: ["sw/device/tests/flash_ctrl_lc_rw_en_test:1"]
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
@@ -408,7 +408,7 @@
     {
       name: chip_sw_flash_rma_unlocked
       uvm_test_seq: chip_sw_flash_rma_unlocked_vseq
-      sw_images: ["sw/device/tests/sim_dv/flash_rma_unlocked_test:0"]
+      sw_images: ["sw/device/tests/flash_rma_unlocked_test:0"]
       en_run_modes: ["sw_test_mode_common"]
       run_opts: ["+sw_test_timeout_ns=200_000_000"]
     }
@@ -428,7 +428,7 @@
       // Set higher reseed value to reach all kmac_data to lc_ctrl toggle coverage.
       name: chip_sw_lc_ctrl_transition
       uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
-      sw_images: ["sw/device/tests/sim_dv/lc_ctrl_transition_test:1"]
+      sw_images: ["sw/device/tests/lc_ctrl_transition_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       reseed: 15
     }
@@ -455,14 +455,14 @@
     {
       name: chip_sw_lc_walkthrough_prodend
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_test:1"]
+      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProdEnd"]
     }
     {
       name: chip_sw_lc_walkthrough_rma
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_test:1"]
+      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStRma",
                  // The test takes long time because it will transit to RMA state
@@ -498,7 +498,7 @@
     {
       name: chip_sw_pwrmgr_usbdev_wakeup
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest:1"]
+      sw_images: ["sw/device/tests/pwrmgr_usbdev_smoketest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
@@ -510,26 +510,26 @@
     {
       name: chip_sw_pwrmgr_main_power_glitch_reset
       uvm_test_seq: chip_sw_main_power_glitch_vseq
-      sw_images: ["sw/device/tests/sim_dv/pwrmgr_main_power_glitch_test:1"]
+      sw_images: ["sw/device/tests/pwrmgr_main_power_glitch_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
     }
     {
       name: chip_sw_pwrmgr_sysrst_ctrl_reset
       uvm_test_seq: chip_sw_sysrst_ctrl_vseq
-      sw_images: ["sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test:1"]
+      sw_images: ["sw/device/tests/pwrmgr_sysrst_ctrl_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_sysrst_reqs
       uvm_test_seq: chip_sw_sysrst_ctrl_vseq
-      sw_images: ["sw/device/tests/sim_dv/pwrmgr_deep_sleep_sysrst_reqs_test:1"]
+      sw_images: ["sw/device/tests/pwrmgr_deep_sleep_sysrst_reqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
       name: chip_sw_pwrmgr_sleep_power_glitch_reset
       uvm_test_seq: chip_sw_main_power_glitch_vseq
-      sw_images: ["sw/device/tests/sim_dv/pwrmgr_sleep_power_glitch_test:1"]
+      sw_images: ["sw/device/tests/pwrmgr_sleep_power_glitch_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
     }
@@ -590,7 +590,7 @@
     {
       name: chip_sw_adc_ctrl_sleep_debug_cable_wakeup
       uvm_test_seq: chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq
-      sw_images: ["sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test:1"]
+      sw_images: ["sw/device/tests/adc_ctrl_sleep_debug_cable_wakeup_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=18000000"]
     }
@@ -646,7 +646,7 @@
     {
       name: chip_sw_alert_test
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/autogen/alert_test:1"]
+      sw_images: ["sw/device/tests/alert_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
@@ -685,7 +685,7 @@
     {
       name: chip_sw_keymgr_key_derivation
       uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
-      sw_images: ["sw/device/tests/sim_dv/keymgr_key_derivation_test:1"]
+      sw_images: ["sw/device/tests/keymgr_key_derivation_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
     }
@@ -730,20 +730,20 @@
     {
       name: chip_sw_rom_ctrl_integrity_check
       uvm_test_seq: chip_sw_rom_ctrl_integrity_check_vseq
-      sw_images: ["sw/device/tests/sim_dv/rom_ctrl_integrity_check_test:1"]
+      sw_images: ["sw/device/tests/rom_ctrl_integrity_check_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
       name: chip_sw_sram_ctrl_ret_scrambled_access
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
-      sw_images: ["sw/device/tests/sim_dv/sram_ctrl_ret_scrambled_access_test:1"]
+      sw_images: ["sw/device/tests/sram_ctrl_ret_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+mem_sel=ret"]
     }
     {
       name: chip_sw_sram_ctrl_main_scrambled_access_jitter_en
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
-      sw_images: ["sw/device/tests/sim_dv/sram_ctrl_main_scrambled_access_test:1"]
+      sw_images: ["sw/device/tests/sram_ctrl_main_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+mem_sel=main",
                  "+sw_test_timeout_ns=7000000",
@@ -752,7 +752,7 @@
     {
       name: chip_sw_sram_ctrl_execution_main
       uvm_test_seq: chip_sw_sram_ctrl_execution_main_vseq
-      sw_images: ["sw/device/tests/sim_dv/sram_ctrl_execution_test_main:1"]
+      sw_images: ["sw/device/tests/sram_ctrl_execution_test_main:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
@@ -812,7 +812,7 @@
     {
       name: chip_plic_all_irqs
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/autogen/plic_all_irqs_test:1"]
+      sw_images: ["sw/device/tests/plic_all_irqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
@@ -830,7 +830,7 @@
     {
       name: chip_sw_clkmgr_external_clk_src_for_lc
       uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
-      sw_images: ["sw/device/tests/sim_dv/clkmgr_external_clk_src_for_lc_test:1"]
+      sw_images: ["sw/device/tests/clkmgr_external_clk_src_for_lc_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+ext_clk_type=ExtClkLowSpeed", "+calibrate_usb_clk=1"]
     }
@@ -875,7 +875,7 @@
     {
       name: chip_sw_pwrmgr_deep_sleep_all_wake_ups
       uvm_test_seq: "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq"
-      sw_images: ["sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_wake_ups:1"]
+      sw_images: ["sw/device/tests/pwrmgr_deep_sleep_all_wake_ups:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=18000000"]
     }

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -212,15 +212,10 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
       end else if ("signed" inside {sw_image_flags[i]}) begin
         // TODO: support multiple signing keys. See "signing_keys" in
         // `sw/device/meson.build` for options.
-        sw_images[i] = $sformatf("%0s/%0s_prog_%0s.test_key_0.signed",
+        sw_images[i] = $sformatf("%0s/%0s_%0s.test_key_0.signed",
           sw_build_bin_dir, sw_images[i], sw_build_device);
       end else begin
-        if (i == SwTypeTest) begin
-          sw_images[i] = $sformatf("%0s/%0s_prog_%0s", sw_build_bin_dir, sw_images[i],
-            sw_build_device);
-        end else begin
-          sw_images[i] = $sformatf("%0s/%0s_%0s", sw_build_bin_dir, sw_images[i], sw_build_device);
-        end
+        sw_images[i] = $sformatf("%0s/%0s_%0s", sw_build_bin_dir, sw_images[i], sw_build_device);
       end
     end
   endfunction


### PR DESCRIPTION
Testing out a rollback of #12761 to see if that helps private CI queue / run times.

Since switching dvsim.py to build SW with Bazel (instead of meson),
private CI job runtimes have increased. This is detailed in #12840. As a
temporary fix, this commit reverts #12761, and switch dvsim.py back to
using meson to build SW images.

Signed-off-by: Timothy Trippel <ttrippel@google.com>