### PR TITLE
[uart] Move to D3

### DIFF
--- a/hw/ip/uart/data/uart.prj.hjson
+++ b/hw/ip/uart/data/uart.prj.hjson
@@ -20,9 +20,11 @@
       {
         version:            "1.1",
         life_stage:         "L1",
-        design_stage:       "D2S",
+        design_stage:       "D3",
         verification_stage: "V2",
         dif_stage:          "S2",
+        commit_id:          "558942bb7869d9a5d8abd4bd0eb46dab820d3564"
+        notes:              ""
       }
     ]
 }

--- a/hw/ip/uart/doc/checklist.md
+++ b/hw/ip/uart/doc/checklist.md
@@ -104,16 +104,16 @@ Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only con
 Documentation | [NEW_FEATURES_D3][]     | N/A         |
 RTL           | [TODO_COMPLETE][]       | Done        |
 Code Quality  | [LINT_COMPLETE][]       | Done        |
-Code Quality  | [CDC_COMPLETE][]        | N/A         |
-Code Quality  | [RDC_COMPLETE][]        | Not Started |
-Review        | [REVIEW_RTL][]          | Done        | by @msfschaffner
-Review        | [REVIEW_DELETED_FF][]   | N/A         | Not reported by FPGA (@eunchan double-check)
-Review        | [REVIEW_SW_CHANGE][]    | N/A         |
+Code Quality  | [CDC_COMPLETE][]        | Waived      | No block-level flow available - waived to top-level signoff
+Code Quality  | [RDC_COMPLETE][]        | Waived      | No block-level flow available - waived to top-level signoff
+Review        | [REVIEW_RTL][]          | Done        |
+Review        | [REVIEW_DELETED_FF][]   | Waived      | No block-level flow available - waived to top-level signoff
+Review        | [REVIEW_SW_CHANGE][]    | Done        | by awill@
 Review        | [REVIEW_SW_ERRATA][]    | Done        |
-Security      | [SEC_NON_RESET_FLOPS][] | Not Started |
-Security      | [SEC_SHADOW_REGS][]     | Not Started |
-Review        | Reviewer(s)             | Done        | @weicaiyang @sjgitty @msfschaffner
-Review        | Signoff date            | Done        | 2019-10-31
+Security      | [SEC_NON_RESET_FLOPS][] | N/A         |
+Security      | [SEC_SHADOW_REGS][]     | N/A         |
+Review        | Reviewer(s)             | Done        | eunchan@ jeoong@ weicai@ awill@
+Review        | Signoff date            | Done        | 2022-06-16
 
 [NEW_FEATURES_D3]:      {{<relref "/doc/project/checklist.md#new_features_d3" >}}
 [TODO_COMPLETE]:        {{<relref "/doc/project/checklist.md#todo_complete" >}}


### PR DESCRIPTION
This commit moves UART to D3 state. CDC has been reviewed at the
top-level and waived
