### PR TITLE
[dv] Add common test for reg write enable check

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
@@ -54,7 +54,12 @@ virtual task test_sec_cm_fi();
       sec_cm_restore_fault(if_proxy);
     end
 
-    check_sec_cm_fi_resp(if_proxy);
+    // when a fault occurs at the reg_we_check, it's treated as a TL intg error
+    if (if_proxy.sec_cm_type == SecCmPrimOnehot && !uvm_re_match("*u_prim_reg_we_check*", if_proxy.path)) begin
+      check_tl_intg_error_response();
+    end else begin
+      check_sec_cm_fi_resp(if_proxy);
+    end
 
     sec_cm_fi_ctrl_svas(if_proxy, .enable(1));
     // issue hard reset for fatal alert to recover

--- a/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
+++ b/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
@@ -1,0 +1,101 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Generic countermeasure interface for hardened onehot_check
+//
+// This contains a proxy class and store the object in sec_cm_pkg, which can be used in vseq to
+// control inject_fault and restore_fault
+interface prim_onehot_check_if #(
+  parameter int unsigned AddrWidth   = 5,
+  parameter int unsigned OneHotWidth = 2**AddrWidth,
+  parameter bit          AddrCheck   = 1,
+  parameter bit          EnableCheck = 1,
+  parameter bit          StrictCheck = 1
+) (
+  input                          clk_i,
+  input                          rst_ni,
+
+  input  logic [OneHotWidth-1:0] oh_i,
+  input  logic [AddrWidth-1:0]   addr_i,
+  input  logic                   en_i);
+
+  `include "dv_macros.svh"
+  `include "uvm_macros.svh"
+  import uvm_pkg::*;
+
+  string msg_id = $sformatf("%m");
+
+  string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
+  string oh_signal_forced = $sformatf("%s.oh_i", path);
+  string en_signal_forced = $sformatf("%s.en_i", path);
+
+  // TODO, so far this parameter is always tie to 0 in design
+  // Add more support when it's used
+  `ASSERT_INIT(AddrCheckNotSupported, !AddrCheck)
+
+  class prim_onehot_check_if_proxy extends sec_cm_pkg::sec_cm_base_if_proxy;
+    `uvm_object_new
+
+    logic[OneHotWidth-1:0] oh_orig_value;
+    logic                  en_orig_value;
+
+    virtual task inject_fault();
+      logic[OneHotWidth-1:0] oh_force_value;
+      logic                  en_force_value;
+
+      @(negedge clk_i);
+      `DV_CHECK(uvm_hdl_read(oh_signal_forced, oh_orig_value))
+      `DV_CHECK(uvm_hdl_read(en_signal_forced, en_orig_value))
+      `DV_CHECK_STD_RANDOMIZE_FATAL(en_force_value)
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(oh_force_value,
+                                         if (StrictCheck) {
+                                           if (en_force_value) $countones(oh_force_value) != 1;
+                                           else                $countones(oh_force_value) != 0;
+                                         } else if (!StrictCheck) {
+                                           if (en_force_value) $countones(oh_force_value) > 1;
+                                           else                $countones(oh_force_value) != 0;
+                                         }
+                                         // higher chance to test oh=0/1, when StrictCheck is set
+                                         oh_force_value dist {
+                                           0     :/ 1,
+                                           1     :/ 1,
+                                           [2:$] :/ 5};
+                                         )
+
+      `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
+                                  en_signal_forced, en_orig_value, en_force_value), UVM_LOW)
+      `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
+                                  oh_signal_forced, oh_orig_value, oh_force_value), UVM_LOW)
+      `DV_CHECK(uvm_hdl_force(en_signal_forced, en_force_value))
+      `DV_CHECK(uvm_hdl_force(oh_signal_forced, oh_force_value))
+      @(negedge clk_i);
+      `DV_CHECK(uvm_hdl_release(en_signal_forced))
+      `DV_CHECK(uvm_hdl_release(oh_signal_forced))
+    endtask
+
+    virtual task restore_fault();
+      `uvm_info(msg_id, $sformatf("Forcing %s original value %0d",
+                                  en_signal_forced, en_orig_value), UVM_LOW)
+      `uvm_info(msg_id, $sformatf("Forcing %s original value %0d",
+                                  oh_signal_forced, oh_orig_value), UVM_LOW)
+      `DV_CHECK(uvm_hdl_deposit(en_signal_forced, en_orig_value))
+      `DV_CHECK(uvm_hdl_deposit(oh_signal_forced, oh_orig_value))
+    endtask
+  endclass
+
+  prim_onehot_check_if_proxy if_proxy;
+
+  initial begin
+    `DV_CHECK_FATAL(uvm_hdl_check_path(en_signal_forced), , msg_id)
+    `DV_CHECK_FATAL(uvm_hdl_check_path(oh_signal_forced), , msg_id)
+
+    // Store the proxy object for TB to use
+    if_proxy = new("if_proxy");
+    if_proxy.sec_cm_type = sec_cm_pkg::SecCmPrimOnehot;
+    if_proxy.path = path;
+    sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
+
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+  end
+endinterface

--- a/hw/dv/sv/sec_cm/sec_cm.core
+++ b/hw/dv/sv/sec_cm/sec_cm.core
@@ -9,6 +9,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:prim:alert
+      - lowrisc:prim:onehot_check
       - lowrisc:prim:count
       - lowrisc:prim:sparse_fsm
       - lowrisc:prim:double_lfsr
@@ -16,9 +17,11 @@ filesets:
     files:
       - sec_cm_pkg.sv
       - sec_cm_base_if_proxy.sv: {is_include_file: true}
+      - prim_onehot_check_if.sv
       - prim_count_if.sv
       - prim_sparse_fsm_flop_if.sv
       - prim_double_lfsr_if.sv
+      - sec_cm_prim_onehot_check_bind.sv
       - sec_cm_prim_count_bind.sv
       - sec_cm_prim_sparse_fsm_flop_bind.sv
       - sec_cm_prim_double_lfsr_bind.sv

--- a/hw/dv/sv/sec_cm/sec_cm_pkg.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_pkg.sv
@@ -17,7 +17,8 @@ package sec_cm_pkg;
   typedef enum int {
     SecCmPrimCount,
     SecCmPrimSparseFsmFlop,
-    SecCmPrimDoubleLfsr
+    SecCmPrimDoubleLfsr,
+    SecCmPrimOnehot
   } sec_cm_type_e;
 
   `include "sec_cm_base_if_proxy.sv"

--- a/hw/dv/sv/sec_cm/sec_cm_prim_onehot_check_bind.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_prim_onehot_check_bind.sv
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module sec_cm_prim_onehot_check_bind();
+  bind prim_onehot_check prim_onehot_check_if #(.AddrWidth(AddrWidth),
+                                                .OneHotWidth(OneHotWidth),
+                                                .AddrCheck(AddrCheck),
+                                                .EnableCheck(EnableCheck),
+                                                .StrictCheck(StrictCheck)
+                                              ) u_prim_onehot_check_if (.*);
+endmodule

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -41,7 +41,8 @@
   en_build_modes: ["{tool}_memutil_dpi_scrambled_build_opts"]
 
   // Add additional tops for simulation.
-  sim_tops: ["sram_ctrl_bind", "sram_ctrl_cov_bind", "sec_cm_prim_count_bind"]
+  sim_tops: ["sram_ctrl_bind", "sram_ctrl_cov_bind",
+             "sec_cm_prim_onehot_check_bind", "sec_cm_prim_count_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
Address #12113
- Inject a fault in the prim_onehot_check to trigger reg integrity error
- Check status reg and fatal alert

Next steps:
- Only add it for sram_ctrl. Will create a separate PR to enable this for
all other blocks
- Add assertion to check this error leads to a fatal alert
- Enable FPV for prim_onehot_check and FPV for the block that contains this prim.

Signed-off-by: Weicai Yang <weicai@google.com>