### PR TITLE
ci: add cdc attribute and build-type

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# cdc
+hw/top_*/cdc/*.tcl          cdc
+hw/cdc/tools/*/run-cdc.tcl  cdc
+hw/cdc/tools/dvsim/cdc.mk   cdc
+# common_cdc_cfg.hjson & verixcdc.hjson may affect dvsim flow, so leave it

--- a/ci/scripts/get-build-type.sh
+++ b/ci/scripts/get-build-type.sh
@@ -19,6 +19,7 @@ build_reason="$2"
 only_doc_changes=0
 only_dv_changes=0
 has_otbn_changes=1
+only_cdc_changes=0
 if [[ "$build_reason" = "PullRequest" ]]; then
     # Conservative way of checking for documentation-only and OTBN changes.
     # Only relevant for pipelines triggered from pull requests
@@ -57,7 +58,18 @@ if [[ "$build_reason" = "PullRequest" ]]; then
     else
         echo "PR doesn't contain OTBN changes"
     fi
+
+    # Check if the commit has only CDC related changes (run-cdc.tcl,
+    # cdc_waivers*.tcl).
+    echo "Checking for changes in this PR other than to CDC waivers"
+    git diff --quiet "$merge_base" -- ':(attr:!cdc)' && only_cdc_change=1 || true
+    if [[ $only_cdc_change -eq 1 ]]; then
+        echo "PR is only CDC waiver changes"
+    else
+        echo "PR contains non CDC-related changes"
+    fi
 fi
 echo "##vso[task.setvariable variable=onlyDocChanges;isOutput=true]${only_doc_changes}"
 echo "##vso[task.setvariable variable=onlyDvChanges;isOutput=true]${only_dv_changes}"
 echo "##vso[task.setvariable variable=hasOTBNChanges;isOutput=true]${has_otbn_changes}"
+echo "##vso[task.setvariable variable=onlyCdcChanges;isOutput=true]${only_cdc_changes}"


### PR DESCRIPTION
This commit to test if build-type script checks cdc changes correctly.
It does not revise azure-pipelines.yml to skip the FPGA test but print
out the build-type log.

```console
$ git ls-files -- ':(attr:cdc)'
hw/cdc/tools/dvsim/cdc.mk
hw/cdc/tools/verixcdc/run-cdc.tcl
hw/top_earlgrey/cdc/cdc_waivers.gpio.tcl
hw/top_earlgrey/cdc/cdc_waivers.lc_ctrl.tcl
hw/top_earlgrey/cdc/cdc_waivers.spi_device.tcl
hw/top_earlgrey/cdc/cdc_waivers.tcl
hw/top_earlgrey/cdc/cdc_waivers.uart.tcl
```

After this has been merged, with probation period (to check if the
build-type indeed works), azr-pipelines.yml will be revised to skip the
fpga test.
