### PR TITLE
[ci] reset the cw310 at the end of the tests so it's not left in a bad state for the next test

### DIFF
--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -16,6 +16,8 @@ echo "" >> ${BITCACHE_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice
 echo -n ${SHA} > ${BITCACHE_DIR}/../../latest.txt
 export BITSTREAM="--offline --list ${SHA}"
 
+python3 ./util/fpga/cw310_reboot.py
+
 # TODO: remove the --notest_keep_going and --nokeep_going flag after the CW310
 # tests are reliable (#13044)
 ci/bazelisk.sh test \

--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -16,7 +16,9 @@ echo "" >> ${BITCACHE_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice
 echo -n ${SHA} > ${BITCACHE_DIR}/../../latest.txt
 export BITSTREAM="--offline --list ${SHA}"
 
-python3 ./util/fpga/cw310_reboot.py
+# We will lose serial access when we reboot, but if tests fail we should reboot
+# in case we've crashed the UART handler on the CW310's SAM3U
+trap 'python3 ./util/fpga/cw310_reboot.py' EXIT
 
 # TODO: remove the --notest_keep_going and --nokeep_going flag after the CW310
 # tests are reliable (#13044)

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -51,4 +51,4 @@ git+https://github.com/lowRISC/edalize.git@ot-0.1
 # Development version of minimal ChipWhisperer toolchain with latest features
 # and bug fixes. We fix the version for improved stability and manually update
 # if necessary.
-git+https://github.com/newaetech/chipwhisperer-minimal.git@ec1eab08fb3086b705706a9b35d9a05cb26ecf99#egg=chipwhisperer
+git+https://github.com/newaetech/chipwhisperer-minimal.git@2643131b71e528791446ee1bab7359120288f4ab#egg=chipwhisperer

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -47,3 +47,8 @@ git+https://github.com/lowRISC/fusesoc.git@ot-0.1
 
 # Development version with OT-specific changes
 git+https://github.com/lowRISC/edalize.git@ot-0.1
+
+# Development version of minimal ChipWhisperer toolchain with latest features
+# and bug fixes. We fix the version for improved stability and manually update
+# if necessary.
+git+https://github.com/newaetech/chipwhisperer-minimal.git@ec1eab08fb3086b705706a9b35d9a05cb26ecf99#egg=chipwhisperer

--- a/util/fpga/cw310_reboot.py
+++ b/util/fpga/cw310_reboot.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import chipwhisperer as cw
+
+
+def main():
+    target = cw.target(None, cw.targets.CW310)
+    print("Found CW310 with FW Version: " + target.fw_version_str)
+    target.reset_sam3u()
+
+
+if __name__ == "__main__":
+    main()

--- a/util/fpga/cw310_reboot.py
+++ b/util/fpga/cw310_reboot.py
@@ -7,7 +7,7 @@ import chipwhisperer as cw
 
 
 def main():
-    target = cw.target(None, cw.targets.CW310)
+    target = cw.target(None, cw.targets.CW310, slurp=False)
     print("Found CW310 with FW Version: " + target.fw_version_str)
     target.reset_sam3u()
 


### PR DESCRIPTION
This requires the CW310 to be running firmware version 0.40.1 and will
make the content of
https://github.com/newaetech/chipwhisperer/pull/410 be available in
chipwhisperer to work

Fixes: #13106 

There's a compromise here, the reset occurs after failing tests, to restore the cw310 to a good state. I'd like it to happen at the beginning, but the container is connected to the serial ports before the test runs so that's not an option.

We reset after successful tests to check the reset is working.

Signed-off-by: Drew Macrae <drewmacrae@google.com>