### PR TITLE
Revert "[python] Bump fusesoc/edalize versions"

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -44,13 +44,13 @@ anytree
 
 # To be removed with Meson.
 # Minimum matches version in meson.build
-meson >= 0.56.2, <= 0.57.2 
+meson >= 0.56.2, <= 0.57.2
 
 # Development version with OT-specific changes
-git+https://github.com/lowRISC/fusesoc.git@ot-0.2
+git+https://github.com/lowRISC/fusesoc.git@ot-0.1
 
 # Development version with OT-specific changes
-git+https://github.com/lowRISC/edalize.git@ot-0.2
+git+https://github.com/lowRISC/edalize.git@ot-0.1
 
 # Development version of ChipWhisperer toolchain
 # Use a development version until support for the CW310 board works in a


### PR DESCRIPTION
This reverts commit 8339519c379ad270bd2a091522ec564b08ebc41e in order to fix #12769.

If there is no real reason to use the newer fusesoc / edalize versions, we should revert in order to unblock Nuvoton.
We can still re-apply this patch later on, but we need to have a workaround for Nuvoton in place before we do that.

