### PR TITLE
doc(prim): Specify ICEBOX for prim_packer

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -556,6 +556,8 @@ module hmac
   //  - HMAC_CORE --> hmac_core_idle
   //  - SHA2_CORE --> sha_core_idle
   //  - Clean interrupt status
+  // ICEBOX(#12958): Revise prim_packer and replace `reg_fifo_wvalid` to the
+  // empty status.
   logic idle;
   assign idle = !reg_fifo_wvalid && !fifo_rvalid
               && hmac_core_idle && sha_core_idle;

--- a/hw/ip/prim/rtl/prim_packer.sv
+++ b/hw/ip/prim/rtl/prim_packer.sv
@@ -6,6 +6,7 @@
 
 `include "prim_assert.sv"
 
+// ICEBOX(#12958): Revise to send out the empty status.
 module prim_packer #(
   parameter int InW  = 32,
   parameter int OutW = 32,


### PR DESCRIPTION
prim_packer needs empty signal for HMAC to set the idle state correctly.
