### PR TITLE
[flash_ctrl/data] Fix flash_ctrl.hjson inconsistency

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -376,9 +376,9 @@
     },
 
     { name: "RegBusPgmResBytes",
-      desc: "Number of pages per bank",
+      desc: "Program resolution window in bytes",
       type: "int",
-      default: "512",
+      default: "64",
       local: "true"
     },
 

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -387,7 +387,7 @@
     },
 
     { name: "RegBusPgmResBytes",
-      desc: "Number of pages per bank",
+      desc: "Program resolution window in bytes",
       type: "int",
       default: "${cfg.pgm_resolution_bytes}",
       local: "true"

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -9,7 +9,7 @@ package flash_ctrl_reg_pkg;
   // Param list
   parameter int RegNumBanks = 2;
   parameter int RegPagesPerBank = 256;
-  parameter int RegBusPgmResBytes = 512;
+  parameter int RegBusPgmResBytes = 64;
   parameter int RegPageWidth = 8;
   parameter int RegBankWidth = 1;
   parameter int NumRegions = 8;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4392,7 +4392,8 @@
           {
             banks: 2
             pages_per_bank: 256
-            program_resolution: 64
+            program_resolution: 8
+            pgm_resolution_bytes: 64
             bytes_per_page: 2048
             bytes_per_bank: 524288
             size: 0x100000

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -382,7 +382,7 @@
     },
 
     { name: "RegBusPgmResBytes",
-      desc: "Number of pages per bank",
+      desc: "Program resolution window in bytes",
       type: "int",
       default: "64",
       local: "true"

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -324,7 +324,8 @@ class Flash:
         return {
             'banks': self.banks,
             'pages_per_bank': self.pages_per_bank,
-            'program_resolution': self.pgm_resolution_bytes,
+            'program_resolution': self.program_resolution,
+            'pgm_resolution_bytes': self.pgm_resolution_bytes,
             'bytes_per_page': self.bytes_per_page,
             'bytes_per_bank': self.bytes_per_bank,
             'size': self.size


### PR DESCRIPTION
@alphan pointed out that flash_ctrl.hjson under top_earlgrey and
hw/ip were inconsistent and leading to issues depending on which
hjson the software happened to use.

This is a long-standing confusion stemming from template files
that should one day be resolved by moving flash_ctrl to ip_autogen.

Signed-off-by: Timothy Chen <timothytim@google.com>