### PR TITLE
[otbn] Remove un-needed Verilator waiver

### DIFF
--- a/hw/ip/otbn/lint/otbn.vlt
+++ b/hw/ip/otbn/lint/otbn.vlt
@@ -13,9 +13,4 @@ lint_off -rule UNUSED -file "*/rtl/otbn_decoder.sv" -match "Bits of signal are n
 // imem_wmask_bus is only used in an assertion (which Verilator doesn't see).
 lint_off -rule UNUSED -file "*/rtl/otbn.sv" -match "Signal is not used: 'imem_wmask_bus'"
 
-// TODO: Remove this waiver once Verilator #3177
-// (https://github.com/verilator/verilator/issues/3177) is fixed in a version we depend on.
-// split_var of err_bits below should fix this but doesn't.
-lint_off -rule UNOPTFLAT -file "*/rtl/otbn_controller.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*.u_otbn_controller.non_insn_addr_software_err'"
-
 split_var -module "otbn_controller" -var "err_bits"


### PR DESCRIPTION
This isn't needed now that we've refactored how error bits get passed
around.
