### PR TITLE
[dif, ibex] Add nmi api with unittests

### DIFF
--- a/sw/device/lib/dif/dif_rv_core_ibex.c
+++ b/sw/device/lib/dif/dif_rv_core_ibex.c
@@ -205,3 +205,69 @@ dif_result_t dif_rv_core_ibex_clear_error_status(
 
   return kDifOk;
 }
+
+dif_result_t dif_rv_core_ibex_enable_nmi(const dif_rv_core_ibex_t *rv_core_ibex,
+                                         dif_rv_core_ibex_nmi_source_t nmi) {
+  if (rv_core_ibex == NULL || (nmi & ~kDifRvCoreIbexNmiSourceAll) != 0) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg = 0;
+  reg = bitfield_bit32_write(
+      reg, RV_CORE_IBEX_NMI_ENABLE_ALERT_EN_BIT,
+      (nmi & kDifRvCoreIbexNmiSourceAlert) == kDifRvCoreIbexNmiSourceAlert);
+  reg = bitfield_bit32_write(
+      reg, RV_CORE_IBEX_NMI_ENABLE_WDOG_EN_BIT,
+      (nmi & kDifRvCoreIbexNmiSourceWdog) == kDifRvCoreIbexNmiSourceWdog);
+
+  mmio_region_write32(rv_core_ibex->base_addr,
+                      RV_CORE_IBEX_NMI_ENABLE_REG_OFFSET, reg);
+
+  return kDifOk;
+}
+
+dif_result_t dif_rv_core_ibex_get_nmi_state(
+    const dif_rv_core_ibex_t *rv_core_ibex,
+    dif_rv_core_ibex_nmi_state_t *nmi_state) {
+  if (rv_core_ibex == NULL || nmi_state == NULL) {
+    return kDifBadArg;
+  }
+
+  *nmi_state = (dif_rv_core_ibex_nmi_state_t){0};
+
+  uint32_t reg = mmio_region_read32(rv_core_ibex->base_addr,
+                                    RV_CORE_IBEX_NMI_ENABLE_REG_OFFSET);
+  nmi_state->alert_enabled =
+      bitfield_bit32_read(reg, RV_CORE_IBEX_NMI_ENABLE_ALERT_EN_BIT);
+  nmi_state->wdog_enabled =
+      bitfield_bit32_read(reg, RV_CORE_IBEX_NMI_ENABLE_WDOG_EN_BIT);
+
+  reg = mmio_region_read32(rv_core_ibex->base_addr,
+                           RV_CORE_IBEX_NMI_STATE_REG_OFFSET);
+  nmi_state->alert_raised =
+      bitfield_bit32_read(reg, RV_CORE_IBEX_NMI_STATE_ALERT_BIT);
+  nmi_state->wdog_barked =
+      bitfield_bit32_read(reg, RV_CORE_IBEX_NMI_STATE_WDOG_BIT);
+
+  return kDifOk;
+}
+
+dif_result_t dif_rv_core_ibex_clear_nmi_state(
+    const dif_rv_core_ibex_t *rv_core_ibex, dif_rv_core_ibex_nmi_source_t nmi) {
+  if (rv_core_ibex == NULL || (nmi & ~kDifRvCoreIbexNmiSourceAll) != 0) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg = 0;
+  reg = bitfield_bit32_write(
+      reg, RV_CORE_IBEX_NMI_STATE_ALERT_BIT,
+      (nmi & kDifRvCoreIbexNmiSourceAlert) == kDifRvCoreIbexNmiSourceAlert);
+  reg = bitfield_bit32_write(
+      reg, RV_CORE_IBEX_NMI_STATE_WDOG_BIT,
+      (nmi & kDifRvCoreIbexNmiSourceWdog) == kDifRvCoreIbexNmiSourceWdog);
+
+  mmio_region_write32(rv_core_ibex->base_addr,
+                      RV_CORE_IBEX_NMI_STATE_REG_OFFSET, reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_rv_core_ibex.h
+++ b/sw/device/lib/dif/dif_rv_core_ibex.h
@@ -107,6 +107,43 @@ typedef enum dif_rv_core_ibex_error_status {
 } dif_rv_core_ibex_error_status_t;
 
 /**
+ * NMI enabled status and current state.
+ */
+typedef struct dif_rv_core_ibex_nmi_state {
+  /**
+   * NMI alert is currently enabled.
+   */
+  bool alert_enabled;
+  /**
+   * Alert has been raised.
+   */
+  bool alert_raised;
+  /**
+   * NMI watchdog is currently enabled.
+   */
+  bool wdog_enabled;
+  /**
+   * Watchdog has barked.
+   */
+  bool wdog_barked;
+} dif_rv_core_ibex_nmi_state_t;
+
+typedef enum dif_rv_core_ibex_nmi_source {
+  /**
+   * NMI alert handler.
+   */
+  kDifRvCoreIbexNmiSourceAlert = 1 << 0,
+  /**
+   * NMI watchdog bark.
+   */
+  kDifRvCoreIbexNmiSourceWdog = 1 << 1,
+  /**
+   * All ibex NMIs.
+   */
+  kDifRvCoreIbexNmiSourceAll = 0x3,
+} dif_rv_core_ibex_nmi_source_t;
+
+/**
  * Configure the instruction and data bus in the address translation `slot`.
  *
  * @param rv_core_ibex Handle.
@@ -169,6 +206,40 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_core_ibex_clear_error_status(
     const dif_rv_core_ibex_t *rv_core_ibex,
     dif_rv_core_ibex_error_status_t error_status);
+
+/**
+ * Enables NMI support for security alert events and watchdog bark.
+ *
+ * @param rv_core_ibex Handle.
+ * @param nmi A bitmask with nmi sources to be enabled.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_enable_nmi(const dif_rv_core_ibex_t *rv_core_ibex,
+                                         dif_rv_core_ibex_nmi_source_t nmi);
+
+/**
+ * Read the NMI enable status and current event state.
+ *
+ * @param rv_core_ibex Handle.
+ * @param[out] nmi_state The nmi state.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_get_nmi_state(
+    const dif_rv_core_ibex_t *rv_core_ibex,
+    dif_rv_core_ibex_nmi_state_t *nmi_state);
+
+/**
+ * Clear the NMI current event state.
+ *
+ * @param rv_core_ibex Handle
+ * @param nmi A bitmask with nmi sources to be cleared.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_clear_nmi_state(
+    const dif_rv_core_ibex_t *rv_core_ibex, dif_rv_core_ibex_nmi_source_t nmi);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Add nmi api with unittests in the `dif_rv_core_ibex`
Signed-off-by: Douglas Reis <doreis@lowrisc.org>