### PR TITLE
[clkmgr] Fix cdc issues from reg status

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -432,7 +432,7 @@ from topgen.lib import Name
   prim_clock_gating #(
     .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_${k}_cg (
-    .clk_i(clk_${v.src.name}_root),
+    .clk_i(clk_${v.src.name}_i),
     .en_i(${k}_combined_en),
     .test_en_i(mubi4_test_true_strict(${k}_scanmode[0])),
     .clk_o(clocks_o.${k})
@@ -468,16 +468,18 @@ from topgen.lib import Name
 % endif
   ) u_${clk}_trans (
     .clk_i(clk_${sig.src.name}_i),
+    .clk_gated_i(clk_${sig.src.name}_root),
     .rst_ni(rst_${sig.src.name}_ni),
-    .clk_root_i(clk_${sig.src.name}_root),
-    .clk_root_en_i(clk_${sig.src.name}_en),
+    .en_i(clk_${sig.src.name}_en),
     .idle_i(idle_i[${hint_names[clk]}]),
     .sw_hint_i(reg2hw.clk_hints.${clk}_hint.q),
     .scanmode_i,
     .alert_cg_en_o(cg_en_o.${clk.split('clk_')[-1]}),
     .clk_o(clocks_o.${clk}),
-    .clk_en_o(hw2reg.clk_hints_status.${clk}_val.d),
-    .cnt_err_o(idle_cnt_err[${hint_names[clk]}])
+    .clk_reg_i(clk_i),
+    .rst_reg_ni(rst_ni),
+    .reg_en_o(hw2reg.clk_hints_status.${clk}_val.d),
+    .reg_cnt_err_o(idle_cnt_err[${hint_names[clk]}])
   );
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(
     ${assert_name.as_camel_case()}CountCheck_A,

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -790,7 +790,7 @@
   prim_clock_gating #(
     .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_io_div4_peri_cg (
-    .clk_i(clk_io_div4_root),
+    .clk_i(clk_io_div4_i),
     .en_i(clk_io_div4_peri_combined_en),
     .test_en_i(mubi4_test_true_strict(clk_io_div4_peri_scanmode[0])),
     .clk_o(clocks_o.clk_io_div4_peri)
@@ -832,7 +832,7 @@
   prim_clock_gating #(
     .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_io_div2_peri_cg (
-    .clk_i(clk_io_div2_root),
+    .clk_i(clk_io_div2_i),
     .en_i(clk_io_div2_peri_combined_en),
     .test_en_i(mubi4_test_true_strict(clk_io_div2_peri_scanmode[0])),
     .clk_o(clocks_o.clk_io_div2_peri)
@@ -874,7 +874,7 @@
   prim_clock_gating #(
     .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_io_peri_cg (
-    .clk_i(clk_io_root),
+    .clk_i(clk_io_i),
     .en_i(clk_io_peri_combined_en),
     .test_en_i(mubi4_test_true_strict(clk_io_peri_scanmode[0])),
     .clk_o(clocks_o.clk_io_peri)
@@ -916,7 +916,7 @@
   prim_clock_gating #(
     .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_usb_peri_cg (
-    .clk_i(clk_usb_root),
+    .clk_i(clk_usb_i),
     .en_i(clk_usb_peri_combined_en),
     .test_en_i(mubi4_test_true_strict(clk_usb_peri_scanmode[0])),
     .clk_o(clocks_o.clk_usb_peri)
@@ -945,16 +945,18 @@
     .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
   ) u_clk_main_aes_trans (
     .clk_i(clk_main_i),
+    .clk_gated_i(clk_main_root),
     .rst_ni(rst_main_ni),
-    .clk_root_i(clk_main_root),
-    .clk_root_en_i(clk_main_en),
+    .en_i(clk_main_en),
     .idle_i(idle_i[HintMainAes]),
     .sw_hint_i(reg2hw.clk_hints.clk_main_aes_hint.q),
     .scanmode_i,
     .alert_cg_en_o(cg_en_o.main_aes),
     .clk_o(clocks_o.clk_main_aes),
-    .clk_en_o(hw2reg.clk_hints_status.clk_main_aes_val.d),
-    .cnt_err_o(idle_cnt_err[HintMainAes])
+    .clk_reg_i(clk_i),
+    .rst_reg_ni(rst_ni),
+    .reg_en_o(hw2reg.clk_hints_status.clk_main_aes_val.d),
+    .reg_cnt_err_o(idle_cnt_err[HintMainAes])
   );
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(
     ClkMainAesCountCheck_A,
@@ -965,16 +967,18 @@
     .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
   ) u_clk_main_hmac_trans (
     .clk_i(clk_main_i),
+    .clk_gated_i(clk_main_root),
     .rst_ni(rst_main_ni),
-    .clk_root_i(clk_main_root),
-    .clk_root_en_i(clk_main_en),
+    .en_i(clk_main_en),
     .idle_i(idle_i[HintMainHmac]),
     .sw_hint_i(reg2hw.clk_hints.clk_main_hmac_hint.q),
     .scanmode_i,
     .alert_cg_en_o(cg_en_o.main_hmac),
     .clk_o(clocks_o.clk_main_hmac),
-    .clk_en_o(hw2reg.clk_hints_status.clk_main_hmac_val.d),
-    .cnt_err_o(idle_cnt_err[HintMainHmac])
+    .clk_reg_i(clk_i),
+    .rst_reg_ni(rst_ni),
+    .reg_en_o(hw2reg.clk_hints_status.clk_main_hmac_val.d),
+    .reg_cnt_err_o(idle_cnt_err[HintMainHmac])
   );
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(
     ClkMainHmacCountCheck_A,
@@ -985,16 +989,18 @@
     .FpgaBufGlobal(1'b1) // KMAC is getting too big for a single clock region.
   ) u_clk_main_kmac_trans (
     .clk_i(clk_main_i),
+    .clk_gated_i(clk_main_root),
     .rst_ni(rst_main_ni),
-    .clk_root_i(clk_main_root),
-    .clk_root_en_i(clk_main_en),
+    .en_i(clk_main_en),
     .idle_i(idle_i[HintMainKmac]),
     .sw_hint_i(reg2hw.clk_hints.clk_main_kmac_hint.q),
     .scanmode_i,
     .alert_cg_en_o(cg_en_o.main_kmac),
     .clk_o(clocks_o.clk_main_kmac),
-    .clk_en_o(hw2reg.clk_hints_status.clk_main_kmac_val.d),
-    .cnt_err_o(idle_cnt_err[HintMainKmac])
+    .clk_reg_i(clk_i),
+    .rst_reg_ni(rst_ni),
+    .reg_en_o(hw2reg.clk_hints_status.clk_main_kmac_val.d),
+    .reg_cnt_err_o(idle_cnt_err[HintMainKmac])
   );
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(
     ClkMainKmacCountCheck_A,
@@ -1005,16 +1011,18 @@
     .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
   ) u_clk_main_otbn_trans (
     .clk_i(clk_main_i),
+    .clk_gated_i(clk_main_root),
     .rst_ni(rst_main_ni),
-    .clk_root_i(clk_main_root),
-    .clk_root_en_i(clk_main_en),
+    .en_i(clk_main_en),
     .idle_i(idle_i[HintMainOtbn]),
     .sw_hint_i(reg2hw.clk_hints.clk_main_otbn_hint.q),
     .scanmode_i,
     .alert_cg_en_o(cg_en_o.main_otbn),
     .clk_o(clocks_o.clk_main_otbn),
-    .clk_en_o(hw2reg.clk_hints_status.clk_main_otbn_val.d),
-    .cnt_err_o(idle_cnt_err[HintMainOtbn])
+    .clk_reg_i(clk_i),
+    .rst_reg_ni(rst_ni),
+    .reg_en_o(hw2reg.clk_hints_status.clk_main_otbn_val.d),
+    .reg_cnt_err_o(idle_cnt_err[HintMainOtbn])
   );
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(
     ClkMainOtbnCountCheck_A,


### PR DESCRIPTION
- Addresses #12921
- The transactional clock group currently feeds the status
  and error information into the wrong domain.  Add
  appropriate synchronizers to handle the crossing.
