### PR TITLE
[dv/chip] walkthrough test fixes

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -435,7 +435,7 @@
     {
       name: chip_sw_lc_walkthrough_dev
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStDev",
                  // The test takes long time because it will transit to RMA state
@@ -445,7 +445,7 @@
     {
       name: chip_sw_lc_walkthrough_prod
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProd",
                  // The test takes long time because it will transit to RMA state
@@ -455,14 +455,14 @@
     {
       name: chip_sw_lc_walkthrough_prodend
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProdEnd"]
     }
     {
       name: chip_sw_lc_walkthrough_rma
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStRma",
                  // The test takes long time because it will transit to RMA state

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
@@ -61,7 +61,7 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
     jtag_lc_state_transition(DecLcStRaw, DecLcStTestUnlocked0);
     apply_reset();
 
-    wait (cfg.sw_logger_vif.printed_log == "Waiting for LC transtition done and reboot.");
+    wait (cfg.sw_logger_vif.printed_log == "Waiting for LC transition done and reboot.");
     // Wait for a large number of cycles to transit to RMA state.
     wait_lc_status(LcTransitionSuccessful, 50_000);
     apply_reset();
@@ -70,7 +70,7 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
 
     // The following states will transfer twice to make sure LC_EXIT and RMA tokens are used.
     if (dest_dec_state inside {DecLcStProd, DecLcStDev}) begin
-      wait (cfg.sw_logger_vif.printed_log == "Waiting for LC RMA transtition done and reboot.");
+      wait (cfg.sw_logger_vif.printed_log == "Waiting for LC RMA transition done and reboot.");
       // Wait for a large number of cycles to transit to RMA state.
       wait_lc_status(LcTransitionSuccessful, 50_000);
       apply_reset();

--- a/sw/device/tests/sim_dv/lc_walkthrough_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_test.c
@@ -260,7 +260,7 @@ bool test_main(void) {
                      "LC transition configuration failed!");
         CHECK_DIF_OK(dif_lc_ctrl_transition(&lc), "LC transition failed!");
 
-        LOG_INFO("Waiting for LC RMA transtition done and reboot.");
+        LOG_INFO("Waiting for LC RMA transition done and reboot.");
         wait_for_interrupt();
 
         // Unreachable.


### PR DESCRIPTION
1). Fix typo in walkthrough test: transtition -> transition.
2). Fix bazel sw_image path, adding a `sim_dv` folder in the path.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>