### PR TITLE
Verilator testbench is now found with a query

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,7 +255,7 @@ jobs:
   - bash: |
       . util/build_consts.sh
       mkdir -p "$BIN_DIR/hw/top_earlgrey/"
-      cp $(find bazel-out/* -name Vchip_sim_tb) \
+      cp $(ci/scripts/target-location.sh //hw:verilator)/sim-verilator/Vchip_sim_tb \
         "$BIN_DIR/hw/top_earlgrey/Vchip_earlgrey_verilator"
     displayName: Copy //hw:verilator to $BIN_DIR
   - template: ci/upload-artifacts-template.yml


### PR DESCRIPTION
Instead of using find (which could experience collisions in some platforms and is less generally applicable,) we use a Bazel query to locate the output testbench to copy it into the archive.

This method is also useful for scripts that may want to access Bazel built binaries and files from the command-line.

Fixes: #12704