### PR TITLE
[dv/tool] Collect csr assertion cov in auto-generated CSR tests

### DIFF
--- a/hw/dv/tools/vcs/cover_reg_top.cfg
+++ b/hw/dv/tools/vcs/cover_reg_top.cfg
@@ -7,11 +7,13 @@
 
 +moduletree *_reg_top
 +node tb.dut tl_*
-+assert tb.dut.tlul_assert*
 
 begin assert
-  -module prim_cdc_rand_delay // TODO: CDC not enabled yet
+  +moduletree *csr_assert_fpv
+  +moduletree tlul_assert
+  -moduletree prim_cdc_rand_delay // TODO: CDC not enabled yet
 end
+
 // Remove everything else from toggle coverage except:
 // - `prim_alert_sender`: the `alert_test` task under `cip_base_vseq` drives `alert_test_i` and
 // verifies `alert_rx/tx` handshake in each IP.

--- a/hw/dv/tools/xcelium/cover_reg_top.ccf
+++ b/hw/dv/tools/xcelium/cover_reg_top.ccf
@@ -9,6 +9,7 @@ include_ccf ${dv_root}/tools/xcelium/common.ccf
 deselect_coverage -betfs -module ${DUT_TOP}...
 select_coverage -befs -module *_reg_top...
 select_coverage -assert -module tlul_assert
+select_coverage -assert -module *_csr_assert_fpv
 
 // Include toggle coverage on `prim_alert_sender` because the `alert_test` task under
 // `cip_base_vseq` drives `alert_test_i` and verifies `alert_rx/tx` handshake in each IP.


### PR DESCRIPTION
This PR adds a knob to collect csr assertion cov in auto-generated csr tests for
xcelium and vcs.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>