### PR TITLE
[flash_ctrl/prim] Flash interrupt usability and modeling updates 

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -18,7 +18,10 @@ module flash_ctrl
   parameter lfsr_perm_t           RndCnstLfsrPerm = RndCnstLfsrPermDefault,
   parameter int                   ProgFifoDepth   = MaxFifoDepth,
   parameter int                   RdFifoDepth     = MaxFifoDepth,
-  parameter bit                   SecScrambleEn   = 1'b1
+  parameter bit                   SecScrambleEn   = 1'b1,
+  parameter int                   ModelOnlyReadLatency   = 1,  // generic model read latency
+  parameter int                   ModelOnlyProgLatency   = 50, // generic model program latency
+  parameter int                   ModelOnlyEraseLatency  = 200 // generic model program latency
 ) (
   input        clk_i,
   input        rst_ni,
@@ -1273,7 +1276,10 @@ module flash_ctrl
   );
 
   flash_phy #(
-    .SecScrambleEn(SecScrambleEn)
+    .SecScrambleEn(SecScrambleEn),
+    .ModelOnlyReadLatency(ModelOnlyReadLatency),
+    .ModelOnlyProgLatency(ModelOnlyProgLatency),
+    .ModelOnlyEraseLatency(ModelOnlyEraseLatency)
   ) u_eflash (
     .clk_i,
     .rst_ni,

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -18,7 +18,10 @@ module flash_ctrl
   parameter lfsr_perm_t           RndCnstLfsrPerm = RndCnstLfsrPermDefault,
   parameter int                   ProgFifoDepth   = MaxFifoDepth,
   parameter int                   RdFifoDepth     = MaxFifoDepth,
-  parameter bit                   SecScrambleEn   = 1'b1
+  parameter bit                   SecScrambleEn   = 1'b1,
+  parameter int                   ModelOnlyReadLatency   = 1,  // generic model read latency
+  parameter int                   ModelOnlyProgLatency   = 50, // generic model program latency
+  parameter int                   ModelOnlyEraseLatency  = 200 // generic model program latency
 ) (
   input        clk_i,
   input        rst_ni,
@@ -1274,7 +1277,10 @@ module flash_ctrl
   );
 
   flash_phy #(
-    .SecScrambleEn(SecScrambleEn)
+    .SecScrambleEn(SecScrambleEn),
+    .ModelOnlyReadLatency(ModelOnlyReadLatency),
+    .ModelOnlyProgLatency(ModelOnlyProgLatency),
+    .ModelOnlyEraseLatency(ModelOnlyEraseLatency)
   ) u_eflash (
     .clk_i,
     .rst_ni,

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -1077,12 +1077,25 @@ module flash_ctrl
     assign hw2reg.ecc_single_err_addr[i].d = {flash_phy_rsp.ecc_addr[i], {BusByteWidth{1'b0}}};
   end
 
+  logic rd_fifo_wr_q;
+  logic prog_fifo_rd_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rd_fifo_wr_q <= '0;
+      prog_fifo_rd_q <= '0;
+    end else begin
+      rd_fifo_wr_q <= rd_fifo_wen & rd_fifo_wready;
+      prog_fifo_rd_q <= prog_fifo_rvalid & prog_fifo_ren;
+    end
+  end
+
   // general interrupt events
   logic [LastIntrIdx-1:0] intr_event;
 
   prim_edge_detector #(
     .Width(1),
-    .ResetValue(1)
+    .ResetValue(1),
+    .EnSync(0)
   ) u_prog_empty_event (
     .clk_i,
     .rst_ni,
@@ -1107,11 +1120,12 @@ module flash_ctrl
 
   prim_edge_detector #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue(0),
+    .EnSync(0)
   ) u_prog_lvl_event (
     .clk_i,
     .rst_ni,
-    .d_i(reg2hw.fifo_lvl.prog.q == MaxFifoWidth'(prog_fifo_depth)),
+    .d_i(prog_fifo_rd_q & (reg2hw.fifo_lvl.prog.q == MaxFifoWidth'(prog_fifo_depth))),
     .q_sync_o(),
     .q_posedge_pulse_o(intr_event[ProgLvl]),
     .q_negedge_pulse_o()
@@ -1132,7 +1146,8 @@ module flash_ctrl
 
   prim_edge_detector #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue(0),
+    .EnSync(0)
   ) u_rd_full_event (
     .clk_i,
     .rst_ni,
@@ -1157,11 +1172,12 @@ module flash_ctrl
 
   prim_edge_detector #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue(0),
+    .EnSync(0)
   ) u_rd_lvl_event (
     .clk_i,
     .rst_ni,
-    .d_i(reg2hw.fifo_lvl.rd.q == rd_fifo_depth),
+    .d_i(rd_fifo_wr_q & (reg2hw.fifo_lvl.rd.q == rd_fifo_depth)),
     .q_sync_o(),
     .q_posedge_pulse_o(intr_event[RdLvl]),
     .q_negedge_pulse_o()

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -14,7 +14,10 @@ module flash_phy
   import flash_ctrl_pkg::*;
   import prim_mubi_pkg::mubi4_t;
 #(
-  parameter bit SecScrambleEn = 1'b1
+  parameter bit SecScrambleEn = 1'b1,
+  parameter int ModelOnlyReadLatency   = 1,   // generic model read latency
+  parameter int ModelOnlyProgLatency   = 50,  // generic model program latency
+  parameter int ModelOnlyEraseLatency  = 200 // generic model program latency
 )
 (
   input clk_i,
@@ -328,7 +331,10 @@ module flash_phy
     .InfoTypesWidth(InfoTypesWidth),
     .PagesPerBank(PagesPerBank),
     .WordsPerPage(WordsPerPage),
-    .DataWidth(flash_phy_pkg::FullDataWidth)
+    .DataWidth(flash_phy_pkg::FullDataWidth),
+    .ModelOnlyReadLatency(ModelOnlyReadLatency),
+    .ModelOnlyProgLatency(ModelOnlyProgLatency),
+    .ModelOnlyEraseLatency(ModelOnlyEraseLatency)
   ) u_flash (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -13,6 +13,9 @@ module prim_generic_flash #(
   parameter int PagesPerBank   = 256,// data pages per bank
   parameter int WordsPerPage   = 256,// words per page
   parameter int DataWidth      = 32, // bits per word
+  parameter int ModelOnlyReadLatency   = 1,   // generic model read latency
+  parameter int ModelOnlyProgLatency   = 50,  // generic model program latency
+  parameter int ModelOnlyEraseLatency  = 200, // generic model program latency
   parameter int TestModeWidth  = 2
 ) (
   input clk_i,
@@ -68,7 +71,10 @@ module prim_generic_flash #(
       .InfoTypesWidth(InfoTypesWidth),
       .PagesPerBank(PagesPerBank),
       .WordsPerPage(WordsPerPage),
-      .DataWidth(DataWidth)
+      .DataWidth(DataWidth),
+      .ModelOnlyReadLatency(ModelOnlyReadLatency),
+      .ModelOnlyProgLatency(ModelOnlyProgLatency),
+      .ModelOnlyEraseLatency(ModelOnlyEraseLatency)
     ) u_prim_flash_bank (
       .clk_i,
       .rst_ni,

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -24,7 +24,10 @@ module flash_ctrl
   parameter lfsr_perm_t           RndCnstLfsrPerm = RndCnstLfsrPermDefault,
   parameter int                   ProgFifoDepth   = MaxFifoDepth,
   parameter int                   RdFifoDepth     = MaxFifoDepth,
-  parameter bit                   SecScrambleEn   = 1'b1
+  parameter bit                   SecScrambleEn   = 1'b1,
+  parameter int                   ModelOnlyReadLatency   = 1,  // generic model read latency
+  parameter int                   ModelOnlyProgLatency   = 50, // generic model program latency
+  parameter int                   ModelOnlyEraseLatency  = 200 // generic model program latency
 ) (
   input        clk_i,
   input        rst_ni,
@@ -1280,7 +1283,10 @@ module flash_ctrl
   );
 
   flash_phy #(
-    .SecScrambleEn(SecScrambleEn)
+    .SecScrambleEn(SecScrambleEn),
+    .ModelOnlyReadLatency(ModelOnlyReadLatency),
+    .ModelOnlyProgLatency(ModelOnlyProgLatency),
+    .ModelOnlyEraseLatency(ModelOnlyEraseLatency)
   ) u_eflash (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -1083,12 +1083,25 @@ module flash_ctrl
     assign hw2reg.ecc_single_err_addr[i].d = {flash_phy_rsp.ecc_addr[i], {BusByteWidth{1'b0}}};
   end
 
+  logic rd_fifo_wr_q;
+  logic prog_fifo_rd_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rd_fifo_wr_q <= '0;
+      prog_fifo_rd_q <= '0;
+    end else begin
+      rd_fifo_wr_q <= rd_fifo_wen & rd_fifo_wready;
+      prog_fifo_rd_q <= prog_fifo_rvalid & prog_fifo_ren;
+    end
+  end
+
   // general interrupt events
   logic [LastIntrIdx-1:0] intr_event;
 
   prim_edge_detector #(
     .Width(1),
-    .ResetValue(1)
+    .ResetValue(1),
+    .EnSync(0)
   ) u_prog_empty_event (
     .clk_i,
     .rst_ni,
@@ -1113,11 +1126,12 @@ module flash_ctrl
 
   prim_edge_detector #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue(0),
+    .EnSync(0)
   ) u_prog_lvl_event (
     .clk_i,
     .rst_ni,
-    .d_i(reg2hw.fifo_lvl.prog.q == MaxFifoWidth'(prog_fifo_depth)),
+    .d_i(prog_fifo_rd_q & (reg2hw.fifo_lvl.prog.q == MaxFifoWidth'(prog_fifo_depth))),
     .q_sync_o(),
     .q_posedge_pulse_o(intr_event[ProgLvl]),
     .q_negedge_pulse_o()
@@ -1138,7 +1152,8 @@ module flash_ctrl
 
   prim_edge_detector #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue(0),
+    .EnSync(0)
   ) u_rd_full_event (
     .clk_i,
     .rst_ni,
@@ -1163,11 +1178,12 @@ module flash_ctrl
 
   prim_edge_detector #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue(0),
+    .EnSync(0)
   ) u_rd_lvl_event (
     .clk_i,
     .rst_ni,
-    .d_i(reg2hw.fifo_lvl.rd.q == rd_fifo_depth),
+    .d_i(rd_fifo_wr_q & (reg2hw.fifo_lvl.rd.q == rd_fifo_depth)),
     .q_sync_o(),
     .q_posedge_pulse_o(intr_event[RdLvl]),
     .q_negedge_pulse_o()


### PR DESCRIPTION
- Address some usability issues identified in https://github.com/lowRISC/opentitan/pull/12834

- Read level interrupt is intended to trigger
  when the flash read deposits more than N number of
  entries into the FIFO. Therefore trigger only
  when there has been a deposit and not on withdrawals.

- Similarly, program level interrupt is intended to
  trigger when the flash withdraws more than N number
  of entries from the FIFO.  Therefore trigger only
  when there has been a withdrawwl, and not on
  deposits.

- Added a couple of parameters that could be employed by a user
  to change the model read/program/erase latency

- This is especially useful for interrupt tests, as the default
  access latencies for read are too small to make interrupts
  useable.