### PR TITLE
[kemgyr] Fix input checks when kmac masking is disabled

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -1707,6 +1707,21 @@
         ]
       },
 
+      { name: "DEBUG_STATE",
+        desc: "Current flash fsm state",
+        swaccess: "ro",
+        hwaccess: "hwo",
+        hwext: "true"
+        fields: [
+          { bits: "10:0",
+            name: "lcmgr_state",
+            desc: "Current lcmgr interface staet ",
+            tags: [ // Bit changes immediately after start from reset value to 1b1 due to initialization
+            "excl:CsrAllTests:CsrExclAll"]
+          }
+        ]
+      },
+
       { name: "ERR_CODE",
         desc: '''
           Flash error code register.

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -1182,6 +1182,21 @@
         ]
       },
 
+      { name: "DEBUG_STATE",
+        desc: "Current flash fsm state",
+        swaccess: "ro",
+        hwaccess: "hwo",
+        hwext: "true"
+        fields: [
+          { bits: "10:0",
+            name: "lcmgr_state",
+            desc: "Current lcmgr interface staet ",
+            tags: [ // Bit changes immediately after start from reset value to 1b1 due to initialization
+            "excl:CsrAllTests:CsrExclAll"]
+          }
+        ]
+      },
+
       { name: "ERR_CODE",
         desc: '''
           Flash error code register.

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -489,7 +489,9 @@ module flash_ctrl
     .dis_access_o(dis_access),
 
     // init ongoing
-    .init_busy_o(ctrl_init_busy)
+    .init_busy_o(ctrl_init_busy),
+
+    .debug_state_o(hw2reg.debug_state.d)
   );
 
   // Program FIFO

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -490,7 +490,9 @@ module flash_ctrl
     .dis_access_o(dis_access),
 
     // init ongoing
-    .init_busy_o(ctrl_init_busy)
+    .init_busy_o(ctrl_init_busy),
+
+    .debug_state_o(hw2reg.debug_state.d)
   );
 
   // Program FIFO

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -85,7 +85,10 @@ module flash_ctrl_lcmgr
   output lc_tx_t dis_access_o,
 
   // init ongoing
-  output logic init_busy_o
+  output logic init_busy_o,
+
+  // debug state output
+  output logic [10:0] debug_state_o
 );
 
   import lc_ctrl_pkg::lc_tx_test_true_strict;
@@ -140,6 +143,8 @@ module flash_ctrl_lcmgr
 
   lcmgr_state_e state_q, state_d;
   logic state_err;
+
+  assign debug_state_o = state_q;
 
   //SEC_CM: CTRL.FSM.SPARSE
   `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, lcmgr_state_e, StIdle)

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -554,6 +554,10 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
+    logic [10:0] d;
+  } flash_ctrl_hw2reg_debug_state_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
@@ -755,12 +759,13 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [187:176]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [175:175]
-    flash_ctrl_hw2reg_control_reg_t control; // [174:173]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [172:171]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [170:167]
-    flash_ctrl_hw2reg_status_reg_t status; // [166:157]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [198:187]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [186:186]
+    flash_ctrl_hw2reg_control_reg_t control; // [185:184]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [183:182]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [181:178]
+    flash_ctrl_hw2reg_status_reg_t status; // [177:168]
+    flash_ctrl_hw2reg_debug_state_reg_t debug_state; // [167:157]
     flash_ctrl_hw2reg_err_code_reg_t err_code; // [156:141]
     flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [140:123]
     flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [122:97]
@@ -865,19 +870,20 @@ package flash_ctrl_reg_pkg;
   parameter logic [CoreAw-1:0] FLASH_CTRL_MP_BANK_CFG_SHADOWED_OFFSET = 9'h 168;
   parameter logic [CoreAw-1:0] FLASH_CTRL_OP_STATUS_OFFSET = 9'h 16c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_STATUS_OFFSET = 9'h 170;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_ERR_CODE_OFFSET = 9'h 174;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_STD_FAULT_STATUS_OFFSET = 9'h 178;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_FAULT_STATUS_OFFSET = 9'h 17c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_ERR_ADDR_OFFSET = 9'h 180;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_CNT_OFFSET = 9'h 184;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_0_OFFSET = 9'h 188;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_1_OFFSET = 9'h 18c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_PHY_ALERT_CFG_OFFSET = 9'h 190;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_PHY_STATUS_OFFSET = 9'h 194;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_SCRATCH_OFFSET = 9'h 198;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_FIFO_LVL_OFFSET = 9'h 19c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_FIFO_RST_OFFSET = 9'h 1a0;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_CURR_FIFO_LVL_OFFSET = 9'h 1a4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_DEBUG_STATE_OFFSET = 9'h 174;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_ERR_CODE_OFFSET = 9'h 178;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_STD_FAULT_STATUS_OFFSET = 9'h 17c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_FAULT_STATUS_OFFSET = 9'h 180;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_ERR_ADDR_OFFSET = 9'h 184;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_CNT_OFFSET = 9'h 188;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_0_OFFSET = 9'h 18c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_1_OFFSET = 9'h 190;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_PHY_ALERT_CFG_OFFSET = 9'h 194;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_PHY_STATUS_OFFSET = 9'h 198;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_SCRATCH_OFFSET = 9'h 19c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_FIFO_LVL_OFFSET = 9'h 1a0;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_FIFO_RST_OFFSET = 9'h 1a4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_CURR_FIFO_LVL_OFFSET = 9'h 1a8;
 
   // Reset values for hwext registers and their fields for core interface
   parameter logic [5:0] FLASH_CTRL_INTR_TEST_RESVAL = 6'h 0;
@@ -893,14 +899,15 @@ package flash_ctrl_reg_pkg;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_FATAL_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_CTRL_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] FLASH_CTRL_CTRL_REGWEN_EN_RESVAL = 1'h 1;
+  parameter logic [10:0] FLASH_CTRL_DEBUG_STATE_RESVAL = 11'h 0;
   parameter logic [12:0] FLASH_CTRL_CURR_FIFO_LVL_RESVAL = 13'h 0;
   parameter logic [4:0] FLASH_CTRL_CURR_FIFO_LVL_PROG_RESVAL = 5'h 0;
   parameter logic [4:0] FLASH_CTRL_CURR_FIFO_LVL_RD_RESVAL = 5'h 0;
 
   // Window parameters for core interface
-  parameter logic [CoreAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 1a8;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 1ac;
   parameter int unsigned       FLASH_CTRL_PROG_FIFO_SIZE   = 'h 4;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_RD_FIFO_OFFSET = 9'h 1ac;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_RD_FIFO_OFFSET = 9'h 1b0;
   parameter int unsigned       FLASH_CTRL_RD_FIFO_SIZE   = 'h 4;
 
   // Register index for core interface
@@ -998,6 +1005,7 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_MP_BANK_CFG_SHADOWED,
     FLASH_CTRL_OP_STATUS,
     FLASH_CTRL_STATUS,
+    FLASH_CTRL_DEBUG_STATE,
     FLASH_CTRL_ERR_CODE,
     FLASH_CTRL_STD_FAULT_STATUS,
     FLASH_CTRL_FAULT_STATUS,
@@ -1014,7 +1022,7 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_core_id_e;
 
   // Register width information to check illegal writes for core interface
-  parameter logic [3:0] FLASH_CTRL_CORE_PERMIT [106] = '{
+  parameter logic [3:0] FLASH_CTRL_CORE_PERMIT [107] = '{
     4'b 0001, // index[  0] FLASH_CTRL_INTR_STATE
     4'b 0001, // index[  1] FLASH_CTRL_INTR_ENABLE
     4'b 0001, // index[  2] FLASH_CTRL_INTR_TEST
@@ -1108,19 +1116,20 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[ 90] FLASH_CTRL_MP_BANK_CFG_SHADOWED
     4'b 0001, // index[ 91] FLASH_CTRL_OP_STATUS
     4'b 0001, // index[ 92] FLASH_CTRL_STATUS
-    4'b 0001, // index[ 93] FLASH_CTRL_ERR_CODE
-    4'b 0011, // index[ 94] FLASH_CTRL_STD_FAULT_STATUS
-    4'b 0011, // index[ 95] FLASH_CTRL_FAULT_STATUS
-    4'b 0111, // index[ 96] FLASH_CTRL_ERR_ADDR
-    4'b 0011, // index[ 97] FLASH_CTRL_ECC_SINGLE_ERR_CNT
-    4'b 0111, // index[ 98] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_0
-    4'b 0111, // index[ 99] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_1
-    4'b 0001, // index[100] FLASH_CTRL_PHY_ALERT_CFG
-    4'b 0001, // index[101] FLASH_CTRL_PHY_STATUS
-    4'b 1111, // index[102] FLASH_CTRL_SCRATCH
-    4'b 0011, // index[103] FLASH_CTRL_FIFO_LVL
-    4'b 0001, // index[104] FLASH_CTRL_FIFO_RST
-    4'b 0011  // index[105] FLASH_CTRL_CURR_FIFO_LVL
+    4'b 0011, // index[ 93] FLASH_CTRL_DEBUG_STATE
+    4'b 0001, // index[ 94] FLASH_CTRL_ERR_CODE
+    4'b 0011, // index[ 95] FLASH_CTRL_STD_FAULT_STATUS
+    4'b 0011, // index[ 96] FLASH_CTRL_FAULT_STATUS
+    4'b 0111, // index[ 97] FLASH_CTRL_ERR_ADDR
+    4'b 0011, // index[ 98] FLASH_CTRL_ECC_SINGLE_ERR_CNT
+    4'b 0111, // index[ 99] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_0
+    4'b 0111, // index[100] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_1
+    4'b 0001, // index[101] FLASH_CTRL_PHY_ALERT_CFG
+    4'b 0001, // index[102] FLASH_CTRL_PHY_STATUS
+    4'b 1111, // index[103] FLASH_CTRL_SCRATCH
+    4'b 0011, // index[104] FLASH_CTRL_FIFO_LVL
+    4'b 0001, // index[105] FLASH_CTRL_FIFO_RST
+    4'b 0011  // index[106] FLASH_CTRL_CURR_FIFO_LVL
   };
 
 endpackage

--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -1122,6 +1122,52 @@
       ]
     },
 
+    { name: "DEBUG",
+      desc: '''
+        The register holds some debug information that may be convenient if keymgr
+        misbehaves.
+      ''',
+      swaccess: "rw0c",
+      hwaccess: "hwo",
+      fields: [
+        { bits: "0",
+          name: "INVALID_CREATOR_SEED",
+          resval: "0x0"
+          desc: "Creator seed failed input checks during operation",
+        },
+        { bits: "1",
+          name: "INVALID_OWNER_SEED",
+          resval: "0x0"
+          desc: "Owner seed failed input checks during operation",
+        },
+        { bits: "2",
+          name: "INVALID_DEV_ID",
+          resval: "0x0"
+          desc: "Device ID failed input checks during operation",
+        },
+        { bits: "3",
+          name: "INVALID_HEALTH_STATE",
+          resval: "0x0"
+          desc: "Health state failed input checks during operation",
+        },
+        { bits: "4",
+          name: "INVALID_KEY_VERSION",
+          resval: "0x0"
+          desc: "Key version failed input checks during operation",
+        },
+        { bits: "5",
+          name: "INVALID_KEY",
+          resval: "0x0"
+          desc: "Key fed to kmac failed input checks during operation",
+        },
+        { bits: "6",
+          name: "INVALID_DIGEST",
+          resval: "0x0"
+          desc: "ROM digest failed input checks during operation",
+        },
+
+      ]
+    },
 
   ],
 }

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -465,7 +465,9 @@ module keymgr
   logic key_vld;
   // SEC_CM: CONSTANTS.CONSISTENCY
   // SEC_CM: INTERSIG.CONSISTENCY
-  keymgr_input_checks u_checks (
+  keymgr_input_checks #(
+    .KmacEnMasking(KmacEnMasking)
+  ) u_checks (
     .rom_digest_i,
     .max_key_versions_i(max_key_versions),
     .stage_sel_i(stage_sel),

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -258,6 +258,37 @@ package keymgr_reg_pkg;
     } key_ecc;
   } keymgr_hw2reg_fault_status_reg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_creator_seed;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_owner_seed;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_dev_id;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_health_state;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_key_version;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_key;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_digest;
+  } keymgr_hw2reg_debug_reg_t;
+
   // Register -> HW type
   typedef struct packed {
     keymgr_reg2hw_intr_state_reg_t intr_state; // [945:945]
@@ -281,16 +312,17 @@ package keymgr_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    keymgr_hw2reg_intr_state_reg_t intr_state; // [574:573]
-    keymgr_hw2reg_cfg_regwen_reg_t cfg_regwen; // [572:572]
-    keymgr_hw2reg_start_reg_t start; // [571:570]
-    keymgr_hw2reg_sw_binding_regwen_reg_t sw_binding_regwen; // [569:569]
-    keymgr_hw2reg_sw_share0_output_mreg_t [7:0] sw_share0_output; // [568:305]
-    keymgr_hw2reg_sw_share1_output_mreg_t [7:0] sw_share1_output; // [304:41]
-    keymgr_hw2reg_working_state_reg_t working_state; // [40:37]
-    keymgr_hw2reg_op_status_reg_t op_status; // [36:34]
-    keymgr_hw2reg_err_code_reg_t err_code; // [33:28]
-    keymgr_hw2reg_fault_status_reg_t fault_status; // [27:0]
+    keymgr_hw2reg_intr_state_reg_t intr_state; // [588:587]
+    keymgr_hw2reg_cfg_regwen_reg_t cfg_regwen; // [586:586]
+    keymgr_hw2reg_start_reg_t start; // [585:584]
+    keymgr_hw2reg_sw_binding_regwen_reg_t sw_binding_regwen; // [583:583]
+    keymgr_hw2reg_sw_share0_output_mreg_t [7:0] sw_share0_output; // [582:319]
+    keymgr_hw2reg_sw_share1_output_mreg_t [7:0] sw_share1_output; // [318:55]
+    keymgr_hw2reg_working_state_reg_t working_state; // [54:51]
+    keymgr_hw2reg_op_status_reg_t op_status; // [50:48]
+    keymgr_hw2reg_err_code_reg_t err_code; // [47:42]
+    keymgr_hw2reg_fault_status_reg_t fault_status; // [41:14]
+    keymgr_hw2reg_debug_reg_t debug; // [13:0]
   } keymgr_hw2reg_t;
 
   // Register offsets
@@ -356,6 +388,7 @@ package keymgr_reg_pkg;
   parameter logic [BlockAw-1:0] KEYMGR_OP_STATUS_OFFSET = 8'h ec;
   parameter logic [BlockAw-1:0] KEYMGR_ERR_CODE_OFFSET = 8'h f0;
   parameter logic [BlockAw-1:0] KEYMGR_FAULT_STATUS_OFFSET = 8'h f4;
+  parameter logic [BlockAw-1:0] KEYMGR_DEBUG_OFFSET = 8'h f8;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] KEYMGR_INTR_TEST_RESVAL = 1'h 0;
@@ -431,11 +464,12 @@ package keymgr_reg_pkg;
     KEYMGR_WORKING_STATE,
     KEYMGR_OP_STATUS,
     KEYMGR_ERR_CODE,
-    KEYMGR_FAULT_STATUS
+    KEYMGR_FAULT_STATUS,
+    KEYMGR_DEBUG
   } keymgr_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] KEYMGR_PERMIT [62] = '{
+  parameter logic [3:0] KEYMGR_PERMIT [63] = '{
     4'b 0001, // index[ 0] KEYMGR_INTR_STATE
     4'b 0001, // index[ 1] KEYMGR_INTR_ENABLE
     4'b 0001, // index[ 2] KEYMGR_INTR_TEST
@@ -497,7 +531,8 @@ package keymgr_reg_pkg;
     4'b 0001, // index[58] KEYMGR_WORKING_STATE
     4'b 0001, // index[59] KEYMGR_OP_STATUS
     4'b 0001, // index[60] KEYMGR_ERR_CODE
-    4'b 0011  // index[61] KEYMGR_FAULT_STATUS
+    4'b 0011, // index[61] KEYMGR_FAULT_STATUS
+    4'b 0001  // index[62] KEYMGR_DEBUG
   };
 
 endpackage

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -59,9 +59,9 @@ module keymgr_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [61:0] reg_we_check;
+  logic [62:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(62)
+    .OneHotWidth(63)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -346,6 +346,21 @@ module keymgr_reg_top (
   logic fault_status_side_ctrl_fsm_qs;
   logic fault_status_side_ctrl_sel_qs;
   logic fault_status_key_ecc_qs;
+  logic debug_we;
+  logic debug_invalid_creator_seed_qs;
+  logic debug_invalid_creator_seed_wd;
+  logic debug_invalid_owner_seed_qs;
+  logic debug_invalid_owner_seed_wd;
+  logic debug_invalid_dev_id_qs;
+  logic debug_invalid_dev_id_wd;
+  logic debug_invalid_health_state_qs;
+  logic debug_invalid_health_state_wd;
+  logic debug_invalid_key_version_qs;
+  logic debug_invalid_key_version_wd;
+  logic debug_invalid_key_qs;
+  logic debug_invalid_key_wd;
+  logic debug_invalid_digest_qs;
+  logic debug_invalid_digest_wd;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -2576,8 +2591,185 @@ module keymgr_reg_top (
   );
 
 
+  // R[debug]: V(False)
+  //   F[invalid_creator_seed]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_debug_invalid_creator_seed (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
 
-  logic [61:0] addr_hit;
+    // from register interface
+    .we     (debug_we),
+    .wd     (debug_invalid_creator_seed_wd),
+
+    // from internal hardware
+    .de     (hw2reg.debug.invalid_creator_seed.de),
+    .d      (hw2reg.debug.invalid_creator_seed.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (debug_invalid_creator_seed_qs)
+  );
+
+  //   F[invalid_owner_seed]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_debug_invalid_owner_seed (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (debug_we),
+    .wd     (debug_invalid_owner_seed_wd),
+
+    // from internal hardware
+    .de     (hw2reg.debug.invalid_owner_seed.de),
+    .d      (hw2reg.debug.invalid_owner_seed.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (debug_invalid_owner_seed_qs)
+  );
+
+  //   F[invalid_dev_id]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_debug_invalid_dev_id (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (debug_we),
+    .wd     (debug_invalid_dev_id_wd),
+
+    // from internal hardware
+    .de     (hw2reg.debug.invalid_dev_id.de),
+    .d      (hw2reg.debug.invalid_dev_id.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (debug_invalid_dev_id_qs)
+  );
+
+  //   F[invalid_health_state]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_debug_invalid_health_state (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (debug_we),
+    .wd     (debug_invalid_health_state_wd),
+
+    // from internal hardware
+    .de     (hw2reg.debug.invalid_health_state.de),
+    .d      (hw2reg.debug.invalid_health_state.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (debug_invalid_health_state_qs)
+  );
+
+  //   F[invalid_key_version]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_debug_invalid_key_version (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (debug_we),
+    .wd     (debug_invalid_key_version_wd),
+
+    // from internal hardware
+    .de     (hw2reg.debug.invalid_key_version.de),
+    .d      (hw2reg.debug.invalid_key_version.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (debug_invalid_key_version_qs)
+  );
+
+  //   F[invalid_key]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_debug_invalid_key (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (debug_we),
+    .wd     (debug_invalid_key_wd),
+
+    // from internal hardware
+    .de     (hw2reg.debug.invalid_key.de),
+    .d      (hw2reg.debug.invalid_key.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (debug_invalid_key_qs)
+  );
+
+  //   F[invalid_digest]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_debug_invalid_digest (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (debug_we),
+    .wd     (debug_invalid_digest_wd),
+
+    // from internal hardware
+    .de     (hw2reg.debug.invalid_digest.de),
+    .d      (hw2reg.debug.invalid_digest.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (debug_invalid_digest_qs)
+  );
+
+
+
+  logic [62:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == KEYMGR_INTR_STATE_OFFSET);
@@ -2642,6 +2834,7 @@ module keymgr_reg_top (
     addr_hit[59] = (reg_addr == KEYMGR_OP_STATUS_OFFSET);
     addr_hit[60] = (reg_addr == KEYMGR_ERR_CODE_OFFSET);
     addr_hit[61] = (reg_addr == KEYMGR_FAULT_STATUS_OFFSET);
+    addr_hit[62] = (reg_addr == KEYMGR_DEBUG_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -2710,7 +2903,8 @@ module keymgr_reg_top (
                (addr_hit[58] & (|(KEYMGR_PERMIT[58] & ~reg_be))) |
                (addr_hit[59] & (|(KEYMGR_PERMIT[59] & ~reg_be))) |
                (addr_hit[60] & (|(KEYMGR_PERMIT[60] & ~reg_be))) |
-               (addr_hit[61] & (|(KEYMGR_PERMIT[61] & ~reg_be)))));
+               (addr_hit[61] & (|(KEYMGR_PERMIT[61] & ~reg_be))) |
+               (addr_hit[62] & (|(KEYMGR_PERMIT[62] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -2908,6 +3102,21 @@ module keymgr_reg_top (
   assign err_code_invalid_kmac_input_wd = reg_wdata[1];
 
   assign err_code_invalid_shadow_update_wd = reg_wdata[2];
+  assign debug_we = addr_hit[62] & reg_we & !reg_error;
+
+  assign debug_invalid_creator_seed_wd = reg_wdata[0];
+
+  assign debug_invalid_owner_seed_wd = reg_wdata[1];
+
+  assign debug_invalid_dev_id_wd = reg_wdata[2];
+
+  assign debug_invalid_health_state_wd = reg_wdata[3];
+
+  assign debug_invalid_key_version_wd = reg_wdata[4];
+
+  assign debug_invalid_key_wd = reg_wdata[5];
+
+  assign debug_invalid_digest_wd = reg_wdata[6];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -2974,6 +3183,7 @@ module keymgr_reg_top (
     reg_we_check[59] = op_status_we;
     reg_we_check[60] = err_code_we;
     reg_we_check[61] = 1'b0;
+    reg_we_check[62] = debug_we;
   end
 
   // Read data return
@@ -3244,6 +3454,16 @@ module keymgr_reg_top (
         reg_rdata_next[11] = fault_status_side_ctrl_fsm_qs;
         reg_rdata_next[12] = fault_status_side_ctrl_sel_qs;
         reg_rdata_next[13] = fault_status_key_ecc_qs;
+      end
+
+      addr_hit[62]: begin
+        reg_rdata_next[0] = debug_invalid_creator_seed_qs;
+        reg_rdata_next[1] = debug_invalid_owner_seed_qs;
+        reg_rdata_next[2] = debug_invalid_dev_id_qs;
+        reg_rdata_next[3] = debug_invalid_health_state_qs;
+        reg_rdata_next[4] = debug_invalid_key_version_qs;
+        reg_rdata_next[5] = debug_invalid_key_qs;
+        reg_rdata_next[6] = debug_invalid_digest_qs;
       end
 
       default: begin

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -1713,6 +1713,21 @@
         ]
       },
 
+      { name: "DEBUG_STATE",
+        desc: "Current flash fsm state",
+        swaccess: "ro",
+        hwaccess: "hwo",
+        hwext: "true"
+        fields: [
+          { bits: "10:0",
+            name: "lcmgr_state",
+            desc: "Current lcmgr interface staet ",
+            tags: [ // Bit changes immediately after start from reset value to 1b1 due to initialization
+            "excl:CsrAllTests:CsrExclAll"]
+          }
+        ]
+      },
+
       { name: "ERR_CODE",
         desc: '''
           Flash error code register.

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -496,7 +496,9 @@ module flash_ctrl
     .dis_access_o(dis_access),
 
     // init ongoing
-    .init_busy_o(ctrl_init_busy)
+    .init_busy_o(ctrl_init_busy),
+
+    .debug_state_o(hw2reg.debug_state.d)
   );
 
   // Program FIFO

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -554,6 +554,10 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
+    logic [10:0] d;
+  } flash_ctrl_hw2reg_debug_state_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
@@ -755,12 +759,13 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [187:176]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [175:175]
-    flash_ctrl_hw2reg_control_reg_t control; // [174:173]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [172:171]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [170:167]
-    flash_ctrl_hw2reg_status_reg_t status; // [166:157]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [198:187]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [186:186]
+    flash_ctrl_hw2reg_control_reg_t control; // [185:184]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [183:182]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [181:178]
+    flash_ctrl_hw2reg_status_reg_t status; // [177:168]
+    flash_ctrl_hw2reg_debug_state_reg_t debug_state; // [167:157]
     flash_ctrl_hw2reg_err_code_reg_t err_code; // [156:141]
     flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [140:123]
     flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [122:97]
@@ -865,19 +870,20 @@ package flash_ctrl_reg_pkg;
   parameter logic [CoreAw-1:0] FLASH_CTRL_MP_BANK_CFG_SHADOWED_OFFSET = 9'h 168;
   parameter logic [CoreAw-1:0] FLASH_CTRL_OP_STATUS_OFFSET = 9'h 16c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_STATUS_OFFSET = 9'h 170;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_ERR_CODE_OFFSET = 9'h 174;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_STD_FAULT_STATUS_OFFSET = 9'h 178;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_FAULT_STATUS_OFFSET = 9'h 17c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_ERR_ADDR_OFFSET = 9'h 180;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_CNT_OFFSET = 9'h 184;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_0_OFFSET = 9'h 188;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_1_OFFSET = 9'h 18c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_PHY_ALERT_CFG_OFFSET = 9'h 190;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_PHY_STATUS_OFFSET = 9'h 194;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_SCRATCH_OFFSET = 9'h 198;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_FIFO_LVL_OFFSET = 9'h 19c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_FIFO_RST_OFFSET = 9'h 1a0;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_CURR_FIFO_LVL_OFFSET = 9'h 1a4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_DEBUG_STATE_OFFSET = 9'h 174;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_ERR_CODE_OFFSET = 9'h 178;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_STD_FAULT_STATUS_OFFSET = 9'h 17c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_FAULT_STATUS_OFFSET = 9'h 180;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_ERR_ADDR_OFFSET = 9'h 184;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_CNT_OFFSET = 9'h 188;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_0_OFFSET = 9'h 18c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_1_OFFSET = 9'h 190;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_PHY_ALERT_CFG_OFFSET = 9'h 194;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_PHY_STATUS_OFFSET = 9'h 198;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_SCRATCH_OFFSET = 9'h 19c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_FIFO_LVL_OFFSET = 9'h 1a0;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_FIFO_RST_OFFSET = 9'h 1a4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_CURR_FIFO_LVL_OFFSET = 9'h 1a8;
 
   // Reset values for hwext registers and their fields for core interface
   parameter logic [5:0] FLASH_CTRL_INTR_TEST_RESVAL = 6'h 0;
@@ -893,14 +899,15 @@ package flash_ctrl_reg_pkg;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_FATAL_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_CTRL_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] FLASH_CTRL_CTRL_REGWEN_EN_RESVAL = 1'h 1;
+  parameter logic [10:0] FLASH_CTRL_DEBUG_STATE_RESVAL = 11'h 0;
   parameter logic [12:0] FLASH_CTRL_CURR_FIFO_LVL_RESVAL = 13'h 0;
   parameter logic [4:0] FLASH_CTRL_CURR_FIFO_LVL_PROG_RESVAL = 5'h 0;
   parameter logic [4:0] FLASH_CTRL_CURR_FIFO_LVL_RD_RESVAL = 5'h 0;
 
   // Window parameters for core interface
-  parameter logic [CoreAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 1a8;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_PROG_FIFO_OFFSET = 9'h 1ac;
   parameter int unsigned       FLASH_CTRL_PROG_FIFO_SIZE   = 'h 4;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_RD_FIFO_OFFSET = 9'h 1ac;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_RD_FIFO_OFFSET = 9'h 1b0;
   parameter int unsigned       FLASH_CTRL_RD_FIFO_SIZE   = 'h 4;
 
   // Register index for core interface
@@ -998,6 +1005,7 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_MP_BANK_CFG_SHADOWED,
     FLASH_CTRL_OP_STATUS,
     FLASH_CTRL_STATUS,
+    FLASH_CTRL_DEBUG_STATE,
     FLASH_CTRL_ERR_CODE,
     FLASH_CTRL_STD_FAULT_STATUS,
     FLASH_CTRL_FAULT_STATUS,
@@ -1014,7 +1022,7 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_core_id_e;
 
   // Register width information to check illegal writes for core interface
-  parameter logic [3:0] FLASH_CTRL_CORE_PERMIT [106] = '{
+  parameter logic [3:0] FLASH_CTRL_CORE_PERMIT [107] = '{
     4'b 0001, // index[  0] FLASH_CTRL_INTR_STATE
     4'b 0001, // index[  1] FLASH_CTRL_INTR_ENABLE
     4'b 0001, // index[  2] FLASH_CTRL_INTR_TEST
@@ -1108,19 +1116,20 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[ 90] FLASH_CTRL_MP_BANK_CFG_SHADOWED
     4'b 0001, // index[ 91] FLASH_CTRL_OP_STATUS
     4'b 0001, // index[ 92] FLASH_CTRL_STATUS
-    4'b 0001, // index[ 93] FLASH_CTRL_ERR_CODE
-    4'b 0011, // index[ 94] FLASH_CTRL_STD_FAULT_STATUS
-    4'b 0011, // index[ 95] FLASH_CTRL_FAULT_STATUS
-    4'b 0111, // index[ 96] FLASH_CTRL_ERR_ADDR
-    4'b 0011, // index[ 97] FLASH_CTRL_ECC_SINGLE_ERR_CNT
-    4'b 0111, // index[ 98] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_0
-    4'b 0111, // index[ 99] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_1
-    4'b 0001, // index[100] FLASH_CTRL_PHY_ALERT_CFG
-    4'b 0001, // index[101] FLASH_CTRL_PHY_STATUS
-    4'b 1111, // index[102] FLASH_CTRL_SCRATCH
-    4'b 0011, // index[103] FLASH_CTRL_FIFO_LVL
-    4'b 0001, // index[104] FLASH_CTRL_FIFO_RST
-    4'b 0011  // index[105] FLASH_CTRL_CURR_FIFO_LVL
+    4'b 0011, // index[ 93] FLASH_CTRL_DEBUG_STATE
+    4'b 0001, // index[ 94] FLASH_CTRL_ERR_CODE
+    4'b 0011, // index[ 95] FLASH_CTRL_STD_FAULT_STATUS
+    4'b 0011, // index[ 96] FLASH_CTRL_FAULT_STATUS
+    4'b 0111, // index[ 97] FLASH_CTRL_ERR_ADDR
+    4'b 0011, // index[ 98] FLASH_CTRL_ECC_SINGLE_ERR_CNT
+    4'b 0111, // index[ 99] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_0
+    4'b 0111, // index[100] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_1
+    4'b 0001, // index[101] FLASH_CTRL_PHY_ALERT_CFG
+    4'b 0001, // index[102] FLASH_CTRL_PHY_STATUS
+    4'b 1111, // index[103] FLASH_CTRL_SCRATCH
+    4'b 0011, // index[104] FLASH_CTRL_FIFO_LVL
+    4'b 0001, // index[105] FLASH_CTRL_FIFO_RST
+    4'b 0011  // index[106] FLASH_CTRL_CURR_FIFO_LVL
   };
 
 endpackage

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -217,10 +217,6 @@ cc_test(
 opentitan_functest(
     name = "keymgr_functest",
     srcs = ["keymgr_functest.c"],
-    cw310 = cw310_params(
-        #TODO: Remove this broken tag when #13045 is merged
-        tags = ["broken"],
-    ),
     deps = [
         ":keymgr",
         ":lifecycle",


### PR DESCRIPTION
- the input check module already had the feature, but the
  parameter was not hooked up.


Also revert #13058 