### PR TITLE
[dv/aes] shadow reg with csr_rw fix

### DIFF
--- a/hw/ip/aes/dv/env/seq_lib/aes_common_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_common_vseq.sv
@@ -22,8 +22,10 @@ class aes_common_vseq extends aes_base_vseq;
                                              bit            predict = 1);
     bit [TL_DW-1:0] rdata;
     if (csr.get_name() == "ctrl_shadowed") begin
-      csr_rd(ral.status, rdata);
       // Only update `ctrl_shadowed` register if AES is idle.
+      // Use backdoor read because this sequence will run parallel with csr_rw.
+      wait_no_outstanding_access();
+      csr_rd(.ptr(ral.status), .value(rdata), .backdoor(1));
       if (get_field_val(ral.status.idle, rdata) == 1) begin
         csr_wr(.ptr(csr), .value(wdata), .en_shadow_wr(0), .predict(0));
         if (predict) begin


### PR DESCRIPTION
This PR fixes some errors when shadow reg errors and csr_rw sequences
are running in parallel:
1). The shadow reg will read status register and only update
  `ctrl_shadowed` register if the AES is in idle state.
  Currently we use front door read but should be backdoor read.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>