### PR TITLE
[cleanup] Write a newline into the `latest.txt` file

### DIFF
--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -85,8 +85,8 @@ class BitstreamCache(object):
         Args:
             key: str; The git hash of the latest bitstream.
         """
-        with open(self.latest_update, 'w') as f:
-            f.write(key)
+        with open(self.latest_update, 'wt') as f:
+            print(key, file=f)
 
     def NeedRefresh(self, interval):
         """Determine if the cache needs a refresh.
@@ -124,8 +124,8 @@ class BitstreamCache(object):
                 for d in dirnames:
                     self.available[d] = 'local'
             try:
-                with open(self.latest_update) as f:
-                    self.available['latest'] = f.read()
+                with open(self.latest_update, 'rt') as f:
+                    self.available['latest'] = f.read().strip()
             except FileNotFoundError:
                 if self.offline:
                     logging.error(


### PR DESCRIPTION
1. Write a newline into the `latest.txt` file.  This allows a user to
   `cat` this file without it running into their shell prompt configuration.

Signed-off-by: Chris Frantz <cfrantz@google.com>