### PR TITLE
[sw/silicon_creator] Remove stale TODO in shutdown_unittest.cc

### DIFF
--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -190,7 +190,6 @@ constexpr uint32_t Pack32(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
       Xmacro("LocDummy15",                     X, X, X, X),
 // clang-format on
 
-// TODO: adjust this to match the OTP layout in PR#6921.
 struct OtpConfiguration {
   uint32_t rom_error_reporting;
   uint32_t rom_bootstrap_en;


### PR DESCRIPTION
@cfrantz It looks like the layout of the struct matches the OTP layout (taken from the otp_ctrl memory map [here](https://docs.opentitan.org/hw/ip/otp_ctrl/doc/otp_ctrl_mmap/)):

![image](https://user-images.githubusercontent.com/57949550/171486833-b9377d5e-9124-42cc-b7b1-cdb1ea6e5602.png)

Signed-off-by: Alphan Ulusoy <alphan@google.com>