### PR TITLE
[dif/lc_ctrl] split `dif_lc_ctrl_transition` into two

### DIFF
--- a/sw/device/lib/dif/dif_lc_ctrl.h
+++ b/sw/device/lib/dif/dif_lc_ctrl.h
@@ -260,37 +260,11 @@ typedef enum dif_lc_ctrl_id_state {
 } dif_lc_ctrl_id_state_t;
 
 /**
- * Programming clock settings, indicating whether to use the internal or
- * external clock to perform the life cycle transition.
- */
-typedef enum dif_lc_ctrl_clock_settings {
-  /**
-   * Use internal clock for transition.
-   */
-  kDifLcCtrlInternalClockEn,
-  /**
-   * Use external clock for transition.
-   */
-  kDifLcCtrlExternalClockEn
-} dif_lc_ctrl_clock_settings_t;
-
-/**
  * A 128-bit unlock token used for certain kinds of lifecycle transitions.
  */
 typedef struct dif_lc_ctrl_token {
   uint8_t data[128 / 8];
 } dif_lc_ctrl_token_t;
-
-/**
- * Settings for lifecycle transitions.
- */
-typedef struct dif_lc_ctrl_settings {
-  /**
-   * Indicates whether an external clock source shall be used to perform the
-   * life cycle transition.
-   */
-  dif_lc_ctrl_clock_settings_t clock_select;
-} dif_lc_ctrl_settings_t;
 
 /**
  * A 32-bit hardware revision number.
@@ -402,21 +376,31 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_lc_ctrl_mutex_release(const dif_lc_ctrl_t *lc);
 
 /**
- * Performs a lifecycle transition.
+ * Configures the lifecycle controller to perform a transition.
  *
  * Note that not all transitions require an unlock token; in that case, NULL
  * should be passed as the token.
  *
  * @param lc A lifecycle handle.
  * @param state The state to transition to.
+ * @param use_ext_clock Whether to use the external clock for the transition.
  * @param token A token for unlocking the transition; may be null.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_lc_ctrl_transition(const dif_lc_ctrl_t *lc,
-                                    dif_lc_ctrl_state_t state,
-                                    const dif_lc_ctrl_token_t *token,
-                                    const dif_lc_ctrl_settings_t *settings);
+dif_result_t dif_lc_ctrl_configure(const dif_lc_ctrl_t *lc,
+                                   dif_lc_ctrl_state_t target_state,
+                                   bool use_ext_clock,
+                                   const dif_lc_ctrl_token_t *token);
+
+/**
+ * Performs a lifecycle transition.
+ *
+ * @param lc A lifecycle handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_lc_ctrl_transition(const dif_lc_ctrl_t *lc);
 
 /**
  * Writes settings to the vendor-specific OTP test control register.

--- a/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
+++ b/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
@@ -200,10 +200,9 @@ static void enter_rma_test_phase(void) {
     token.data[i] = kLcRmaUnlockToken[i];
   }
   CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));
-
-  dif_lc_ctrl_settings_t settings = {.clock_select = kDifLcCtrlInternalClockEn};
-  CHECK_DIF_OK(
-      dif_lc_ctrl_transition(&lc, kDifLcCtrlStateRma, &token, &settings));
+  CHECK_DIF_OK(dif_lc_ctrl_configure(&lc, kDifLcCtrlStateRma,
+                                     /*use_ext_clock=*/false, &token));
+  CHECK_DIF_OK(dif_lc_ctrl_transition(&lc));
 
   // Enter WFI for detection in the testbench.
   test_status_set(kTestStatusInWfi);

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
@@ -84,16 +84,14 @@ bool execute_lc_ctrl_transition_test(bool use_ext_clk) {
 
     // Request lc_state transfer to Dev state.
     dif_lc_ctrl_token_t token;
-    dif_lc_ctrl_settings_t settings;
-    settings.clock_select =
-        use_ext_clk ? kDifLcCtrlExternalClockEn : kDifLcCtrlInternalClockEn;
     for (int i = 0; i < LC_TOKEN_SIZE; i++) {
       token.data[i] = kLcExitToken[i];
     }
-    CHECK(dif_lc_ctrl_mutex_try_acquire(&lc) == kDifOk);
-    CHECK(dif_lc_ctrl_transition(&lc, kDifLcCtrlStateDev, &token, &settings) ==
-              kDifOk,
-          "LC_transition failed!");
+    CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));
+    CHECK_DIF_OK(
+        dif_lc_ctrl_configure(&lc, kDifLcCtrlStateDev, use_ext_clk, &token),
+        "LC transition configuration failed!");
+    CHECK_DIF_OK(dif_lc_ctrl_transition(&lc), "LC transition failed!");
 
     LOG_INFO("Waiting for LC transtition done and reboot.");
     wait_for_interrupt();

--- a/sw/device/tests/sim_dv/lc_walkthrough_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_test.c
@@ -198,17 +198,21 @@ bool test_main(void) {
           token.data[i] = 0;
         }
       }
+
       CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));
-      dif_lc_ctrl_settings_t settings;
+
       // TODO(lowRISC/opentitan#12775): randomize using external or internal
       // clock.
-      settings.clock_select = kDifLcCtrlInternalClockEn;
-      CHECK_DIF_OK(dif_lc_ctrl_transition(&lc, kDestState, &token, &settings),
-                   "LC_transition failed!");
+      bool use_ext_clock = false;
+      CHECK_DIF_OK(
+          dif_lc_ctrl_configure(&lc, kDestState, use_ext_clock, &token),
+          "LC transition configuration failed!");
+      CHECK_DIF_OK(dif_lc_ctrl_transition(&lc), "LC transition failed!");
 
-      LOG_INFO("Waiting for LC transtition done and reboot.");
+      LOG_INFO("Waiting for LC transition done and reboot.");
       wait_for_interrupt();
-      // Unreachable
+
+      // Unreachable.
       return false;
     }
   } else if (curr_state == kDestState) {
@@ -246,17 +250,20 @@ bool test_main(void) {
         for (int i = 0; i < LC_TOKEN_SIZE; i++) {
           token.data[i] = kLcRmaToken[i];
         }
+
         CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));
-        dif_lc_ctrl_settings_t settings;
+
         // TODO: randomize using external or internal clock.
-        settings.clock_select = kDifLcCtrlExternalClockEn;
-        CHECK_DIF_OK(
-            dif_lc_ctrl_transition(&lc, kDifLcCtrlStateRma, &token, &settings),
-            "LC_transition failed!");
+        bool use_ext_clock = true;
+        CHECK_DIF_OK(dif_lc_ctrl_configure(&lc, kDifLcCtrlStateRma,
+                                           use_ext_clock, &token),
+                     "LC transition configuration failed!");
+        CHECK_DIF_OK(dif_lc_ctrl_transition(&lc), "LC transition failed!");
 
         LOG_INFO("Waiting for LC RMA transtition done and reboot.");
         wait_for_interrupt();
-        // unreachable
+
+        // Unreachable.
         return false;
       }
     }

--- a/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
@@ -187,17 +187,20 @@ bool test_main(void) {
       // requires to write all zero default tokens.
       token.data[i] = 0;
     }
+
     CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));
-    dif_lc_ctrl_settings_t settings;
+
     // TODO(lowRISC/opentitan#12775): randomize using external or internal
     // clock.
-    settings.clock_select = kDifLcCtrlInternalClockEn;
-    CHECK_DIF_OK(dif_lc_ctrl_transition(&lc, kDestState, &token, &settings),
-                 "LC_transition failed!");
+    bool use_ext_clock = false;
+    CHECK_DIF_OK(dif_lc_ctrl_configure(&lc, kDestState, use_ext_clock, &token),
+                 "LC transition configuration failed!");
+    CHECK_DIF_OK(dif_lc_ctrl_transition(&lc), "LC transition failed!");
 
     LOG_INFO("Waiting for LC transtition %0d done and reboot.", kDestState);
     wait_for_interrupt();
-    // Unreachable
+
+    // Unreachable.
     return false;
   } else {
     // Reached TestUnlock7 state, exit SW test.


### PR DESCRIPTION
As identified during the lc_ctrl D3 review, it is useful to be able to
give the programmer a chance to check the lifecycle transition
state/token/clock-enable registers _before_ issuing a transition
command, as there are a limited number of lifecycle transitions that can
be performed on each chip.

This fixes #12822.

Signed-off-by: Timothy Trippel <ttrippel@google.com>