### PR TITLE
[otbn, dv] Fixed regression issue in otbn_illegal_mem_acc

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -37,6 +37,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   tl_errors_cg_wrap   tl_errors_cgs_wrap[string];
   tl_intg_err_cg_wrap tl_intg_err_cgs_wrap[string];
   tl_intg_err_mem_subword_cg_wrap tl_intg_err_mem_subword_cgs_wrap[string];
+
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
@@ -310,10 +311,15 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   virtual task process_mem_read(tl_seq_item item, string ral_name);
     uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_normalized_addr(item.a_addr);
+
     if (!cfg.under_reset && get_mem_access_by_addr(cfg.ral_models[ral_name], addr) == "RW") begin
-      exp_mem[ral_name].compare(addr, item.d_data, item.a_mask);
+      mem_compare(ral_name, addr, item);
     end
   endtask
+
+  virtual function void mem_compare(string ral_name, uvm_reg_addr_t addr, tl_seq_item item);
+    exp_mem[ral_name].compare(addr, item.d_data, item.a_mask);
+  endfunction
 
   // check if it's mem addr
   virtual function bit is_mem_addr(tl_seq_item item, string ral_name);

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -617,4 +617,21 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     end
   endfunction
 
+  virtual function void mem_compare(string ral_name, uvm_reg_addr_t addr, tl_seq_item item);
+    // We can only compare the contents inside memories when the OTBN is not operating
+    if (model_status == otbn_pkg::StatusIdle) begin
+      super.mem_compare(ral_name, addr, item);
+    // Otherwise the contents will read out as zeros so compare expected memory with zero.
+    end else begin
+      `DV_CHECK_EQ(item.d_data, '0, "Memory read out nonzero value while OTBN is not IDLE")
+    end
+  endfunction
+
+  virtual task process_mem_read(tl_seq_item item, string ral_name);
+    super.process_mem_read(item, ral_name);
+    if (model_status == 'b1 && item.d_data != 0) begin
+      `uvm_error(`gfn, "read data is non zero when memory is accessed while otbn is busy")
+    end
+  endtask
+
 endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_illegal_mem_acc_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_illegal_mem_acc_vseq.sv
@@ -9,6 +9,7 @@ class otbn_illegal_mem_acc_vseq extends otbn_single_vseq;
   `uvm_object_new
 
   task body();
+    do_end_addr_check = 0;
     fork
       begin
         super.body();


### PR DESCRIPTION
This commit disables compare check that happens in the memory model
whenever an illegal access is done to the imem / dmem while the otbn is
busy executing instructions.

it also disables end address check inside run_otbn task.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>