### PR TITLE
[bazel] update closed source example repo with custom test

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -4,14 +4,14 @@
 
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load(
-    "//rules:cc_side_outputs.bzl",
+    "@//rules:cc_side_outputs.bzl",
     "rv_asm",
     "rv_llvm_ir",
     "rv_preprocess",
     "rv_relink_with_linkmap",
 )
 load(
-    "//rules:rv.bzl",
+    "@//rules:rv.bzl",
     "rv_rule",
     _OPENTITAN_CPU = "OPENTITAN_CPU",
     _OPENTITAN_PLATFORM = "OPENTITAN_PLATFORM",
@@ -35,10 +35,10 @@ _targets_compatible_with = {
 # simulation platforms (DV and Verilator), and two FPGA platforms (NexysVideo
 # and CW310).
 PER_DEVICE_DEPS = {
-    "sim_verilator": ["//sw/device/lib/arch:sim_verilator"],
-    "sim_dv": ["//sw/device/lib/arch:sim_dv"],
-    "fpga_nexysvideo": ["//sw/device/lib/arch:fpga_nexysvideo"],
-    "fpga_cw310": ["//sw/device/lib/arch:fpga_cw310"],
+    "sim_verilator": ["@//sw/device/lib/arch:sim_verilator"],
+    "sim_dv": ["@//sw/device/lib/arch:sim_dv"],
+    "fpga_nexysvideo": ["@//sw/device/lib/arch:fpga_nexysvideo"],
+    "fpga_cw310": ["@//sw/device/lib/arch:fpga_cw310"],
 }
 
 def _obj_transform_impl(ctx):
@@ -109,7 +109,7 @@ sign_bin = rv_rule(
         "bin": attr.label(allow_single_file = True),
         "elf": attr.label(allow_single_file = True),
         "key": attr.label(
-            default = "//sw/device/silicon_creator/mask_rom/keys:test_private_key_0",
+            default = "@//sw/device/silicon_creator/mask_rom/keys:test_private_key_0",
             allow_single_file = True,
         ),
         "key_name": attr.string(),
@@ -117,7 +117,7 @@ sign_bin = rv_rule(
         # need for this transition, in order to build the ROM_EXT signer tool.
         "platform": attr.string(default = "@local_config_platform//:host"),
         "_tool": attr.label(
-            default = "//sw/host/rom_ext_image_tools/signer:rom_ext_signer",
+            default = "@//sw/host/rom_ext_image_tools/signer:rom_ext_signer",
             allow_single_file = True,
         ),
     },
@@ -150,7 +150,7 @@ elf_to_disassembly = rv_rule(
         "platform": attr.string(default = OPENTITAN_PLATFORM),
         "_cleanup_script": attr.label(
             allow_single_file = True,
-            default = Label("//rules/scripts:expand_tabs.sh"),
+            default = Label("@//rules/scripts:expand_tabs.sh"),
         ),
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
@@ -194,12 +194,12 @@ elf_to_scrambled_rom_vmem = rv_rule(
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "_scramble_tool": attr.label(
-            default = "//hw/ip/rom_ctrl/util:scramble_image",
+            default = "@//hw/ip/rom_ctrl/util:scramble_image",
             executable = True,
             cfg = "exec",
         ),
         "_config": attr.label(
-            default = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
+            default = "@//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
             allow_single_file = True,
         ),
     },
@@ -291,7 +291,7 @@ scramble_flash_vmem = rv_rule(
     attrs = {
         "vmem": attr.label(allow_single_file = True),
         "_tool": attr.label(
-            default = "//util/design:gen-flash-img",
+            default = "@//util/design:gen-flash-img",
             executable = True,
             cfg = "exec",
         ),
@@ -341,7 +341,7 @@ gen_sim_dv_logs_db = rule(
         "srcs": attr.label_list(allow_files = True),
         "platform": attr.string(default = OPENTITAN_PLATFORM),
         "_tool": attr.label(
-            default = "//util/device_sw_utils:extract_sw_logs_db",
+            default = "@//util/device_sw_utils:extract_sw_logs_db",
             cfg = "exec",
             executable = True,
         ),
@@ -557,7 +557,7 @@ def opentitan_flash_binary(
         name,
         platform = OPENTITAN_PLATFORM,
         signing_keys = {
-            "test_key_0": "//sw/device/silicon_creator/mask_rom/keys:test_private_key_0",
+            "test_key_0": "@//sw/device/silicon_creator/mask_rom/keys:test_private_key_0",
         },
         per_device_deps = PER_DEVICE_DEPS,
         extract_sw_logs_db = True,

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "opentitan_flash_binary", "opentitan_rom_binary")
+load("@//rules:opentitan.bzl", "opentitan_flash_binary", "opentitan_rom_binary")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 _EXIT_SUCCESS = r"PASS.*\n"
@@ -12,10 +12,10 @@ _BASE_PARAMS = {
     "args": [],
     "data": [],
     "local": True,
-    "otp": "//hw/ip/otp_ctrl/data:img_rma",
-    "rom": "//sw/device/lib/testing/test_rom:test_rom_{}_scr_vmem",
+    "otp": "@//hw/ip/otp_ctrl/data:img_rma",
+    "rom": "@//sw/device/lib/testing/test_rom:test_rom_{}_scr_vmem",
     "tags": [],
-    "test_runner": "//util:opentitantool_test_runner.sh",
+    "test_runner": "@//util:opentitantool_test_runner.sh",
     "timeout": "moderate",  # 5 minutes
 }
 
@@ -30,10 +30,10 @@ def dv_params(
         rom = _BASE_PARAMS["rom"].format("sim_dv"),
         tags = _BASE_PARAMS["tags"],
         timeout = _BASE_PARAMS["timeout"],
-        test_runner = "//util:dvsim_test_runner.sh",
+        test_runner = "@//util:dvsim_test_runner.sh",
         # DV-specific Parameters
         bootstrap_sw = False,  # Default to backdoor loading.
-        dvsim_config = "//hw/top_earlgrey/dv:chip_sim_cfg.hjson",
+        dvsim_config = "@//hw/top_earlgrey/dv:chip_sim_cfg.hjson",
         **kwargs):
     """A macro to create DV sim parameters for OpenTitan functional tests.
 
@@ -58,8 +58,8 @@ def dv_params(
     ]
     required_data = [
         dvsim_config,
-        "//util/dvsim",
-        "//hw:all_files",
+        "@//util/dvsim",
+        "@//hw:all_files",
     ]
     required_tags = ["dv"]
     kwargs.update(
@@ -113,14 +113,14 @@ def verilator_params(
         "--logging=info",
         "--interface=verilator",
         "--conf=sw/host/opentitantool/config/opentitan_verilator.json",
-        "--verilator-bin=$(location //hw:verilator)/sim-verilator/Vchip_sim_tb",
+        "--verilator-bin=$(location @//hw:verilator)/sim-verilator/Vchip_sim_tb",
         "--verilator-rom=$(location {rom})",
         "--verilator-flash=$(location {flash})",
         "--verilator-otp=$(location {otp})",
     ]
     required_data = [
-        "//sw/host/opentitantool:test_resources",
-        "//hw:verilator",
+        "@//sw/host/opentitantool:test_resources",
+        "@//hw:verilator",
     ]
     required_tags = ["verilator"]
     kwargs.update(
@@ -153,7 +153,7 @@ def cw310_params(
         timeout = _BASE_PARAMS["timeout"],
         test_runner = _BASE_PARAMS["test_runner"],
         # CW310-specific Parameters
-        bitstream = "//hw/bitstream:test_rom",
+        bitstream = "@//hw/bitstream:test_rom",
         rom_kind = None,
         bootstrap_protocol = "primitive",
         # None
@@ -179,7 +179,7 @@ def cw310_params(
         "--conf=sw/host/opentitantool/config/opentitan_cw310.json",
     ]
     required_data = [
-        "//sw/host/opentitantool:test_resources",
+        "@//sw/host/opentitantool:test_resources",
     ]
     required_tags = [
         "cw310",
@@ -366,7 +366,7 @@ def opentitan_functest(
             # line so that they'll be parsed as global options rather than
             # command-specific options.
             concat_args = select({
-                "//ci:lowrisc_fpga_cw310": ["--cw310-uarts=/dev/ttyACM_CW310_1,/dev/ttyACM_CW310_0"],
+                "@//ci:lowrisc_fpga_cw310": ["--cw310-uarts=/dev/ttyACM_CW310_1,/dev/ttyACM_CW310_0"],
                 "//conditions:default": [],
             }) + concat_args
         concat_data = _format_list(

--- a/sw/device/tests/closed_source/BUILD.bazel
+++ b/sw/device/tests/closed_source/BUILD.bazel
@@ -1,6 +1,9 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+load("@lowrisc_opentitan//rules:opentitan_test.bzl", "opentitan_functest")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -28,4 +31,12 @@ cc_library(
     # We use alwayslink to force the symbols exported by this library to
     # override any weak symbols provided by targets in `@lowrisc_opentitan`.
     alwayslink = True,
+)
+
+opentitan_functest(
+    name = "example_test",
+    srcs = ["example_test.c"],
+    deps = [
+        "@lowrisc_opentitan//sw/device/lib/testing/test_framework:ottf_main",
+    ],
 )

--- a/sw/device/tests/closed_source/example_test.c
+++ b/sw/device/tests/closed_source/example_test.c
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+const test_config_t kTestConfig;
+
+bool test_main(void) { return true; }


### PR DESCRIPTION
In #12631 Bazel infrastructure was added to support closed-source
manufacture test hooks. This extends those capabilities by also enabling
manufacturers to develop entire tests that are also closed source,
inside the same external Bazel repository
(`@manufacturer_test_hooks//`).

Additionally, this commit adds an example closed source test. To build
this test within the default closed-source bazel repo use:
`bazel build @manufacturer_test_hooks//:example_test`

To build a test in a closed-source test hooks repo that is located
elsewhere on your machine, use:

`MANUFACTURER_HOOKS_DIR=/path/to/test_hooks_dir bazel build
@manufacturer_test_hooks//:example_test`

Signed-off-by: Timothy Trippel <ttrippel@google.com>