### PR TITLE
[otbn,dv] Tweaks to make OTBN simulations a bit quicker

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -105,6 +105,12 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
     // values, in case of a TL fault.
     tl_intg_alert_fields[ral.fatal_alert_cause.bus_intg_violation] = 1;
     tl_intg_alert_fields[ral.status.status] = otbn_pkg::StatusLocked;
+
+    // Configure the URND EDN connection to be quick. Unlike RND, there's nothing much that can be
+    // going on while we're waiting for a URND seed, so there's no real benefit to modelling the
+    // possibility that it takes ages.
+    m_edn_pull_agent_cfg[UrndEdnIdx].device_delay_min = 0;
+    m_edn_pull_agent_cfg[UrndEdnIdx].device_delay_max = 2;
   endfunction
 
   function logic [127:0] get_imem_key();

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -88,6 +88,12 @@ package otbn_env_pkg;
 
   } otbn_loaded_word;
 
+  // The mapping from EDN agent indices to RND / URND connections
+  typedef enum {
+    RndEdnIdx,
+    UrndEdnIdx
+  } edn_idx_e;
+
   typedef enum {
     StackEmpty,
     StackPartial,

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -139,13 +139,13 @@ module tb;
 
     .clk_edn_i (edn_clk),
     .rst_edn_ni(edn_rst_n),
-    .edn_rnd_o (edn_if[0].req),
+    .edn_rnd_o (edn_if[RndEdnIdx].req),
     // For now, we force the FIPS bit to 1 as the model cannot yet deal with RND FIPS check
     // failures. For details, see https://github.com/lowRISC/opentitan/issues/11915
-    .edn_rnd_i ({edn_if[0].ack, 1'b1, edn_if[0].d_data[31:0]}),
+    .edn_rnd_i ({edn_if[RndEdnIdx].ack, 1'b1, edn_if[RndEdnIdx].d_data[31:0]}),
 
-    .edn_urnd_o(edn_if[1].req),
-    .edn_urnd_i({edn_if[1].ack, edn_if[1].d_data}),
+    .edn_urnd_o(edn_if[UrndEdnIdx].req),
+    .edn_urnd_i({edn_if[UrndEdnIdx].ack, edn_if[UrndEdnIdx].d_data}),
 
     .clk_otp_i     (otp_clk),
     .rst_otp_ni    (otp_rst_n),
@@ -247,11 +247,11 @@ module tb;
 
     .err_bits_o   (model_if.err_bits),
 
-    .edn_rnd_i           ({edn_if[0].ack, 1'b1, edn_if[0].d_data[31:0]}),
+    .edn_rnd_i           ({edn_if[RndEdnIdx].ack, 1'b1, edn_if[RndEdnIdx].d_data[31:0]}),
     .edn_rnd_o           (edn_rnd_req_model),
     .edn_rnd_cdc_done_i  (edn_rnd_cdc_done),
 
-    .edn_urnd_i          ({edn_if[1].ack, edn_if[1].d_data}),
+    .edn_urnd_i          ({edn_if[UrndEdnIdx].ack, edn_if[UrndEdnIdx].d_data}),
     .edn_urnd_o          (edn_urnd_req_model),
     .edn_urnd_cdc_done_i (edn_urnd_cdc_done),
 


### PR DESCRIPTION
The two changes are
1. Usually zero out the randomised waits in the TL agent while we're front-door loading an ELF file.
2. Make the URND EDN agent respond much more quickly, cutting down the time we spend waiting to start an operation.