### PR TITLE
[clkmgr,dv] regression fix - shadow register error test

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -468,13 +468,13 @@
           desc: "Enable measurement for ${src}",
           mubi: true,
           resval: false,
-          // Measurements can cause recoverable errors depending on the
-          // thresholds which randomized CSR tests will not predict correctly.
-          // To provide better CSR coverage we allow writing the threshold
-          // fields, but not enabling the counters.
-          tags: ["excl:CsrAllTests:CsrExclWrite"]
         },
       ]
+      // Measurements can cause recoverable errors depending on the
+      // thresholds which randomized CSR tests will not predict correctly.
+      // To provide better CSR coverage we allow writing the threshold
+      // fields, but not enabling the counters.
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 <%
   freq = clocks.all_srcs[src].freq

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -95,11 +95,6 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     super.pre_start();
     if (common_seq_type inside {"shadow_reg_errors", "shadow_reg_errors_with_csr_rw"}) begin
       expect_fatal_alerts = 1;
-      $assertoff(0, "tb.dut.u_io_err_sync.SrcPulseCheck_M");
-      $assertoff(0, "tb.dut.u_main_err_sync.SrcPulseCheck_M");
-      $assertoff(0, "tb.dut.u_usb_err_sync.SrcPulseCheck_M");
-      $assertoff(0, "tb.dut.u_io_div2_err_sync.SrcPulseCheck_M");
-      $assertoff(0, "tb.dut.u_io_div4_err_sync.SrcPulseCheck_M");
     end
 
   endtask

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -539,13 +539,13 @@
           desc: "Enable measurement for io",
           mubi: true,
           resval: false,
-          // Measurements can cause recoverable errors depending on the
-          // thresholds which randomized CSR tests will not predict correctly.
-          // To provide better CSR coverage we allow writing the threshold
-          // fields, but not enabling the counters.
-          tags: ["excl:CsrAllTests:CsrExclWrite"]
         },
       ]
+      // Measurements can cause recoverable errors depending on the
+      // thresholds which randomized CSR tests will not predict correctly.
+      // To provide better CSR coverage we allow writing the threshold
+      // fields, but not enabling the counters.
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "IO_MEAS_CTRL_SHADOWED",
@@ -593,13 +593,13 @@
           desc: "Enable measurement for io_div2",
           mubi: true,
           resval: false,
-          // Measurements can cause recoverable errors depending on the
-          // thresholds which randomized CSR tests will not predict correctly.
-          // To provide better CSR coverage we allow writing the threshold
-          // fields, but not enabling the counters.
-          tags: ["excl:CsrAllTests:CsrExclWrite"]
         },
       ]
+      // Measurements can cause recoverable errors depending on the
+      // thresholds which randomized CSR tests will not predict correctly.
+      // To provide better CSR coverage we allow writing the threshold
+      // fields, but not enabling the counters.
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "IO_DIV2_MEAS_CTRL_SHADOWED",
@@ -647,13 +647,13 @@
           desc: "Enable measurement for io_div4",
           mubi: true,
           resval: false,
-          // Measurements can cause recoverable errors depending on the
-          // thresholds which randomized CSR tests will not predict correctly.
-          // To provide better CSR coverage we allow writing the threshold
-          // fields, but not enabling the counters.
-          tags: ["excl:CsrAllTests:CsrExclWrite"]
         },
       ]
+      // Measurements can cause recoverable errors depending on the
+      // thresholds which randomized CSR tests will not predict correctly.
+      // To provide better CSR coverage we allow writing the threshold
+      // fields, but not enabling the counters.
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "IO_DIV4_MEAS_CTRL_SHADOWED",
@@ -701,13 +701,13 @@
           desc: "Enable measurement for main",
           mubi: true,
           resval: false,
-          // Measurements can cause recoverable errors depending on the
-          // thresholds which randomized CSR tests will not predict correctly.
-          // To provide better CSR coverage we allow writing the threshold
-          // fields, but not enabling the counters.
-          tags: ["excl:CsrAllTests:CsrExclWrite"]
         },
       ]
+      // Measurements can cause recoverable errors depending on the
+      // thresholds which randomized CSR tests will not predict correctly.
+      // To provide better CSR coverage we allow writing the threshold
+      // fields, but not enabling the counters.
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "MAIN_MEAS_CTRL_SHADOWED",
@@ -755,13 +755,13 @@
           desc: "Enable measurement for usb",
           mubi: true,
           resval: false,
-          // Measurements can cause recoverable errors depending on the
-          // thresholds which randomized CSR tests will not predict correctly.
-          // To provide better CSR coverage we allow writing the threshold
-          // fields, but not enabling the counters.
-          tags: ["excl:CsrAllTests:CsrExclWrite"]
         },
       ]
+      // Measurements can cause recoverable errors depending on the
+      // thresholds which randomized CSR tests will not predict correctly.
+      // To provide better CSR coverage we allow writing the threshold
+      // fields, but not enabling the counters.
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "USB_MEAS_CTRL_SHADOWED",


### PR DESCRIPTION
- take excl tags out of field bracket cause script will skip this tag if
  register has a single filed
- Add skid_check_fatal_alert_nonblocking task to address multi clock
  alert source from TB
- remove invalid assertions 
Signed-off-by: Jaedon Kim <jdonjdon@google.com>