### PR TITLE
[rust] Add cargo raze to the project

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@
 
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("//rules:quality.bzl", "clang_format_check", "html_coverage_report")
+load("//rules:cargo.bzl", "cargo_raze")
 load("@lowrisc_lint//rules:rules.bzl", "licence_check")
 load("@rules_rust//rust:defs.bzl", "rust_analyzer")
 
@@ -99,5 +100,12 @@ rust_analyzer(
         "//sw/host/opentitantool:opentitantool",
         "//sw/host/rom_ext_image_tools/signer:rom_ext_signer",
         "//sw/host/rom_ext_image_tools/signer/image:rom_ext_image",
+    ],
+)
+
+cargo_raze(
+    name = "cargo_raze",
+    cargo = [
+        "third_party/rust/crates/Cargo.toml",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,6 +43,20 @@ rust_repos()
 load("//third_party/rust:deps.bzl", "rust_deps")
 rust_deps()
 
+# Cargo Raze dependencies
+load("//third_party/cargo_raze:repos.bzl", "raze_repos")
+raze_repos()
+load("//third_party/cargo_raze:deps.bzl", "raze_deps")
+raze_deps()
+# The raze instructions would have us call `cargo_raze_transitive_deps`, but that
+# wants to re-instantiate rules_rust and mess up our rust configuration.
+# Instead, we perform the single other action that transitive_deps would perform:
+# load and instantiate `rules_foreign_cc_dependencies`.
+#load("@cargo_raze//:transitive_deps.bzl", "cargo_raze_transitive_deps")
+#cargo_raze_transitive_deps()
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+rules_foreign_cc_dependencies()
+
 # Protobuf Toolchain
 load("//third_party/protobuf:repos.bzl", "protobuf_repos")
 protobuf_repos()

--- a/rules/cargo.bzl
+++ b/rules/cargo.bzl
@@ -1,0 +1,46 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rust `cargo` related rules for OpenTitan.
+"""
+
+def _cargo_raze_impl(ctx):
+    out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
+    substitutions = {
+        "@@FILES@@": " ".join(ctx.attr.cargo),
+        "@@CARGO_RAZE@@": ctx.attr.cargo_raze,
+    }
+    ctx.actions.expand_template(
+        template = ctx.file._runner,
+        output = out_file,
+        substitutions = substitutions,
+        is_executable = True,
+    )
+    return DefaultInfo(
+        files = depset([out_file]),
+        executable = out_file,
+    )
+
+cargo_raze = rule(
+    implementation = _cargo_raze_impl,
+    attrs = {
+        # This should really be a label_list, but cargo-raze generates a
+        # BUILD file in the same directory as Cargo.toml and prevents us
+        # from making Cargo.toml visible to bazel.
+        "cargo": attr.string_list(
+            doc = "Workspace relative paths of Cargo.toml files",
+        ),
+        # This should also be a label, but we need to pass the raw text
+        # of the label into the template script.
+        "cargo_raze": attr.string(
+            default = "@cargo_raze//:raze",
+            doc = "Label of cargo-raze",
+        ),
+        "_runner": attr.label(
+            default = "//rules/scripts:cargo_raze.template.sh",
+            allow_single_file = True,
+        ),
+    },
+    executable = True,
+)

--- a/rules/scripts/cargo_raze.template.sh
+++ b/rules/scripts/cargo_raze.template.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+FILES=(@@FILES@@)
+
+if ! cd "$BUILD_WORKSPACE_DIRECTORY"; then
+    echo "Unable to change to workspace (BUILD_WORKSPACE_DIRECTORY: ${BUILD_WORKSPACE_DIRECTORY})"
+    exit 1
+fi
+
+for F in ${FILES[@]}; do
+    bazel run @@CARGO_RAZE@@ -- --manifest-path="$BUILD_WORKSPACE_DIRECTORY/$F"
+done

--- a/third_party/cargo_raze/BUILD
+++ b/third_party/cargo_raze/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/cargo_raze/deps.bzl
+++ b/third_party/cargo_raze/deps.bzl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@cargo_raze//:repositories.bzl", "cargo_raze_repositories")
+
+def raze_deps():
+    cargo_raze_repositories()

--- a/third_party/cargo_raze/pr-481-libssh2-pkgconfig.patch
+++ b/third_party/cargo_raze/pr-481-libssh2-pkgconfig.patch
@@ -1,0 +1,102 @@
+diff --git a/impl/Cargo.toml b/impl/Cargo.toml
+index 58c947e6..a427c7ed 100644
+--- a/impl/Cargo.toml
++++ b/impl/Cargo.toml
+@@ -104,10 +104,15 @@ additional_deps = ["@cargo_raze__libgit2//:libgit2"]
+ [package.metadata.raze.crates.libssh2-sys.'*']
+ # build.rs file: https://github.com/alexcrichton/ssh2-rs/blob/master/libssh2-sys/build.rs
+ build_data_dependencies = [
++    "@cargo_raze__libssh2//:libssh2_gen_dir",
++    "@cargo_raze__libssh2//:fix_pkgconfig",
+     "@cargo_raze__libssh2//:libssh2",
+     "@cargo_raze__openssl//:openssl",
+ ]
+ additional_deps = ["@cargo_raze__libssh2//:libssh2"]
++[package.metadata.raze.crates.libssh2-sys.'*'.buildrs_additional_environment_variables]
++    PKG_CONFIG_PATH = "$(execpath @cargo_raze__libssh2//:libssh2_gen_dir)/pkgconfig"
++    LIBSSH2_SYS_USE_PKG_CONFIG = "true"
+ 
+ [package.metadata.raze.crates.libz-sys.'*']
+ # build.rs file: https://github.com/rust-lang/libz-sys/blob/main/build.rs
+@@ -125,7 +130,7 @@ build_data_dependencies = [
+ ]
+ data_attr = "[\"@cargo_raze__openssl//:openssl\"]"
+ additional_deps = ["@cargo_raze__openssl//:openssl"]
+-    [package.metadata.raze.crates.openssl-sys.'*'.buildrs_additional_environment_variables]
++[package.metadata.raze.crates.openssl-sys.'*'.buildrs_additional_environment_variables]
+         OPENSSL_DIR="$(execpath @cargo_raze__openssl//:gen_dir)"
+         OPENSSL_STATIC="1"
+ 
+diff --git a/third_party/cargo/remote/BUILD.libssh2-sys-0.2.21.bazel b/third_party/cargo/remote/BUILD.libssh2-sys-0.2.21.bazel
+index 7ddca981..f46e4580 100644
+--- a/third_party/cargo/remote/BUILD.libssh2-sys-0.2.21.bazel
++++ b/third_party/cargo/remote/BUILD.libssh2-sys-0.2.21.bazel
+@@ -41,12 +41,16 @@ cargo_build_script(
+     name = "libssh2_sys_build_script",
+     srcs = glob(["**/*.rs"]),
+     build_script_env = {
++        "LIBSSH2_SYS_USE_PKG_CONFIG": "true",
++        "PKG_CONFIG_PATH": "$(execpath @cargo_raze__libssh2//:libssh2_gen_dir)/pkgconfig",
+     },
+     crate_features = [
+     ],
+     crate_root = "build.rs",
+     data = glob(["**"]) + [
++        "@cargo_raze__libssh2//:fix_pkgconfig",
+         "@cargo_raze__libssh2//:libssh2",
++        "@cargo_raze__libssh2//:libssh2_gen_dir",
+         "@cargo_raze__openssl//:openssl",
+     ],
+     edition = "2015",
+diff --git a/third_party/libgit2/BUILD.libgit2.bazel b/third_party/libgit2/BUILD.libgit2.bazel
+index f13b36bf..1e4dc867 100644
+--- a/third_party/libgit2/BUILD.libgit2.bazel
++++ b/third_party/libgit2/BUILD.libgit2.bazel
+@@ -13,9 +13,14 @@ _CACHE_ENTRIES = {
+     "BUILD_EXAMPLES": "off",
+     "BUILD_FUZZERS": "off",
+     "BUILD_SHARED_LIBS": "off",
+-    "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/pcre;$EXT_BUILD_DEPS/openssl;$EXT_BUILD_DEPS/libssh2;$EXT_BUILD_DEPS/zlib",
++    "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/pcre;$EXT_BUILD_DEPS/openssl;$EXT_BUILD_DEPS/zlib",
+     "EMBED_SSH_PATH": "$(execpath @cargo_raze__libssh2//:libssh2)",
+     "USE_HTTPS": "on",
++    # Manually configure libssh2 as cmake gets confused about what pkgconfig reports.
++    "USE_SSH": "off",
++    "LIBSSH2_FOUND": "true",
++    "LIBSSH2_INCLUDE_DIRS": "$EXT_BUILD_DEPS/libssh2/include",
++    "LIBSSH2_LIBRARY_DIRS": "$EXT_BUILD_DEPS/libssh2/lib",
+ }
+ 
+ _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
+diff --git a/third_party/libssh2/BUILD.libssh2.bazel b/third_party/libssh2/BUILD.libssh2.bazel
+index 253ed432..3e26f838 100644
+--- a/third_party/libssh2/BUILD.libssh2.bazel
++++ b/third_party/libssh2/BUILD.libssh2.bazel
+@@ -32,3 +32,27 @@ cmake(
+     visibility = ["//visibility:public"],
+     deps = ["@cargo_raze__openssl//:openssl"],
+ )
++
++filegroup(
++    name = "libssh2_gen_dir",
++    srcs = [":libssh2"],
++    output_group = "gen_dir",
++    visibility = ["//visibility:public"],
++)
++
++genrule(
++    name = "fix_pkgconfig",
++    srcs = [":libssh2"],
++    outs = ["pkgconfig/libssh2.pc"],
++    # Get rid of ${EXT_BUILD_ROOT}/ in the pkgconfig file so it references
++    # libssh2 resources from the root of the project rather than expanding
++    # EXT_BUILD_ROOT to "" and resulting in a pkgconfig that claims to start
++    # at the filesystem root (/).
++    cmd = """
++        mkdir -p $(@D)
++        DIRS=($(locations :libssh2))
++        SRC="$${DIRS[0]}/lib/pkgconfig/libssh2.pc"
++        sed -e "s|.{EXT_BUILD_ROOT}/||g" < $$SRC > $@
++    """,
++    visibility = ["//visibility:public"],
++)

--- a/third_party/cargo_raze/pr-488-c11-fixes.patch
+++ b/third_party/cargo_raze/pr-488-c11-fixes.patch
@@ -1,0 +1,39 @@
+diff --git a/third_party/libgit2/BUILD.libgit2.bazel b/third_party/libgit2/BUILD.libgit2.bazel
+index 1e4dc867..dfd33394 100644
+--- a/third_party/libgit2/BUILD.libgit2.bazel
++++ b/third_party/libgit2/BUILD.libgit2.bazel
+@@ -24,7 +24,7 @@ _CACHE_ENTRIES = {
+ }
+ 
+ _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
+-    "CMAKE_C_FLAGS": "-fPIC",
++    "CMAKE_C_FLAGS": "-fPIC -D_GNU_SOURCE=1",
+     "REGEX_BACKEND": "pcre",
+ }.items())
+ 
+diff --git a/third_party/openssl/BUILD.openssl.bazel b/third_party/openssl/BUILD.openssl.bazel
+index 60f81a11..6797bf9d 100644
+--- a/third_party/openssl/BUILD.openssl.bazel
++++ b/third_party/openssl/BUILD.openssl.bazel
+@@ -34,7 +34,7 @@ configure_make(
+     }),
+     env = select({
+         "@rules_rust//rust/platform:darwin": {"AR": ""},
+-        "//conditions:default": {},
++        "//conditions:default": {"CFLAGS": "-Dasm=__asm__ -D_GNU_SOURCE=1"},
+     }),
+     lib_source = ":all_srcs",
+     out_static_libs = [
+diff --git a/third_party/pcre/BUILD.pcre.bazel b/third_party/pcre/BUILD.pcre.bazel
+index b9931e25..1187c391 100644
+--- a/third_party/pcre/BUILD.pcre.bazel
++++ b/third_party/pcre/BUILD.pcre.bazel
+@@ -10,7 +10,7 @@ filegroup(
+ cmake(
+     name = "pcre",
+     cache_entries = {
+-        "CMAKE_C_FLAGS": "-fPIC",
++        "CMAKE_C_FLAGS": "-fPIC -D_GNU_SOURCE=1",
+     },
+     lib_source = ":all",
+     out_static_libs = ["libpcre.a"],

--- a/third_party/cargo_raze/pr-491-local-paths.patch
+++ b/third_party/cargo_raze/pr-491-local-paths.patch
@@ -1,0 +1,83 @@
+diff --git a/impl/src/rendering/templates/remote_crates.bzl.template b/impl/src/rendering/templates/remote_crates.bzl.template
+index f30a6b8b..c0bb4cd8 100644
+--- a/impl/src/rendering/templates/remote_crates.bzl.template
++++ b/impl/src/rendering/templates/remote_crates.bzl.template
+@@ -6,39 +6,55 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")  # buildifier: di
+ {% if experimental_api %}
+ {% include "templates/partials/crates_macro.template" %}
+ {% endif %}
+-def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
+ {%- if crates %}
++def {{workspace.gen_workspace_prefix}}_fetch_remote_crates(
++        # Each of these may be used to temporarily override the location of
++        # the crate to a path on your local filesystem for local development
++        # of crates you may be using in your project.
++{%- for crate in crates %}
++        {{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}=None,
++{%  endfor %}
++    ):
+     """This function defines a collection of repos and should be called in a WORKSPACE file"""
+ {%- for crate in crates %}
++    if {{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}:
++        maybe(
++            native.new_local_repository,
++            name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
++            path = {{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}},
++            build_file = "{{workspace.workspace_path}}/remote:BUILD.{{crate.pkg_name}}-{{crate.pkg_version}}.bazel",
++        )
++    else:
+ {%- if crate.source_details.git_data %}
+-    maybe(
+-        new_git_repository,
+-        name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
+-        remote = "{{crate.source_details.git_data.remote}}",
+-        commit = "{{crate.source_details.git_data.commit}}",
+-        build_file = Label("{{workspace.workspace_path}}/remote:BUILD.{{crate.pkg_name}}-{{crate.pkg_version}}.bazel"),
+-        init_submodules = True,
+-        {%- include "templates/partials/remote_crates_patch.template" %}
+-    )
++        maybe(
++            new_git_repository,
++            name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
++            remote = "{{crate.source_details.git_data.remote}}",
++            commit = "{{crate.source_details.git_data.commit}}",
++            build_file = Label("{{workspace.workspace_path}}/remote:BUILD.{{crate.pkg_name}}-{{crate.pkg_version}}.bazel"),
++            init_submodules = True,
++            {%- include "templates/partials/remote_crates_patch.template" %}
++        )
+ {%- else %}
+-    maybe(
+-        http_archive,
+-        name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
+-        url = "{{ crate.source_details.download_url }}",
+-        type = "tar.gz",
+-{%- if crate.sha256 %}
+-        sha256 = "{{crate.sha256}}",
+-{%- endif %}
+-        strip_prefix = "{{crate.pkg_name}}-{{crate.pkg_version}}",
+-        {%- include "templates/partials/remote_crates_patch.template" %}
+-        build_file = Label("{{workspace.workspace_path}}/remote:BUILD.{{crate.pkg_name}}-{{crate.pkg_version}}.bazel"),
+-    )
++        maybe(
++            http_archive,
++            name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
++            url = "{{ crate.source_details.download_url }}",
++            type = "tar.gz",
++    {%- if crate.sha256 %}
++            sha256 = "{{crate.sha256}}",
++    {%- endif %}
++            strip_prefix = "{{crate.pkg_name}}-{{crate.pkg_version}}",
++            {%- include "templates/partials/remote_crates_patch.template" %}
++            build_file = Label("{{workspace.workspace_path}}/remote:BUILD.{{crate.pkg_name}}-{{crate.pkg_version}}.bazel"),
++        )
+ {%- endif %}
+ {%  endfor %}
+ {%- else %}
++def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
+     """No crates were detected in the source Cargo.toml. This is a no-op"""
+     pass
+ {% endif %}
+ {%- else %}
+ {% include "templates/partials/crates_macro.template" %}
+-{% endif %}
++{% endif %}

--- a/third_party/cargo_raze/pr-492-skip-submodules.patch
+++ b/third_party/cargo_raze/pr-492-skip-submodules.patch
@@ -1,0 +1,42 @@
+diff --git a/impl/src/rendering/templates/remote_crates.bzl.template b/impl/src/rendering/templates/remote_crates.bzl.template
+index c0bb4cd8..6b64f259 100644
+--- a/impl/src/rendering/templates/remote_crates.bzl.template
++++ b/impl/src/rendering/templates/remote_crates.bzl.template
+@@ -32,7 +32,11 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates(
+             remote = "{{crate.source_details.git_data.remote}}",
+             commit = "{{crate.source_details.git_data.commit}}",
+             build_file = Label("{{workspace.workspace_path}}/remote:BUILD.{{crate.pkg_name}}-{{crate.pkg_version}}.bazel"),
++    {%- if crate.raze_settings.skip_submodules %}
++            init_submodules = False,
++    {%- else %}
+             init_submodules = True,
++    {%- endif %}
+             {%- include "templates/partials/remote_crates_patch.template" %}
+         )
+ {%- else %}
+diff --git a/impl/src/settings.rs b/impl/src/settings.rs
+index f25a1a99..c6b04c99 100644
+--- a/impl/src/settings.rs
++++ b/impl/src/settings.rs
+@@ -244,6 +244,13 @@ pub struct CrateSettings {
+   /// context, see https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
+   #[serde(default)]
+   pub additional_build_file: Option<PathBuf>,
++
++
++  /// Skip initializing submodules in the target repository.
++  ///
++  /// Some crates may not need their submodules initialized in order to build.
++  #[serde(default)]
++  pub skip_submodules: bool,
+ }
+ 
+ /// Describes how dependencies should be managed in tree.
+@@ -280,6 +287,7 @@ impl Default for CrateSettings {
+       patch_tool: None,
+       patches: Vec::new(),
+       additional_build_file: None,
++      skip_submodules: false,
+     }
+   }
+ }

--- a/third_party/cargo_raze/repos.bzl
+++ b/third_party/cargo_raze/repos.bzl
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:repo.bzl", "http_archive_or_local")
+
+def raze_repos(local = None):
+    http_archive_or_local(
+        name = "cargo_raze",
+        local = local,
+        strip_prefix = "cargo-raze-0.15.0",
+        url = "https://github.com/google/cargo-raze/archive/v0.15.0.tar.gz",
+        sha256 = "58ecdbae2680b71edc19a0f563cdb73e66c8914689b6edab258c8b90a93b13c7",
+        patches = [
+            Label("//third_party/cargo_raze:pr-481-libssh2-pkgconfig.patch"),
+            Label("//third_party/cargo_raze:pr-488-c11-fixes.patch"),
+            Label("//third_party/cargo_raze:pr-491-local-paths.patch"),
+            Label("//third_party/cargo_raze:pr-492-skip-submodules.patch"),
+        ],
+        patch_args = ["-p1"],
+    )


### PR DESCRIPTION
I've included a number of patches, all corresponding to open PRs with
the cargo_raze project:

google/cargo-raze#481 - Link the project-local libssh2 with libssh2-sys.
google/cargo-raze#488 - Add compiler flags to build correctly in a C11 environment.
google/cargo-raze#491 - Facilitate local crate development by allowing local_repository
    overrides.
google/cargo-raze#492 - Allow skipping submodule initialization on git repositories.

Cargo raze can be invoked from bazel and will update dependencies in known Cargo.toml files:
```
bazel run //:cargo_raze
```