### PR TITLE
[ci,sw/silicon_creator] Temporarily disable keymgr_functest on fpga

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -217,6 +217,10 @@ cc_test(
 opentitan_functest(
     name = "keymgr_functest",
     srcs = ["keymgr_functest.c"],
+    cw310 = cw310_params(
+        #TODO: Remove this broken tag when #13045 is merged
+        tags = ["broken"],
+    ),
     deps = [
         ":keymgr",
         ":lifecycle",


### PR DESCRIPTION
Merging #12912 broke
//sw/device/silicon_creator/lib/drivers:keymgr_functest_fpga_cw310. This
commit temporarily disables that test until #13045 can fix it.

Signed-off-by: Miles Dai <milesdai@google.com>