### PR TITLE
[flash_ctrl] increase time precision of flash_ctrl block

### DIFF
--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -38,6 +38,10 @@
       name: design_level
       value: "top"
     }
+    {
+      name: "timescale"
+      value: "1ns/100ps"
+    }
   ]
 
   // Add additional tops for simulation.


### PR DESCRIPTION
- some of flash_ctrl tb runs more than 1s simulation time.
- After discussing with DD (@tjaychen ), we can increase our time precision up to 100 ps\
- This will improve run time of long run tests and address some of regression failure

Signed-off-by: Jaedon Kim <jdonjdon@google.com>