### PR TITLE
[rtl/alert_handler] Fix sec_cm related assertions

### DIFF
--- a/hw/ip_templates/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -307,13 +307,13 @@ module alert_handler_esc_timer import alert_pkg::*; (
       !(state_q inside {IdleSt, TimeoutSt, FsmErrorSt})
       |=>
       state_q == IdleSt)
-  // if currently in idle and not enabled, must remain here
+  // if currently in idle and not enabled, must remain here or goes to Error state
   `ASSERT(CheckEn_A,
       !accu_fail_i &&
       state_q == IdleSt &&
       !en_i
       |=>
-      state_q == IdleSt)
+      state_q inside {IdleSt, FsmErrorSt})
   // Check if accumulation trigger correctly captured
   `ASSERT(CheckAccumTrig0_A,
       !accu_fail_i &&

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -307,13 +307,13 @@ module alert_handler_esc_timer import alert_pkg::*; (
       !(state_q inside {IdleSt, TimeoutSt, FsmErrorSt})
       |=>
       state_q == IdleSt)
-  // if currently in idle and not enabled, must remain here
+  // if currently in idle and not enabled, must remain here or goes to Error state
   `ASSERT(CheckEn_A,
       !accu_fail_i &&
       state_q == IdleSt &&
       !en_i
       |=>
-      state_q == IdleSt)
+      state_q inside {IdleSt, FsmErrorSt})
   // Check if accumulation trigger correctly captured
   `ASSERT(CheckAccumTrig0_A,
       !accu_fail_i &&


### PR DESCRIPTION
Fix one assertion about escalatoin check in FSM.
In default it should stay at idle mode, but in case of sec_cm injection,
it might go to FsmErrorSt.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>