### PR TITLE
[top] cdc fix and cdc constraints

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -269,6 +269,21 @@ module rv_core_ibex
     .lc_en_o(pwrmgr_cpu_en)
   );
 
+  // TODO: This is a hoaky fix, we really should converge everthing
+  // through rv_plic.
+  // timer interrupts do not come from
+  // rv_plic and may not be synchronous to the ibex core
+  logic irq_timer_sync;
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_intr_timer_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(irq_timer_i),
+    .q_o(irq_timer_sync)
+  );
+
+
   logic irq_software;
   logic irq_timer;
   logic irq_external;
@@ -277,7 +292,7 @@ module rv_core_ibex
     .Width(3)
   ) u_prim_buf_irq (
     .in_i({irq_software_i,
-           irq_timer_i,
+           irq_timer_sync,
            irq_external_i}),
     .out_o({irq_software,
             irq_timer,


### PR DESCRIPTION
**[rv_core_ibex] synchronize timer interrupts**
- timer interrupts do not currently come from the main clock domain
- this PR is a quick fix that synchronizes the interrupts
- long term, we should forward everything through rv_plic only and
  give rv_plic the responsibility of synchronization like it does
  with external interrupts now.


**[top/cdc] Add a few cdc constraints to waive async fifo paths**
Specifically, two types of paths are waived

- fifo rdata outputs that are coupled into integrity errors,
  which then affect whether ibex should cancel or continue
  with the next data fetch

- fifo rdata outputs that are coupled into socket_m1's
  return path selection.  The source ID is used along side
  rvalid to pick a specific dvalid

This fix is hacky right now, as we need to enhance the flow
such that an additional CDC constraint file can be supplied.