### PR TITLE
[ci] Temporary mitigation for the flaky tests on the CW310

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -416,8 +416,10 @@ jobs:
       echo "" >> ${BITCACHE_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice
       echo -n ${SHA} > ${BITCACHE_DIR}/../../latest.txt
       export BITSTREAM="--offline --list ${SHA}"
+      # TODO: remove the --notest_keep_going flag after the CW310 UART is reliable (#13044)
       ci/bazelisk.sh test \
           --define DISABLE_VERILATOR_BUILD=true \
+          --notest_keep_going \ 
           --test_tag_filters=cw310,-broken \
           --test_output=all \
           --build_tests_only \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -406,26 +406,7 @@ jobs:
         - sw_build
   - bash: |
       set -e
-      set -x
-      . util/build_consts.sh
-      SHA=$(git rev-parse HEAD)
-      BITCACHE_DIR=~/.cache/opentitan-bitstreams/cache/${SHA}
-      mkdir -p $BITCACHE_DIR
-      BITCACHE_FILE=$BITCACHE_DIR/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig
-      cp $BIN_DIR/hw/top_earlgrey/lowrisc_systems_chip_earlgrey_cw310_0.1.bit ${BITCACHE_FILE}
-      echo "" >> ${BITCACHE_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice
-      echo -n ${SHA} > ${BITCACHE_DIR}/../../latest.txt
-      export BITSTREAM="--offline --list ${SHA}"
-      # TODO: remove the --notest_keep_going flag after the CW310 UART is reliable (#13044)
-      ci/bazelisk.sh test \
-          --define DISABLE_VERILATOR_BUILD=true \
-          --notest_keep_going \ 
-          --test_tag_filters=cw310,-broken \
-          --test_output=all \
-          --build_tests_only \
-          --define cw310=lowrisc \
-          $(./bazelisk.sh query 'rdeps(//...,@bitstreams//:bitstream_test_rom)') \
-          # All the tests that depend on the test rom
+      ci/scripts/run-fpga-cw310-tests.sh
     displayName: Execute tests
 
 - job: deploy_release_artifacts

--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -x
+set -e
+
+. util/build_consts.sh
+SHA=$(git rev-parse HEAD)
+BITCACHE_DIR=~/.cache/opentitan-bitstreams/cache/${SHA}
+mkdir -p $BITCACHE_DIR
+BITCACHE_FILE=$BITCACHE_DIR/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig
+cp $BIN_DIR/hw/top_earlgrey/lowrisc_systems_chip_earlgrey_cw310_0.1.bit ${BITCACHE_FILE}
+echo "" >> ${BITCACHE_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice
+echo -n ${SHA} > ${BITCACHE_DIR}/../../latest.txt
+export BITSTREAM="--offline --list ${SHA}"
+
+# TODO: remove the --notest_keep_going and --nokeep_going flag after the CW310
+# tests are reliable (#13044)
+ci/bazelisk.sh test \
+    --define DISABLE_VERILATOR_BUILD=true \
+    --notest_keep_going \
+    --nokeep_going \
+    --test_tag_filters=cw310,-broken \
+    --test_output=all \
+    --build_tests_only \
+    --define cw310=lowrisc \
+    //sw/device/tests:otbn_randomness_test_fpga_cw310 \
+    //sw/device/tests:kmac_mode_cshake_test_fpga_cw310 \
+    //sw/device/tests:kmac_mode_kmac_test_fpga_cw310 \
+    //sw/device/silicon_creator/lib/drivers:hmac_functest_fpga_cw310 \
+    //sw/device/silicon_creator/lib/drivers:uart_functest_fpga_cw310 \
+    //sw/device/silicon_creator/lib/drivers:retention_sram_functest_fpga_cw310
+    # //sw/device/tests:pmp_smoketest_napot_fpga_cw310 \
+    # //sw/device/tests:pmp_smoketest_tor_fpga_cw310 \
+    # Note that the pmp_smoketest_* tests were included in the original
+    # systemtest but are failing when run under bazel and so are excluded from
+    # this run
+    # TODO: use the following query instead of the list above after the CW310
+    # UART is reliable (#13044)
+    # $(./bazelisk.sh query 'rdeps(//...,@bitstreams//:bitstream_test_rom)') \
+    # All the tests that depend on the test rom


### PR DESCRIPTION
This PR adds two temporary mitigations to address the communications failures being observed on the CW310 in CI.
- Adding `--notest_keep_going` to the cw310 tests prevents tests from queueing up on the FPGA runner when opentitantool's uart connection times out
- Reducing the number of CW310 tests being run in CI decreases the frequency of the FPGA failures.

This is a temporary measure as we diagnose the issue. As tracked in #13044, these changes should be undone after this is fixed.