### PR TITLE
[adc_ctrl,dv] regression fix fsm_reset test

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
@@ -170,7 +170,10 @@ class adc_ctrl_fsm_reset_vseq extends adc_ctrl_base_vseq;
                 end
                 AdcCtrlResetModeHw: begin
                   // Hardware reset
-                  cfg.clk_aon_rst_vif.apply_reset();
+                  fork
+                    cfg.clk_aon_rst_vif.apply_reset();
+                    cfg.clk_rst_vif.apply_reset();
+                  join
                 end
                 default: `uvm_fatal(`gfn, "Undefined test mode")
               endcase

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr_sec_cm_testplan.hjson
@@ -40,7 +40,7 @@
             value during the test.
 
             **Check**:
-            If dut accepts any of invalid values, test will fail by turing dut to scanmode.
+            If dut accepts any of invalid values, test will fail by turning dut to scanmode.
             '''
       milestone: V2S
       tests: ["rstmgr_sec_cm_scan_intersig_mubi"]
@@ -52,8 +52,10 @@
             ** Stimulus**:
             Execute a series of reset event - lowpower, hwreq, ndm, and
             sw reset -. And at the beginning of these events, create
-            reset consistency error to one of 27 leaf modules.
-            Do the same test for all 27 modules.
+            reset consistency error to one of 25 leaf modules.
+            (exclude u_daon_por_io_div4 and u_daon_por_io_div4_shadowed,
+            see #11858, #12729 for details)
+            Do the same test for all 25 modules.
 
             **Check**:
             Upon asserting each reset consistency error,


### PR DESCRIPTION
- apply both reset (aon and main) at the same time during the test