### PR TITLE
Otbn sec cm labels

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -124,6 +124,21 @@
     },
   ],
   countermeasures: [
+    { name: "MEM.SCRAMBLE",
+      desc: "Both the imem and dmem are scrambled by using prim_ram_1p_scr."
+    }
+    { name: "DATA.MEM.INTEGRITY",
+      desc: '''
+        Dmem is protected with ECC integrity.
+        This is carried through to OTBN's register file.
+      '''
+    }
+    { name: "INSTRUCTION.MEM.INTEGRITY",
+      desc: '''
+        Imem is protected with ECC integrity.
+        This is carried through into OTBN's execute stage.
+      '''
+    }
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."
     }
@@ -151,6 +166,9 @@
     { name: "SCRAMBLE_CTRL.FSM.SPARSE",
       desc: "The scramble control FSM uses a sparse state encoding."
     }
+    { name: "START_STOP_CTRL.FSM.GLOBAL_ESC",
+      desc: "The start-stop control FSM moves to a terminal error state upon global escalation."
+    }
     { name: "START_STOP_CTRL.FSM.LOCAL_ESC",
       desc: '''
         The start-stop control FSM moves to a terminal error state upon local escalation.
@@ -166,32 +184,49 @@
     { name: "CTRL.REDUN",
       desc: "Check pre-decoded control used for blanking matches seperately decoded control from main decoder."
     }
+    { name: "PC.CTRL_FLOW.REDUN",
+      desc: '''
+        Check prefetch stage PC and execute stage PC match.
+        The prefetch stage and execute stage store their PC's seperately and have seperate increment calculations.
+      '''
+    }
     { name: "RND.BUS.CONSISTENCY",
       desc: "Comparison on successive bus values received over the EDN RND interface."
     }
     { name: "RND.RNG.DIGEST",
       desc: "Checking that the random numbers received over the EDN RND interface have not been generated from entropy that failed the FIPS health checks in the entropy source."
     }
+    { name: "RF_BASE.DATA_REG_SW.INTEGRITY"
+      desc: "Register file is protected with ECC integrity."
+    }
     { name: "RF_BASE.DATA_REG_SW.GLITCH_DETECT"
       desc: '''
-        This countermeasure checks for spurious write-enable signals on the register
-        file by monitoring the one-hot0 property of the individual write-enable strobes.
+        This countermeasure checks for spurious write-enable signals on the register file by monitoring the one-hot0 property of the individual write-enable strobes.
       '''
     }
     { name: "STACK_WR_PTR.CTR.REDUN"
       desc: '''
-        The write pointer of the stack (used for calls and loops) is redundant.  If the two
-        instances of the counter mismatch, an error is emitted.
+        The write pointer of the stack (used for calls and loops) is redundant.
+        If the two instances of the counter mismatch, an error is emitted.
       '''
     }
     { name: "STACK_WR_PTR.CTR.GLITCH_DETECT"
       desc: "Glitches are detected on the stack counter increment / decrement control signal."
     }
+    { name: "RF_BIGNUM.DATA_REG_SW.INTEGRITY"
+      desc: "Register file is protected with ECC integrity."
+    }
     { name: "RF_BIGNUM.DATA_REG_SW.GLITCH_DETECT"
-      desc: '''
-        This countermeasure checks for spurious write-enable signals on the register
-        file by monitoring the one-hot0 property of the individual write-enable strobes.
-      '''
+      desc: "This countermeasure checks for spurious write-enable signals on the register file by monitoring the one-hot0 property of the individual write-enable strobes."
+    }
+    { name: "LOOP_STACK.CTR.REDUN"
+      desc: "The iteration counter of each entry in the loop step uses cross counts via prim_count."
+    }
+    { name: "LOOP_STACK.ADDR.INTEGRITY"
+      desc: "Loop start and end address on the loop stack are protected with ECC integrity."
+    }
+    { name: "CALL_STACK.ADDR.INTEGRITY"
+      desc: "Call stack entries are protected with ECC integrity."
     }
   ]
 

--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -24,6 +24,24 @@
 {
   testpoints: [
     {
+      name: sec_cm_mem_scramble
+      desc: "Verify the countermeasure(s) MEM.SCRAMBLE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_data_mem_integrity
+      desc: "Verify the countermeasure(s) DATA.MEM.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_instruction_mem_integrity
+      desc: "Verify the countermeasure(s) INSTRUCTION.MEM.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
       milestone: V2S
@@ -66,6 +84,12 @@
       tests: []
     }
     {
+      name: sec_cm_start_stop_ctrl_fsm_global_esc
+      desc: "Verify the countermeasure(s) START_STOP_CTRL.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
       name: sec_cm_start_stop_ctrl_fsm_local_esc
       desc: "Verify the countermeasure(s) START_STOP_CTRL.FSM.LOCAL_ESC."
       milestone: V2S
@@ -90,6 +114,12 @@
       tests: []
     }
     {
+      name: sec_cm_pc_ctrl_flow_redun
+      desc: "Verify the countermeasure(s) PC.CTRL_FLOW.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
       name: sec_cm_rnd_bus_consistency
       desc: "Verify the countermeasure(s) RND.BUS.CONSISTENCY."
       milestone: V2S
@@ -98,6 +128,12 @@
     {
       name: sec_cm_rnd_rng_digest
       desc: "Verify the countermeasure(s) RND.RNG.DIGEST."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_rf_base_data_reg_sw_integrity
+      desc: "Verify the countermeasure(s) RF_BASE.DATA_REG_SW.INTEGRITY."
       milestone: V2S
       tests: []
     }
@@ -120,8 +156,32 @@
       tests: []
     }
     {
+      name: sec_cm_rf_bignum_data_reg_sw_integrity
+      desc: "Verify the countermeasure(s) RF_BIGNUM.DATA_REG_SW.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
       name: sec_cm_rf_bignum_data_reg_sw_glitch_detect
       desc: "Verify the countermeasure(s) RF_BIGNUM.DATA_REG_SW.GLITCH_DETECT."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_loop_stack_ctr_redun
+      desc: "Verify the countermeasure(s) LOOP_STACK.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_loop_stack_addr_integrity
+      desc: "Verify the countermeasure(s) LOOP_STACK.ADDR.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_call_stack_addr_integrity
+      desc: "Verify the countermeasure(s) CALL_STACK.ADDR.INTEGRITY."
       milestone: V2S
       tests: []
     }

--- a/hw/ip/otbn/dv/smoke/run_smoke.sh
+++ b/hw/ip/otbn/dv/smoke/run_smoke.sh
@@ -41,7 +41,7 @@ trap "rm -rf $RUN_LOG" EXIT
 
 timeout 5s \
   $REPO_TOP/build/lowrisc_ip_otbn_top_sim_0.1/sim-verilator/Votbn_top_sim \
-  --load-elf=$SMOKE_BIN_DIR/smoke.elf | tee $RUN_LOG
+  --load-elf=$SMOKE_BIN_DIR/smoke.elf -t | tee $RUN_LOG
 
 if [ $? -eq 124 ]; then
   fail "Simulation timeout"

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -261,6 +261,7 @@ module otbn
 
   logic otbn_scramble_state_error;
 
+  // SEC_CM: SCRAMBLE.KEY.SIDELOAD
   otbn_scramble_ctrl #(
     .RndCnstOtbnKey  (RndCnstOtbnKey),
     .RndCnstOtbnNonce(RndCnstOtbnNonce)
@@ -295,6 +296,7 @@ module otbn
     .state_error_o(otbn_scramble_state_error)
   );
 
+  // SEC_CM: MEM.SCRAMBLE
   prim_ram_1p_scr #(
     .Width          (39),
     .Depth          (ImemSizeWords),
@@ -389,6 +391,7 @@ module otbn
   assign imem_wmask = imem_access_core ? '1 : imem_wmask_bus;
   `ASSERT(ImemWmaskBusIsFullWord_A, imem_req_bus && imem_write_bus |-> imem_wmask_bus == '1)
 
+  // SEC_CM: DATA_REG_SW.SCA
   // Blank bus read data interface during core operation to avoid leaking the currently executed
   // instruction from IMEM through the bus unintentionally. Also blank when OTBN is returning
   // a dummy response (responding to an illegal bus access) and when OTBN is locked.
@@ -492,6 +495,7 @@ module otbn
   logic unused_dmem_addr_core_wordbits;
   assign unused_dmem_addr_core_wordbits = ^dmem_addr_core[DmemAddrWidth-DmemIndexWidth-1:0];
 
+  // SEC_CM: MEM.SCRAMBLE
   prim_ram_1p_scr #(
     .Width             (ExtWLEN),
     .Depth             (DmemSizeWords),
@@ -535,6 +539,7 @@ module otbn
     end
   end
 
+  // SEC_CM: DATA.MEM.INTEGRITY
   for (genvar i_word = 0; i_word < BaseWordsPerWLEN; ++i_word) begin : g_dmem_intg_check
     logic [1:0] dmem_rerror_raw;
 
@@ -611,10 +616,10 @@ module otbn
     end
   end
 
+  // SEC_CM: DATA_REG_SW.SCA
   // Blank bus read data interface during core operation to avoid leaking DMEM data through the bus
   // unintentionally. Also blank when OTBN is returning a dummy response (responding to an illegal
   // bus access) and when OTBN is locked.
-
   assign dmem_rdata_bus_en_d = ~(busy_execute_d | start_d) & ~imem_dummy_response_d & ~locking;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -724,6 +729,7 @@ module otbn
     .devmode_i (1'b1)
   );
 
+  // SEC_CM: BUS.INTEGRITY
   logic bus_intg_violation;
   assign bus_intg_violation = (imem_bus_intg_violation | dmem_bus_intg_violation |
                                reg_bus_intg_violation);
@@ -977,6 +983,7 @@ module otbn
 
   prim_edn_req #(
     .OutWidth(EdnDataWidth),
+    // SEC_CM: RND.BUS.CONSISTENCY
     .RepCheck(1'b1)
   ) u_prim_edn_rnd_req (
     .clk_i,

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -336,6 +336,7 @@ module otbn_alu_bignum
   logic [WLEN-1:0]    ispr_rdata_no_intg;
   logic [ExtWLEN-1:0] ispr_rdata_intg_calc;
 
+  // SEC_CM: DATA_REG_SW.SCA
   prim_onehot_mux #(
     .Width  (WLEN),
     .Inputs (NIspr)
@@ -410,7 +411,7 @@ module otbn_alu_bignum
     .out_o (expected_ispr_wr_en_onehot)
   );
 
-  // SEC_CM: DATA_REG_SW.SCA
+  // SEC_CM: CTRL.REDUN
   assign ispr_predec_error_o =
     |{expected_ispr_rd_en_onehot != ispr_predec_bignum_i.ispr_rd_en,
       expected_ispr_wr_en_onehot != ispr_predec_bignum_i.ispr_wr_en};
@@ -687,7 +688,7 @@ module otbn_alu_bignum
     endcase
   end
 
-  // SEC_CM: DATA_REG_SW.SCA
+  // SEC_CM: CTRL.REDUN
   assign alu_predec_error_o =
     |{expected_adder_x_en != alu_predec_bignum_i.adder_x_en,
       expected_adder_y_op_a_en != alu_predec_bignum_i.adder_y_op_a_en,

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -971,6 +971,7 @@ module otbn_controller
       end
       RfWdSelLsu: begin
         rf_bignum_wr_data_intg_sel_o = 1'b1;
+        //SEC_CM: BUS.INTEGRITY
         rf_bignum_wr_data_intg_o     = lsu_bignum_rdata_i;
       end
       default: begin

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -364,7 +364,7 @@ module otbn_core
     .insn_dec_shared_o(insn_dec_shared)
   );
 
-  // SEC_CM: DATA_REG_SW.SCA
+  // SEC_CM: CTRL.REDUN
   // ALU and MAC predecode is only relevant when there is a valid instruction, as without one it is
   // guaranteed there are no register reads (hence no sensitive data bits being fed into the blanked
   // data paths). RF and ISPR predecode must always be checked to ensure read and write data paths

--- a/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
+++ b/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
@@ -233,6 +233,7 @@ module otbn_instruction_fetch
     end
   end
 
+  // SEC_CM: INSTRUCTION.MEM.INTEGRITY
   // Check integrity on prefetched instruction
   prim_secded_inv_39_32_dec u_insn_intg_check (
     .data_i    (insn_fetch_resp_data_intg_q),
@@ -251,6 +252,7 @@ module otbn_instruction_fetch
 
   assign insn_fetch_err_o = |insn_fetch_resp_intg_error_vec & insn_fetch_resp_valid_q;
 
+  // SEC_CM: PC.CTRL_FLOW.REDUN
   // Signal an `insn_addr_err` if the instruction the execute stage requests is not the one that was
   // prefetched. By design the prefetcher is either correct or doesn't prefetch, so a mismatch
   // here indicates a fault.  `insn_fetch_req_valid_raw_i` is used as it doesn't factor in errors,

--- a/hw/ip/otbn/rtl/otbn_loop_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_loop_controller.sv
@@ -62,7 +62,7 @@ module otbn_loop_controller
   logic        at_current_loop_end_insn;
   logic        current_loop_finish;
   logic        current_loop_counter_dec;
-  logic [38:0] current_loop_addrs_padded_intg;
+  logic [38:0] current_loop_addrs_padded_intg_unbuf, current_loop_addrs_padded_intg_buf;
   logic [1:0]  current_loop_intg_err;
 
   loop_info_t                  new_loop;
@@ -237,15 +237,22 @@ module otbn_loop_controller
 
   assign current_loop.loop_iterations = loop_counters[loop_stack_rd_idx];
 
-  assign current_loop_addrs_padded_intg =
+  assign current_loop_addrs_padded_intg_unbuf =
     {current_loop.loop_addr_info.loop_addrs_intg,
      {(32 - (ImemAddrWidth * 2) - 1){1'b0}},
      current_loop.loop_addr_info.loop_start,
      current_loop.loop_addr_info.loop_end};
 
+  prim_buf #(
+    .Width(39)
+  ) u_current_loop_addrs_padded_intg_buf (
+    .in_i (current_loop_addrs_padded_intg_unbuf),
+    .out_o(current_loop_addrs_padded_intg_buf)
+  );
+
   //SEC_CM: LOOP_STACK.ADDR.INTEGRITY
   prim_secded_inv_39_32_dec u_loop_addrs_intg_dec (
-    .data_i     (current_loop_addrs_padded_intg),
+    .data_i     (current_loop_addrs_padded_intg_buf),
     .data_o     (),
     .syndrome_o (),
     .err_o      (current_loop_intg_err)

--- a/hw/ip/otbn/rtl/otbn_loop_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_loop_controller.sv
@@ -217,6 +217,7 @@ module otbn_loop_controller
     assign loop_count_set = loop_stack_write & (loop_stack_wr_idx == i_count);
     assign loop_count_dec = current_loop_counter_dec & (loop_stack_rd_idx == i_count);
 
+    //SEC_CM: LOOP_STACK.CTR.REDUN
     prim_count #(.Width(32), .CntStyle(prim_count_pkg::CrossCnt)) u_loop_count (
       .clk_i,
       .rst_ni,
@@ -242,6 +243,7 @@ module otbn_loop_controller
      current_loop.loop_addr_info.loop_start,
      current_loop.loop_addr_info.loop_end};
 
+  //SEC_CM: LOOP_STACK.ADDR.INTEGRITY
   prim_secded_inv_39_32_dec u_loop_addrs_intg_dec (
     .data_i     (current_loop_addrs_padded_intg),
     .data_o     (),

--- a/hw/ip/otbn/rtl/otbn_mac_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_mac_bignum.sv
@@ -231,7 +231,7 @@ module otbn_mac_bignum
   assign expected_op_en     = mac_en_i;
   assign expected_acc_rd_en = ~operation_i.zero_acc & mac_en_i;
 
-  // SEC_CM: DATA_REG_SW.SCA
+  // SEC_CM: CTRL.REDUN
   assign predec_error_o = |{expected_op_en     != mac_predec_bignum_i.op_en,
                             expected_acc_rd_en != mac_predec_bignum_i.acc_rd_en};
 

--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -116,6 +116,7 @@ module otbn_rf_base
   // all other committed writes are passed straight through
   assign wr_en_masked = wr_en_i & wr_commit_i & ~push_stack;
 
+  // SEC_CM: CALL_STACK.ADDR.INTEGRITY
   // Ignore read data from the register file if reading from the stack register,
   // otherwise pass data through from register file.
   assign rd_data_a_intg_o = pop_stack_a ? stack_data_intg : rd_data_a_raw_intg;
@@ -130,6 +131,7 @@ module otbn_rf_base
   assign wr_data_intg_mux_out = wr_data_intg_sel_i ? wr_data_intg_i : wr_data_intg_calc;
 
   otbn_stack #(
+    // SEC_CM: CALL_STACK.ADDR.INTEGRITY
     .StackWidth(39),
     .StackDepth(CallStackDepth)
   ) u_call_stack (
@@ -197,6 +199,7 @@ module otbn_rf_base
     );
   end
 
+  // SEC_CM: RF_BASE.DATA_REG_SW.INTEGRITY
   // Integrity decoders used to detect errors only, corrections (`syndrome_o`/`d_o`) are ignored
   prim_secded_inv_39_32_dec u_rd_data_a_intg_dec (
     .data_i    (rd_data_a_intg_o),

--- a/hw/ip/otbn/rtl/otbn_rf_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum.sv
@@ -127,7 +127,7 @@ module otbn_rf_bignum
     .out_o (expected_wr_en_onehot)
   );
 
-  // SEC_CM: DATA_REG_SW.SCA
+  // SEC_CM: CTRL.REDUN
   assign rd_en_a_mismatch = expected_rd_en_a_onehot != rf_predec_bignum_i.rf_ren_a;
   assign rd_en_b_mismatch = expected_rd_en_b_onehot != rf_predec_bignum_i.rf_ren_b;
   assign wr_en_mismatch   = expected_wr_en_onehot   != rf_predec_bignum_i.rf_we;
@@ -137,6 +137,7 @@ module otbn_rf_bignum
   // New data can have its integrity from an external source or the integrity can be calculated here
   assign wr_data_intg_mux_out = wr_data_intg_sel_i ? wr_data_intg_i : wr_data_intg_calc;
 
+  // SEC_CM: RF_BIGNUM.DATA_REG_SW.INTEGRITY
   // Separate integrity encode and decode per 32-bit integrity granule
   for (genvar i = 0; i < BaseWordsPerWLEN; ++i) begin : g_rf_intg_calc
     prim_secded_inv_39_32_enc u_wr_data_intg_enc (

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -72,6 +72,7 @@ module otbn_start_stop_control
   // An escalation signal gets latched into should_lock. If we were running some instructions, we'll
   // go through the secure wipe process, but we'll see the should_lock_q signal when done and go
   // into the local locked state.
+  // SEC_CM: CONTROLLER.FSM.GLOBAL_ESC
   logic esc_request, should_lock_d, should_lock_q, stop;
   assign esc_request   = mubi4_test_true_loose(escalate_en_i);
   assign stop          = esc_request | start_secure_wipe_i;
@@ -179,6 +180,7 @@ module otbn_start_stop_control
         state_d = should_lock_d ? OtbnStartStopStateLocked : OtbnStartStopStateHalt;
       end
       OtbnStartStopStateLocked: begin
+        // SEC_CM: START_STOP_CTRL.FSM.GLOBAL_ESC
         // SEC_CM: START_STOP_CTRL.FSM.LOCAL_ESC
         //
         // Terminal state. This is either accessed by glitching state_q (and going through the


### PR DESCRIPTION
This adds SEC_CM labels but we may wish to add some more. We've got various security features that are part of the OTBN Architecture rather than just hardening features (e.g. the scratchpad memory where Ibex can only access a part of dmem is a security feature, but an architectural one, contrast with use of duplicated counters in the stacks to detect faults). Do these architectural features also need SEC_CM labels? If so there are more to add (@msfschaffner any thoughts?).