### PR TITLE
[sw/silicon_creator] Increase min HD in error_unittest.cc

### DIFF
--- a/sw/device/silicon_creator/lib/error_unittest.cc
+++ b/sw/device/silicon_creator/lib/error_unittest.cc
@@ -15,8 +15,7 @@
 namespace error_unittest {
 namespace {
 
-// FIXME: what should this value be?
-constexpr int kMinimumHammingDistance = 4;
+constexpr int kMinimumHammingDistance = 6;
 
 const std::map<std::string, uint32_t> &GetErrorMap() {
 #define STRINGIFY(x) #x


### PR DESCRIPTION
This commit increases the value of `kMinimumHammingDistance` to 6 (one less than the current minimum HD from `kErrorOk`) and removes the FIXME.

Signed-off-by: Alphan Ulusoy <alphan@google.com>