### PR TITLE
[dv/alert_handler] disable assertions in sec_cm tests

### DIFF
--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -33,6 +33,7 @@
 
   // Add additional tops for simulation.
   sim_tops: ["alert_handler_bind",
+             "sec_cm_prim_sparse_fsm_flop_bind",
              "sec_cm_prim_count_bind",
              "sec_cm_prim_double_lfsr_bind"]
 

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -13,6 +13,7 @@ package alert_handler_env_pkg;
   import dv_base_reg_pkg::*;
   import cip_base_pkg::*;
   import alert_handler_ral_pkg::*;
+  import sec_cm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -58,7 +58,7 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
     end
   endfunction
 
-  virtual task check_sec_cm_fi_resp(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
+  virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
     if (!uvm_re_match("tb.dut.u_ping_timer.*", if_proxy.path)) begin
       // TODO:  check local alert regarding ping timeout triggered.
     end else begin
@@ -70,7 +70,21 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
   endtask
 
   virtual task pre_run_sec_cm_fi_vseq();
+    // Disable prim_sparse_fsm assertions.
+    $assertoff(0, "tb.dut.gen_classes[0].u_esc_timer.CheckEn_A");
+    $assertoff(0, "tb.dut.gen_classes[1].u_esc_timer.CheckEn_A");
+    $assertoff(0, "tb.dut.gen_classes[2].u_esc_timer.CheckEn_A");
+    $assertoff(0, "tb.dut.gen_classes[3].u_esc_timer.CheckEn_A");
     // Enable ping timer to get ping counter error
     csr_wr(ral.ping_timer_en_shadowed, 1);
   endtask : pre_run_sec_cm_fi_vseq
+
+  virtual task post_run_sec_cm_fi_vseq();
+    // Enable prim_sparse_fsm assertions.
+    $asserton(0, "tb.dut.gen_classes[0].u_esc_timer.CheckEn_A");
+    $asserton(0, "tb.dut.gen_classes[1].u_esc_timer.CheckEn_A");
+    $asserton(0, "tb.dut.gen_classes[2].u_esc_timer.CheckEn_A");
+    $asserton(0, "tb.dut.gen_classes[3].u_esc_timer.CheckEn_A");
+  endtask : post_run_sec_cm_fi_vseq
+
 endclass

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -33,6 +33,7 @@
 
   // Add additional tops for simulation.
   sim_tops: ["alert_handler_bind",
+             "sec_cm_prim_sparse_fsm_flop_bind",
              "sec_cm_prim_count_bind",
              "sec_cm_prim_double_lfsr_bind"]
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -13,6 +13,7 @@ package alert_handler_env_pkg;
   import dv_base_reg_pkg::*;
   import cip_base_pkg::*;
   import alert_handler_ral_pkg::*;
+  import sec_cm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -58,7 +58,7 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
     end
   endfunction
 
-  virtual task check_sec_cm_fi_resp(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
+  virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
     if (!uvm_re_match("tb.dut.u_ping_timer.*", if_proxy.path)) begin
       // TODO:  check local alert regarding ping timeout triggered.
     end else begin
@@ -70,7 +70,21 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
   endtask
 
   virtual task pre_run_sec_cm_fi_vseq();
+    // Disable prim_sparse_fsm assertions.
+    $assertoff(0, "tb.dut.gen_classes[0].u_esc_timer.CheckEn_A");
+    $assertoff(0, "tb.dut.gen_classes[1].u_esc_timer.CheckEn_A");
+    $assertoff(0, "tb.dut.gen_classes[2].u_esc_timer.CheckEn_A");
+    $assertoff(0, "tb.dut.gen_classes[3].u_esc_timer.CheckEn_A");
     // Enable ping timer to get ping counter error
     csr_wr(ral.ping_timer_en_shadowed, 1);
   endtask : pre_run_sec_cm_fi_vseq
+
+  virtual task post_run_sec_cm_fi_vseq();
+    // Enable prim_sparse_fsm assertions.
+    $asserton(0, "tb.dut.gen_classes[0].u_esc_timer.CheckEn_A");
+    $asserton(0, "tb.dut.gen_classes[1].u_esc_timer.CheckEn_A");
+    $asserton(0, "tb.dut.gen_classes[2].u_esc_timer.CheckEn_A");
+    $asserton(0, "tb.dut.gen_classes[3].u_esc_timer.CheckEn_A");
+  endtask : post_run_sec_cm_fi_vseq
+
 endclass


### PR DESCRIPTION
This PR disables assertions related to prim_sparse_fsm. Because when
doing random injection, these assertion checks are not valid anymore.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>