### PR TITLE
[entropy_src/dv] Test support for SW_REGUPD and CSR autolock

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
@@ -1,0 +1,252 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Class to hold register configuration values for the DUT
+//
+// This class is intended to contain all the dut register configuration values, and their
+// corresponding constraints.  Holding these values in a separate class from entropy_src_env_cfg
+// allows for clean generation of alternative register configurations, under the same constraints,
+// without randomizing any of the other environment config variables typically found in
+// entropy_src_env_cfg.
+//
+
+class entropy_src_dut_cfg extends uvm_object;
+
+  `uvm_object_utils(entropy_src_dut_cfg)
+  `uvm_object_new
+
+  ///////////////////////
+  // Constraint knobs  //
+  ///////////////////////
+
+  // Constraint knob for module_enable field
+  uint          module_enable_pct;
+
+  // Constraint knob for SW-accessible REGWEN-related fields
+  uint          me_regwen_pct, sw_regupd_pct;
+
+  // Constraint knobs for Boolean fields in CONF register
+  // (RNG_BIT_SEL is always uniform)
+  uint          fips_enable_pct, entropy_data_reg_enable_pct, ht_threshold_scope_pct,
+                rng_bit_enable_pct;
+
+  // Constraint knobs for Boolean fields in ENTROPY_CONTROL register
+  uint          route_software_pct, type_bypass_pct;
+
+  // Constraint knobs for Boolean fields in FW_OV_CONTROL register
+  uint          fw_read_pct, fw_over_pct;
+
+  // Health test-related knobs
+  // Real constraints on sigma ranges (floating point value)
+  real adaptp_sigma_max, adaptp_sigma_min;
+  real markov_sigma_max, markov_sigma_min;
+  real bucket_sigma_max, bucket_sigma_min;
+
+  // Knob to leave thresholds at default, completely disabling them
+  uint          default_ht_thresholds_pct;
+
+  bit           use_invalid_mubi;
+
+  ///////////////////////////////////////////////
+  // Fixed DUT configurations (TODO:RANDOMIZE) //
+  ///////////////////////////////////////////////
+
+  uint fips_window_size, bypass_window_size, boot_mode_retry_limit;
+
+  ///////////////////////
+  // Randomized fields //
+  ///////////////////////
+
+  rand bit                      sw_regupd, me_regwen;
+  rand bit [1:0]                rng_bit_sel;
+
+  rand prim_mubi_pkg::mubi4_t   module_enable, fips_enable, route_software, type_bypass,
+                                entropy_data_reg_enable, rng_bit_enable, ht_threshold_scope;
+
+  rand int                      observe_fifo_thresh;
+
+  rand prim_mubi_pkg::mubi4_t   fw_read_enable, fw_over_enable;
+
+  // Note: These integer-valued fields are used to derive their real-valued counterparts.
+  rand int unsigned adaptp_sigma_i, markov_sigma_i, bucket_sigma_i;
+
+  // Randomized real values: to be managed in post_randomize
+  // Controlled by the knobs <test>_sigma_max, <test>_sigma_min
+  real              adaptp_sigma, markov_sigma, bucket_sigma;
+  rand int          default_ht_thresholds;
+
+  rand invalid_mubi_e   which_invalid_mubi;
+
+  /////////////////
+  // Constraints //
+  /////////////////
+
+  constraint sw_regupd_c {sw_regupd dist {
+      1 :/ sw_regupd_pct,
+      0 :/ (100 - sw_regupd_pct) };}
+
+  constraint me_regwen_c {me_regwen dist {
+      1 :/ me_regwen_pct,
+      0 :/ (100 - me_regwen_pct) };}
+
+  constraint fw_read_enable_c {fw_read_enable dist {
+      prim_mubi_pkg::MuBi4True  :/ fw_read_pct,
+      prim_mubi_pkg::MuBi4False :/ (100 - fw_read_pct) };}
+
+  constraint fw_over_enable_c {fw_over_enable dist {
+      prim_mubi_pkg::MuBi4True  :/ fw_over_pct,
+      prim_mubi_pkg::MuBi4False :/ (100 - fw_over_pct) };}
+
+  constraint module_enable_c {module_enable dist {
+      prim_mubi_pkg::MuBi4True  :/ module_enable_pct,
+      prim_mubi_pkg::MuBi4False :/ (100 - module_enable_pct) };}
+
+  constraint fips_enable_c {fips_enable dist {
+      prim_mubi_pkg::MuBi4True  :/ fips_enable_pct,
+      prim_mubi_pkg::MuBi4False :/ (100 - fips_enable_pct) };}
+
+  constraint route_c {route_software dist {
+      prim_mubi_pkg::MuBi4True  :/ route_software_pct,
+      prim_mubi_pkg::MuBi4False :/ (100 - route_software_pct) };}
+
+  constraint bypass_c {type_bypass dist {
+      prim_mubi_pkg::MuBi4True  :/ type_bypass_pct,
+      prim_mubi_pkg::MuBi4False :/ (100 - type_bypass_pct) };}
+
+  constraint entropy_data_reg_enable_c {entropy_data_reg_enable dist {
+      prim_mubi_pkg::MuBi4True  :/ entropy_data_reg_enable_pct,
+      prim_mubi_pkg::MuBi4False :/ (100 - entropy_data_reg_enable_pct) };}
+
+  constraint rng_bit_enable_c {rng_bit_enable dist {
+      prim_mubi_pkg::MuBi4True  :/ rng_bit_enable_pct,
+      prim_mubi_pkg::MuBi4False :/ (100 - rng_bit_enable_pct) };}
+
+  constraint ht_threshold_scope_c {ht_threshold_scope dist {
+      prim_mubi_pkg::MuBi4True  :/ ht_threshold_scope_pct,
+      prim_mubi_pkg::MuBi4False :/ (100 - ht_threshold_scope_pct)};}
+
+  constraint default_ht_thresholds_c {default_ht_thresholds dist {
+      1 :/ default_ht_thresholds_pct,
+      0 :/ (100 - default_ht_thresholds_pct)};}
+
+  // TODO: Is zero a valid value for this register?
+  // What does the DUT do with a value of zero?
+  constraint observe_fifo_thresh_c {observe_fifo_thresh dist {
+      [1:OBSERVE_FIFO_DEPTH]  :/ 1};}
+
+  ///////////////
+  // Functions //
+  ///////////////
+
+  virtual function string convert2string();
+    string str = "";
+    str = {str, "\n"};
+    str = {str, "\n\t |**************** entropy_src_dut_cfg *****************| \t"};
+
+    str = {
+        str,
+        $sformatf("\n\t |***** module_enable               : %12s *****| \t",
+                  module_enable.name()),
+        $sformatf("\n\t |***** fips_enable                 : %12s *****| \t",
+                  fips_enable.name()),
+        $sformatf("\n\t |***** route_software              : %12s *****| \t",
+                  route_software.name()),
+        $sformatf("\n\t |***** type_bypass                 : %12s *****| \t",
+                  type_bypass.name()),
+        $sformatf("\n\t |***** entropy_data_reg_enable     : %12s *****| \t",
+                  entropy_data_reg_enable.name()),
+        $sformatf("\n\t |***** rng_bit_enable              : %12s *****| \t",
+                  rng_bit_enable.name()),
+        $sformatf("\n\t |***** rng_bit_sel                 : %12d *****| \t",
+                  rng_bit_sel),
+        $sformatf("\n\t |***** fips_window_size            : %12d *****| \t",
+                  fips_window_size),
+        $sformatf("\n\t |***** bypass_window_size          : %12d *****| \t",
+                  bypass_window_size),
+        $sformatf("\n\t |***** boot_mode_retry_limit       : %12d *****| \t",
+                  boot_mode_retry_limit),
+        $sformatf("\n\t |***** fw_read_enable              : %12s *****| \t",
+                  fw_read_enable.name()),
+        $sformatf("\n\t |***** fw_over_enable              : %12s *****| \t",
+                  fw_over_enable.name()),
+        $sformatf("\n\t |***** observe_fifo_threshold      : %12d *****| \t",
+                  observe_fifo_thresh),
+        $sformatf("\n\t |***** adaptp_sigma                : %12.3f *****| \t",
+                  adaptp_sigma),
+        $sformatf("\n\t |***** bucket_sigma                : %12.3f *****| \t",
+                  bucket_sigma),
+        $sformatf("\n\t |***** markov_sigma                : %12.3f *****| \t",
+                  markov_sigma)
+    };
+
+    str = {str, "\n\t |----------------- knobs ------------------------------| \t"};
+
+    str = {
+        str,
+        $sformatf("\n\t |***** fw_read_pct                 : %12d *****| \t",
+                  fw_read_pct),
+        $sformatf("\n\t |***** fw_over_pct                 : %12d *****| \t",
+                  fw_over_pct),
+        $sformatf("\n\t |***** module_enable_pct           : %12d *****| \t",
+                  module_enable_pct),
+        $sformatf("\n\t |***** fips_enable_pct             : %12d *****| \t",
+                  fips_enable_pct),
+        $sformatf("\n\t |***** route_software_pct          : %12d *****| \t",
+                  route_software_pct),
+        $sformatf("\n\t |***** type_bypass_pct             : %12d *****| \t",
+                  type_bypass_pct),
+        $sformatf("\n\t |***** entropy_data_reg_enable_pct : %12d *****| \t",
+                  entropy_data_reg_enable_pct),
+        $sformatf("\n\t |***** rng_bit_enable_pct          : %12d *****| \t",
+                  rng_bit_enable_pct),
+        $sformatf("\n\t |***** adaptp_sigma range          : (%04.2f, %04.2f) *****| \t",
+                  adaptp_sigma_min, adaptp_sigma_max),
+        $sformatf("\n\t |***** bucket_sigma range          : (%04.2f, %04.2f) *****| \t",
+                  bucket_sigma_min, bucket_sigma_max),
+        $sformatf("\n\t |***** markov_sigma range          : (%04.2f, %04.2f) *****| \t",
+                  markov_sigma_min, markov_sigma_max)
+    };
+
+    str = {str, "\n\t |******************************************************| \t"};
+    str = {str, "\n"};
+
+    return str;
+  endfunction
+
+  function void post_randomize();
+    // temporary variable to map randomized integer variables to the range [0, 1]
+    real tmp_r;
+
+    tmp_r = real'(adaptp_sigma_i)/{$bits(adaptp_sigma_i){1'b1}};
+    adaptp_sigma = adaptp_sigma_min + (adaptp_sigma_max - adaptp_sigma_min) * tmp_r;
+
+    tmp_r = real'(markov_sigma_i)/{$bits(markov_sigma_i){1'b1}};
+    markov_sigma = markov_sigma_min + (markov_sigma_max - markov_sigma_min) * tmp_r;
+
+    tmp_r = real'(bucket_sigma_i)/{$bits(bucket_sigma_i){1'b1}};
+    bucket_sigma = bucket_sigma_min + (bucket_sigma_max - bucket_sigma_min) * tmp_r;
+
+    if (use_invalid_mubi) begin
+      prim_mubi_pkg::mubi4_t invalid_mubi_val;
+      invalid_mubi_val = get_rand_mubi4_val(.t_weight(0), .f_weight(0), .other_weight(1));
+
+      case (which_invalid_mubi)
+        invalid_fips_enable: fips_enable = invalid_mubi_val;
+        invalid_entropy_data_reg_enable: entropy_data_reg_enable = invalid_mubi_val;
+        invalid_module_enable: module_enable = invalid_mubi_val;
+        invalid_threshold_scope: ht_threshold_scope = invalid_mubi_val;
+        invalid_rng_bit_enable: rng_bit_enable = invalid_mubi_val;
+        invalid_fw_ov_mode: fw_read_enable = invalid_mubi_val;
+        invalid_fw_ov_entropy_insert: fw_over_enable = invalid_mubi_val;
+        invalid_es_route: route_software = invalid_mubi_val;
+        invalid_es_type: type_bypass = invalid_mubi_val;
+        default: begin
+          `uvm_fatal(`gfn, "Invalid case! (bug in environment)")
+        end
+      endcase // case (which_invalid_mubi)
+    end
+
+  endfunction
+
+endclass

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.core
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.core
@@ -15,6 +15,7 @@ filesets:
       - entropy_src_env_pkg.sv
       - entropy_src_path_if.sv
       - entropy_src_env_cfg.sv: {is_include_file: true}
+      - entropy_src_dut_cfg.sv: {is_include_file: true}
       - entropy_src_env_cov.sv: {is_include_file: true}
       - entropy_src_virtual_sequencer.sv: {is_include_file: true}
       - entropy_src_scoreboard.sv: {is_include_file: true}

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -18,6 +18,9 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   virtual pins_if#(8)   otp_en_es_fw_read_vif;
   virtual pins_if#(8)   otp_en_es_fw_over_vif;
 
+  // Configuration for DUT CSRs (held in a separate object for easy re-randomization)
+  entropy_src_dut_cfg dut_cfg;
+
   // handle to csrng assert interface
   virtual entropy_src_assert_if entropy_src_assert_if;
   // handle to edn path interface
@@ -37,35 +40,17 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // Mean time before "soft" RNG failure (still functions but less entropy per bit)
   realtime soft_mtbf;
 
+  // Mean time between an unexpected configuration update events
+  realtime mean_rand_reconfig_time;
+
   int      seed_cnt;
-
-  uint     fips_window_size, bypass_window_size, boot_mode_retry_limit;
-
-  bit      use_invalid_mubi;
 
   /////////////////////
   // Knobs & Weights //
   /////////////////////
 
-  // Constraint knob for module_enable field
-  uint          module_enable_pct;
-
-  // Constraint knob for SW-accessible REGWEN-related fields
-  uint          me_regwen_pct, sw_regupd_pct;
-
-  // Constraint knobs for Boolean fields in CONF register
-  // (RNG_BIT_SEL is always uniform)
-  uint          fips_enable_pct, entropy_data_reg_enable_pct, ht_threshold_scope_pct,
-                rng_bit_enable_pct;
-
-  // Constraint knobs for Boolean fields in ENTROPY_CONTROL register
-  uint          route_software_pct, type_bypass_pct;
-
-  // Constraint knobs for Boolean fields in FW_OV_CONTROL register
-  uint          fw_read_pct, fw_over_pct;
-
   // Knob to inject entropy even if the DUT is configured to not accept it
-  rand bit      spurious_inject_entropy_pct;
+  uint          spurious_inject_entropy_pct;
 
   // Constraint knobs for OTP-driven inputs
   uint          otp_en_es_fw_read_pct, otp_en_es_fw_over_pct;
@@ -75,40 +60,6 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // (100% corresponds to a full diagnostic chack after every HT alert,
   // If less than 100%, this full-diagnostic is skipped after some alerts)
   uint          do_check_ht_diag_pct;
-
-  // Health test-related knobs
-  // Real constraints on sigma ranges (floating point value)
-  real adaptp_sigma_max, adaptp_sigma_min;
-  real markov_sigma_max, markov_sigma_min;
-  real bucket_sigma_max, bucket_sigma_min;
-
-  // Knob to leave thresholds at default, completely disabling them
-  uint          default_ht_thresholds_pct;
-
-  ///////////////////////
-  // Randomized fields //
-  ///////////////////////
-
-  rand bit                      sw_regupd, me_regwen;
-  rand bit [1:0]                rng_bit_sel;
-
-  rand prim_mubi_pkg::mubi4_t   module_enable, fips_enable, route_software, type_bypass,
-                                entropy_data_reg_enable, rng_bit_enable, ht_threshold_scope;
-
-  rand int                      observe_fifo_thresh;
-
-  rand prim_mubi_pkg::mubi8_t   otp_en_es_fw_read, otp_en_es_fw_over;
-  rand prim_mubi_pkg::mubi4_t   fw_read_enable, fw_over_enable;
-  rand bit                      spurious_inject_entropy;
-
-
-  // Note: These integer-valued fields are used to derive their real-valued counterparts.
-  rand int unsigned adaptp_sigma_i, markov_sigma_i, bucket_sigma_i;
-
-  // Randomized real values: to be managed in post_randomize
-  // Controlled by the knobs <test>_sigma_max, <test>_sigma_min
-  real              adaptp_sigma, markov_sigma, bucket_sigma;
-  rand int          default_ht_thresholds;
 
   /////////////////////////////////////////////////////////////////
   // Implementation-specific constants related to the DUT        //
@@ -125,12 +76,20 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // alert within alert_max_delay clock cycles.
   int      alert_max_delay;
 
+  ///////////////////////
+  // Randomized fields //
+  ///////////////////////
+
+  // OTP variables.
+  rand prim_mubi_pkg::mubi8_t   otp_en_es_fw_read, otp_en_es_fw_over;
+
+  rand bit                      spurious_inject_entropy;
+
   // Random values for interrupt, alert and error tests
   rand fatal_err_e      which_fatal_err;
   rand err_code_e       which_err_code;
   rand which_fifo_e     which_fifo;
   rand which_fifo_err_e which_fifo_err;
-  rand invalid_mubi_e   which_invalid_mubi;
   rand ht_fail_e        which_ht_fail;
   rand cntr_e           which_cntr;
   rand which_ht_e       which_ht;
@@ -146,14 +105,6 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // Constraints //
   /////////////////
 
-  constraint sw_regupd_c {sw_regupd dist {
-      1 :/ sw_regupd_pct,
-      0 :/ (100 - sw_regupd_pct) };}
-
-  constraint me_regwen_c {me_regwen dist {
-      1 :/ me_regwen_pct,
-      0 :/ (100 - me_regwen_pct) };}
-
   constraint otp_en_es_fw_read_c {otp_en_es_fw_read dist {
       prim_mubi_pkg::MuBi8True  :/ otp_en_es_fw_read_pct,
       prim_mubi_pkg::MuBi8False :/ (100 - otp_en_es_fw_read_pct) };}
@@ -162,54 +113,10 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
       prim_mubi_pkg::MuBi8True  :/ otp_en_es_fw_over_pct,
       prim_mubi_pkg::MuBi8False :/ (100 - otp_en_es_fw_over_pct) };}
 
-  constraint fw_read_enable_c {fw_read_enable dist {
-      prim_mubi_pkg::MuBi4True  :/ fw_read_pct,
-      prim_mubi_pkg::MuBi4False :/ (100 - fw_read_pct) };}
-
-  constraint fw_over_enable_c {fw_over_enable dist {
-      prim_mubi_pkg::MuBi4True  :/ fw_over_pct,
-      prim_mubi_pkg::MuBi4False :/ (100 - fw_over_pct) };}
-
   constraint spurious_inject_entropy_c {spurious_inject_entropy dist {
       1                         :/ spurious_inject_entropy_pct,
       0                         :/ (100 - spurious_inject_entropy_pct) };}
 
-  constraint module_enable_c {module_enable dist {
-      prim_mubi_pkg::MuBi4True  :/ module_enable_pct,
-      prim_mubi_pkg::MuBi4False :/ (100 - module_enable_pct) };}
-
-  constraint fips_enable_c {fips_enable dist {
-      prim_mubi_pkg::MuBi4True  :/ fips_enable_pct,
-      prim_mubi_pkg::MuBi4False :/ (100 - fips_enable_pct) };}
-
-  constraint route_c {route_software dist {
-      prim_mubi_pkg::MuBi4True  :/ route_software_pct,
-      prim_mubi_pkg::MuBi4False :/ (100 - route_software_pct) };}
-
-  constraint bypass_c {type_bypass dist {
-      prim_mubi_pkg::MuBi4True  :/ type_bypass_pct,
-      prim_mubi_pkg::MuBi4False :/ (100 - type_bypass_pct) };}
-
-  constraint entropy_data_reg_enable_c {entropy_data_reg_enable dist {
-      prim_mubi_pkg::MuBi4True  :/ entropy_data_reg_enable_pct,
-      prim_mubi_pkg::MuBi4False :/ (100 - entropy_data_reg_enable_pct) };}
-
-  constraint rng_bit_enable_c {rng_bit_enable dist {
-      prim_mubi_pkg::MuBi4True  :/ rng_bit_enable_pct,
-      prim_mubi_pkg::MuBi4False :/ (100 - rng_bit_enable_pct) };}
-
-  constraint ht_threshold_scope_c {ht_threshold_scope dist {
-      prim_mubi_pkg::MuBi4True  :/ ht_threshold_scope_pct,
-      prim_mubi_pkg::MuBi4False :/ (100 - ht_threshold_scope_pct)};}
-
-  constraint default_ht_thresholds_c {default_ht_thresholds dist {
-      1 :/ default_ht_thresholds_pct,
-      0 :/ (100 - default_ht_thresholds_pct)};}
-
-  // TODO: Is zero a valid value for this register?
-  // What does the DUT do with a value of zero?
-  constraint observe_fifo_thresh_c {observe_fifo_thresh dist {
-      [1:OBSERVE_FIFO_DEPTH]  :/ 1};}
 
   ///////////////
   // Functions //
@@ -219,6 +126,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
     list_of_alerts = entropy_src_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_alert";
     super.initialize(csr_base_addr);
+
+    dut_cfg = entropy_src_dut_cfg::type_id::create("dut_cfg");
 
     // create agent config objs
     m_rng_agent_cfg   = push_pull_agent_cfg#(.HostDataWidth(RNG_BUS_WIDTH))::
@@ -252,42 +161,10 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
                   otp_en_es_fw_read.name()),
         $sformatf("\n\t |***** otp_en_es_fw_over           : %12s *****| \t",
                   otp_en_es_fw_over.name()),
-        $sformatf("\n\t |***** module_enable               : %12s *****| \t",
-                  module_enable.name()),
-        $sformatf("\n\t |***** fips_enable                 : %12s *****| \t",
-                  fips_enable.name()),
-        $sformatf("\n\t |***** route_software              : %12s *****| \t",
-                  route_software.name()),
-        $sformatf("\n\t |***** type_bypass                 : %12s *****| \t",
-                  type_bypass.name()),
-        $sformatf("\n\t |***** entropy_data_reg_enable     : %12s *****| \t",
-                  entropy_data_reg_enable.name()),
-        $sformatf("\n\t |***** rng_bit_enable              : %12s *****| \t",
-                  rng_bit_enable.name()),
-        $sformatf("\n\t |***** rng_bit_sel                 : %12d *****| \t",
-                  rng_bit_sel),
-        $sformatf("\n\t |***** fips_window_size            : %12d *****| \t",
-                  fips_window_size),
-        $sformatf("\n\t |***** bypass_window_size          : %12d *****| \t",
-                  bypass_window_size),
-        $sformatf("\n\t |***** boot_mode_retry_limit       : %12d *****| \t",
-                  boot_mode_retry_limit),
-        $sformatf("\n\t |***** fw_read_enable              : %12s *****| \t",
-                  fw_read_enable.name()),
-        $sformatf("\n\t |***** fw_over_enable              : %12s *****| \t",
-                  fw_over_enable.name()),
-        $sformatf("\n\t |***** observe_fifo_threshold      : %12d *****| \t",
-                  observe_fifo_thresh),
         $sformatf("\n\t |***** seed_cnt                    : %12d *****| \t",
                   seed_cnt),
         $sformatf("\n\t |***** sim_duration                : %9.2f ms *****| \t",
-                  sim_duration/1ms),
-        $sformatf("\n\t |***** adaptp_sigma                : %12.3f *****| \t",
-                  adaptp_sigma),
-        $sformatf("\n\t |***** bucket_sigma                : %12.3f *****| \t",
-                  bucket_sigma),
-        $sformatf("\n\t |***** markov_sigma                : %12.3f *****| \t",
-                  markov_sigma)
+                  sim_duration/1ms)
     };
 
     str = {str, "\n\t |----------------- knobs ------------------------------| \t"};
@@ -297,70 +174,19 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
         $sformatf("\n\t |***** otp_en_es_fw_read_pct       : %12d *****| \t",
                   otp_en_es_fw_read_pct),
         $sformatf("\n\t |***** otp_en_es_fw_over_pct       : %12d *****| \t",
-                  otp_en_es_fw_over_pct),
-        $sformatf("\n\t |***** fw_read_pct                 : %12d *****| \t",
-                  fw_read_pct),
-        $sformatf("\n\t |***** fw_over_pct                 : %12d *****| \t",
-                  fw_over_pct),
-        $sformatf("\n\t |***** module_enable_pct           : %12d *****| \t",
-                  module_enable_pct),
-        $sformatf("\n\t |***** fips_enable_pct             : %12d *****| \t",
-                  fips_enable_pct),
-        $sformatf("\n\t |***** route_software_pct          : %12d *****| \t",
-                  route_software_pct),
-        $sformatf("\n\t |***** type_bypass_pct             : %12d *****| \t",
-                  type_bypass_pct),
-        $sformatf("\n\t |***** entropy_data_reg_enable_pct : %12d *****| \t",
-                  entropy_data_reg_enable_pct),
-        $sformatf("\n\t |***** rng_bit_enable_pct          : %12d *****| \t",
-                  rng_bit_enable_pct),
-        $sformatf("\n\t |***** adaptp_sigma range          : (%04.2f, %04.2f) *****| \t",
-                  adaptp_sigma_min, adaptp_sigma_max),
-        $sformatf("\n\t |***** bucket_sigma range          : (%04.2f, %04.2f) *****| \t",
-                  bucket_sigma_min, bucket_sigma_max),
-        $sformatf("\n\t |***** markov_sigma range          : (%04.2f, %04.2f) *****| \t",
-                  markov_sigma_min, markov_sigma_max)
-
+                  otp_en_es_fw_over_pct)
     };
 
     str = {str, "\n\t |******************************************************| \t"};
-    str = {str, "\n"};
+    str = {str, dut_cfg.convert2string()};
+
     return str;
   endfunction
 
-  function void post_randomize();
-    // temporary variable to map randomized integer variables to the range [0, 1]
-    real tmp_r;
-
-    tmp_r = real'(adaptp_sigma_i)/{$bits(adaptp_sigma_i){1'b1}};
-    adaptp_sigma = adaptp_sigma_min + (adaptp_sigma_max - adaptp_sigma_min) * tmp_r;
-
-    tmp_r = real'(markov_sigma_i)/{$bits(markov_sigma_i){1'b1}};
-    markov_sigma = markov_sigma_min + (markov_sigma_max - markov_sigma_min) * tmp_r;
-
-    tmp_r = real'(bucket_sigma_i)/{$bits(bucket_sigma_i){1'b1}};
-    bucket_sigma = bucket_sigma_min + (bucket_sigma_max - bucket_sigma_min) * tmp_r;
-
-    if (use_invalid_mubi) begin
-      prim_mubi_pkg::mubi4_t invalid_mubi_val;
-      invalid_mubi_val = get_rand_mubi4_val(.t_weight(0), .f_weight(0), .other_weight(1));
-
+  function post_randomize();
+    dut_cfg.randomize();
+    if (dut_cfg.use_invalid_mubi) begin
       entropy_src_assert_if.assert_off_alert();
-
-      case (which_invalid_mubi)
-        invalid_fips_enable: fips_enable = invalid_mubi_val;
-        invalid_entropy_data_reg_enable: entropy_data_reg_enable = invalid_mubi_val;
-        invalid_module_enable: module_enable = invalid_mubi_val;
-        invalid_threshold_scope: ht_threshold_scope = invalid_mubi_val;
-        invalid_rng_bit_enable: rng_bit_enable = invalid_mubi_val;
-        invalid_fw_ov_mode: fw_read_enable = invalid_mubi_val;
-        invalid_fw_ov_entropy_insert: fw_over_enable = invalid_mubi_val;
-        invalid_es_route: route_software = invalid_mubi_val;
-        invalid_es_type: type_bypass = invalid_mubi_val;
-        default: begin
-          `uvm_fatal(`gfn, "Invalid case! (bug in environment)")
-        end
-      endcase // case (which_invalid_mubi)
     end
   endfunction
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -169,7 +169,39 @@ package entropy_src_env_pkg;
 
   endfunction
 
+  // Determine a random failure time according to an exponential distribution with
+  // mean failure time mtbf.
+  //
+  // The exponential distribution is appropriate for any process where the instantaneous likelihood
+  // of failure is the same regardless of how long the device has been active.  For example,
+  // if the MTBF is 1s, then the probability of failing in any particular 1 ns period is 1e-9.
+  //
+  // For more information about the exponential distribution see (for example):
+  // https://en.wikipedia.org/wiki/Exponential_distribution
+
+  function automatic realtime randomize_failure_time(realtime mtbf);
+    // Random non-zero integer
+    int      rand_i;
+    // Uniformly distributed random float in range (0, 1].
+    // 0 is not included in this range, but 1 is.
+    real     rand_r;
+    realtime now, random_fail_time;
+
+    if (!std::randomize(rand_i) with {rand_i > 0;}) begin
+      return -1;
+    end
+
+    rand_r = real'(rand_i)/{$bits(rand_i){1'b1}};
+
+    now = $realtime();
+
+    random_fail_time = now - $ln(rand_r) * mtbf;
+
+    return random_fail_time;
+  endfunction // randomize_failure_time
+
   // package sources
+  `include "entropy_src_dut_cfg.sv"
   `include "entropy_src_env_cfg.sv"
   `include "entropy_src_env_cov.sv"
   `include "entropy_src_virtual_sequencer.sv"

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_alert_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_alert_vseq.sv
@@ -189,17 +189,17 @@ class entropy_src_alert_vseq extends entropy_src_base_vseq;
     uvm_reg_field fld;
 
     // Set the fields to invalid values
-    ral.conf.threshold_scope.set(cfg.ht_threshold_scope);
+    ral.conf.threshold_scope.set(cfg.dut_cfg.ht_threshold_scope);
     csr_update(.csr(ral.conf));
-    ral.fw_ov_control.fw_ov_mode.set(cfg.fw_read_enable);
-    ral.fw_ov_control.fw_ov_entropy_insert.set(cfg.fw_over_enable);
+    ral.fw_ov_control.fw_ov_mode.set(cfg.dut_cfg.fw_read_enable);
+    ral.fw_ov_control.fw_ov_entropy_insert.set(cfg.dut_cfg.fw_over_enable);
     csr_update(.csr(ral.fw_ov_control));
 
     cfg.clk_rst_vif.wait_clks(100);
 
     // Check the recov_alert_sts register
     reg_name = "recov_alert_sts";
-    fld_name = cfg.which_invalid_mubi.name();
+    fld_name = cfg.dut_cfg.which_invalid_mubi.name();
 
     first_index = find_index("_", fld_name, "first");
 

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -94,46 +94,64 @@ class entropy_src_base_vseq extends cip_base_vseq #(
   endtask
 
   // setup basic entropy_src features
-  virtual task entropy_src_init();
+  virtual task entropy_src_init(entropy_src_dut_cfg newcfg=cfg.dut_cfg);
+
+    #50us;
+
     // Controls
-    ral.entropy_control.es_type.set(cfg.type_bypass);
-    ral.entropy_control.es_route.set(cfg.route_software);
+    ral.entropy_control.es_type.set(newcfg.type_bypass);
+    ral.entropy_control.es_route.set(newcfg.route_software);
     csr_update(.csr(ral.entropy_control));
 
     // Thresholds managed in derived vseq classes
 
-    // FW_OV registers
-    ral.fw_ov_control.fw_ov_mode.set(cfg.fw_read_enable);
-    ral.fw_ov_control.fw_ov_entropy_insert.set(cfg.fw_over_enable);
-    csr_update(.csr(ral.fw_ov_control));
+    #50us;
 
-    ral.observe_fifo_thresh.observe_fifo_thresh.set(cfg.observe_fifo_thresh);
+
+    // FW_OV registers
+    ral.fw_ov_control.fw_ov_mode.set(newcfg.fw_read_enable);
+    ral.fw_ov_control.fw_ov_entropy_insert.set(newcfg.fw_over_enable);
+    csr_update(.csr(ral.fw_ov_control));
+    #50us;
+
+    ral.observe_fifo_thresh.observe_fifo_thresh.set(newcfg.observe_fifo_thresh);
     csr_update(ral.observe_fifo_thresh);
 
+    #50us;
+
     // Enables (should be done last)
-    ral.conf.fips_enable.set(cfg.fips_enable);
-    ral.conf.entropy_data_reg_enable.set(cfg.entropy_data_reg_enable);
-    ral.conf.rng_bit_enable.set(cfg.rng_bit_enable);
-    ral.conf.rng_bit_sel.set(cfg.rng_bit_sel);
-    ral.conf.threshold_scope.set(cfg.ht_threshold_scope);
+    ral.conf.fips_enable.set(newcfg.fips_enable);
+    ral.conf.entropy_data_reg_enable.set(newcfg.entropy_data_reg_enable);
+    ral.conf.rng_bit_enable.set(newcfg.rng_bit_enable);
+    ral.conf.rng_bit_sel.set(newcfg.rng_bit_sel);
+    ral.conf.threshold_scope.set(newcfg.ht_threshold_scope);
     csr_update(.csr(ral.conf));
+
+    #50us;
 
     // Register write enable lock is on be default
     // Setting this to zero will lock future writes
-    csr_wr(.ptr(ral.sw_regupd), .value(cfg.sw_regupd));
+    csr_wr(.ptr(ral.sw_regupd), .value(newcfg.sw_regupd));
+
+    #50us;
+
 
     // Module_enables (should be done last)
-    ral.module_enable.set(cfg.module_enable);
+    ral.module_enable.set(newcfg.module_enable);
     csr_update(.csr(ral.module_enable));
 
-    ral.me_regwen.set(cfg.me_regwen);
+    #50us;
+
+    ral.me_regwen.set(newcfg.me_regwen);
     csr_update(.csr(ral.me_regwen));
+
+    #50us;
 
     if (do_interrupt) begin
       ral.intr_enable.set(en_intr);
       csr_update(ral.intr_enable);
     end
-  endtask
+  endtask // entropy_src_init
 
   typedef enum int {
     TlSrcEntropyDataReg,

--- a/hw/ip/entropy_src/dv/tests/entropy_src_alert_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_alert_test.sv
@@ -10,16 +10,16 @@ class entropy_src_alert_test extends entropy_src_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.en_scb                      = 0;
-    cfg.use_invalid_mubi            = 1;
-    cfg.route_software_pct          = 0;
-    cfg.entropy_data_reg_enable_pct = 100;
-    cfg.fw_read_pct                 = 100;
-    cfg.fw_over_pct                 = 100;
-    cfg.module_enable_pct           = 0;
-    cfg.fips_enable_pct             = 100;
-    cfg.sw_regupd_pct               = 100;
-    cfg.type_bypass_pct             = 0;
+    cfg.en_scb                              = 0;
+    cfg.dut_cfg.use_invalid_mubi            = 1;
+    cfg.dut_cfg.route_software_pct          = 0;
+    cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
+    cfg.dut_cfg.fw_read_pct                 = 100;
+    cfg.dut_cfg.fw_over_pct                 = 100;
+    cfg.dut_cfg.module_enable_pct           = 0;
+    cfg.dut_cfg.fips_enable_pct             = 100;
+    cfg.dut_cfg.sw_regupd_pct               = 100;
+    cfg.dut_cfg.type_bypass_pct             = 0;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -28,12 +28,12 @@ class entropy_src_base_test extends cip_base_test #(
 
   virtual function void configure_env();
     // TODO: randomize seed_cnt
-    cfg.seed_cnt               = 1;
-    cfg.otp_en_es_fw_read_pct  = 100;
-    cfg.otp_en_es_fw_over_pct  = 100;
-    cfg.me_regwen_pct          = 100;
-    cfg.module_enable_pct      = 100;
-    cfg.type_bypass_pct        = 100;
+    cfg.seed_cnt                  = 1;
+    cfg.otp_en_es_fw_read_pct     = 100;
+    cfg.otp_en_es_fw_over_pct     = 100;
+    cfg.dut_cfg.me_regwen_pct     = 100;
+    cfg.dut_cfg.module_enable_pct = 100;
+    cfg.dut_cfg.type_bypass_pct   = 100;
   endfunction
 
 endclass : entropy_src_base_test

--- a/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
@@ -10,43 +10,43 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.en_scb                      = 1;
-    cfg.alert_max_delay             = 5;
+    cfg.en_scb                              = 1;
+    cfg.alert_max_delay                     = 5;
 
-    cfg.fips_window_size            = 2048;
-    cfg.bypass_window_size          = 384;
-    cfg.boot_mode_retry_limit       = 10;
-    cfg.sim_duration                = 10ms;
-    cfg.hard_mtbf                   = 100s;
-    cfg.soft_mtbf                   = 7500us;
+    cfg.dut_cfg.fips_window_size            = 2048;
+    cfg.dut_cfg.bypass_window_size          = 384;
+    cfg.dut_cfg.boot_mode_retry_limit       = 10;
+    cfg.sim_duration                        = 10ms;
+    cfg.hard_mtbf                           = 100s;
+    cfg.soft_mtbf                           = 7500us;
     // Apply truly impossible standards, to confirm that HT's don't matter here
-    cfg.adaptp_sigma_min            = 0.0;
-    cfg.adaptp_sigma_max            = 0.0;
-    cfg.bucket_sigma_min            = 0.0;
-    cfg.bucket_sigma_max            = 0.0;
-    cfg.markov_sigma_min            = 0.0;
-    cfg.markov_sigma_max            = 0.0;
+    cfg.dut_cfg.adaptp_sigma_min            = 0.0;
+    cfg.dut_cfg.adaptp_sigma_max            = 0.0;
+    cfg.dut_cfg.bucket_sigma_min            = 0.0;
+    cfg.dut_cfg.bucket_sigma_max            = 0.0;
+    cfg.dut_cfg.markov_sigma_min            = 0.0;
+    cfg.dut_cfg.markov_sigma_max            = 0.0;
 
     // TODO: Randomize (Ideally @50%)
-    cfg.entropy_data_reg_enable_pct = 100;
+    cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
     // TODO: Randomize@50% (requires vseq update)
-    cfg.route_software_pct          = 0;
+    cfg.dut_cfg.route_software_pct          = 0;
     // TODO: Randomize@50%
-    cfg.type_bypass_pct             = 0;
-    cfg.default_ht_thresholds_pct   = 100;
+    cfg.dut_cfg.type_bypass_pct             = 0;
+    cfg.dut_cfg.default_ht_thresholds_pct   = 100;
 
     // Always read data from the Observe FIFO
-    cfg.fw_read_pct                 = 100;
-    cfg.fw_over_pct                 = 100;
+    cfg.dut_cfg.fw_read_pct                 = 100;
+    cfg.dut_cfg.fw_over_pct                 = 100;
     // Spurious injection parameter has no meaning here.
     cfg.spurious_inject_entropy_pct = 50;
 
     // RNG bit Enable shouldn't matter for this test. Randomize anyway
-    cfg.rng_bit_enable_pct          = 50;
+    cfg.dut_cfg.rng_bit_enable_pct          = 50;
 
     // TODO: Randomize@50%
-    cfg.fips_enable_pct             = 100;
-    cfg.module_enable_pct           = 100;
+    cfg.dut_cfg.fips_enable_pct             = 100;
+    cfg.dut_cfg.module_enable_pct           = 100;
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction

--- a/hw/ip/entropy_src/dv/tests/entropy_src_intr_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_intr_test.sv
@@ -10,17 +10,17 @@ class entropy_src_intr_test extends entropy_src_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.en_scb                      = 0;
-    cfg.use_invalid_mubi            = 0;
-    cfg.route_software_pct          = 100;
-    cfg.entropy_data_reg_enable_pct = 100;
-    cfg.route_software_pct          = 100;
-    cfg.entropy_data_reg_enable_pct = 100;
-    cfg.fw_read_pct                 = 100;
-    cfg.fw_over_pct                 = 0;
-    cfg.module_enable_pct           = 0;
-    cfg.fips_enable_pct             = 100;
-    cfg.sw_regupd_pct               = 100;
+    cfg.en_scb                              = 0;
+    cfg.dut_cfg.use_invalid_mubi            = 0;
+    cfg.dut_cfg.route_software_pct          = 100;
+    cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
+    cfg.dut_cfg.route_software_pct          = 100;
+    cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
+    cfg.dut_cfg.fw_read_pct                 = 100;
+    cfg.dut_cfg.fw_over_pct                 = 0;
+    cfg.dut_cfg.module_enable_pct           = 0;
+    cfg.dut_cfg.fips_enable_pct             = 100;
+    cfg.dut_cfg.sw_regupd_pct               = 100;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -13,42 +13,42 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.en_scb                      = 1;
     cfg.alert_max_delay             = 5;
 
-    cfg.fips_window_size            = 2048;
-    cfg.bypass_window_size          = 384;
-    cfg.boot_mode_retry_limit       = 10;
+    cfg.dut_cfg.fips_window_size            = 2048;
+    cfg.dut_cfg.bypass_window_size          = 384;
+    cfg.dut_cfg.boot_mode_retry_limit       = 10;
     cfg.sim_duration                = 20ms;
     cfg.hard_mtbf                   = 100s;
+    cfg.mean_rand_reconfig_time     = 1ms;
+
     cfg.soft_mtbf                   = 7500us;
     // Apply standards ranging from strict to relaxed
-    cfg.adaptp_sigma_min            = 1.0;
-    cfg.adaptp_sigma_max            = 6.0;
-    cfg.bucket_sigma_min            = 1.0;
-    cfg.bucket_sigma_max            = 6.0;
-    cfg.markov_sigma_min            = 1.0;
-    cfg.markov_sigma_max            = 6.0;
+    cfg.dut_cfg.adaptp_sigma_min            = 1.0;
+    cfg.dut_cfg.adaptp_sigma_max            = 6.0;
+    cfg.dut_cfg.bucket_sigma_min            = 1.0;
+    cfg.dut_cfg.bucket_sigma_max            = 6.0;
+    cfg.dut_cfg.markov_sigma_min            = 1.0;
+    cfg.dut_cfg.markov_sigma_max            = 6.0;
 
-    // TODO: Randomize
-    // (Also requires some scoreboarding checks)
-    cfg.sw_regupd_pct               = 100;
+    cfg.dut_cfg.sw_regupd_pct               = 50;
 
-    cfg.entropy_data_reg_enable_pct = 50;
-    cfg.route_software_pct          = 50;
+    cfg.dut_cfg.entropy_data_reg_enable_pct = 50;
+    cfg.dut_cfg.route_software_pct          = 50;
     cfg.otp_en_es_fw_read_pct       = 50;
     cfg.otp_en_es_fw_over_pct       = 50;
 
-    cfg.type_bypass_pct             = 50;
-    cfg.default_ht_thresholds_pct   = 100;
+    cfg.dut_cfg.type_bypass_pct             = 50;
+    cfg.dut_cfg.default_ht_thresholds_pct   = 100;
 
     // Sometimes read data from the Observe FIFO (but always take entropy from RNG)
-    cfg.fw_read_pct                 = 50;
-    cfg.fw_over_pct                 = 0;
+    cfg.dut_cfg.fw_read_pct                 = 50;
+    cfg.dut_cfg.fw_over_pct                 = 0;
     // Sometimes inject data, even if not configured
     cfg.spurious_inject_entropy_pct = 50;
 
-    cfg.rng_bit_enable_pct          = 50;
+    cfg.dut_cfg.rng_bit_enable_pct          = 50;
 
-    cfg.fips_enable_pct             = 50;
-    cfg.module_enable_pct           = 100;
+    cfg.dut_cfg.fips_enable_pct             = 50;
+    cfg.dut_cfg.module_enable_pct           = 100;
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)

--- a/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
@@ -10,15 +10,15 @@ class entropy_src_smoke_test extends entropy_src_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.en_scb                      = 1;
-    cfg.fips_window_size            = 2048;
-    cfg.bypass_window_size          = 384;
-    cfg.seed_cnt                    = 1;
-    cfg.boot_mode_retry_limit       = 10;
-    cfg.route_software_pct          = 100;
-    cfg.entropy_data_reg_enable_pct = 100;
-    cfg.ht_threshold_scope_pct      = 100;
-    cfg.use_invalid_mubi            = 0;
+    cfg.en_scb                              = 1;
+    cfg.seed_cnt                            = 1;
+    cfg.dut_cfg.fips_window_size            = 2048;
+    cfg.dut_cfg.bypass_window_size          = 384;
+    cfg.dut_cfg.boot_mode_retry_limit       = 10;
+    cfg.dut_cfg.route_software_pct          = 100;
+    cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
+    cfg.dut_cfg.ht_threshold_scope_pct      = 100;
+    cfg.dut_cfg.use_invalid_mubi            = 0;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_stress_all_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_stress_all_test.sv
@@ -10,13 +10,13 @@ class entropy_src_stress_all_test extends entropy_src_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.en_scb                      = 1;
-    cfg.fips_window_size            = 2048;
-    cfg.bypass_window_size          = 384;
-    cfg.seed_cnt                    = 1;
-    cfg.boot_mode_retry_limit       = 10;
-    cfg.route_software_pct          = 100;
-    cfg.entropy_data_reg_enable_pct = 100;
+    cfg.en_scb                              = 1;
+    cfg.dut_cfg.fips_window_size            = 2048;
+    cfg.dut_cfg.bypass_window_size          = 384;
+    cfg.seed_cnt                            = 1;
+    cfg.dut_cfg.boot_mode_retry_limit       = 10;
+    cfg.dut_cfg.route_software_pct          = 100;
+    cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 


### PR DESCRIPTION
- entropy_src_rng_vseq now randomly reconfigures the DUT while it is
  enabled or while SW_REGUPD is zero.  Such events should have no
  impact on the DUT in these states.
  - Adds a new timing parameter, mean_rand_reconfig_time
    to control the average frequency of these random events.
    Like the hard_mtbf, and soft_mtbf parameters, these
    events occur with an exponential distribution, meaning
    that on average the probability of such an update occuring
    in a period of duration dt is:
    P(t)dt = dt/mean_rand_reconfig_time
  - These update events are also scheduled to NOT happen
    during other maintaince events (DUT resets, FIFO reads,
    etc).
- Updates the Scoreboard to properly support this feature
- Adds support in the rng and base vseqs for generating new
  configurations, subject to the same original constraints.
- In order to support the randomization of DUT configurations
  a new entropy_src_dut_cfg class is added to separate the
  config fields that describe DUT configs from more generic
  environment or sequence configurations.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>