### PR TITLE
[dv/alert_handler] Add common sec_cm test for alert_handler

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -520,6 +520,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   virtual task run_alert_test_vseq(int num_times = 1);
     int num_alerts = cfg.list_of_alerts.size();
     dv_base_reg alert_test_csr = ral.get_dv_base_reg_by_name("alert_test");
+    `DV_CHECK_FATAL(num_alerts > 0, "Please declare `list_of_alerts` under cfg!")
 
     for (int trans = 1; trans <= num_times; trans++) begin
       `uvm_info(`gfn, $sformatf("Running alert test iteration %0d/%0d", trans, num_times), UVM_LOW)

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
@@ -3,9 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 virtual task run_sec_cm_fi_vseq(int num_times = 1);
-  `DV_CHECK_FATAL(cfg.sec_cm_alert_name inside {cfg.list_of_alerts},
-                  $sformatf("sec_cm_alert_name (%s) is not inside %p",
-                            cfg.sec_cm_alert_name, cfg.list_of_alerts))
+  // Adding an exception for alert_handler who does not have list_of_alerts.
+  if (cfg.list_of_alerts.size()) begin
+    `DV_CHECK_FATAL(cfg.sec_cm_alert_name inside {cfg.list_of_alerts},
+                    $sformatf("sec_cm_alert_name (%s) is not inside %p",
+                              cfg.sec_cm_alert_name, cfg.list_of_alerts))
+  end
 
   pre_run_sec_cm_fi_vseq();
   for (int trans = 1; trans <= num_times; trans++) begin

--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -27,11 +27,14 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["alert_handler_bind"]
+  sim_tops: ["alert_handler_bind",
+             "sec_cm_prim_count_bind",
+             "sec_cm_prim_double_lfsr_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -58,4 +58,19 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
     end
   endfunction
 
+  virtual task check_sec_cm_fi_resp(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
+    if (!uvm_re_match("tb.dut.u_ping_timer.*", if_proxy.path)) begin
+      // TODO:  check local alert regarding ping timeout triggered.
+    end else begin
+      foreach (cfg.esc_device_cfg[i]) begin
+        `DV_CHECK_EQ(cfg.esc_device_cfg[i].vif.esc_tx.esc_p, 1,
+                     $sformatf("escalation protocol_%0d is not set", i));
+      end
+    end
+  endtask
+
+  virtual task pre_run_sec_cm_fi_vseq();
+    // Enable ping timer to get ping counter error
+    csr_wr(ral.ping_timer_en_shadowed, 1);
+  endtask : pre_run_sec_cm_fi_vseq
 endclass

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -27,11 +27,14 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["alert_handler_bind"]
+  sim_tops: ["alert_handler_bind",
+             "sec_cm_prim_count_bind",
+             "sec_cm_prim_double_lfsr_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -58,4 +58,19 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
     end
   endfunction
 
+  virtual task check_sec_cm_fi_resp(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
+    if (!uvm_re_match("tb.dut.u_ping_timer.*", if_proxy.path)) begin
+      // TODO:  check local alert regarding ping timeout triggered.
+    end else begin
+      foreach (cfg.esc_device_cfg[i]) begin
+        `DV_CHECK_EQ(cfg.esc_device_cfg[i].vif.esc_tx.esc_p, 1,
+                     $sformatf("escalation protocol_%0d is not set", i));
+      end
+    end
+  endtask
+
+  virtual task pre_run_sec_cm_fi_vseq();
+    // Enable ping timer to get ping counter error
+    csr_wr(ral.ping_timer_en_shadowed, 1);
+  endtask : pre_run_sec_cm_fi_vseq
 endclass


### PR DESCRIPTION
Alert_handler does not have alerts, so sec_cm violation will directly
fires escalations or causes a local alert.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>