### PR TITLE
[edn/dv] Change type from bit->mubi4_t, remove redundant constraints

### DIFF
--- a/hw/ip/edn/dv/cov/edn_cov_if.sv
+++ b/hw/ip/edn/dv/cov/edn_cov_if.sv
@@ -28,9 +28,9 @@ interface edn_cov_if (
                         ep_req[2], ep_req[1], ep_req[0]};
 
   covergroup edn_cfg_cg with function sample(bit [2:0] num_endpoints,
-                                             uint num_boot_reqs,
-                                             bit  boot_req_mode,
-                                             bit  auto_req_mode);
+                                             uint      num_boot_reqs,
+                                             mubi4_t   boot_req_mode,
+                                             mubi4_t   auto_req_mode);
     option.name         = "edn_cfg_cg";
     option.per_instance = 1;
 

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -48,12 +48,6 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
   constraint enable_c {enable dist {
     MuBi4True  :/ enable_pct,
     MuBi4False :/ (100 - enable_pct) };}
-  constraint boot_req_mode_c {boot_req_mode dist {
-    MuBi4True  :/ boot_req_mode_pct,
-    MuBi4False :/ (100 - boot_req_mode_pct) };}
-  constraint auto_req_mode_c {auto_req_mode dist {
-    MuBi4True  :/ auto_req_mode_pct,
-    MuBi4False :/ (100 - auto_req_mode_pct) };}
   constraint cmd_fifo_rst_c {cmd_fifo_rst dist {
     MuBi4True  :/ cmd_fifo_rst_pct,
     MuBi4False :/ (100 - cmd_fifo_rst_pct) };}
@@ -61,7 +55,6 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
     MIN_NUM_ENDPOINTS :/ 40,
     MAX_NUM_ENDPOINTS :/ 40,
     [MIN_NUM_ENDPOINTS + 1:MAX_NUM_ENDPOINTS - 1] :/ 20 };}
-
   constraint req_mode_c {{boot_req_mode, auto_req_mode} dist {
     {MuBi4True, MuBi4False}  :/ boot_req_mode_pct,
     {MuBi4False, MuBi4True}  :/ auto_req_mode_pct,


### PR DESCRIPTION
Coverpoint bins were always 0 because of incorrect type.

Signed-off-by: Steve Nelson <steve.nelson@wdc.com>