### PR TITLE
[bazel, ci] Build CW305 bitstream with Bazel-built sw

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -307,6 +307,16 @@ jobs:
       ci/scripts/run-english-breakfast-verilator-tests.sh
     displayName: Execute tests
     continueOnError: true #TODO: remove this line once this job is proven to be stable
+  - bash: |
+      . util/build_consts.sh
+      mkdir -p "$BIN_DIR/sw/device/lib/testing/test_rom"
+      cp $(ci/scripts/target-location.sh //sw/device/lib/testing/test_rom:test_rom_fpga_nexysvideo_vmem) \
+        "$BIN_DIR/sw/device/lib/testing/test_rom"
+    displayName: Copy test_rom_fpga_nexysvideo_vmem to $BIN_DIR
+  - template: ci/upload-artifacts-template.yml
+    parameters:
+      includePatterns:
+        - "/sw/device/lib/testing/test_rom/test_rom_fpga_nexysvideo.32.vmem"
 
 - job: otbn_standalone_tests
   displayName: Run OTBN Smoke Test
@@ -419,11 +429,10 @@ jobs:
     displayName: Upload all Vivado artifacts for CW310
     condition: failed()
 
+# TODO: change all instances of bazel_build_and_execute_verilated_tests_englishbreakfast to the new EB software build job after meson is removed.
 - job: chip_englishbreakfast_cw305
   displayName: Build CW305 variant of the English Breakfast toplevel design using Vivado
-  dependsOn:
-    - lint
-    - sw_build_englishbreakfast
+  dependsOn: bazel_build_and_execute_verilated_tests_englishbreakfast
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'))
   pool: ci-public
   timeoutInMinutes: 120 # 2 hours
@@ -432,7 +441,7 @@ jobs:
   - template: ci/download-artifacts-template.yml
     parameters:
       downloadPartialBuildBinFrom:
-        - sw_build_englishbreakfast
+        - bazel_build_and_execute_verilated_tests_englishbreakfast
   - bash: |
       set -e
       module load "xilinx/vivado/$(VIVADO_VERSION)"

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -37,6 +37,7 @@ _targets_compatible_with = {
 PER_DEVICE_DEPS = {
     "sim_verilator": ["//sw/device/lib/arch:sim_verilator"],
     "sim_dv": ["//sw/device/lib/arch:sim_dv"],
+    "fpga_nexysvideo": ["//sw/device/lib/arch:fpga_nexysvideo"],
     "fpga_cw310": ["//sw/device/lib/arch:fpga_cw310"],
 }
 

--- a/rules/rv.bzl
+++ b/rules/rv.bzl
@@ -14,6 +14,7 @@ OPENTITAN_PLATFORM = "@bazel_embedded//platforms:opentitan_rv32imc"
 PER_DEVICE_DEPS = {
     "sim_verilator": ["//sw/device/lib/arch:sim_verilator"],
     "sim_dv": ["//sw/device/lib/arch:sim_dv"],
+    "fpga_nexysvideo": ["//sw/device/lib/arch:fpga_nexysvideo"],
     "fpga_cw310": ["//sw/device/lib/arch:fpga_cw310"],
 }
 

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -10,6 +10,12 @@ cc_library(
 )
 
 cc_library(
+    name = "fpga_nexysvideo",
+    srcs = ["device_fpga_nexysvideo.c"],
+    deps = [":device"],
+)
+
+cc_library(
     name = "fpga_cw310",
     srcs = ["device_fpga_cw310.c"],
     deps = [":device"],


### PR DESCRIPTION
This PR makes the CW305 bitstream build using the bazel-built software instead of the meson-built software.

Closes #12953