### PR TITLE
[entropy_src/dv] Implement CGs for seed output

### DIFF
--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -3,14 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Implements functional coverage for entropy_src.
-interface entropy_src_cov_if (
-  input logic clk_i
+interface entropy_src_cov_if
+  import entropy_src_pkg::*;
+  import prim_mubi_pkg::*;
+(
+  input logic clk_i,
+  mubi8_t     otp_en_entropy_src_fw_read_i,
+  mubi8_t     otp_en_entropy_src_fw_over_i
 );
 
   import uvm_pkg::*;
   import dv_utils_pkg::*;
-  import prim_mubi_pkg::*;
-  import entropy_src_pkg::*;
+  import entropy_src_reg_pkg::*;
   import entropy_src_env_pkg::*;
   `include "dv_fcov_macros.svh"
 
@@ -101,14 +105,189 @@ interface entropy_src_cov_if (
 
     // Entropy data interface is tested with all valid configurations
     cr_config: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit_enable,
-        cp_rng_bit_sel, cp_es_type;
+        cp_rng_bit_sel, cp_es_type, cp_otp_en_es_fw_read;
 
     // Entropy data interface functions despite any changes to the fw_ov settings
     cr_fw_ov: cross cp_fw_ov_mode, cp_entropy_insert;
 
   endgroup : entropy_src_seed_output_csr_cg;
 
+  // Covergroup to confirm that the CSRNG HW interface works
+  // for all configurations
+  covergroup entropy_src_csrng_hw_cg with function sample(mubi4_t   fips_enable,
+                                                          mubi4_t   threshold_scope,
+                                                          mubi4_t   rng_bit_enable,
+                                                          bit [1:0] rng_bit_sel,
+                                                          mubi4_t   es_route,
+                                                          mubi4_t   es_type,
+                                                          mubi4_t   entropy_data_reg_enable,
+                                                          mubi8_t   otp_en_es_fw_read,
+                                                          mubi4_t   fw_ov_mode,
+                                                          mubi4_t   entropy_insert);
+
+    option.name         = "entropy_src_csrng_hw_cg";
+    option.per_instance = 1;
+
+    // For the purposes of this CG, ignore coverage of invalid MuBi values
+    cp_fips_enable: coverpoint fips_enable {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    cp_threshold_scope: coverpoint threshold_scope {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    cp_rng_bit_enable: coverpoint rng_bit_enable {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    cp_rng_bit_sel: coverpoint rng_bit_sel;
+
+    // Signal an error if data is observed when es_route is true.
+    cp_es_route: coverpoint es_route {
+      illegal_bins mubi_true  = { MuBi4True };
+      bins         mubi_false = { MuBi4False };
+    }
+
+    // This should have no effect on the CSRNG HW IF
+    // but we should cover it anyway.
+    cp_es_type: coverpoint es_type {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    // This should have no effect on the CSRNG HW IF
+    // but we should cover it anyway.
+    cp_entropy_data_reg_enable: coverpoint entropy_data_reg_enable {
+      bins         mubi_true  = { MuBi4True };
+      bins         mubi_false = { MuBi4False };
+    }
+
+    // This should have no effect on the CSRNG HW IF
+    // but we should cover it anyway.
+    cp_otp_en_es_fw_read: coverpoint otp_en_es_fw_read {
+      bins         mubi_true  = { MuBi8True };
+      bins         mubi_false = { MuBi8False };
+    }
+
+    // Sample the FW_OV parameters, just to be sure that they
+    // don't interfere with the entropy_data interface.
+    cp_fw_ov_mode: coverpoint fw_ov_mode {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    cp_entropy_insert: coverpoint entropy_insert {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    // Cross coverage points
+
+    // CSRNG HW interface is tested with all valid configurations
+    cr_config: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit_enable,
+        cp_rng_bit_sel, cp_es_type, cp_otp_en_es_fw_read;
+
+    // CSRNG HW interface functions despite any changes to the fw_ov settings
+    cr_fw_ov: cross cp_fw_ov_mode, cp_entropy_insert;
+
+  endgroup : entropy_src_csrng_hw_cg;
+
+  // Covergroup to confirm that the Observe FIFO interface works
+  // for all configurations
+  covergroup entropy_src_observe_fifo_cg with function sample(mubi4_t   fips_enable,
+                                                              mubi4_t   threshold_scope,
+                                                              mubi4_t   rng_bit_enable,
+                                                              bit [1:0] rng_bit_sel,
+                                                              mubi4_t   es_route,
+                                                              mubi4_t   es_type,
+                                                              mubi4_t   entropy_data_reg_enable,
+                                                              mubi8_t   otp_en_es_fw_read,
+                                                              mubi4_t   fw_ov_mode,
+                                                              mubi4_t   entropy_insert);
+
+    option.name         = "entropy_src_seed_observe_fifo_cg";
+    option.per_instance = 1;
+
+    // For the purposes of this CG, ignore coverage of invalid MuBi values
+
+    // This should have no effect on the Observe FIFO IF
+    // but we should cover it anyway.
+    cp_fips_enable: coverpoint fips_enable {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+     }
+
+    // This should have no effect on the Observe FIFO IF
+    // but we should cover it anyway.
+    cp_threshold_scope: coverpoint threshold_scope {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    cp_rng_bit_enable: coverpoint rng_bit_enable {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    cp_rng_bit_sel: coverpoint rng_bit_sel;
+
+    // This should have no effect on the Observe FIFO IF
+    // but we should cover it anyway.
+    cp_es_route: coverpoint es_route {
+      bins         mubi_true  = { MuBi4True };
+      bins         mubi_false = { MuBi4False };
+    }
+
+    // This should have no effect on the Observe FIFO IF
+    // but we should cover it anyway.
+    cp_es_type: coverpoint es_type {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    // This should have no effect on the Observe FIFO IF
+    // but we should cover it anyway.
+    cp_entropy_data_reg_enable: coverpoint entropy_data_reg_enable {
+      bins         mubi_true  = { MuBi4True };
+      bins         mubi_false = { MuBi4False };
+    }
+
+    // This should have no effect on the Observe FIFO IF
+    // but we should cover it anyway.
+    cp_otp_en_es_fw_read: coverpoint otp_en_es_fw_read {
+      bins         mubi_true  = { MuBi8True };
+      bins         mubi_false = { MuBi8False };
+    }
+
+    // No data should emerge from the Observe FIFO when disabled
+    cp_fw_ov_mode: coverpoint fw_ov_mode {
+      bins         mubi_true  = { MuBi4True };
+      illegal_bins mubi_false = { MuBi4False };
+    }
+
+    cp_entropy_insert: coverpoint entropy_insert {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    // Cross coverage points
+
+    // Entropy data interface is tested with all valid configurations
+    cr_config: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit_enable,
+        cp_rng_bit_sel, cp_es_type;
+
+    // Entropy data interface functions despite any changes to the fw_ov settings
+    cr_fw_ov: cross cp_fw_ov_mode, cp_entropy_insert;
+
+  endgroup : entropy_src_observe_fifo_cg;
+
   `DV_FCOV_INSTANTIATE_CG(entropy_src_seed_output_csr_cg, en_full_cov)
+  `DV_FCOV_INSTANTIATE_CG(entropy_src_csrng_hw_cg, en_full_cov)
+  `DV_FCOV_INSTANTIATE_CG(entropy_src_observe_fifo_cg, en_full_cov)
 
   // Sample functions needed for xcelium
   function automatic void cg_seed_output_csr_sample(mubi4_t   fips_enable,
@@ -127,5 +306,60 @@ interface entropy_src_cov_if (
                                                entropy_data_reg_enable, otp_en_es_fw_read,
                                                fw_ov_mode, entropy_insert, full_seed);
   endfunction
+
+  function automatic void cg_csrng_hw_sample(mubi4_t   fips_enable,
+                                             mubi4_t   threshold_scope,
+                                             mubi4_t   rng_bit_enable,
+                                             bit [1:0] rng_bit_sel,
+                                             mubi4_t   es_route,
+                                             mubi4_t   es_type,
+                                             mubi4_t   entropy_data_reg_enable,
+                                             mubi8_t   otp_en_es_fw_read,
+                                             mubi4_t   fw_ov_mode,
+                                             mubi4_t   entropy_insert);
+    entropy_src_csrng_hw_cg_inst.sample(fips_enable, threshold_scope, rng_bit_enable,
+                                        rng_bit_sel, es_route, es_type,
+                                        entropy_data_reg_enable, otp_en_es_fw_read,
+                                        fw_ov_mode, entropy_insert);
+  endfunction
+
+  function automatic void cg_observe_fifo_sample(mubi4_t   fips_enable,
+                                                 mubi4_t   threshold_scope,
+                                                 mubi4_t   rng_bit_enable,
+                                                 bit [1:0] rng_bit_sel,
+                                                 mubi4_t   es_route,
+                                                 mubi4_t   es_type,
+                                                 mubi4_t   entropy_data_reg_enable,
+                                                 mubi8_t   otp_en_es_fw_read,
+                                                 mubi4_t   fw_ov_mode,
+                                                 mubi4_t   entropy_insert);
+    entropy_src_observe_fifo_cg_inst.sample(fips_enable, threshold_scope, rng_bit_enable,
+                                            rng_bit_sel, es_route, es_type,
+                                            entropy_data_reg_enable, otp_en_es_fw_read,
+                                            fw_ov_mode, entropy_insert);
+  endfunction
+
+  logic csrng_if_req, csrng_if_ack;
+  mubi4_t fips_enable_csr, threshold_scope_csr, rng_bit_enable_csr, rng_bit_sel_csr, es_route_csr,
+          es_type_csr, entropy_data_reg_enable_csr, fw_ov_mode_csr, entropy_insert_csr;
+  mubi8_t otp_en_es_fw_read_val;
+
+  assign csrng_if_req = entropy_src_hw_if_i.es_req;
+  assign csrng_if_ack = entropy_src_hw_if_o.es_ack;
+
+  always @(posedge clk_i) begin
+    if(csrng_if_req && csrng_if_ack) begin
+      cg_csrng_hw_sample(reg2hw.conf.fips_enable.q,
+                         reg2hw.conf.threshold_scope.q,
+                         reg2hw.conf.rng_bit_enable.q,
+                         reg2hw.conf.rng_bit_sel.q,
+                         reg2hw.entropy_control.es_route.q,
+                         reg2hw.entropy_control.es_type.q,
+                         reg2hw.conf.entropy_data_reg_enable.q,
+                         otp_en_entropy_src_fw_read_i,
+                         reg2hw.fw_ov_control.fw_ov_mode.q,
+                         reg2hw.fw_ov_control.fw_ov_entropy_insert.q);
+    end
+  end
 
 endinterface : entropy_src_cov_if

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1363,6 +1363,18 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
           `DV_CHECK_FATAL(csr.predict(.value(prediction), .kind(UVM_PREDICT_READ)))
           observe_fifo_words++;
           match_found = 1;
+          cov_vif.cg_observe_fifo_sample(
+              ral.conf.fips_enable.get_mirrored_value(),
+              ral.conf.threshold_scope.get_mirrored_value(),
+              ral.conf.rng_bit_enable.get_mirrored_value(),
+              ral.conf.rng_bit_sel.get_mirrored_value(),
+              ral.entropy_control.es_route.get_mirrored_value(),
+              ral.entropy_control.es_type.get_mirrored_value(),
+              ral.conf.entropy_data_reg_enable.get_mirrored_value(),
+              cfg.otp_en_es_fw_read,
+              ral.fw_ov_control.fw_ov_mode.get_mirrored_value(),
+              ral.fw_ov_control.fw_ov_entropy_insert.get_mirrored_value()
+          );
           msg = $sformatf("Match found: %d\n", observe_fifo_words);
           `uvm_info(`gfn, msg, UVM_FULL)
           break;


### PR DESCRIPTION
- Implements seed_output_hw_cg to monitor coverage of entropy output via the CSRNG interface under all configurations.
- Implements fw_ov_output_cg to monitor coverage of entropy output via observe FIFO interface under all configurations

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>