### PR TITLE
[dvsim] issue `bazel clean` before `bazel build`

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -97,10 +97,11 @@ ifneq (${sw_images},)
 				bazel_opts+=" --distdir=$${BAZEL_DISTDIR} --repository_cache=$${BAZEL_CACHE}"; \
 				bazel_cmd="bazel"; \
 			fi; \
+			$${bazel_cmd} clean; \
 			$${bazel_cmd} build $${bazel_opts} $${bazel_label}; \
 			find -L $$($${bazel_cmd} info output_path)/ \
 				-type f -name "$$(basename $${image})*" | \
-				xargs -I % cp % $${target_dir}; \
+				xargs -I % install -C -m 777 % $${target_dir}; \
 		fi; \
 	done;
 endif


### PR DESCRIPTION
The ralgen.py script is using relative paths to find the topgen.py
script. This caused issues when migrating dvsim.py to use bazel over
meson, specifically two consecutive invocations of dvsim.py without a
bazel clean in between seemed to cause the topgen.py not to be
found.

PR #13071 tried to fix this, but had to be reverted in #13088 due to
issues with the dvsim.py scratch directory being outside the REPO_TOP.
Instead this updates the sim.mk file to always issue a `bazel clean`
before the `bazel build` which should also fix the issue #13071 tried to
fix.

Signed-off-by: Timothy Trippel <ttrippel@google.com>