### PR TITLE
[dv/aes] shadow reg fix

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -32,9 +32,6 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   // reset is issued
   bit en_auto_alerts_response = 1'b1;
 
-  // knobs to lock shadow register write access if fatal storage error occurred
-  bit do_lock_shadow_reg = 1'b1;
-
   // knob to enable/disable running csr_vseq with passthru_mem_tl_intg_err
   bit en_csr_vseq_w_passthru_mem_intg = 1;
 


### PR DESCRIPTION
According to discussion in issue #10617, align shadow regs:
1). Writing correct value to `ctrl_shadowed` will clear update error
  bit.
2). Once fatal storage error happened, locked shadow register write
  access.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>