### PR TITLE
[dif, rv_core_ibex] Add rnd api with unittests

### DIFF
--- a/sw/device/lib/dif/dif_rv_core_ibex.c
+++ b/sw/device/lib/dif/dif_rv_core_ibex.c
@@ -208,7 +208,7 @@ dif_result_t dif_rv_core_ibex_clear_error_status(
 
 dif_result_t dif_rv_core_ibex_enable_nmi(const dif_rv_core_ibex_t *rv_core_ibex,
                                          dif_rv_core_ibex_nmi_source_t nmi) {
-  if (rv_core_ibex == NULL || (nmi & ~kDifRvCoreIbexNmiSourceAll) != 0) {
+  if (rv_core_ibex == NULL || nmi & ~kDifRvCoreIbexNmiSourceAll) {
     return kDifBadArg;
   }
 
@@ -254,7 +254,7 @@ dif_result_t dif_rv_core_ibex_get_nmi_state(
 
 dif_result_t dif_rv_core_ibex_clear_nmi_state(
     const dif_rv_core_ibex_t *rv_core_ibex, dif_rv_core_ibex_nmi_source_t nmi) {
-  if (rv_core_ibex == NULL || (nmi & ~kDifRvCoreIbexNmiSourceAll) != 0) {
+  if (rv_core_ibex == NULL || nmi & ~kDifRvCoreIbexNmiSourceAll) {
     return kDifBadArg;
   }
 
@@ -268,6 +268,33 @@ dif_result_t dif_rv_core_ibex_clear_nmi_state(
 
   mmio_region_write32(rv_core_ibex->base_addr,
                       RV_CORE_IBEX_NMI_STATE_REG_OFFSET, reg);
+  return kDifOk;
+}
 
+dif_result_t dif_rv_core_ibex_get_rnd_status(
+    const dif_rv_core_ibex_t *rv_core_ibex,
+    dif_rv_core_ibex_rnd_status_t *status) {
+  if (rv_core_ibex == NULL || status == NULL) {
+    return kDifBadArg;
+  }
+
+  *status = mmio_region_read32(rv_core_ibex->base_addr,
+                               RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
+  return kDifOk;
+}
+
+dif_result_t dif_rv_core_ibex_read_rnd_data(
+    const dif_rv_core_ibex_t *rv_core_ibex, uint32_t *data) {
+  if (rv_core_ibex == NULL || data == NULL) {
+    return kDifBadArg;
+  }
+  uint32_t reg = mmio_region_read32(rv_core_ibex->base_addr,
+                                    RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
+  if (!bitfield_bit32_read(reg, RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT)) {
+    return kDifError;
+  }
+
+  *data = mmio_region_read32(rv_core_ibex->base_addr,
+                             RV_CORE_IBEX_RND_DATA_REG_OFFSET);
   return kDifOk;
 }

--- a/sw/device/lib/dif/dif_rv_core_ibex.h
+++ b/sw/device/lib/dif/dif_rv_core_ibex.h
@@ -106,6 +106,22 @@ typedef enum dif_rv_core_ibex_error_status {
   kDifRvCoreIbexErrorStatusAll = (1 << 0 | 1 << 8 | 1 << 9 | 1 << 10),
 } dif_rv_core_ibex_error_status_t;
 
+typedef enum dif_rv_core_ibex_rnd_status_code {
+  /**
+   * The current rnd word is valid.
+   */
+  kDifRvCoreIbexRndStatusValid = 1 << 0,
+  /**
+   * The current rnd word is fips compliant.
+   */
+  kDifRvCoreIbexRndStatusFipsCompliant = 1 << 1,
+} dif_rv_core_ibex_rnd_status_code_t;
+
+/**
+ * Bitmask with the `dif_rv_core_ibex_rnd_status_code_t` values.
+ */
+typedef uint32_t dif_rv_core_ibex_rnd_status_t;
+
 /**
  * NMI enabled status and current state.
  */
@@ -240,6 +256,29 @@ dif_result_t dif_rv_core_ibex_get_nmi_state(
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_core_ibex_clear_nmi_state(
     const dif_rv_core_ibex_t *rv_core_ibex, dif_rv_core_ibex_nmi_source_t nmi);
+
+/**
+ * Reads a random word from the RISC-V Ibex core wrapper.
+ *
+ * @param rv_core_ibex Handle.
+ * @param[out] data Pointer to be filled with the random word.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_read_rnd_data(
+    const dif_rv_core_ibex_t *rv_core_ibex, uint32_t *data);
+
+/**
+ * Gets whether the rnd data is either valid or is FIPS compliant.
+ *
+ * @param rv_core_ibex Handle.
+ * @param[out] status Pointer to be filled with the current rnd status.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_get_rnd_status(
+    const dif_rv_core_ibex_t *rv_core_ibex,
+    dif_rv_core_ibex_rnd_status_t *status);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_rv_core_ibex_unittest.cc
+++ b/sw/device/lib/dif/dif_rv_core_ibex_unittest.cc
@@ -428,4 +428,52 @@ TEST_F(NMITest, ClearBadArg) {
       &ibex_, static_cast<dif_rv_core_ibex_nmi_source_t>(-1)));
 }
 
+class RndTest : public RvCoreIbexTestInitialized {};
+
+TEST_F(RndTest, ReadSuccess) {
+  EXPECT_READ32(RV_CORE_IBEX_RND_STATUS_REG_OFFSET,
+                {{RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT, true}});
+  EXPECT_READ32(RV_CORE_IBEX_RND_DATA_REG_OFFSET, 0xf55ef65e);
+
+  uint32_t data;
+  EXPECT_DIF_OK(dif_rv_core_ibex_read_rnd_data(&ibex_, &data));
+  EXPECT_EQ(data, 0xf55ef65e);
+}
+
+TEST_F(RndTest, ReadBadArg) {
+  uint32_t data;
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_read_rnd_data(nullptr, &data));
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_read_rnd_data(&ibex_, nullptr));
+}
+
+TEST_F(RndTest, ReadNotValid) {
+  EXPECT_READ32(RV_CORE_IBEX_RND_STATUS_REG_OFFSET,
+                {{RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT, false}});
+  uint32_t data;
+  EXPECT_EQ(dif_rv_core_ibex_read_rnd_data(&ibex_, &data), kDifError);
+}
+
+TEST_F(RndTest, StatusValid) {
+  EXPECT_READ32(RV_CORE_IBEX_RND_STATUS_REG_OFFSET,
+                {{RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT, true}});
+
+  dif_rv_core_ibex_rnd_status_t status;
+  EXPECT_DIF_OK(dif_rv_core_ibex_get_rnd_status(&ibex_, &status));
+  EXPECT_EQ(status, kDifRvCoreIbexRndStatusValid);
+}
+
+TEST_F(RndTest, StatusFipsCompliant) {
+  EXPECT_READ32(RV_CORE_IBEX_RND_STATUS_REG_OFFSET,
+                {{RV_CORE_IBEX_RND_STATUS_RND_DATA_FIPS_BIT, true}});
+
+  dif_rv_core_ibex_rnd_status_t status;
+  EXPECT_DIF_OK(dif_rv_core_ibex_get_rnd_status(&ibex_, &status));
+  EXPECT_EQ(status, kDifRvCoreIbexRndStatusFipsCompliant);
+}
+
+TEST_F(RndTest, StatusBadArg) {
+  dif_rv_core_ibex_rnd_status_t status;
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_get_rnd_status(nullptr, &status));
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_get_rnd_status(&ibex_, nullptr));
+}
 }  // namespace dif_rv_core_ibex_test


### PR DESCRIPTION
Add the rnd api with unittests in the `dif_rv_core_ibex`.
Changing the priority to P0 as these funcions are needed for the `chip_sw_edn_entropy_reqs` chip level test.