### PR TITLE
[sw/tests] update non-volatile flash region example

### DIFF
--- a/sw/device/tests/example_test_from_flash.c
+++ b/sw/device/tests/example_test_from_flash.c
@@ -11,6 +11,12 @@
  */
 
 /**
+ * Uncomment if you want to initialize the non-volatile scratch region below
+ * using UINT32_MAX.
+ */
+// #include <stdint.h>
+
+/**
  * Uncomment if you want to log messages with `LOG_{INFO,WARNING,ERROR,FATAL()`.
  */
 // #include "sw/device/lib/runtime/log.h"
@@ -73,10 +79,15 @@ const test_config_t kTestConfig = {
 /**
  * Place data in flash that will need to persist across resets by marking with
  * with the section ".non_volatile_scratch"). Write to this region with the
- * flash controller DIF. Read from it with `abs_mmio_read32(...)`.
+ * flash controller DIFs. Read from it with `abs_mmio_read32(...)`.
+ * Additionally, be sure to initialize the bits in this array to all 1s,
+ * otherwise this region may not be programmed properly, depending on the
+ * programming transactions issued. According to the hardware specification:
+ *  - a bit cannot be programmed back to 1 once it has been programmed to 0, and
+ *  - only erase can restore a bit to 1 under normal circumstances.
  */
 // __attribute__((section(".non_volatile_scratch")))
-// const volatile uint32_t non_volatile_data[SIZE_OF_DATA];
+// const volatile uint32_t non_volatile_data[2] = {UINT32_MAX, UINT32_MAX};
 
 bool test_main(void) {
   /**


### PR DESCRIPTION
The non-volatile flash region example did not make it clear that any
non-volatile flash data should be initialized to all 1s to achieve the
desired behavior.

Signed-off-by: Timothy Trippel <ttrippel@google.com>