### PR TITLE
[ci] Retry install-package-dependencies up to 3 times on failure

### DIFF
--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -29,4 +29,5 @@ steps:
         --openocd-version $(OPENOCD_VERSION) \
         --verible-version $(VERIBLE_VERSION) \
         --rust-version $(RUST_VERSION)
+    retryCountOnTaskFailure: 3
     displayName: 'Install package dependencies'


### PR DESCRIPTION
Turns out Azure pipelines added [this feature](https://docs.microsoft.com/en-us/azure/devops/release-notes/2021/sprint-195-update#automatic-retries-for-a-task) specifically to address the problem of failing to fetch dependencies from external repositories.