### PR TITLE
[spi_device] Default to Flash Mode

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -160,6 +160,7 @@
         { bits: "5:4",
           name: "MODE",
           desc: "SPI Device operation mode. Currently only FwMode is supported.",
+          resval: "1"
           enum: [
             { value: "0",
               name: "fwmode",

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -2394,7 +2394,7 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h1)
   ) u_control_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),


### PR DESCRIPTION
As discussed in #12808, SPI_DEVICE default mode is changed to Flash mode
in this commit. It removes three register writes in the Boot ROM.

As Generic feature still lives in the SPI_DEVICE IP, SW can always
change back to Generic mode.

Justification:

    BootROM has been switched to SPI Flash mode to download the ROM
    Extension images. The usage of SPI_DEVICE is focused on Flash mode
    and Passthrough mode. Changing between Generic mode and
    (Flash/Passthrough) mode is not easy due to the clock change. SW
    shall follow the steps in the doc. This change eliminates the
    unnecessary steps in most cases.
