### PR TITLE
[sw/silicon_creator] Remove mode change code from spi_device_init()

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -617,17 +617,6 @@ void spi_device_init(void) {
 
   // Reset status register
   abs_mmio_write32(kBase + SPI_DEVICE_FLASH_STATUS_REG_OFFSET, 0);
-
-  // Switch to flash mode. Both clocks (SRAM and SPI) must be disabled prior to
-  // mode change for proper SRAM operation.
-  reg = abs_mmio_read32(kBase + SPI_DEVICE_CONTROL_REG_OFFSET);
-  reg = bitfield_bit32_write(reg, SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, false);
-  abs_mmio_write32(kBase + SPI_DEVICE_CONTROL_REG_OFFSET, reg);
-  reg = bitfield_field32_write(0, SPI_DEVICE_CONTROL_MODE_FIELD,
-                               SPI_DEVICE_CONTROL_MODE_VALUE_FLASHMODE);
-  abs_mmio_write32(kBase + SPI_DEVICE_CONTROL_REG_OFFSET, reg);
-  reg = bitfield_bit32_write(reg, SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, true);
-  abs_mmio_write32(kBase + SPI_DEVICE_CONTROL_REG_OFFSET, reg);
 }
 
 rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd) {

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -162,23 +162,6 @@ TEST_F(InitTest, Init) {
 
   EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_FLASH_STATUS_REG_OFFSET, 0);
 
-  uint32_t control_reg = std::numeric_limits<uint32_t>::max();
-  EXPECT_ABS_READ32(base_ + SPI_DEVICE_CONTROL_REG_OFFSET, control_reg);
-  EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_CONTROL_REG_OFFSET,
-                     control_reg ^ 1 << SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT);
-  EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_CONTROL_REG_OFFSET,
-                     {
-                         {SPI_DEVICE_CONTROL_MODE_OFFSET,
-                          SPI_DEVICE_CONTROL_MODE_VALUE_FLASHMODE},
-                         {SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, 0},
-                     });
-  EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_CONTROL_REG_OFFSET,
-                     {
-                         {SPI_DEVICE_CONTROL_MODE_OFFSET,
-                          SPI_DEVICE_CONTROL_MODE_VALUE_FLASHMODE},
-                         {SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, 1},
-                     });
-
   spi_device_init();
 }
 


### PR DESCRIPTION
lowRISC/opentitan#12955 changes the default mode of spi_device to SPI flash. This commit removes the writes to the CONTROL register for switching to SPI flash mode from spi_device_init().

Signed-off-by: Alphan Ulusoy <alphan@google.com>