### PR TITLE
[rstmgr] Address comment from #12890

### DIFF
--- a/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -253,6 +253,7 @@ module rstmgr_cnsty_chk
 
       default: begin
         state_d = FsmError;
+        fsm_err_o = 1'b1;
       end
     endcase // unique case (state_q)
   end // always_comb


### PR DESCRIPTION
The consistency check default state does not currently signal an error,
it creates a situation where a continuous glitch or a
severed enable/clock to the fsm flops could suppress the error/alert.

This does not seem feasible, but it's better to be safe since it
has a very low cost.