### PR TITLE
[dv/chip] Fix same csr outstanding error

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -264,6 +264,10 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen: "CTRL_CFG_REGWEN",
+      tags: [// Turning off USB clock in active state impacts other CSRs
+             // at the chip level (in other blocks, such as clkmgr),
+             // so we exclude writing from this register.
+             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         { bits: "0",
           hwaccess: "hrw",
@@ -374,9 +378,6 @@
                 '''
             },
           ]
-          tags: [// Turning off USB clock in active state impacts other CSRs
-                 // at the chip level (in other blocks, such as clkmgr).
-                 "excl:CsrAllTests:CsrExclWrite"]
         },
 
         { bits: "8",

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -106,7 +106,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   function void disable_unnecessary_exclusions();
     csr_excl_item csr_excl = ral.get_excl_item();
     `uvm_info(`gfn, "Dealing with exclusions", UVM_MEDIUM)
-    csr_excl.enable_excl(.obj("pwrmgr_reg_block.control.usb_clk_en_active"), .enable(1'b0));
+    csr_excl.enable_excl(.obj("pwrmgr_reg_block.control"), .enable(1'b0));
     csr_excl.enable_excl(.obj("pwrmgr_reg_block.reset_en"), .enable(1'b0));
     csr_excl.print_exclusions(UVM_MEDIUM);
   endfunction

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -303,6 +303,10 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen: "CTRL_CFG_REGWEN",
+      tags: [// Turning off USB clock in active state impacts other CSRs
+             // at the chip level (in other blocks, such as clkmgr),
+             // so we exclude writing from this register.
+             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         { bits: "0",
           hwaccess: "hrw",
@@ -413,9 +417,6 @@
                 '''
             },
           ]
-          tags: [// Turning off USB clock in active state impacts other CSRs
-                 // at the chip level (in other blocks, such as clkmgr).
-                 "excl:CsrAllTests:CsrExclWrite"]
         },
 
         { bits: "8",


### PR DESCRIPTION
This PR fixes the same csr outstanding chip level failure.
The reason is that we put a pwrmgr write exclusion in a field instead of
the entire register, thus the register field write exclusion is not
applied.
Solution - move the exclusion to register level.
More discussion in this issue: https://github.com/lowRISC/opentitan/issues/13121
Signed-off-by: Cindy Chen <chencindy@opentitan.org>