### PR TITLE
[otbn,dv] Handle injected errors in middle of memory secure wipe

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -210,6 +210,12 @@ class OTBNState:
     def wiping(self) -> bool:
         return self._fsm_state in [FsmState.WIPING_GOOD, FsmState.WIPING_BAD]
 
+    def stop_if_pending_halt(self) -> bool:
+        if self.pending_halt:
+            self.stop()
+            return True
+        return False
+
     def step(self, handle_injected_error: bool) -> None:
         if handle_injected_error:
             self.take_injected_err_bits()


### PR DESCRIPTION
The _step_ext_wipe stepper function didn't have code to stop on a
pending halt: add it! While we're at it, factor out the repeated code
into a method on the State object.
