### PR TITLE
[otbn, dv] Fixes regression issue in otbn_zero_state_err_urnd

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
@@ -30,6 +30,7 @@ class otbn_single_vseq extends otbn_base_vseq;
     if (cfg.under_reset) begin
         `uvm_info(`gfn, "under reset", UVM_LOW)
         cfg.clk_rst_vif.wait_for_reset(.wait_negedge(1'b0), .wait_posedge(1'b1));
+        return;
     end
     // We've loaded the binary. Run the processor to see what happens!
     run_otbn();

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
@@ -13,15 +13,17 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
       end
       begin
         bit [31:0] err_val = 32'd1 << 20;
-        string prng_path = "tb.dut.u_otbn_core.u_otbn_rnd.u_xoshiro256pp.xoshiro_d";
+        string prng_path = "tb.dut.u_otbn_core.u_otbn_rnd.u_xoshiro256pp.xoshiro_q";
 
         cfg.clk_rst_vif.wait_clks($urandom_range(10, 1000));
         `DV_CHECK_FATAL(uvm_hdl_force(prng_path, 'b0) == 1);
+        `uvm_info(`gfn,"injecting zero state error into ISS", UVM_HIGH)
+        cfg.model_agent_cfg.vif.send_err_escalation(err_val);
         cfg.clk_rst_vif.wait_clks(1);
         cfg.model_agent_cfg.vif.otbn_set_no_sec_wipe_chk();
-        cfg.model_agent_cfg.vif.send_err_escalation(err_val);
-        `uvm_info(`gfn,"injecting zero state error into ISS", UVM_HIGH)
         `DV_CHECK_FATAL(uvm_hdl_release(prng_path) == 1);
+        `uvm_info(`gfn,"string released", UVM_HIGH)
+        wait (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
         reset_if_locked();
       end
     join

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -92,7 +92,9 @@ interface otbn_model_if
     force u_model.wakeup_iss = 1;
     `DV_CHECK_FATAL(u_model.otbn_model_send_err_escalation(handle, err_val) == 0,
                     "Failed to escalate errors", "otbn_model_if")
+
     @(posedge clk_i or negedge rst_ni);
+    force u_model.wakeup_iss = 0;
     release u_model.wakeup_iss;
   endtask: send_err_escalation
 


### PR DESCRIPTION
The following issues were present in otbn_zero_state_err_urnd_vseq if
the zero state error was injected before the instruction fetch had
started:
1. The values deposited on wakeup_iss and xoshiro_q never changed after
the execution of release statement as there were no active drivers on
them.
2. reset_if_locked was executing too soon and not waiting for the status
to go to locked and hence the dut was not getting reset.
3. The parent vseq called run_otbn task while the reset was asserted if
reset was asserted immediately after the status went to locked.