### PR TITLE
[sw/silicon_creator] Watchdog updates

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/watchdog.h
+++ b/sw/device/silicon_creator/lib/drivers/watchdog.h
@@ -36,7 +36,6 @@ enum {
  * OTP is less than this value.
  */
 enum {
-  // TODO(#10808): Determine this value.
   kWatchdogMinThreshold = 1,
 };
 

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -334,7 +334,6 @@ void mask_rom_main(void) {
   hardened_bool_t bootstrap_req = bootstrap_requested();
   if (launder32(bootstrap_req) == kHardenedBoolTrue) {
     HARDENED_CHECK_EQ(bootstrap_req, kHardenedBoolTrue);
-    // TODO(lowRISC/opentitan#10631): decide on watchdog strategy for bootstrap.
     watchdog_disable();
     shutdown_finalize(bootstrap());
   }

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -143,10 +143,11 @@ _mask_rom_start_boot:
   sw t1, PWRMGR_CFG_CDC_SYNC_REG_OFFSET(t0)
 
   // Setup the watchdog bite timer in order to reset the chip if the ROM stalls.
+  // The value below corresponds to 1 s for a clock frequency of 200 kHz.
   // Since interrupts are disabled the watchdog bark will have no effect
   // therefore the bark threshold is just set to the highest possible value.
   li t0, TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR
-  li t1, 0xffffffff // TODO(lowRISC/opentitan#10215): reduce bite timer value.
+  li t1, 0x30d40
   sw t1, AON_TIMER_WDOG_BITE_THOLD_REG_OFFSET(t0)
   li t1, 0xffffffff
   sw t1, AON_TIMER_WDOG_BARK_THOLD_REG_OFFSET(t0)


### PR DESCRIPTION
This PR resolves the following issues:

#10808: Keep `kWatchdogMinThreshold` as `1`, i.e. `0` disables the watchdog.
#10631, #12387: Keep the watchdog disabled during bootstrap. Watchdog will be enabled after the reset that concludes the bootstrap.
#10215: Set the bite threshold to `200_000` (`0x30d40`) in `mask_rom_start.S`. This corresponds to a duration of 1 s for a clock frequency of 200 kHz.