### PR TITLE
[sw/silicon_creator] Initialize cpuctrl CSR using OTP

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -321,6 +321,18 @@
       default: "4",
       local: "true"
     },
+    { name: "CreatorSwCfgCpuctrlOffset",
+      desc: "Offset of CREATOR_SW_CFG_CPUCTRL",
+      type: "int",
+      default: "268",
+      local: "true"
+    },
+    { name: "CreatorSwCfgCpuctrlSize",
+      desc: "Size of CREATOR_SW_CFG_CPUCTRL",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
     { name: "CreatorSwCfgDigestOffset",
       desc: "Offset of CREATOR_SW_CFG_DIGEST",
       type: "int",

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
@@ -41,6 +41,12 @@
                     // non-zero value.
                     value: "0xffffffff",
                 },
+                {
+                    name: "CREATOR_SW_CFG_CPUCTRL",
+                    // Value to write to the cpuctrl CSR in `mask_rom_init()`.
+                    // See: https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html#cpu-control-register-cpuctrl
+                    value: "0x1",
+                },
             ],
         }
         {

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -48,6 +48,12 @@
                     // non-zero value.
                     value: "0xffffffff",
                 },
+                {
+                    name: "CREATOR_SW_CFG_CPUCTRL",
+                    // Value to write to the cpuctrl CSR in `mask_rom_init()`.
+                    // See: https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html#cpu-control-register-cpuctrl
+                    value: "0x1",
+                },
             ],
         }
         {

--- a/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
@@ -160,6 +160,10 @@
                     name: "CREATOR_SW_CFG_ROM_EXEC_EN",
                     size: "4"
                 }
+                {
+                    name: "CREATOR_SW_CFG_CPUCTRL",
+                    size: "4"
+                }
             ],
             desc: '''Software configuration partition for
             device-specific calibration data (Clock, LDO,

--- a/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
+++ b/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
@@ -19,6 +19,7 @@ It has been generated with ./util/design/gen-otp-mmap.py
 |         |                |            |      32bit       |           CREATOR_SW_CFG_RET_RAM_RESET_MASK           |     0x100      |     4      |
 |         |                |            |      32bit       |              CREATOR_SW_CFG_MANUF_STATE               |     0x104      |     4      |
 |         |                |            |      32bit       |              CREATOR_SW_CFG_ROM_EXEC_EN               |     0x108      |     4      |
+|         |                |            |      32bit       |                CREATOR_SW_CFG_CPUCTRL                 |     0x10C      |     4      |
 |         |                |            |      64bit       | [CREATOR_SW_CFG_DIGEST](#Reg_creator_sw_cfg_digest_0) |     0x358      |     8      |
 |    2    |  OWNER_SW_CFG  |    800     |      32bit       |                  ROM_ERROR_REPORTING                  |     0x360      |     4      |
 |         |                |            |      32bit       |                   ROM_BOOTSTRAP_EN                    |     0x364      |     4      |

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -322,7 +322,8 @@ package otp_ctrl_part_pkg;
     }),
     6400'({
       64'h7D7EA64D850E128D,
-      4704'h0, // unallocated space
+      4672'h0, // unallocated space
+      32'h0,
       32'h0,
       32'h0,
       32'h0,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -46,6 +46,8 @@ package otp_ctrl_reg_pkg;
   parameter int CreatorSwCfgManufStateSize = 4;
   parameter int CreatorSwCfgRomExecEnOffset = 264;
   parameter int CreatorSwCfgRomExecEnSize = 4;
+  parameter int CreatorSwCfgCpuctrlOffset = 268;
+  parameter int CreatorSwCfgCpuctrlSize = 4;
   parameter int CreatorSwCfgDigestOffset = 856;
   parameter int CreatorSwCfgDigestSize = 8;
   parameter int OwnerSwCfgOffset = 864;

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -48,14 +48,24 @@
  * Each counter is indexed by Name. The Initial Value is used to initialize the
  * counters with unique values with a good hamming distance. The values are
  * restricted to 11-bit to be able use immediate load instructions.
+
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 6 -n 11 \
+ *     -s 1630646358 --language=c
+ *
+ * Minimum Hamming distance: 6
+ * Maximum Hamming distance: 8
+ * Minimum Hamming weight: 5
+ * Maximum Hamming weight: 8
  */
 // clang-format off
 #define ROM_CFI_FUNC_COUNTERS_TABLE(X) \
-  X(kCfiRomMain,    0xf05) \
-  X(kCfiRomInit,    0x042) \
-  X(kCfiRomVerify,  0x89d) \
-  X(kCfiRomTryBoot, 0x4c7) \
-  X(kCfiRomBoot,    0x0fb) \
+  X(kCfiRomMain,         0x14b) \
+  X(kCfiRomInit,         0x7dc) \
+  X(kCfiRomVerify,       0x5a7) \
+  X(kCfiRomTryBoot,      0x235) \
+  X(kCfiRomPreBootCheck, 0x43a) \
+  X(kCfiRomBoot,         0x2e2)
 // clang-format on
 
 // Define counters and constant values required by the CFI counter macros.
@@ -219,6 +229,36 @@ static inline  uintptr_t rom_ext_vma_get(const manifest_t *manifest, uintptr_t l
 }
 
 /**
+ * Performs consistency checks before booting a ROM_EXT.
+ *
+ * All of the checks in this function are expected to pass and any failures
+ * result in shutdown.
+ */
+static void mask_rom_pre_boot_check(void) {
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 1);
+
+  // Check cached life cycle state against the value reported by hardware.
+  lifecycle_state_t lc_state_check = lifecycle_state_get();
+  if (launder32(lc_state_check) != lc_state) {
+    HARDENED_UNREACHABLE();
+  }
+  HARDENED_CHECK_EQ(lc_state_check, lc_state);
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 2);
+
+  // Check cached boot data.
+  rom_error_t boot_data_ok = boot_data_check(&boot_data);
+  if (launder32(boot_data_ok) != kErrorOk) {
+    HARDENED_UNREACHABLE();
+  }
+  HARDENED_CHECK_EQ(boot_data_ok, kErrorOk);
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 3);
+
+  sec_mmio_check_values(rnd_uint32());
+  sec_mmio_check_counters(/*expected_check_count=*/4);
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 4);
+}
+
+/**
  * Boots a ROM_EXT.
  *
  * Note: This function should not return under normal conditions. Any returns
@@ -236,16 +276,6 @@ static rom_error_t mask_rom_boot(const manifest_t *manifest,
   keymgr_creator_max_ver_set(manifest->max_key_version);
   SEC_MMIO_WRITE_INCREMENT(kKeymgrSecMmioSwBindingSet +
                            kKeymgrSecMmioCreatorMaxVerSet);
-
-  // Check cached life cycle state against the value reported by hardware.
-  lifecycle_state_t lc_state_check = lifecycle_state_get();
-  if (launder32(lc_state_check) != lc_state) {
-    return kErrorMaskRomBootFailed;
-  }
-  HARDENED_CHECK_EQ(lc_state_check, lc_state);
-
-  // Check cached boot data.
-  HARDENED_RETURN_IF_ERROR(boot_data_check(&boot_data));
 
   sec_mmio_check_counters(/*expected_check_count=*/2);
 
@@ -284,15 +314,20 @@ static rom_error_t mask_rom_boot(const manifest_t *manifest,
   mask_rom_epmp_unlock_rom_ext_rx(&epmp, text_region);
   HARDENED_RETURN_IF_ERROR(epmp_state_check(&epmp));
 
+  CFI_FUNC_COUNTER_PREPCALL(rom_counters, kCfiRomBoot, 2, kCfiRomPreBootCheck);
+  mask_rom_pre_boot_check();
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomBoot, 4);
+  CFI_FUNC_COUNTER_CHECK(rom_counters, kCfiRomPreBootCheck, 5);
+
   // Enable execution of code from flash if signature is verified.
   flash_ctrl_exec_set(flash_exec);
   SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioExecSet);
 
   sec_mmio_check_values(rnd_uint32());
-  sec_mmio_check_counters(/*expected_check_count=*/4);
+  sec_mmio_check_counters(/*expected_check_count=*/5);
 
   // Jump to ROM_EXT entry point.
-  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomBoot, 2);
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomBoot, 5);
   ((rom_ext_entry_point *)entry_point)();
 
   return kErrorMaskRomBootFailed;

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -96,6 +96,11 @@ static rom_error_t mask_rom_init(void) {
   // Configure UART0 as stdout.
   uart_init(kUartNCOValue);
 
+  // Write the OTP value to bits 0 to 5 of the cpuctrl CSR.
+  uint32_t cpuctrl_otp =
+      otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_CPUCTRL_OFFSET) & 0x3f;
+  CSR_WRITE(CSR_REG_CPUCTRL, cpuctrl_otp);
+
   lc_state = lifecycle_state_get();
 
   // Update epmp config for debug rom according to lifecycle state.

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -133,6 +133,7 @@ cc_library(
 opentitan_flash_binary(
     name = "slot_a",
     srcs = ["rom_ext_start.S"],
+    output_signed = True,
     deps = [
         ":ld_slot_a",
         ":rom_ext",
@@ -144,6 +145,7 @@ opentitan_flash_binary(
 opentitan_flash_binary(
     name = "slot_b",
     srcs = ["rom_ext_start.S"],
+    output_signed = True,
     deps = [
         ":ld_slot_b",
         ":rom_ext",
@@ -155,6 +157,7 @@ opentitan_flash_binary(
 opentitan_flash_binary(
     name = "virtual_addr",
     srcs = ["rom_ext_start.S"],
+    output_signed = True,
     deps = [
         ":ld_virtual_addr",
         ":rom_ext",


### PR DESCRIPTION
This PR adds the `CREATOR_SW_CFG_CPUCTRL` OTP item and writes its value to the `cpuctrl` CSR (after masking with 0x3f to preserve the `double_fault_seen` `sync_exc_seen` and bits). This way we can control and test `dummy_instr_mask`, `dummy_instr_en`, and `data_ind_timing` in addition to `icache_enable`.

Please let me know if I should update the mask to preserve the reset values of the bits other than `icache_enable`.

Please see [this page](https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html#cpu-control-register-cpuctrl) for more information on the `cpuctrl` CSR.

This PR also sets the value of this entry to `0x1` in the RMA OTP image. I'll give the resulting bitstream a try before merging this PR.