### PR TITLE
[aes/rtl] Enhance alert output in AES FSM

### DIFF
--- a/hw/ip/aes/rtl/aes_cipher_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm.sv
@@ -464,6 +464,7 @@ module aes_cipher_control_fsm import aes_pkg::*;
       // We should never get here. If we do (e.g. via a malicious glitch), error out immediately.
       default: begin
         aes_cipher_ctrl_ns = ERROR;
+        alert_o = 1'b1;
       end
     endcase
 

--- a/hw/ip/aes/rtl/aes_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm.sv
@@ -647,6 +647,7 @@ module aes_control_fsm
       // We should never get here. If we do (e.g. via a malicious glitch), error out immediately.
       default: begin
         aes_ctrl_ns = ERROR;
+        alert_o = 1'b1;
       end
     endcase
 

--- a/hw/ip/aes/rtl/aes_ctr_fsm.sv
+++ b/hw/ip/aes/rtl/aes_ctr_fsm.sv
@@ -110,6 +110,7 @@ module aes_ctr_fsm import aes_pkg::*;
       // glitch), error out immediately.
       default: begin
         aes_ctr_ns = ERROR;
+        alert_o = 1'b1;
       end
     endcase
 


### PR DESCRIPTION
Follow the change in PR #12898, we think it is better to immediately
output error signal when the state goes to `default` unknown state.
The reason is because if the attacker continues to drive the FSM to
unknown states, the alert actually won't fire.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>