### PR TITLE
[bazel] clean up failing_verilator and cpu:4 tags

### DIFF
--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -13,7 +13,7 @@ xargs ci/bazelisk.sh test \
     --test_timeout=2400,2400,3600,-1 \
     --local_test_jobs=4 \
     --local_cpu_resources=4 \
-    --test_tag_filters=verilator,-failing_verilator,-broken \
+    --test_tag_filters=verilator,-broken \
     --test_output=errors \
     --//hw:verilator_options=--threads,1 \
     //sw/device/tests:crt_test_sim_verilator \

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -149,7 +149,7 @@ def cw310_params(
         local = _BASE_PARAMS["local"],
         otp = _BASE_PARAMS["otp"],
         rom = _BASE_PARAMS["rom"].format("fpga_cw310"),
-        tags = _BASE_PARAMS["tags"] + ["cpu:4"],
+        tags = _BASE_PARAMS["tags"],
         timeout = _BASE_PARAMS["timeout"],
         test_runner = _BASE_PARAMS["test_runner"],
         # CW310-specific Parameters

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -64,7 +64,6 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "long",
         tags = [
-            "cpu:4",
             "manual",
         ],
     ),
@@ -118,7 +117,6 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "long",
         tags = [
-            "cpu:4",
             "manual",
         ],
     ),
@@ -191,7 +189,6 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "long",
         tags = [
-            "cpu:4",
             "manual",
         ],
     ),
@@ -209,7 +206,6 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "long",
         tags = [
-            "cpu:4",
             "manual",
         ],
     ),

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -318,7 +318,6 @@ opentitan_functest(
         rom = ":mask_rom_sim_verilator_scr_vmem",
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -15,7 +15,6 @@ opentitan_functest(
     verilator = verilator_params(
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -40,7 +39,6 @@ opentitan_functest(
     verilator = verilator_params(
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -151,7 +149,6 @@ opentitan_functest(
     verilator = verilator_params(
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -173,8 +170,7 @@ opentitan_functest(
     srcs = ["pwrmgr_wdog_reset_reqs_test.c"],
     verilator = verilator_params(
         tags = [
-            "cpu:4",
-            "failing_verilator",
+            "broken",
         ],
     ),
     deps = [
@@ -245,7 +241,6 @@ opentitan_functest(
     verilator = verilator_params(
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -264,7 +259,6 @@ opentitan_functest(
     verilator = verilator_params(
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -403,7 +397,6 @@ opentitan_functest(
     verilator = verilator_params(
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -425,7 +418,6 @@ opentitan_functest(
     verilator = verilator_params(
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -448,7 +440,7 @@ opentitan_functest(
     ),
     verilator = verilator_params(
         timeout = "long",
-        tags = ["failing_verilator"],
+        tags = ["broken"],
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -480,7 +472,7 @@ opentitan_functest(
     # Verilator or CW310 params).
     test_in_rom = True,
     verilator = verilator_params(
-        tags = ["failing_verilator"],
+        tags = ["broken"],
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -508,7 +500,6 @@ opentitan_functest(
     verilator = verilator_params(
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -609,7 +600,6 @@ opentitan_functest(
     verilator = verilator_params(
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -891,7 +881,6 @@ opentitan_functest(
         # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -915,7 +904,6 @@ opentitan_functest(
         # FIXME #12486 [bazel] pmp_smoketest_tor failing on cw310 and verilator when built by bazel
         tags = [
             "broken",
-            "cpu:4",
         ],
     ),
     deps = [
@@ -1259,7 +1247,7 @@ opentitan_functest(
     ),
     verilator = verilator_params(
         timeout = "long",
-        tags = ["failing_verilator"],
+        tags = ["broken"],
     ),
     deps = [
         "//hw/top_earlgrey:alert_handler_regs",

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -58,7 +58,7 @@ opentitan_functest(
     test_in_rom = True,
     # This test currently fails in Verilator when run by Bazel (#12486)
     verilator = verilator_params(
-        tags = ["failing_verilator"],
+        tags = ["broken"],
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",


### PR DESCRIPTION
The "failing_verilator" tag was doing the same thing as the "broken" tag and
required bazel users to remember to filter for both, so all instances of
"failing_verilator" are replaced by broken.

"cpu:4" is applied to all verilator tests by rules/opentitan_test.bzl so
other applications are removed and it's removed from the cw310 tests
which are exclusive and aren't affected by it.

Signed-off-by: Drew Macrae <drewmacrae@google.com>