### PR TITLE
[otbn, dv] Fixes regression failure in otbn_csr_mem_rw_with_rand_reset

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -41,7 +41,7 @@ class otbn_common_vseq extends otbn_base_vseq;
 
     // If we see a write which causes an integrity error AND we've disabled the scoreboard (which
     // has its own predictor), we update the predicted value of the STATUS register to be LOCKED.
-    if (completed && saw_err && !cfg.en_scb) begin
+    if (completed && saw_err && !cfg.en_scb && tl_intg_err_type != TlIntgErrNone) begin
       `DV_CHECK_FATAL(ral.status.status.predict(otbn_pkg::StatusLocked, .kind(UVM_PREDICT_READ)),
                       "Failed to update STATUS register")
     end


### PR DESCRIPTION
This commit fixes the failure in otbn_csr_mem_rw_with_rand_reset by
adding an extra check to figure out if a write causes an integrity
error.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>