### PR TITLE
[dv/fpv] Add clkmgr to fpv sec cm script

### DIFF
--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -432,6 +432,15 @@
                cov: false
              } */
              {
+               name: clkmgr_sec_cm
+               dut: clkmgr
+               fusesoc_core: lowrisc:dv:clkmgr_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/clkmgr/{sub_flow}/{tool}"
+               cov: false
+               task: "FpvSecCm"
+             }
+             {
                name: csrng_sec_cm
                dut: csrng
                fusesoc_core: lowrisc:dv:csrng_sva


### PR DESCRIPTION
This PR adds clkmgr_sec_cm list to run fpv regression.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>