### PR TITLE
[cdc] Waive IO input to internal logic

### DIFF
--- a/hw/top_earlgrey/cdc/cdc_waivers.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.tcl
@@ -45,6 +45,11 @@ set_rule_status -rule {W_CNTL} -status {Waived}                           \
   -expression {(Signal=~"IO*") && (ReceivingFlop=~"*u_i2c*.*.u_sync_1*")} \
   -comment {PAD driving to I2C. PADs are not clock bounded}
 
+set_rule_status -rule {W_GLITCH} -status {Waived}          \
+  -expression {(GlitchInput=~"IO*") &&                     \
+    (GlitchOutput=~"*u_sync_1*")} \
+  -comment {Waive PADs input goes into synchronizer}
+
 # PADs attribute to multiple IPs
 # Assume the attributes are not used when IPs are active
 set_rule_status -rule {W_FANOUT} -status {Waived}           \

--- a/hw/top_earlgrey/cdc/cdc_waivers.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.tcl
@@ -33,6 +33,18 @@ set_rule_status -rule {W_DATA W_MASYNC} -status {Waived} \
   -expression {(ReceivingFlop =~ "IO*")}                 \
   -comment {Direct output without flop}
 
+# Driving from PAD to gpio/ uart/ i2c
+set_rule_status -rule {W_MASYNC} -status {Waived}           \
+  -expression {(Driver=~"IO*") &&                           \
+    (ReceivingFlop=~"*u_gpio.gen_filter*prim_flop_2sync*")} \
+  -comment {Other than PADS, other signals are static}
+set_rule_status -rule {W_MASYNC} -status {Waived}                         \
+  -expression {(Driver=~"IO*") && (ReceivingFlop=~"*u_uart*.*u_sync_1*")} \
+  -comment {Other than PADS, other signals are static}
+set_rule_status -rule {W_CNTL} -status {Waived}                           \
+  -expression {(Signal=~"IO*") && (ReceivingFlop=~"*u_i2c*.*.u_sync_1*")} \
+  -comment {PAD driving to I2C. PADs are not clock bounded}
+
 # PADs attribute to multiple IPs
 # Assume the attributes are not used when IPs are active
 set_rule_status -rule {W_FANOUT} -status {Waived}           \


### PR DESCRIPTION
(cdc): Waive IO driving the uart/gpio
Waive W_MASYNC that IO* driving the uart/gpio synchronizer. Mainly due
to the pad attribute affects the IO driving signals

(cdc): Waive W_GLITCH for pads input to sync
This commit waives the W_GLITCH errors on the path from PADs input to
any 2FF sync cells.