### PR TITLE
[otbn,rtl] Drop pending RND prefetch at end of operation

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/edn_client.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/edn_client.py
@@ -48,6 +48,19 @@ class EdnClient:
             self._poisoned = True
             self._retry = False
 
+    def forget(self) -> None:
+        '''Clear the retry flag, if set.
+
+        This is used at the end of an operation to model the situation where a
+        previous run had started a prefetch that we're still waiting for. In
+        the meantime, we started an operation that also requested a prefetch.
+        Normally, we'd want to make sure to send out *that* request as soon as
+        the first (ignored) result came in. But maybe we've actually finished
+        this run as well! In that case, we don't care about the prefetch that
+        was pending and should just discard it.
+        '''
+        self._retry = False
+
     def take_word(self, word: int) -> None:
         '''Take a 32-bit data word that we've been waiting for'''
         assert 0 <= word < (1 << 32)

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -207,6 +207,9 @@ class RndReq(RGReg):
     def poison(self) -> None:
         self._client.poison()
 
+    def forget(self) -> None:
+        self._client.forget()
+
     def take_word(self, word: int) -> None:
         self._client.take_word(word)
 
@@ -353,3 +356,6 @@ class OTBNExtRegs:
 
     def rnd_poison(self) -> None:
         self._rnd_req.poison()
+
+    def rnd_forget(self) -> None:
+        self._rnd_req.forget()

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -356,6 +356,9 @@ class OTBNState:
             next_status = Status.LOCKED
             self.ext_regs.write('STATUS', next_status, True)
 
+        # Clear any pending request in the RND EDN client
+        self.ext_regs.rnd_forget()
+
         # Clear the "we should stop soon" flag
         self.pending_halt = False
 

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -806,7 +806,9 @@ module otbn_core
     .clk_i,
     .rst_ni,
 
-    .rnd_wipe_i        (controller_start),
+    .opn_start_i (controller_start),
+    .opn_end_i   (start_secure_wipe),
+
     .rnd_req_i         (rnd_req),
     .rnd_prefetch_req_i(rnd_prefetch_req),
     .rnd_valid_o       (rnd_valid),


### PR DESCRIPTION
The interesting commit here is the second one, with the following commit message:

> Consider a situation where we have two operations, A and B, that run
back-to-back. Suppose operation A writes to RND_PREFETCH and then
finishes before the EDN replies. Now suppose that operation B also
writes to RND_PREFETCH. In this case, the RTL uses a signal called
rnd_req_queued_q to track the fact that it should send out another RND
request once the first (ignored) one comes back. But what if operation
B also finishes before the EDN has replied to the first request?
>
> Once the result comes in, there was a slight mismatch between how the
ISS and RTL handled things (depending on the timing of the *next*
operation, the ISS might or might not have sent out another request).
But this whole situation is silly! We know we don't care about the
result of the second prefetch, so we don't need to do it at all.
>
> This patch tweaks the RTL to drop the pending request in this
situation and adds a "forget" function in the ISS to do the same.

However, making this change exposes a second (simpler) problem: that we weren't updating `rnd_prefetch_pending_q` correctly if we ignored the result of the prefetch. The first commit fixes that by getting rid of the signal entirely.