### PR TITLE
Generate rv_dm rom size

### DIFF
--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
@@ -70,6 +70,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_UART0_BASE_ADDR 0x40000000
+
+/**
+ * Peripheral size for uart0 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_UART0_BASE_ADDR and
+ * `TOP_EARLGREY_UART0_BASE_ADDR + TOP_EARLGREY_UART0_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_UART0_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for uart1 in top earlgrey.
  *
@@ -77,6 +87,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_UART1_BASE_ADDR 0x40010000
+
+/**
+ * Peripheral size for uart1 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_UART1_BASE_ADDR and
+ * `TOP_EARLGREY_UART1_BASE_ADDR + TOP_EARLGREY_UART1_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_UART1_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for uart2 in top earlgrey.
  *
@@ -84,6 +104,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_UART2_BASE_ADDR 0x40020000
+
+/**
+ * Peripheral size for uart2 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_UART2_BASE_ADDR and
+ * `TOP_EARLGREY_UART2_BASE_ADDR + TOP_EARLGREY_UART2_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_UART2_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for uart3 in top earlgrey.
  *
@@ -91,6 +121,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_UART3_BASE_ADDR 0x40030000
+
+/**
+ * Peripheral size for uart3 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_UART3_BASE_ADDR and
+ * `TOP_EARLGREY_UART3_BASE_ADDR + TOP_EARLGREY_UART3_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_UART3_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for gpio in top earlgrey.
  *
@@ -98,6 +138,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_GPIO_BASE_ADDR 0x40040000
+
+/**
+ * Peripheral size for gpio in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_GPIO_BASE_ADDR and
+ * `TOP_EARLGREY_GPIO_BASE_ADDR + TOP_EARLGREY_GPIO_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_GPIO_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for spi_device in top earlgrey.
  *
@@ -105,6 +155,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_SPI_DEVICE_BASE_ADDR 0x40050000
+
+/**
+ * Peripheral size for spi_device in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_SPI_DEVICE_BASE_ADDR and
+ * `TOP_EARLGREY_SPI_DEVICE_BASE_ADDR + TOP_EARLGREY_SPI_DEVICE_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_SPI_DEVICE_SIZE_BYTES 0x2000
 /**
  * Peripheral base address for i2c0 in top earlgrey.
  *
@@ -112,6 +172,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_I2C0_BASE_ADDR 0x40080000
+
+/**
+ * Peripheral size for i2c0 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_I2C0_BASE_ADDR and
+ * `TOP_EARLGREY_I2C0_BASE_ADDR + TOP_EARLGREY_I2C0_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_I2C0_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for i2c1 in top earlgrey.
  *
@@ -119,6 +189,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_I2C1_BASE_ADDR 0x40090000
+
+/**
+ * Peripheral size for i2c1 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_I2C1_BASE_ADDR and
+ * `TOP_EARLGREY_I2C1_BASE_ADDR + TOP_EARLGREY_I2C1_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_I2C1_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for i2c2 in top earlgrey.
  *
@@ -126,6 +206,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_I2C2_BASE_ADDR 0x400A0000
+
+/**
+ * Peripheral size for i2c2 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_I2C2_BASE_ADDR and
+ * `TOP_EARLGREY_I2C2_BASE_ADDR + TOP_EARLGREY_I2C2_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_I2C2_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for pattgen in top earlgrey.
  *
@@ -133,6 +223,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_PATTGEN_BASE_ADDR 0x400E0000
+
+/**
+ * Peripheral size for pattgen in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_PATTGEN_BASE_ADDR and
+ * `TOP_EARLGREY_PATTGEN_BASE_ADDR + TOP_EARLGREY_PATTGEN_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_PATTGEN_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for rv_timer in top earlgrey.
  *
@@ -140,6 +240,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_RV_TIMER_BASE_ADDR 0x40100000
+
+/**
+ * Peripheral size for rv_timer in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_RV_TIMER_BASE_ADDR and
+ * `TOP_EARLGREY_RV_TIMER_BASE_ADDR + TOP_EARLGREY_RV_TIMER_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_RV_TIMER_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for usbdev in top earlgrey.
  *
@@ -147,6 +257,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_USBDEV_BASE_ADDR 0x40110000
+
+/**
+ * Peripheral size for usbdev in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_USBDEV_BASE_ADDR and
+ * `TOP_EARLGREY_USBDEV_BASE_ADDR + TOP_EARLGREY_USBDEV_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_USBDEV_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for core device on otp_ctrl in top earlgrey.
  *
@@ -154,6 +274,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR 0x40130000
+
+/**
+ * Peripheral size for core device on otp_ctrl in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR and
+ * `TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + TOP_EARLGREY_OTP_CTRL_CORE_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_OTP_CTRL_CORE_SIZE_BYTES 0x2000
 /**
  * Peripheral base address for prim device on otp_ctrl in top earlgrey.
  *
@@ -161,6 +291,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_OTP_CTRL_PRIM_BASE_ADDR 0x40132000
+
+/**
+ * Peripheral size for prim device on otp_ctrl in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_OTP_CTRL_PRIM_BASE_ADDR and
+ * `TOP_EARLGREY_OTP_CTRL_PRIM_BASE_ADDR + TOP_EARLGREY_OTP_CTRL_PRIM_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_OTP_CTRL_PRIM_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for lc_ctrl in top earlgrey.
  *
@@ -168,6 +308,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_LC_CTRL_BASE_ADDR 0x40140000
+
+/**
+ * Peripheral size for lc_ctrl in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_LC_CTRL_BASE_ADDR and
+ * `TOP_EARLGREY_LC_CTRL_BASE_ADDR + TOP_EARLGREY_LC_CTRL_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_LC_CTRL_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for alert_handler in top earlgrey.
  *
@@ -175,6 +325,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR 0x40150000
+
+/**
+ * Peripheral size for alert_handler in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR and
+ * `TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR + TOP_EARLGREY_ALERT_HANDLER_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_ALERT_HANDLER_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for spi_host0 in top earlgrey.
  *
@@ -182,6 +342,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_SPI_HOST0_BASE_ADDR 0x40300000
+
+/**
+ * Peripheral size for spi_host0 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_SPI_HOST0_BASE_ADDR and
+ * `TOP_EARLGREY_SPI_HOST0_BASE_ADDR + TOP_EARLGREY_SPI_HOST0_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_SPI_HOST0_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for spi_host1 in top earlgrey.
  *
@@ -189,6 +359,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_SPI_HOST1_BASE_ADDR 0x40310000
+
+/**
+ * Peripheral size for spi_host1 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_SPI_HOST1_BASE_ADDR and
+ * `TOP_EARLGREY_SPI_HOST1_BASE_ADDR + TOP_EARLGREY_SPI_HOST1_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_SPI_HOST1_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for pwrmgr_aon in top earlgrey.
  *
@@ -196,6 +376,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_PWRMGR_AON_BASE_ADDR 0x40400000
+
+/**
+ * Peripheral size for pwrmgr_aon in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_PWRMGR_AON_BASE_ADDR and
+ * `TOP_EARLGREY_PWRMGR_AON_BASE_ADDR + TOP_EARLGREY_PWRMGR_AON_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_PWRMGR_AON_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for rstmgr_aon in top earlgrey.
  *
@@ -203,6 +393,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_RSTMGR_AON_BASE_ADDR 0x40410000
+
+/**
+ * Peripheral size for rstmgr_aon in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_RSTMGR_AON_BASE_ADDR and
+ * `TOP_EARLGREY_RSTMGR_AON_BASE_ADDR + TOP_EARLGREY_RSTMGR_AON_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_RSTMGR_AON_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for clkmgr_aon in top earlgrey.
  *
@@ -210,6 +410,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_CLKMGR_AON_BASE_ADDR 0x40420000
+
+/**
+ * Peripheral size for clkmgr_aon in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_CLKMGR_AON_BASE_ADDR and
+ * `TOP_EARLGREY_CLKMGR_AON_BASE_ADDR + TOP_EARLGREY_CLKMGR_AON_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_CLKMGR_AON_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for sysrst_ctrl_aon in top earlgrey.
  *
@@ -217,6 +427,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR 0x40430000
+
+/**
+ * Peripheral size for sysrst_ctrl_aon in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR and
+ * `TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR + TOP_EARLGREY_SYSRST_CTRL_AON_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_SYSRST_CTRL_AON_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for adc_ctrl_aon in top earlgrey.
  *
@@ -224,6 +444,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_ADC_CTRL_AON_BASE_ADDR 0x40440000
+
+/**
+ * Peripheral size for adc_ctrl_aon in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_ADC_CTRL_AON_BASE_ADDR and
+ * `TOP_EARLGREY_ADC_CTRL_AON_BASE_ADDR + TOP_EARLGREY_ADC_CTRL_AON_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_ADC_CTRL_AON_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for pwm_aon in top earlgrey.
  *
@@ -231,6 +461,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_PWM_AON_BASE_ADDR 0x40450000
+
+/**
+ * Peripheral size for pwm_aon in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_PWM_AON_BASE_ADDR and
+ * `TOP_EARLGREY_PWM_AON_BASE_ADDR + TOP_EARLGREY_PWM_AON_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_PWM_AON_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for pinmux_aon in top earlgrey.
  *
@@ -238,6 +478,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_PINMUX_AON_BASE_ADDR 0x40460000
+
+/**
+ * Peripheral size for pinmux_aon in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_PINMUX_AON_BASE_ADDR and
+ * `TOP_EARLGREY_PINMUX_AON_BASE_ADDR + TOP_EARLGREY_PINMUX_AON_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_PINMUX_AON_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for aon_timer_aon in top earlgrey.
  *
@@ -245,6 +495,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR 0x40470000
+
+/**
+ * Peripheral size for aon_timer_aon in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR and
+ * `TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR + TOP_EARLGREY_AON_TIMER_AON_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_AON_TIMER_AON_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for ast in top earlgrey.
  *
@@ -252,6 +512,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_AST_BASE_ADDR 0x40480000
+
+/**
+ * Peripheral size for ast in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_AST_BASE_ADDR and
+ * `TOP_EARLGREY_AST_BASE_ADDR + TOP_EARLGREY_AST_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_AST_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for sensor_ctrl in top earlgrey.
  *
@@ -259,6 +529,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_SENSOR_CTRL_BASE_ADDR 0x40490000
+
+/**
+ * Peripheral size for sensor_ctrl in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_SENSOR_CTRL_BASE_ADDR and
+ * `TOP_EARLGREY_SENSOR_CTRL_BASE_ADDR + TOP_EARLGREY_SENSOR_CTRL_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_SENSOR_CTRL_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for regs device on sram_ctrl_ret_aon in top earlgrey.
  *
@@ -266,6 +546,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR 0x40500000
+
+/**
+ * Peripheral size for regs device on sram_ctrl_ret_aon in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR and
+ * `TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR + TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for ram device on sram_ctrl_ret_aon in top earlgrey.
  *
@@ -273,6 +563,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR 0x40600000
+
+/**
+ * Peripheral size for ram device on sram_ctrl_ret_aon in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR and
+ * `TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR + TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for core device on flash_ctrl in top earlgrey.
  *
@@ -280,6 +580,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR 0x41000000
+
+/**
+ * Peripheral size for core device on flash_ctrl in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR and
+ * `TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR + TOP_EARLGREY_FLASH_CTRL_CORE_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_FLASH_CTRL_CORE_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for prim device on flash_ctrl in top earlgrey.
  *
@@ -287,6 +597,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_FLASH_CTRL_PRIM_BASE_ADDR 0x41008000
+
+/**
+ * Peripheral size for prim device on flash_ctrl in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_FLASH_CTRL_PRIM_BASE_ADDR and
+ * `TOP_EARLGREY_FLASH_CTRL_PRIM_BASE_ADDR + TOP_EARLGREY_FLASH_CTRL_PRIM_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_FLASH_CTRL_PRIM_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for mem device on flash_ctrl in top earlgrey.
  *
@@ -294,6 +614,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR 0x20000000
+
+/**
+ * Peripheral size for mem device on flash_ctrl in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR and
+ * `TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR + TOP_EARLGREY_FLASH_CTRL_MEM_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_FLASH_CTRL_MEM_SIZE_BYTES 0x100000
 /**
  * Peripheral base address for regs device on rv_dm in top earlgrey.
  *
@@ -301,6 +631,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_RV_DM_REGS_BASE_ADDR 0x41200000
+
+/**
+ * Peripheral size for regs device on rv_dm in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_RV_DM_REGS_BASE_ADDR and
+ * `TOP_EARLGREY_RV_DM_REGS_BASE_ADDR + TOP_EARLGREY_RV_DM_REGS_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_RV_DM_REGS_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for rom device on rv_dm in top earlgrey.
  *
@@ -308,6 +648,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_RV_DM_ROM_BASE_ADDR 0x10000
+
+/**
+ * Peripheral size for rom device on rv_dm in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_RV_DM_ROM_BASE_ADDR and
+ * `TOP_EARLGREY_RV_DM_ROM_BASE_ADDR + TOP_EARLGREY_RV_DM_ROM_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_RV_DM_ROM_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for rv_plic in top earlgrey.
  *
@@ -315,6 +665,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_RV_PLIC_BASE_ADDR 0x48000000
+
+/**
+ * Peripheral size for rv_plic in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_RV_PLIC_BASE_ADDR and
+ * `TOP_EARLGREY_RV_PLIC_BASE_ADDR + TOP_EARLGREY_RV_PLIC_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_RV_PLIC_SIZE_BYTES 0x8000000
 /**
  * Peripheral base address for aes in top earlgrey.
  *
@@ -322,6 +682,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_AES_BASE_ADDR 0x41100000
+
+/**
+ * Peripheral size for aes in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_AES_BASE_ADDR and
+ * `TOP_EARLGREY_AES_BASE_ADDR + TOP_EARLGREY_AES_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_AES_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for hmac in top earlgrey.
  *
@@ -329,6 +699,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_HMAC_BASE_ADDR 0x41110000
+
+/**
+ * Peripheral size for hmac in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_HMAC_BASE_ADDR and
+ * `TOP_EARLGREY_HMAC_BASE_ADDR + TOP_EARLGREY_HMAC_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_HMAC_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for kmac in top earlgrey.
  *
@@ -336,6 +716,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_KMAC_BASE_ADDR 0x41120000
+
+/**
+ * Peripheral size for kmac in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_KMAC_BASE_ADDR and
+ * `TOP_EARLGREY_KMAC_BASE_ADDR + TOP_EARLGREY_KMAC_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_KMAC_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for otbn in top earlgrey.
  *
@@ -343,6 +733,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_OTBN_BASE_ADDR 0x41130000
+
+/**
+ * Peripheral size for otbn in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_OTBN_BASE_ADDR and
+ * `TOP_EARLGREY_OTBN_BASE_ADDR + TOP_EARLGREY_OTBN_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_OTBN_SIZE_BYTES 0x10000
 /**
  * Peripheral base address for keymgr in top earlgrey.
  *
@@ -350,6 +750,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_KEYMGR_BASE_ADDR 0x41140000
+
+/**
+ * Peripheral size for keymgr in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_KEYMGR_BASE_ADDR and
+ * `TOP_EARLGREY_KEYMGR_BASE_ADDR + TOP_EARLGREY_KEYMGR_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_KEYMGR_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for csrng in top earlgrey.
  *
@@ -357,6 +767,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_CSRNG_BASE_ADDR 0x41150000
+
+/**
+ * Peripheral size for csrng in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_CSRNG_BASE_ADDR and
+ * `TOP_EARLGREY_CSRNG_BASE_ADDR + TOP_EARLGREY_CSRNG_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_CSRNG_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for entropy_src in top earlgrey.
  *
@@ -364,6 +784,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR 0x41160000
+
+/**
+ * Peripheral size for entropy_src in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR and
+ * `TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR + TOP_EARLGREY_ENTROPY_SRC_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_ENTROPY_SRC_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for edn0 in top earlgrey.
  *
@@ -371,6 +801,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_EDN0_BASE_ADDR 0x41170000
+
+/**
+ * Peripheral size for edn0 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_EDN0_BASE_ADDR and
+ * `TOP_EARLGREY_EDN0_BASE_ADDR + TOP_EARLGREY_EDN0_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_EDN0_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for edn1 in top earlgrey.
  *
@@ -378,6 +818,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_EDN1_BASE_ADDR 0x41180000
+
+/**
+ * Peripheral size for edn1 in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_EDN1_BASE_ADDR and
+ * `TOP_EARLGREY_EDN1_BASE_ADDR + TOP_EARLGREY_EDN1_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_EDN1_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for regs device on sram_ctrl_main in top earlgrey.
  *
@@ -385,6 +835,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR 0x411C0000
+
+/**
+ * Peripheral size for regs device on sram_ctrl_main in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR and
+ * `TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR + TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for ram device on sram_ctrl_main in top earlgrey.
  *
@@ -392,6 +852,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR 0x10000000
+
+/**
+ * Peripheral size for ram device on sram_ctrl_main in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR and
+ * `TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR + TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES 0x20000
 /**
  * Peripheral base address for regs device on rom_ctrl in top earlgrey.
  *
@@ -399,6 +869,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_ROM_CTRL_REGS_BASE_ADDR 0x411E0000
+
+/**
+ * Peripheral size for regs device on rom_ctrl in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_ROM_CTRL_REGS_BASE_ADDR and
+ * `TOP_EARLGREY_ROM_CTRL_REGS_BASE_ADDR + TOP_EARLGREY_ROM_CTRL_REGS_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_ROM_CTRL_REGS_SIZE_BYTES 0x1000
 /**
  * Peripheral base address for rom device on rom_ctrl in top earlgrey.
  *
@@ -406,6 +886,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR 0x8000
+
+/**
+ * Peripheral size for rom device on rom_ctrl in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR and
+ * `TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR + TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES 0x8000
 /**
  * Peripheral base address for cfg device on rv_core_ibex in top earlgrey.
  *
@@ -413,6 +903,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR 0x411F0000
+
+/**
+ * Peripheral size for cfg device on rv_core_ibex in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR and
+ * `TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR + TOP_EARLGREY_RV_CORE_IBEX_CFG_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_RV_CORE_IBEX_CFG_SIZE_BYTES 0x1000
 #endif  // __ASSEMBLER__
 
 #endif  // OPENTITAN_HW_TOP_EARLGREY_SW_AUTOGEN_TOP_EARLGREY_MEMORY_H_

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp_init.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp_init.S
@@ -80,8 +80,7 @@ mask_rom_epmp_init:
   csrw pmpaddr11, t0
 
   // Debug ROM
-  // TODO(#11092): use TOP_EARLGREY_RV_DM_ROM_SIZE_BYTES instead of constant
-  li   t0, NAPOT(TOP_EARLGREY_RV_DM_ROM_BASE_ADDR, 0x1000)
+  li   t0, NAPOT(TOP_EARLGREY_RV_DM_ROM_BASE_ADDR, TOP_EARLGREY_RV_DM_ROM_SIZE_BYTES)
   csrw pmpaddr13, t0
 
   // Stack guard

--- a/util/topgen/templates/toplevel_memory.h.tpl
+++ b/util/topgen/templates/toplevel_memory.h.tpl
@@ -55,7 +55,10 @@
 <%
     if_desc = inst_name if if_name is None else '{} device on {}'.format(if_name, inst_name)
     hex_base_addr = "0x{:X}".format(region.base_addr)
+    hex_size_bytes = "0x{:X}".format(region.size_bytes)
+
     base_addr_name = region.base_addr_name().as_c_define()
+    size_bytes_name = region.size_bytes_name().as_c_define()
 %>\
 /**
  * Peripheral base address for ${if_desc} in top ${top["name"]}.
@@ -64,6 +67,16 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define ${base_addr_name} ${hex_base_addr}
+
+/**
+ * Peripheral size for ${if_desc} in top ${top["name"]}.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #${base_addr_name} and
+ * `${base_addr_name} + ${size_bytes_name}`.
+ */
+#define ${size_bytes_name} ${hex_size_bytes}
 % endfor
 #endif  // __ASSEMBLER__
 


### PR DESCRIPTION
This PR updates `toplevel_memory.h.tpl` to generate macros for the sizes of the peripherals and replaces the literal in `mask_rom_epmp_init.S` with the `TOP_EARLGREY_RV_DM_ROM_SIZE_BYTES` macro.

Fixes #11092