### PR TITLE
[dv/chip] use bazel to build SW

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -435,7 +435,7 @@
     {
       name: chip_sw_lc_walkthrough_dev
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStDev",
                  // The test takes long time because it will transit to RMA state
@@ -445,7 +445,7 @@
     {
       name: chip_sw_lc_walkthrough_prod
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProd",
                  // The test takes long time because it will transit to RMA state
@@ -471,7 +471,7 @@
     {
       name: chip_sw_lc_walkthrough_testunlocks
       uvm_test_seq: chip_sw_lc_walkthrough_testunlocks_vseq
-      sw_images: ["sw/device/tests/lc_walkthrough_testunlocks_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStTestUnlock7"]
       reseed: 1


### PR DESCRIPTION
Follow PR #12761, update the sw_images path to migrate to bazel build.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>