### PR TITLE
[dv/flash_ctrl] Fix testplan unmapped flash test

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -201,6 +201,15 @@
       tests: ["flash_ctrl_error_prog_type"]
     }
     {
+      name: stress_all
+      desc: '''
+            - combine above sequences in one test to run sequentially, except csr sequence
+            - randomly add reset between each sequence
+            '''
+      milestone: V2
+      tests: ["flash_ctrl_stress_all"]
+    }
+    {
       name: error_flash_phy
       desc: '''
             Perform accesses in order to provoke native flash error. Test both, Software interface


### PR DESCRIPTION
This PR adds a testplan entry in flash_ctrl to resolve nightly unmapped
`stress_all` test.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>