### PR TITLE
[COMMITTERS] Update committer list to add Douglas Reis

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,6 @@ COPYING*            @mundaym
 /util/licence-checker.hjson  @mundaym
 
 # CI and testing
-/ci/                @mcy @milesdai @rswarbrick
-/test/              @mcy
-azure-pipelines.yml @mcy @milesdai @rswarbrick
+/ci/                @milesdai @rswarbrick
+# /test/            # TBD
+azure-pipelines.yml @milesdai @rswarbrick

--- a/COMMITTERS
+++ b/COMMITTERS
@@ -21,6 +21,7 @@ Committer list:
 * Michael Munday (mundaym)
 * Miguel Osorio (moidx)
 * Jade Philipoom (jadephilipoom)
+* Douglas Reis (engdoreis)
 * Dominic Rizzo (domrizz0)
 * Michael Schaffner (msfschaffner)
 * Rupert Swarbrick (rswarbrick)
@@ -30,4 +31,3 @@ Committer list:
 * Pirmin Vogel (vogelpi)
 * Alex Williams (a-will)
 * Weicai Yang (weicaiyang)
-* Miguel Young (mcy)


### PR DESCRIPTION
The Technical Committee has granted committer status to Douglas.
Congratulations Douglas, thank you for all your hard work on the
project so far.

Also, remove Miguel Young de la Sota from the COMMITTERS and
CODEOWNERS lists as he is no longer working on the project. Thanks
for all your contributions over the years Miguel!