### PR TITLE
chore(cdc): Prim Reg CDC waivers

### DIFF
--- a/hw/top_earlgrey/cdc/cdc_waivers.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.tcl
@@ -63,3 +63,13 @@ set_rule_status -rule {W_CNTL} -status {Waived}                              \
 set_rule_status -rule {W_MASYNC} -status {Waived}        \
   -expression {(Driver=~"*u_pinmux_aon.dio_pad_attr_*")} \
   -comment {PAD Attributes are static signals.}
+
+## Waive prim_reg_cdc (core_tgl -> reg src_update)
+set_rule_status -rule {W_RECON_GROUPS} -status {Waived} \
+  -expression {(ControlSignal =~ "*.u_reg.u_core_tgl.req_sync*") && \
+  (ReconSignal =~ "*.u_reg.u_*_cdc.src_q*")} \
+  -comment {core_tgl generates pulse at every edge, then reconvergence issue is not concern here}
+set_rule_status -rule {W_RECON_GROUPS} -status {Waived} \
+  -expression {(ControlSignal =~ "*.u_reg.u_*_cdc.u_prim_sync.ack_sync.*") && \
+  (ReconSignal =~ "*.u_reg.u_*_cdc.src_q*")} \
+  -comment {core_tgl generates pulse at every edge, then reconvergence issue is not concern here}


### PR DESCRIPTION
_Please review the last commit only_

the `u_core_tgl` is to catch the edge of the slower clock. The signal is
used to update the value to the faster clock domain.

The reconvergence error complains the signal combines with the src_ack.
However, src_ack comes from the slower clock domain and related to the
src_req(busy_q). Update signal is other one. If both happens, it is
still OK. If both happens at the different clock phase (1clk apart),
still OK as the intention is to update the registers in slower clock to
the faster clock.