### PR TITLE
[dv] fix keymgr functest dvsim target

### DIFF
--- a/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
@@ -20,7 +20,7 @@
     {
       name: mask_rom_keymgr_functest
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/silicon_creator/testing/sw_silicon_creator_lib_driver_keymgr_functest:1"]
+      sw_images: ["sw/device/silicon_creator/lib/drivers/keymgr_functest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=5000000"]
     }


### PR DESCRIPTION
Since dvsim.py now uses Bazel instead of meson to build SW images, the
build target must be updated.

Signed-off-by: Timothy Trippel <ttrippel@google.com>