### PR TITLE
[regtool] Add option to scrub alias definitions 

### DIFF
--- a/util/reggen/field.py
+++ b/util/reggen/field.py
@@ -336,7 +336,6 @@ class Field:
         rd = {
             'bits': self.bits.as_str(),
             'name': self.name,
-            'alias_target': self.alias_target,
             'swaccess': self.swaccess.key,
             'hwaccess': self.hwaccess.key,
             'resval': 'x' if self.resval is None else str(self.resval),
@@ -347,6 +346,8 @@ class Field:
             rd['desc'] = self.desc
         if self.enum is not None:
             rd['enum'] = self.enum
+        if self.alias_target is not None:
+            rd['alias_target'] = self.alias_target
         return rd
 
     def sw_readable(self) -> bool:
@@ -381,3 +382,17 @@ class Field:
         # This gives us a way to check whether a register has been overridden
         # or not, and what the name of the original register was.
         self.alias_target = alias_field.alias_target
+
+    def scrub_alias(self, where: str) -> None:
+        '''Replaces sensitive fields in field with generic names
+
+        This function can be used to create the generic field descriptions
+        from full alias hjson definitions.
+        '''
+        # These attributes are scrubbed. Note that the name is scrubbed in
+        # register.py already.
+        self.desc = ''
+        self.enum = []
+        self.resval = 0
+        self.tags = []
+        self.alias_target = None

--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -186,6 +186,9 @@ class MultiRegister(RegBase):
         rd['regwen_multi'] = str(self.regwen_multi)
         rd['compact'] = str(self.compact)
 
+        if self.alias_target is not None:
+            rd['alias_target'] = self.alias_target
+
         return {'multireg': rd}
 
     def apply_alias(self, alias_reg: 'MultiRegister', where: str) -> None:
@@ -220,3 +223,23 @@ class MultiRegister(RegBase):
         # Finally, iterate over expanded regs and update them as well.
         for creg, alias_creg in zip(self.regs, alias_reg.regs):
             creg.apply_alias(alias_creg, where)
+
+    def scrub_alias(self, where: str) -> None:
+        '''Replaces sensitive fields in multiregister with generic names
+
+        This function can be used to create the generic register descriptions
+        from full alias hjson definitions. It will only work on registers
+        where the alias_target keys are defined, and otherwise throw an error.
+        '''
+        # These attributes are scrubbed in the multireg.
+        assert self.alias_target is not None
+        self.name = self.alias_target
+        self.cname = 'creg'
+        self.alias_target = None
+
+        # Then, update the template register.
+        self.reg.scrub_alias(where)
+
+        # Finally, iterate over expanded regs and scrub them as well.
+        for creg in self.regs:
+            creg.scrub_alias(where)

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -49,6 +49,11 @@ def main():
                         type=Path,
                         default=None,
                         help='Alias register file in Hjson type')
+    parser.add_argument('-S',
+                        '--scrub',
+                        default=False,
+                        action='store_true',
+                        help='Scrub alias register definition')
     parser.add_argument('--cdefines',
                         '-D',
                         action='store_true',
@@ -230,10 +235,14 @@ def main():
     # identical).
     if args.alias is not None:
         try:
-            obj.alias_from_path(args.alias)
+            obj.alias_from_path(args.scrub, args.alias)
         except ValueError as err:
             log.error(str(err))
             exit(1)
+    else:
+        if args.scrub:
+            raise ValueError('The --scrub argument is only meaningful in '
+                             'combination with the --alias argument')
 
     # If this block has countermeasures, we grep for RTL annotations in all
     # .sv implementation files and check whether they match up with what is

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -138,9 +138,9 @@ def main():
     else:
         log.basicConfig(format="%(levelname)s: %(message)s")
 
-    # Entries are triples of the form (arg, (format, dirspec)).
+    # Entries are triples of the form (arg, (fmt, dirspec)).
     #
-    # arg is the name of the argument that selects the format. format is the
+    # arg is the name of the argument that selects the format. fmt is the
     # name of the format. dirspec is None if the output is a single file; if
     # the output needs a directory, it is a default path relative to the source
     # file (used when --outdir is not given).
@@ -150,17 +150,17 @@ def main():
                      ('f', ('fpv', 'fpv/vip')), ('cdefines', ('cdh', None)),
                      ('sec_cm_testplan', ('sec_cm_testplan', 'data')),
                      ('rust', ('rs', None)), ('tock', ('trs', None))]
-    format = None
+    fmt = None
     dirspec = None
     for arg_name, spec in arg_to_format:
         if getattr(args, arg_name):
-            if format is not None:
+            if fmt is not None:
                 log.error('Multiple output formats specified on '
-                          'command line ({} and {}).'.format(format, spec[0]))
+                          'command line ({} and {}).'.format(fmt, spec[0]))
                 sys.exit(1)
-            format, dirspec = spec
-    if format is None:
-        format = 'hjson'
+            fmt, dirspec = spec
+    if fmt is None:
+        fmt = 'hjson'
 
     infile = args.input
 
@@ -182,14 +182,14 @@ def main():
     if dirspec is None:
         if args.outdir is not None:
             log.error('The {} format expects an output file, '
-                      'not an output directory.'.format(format))
+                      'not an output directory.'.format(fmt))
             sys.exit(1)
 
         outfile = args.outfile
     else:
         if args.outfile is not sys.stdout:
             log.error('The {} format expects an output directory, '
-                      'not an output file.'.format(format))
+                      'not an output file.'.format(fmt))
             sys.exit(1)
 
         if args.outdir is not None:
@@ -202,7 +202,7 @@ def main():
                 'The {} format writes to an output directory, which '
                 'cannot be inferred automatically if the input comes '
                 'from stdin. Use --outdir to specify it manually.'.format(
-                    format))
+                    fmt))
             sys.exit(1)
 
     version_stamp = {}
@@ -212,7 +212,7 @@ def main():
                 k, v = line.strip().split(' ', 1)
                 version_stamp[k] = v
 
-    if format == 'doc':
+    if fmt == 'doc':
         with outfile:
             gen_selfdoc.document(outfile)
         exit(0)
@@ -239,7 +239,7 @@ def main():
     # .sv implementation files and check whether they match up with what is
     # defined inside the Hjson.
     # Skip this check when generating DV code - its not needed.
-    if format != 'dv':
+    if fmt != 'dv':
         sv_files = Path(
             infile.name).parent.joinpath('..').joinpath('rtl').glob('*.sv')
         rtl_names = CounterMeasure.search_rtl_files(sv_files)
@@ -247,16 +247,16 @@ def main():
 
     if args.novalidate:
         with outfile:
-            gen_json.gen_json(obj, outfile, format)
+            gen_json.gen_json(obj, outfile, fmt)
             outfile.write('\n')
     else:
-        if format == 'rtl':
+        if fmt == 'rtl':
             return gen_rtl.gen_rtl(obj, outdir)
-        if format == 'sec_cm_testplan':
+        if fmt == 'sec_cm_testplan':
             return gen_sec_cm_testplan.gen_sec_cm_testplan(obj, outdir)
-        if format == 'dv':
+        if fmt == 'dv':
             return gen_dv.gen_dv(obj, args.dv_base_names, outdir)
-        if format == 'fpv':
+        if fmt == 'fpv':
             return gen_fpv.gen_fpv(obj, outdir)
         src_lic = None
         src_copy = ''
@@ -281,18 +281,18 @@ def main():
             src_lic += '\n' + found_spdx
 
         with outfile:
-            if format == 'html':
+            if fmt == 'html':
                 return gen_html.gen_html(obj, outfile)
-            elif format == 'cdh':
+            elif fmt == 'cdh':
                 return gen_cheader.gen_cdefines(obj, outfile, src_lic,
                                                 src_copy)
-            elif format == 'rs':
+            elif fmt == 'rs':
                 return gen_rust.gen_rust(obj, outfile, src_lic, src_copy)
-            elif format == 'trs':
+            elif fmt == 'trs':
                 return gen_tock.gen_tock(obj, outfile, infile.name, src_lic,
                                          src_copy, version_stamp)
             else:
-                return gen_json.gen_json(obj, outfile, format)
+                return gen_json.gen_json(obj, outfile, fmt)
 
             outfile.write('\n')
 


### PR DESCRIPTION
This adds the option to generate generic register definitions from a an alias register definition. It can be used as follows:
```
regtool.py <path to generic hjson> --alias <path to alias hjson> --scrub -j
```
This will replace ALL CSR descriptions in the aliased interface and replace them with a scrubbed version of the alias definitions.