### PR TITLE
[dv,chip_sw_pwrmgr] Fix all_reset_reqs test

### DIFF
--- a/sw/device/tests/pwrmgr_wdog_reset_reqs_test.c
+++ b/sw/device/tests/pwrmgr_wdog_reset_reqs_test.c
@@ -104,7 +104,8 @@ bool test_main(void) {
     wdog_bite_test(&aon_timer, &pwrmgr, /*bark_time_us=*/200);
   } else if (rst_info == kDifRstmgrResetInfoWatchdog) {
     LOG_INFO("Booting for the second time due to wdog bite reset");
+    return true;
   }
-
-  return true;
+  LOG_ERROR("Got unexpected reset info 0x%x", rst_info);
+  return false;
 }


### PR DESCRIPTION
The test must fail if reset_info is unexpected.

Signed-off-by: Guillermo Maturana <maturana@google.com>