### PR TITLE
[flash/tlul] Enhance tlul_lc_gate to handle outstanding

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -114,6 +114,7 @@ module flash_ctrl
   logic update_err;
   logic intg_err;
   logic eflash_cmd_intg_err;
+  logic tl_gate_intg_err;
 
   // SEC_CM: REG.BUS.INTEGRITY
   // SEC_CM: CTRL.CONFIG.REGWEN
@@ -1057,7 +1058,8 @@ module flash_ctrl
   assign hw2reg.std_fault_status.phy_fsm_err.d     = 1'b1;
   assign hw2reg.std_fault_status.ctrl_cnt_err.d    = 1'b1;
   assign hw2reg.std_fault_status.fifo_err.d        = 1'b1;
-  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err;
+  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err |
+                                                     tl_gate_intg_err;
   assign hw2reg.std_fault_status.prog_intg_err.de  = flash_phy_rsp.prog_intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de      = lcmgr_err;
   assign hw2reg.std_fault_status.lcmgr_intg_err.de = lcmgr_intg_err;
@@ -1260,7 +1262,8 @@ module flash_ctrl
     .tl_d2h_o(mem_tl_o),
     .tl_h2d_o(gate_tl_h2d),
     .tl_d2h_i(gate_tl_d2h),
-    .lc_en_i(host_enable)
+    .lc_en_i(host_enable),
+    .err_o(tl_gate_intg_err)
   );
 
   // SEC_CM: HOST.BUS.INTEGRITY
@@ -1380,6 +1383,8 @@ module flash_ctrl
     u_flash_hw_if.u_rma_state_regs, alert_tx_o[1])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(ArbFsmCheck_A,
     u_ctrl_arb.u_state_regs, alert_tx_o[1])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(TlLcGateFsm_A,
+    u_tl_gate.u_state_regs, alert_tx_o[1])
 
    for (genvar i=0; i<NumBanks; i++) begin : gen_phy_assertions
      `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyFsmCheck_A,

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -114,6 +114,7 @@ module flash_ctrl
   logic update_err;
   logic intg_err;
   logic eflash_cmd_intg_err;
+  logic tl_gate_intg_err;
 
   // SEC_CM: REG.BUS.INTEGRITY
   // SEC_CM: CTRL.CONFIG.REGWEN
@@ -1058,7 +1059,8 @@ module flash_ctrl
   assign hw2reg.std_fault_status.phy_fsm_err.d     = 1'b1;
   assign hw2reg.std_fault_status.ctrl_cnt_err.d    = 1'b1;
   assign hw2reg.std_fault_status.fifo_err.d        = 1'b1;
-  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err;
+  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err |
+                                                     tl_gate_intg_err;
   assign hw2reg.std_fault_status.prog_intg_err.de  = flash_phy_rsp.prog_intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de      = lcmgr_err;
   assign hw2reg.std_fault_status.lcmgr_intg_err.de = lcmgr_intg_err;
@@ -1261,7 +1263,8 @@ module flash_ctrl
     .tl_d2h_o(mem_tl_o),
     .tl_h2d_o(gate_tl_h2d),
     .tl_d2h_i(gate_tl_d2h),
-    .lc_en_i(host_enable)
+    .lc_en_i(host_enable),
+    .err_o(tl_gate_intg_err)
   );
 
   // SEC_CM: HOST.BUS.INTEGRITY
@@ -1381,6 +1384,8 @@ module flash_ctrl
     u_flash_hw_if.u_rma_state_regs, alert_tx_o[1])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(ArbFsmCheck_A,
     u_ctrl_arb.u_state_regs, alert_tx_o[1])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(TlLcGateFsm_A,
+    u_tl_gate.u_state_regs, alert_tx_o[1])
 
    for (genvar i=0; i<NumBanks; i++) begin : gen_phy_assertions
      `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyFsmCheck_A,

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -224,9 +224,9 @@ module tb;
     $assertoff(0, tb.dut.u_prim_lc_sync_dft_en.PrimLcSyncCheckTransients_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_dft_en.PrimLcSyncCheckTransients0_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_dft_en.PrimLcSyncCheckTransients1_A);
-    $assertoff(0, tb.dut.u_tlul_lc_gate.u_prim_lc_sync.PrimLcSyncCheckTransients_A);
-    $assertoff(0, tb.dut.u_tlul_lc_gate.u_prim_lc_sync.PrimLcSyncCheckTransients0_A);
-    $assertoff(0, tb.dut.u_tlul_lc_gate.u_prim_lc_sync.PrimLcSyncCheckTransients1_A);
+    $assertoff(0, tb.dut.u_tlul_lc_gate.u_err_en_sync.PrimLcSyncCheckTransients_A);
+    $assertoff(0, tb.dut.u_tlul_lc_gate.u_err_en_sync.PrimLcSyncCheckTransients0_A);
+    $assertoff(0, tb.dut.u_tlul_lc_gate.u_err_en_sync.PrimLcSyncCheckTransients1_A);
 
     // These SVA checks the lc_sync_creator_seed_sw_rw_en is either Off or On, we will use more
     // than these 2 values.

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -113,8 +113,8 @@ module otp_ctrl
   // Regfile //
   /////////////
 
-  // We have one CSR node and one functional TL-UL window.
-  logic [1:0] intg_error;
+  // We have one CSR node, one functional TL-UL window and a gate module for that window
+  logic [2:0] intg_error;
 
   tlul_pkg::tl_h2d_t tl_win_h2d;
   tlul_pkg::tl_d2h_t tl_win_d2h;
@@ -735,7 +735,8 @@ module otp_ctrl
     .tl_d2h_o(prim_tl_o),
     .tl_h2d_o(prim_tl_h2d_gated),
     .tl_d2h_i(prim_tl_d2h_gated),
-    .lc_en_i (lc_dft_en[0])
+    .lc_en_i (lc_dft_en[0]),
+    .err_o   (intg_error[2])
   );
 
   // Test-related GPIOs.
@@ -1440,6 +1441,8 @@ module otp_ctrl
       u_otp_ctrl_lci.u_prim_count, alert_tx_o[1])
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntScrmblCheck_A,
       u_otp_ctrl_scrmbl.u_prim_count, alert_tx_o[1])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(TlLcGateFsm_A,
+      u_tlul_lc_gate.u_state_regs, alert_tx_o[1])
 
   // Alert assertions for double LFSR.
   `ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ALERT(DoubleLfsrCheck_A,

--- a/hw/ip/tlul/tlul_lc_gate.core
+++ b/hw/ip/tlul/tlul_lc_gate.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:tlul:common
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:prim:blanker
+      - lowrisc:prim:sparse_fsm
     files:
       - rtl/tlul_lc_gate.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -120,6 +120,7 @@ module flash_ctrl
   logic update_err;
   logic intg_err;
   logic eflash_cmd_intg_err;
+  logic tl_gate_intg_err;
 
   // SEC_CM: REG.BUS.INTEGRITY
   // SEC_CM: CTRL.CONFIG.REGWEN
@@ -1064,7 +1065,8 @@ module flash_ctrl
   assign hw2reg.std_fault_status.phy_fsm_err.d     = 1'b1;
   assign hw2reg.std_fault_status.ctrl_cnt_err.d    = 1'b1;
   assign hw2reg.std_fault_status.fifo_err.d        = 1'b1;
-  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err;
+  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err |
+                                                     tl_gate_intg_err;
   assign hw2reg.std_fault_status.prog_intg_err.de  = flash_phy_rsp.prog_intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de      = lcmgr_err;
   assign hw2reg.std_fault_status.lcmgr_intg_err.de = lcmgr_intg_err;
@@ -1267,7 +1269,8 @@ module flash_ctrl
     .tl_d2h_o(mem_tl_o),
     .tl_h2d_o(gate_tl_h2d),
     .tl_d2h_i(gate_tl_d2h),
-    .lc_en_i(host_enable)
+    .lc_en_i(host_enable),
+    .err_o(tl_gate_intg_err)
   );
 
   // SEC_CM: HOST.BUS.INTEGRITY
@@ -1387,6 +1390,8 @@ module flash_ctrl
     u_flash_hw_if.u_rma_state_regs, alert_tx_o[1])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(ArbFsmCheck_A,
     u_ctrl_arb.u_state_regs, alert_tx_o[1])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(TlLcGateFsm_A,
+    u_tl_gate.u_state_regs, alert_tx_o[1])
 
    for (genvar i=0; i<NumBanks; i++) begin : gen_phy_assertions
      `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyFsmCheck_A,


### PR DESCRIPTION
- enhance tlul_lc_gate to better handle outstanding transactions
- when lc_en drops when there are outstanding trasnactions, any
  further commands are blocked but existing trasnactions are allowed
  to complete. Then the tlul_lc_gate transitions to an error state
  where all future commands are directly err'd.

- Also adjust existing instantiations in otp_ctrl and rv_dm

Needed to address #11863