### PR TITLE
[prim_assert] Fix ASSERT_FPV_LINEAR_FSM

### DIFF
--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -157,7 +157,7 @@
       property __name``_p;                                                                                       \
         __type initial_state;                                                                                    \
         (!$stable(__state), initial_state = $past(__state)) |->                                                  \
-            always (__state != initial_state);                                                                   \
+            (__state != initial_state) until (__rst == 1'b1);                                                    \
       endproperty                                                                                                \
     `ASSERT(__name, __name``_p, __clk, __rst)                                                                    \
   `endif


### PR DESCRIPTION
This assertion should handle an lc reset, even though the reset and idle
states will be revisited.

Signed-off-by: Guillermo Maturana <maturana@google.com>