### PR TITLE
[cleanup] Make `bazelisk.sh` operate in the workspace

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -12,6 +12,9 @@
 
 set -euo pipefail
 
+# Change to this script's directory, as it is the location of the bazel workspace.
+cd "$(dirname "$0")"
+
 : "${CURL_FLAGS:=--silent}"
 : "${REPO_TOP:=$(git rev-parse --show-toplevel)}"
 : "${BINDIR:=.bin}"


### PR DESCRIPTION
The `bazelisk.sh` script should chdir to its containing subdirectory
so that it always operates in the project's workspace.  This will allow
other projects (e.g. tock) to invoke bazelisk to build binaries or
execute tools.

Signed-off-by: Chris Frantz <cfrantz@google.com>