### PR TITLE
[cdc] Alert Handler PING/ACK waivers

### DIFF
--- a/hw/top_earlgrey/cdc/cdc_waivers.alert_handler.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.alert_handler.tcl
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verix CDC waiver file
+# Expression:
+#  ControlSignal==""
+#  ReconSignal==""
+#  MultiClockDomains=="IO_DIV2_CLK::IO_DIV4_CLK"
+
+set_rule_status -rule {W_CNTL} -status {Waived} -expression {(Signal=~"*u_alert_handler.gen_alerts*u_secure_anchor_flop*") && (ReceivingFlop=~"*u_*alert_sender*.u_decode_ack*")} -comment {Alert ACK remains high until alert sender acked}
+set_rule_status -rule {W_CNTL} -status {Waived} -expression {(Signal=~"*u_alert_handler.gen_alerts*u_secure_anchor_flop*") && (ReceivingFlop=~"*u_*alert_sender*.u_decode_ping*")} -comment {Alert PING remains high until alert sender acked}

--- a/hw/top_earlgrey/cdc/cdc_waivers.lc_ctrl.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.lc_ctrl.tcl
@@ -14,3 +14,6 @@
 set_rule_status -rule {W_FANOUT} -status {Waived} \
   -expression {(Driver =~ "*u_lc_ctrl*.u_prim_lc_sender_escalate_en*")} \
   -comment {No Reconvergence issue. Each IP handles Escalate En individually}
+
+# lc_sender output (to be changed once in a power up)
+set_rule_status -rule {W_CNTL} -status {Waived} -expression {((Signal=~"*u_lc_ctrl.*.u_prim_lc_sender_*_en.gen_flops*") || (Signal=~"*u_lc_ctrl.*.u_prim_lc_sender_*rma_req*.gen_flops*")) && (ReceivingFlop=~"*u_prim_flop_2sync*")} -comment {LC EN is one-time change during a power up. Slow to fast clock error can be ignored}

--- a/hw/top_earlgrey/cdc/cdc_waivers.spi_device.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.spi_device.tcl
@@ -176,3 +176,9 @@ set_rule_status -rule {W_DATA} -status {Waived} \
       (ReceivingFlop=~"*u_spi_device.u_fwmode.u_rx_fifo.fifo_rptr*") ) && \
     (MultiClockDomains=~"IO_DIV4_CLK::*SPI_DEV_IN_CLK,SPI_DEV_PASSTHRU_IN_CLK")} \
   -comment {?xf_ctrl sits in DIV4, due to clock mux while Generic is not active, tool confused}
+
+# Waive W_G_CLK_GLITCH: When SPI_DEV_CLK toggles, other signals are static
+set_rule_status -rule {W_G_CLK_GLITCH} -status {Waived}    \
+  -expression {(GatedClock=~"*.u_spi_device.clk_spi_*") || \
+    (GatedClock=~"*.u_spi_device.u_sram_clk_*")}           \
+  -comment {When SPI_DEV_CLK toggles, other signals are static}


### PR DESCRIPTION
chore(cdc): Alert Handler PING/ACK waivers
Alert handler sender/receiver follows handshake mechanism with
differential signal method. The request(ping) and ack are converted into
level so that slow-to-fast clock 2FF sync error can be ignored.


chore(cdc): Waive LC sender output
LC sender outputs (e.g. cpu_en) are one-time change after getting OTP
LifeCycle State value. It keeps the value until changing the LC state or
reset. It is guaranteed to be received on the other side.