### PR TITLE
[test, entropy_src] Add entropy_src_edn  chip level test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2060,7 +2060,7 @@
             X'ref'ed with each IP test that requsts entropy from EDN.
             '''
       milestone: V2
-      tests: []
+      tests: ['chip_sw_edn_entropy_reqs_test']
     }
 
     // KEYMGR (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -757,7 +757,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/entropy_src_edn_reqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15000000","+rng_srate_value=1"]
+      run_opts: ["+sw_test_timeout_ns=15000000","+rng_srate_value=30"]
     }
     {
       name: chip_sw_hmac_enc_irq

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -753,6 +753,19 @@
       run_opts: ["+sw_test_timeout_ns=15000000"]
     }
     {
+      name: chip_sw_edn_entropy_reqs
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/entropy_src_edn_reqs_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=15000000","+rng_srate_value=1"]
+    }
+    {
+      name: chip_sw_hmac_enc_irq
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/hmac_enc_irq_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_hmac_enc
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:hmac_enc_test:1"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -755,7 +755,7 @@
     {
       name: chip_sw_edn_entropy_reqs
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/entropy_src_edn_reqs_test:1"]
+      sw_images: ["//sw/device/tests:entropy_src_edn_reqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=15000000","+rng_srate_value=30"]
     }

--- a/sw/device/lib/dif/dif_edn.c
+++ b/sw/device/lib/dif/dif_edn.c
@@ -69,10 +69,17 @@ dif_result_t dif_edn_set_auto_mode(const dif_edn_t *edn,
   DIF_RETURN_IF_ERROR(check_locked(edn));
 
   uint32_t reg = mmio_region_read32(edn->base_addr, EDN_CTRL_REG_OFFSET);
+
+  // first pulse fifo reset to clear out old fifo contents
   reg = bitfield_field32_write(reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
                                kMultiBitBool4True);
   mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, reg);
 
+  reg = bitfield_field32_write(reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
+                               kMultiBitBool4False);
+  mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, reg);
+
+  // program ctrl contents
   for (size_t i = 0; i < config.reseed_material.len; ++i) {
     mmio_region_write32(edn->base_addr, EDN_RESEED_CMD_REG_OFFSET,
                         config.reseed_material.data[i]);

--- a/sw/device/lib/dif/dif_edn.h
+++ b/sw/device/lib/dif/dif_edn.h
@@ -42,6 +42,15 @@ enum {
   kDifEntropySeedMaterialMaxWordLen = 12,
 };
 
+enum {
+  /**
+   * Csrng commands
+   */
+  kDifEdnCmdInstantiate = 1,
+  kDifEdnCmdReseed = 2,
+  kDifEdnCmdGenerate = 3
+};
+
 /**
  * CSRNG additional parameters for instantiate and generate commands.
  */

--- a/sw/device/lib/dif/dif_edn_unittest.cc
+++ b/sw/device/lib/dif/dif_edn_unittest.cc
@@ -96,6 +96,14 @@ TEST_F(SetModeTest, Auto) {
                      {EDN_CTRL_CMD_FIFO_RST_OFFSET, kMultiBitBool4True},
                  });
 
+  EXPECT_WRITE32(EDN_CTRL_REG_OFFSET,
+                 {
+                     {EDN_CTRL_EDN_ENABLE_OFFSET, kMultiBitBool4False},
+                     {EDN_CTRL_BOOT_REQ_MODE_OFFSET, kMultiBitBool4False},
+                     {EDN_CTRL_AUTO_REQ_MODE_OFFSET, kMultiBitBool4False},
+                     {EDN_CTRL_CMD_FIFO_RST_OFFSET, kMultiBitBool4False},
+                 });
+
   dif_edn_auto_params_t params = {
       .reseed_material =
           {
@@ -125,7 +133,7 @@ TEST_F(SetModeTest, Auto) {
                      {EDN_CTRL_EDN_ENABLE_OFFSET, kMultiBitBool4False},
                      {EDN_CTRL_BOOT_REQ_MODE_OFFSET, kMultiBitBool4False},
                      {EDN_CTRL_AUTO_REQ_MODE_OFFSET, kMultiBitBool4True},
-                     {EDN_CTRL_CMD_FIFO_RST_OFFSET, kMultiBitBool4True},
+                     {EDN_CTRL_CMD_FIFO_RST_OFFSET, kMultiBitBool4False},
                  });
 
   EXPECT_DIF_OK(dif_edn_set_auto_mode(&edn_, params));

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -111,6 +111,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:edn",
         "//sw/device/lib/dif:entropy_src",
         "//sw/device/lib/testing/test_framework:check",
     ],

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -31,6 +31,8 @@ static void setup_csrng(void) {
   dif_csrng_t csrng;
   CHECK_DIF_OK(dif_csrng_init(
       mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
+
+  CHECK_DIF_OK(dif_csrng_stop(&csrng));
   CHECK_DIF_OK(dif_csrng_configure(&csrng));
 }
 
@@ -38,7 +40,20 @@ static void setup_edn(void) {
   // Temporary solution to configure/enable the EDN and CSRNG to allow OTBN to
   // run before a DIF is available,
   // https://github.com/lowRISC/opentitan/issues/6082
-  uint32_t reg =
+  // disable edn.
+  uint32_t reg = 0;
+  reg =
+      bitfield_field32_write(0, EDN_CTRL_EDN_ENABLE_FIELD, kMultiBitBool4False);
+  reg = bitfield_field32_write(reg, EDN_CTRL_BOOT_REQ_MODE_FIELD,
+                               kMultiBitBool4False);
+  reg = bitfield_field32_write(reg, EDN_CTRL_AUTO_REQ_MODE_FIELD,
+                               kMultiBitBool4False);
+  reg = bitfield_field32_write(reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
+                               kMultiBitBool4False);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
+                      EDN_CTRL_REG_OFFSET, reg);
+
+  reg =
       bitfield_field32_write(0, EDN_CTRL_EDN_ENABLE_FIELD, kMultiBitBool4True);
   reg = bitfield_field32_write(reg, EDN_CTRL_BOOT_REQ_MODE_FIELD,
                                kMultiBitBool4True);

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_edn.h"
 #include "sw/device/lib/dif/dif_entropy_src.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
@@ -36,7 +37,7 @@ static void setup_csrng(void) {
   CHECK_DIF_OK(dif_csrng_configure(&csrng));
 }
 
-static void setup_edn(void) {
+static void setup_edn(bool auto_mode) {
   // Temporary solution to configure/enable the EDN and CSRNG to allow OTBN to
   // run before a DIF is available,
   // https://github.com/lowRISC/opentitan/issues/6082
@@ -53,24 +54,71 @@ static void setup_edn(void) {
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
                       EDN_CTRL_REG_OFFSET, reg);
 
-  reg =
-      bitfield_field32_write(0, EDN_CTRL_EDN_ENABLE_FIELD, kMultiBitBool4True);
-  reg = bitfield_field32_write(reg, EDN_CTRL_BOOT_REQ_MODE_FIELD,
-                               kMultiBitBool4True);
-  reg = bitfield_field32_write(reg, EDN_CTRL_AUTO_REQ_MODE_FIELD,
-                               kMultiBitBool4False);
-  reg = bitfield_field32_write(reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
-                               kMultiBitBool4False);
-  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
-                      EDN_CTRL_REG_OFFSET, reg);
-  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
-                      EDN_CTRL_REG_OFFSET, reg);
+  if (auto_mode) {
+    dif_edn_t edn0, edn1;
+
+    // temporarily declare handle in here, should fix later
+    CHECK_DIF_OK(dif_edn_init(
+        mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));
+    CHECK_DIF_OK(dif_edn_init(
+        mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR), &edn1));
+
+    dif_edn_seed_material_t inst_cmd = {.len = 1,
+                                        .data = {kDifEdnCmdInstantiate}};
+
+    dif_edn_seed_material_t reseed_cmd = {.len = 1, .data = {kDifEdnCmdReseed}};
+
+    dif_edn_seed_material_t generate_cmd = {
+        .len = 1, .data = {0xf000 | kDifEdnCmdGenerate}};
+
+    dif_edn_auto_params_t edn0_params = {.reseed_material = reseed_cmd,
+                                         .generate_material = generate_cmd,
+                                         .reseed_interval = 1 << 31};
+
+    dif_edn_auto_params_t edn1_params = {.reseed_material = reseed_cmd,
+                                         .generate_material = generate_cmd,
+                                         .reseed_interval = 1};
+
+    // setup edn parameters
+    CHECK_DIF_OK(dif_edn_set_auto_mode(&edn0, edn0_params));
+    CHECK_DIF_OK(dif_edn_set_auto_mode(&edn1, edn1_params));
+
+    // enable
+    CHECK_DIF_OK(dif_edn_configure(&edn0));
+    CHECK_DIF_OK(dif_edn_configure(&edn1));
+
+    // instantiate csrng instances
+    CHECK_DIF_OK(
+        dif_edn_instantiate(&edn0, kDifEdnEntropySrcToggleEnable, &inst_cmd));
+    CHECK_DIF_OK(
+        dif_edn_instantiate(&edn1, kDifEdnEntropySrcToggleEnable, &inst_cmd));
+
+  } else {
+    reg = bitfield_field32_write(0, EDN_CTRL_EDN_ENABLE_FIELD,
+                                 kMultiBitBool4True);
+    reg = bitfield_field32_write(reg, EDN_CTRL_BOOT_REQ_MODE_FIELD,
+                                 kMultiBitBool4True);
+    reg = bitfield_field32_write(reg, EDN_CTRL_AUTO_REQ_MODE_FIELD,
+                                 kMultiBitBool4False);
+    reg = bitfield_field32_write(reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
+                                 kMultiBitBool4False);
+    mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
+                        EDN_CTRL_REG_OFFSET, reg);
+    mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
+                        EDN_CTRL_REG_OFFSET, reg);
+  }
 }
 
 void entropy_testutils_boot_mode_init(void) {
   setup_entropy_src();
   setup_csrng();
-  setup_edn();
+  setup_edn(false);
+}
+
+void entropy_testutils_auto_mode_init(void) {
+  setup_entropy_src();
+  setup_csrng();
+  setup_edn(true);
 }
 
 void entropy_testutils_wait_for_state(const dif_entropy_src_t *entropy_src,

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -8,7 +8,8 @@
 #include "sw/device/lib/dif/dif_entropy_src.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "edn_regs.h"  // Generated
+#include "edn_regs.h"          // Generated
+#include "entropy_src_regs.h"  // Generated
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 static void setup_entropy_src(void) {
@@ -23,7 +24,9 @@ static void setup_entropy_src(void) {
       .fips_enable = true,
       .route_to_firmware = false,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
-  };
+      .health_test_threshold_scope = true,
+      .health_test_window_size =
+          (uint16_t)ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_RESVAL};
   CHECK_DIF_OK(
       dif_entropy_src_configure(&entropy_src, config, kDifToggleEnabled));
 }

--- a/sw/device/lib/testing/entropy_testutils.h
+++ b/sw/device/lib/testing/entropy_testutils.h
@@ -14,6 +14,7 @@
  * configuration to enable entropy distribution for testing purposes.
  */
 void entropy_testutils_boot_mode_init(void);
+void entropy_testutils_auto_mode_init(void);
 
 /**
  * Wait for the entropy_src to reach a certain state.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -601,6 +601,7 @@ opentitan_functest(
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:otbn",
         "//sw/device/lib/testing:aes_testutils",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -588,7 +588,6 @@ opentitan_functest(
 opentitan_functest(
     name = "entropy_src_edn_reqs_test",
     srcs = ["entropy_src_edn_reqs_test.c"],
-    targets = ["dv"],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -586,6 +586,36 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "entropy_src_edn_reqs_test",
+    srcs = ["entropy_src_edn_reqs_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:aes",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/dif:kmac",
+        "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:otbn",
+        "//sw/device/lib/testing:aes_testutils",
+        "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:keymgr_testutils",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/otbn/code-snippets:randomness",
+    ],
+)
+
+opentitan_functest(
     name = "example_test_from_flash",
     srcs = ["example_test_from_flash.c"],
     deps = [

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -244,6 +244,7 @@ bool test_main() {
   static entropy_src_test_context_t ctx;
   uint32_t loop = 1;
   test_initialize(&ctx);
+  wait_entropy_src_state(kDifEntropySrcMainFsmStateContHTRunning);
   CHECK_DIF_OK(dif_rv_core_ibex_read_fpga_info(&ctx.ibex, &ctx.fpga_info));
 
   // Run multiple times if in a FPGA.

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -208,10 +208,14 @@ static void alert_handler_test(entropy_src_test_context_t *ctx) {
 
 void test_initialize(entropy_src_test_context_t *ctx) {
   LOG_INFO("%s", __func__);
-  entropy_testutils_auto_mode_init();
 
-   mmio_region_t addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR);
+  mmio_region_t addr =
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR);
   CHECK_DIF_OK(dif_entropy_src_init(addr, &ctx->entropy_src));
+
+  entropy_testutils_auto_mode_init();
+  entropy_testutils_wait_for_state(&ctx->entropy_src,
+                                   kDifEntropySrcMainFsmStateContHTRunning);
 
   addr = mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR);
   CHECK_DIF_OK(dif_rv_core_ibex_init(addr, &ctx->ibex));
@@ -247,10 +251,7 @@ bool test_main() {
   static entropy_src_test_context_t ctx;
   uint32_t loop = 1;
   test_initialize(&ctx);
-
   CHECK_DIF_OK(dif_rv_core_ibex_read_fpga_info(&ctx.ibex, &ctx.fpga_info));
-  // entropy_testutils_wait_for_state(&ctx.entropy_src,
-  //                                  kDifEntropySrcMainFsmStateContHTRunning);
 
   // Run multiple times if in a FPGA.
   loop = (ctx.fpga_info != 0) ? kFpgaLoop : loop;

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -207,7 +207,7 @@ static void alert_handler_test(entropy_src_test_context_t *ctx) {
 
 void test_initialize(entropy_src_test_context_t *ctx) {
   LOG_INFO("%s", __func__);
-  entropy_testutils_boot_mode_init();
+  entropy_testutils_auto_mode_init();
 
   mmio_region_t addr =
       mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR);
@@ -248,7 +248,8 @@ bool test_main() {
   CHECK_DIF_OK(dif_rv_core_ibex_read_fpga_info(&ctx.ibex, &ctx.fpga_info));
 
   // Run multiple times if in a FPGA.
-  loop = (ctx.fpga_info != 0) ? kFpgaLoop : loop;
+  // loop = (ctx.fpga_info != 0) ? kFpgaLoop : loop;
+  loop = kFpgaLoop;
 
   for (int i = 0; i < loop; ++i) {
     LOG_INFO("Entropy src test %d/%d", i, loop);

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -1,0 +1,268 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_aes.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/dif/dif_keymgr.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/dif/dif_otbn.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/otbn.h"
+#include "sw/device/lib/testing/aes_testutils.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/keymgr_testutils.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "alert_handler_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTBN_DECLARE_APP_SYMBOLS(randomness);
+OTBN_DECLARE_SYMBOL_ADDR(randomness, rv);
+OTBN_DECLARE_SYMBOL_ADDR(randomness, fail_idx);
+OTBN_DECLARE_SYMBOL_ADDR(randomness, rnd_out);
+OTBN_DECLARE_SYMBOL_ADDR(randomness, urnd_out);
+
+static const otbn_app_t kOtbnAppCfiTest = OTBN_APP_T_INIT(randomness);
+static const otbn_addr_t kVarRv = OTBN_ADDR_T_INIT(randomness, rv);
+static const otbn_addr_t kVarFailIdx = OTBN_ADDR_T_INIT(randomness, fail_idx);
+static const otbn_addr_t kVarRndOut = OTBN_ADDR_T_INIT(randomness, rnd_out);
+static const otbn_addr_t kVarUrndOut = OTBN_ADDR_T_INIT(randomness, urnd_out);
+
+typedef struct entropy_src_test_context {
+  otbn_t otbn;
+  dif_aes_t aes;
+  dif_kmac_t kmac;
+  dif_keymgr_t kmgr;
+  dif_otp_ctrl_t otp;
+  dif_pwrmgr_t pwrmgr;
+  dif_rv_core_ibex_t ibex;
+  dif_alert_handler_t alert_handler;
+  dif_rv_core_ibex_fpga_info_t fpga_info;
+} entropy_src_test_context_t;
+
+enum {
+  kFpgaLoop = 5,
+};
+
+OTTF_DEFINE_TEST_CONFIG();
+
+/**
+ * Trigger an reseed operation.
+ *
+ * @param aes Aes dif handle.
+ */
+static void aes_test(entropy_src_test_context_t *ctx) {
+  LOG_INFO("%s", __func__);
+
+  dif_aes_transaction_t transaction = {
+      .operation = kDifAesOperationEncrypt,
+      .mode = kDifAesModeEcb,
+      .key_len = kDifAesKey128,
+      .manual_operation = kDifAesManualOperationManual,
+      .key_provider = kDifAesKeySideload,
+  };
+  CHECK_DIF_OK(dif_aes_start(&ctx->aes, &transaction, NULL, NULL));
+  CHECK_DIF_OK(dif_aes_trigger(&ctx->aes, kDifAesTriggerPrngReseed));
+}
+
+/**
+ * Configure the kmac to use entropy from edn to request entropy.
+ */
+static void kmac_test(entropy_src_test_context_t *ctx) {
+  dif_kmac_operation_state_t kmac_operation_state;
+
+  LOG_INFO("%s", __func__);
+
+  dif_kmac_config_t config = (dif_kmac_config_t){
+      .entropy_mode = kDifKmacEntropyModeEdn,
+      .entropy_fast_process = kDifToggleDisabled,
+  };
+  CHECK_DIF_OK(dif_kmac_configure(&ctx->kmac, config));
+}
+
+/**
+ * Configure the opt to request entropy from the edn.
+ */
+static void otp_ctrl_test(entropy_src_test_context_t *ctx) {
+  LOG_INFO("%s", __func__);
+
+  // For security reasons, the LFSR is periodically reseeded with entropy coming
+  // from EDN. Setting the integrity period to a small value will make the
+  // otp_ctrl to fetch entropy from EDN.
+  dif_otp_ctrl_config_t config = {
+      .check_timeout = 100000,
+      .integrity_period_mask = 0x4,
+      .consistency_period_mask = 0x3ffffff,
+  };
+  CHECK_DIF_OK(dif_otp_ctrl_configure(&ctx->otp, config));
+  otp_ctrl_testutils_wait_for_dai(&ctx->otp);
+}
+
+/**
+ * Load the randomness app and start its execution, which
+ * will request entropy from the edn.
+ */
+static void otbn_test(entropy_src_test_context_t *ctx) {
+  LOG_INFO("%s", __func__);
+
+  CHECK(otbn_load_app(&ctx->otbn, kOtbnAppCfiTest) == kOtbnOk);
+  CHECK(otbn_execute(&ctx->otbn) == kOtbnOk);
+}
+
+/**
+ * Configure the reseed interval to a short period and
+ * advance to the `kDifKeymgrStateInitialized` to request entropy from the edn.
+ */
+static void keymgr_test(entropy_src_test_context_t *ctx) {
+  /**
+   * Key manager can only be tested once per boot.
+   */
+  static bool tested = false;
+  if (!tested) {
+    LOG_INFO("%s", __func__);
+    dif_keymgr_config_t config = {.entropy_reseed_interval = 4};
+    CHECK_DIF_OK(dif_keymgr_configure(&ctx->kmgr, config));
+    CHECK_DIF_OK(dif_keymgr_advance_state(&ctx->kmgr, NULL));
+    tested = true;
+  }
+}
+
+/**
+ * Read 4 words of rnd data to request entropy from the edn.
+ */
+static void ibex_test(entropy_src_test_context_t *ctx) {
+  LOG_INFO("%s", __func__);
+
+  for (int i = 0; i < 4; i++) {
+    uint32_t rnd;
+    CHECK_DIF_OK(dif_rv_core_ibex_read_rnd_data(&ctx->ibex, &rnd));
+  }
+}
+
+/**
+ * Configure the `alert_handler`to escalate up to phase 0.
+ */
+static void alert_handler_configure(entropy_src_test_context_t *ctx) {
+  LOG_INFO("%s", __func__);
+
+  dif_alert_handler_local_alert_t loc_alerts[] = {
+      kDifAlertHandlerLocalAlertAlertPingFail};
+  dif_alert_handler_class_t loc_alert_classes[] = {kDifAlertHandlerClassB};
+
+  dif_alert_handler_escalation_phase_t esc_phases[] = {
+      {.phase = kDifAlertHandlerClassStatePhase0,
+       .signal = 0,
+       .duration_cycles = 2000}};
+
+  dif_alert_handler_class_config_t class_config = {
+      .auto_lock_accumulation_counter = kDifToggleDisabled,
+      .accumulator_threshold = 0,
+      .irq_deadline_cycles = 10000,
+      .escalation_phases = esc_phases,
+      .escalation_phases_len = ARRAYSIZE(esc_phases),
+      .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase1,
+  };
+
+  dif_alert_handler_class_config_t class_configs[] = {class_config,
+                                                      class_config};
+  dif_alert_handler_class_t classes[] = {kDifAlertHandlerClassA,
+                                         kDifAlertHandlerClassB};
+  dif_alert_handler_config_t config = {
+      .alerts = NULL,
+      .alert_classes = NULL,
+      .alerts_len = 0,
+      .local_alerts = loc_alerts,
+      .local_alert_classes = loc_alert_classes,
+      .local_alerts_len = ARRAYSIZE(loc_alerts),
+      .classes = classes,
+      .class_configs = class_configs,
+      .classes_len = ARRAYSIZE(class_configs),
+      .ping_timeout = 10,
+  };
+  alert_handler_testutils_configure_all(&ctx->alert_handler, config,
+                                        kDifToggleEnabled);
+}
+
+/**
+ * Trigger fault in the pwrmgr in order to escalate the alert handler.
+ */
+static void alert_handler_test(entropy_src_test_context_t *ctx) {
+  LOG_INFO("%s", __func__);
+
+  // Trigger the alert handler to escalate.
+  dif_pwrmgr_alert_t alert = kDifPwrmgrAlertFatalFault;
+  CHECK_DIF_OK(dif_pwrmgr_alert_force(&ctx->pwrmgr, alert));
+}
+
+void test_initialize(entropy_src_test_context_t *ctx) {
+  LOG_INFO("%s", __func__);
+  entropy_testutils_boot_mode_init();
+
+  mmio_region_t addr =
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR);
+  CHECK_DIF_OK(dif_alert_handler_init(addr, &ctx->alert_handler));
+  alert_handler_configure(ctx);
+
+  addr = mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR);
+  CHECK_DIF_OK(dif_rv_core_ibex_init(addr, &ctx->ibex));
+
+  addr = mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_pwrmgr_init(addr, &ctx->pwrmgr));
+
+  addr = mmio_region_from_addr(TOP_EARLGREY_KEYMGR_BASE_ADDR);
+  CHECK_DIF_OK(dif_keymgr_init(addr, &ctx->kmgr));
+
+  addr = mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR);
+  CHECK(otbn_init(&ctx->otbn, addr) == kOtbnOk);
+
+  addr = mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR);
+  CHECK_DIF_OK(dif_otp_ctrl_init(addr, &ctx->otp));
+
+  addr = mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR);
+  CHECK_DIF_OK(dif_aes_init(addr, &ctx->aes));
+
+  addr = mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR);
+  CHECK_DIF_OK(dif_kmac_init(addr, &ctx->kmac));
+}
+
+/**
+ * TODO: Run the test entropy src end reqs in continuous mode
+ * (https://github.com/lowRISC/opentitan/issues/13393)
+ */
+bool test_main() {
+  static entropy_src_test_context_t ctx;
+  uint32_t loop = 1;
+  test_initialize(&ctx);
+  CHECK_DIF_OK(dif_rv_core_ibex_read_fpga_info(&ctx.ibex, &ctx.fpga_info));
+
+  // Run multiple times if in a FPGA.
+  loop = (ctx.fpga_info != 0) ? kFpgaLoop : loop;
+
+  for (int i = 0; i < loop; ++i) {
+    LOG_INFO("Entropy src test %d/%d", i, loop);
+    alert_handler_test(&ctx);
+    aes_test(&ctx);
+    otbn_test(&ctx);
+    keymgr_test(&ctx);
+    otp_ctrl_test(&ctx);
+    kmac_test(&ctx);
+    ibex_test(&ctx);
+
+    AES_TESTUTILS_WAIT_FOR_STATUS(&ctx.aes, kDifAesStatusIdle, true, 100000);
+    CHECK(otbn_busy_wait_for_done(&ctx.otbn) == kOtbnOk);
+    keymgr_testutils_wait_for_operation_done(&ctx.kmgr);
+    keymgr_testutils_check_state(&ctx.kmgr, kDifKeymgrStateInitialized);
+  }
+  return true;
+}


### PR DESCRIPTION
# Test
The objective of this test is to have all the peripherals connected to the EDN requesting entropy data.

Fixes #13224