### PR TITLE
[rtl/alert_handler] Enhance alert_handler FSM for sec_cm

### DIFF
--- a/hw/ip_templates/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -267,6 +267,7 @@ module alert_handler_esc_timer import alert_pkg::*; (
       default: begin
         state_d = FsmErrorSt;
         esc_state_o = FsmError;
+        fsm_error = 1'b1;
       end
     endcase
 
@@ -275,6 +276,7 @@ module alert_handler_esc_timer import alert_pkg::*; (
     // we move into the terminal FSM error state.
     if (accu_fail_i || cnt_error) begin
       state_d = FsmErrorSt;
+      fsm_error = 1'b1;
     end
   end
 

--- a/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -362,6 +362,8 @@ module alert_handler_ping_timer import alert_pkg::*; #(
       end
       default: begin
         state_d = FsmErrorSt;
+        alert_ping_fail_o = 1'b1;
+        esc_ping_fail_o   = 1'b1;
       end
     endcase
 
@@ -369,7 +371,9 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     // if the two LFSR or counter states do not agree,
     // we move into the terminal state.
     if (lfsr_err || cnt_error || esc_cnt_error) begin
-       state_d = FsmErrorSt;
+      state_d = FsmErrorSt;
+      alert_ping_fail_o = 1'b1;
+      esc_ping_fail_o   = 1'b1;
     end
   end
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -267,6 +267,7 @@ module alert_handler_esc_timer import alert_pkg::*; (
       default: begin
         state_d = FsmErrorSt;
         esc_state_o = FsmError;
+        fsm_error = 1'b1;
       end
     endcase
 
@@ -275,6 +276,7 @@ module alert_handler_esc_timer import alert_pkg::*; (
     // we move into the terminal FSM error state.
     if (accu_fail_i || cnt_error) begin
       state_d = FsmErrorSt;
+      fsm_error = 1'b1;
     end
   end
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -362,6 +362,8 @@ module alert_handler_ping_timer import alert_pkg::*; #(
       end
       default: begin
         state_d = FsmErrorSt;
+        alert_ping_fail_o = 1'b1;
+        esc_ping_fail_o   = 1'b1;
       end
     endcase
 
@@ -369,7 +371,9 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     // if the two LFSR or counter states do not agree,
     // we move into the terminal state.
     if (lfsr_err || cnt_error || esc_cnt_error) begin
-       state_d = FsmErrorSt;
+      state_d = FsmErrorSt;
+      alert_ping_fail_o = 1'b1;
+      esc_ping_fail_o   = 1'b1;
     end
   end
 


### PR DESCRIPTION
This PR enhances alert_handler's FSM error output to avoid attackers
continuously drive state_d or attack FSM and prim_counter/lfsr together.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>