### PR TITLE
[bazel] further enhance manufacturer test hooks repo setup

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -63,18 +63,14 @@ static void report_test_status(bool result) {
   test_status_set(result ? kTestStatusPassed : kTestStatusFailed);
 }
 
-OT_WEAK bool manufacturer_pre_test_hook(void) { return true; }
-
-OT_WEAK bool manufacturer_post_test_hook(void) { return true; }
-
 // A wrapper function is required to enable `test_main()` and test teardown
 // logic to be invoked as a FreeRTOS task. This wrapper can be used by tests
 // that are run on bare-metal.
 static void test_wrapper(void *task_parameters) {
-  // Invoke weak symbol that can be overriden in closed source code.
+  // Invoke test hooks that can be overridden by closed-source code.
   bool result = manufacturer_pre_test_hook();
-
-  result = result && test_main() && manufacturer_post_test_hook();
+  result = result && test_main();
+  result = result && manufacturer_post_test_hook();
   report_test_status(result);
 }
 

--- a/sw/device/lib/testing/test_framework/ottf_main.h
+++ b/sw/device/lib/testing/test_framework/ottf_main.h
@@ -77,4 +77,14 @@ extern const test_config_t kTestConfig;
  */
 extern bool test_main(void);
 
+/**
+ * TODO: add description
+ */
+extern bool manufacturer_pre_test_hook(void);
+
+/**
+ * TODO: add description
+ */
+extern bool manufacturer_post_test_hook(void);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_MAIN_H_

--- a/sw/device/tests/closed_source/BUILD.bazel
+++ b/sw/device/tests/closed_source/BUILD.bazel
@@ -2,41 +2,136 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@lowrisc_opentitan//rules:opentitan_test.bzl", "opentitan_functest")
+load("@//rules:opentitan_test.bzl", "opentitan_functest")
 
 package(default_visibility = ["//visibility:public"])
 
+# Note, this file contains step-by-step instructions on how to both:
+# 1. add custom test hook libraries (that override the default), labeled
+#    `TH-STEP *` for "Test Hook Step *", and,
+# 2. add custom closed-source tests, labeled `OTFT-STEP *` for "OpenTitan
+#    Functest Step *".
+# Read on to learn more about these features.
+
+################################################################################
+# Config Settings for each Test Hook Library.
+#
+# These allow you to select which set of test hooks Bazel should use via a
+# command line argument, e.g., `--define test_hooks=<config setting name>`
+#
+# Modify this as described below to add more test hooks libraries.
+################################################################################
+# Example running the open-source AES smoketest with default test hooks:
+#   bazel test //sw/device/tests:aes_smoketest --define test_hooks=default
+#        - or -
+#   bazel test //sw/device/tests:aes_smoketest
+config_setting(
+    name = "hooks_default",
+    define_values = {
+        "test_hooks": "default",
+    },
+)
+
+# Example running the open-source AES smoketest with non-default test hooks:
+#   bazel test //sw/device/tests:aes_smoketest --define test_hooks=hooks_1
+config_setting(
+    name = "hooks_1",
+    define_values = {
+        "test_hooks": "hooks_1",
+    },
+)
+
+# TH-Step 1: Copy/Uncomment below to add an additional set of test hooks.
+# config_setting(
+#     name = "hooks_2",
+#     define_values = {
+#         "test_hooks": "hooks_2",
+#     },
+# )
+
+# TH-Step 2: Copy/Uncomment the row below to add an additional set of test hooks.
+_TEST_HOOKS_DEPS = select({
+    "hooks_1": [":test_hooks_1"],
+    # "hooks_2": [":test_hooks_2"],
+    "hooks_default": [],
+    "//conditions:default": [],
+})
+
+################################################################################
+# Example Manufacturer Test Hook Library.
+#
+# Modify this section as described below to add more test hooks libraries.
+################################################################################
 cc_library(
-    # The name is the label that will be used to refer to this library.
-    # Tests will use the full label `@manufacturer_test_hooks//:test_hooks`.
-    name = "test_hooks",
-
-    # `srcs` is a list of source files and private header files.
-    srcs = [
-        "test_hooks.c",
-    ],
-
-    # `hdrs` is a list of public header files for this library.
-    hdrs = [],
-
-    # `deps` is a list of dependencies for this library.  You may use
-    # any library from the main opentitan repo; just prefix the label
-    # with `@lowrisc_opentitan`.
-    #
-    # Any dependencies local to this repo can simply start with `//`.
+    name = "test_hooks_1",
+    srcs = ["test_hooks_1.c"],
     deps = [
-        "@lowrisc_opentitan//sw/device/lib/runtime:log",
+        "@//sw/device/lib/runtime:log",
     ],
-
-    # We use alwayslink to force the symbols exported by this library to
-    # override any weak symbols provided by targets in `@lowrisc_opentitan`.
     alwayslink = True,
 )
 
+# TH-Step 3: Copy/Uncomment below to add an additional test hooks library that
+# may override the default test hooks.
+# cc_library(
+#    # The name is the label that will be used to refer to this library below,
+#    # in the single `test_hooks` library that is a dependency of the OTTF.
+#    name = "test_hooks_2",
+#
+#    # `srcs` is a list of source files and private header files.
+#    srcs = ["test_hooks_2.c"],
+#
+#    # `hdrs` is a list of public header files for the `test_hooks` library.
+#    hdrs = [],
+#
+#    # `deps` is a list of dependencies for this library.
+#    # Any dependencies local to this repo can start with `//`.
+#    # Any dependencies from the main opentitan repo must start with `@//`.
+#    deps = ["@//sw/device/lib/runtime:log"],
+#
+#    # We use alwayslink to force the symbols exported by this library to
+#    # override the default test hook weak symbols provided by the default
+#    # `test_hooks` library below.
+#    alwayslink = True,
+# )
+
+################################################################################
+# DO NOT MODIFY THIS SECTION
+#
+# The main `test_hooks` library that may be overridden by manufacturer test hook
+# libraries defined above.
+################################################################################
+cc_library(
+    name = "test_hooks",
+    srcs = ["test_hooks_default.c"],
+    deps = ["@//sw/device/lib/base:macros"] + _TEST_HOOKS_DEPS,
+)
+
+################################################################################
+# Manufacturer Tests
+#
+# These may make use of any manufacturer test hook libraries the same was as
+# open-source tests may, but it is probably uneccessary, since these are custom
+# manufacturer defined tests.
+#
+# Additional tests may be added below as `opentitan_functest` rules. Same as
+# above, any dependencies local to this repo can start with `//`. However, any
+# dependencies from the main opentitan repo must start with `@//`.
+#
+# To run the example test below using the default location:
+# `bazel test @manufacturer_test_hooks//:example_test`
+#
+# To run the example test below when the `@manufacturer_test_hooks` repo is in a
+# different location on the system, use:
+# `MANUFACTURER_HOOKS_DIR=/path/to/test_hooks
+#     bazel test @manufacturer_test_hooks//:example_test`
+################################################################################
+# OTFT-Step 1: Copy/paste the below `opentitan_functest` to add an additional
+# manufacturer-specific (closed-source) tests.
 opentitan_functest(
     name = "example_test",
     srcs = ["example_test.c"],
     deps = [
-        "@lowrisc_opentitan//sw/device/lib/testing/test_framework:ottf_main",
+        "@//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/closed_source/README.md
+++ b/sw/device/tests/closed_source/README.md
@@ -16,19 +16,37 @@ This feature is implemented with the help of some custom Bazel repository rules.
 Specifically, in `sw/device/test/closed_source` we define a secondary Bazel
 repository (`@manufacturer_test_hooks`) that is designed to be used in
 conjunction with the main OpenTitan Bazel repository. Within this repository, we
-define a `test_hooks` library that is linked with the OTTF. However, the
-`test_hooks` library provided in this repository is merely an example, as the
-test hook functions implemented do nothing, except `return true;`. Specifically,
-running `bazel test //sw/device/tests:<target>` will run the test with the
-default test hooks defined in `sw/device/tests/closed_source/test_hooks.c`.
+define a single `test_hooks` library that is linked with the OTTF. The
+`test_hooks` library itself just contains default weak symbols for each test
+hook function. However, the `test_hooks` library is linked with other libraries
+based on a Bazel `config_setting` that allows you to toggle which test hook
+library should be override the defaults. However, the Bazel `config_setting`s
+and example manufacturer test hooks library (`test_hooks_1`) provided in this
+repository are merely examples, as the test hook functions implemented do
+nothing, except print a message and `return true;`.
+
+To learn how to use the example default and non-default test hooks with existing
+(open-source) tests, see the `sw/default/tests/closed_source/BUILD.bazel` file.
 
 ## Implementing your own Test Hooks
 If you are a manufacturer, and would like to implement custom test hooks (that
 replace the defaults) you may do so by:
 
-1. copying the `sw/device/tests/closed_source/` directory to another location on your system,
-1. changing the implementation of the test hooks functions in `test_hooks.c`, and
-1. invoking bazel with the `MANUFACTURER_HOOKS_DIR` environment variable set, e.g.,
-   `MANUFACTURER_HOOKS_DIR=</path/to/test_hooks/> bazel test //sw/device/tests:<target>`
+1. copying the `sw/device/tests/closed_source/` directory to another location on
+   your system,
+1. follow the steps (labeled `TH-Step *`) in the
+   `sw/default/tests/closed_source/BUILD.bazel` file to add additional test
+   hook libraries / config settings,
+1. invoking bazel with the `MANUFACTURER_HOOKS_DIR` environment variable set,
+   and the proper `config_setting` , e.g.,
+   `MANUFACTURER_HOOKS_DIR=</path/to/test_hooks/> bazel test
+      //sw/device/tests:<target>
+      --define test_hooks=<test hooks setting>`
 
-Note, you may do the above for multiple sets of test hooks if you so desire.
+Note, with the above configuration you may place several test hook libraries in
+the same `MANUFACTURER_HOOKS_DIR`.
+
+## Implementing your own Tests
+If you are a manufacturer, and would like to implement custom (closed-source)
+tests, you may do so by following the single step (labeled `OTFT-Step 1`) in the
+`sw/default/tests/closed_source/BUILD.bazel` file.

--- a/sw/device/tests/closed_source/test_hooks_1.c
+++ b/sw/device/tests/closed_source/test_hooks_1.c
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
+#include <stdbool.h>
 
 #include "sw/device/lib/runtime/log.h"
 
 bool manufacturer_pre_test_hook(void) {
-  // LOG_INFO("open_source_pre_test_hook");
+  LOG_INFO("Manufacturer pre-test hook running ...");
 
   // Perform whatever pre-test setup needs to be done.
   // Return true if successful, false if unsuccessful.
@@ -15,7 +15,7 @@ bool manufacturer_pre_test_hook(void) {
 }
 
 bool manufacturer_post_test_hook(void) {
-  // LOG_INFO("open_source_post_test_hook");
+  LOG_INFO("Manufacturer post-test hook running ...");
 
   // Perform whatever post-test teardown needs to be done.
   // Return true if successful, false if unsuccessful.

--- a/sw/device/tests/closed_source/test_hooks_default.c
+++ b/sw/device/tests/closed_source/test_hooks_default.c
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/base/macros.h"
+
+// The default test hooks do nothing, but exist as the OTTF expects some hooks
+// to exist. Additionally, they are weak symbols so they may be overridden by
+// other custom test hooks.
+
+OT_WEAK
+bool manufacturer_pre_test_hook(void) { return true; }
+
+OT_WEAK
+bool manufacturer_post_test_hook(void) { return true; }


### PR DESCRIPTION
This further enhances the manufacturer test hooks bazel repository to:

1. support writing multiple sets of test hooks in the same MANUFACTURER_HOOKS_DIR,
2. support toggling between which test hooks are enabled via a bazel command line switch, e.g., `--define test_hooks=<hooks library>`,
3. support writing multiple closed source `opentitan_functest` tests in the same MANUFACTURER_HOOKS_DIR as the test hooks, and
4. updating the `README.md` and `BUILD.bazel` comments with detailed instructions on how extend these features.

Signed-off-by: Timothy Trippel <ttrippel@google.com>

**_Note: this depends on #13004._**