### PR TITLE
[dv,pwrmgr,top] update pwrmgr_deep_sleep_all_wake_ups test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -874,7 +874,7 @@
       tests: ["chip_sw_pwrmgr_full_aon_reset"]
     }
     {
-      name: chip_sw_pwrmgr_sleep_all_wake_ups
+      name: chip_sw_pwrmgr_normal_sleep_all_wake_ups
       desc: '''Verify that the chip can go into normal sleep state and be woken up by ALL wake up
             sources.
 
@@ -911,9 +911,7 @@
             chip_pwrmgr_sleep_all_wake_ups, except `control.main_pd_n` is set to 0.
             '''
       milestone: V2
-      tests: ["chip_sw_pwrmgr_smoketest",
-              "chip_sw_pwrmgr_deep_sleep_all_wake_ups",
-              "chip_sw_pwrmgr_usbdev_wakeup"]
+      tests: ["chip_sw_pwrmgr_deep_sleep_all_wake_ups"]
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_all_reset_reqs

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
@@ -19,15 +19,15 @@ class chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq extends chip_sw_base_vseq;
     // Loop with sformatf %d doesn't work
       wait(cfg.sw_logger_vif.printed_log == "Issue WFI to enter sleep 0");
       wakeup_action(0);
-      wait(cfg.sw_logger_vif.printed_log == "Wake from sleep 0");
+      wait(cfg.sw_logger_vif.printed_log == "Woke up by source 0");
       release_action(0);
       wait(cfg.sw_logger_vif.printed_log == "Issue WFI to enter sleep 1");
       wakeup_action(1);
-      wait(cfg.sw_logger_vif.printed_log == "Wake from sleep 1");
+      wait(cfg.sw_logger_vif.printed_log == "Woke up by source 1");
       release_action(1);
       wait(cfg.sw_logger_vif.printed_log == "Issue WFI to enter sleep 2");
       wakeup_action(2);
-      wait(cfg.sw_logger_vif.printed_log == "Wake from sleep 2");
+      wait(cfg.sw_logger_vif.printed_log == "Woke up by source 2");
       release_action(2);
   endtask // body
 

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")
-load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
+load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest", "verilator_params")
 
 opentitan_functest(
     name = "uart_tx_rx_test",
@@ -413,10 +413,20 @@ opentitan_functest(
 opentitan_functest(
     name = "pwrmgr_deep_sleep_all_wake_ups",
     srcs = ["pwrmgr_deep_sleep_all_wake_ups.c"],
+    cw310 = cw310_params(
+        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+        tags = ["broken"],
+    ),
     targets = ["dv"],
+    verilator = verilator_params(
+        timeout = "long",
+        tags = ["failing_verilator"],
+    ),
     deps = [
+        "//hw/top_earlgrey/ip/pwrmgr/data/autogen:pwrmgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib:irq",
+        "//sw/device/lib:usb",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:adc_ctrl",
         "//sw/device/lib/dif:pinmux",
@@ -424,6 +434,7 @@ opentitan_functest(
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aon_timer_testutils",
         "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -293,8 +293,10 @@ pwrmgr_deep_sleep_all_wake_ups_lib = declare_dependency(
   link_with: static_library(
     'pwrmgr_deep_sleep_all_wake_ups_lib',
     sources: [
+      hw_ip_pwrmgr_reg_h,
       'pwrmgr_deep_sleep_all_wake_ups.c'],
     dependencies: [
+      sw_lib_usb,
       sw_lib_mmio,
       sw_lib_dif_pwrmgr,
       sw_lib_dif_rv_plic,
@@ -306,6 +308,7 @@ pwrmgr_deep_sleep_all_wake_ups_lib = declare_dependency(
       sw_lib_runtime_log,
       sw_lib_testing_isr_testutils,
       sw_lib_testing_pwrmgr_testutils,
+      sw_lib_testing_aon_timer_testutils,
       sw_lib_testing_rv_plic_testutils,
       top_earlgrey,
     ],


### PR DESCRIPTION
- Previously this test only covers wakeup source 1,2, and 3.
  and 4 and 5 are covered by other tests.
- As we move forward to create two different sleep mode and
  randomize them, it would be beeter to have on test to cover
  all wakeup sources.
  So I added wakeup source 4 and 5 to this test

Signed-off-by: Jaedon Kim <jdonjdon@google.com>