### PR TITLE
[opentitantool]: Allow SPI chip select across transactions

### DIFF
--- a/sw/host/opentitanlib/src/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/proxy/mod.rs
@@ -19,7 +19,7 @@ mod socket_server;
 /// Interface for handlers of protocol messages, responding to each message with a single
 /// instance of the same protocol message.
 pub trait CommandHandler<Msg> {
-    fn execute_cmd(&self, msg: &Msg) -> Result<Msg>;
+    fn execute_cmd(&mut self, msg: &Msg) -> Result<Msg>;
 }
 
 /// This is the main entry point for the session proxy.  This struct will either bind on a

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -116,6 +116,8 @@ pub enum SpiRequest {
     RunTransaction {
         transaction: Vec<SpiTransferRequest>,
     },
+    AssertChipSelect,
+    DeassertChipSelect,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -142,6 +144,8 @@ pub enum SpiResponse {
     RunTransaction {
         transaction: Vec<SpiTransferResponse>,
     },
+    AssertChipSelect,
+    DeassertChipSelect,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/sw/host/opentitanlib/src/proxy/socket_server.rs
+++ b/sw/host/opentitanlib/src/proxy/socket_server.rs
@@ -159,7 +159,7 @@ impl<Msg: DeserializeOwned + Serialize, T: CommandHandler<Msg>> JsonSocketServer
                 }
                 if event.is_readable() {
                     conn.read()?;
-                    Self::process_any_requests(conn, &self.command_handler)?;
+                    Self::process_any_requests(conn, &mut self.command_handler)?;
                 }
                 // Return whether this connection object should be dropped.
                 return Ok((conn.rx_eof && (conn.tx_buf.len() == 0)) || conn.broken);
@@ -199,7 +199,7 @@ impl<Msg: DeserializeOwned + Serialize, T: CommandHandler<Msg>> JsonSocketServer
     }
 
     // Look for any completely received requests in the rx_buf, and handle them one by one.
-    fn process_any_requests(conn: &mut Connection, command_handler: &T) -> Result<()> {
+    fn process_any_requests(conn: &mut Connection, command_handler: &mut T) -> Result<()> {
         while let Some(request) = Self::get_complete_request(conn)? {
             // One complete request received, execute it.
             let resp = command_handler.execute_cmd(&request)?;

--- a/sw/host/opentitanlib/src/transport/cw310/spi.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/spi.rs
@@ -6,9 +6,10 @@ use anyhow::Result;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::io::spi::{SpiError, Target, Transfer, TransferMode};
+use crate::io::spi::{AssertChipSelect, SpiError, Target, Transfer, TransferMode};
 use crate::transport::cw310::usb::Backend;
 use crate::transport::cw310::CW310;
+use crate::transport::TransportError;
 
 pub struct CW310Spi {
     device: Rc<RefCell<Backend>>,
@@ -100,5 +101,9 @@ impl Target for CW310Spi {
         // Release CS# (allow to float high).
         self.device.borrow().spi1_set_cs_pin(true)?;
         result
+    }
+
+    fn assert_cs(self: Rc<Self>) -> Result<AssertChipSelect> {
+        Err(TransportError::UnsupportedOperation.into())
     }
 }

--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -41,6 +41,8 @@ pub enum TransportError {
     InvalidStrappingName(String),
     #[error("Transport does not support the requested operation")]
     UnsupportedOperation,
+    #[error("Requested operation invalid at this time")]
+    InvalidOperation,
     #[error("Error communicating with FTDI: {0}")]
     FtdiError(String),
     #[error("Error communicating with debugger: {0}")]

--- a/sw/host/opentitanlib/src/transport/ti50emulator/spi.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/spi.rs
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use std::rc::Rc;
 
-use crate::io::spi::{SpiError, Target, Transfer, TransferMode};
+use crate::io::spi::{AssertChipSelect, SpiError, Target, Transfer, TransferMode};
 use crate::transport::TransportError;
 use crate::util::voltage::Voltage;
 
@@ -57,6 +58,12 @@ impl Target for Ti50Spi {
 
     /// Runs a SPI transaction composed from the slice of [`Transfer`] objects.
     fn run_transaction(&self, _transaction: &mut [Transfer]) -> Result<()> {
+        Err(TransportError::UnsupportedOperation.into())
+    }
+
+    /// Assert the CS signal.  Uses reference counting, will be deasserted when each and every
+    /// returned `AssertChipSelect` object have gone out of scope.
+    fn assert_cs(self: Rc<Self>) -> Result<AssertChipSelect> {
         Err(TransportError::UnsupportedOperation.into())
     }
 }


### PR DESCRIPTION
While implementing TPM communication, I came across a use case in which
I wanted to perform a few SPI transfers, inspect the data that was read,
and then possibly issue some more SPI transfers, while keeping CS
asserted throughout.

The current `spi::Target` interface is such that `run_transaction()`
keeps CS asserted for the duration of the list of transfers given in the
parameter list and then deasserts it unconditionally, with no option to
add more based on the result of the previous ones.

This PR introduces an explicit `assert_cs()` function, which can be used
to keep CS asserted across multiple invocations of `run_transaction()`,
like below.

```
let spi = ...;
{
  let _cs_asserted = spi.assert_cs()?;
  spi.run_transaction(...)?;
  if ... {
    spi.run_transaction(...)?;
  }
  // CS will automatically deassert here (or earlier if bailing out.)
}
```

Furthermore, `assert_cs()` counts its invocations, and releases CS only
when every nested assertion has been released, such that if the above
code was part of a helper method, and the called wanted to make several
invocations of the helper, during a single CS session, then it could put
another `assert_cs()` around its logic.

Change-Id: I219f3647d29129c4dfc1fc346f855fb4e9da2e53