### PR TITLE
[pwrmgr] Fix escalate request CDC

### DIFF
--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_bind.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_bind.sv
@@ -17,7 +17,7 @@ module pwrmgr_rstmgr_bind;
     .reset_en(reg2hw.reset_en),
     .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(sw_rst_req_i)),
     .main_rst_req_i(!rst_main_ni),
-    .esc_rst_req_i(esc_rst_req),
+    .esc_rst_req_i(esc_rst_req_q),
     // The outputs from pwrmgr.
     .rst_lc_req(pwr_rst_o.rst_lc_req),
     .rst_sys_req(pwr_rst_o.rst_sys_req),

--- a/hw/top_earlgrey/dv/sva/top_earlgrey_bind.sv
+++ b/hw/top_earlgrey/dv/sva/top_earlgrey_bind.sv
@@ -16,7 +16,7 @@ module top_earlgrey_bind;
     .reset_en(u_pwrmgr_aon.reg2hw.reset_en),
     .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(u_pwrmgr_aon.sw_rst_req_i)),
     .main_rst_req_i(!u_pwrmgr_aon.rst_main_ni),
-    .esc_rst_req_i(u_pwrmgr_aon.esc_rst_req),
+    .esc_rst_req_i(u_pwrmgr_aon.esc_rst_req_q),
     // The outputs from pwrmgr.
     .rst_lc_req(u_pwrmgr_aon.pwr_rst_o.rst_lc_req),
     .rst_sys_req(u_pwrmgr_aon.pwr_rst_o.rst_sys_req),


### PR DESCRIPTION
- addresses #12981
- If the escalate request is not permanent, it is possible
  for the pwrmgr to miss this request since it goes through
  an always-on clock synchronization.
- capture and hold escalate request until the system resets.

Signed-off-by: Timothy Chen <timothytim@google.com>