### PR TITLE
[dv/top] Update wdog_lc_escalate test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -676,7 +676,7 @@
       desc: '''Verify that the LC escalation signal disables the AON timer wdog.
 
             - Program the AON timer wdog to 'bark' after some time and enable the bark interrupt.
-            - Stop the escalation process and fail the test in the interrupt handler in case the
+            - Start the escalation process and fail the test in the interrupt handler in case the
               bark interrupt is fired.
             - Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but the
               phase 1 (i.e. wipe secrets) should occur and last during the time the wdog is

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -37,8 +37,13 @@ enum {
   kWdogBarkMicros = 3 * 1000,          // 3 ms
   kWdogBiteMicros = 4 * 1000,          // 4 ms
   kEscalationPhase0Micros = 1 * 1000,  // 1 ms
-  kEscalationPhase1Micros = 5 * 1000,  // 5 ms
-  kEscalationPhase2Micros = 500,       // 500 us
+  // The cpu value is slightly larger as the busy_spin_micros
+  // routine cycle count comes out slightly smaller due to the
+  // fact that it does not divide by exactly 1M
+  // see sw/device/lib/runtime/hart.c
+  kEscalationPhase0MicrosCpu = kEscalationPhase0Micros + 200,  // 1.2 ms
+  kEscalationPhase1Micros = 5 * 1000,                          // 5 ms
+  kEscalationPhase2Micros = 500,                               // 500 us
 };
 
 static_assert(
@@ -209,7 +214,7 @@ static void execute_test(dif_aon_timer_t *aon_timer) {
   // Trigger the alert handler to escalate.
   dif_pwrmgr_alert_t alert = kDifPwrmgrAlertFatalFault;
   CHECK_DIF_OK(dif_pwrmgr_alert_force(&pwrmgr, alert));
-  busy_spin_micros(kEscalationPhase0Micros);
+  busy_spin_micros(kEscalationPhase0MicrosCpu);
   CHECK(false, "The alert handler failed to escalate");
 }
 


### PR DESCRIPTION
- the test was previous faililng because the busy_spin_macro
  has a slightly different cycle count from the escalator phase.
- this caused the test to mistakenly think the alert was not triggered
  even though it just needed to wait a little bit more time.

Signed-off-by: Timothy Chen <timothytim@google.com>