### PR TITLE
[ci] re-add mask_rom_epmp_test_sim_verilator

### DIFF
--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -28,4 +28,5 @@ xargs ci/bazelisk.sh test \
     //sw/device/silicon_creator/lib/drivers:retention_sram_functest_sim_verilator \
     //sw/device/silicon_creator/lib/drivers:alert_functest_sim_verilator \
     //sw/device/silicon_creator/lib/drivers:watchdog_functest_sim_verilator \
-    //sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator
+    //sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator \
+    //sw/device/silicon_creator/mask_rom:mask_rom_epmp_test_sim_verilator


### PR DESCRIPTION
Looks like this may have been fixed this morning, so let's run the test in CI so it doesn't get broken again 

Signed-off-by: Drew Macrae <drewmacrae@google.com>