### PR TITLE
[ci] Clean up verilator chip-level testing configuration.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -232,7 +232,7 @@ jobs:
 - job: execute_verilated_tests
   displayName: Build and run fast tests on sim_verilator
   pool: ci-public
-  timeoutInMinutes: 200
+  timeoutInMinutes: 120
   dependsOn: lint
   steps:
   - template: ci/install-package-dependencies.yml
@@ -248,7 +248,6 @@ jobs:
       export GCP_BAZEL_CACHE_KEY=$(bazelCacheGcpKeyPath)
       ci/scripts/run-verilator-tests.sh
     displayName: Build and execute tests
-    continueOnError: true # Temporary workaround for #12603
   # TODO: build and cache the verilator model to avoid building twice (#12574)
   - bash: |
       . util/build_consts.sh

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -382,7 +382,6 @@ def opentitan_functest(
             name = test_name,
             srcs = [test_runner],
             args = concat_args,
-            flaky = target == "sim_verilator",  # Temporary workaround for #12603
             data = [
                 flash,
                 rom,


### PR DESCRIPTION
This commit undoes the temporary actions in #12603 that were taken to
prevent blocking on the Verilator chip-level tests back when these tests
were flaky.

Closes #12603 