### PR TITLE
[cleanup, ottool] Logging and user experience improvements

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -109,6 +109,7 @@ rust_library(
         "//third_party/rust/crates:erased_serde",
         "//third_party/rust/crates:hex",
         "//third_party/rust/crates:humantime",
+        "//third_party/rust/crates:indicatif",
         "//third_party/rust/crates:lazy_static",
         "//third_party/rust/crates:log",
         "//third_party/rust/crates:memoffset",

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -15,10 +15,22 @@ use crate::transport::{ProxyOps, Transport, TransportError};
 use anyhow::Result;
 
 use erased_serde::Serialize;
+use indicatif::{ProgressBar, ProgressStyle};
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+
+/// Helper function to create a progress bar in the same form for each of
+/// the commands which will use it.
+pub fn progress_bar(total: u64) -> ProgressBar {
+    let progress = ProgressBar::new(total);
+    progress.set_style(
+        ProgressStyle::default_bar()
+            .template("[{elapsed_precise}] [{wide_bar}] {bytes}/{total_bytes} ({eta})"),
+    );
+    progress
+}
 
 #[derive(Default)]
 pub struct PinConfiguration {

--- a/sw/host/opentitanlib/src/bootstrap/eeprom.rs
+++ b/sw/host/opentitanlib/src/bootstrap/eeprom.rs
@@ -42,11 +42,12 @@ impl UpdateProtocol for Eeprom {
         container: &Bootstrap,
         transport: &TransportWrapper,
         payload: &[u8],
+        progress: &dyn Fn(u32, u32),
     ) -> Result<()> {
         let spi = container.spi_params.create(transport)?;
         let flash = SpiFlash::from_spi(&*spi)?;
         flash.chip_erase(&*spi)?;
-        flash.program(&*spi, 0, payload)?;
+        flash.program_with_progress(&*spi, 0, payload, progress)?;
         SpiFlash::chip_reset(&*spi)?;
         Ok(())
     }

--- a/sw/host/opentitanlib/src/bootstrap/legacy.rs
+++ b/sw/host/opentitanlib/src/bootstrap/legacy.rs
@@ -230,6 +230,7 @@ impl UpdateProtocol for Legacy {
         container: &Bootstrap,
         transport: &TransportWrapper,
         payload: &[u8],
+        progress: &dyn Fn(u32, u32),
     ) -> Result<()> {
         let spi = container.spi_params.create(transport)?;
 
@@ -269,6 +270,7 @@ impl UpdateProtocol for Legacy {
             std::thread::sleep(self.inter_frame_delay);
 
             // Write the frame and read back the ack of a previously transmitted frame.
+            progress(frame.header.flash_offset, frame.data.len() as u32);
             let mut response = [0u8; std::mem::size_of::<Frame>()];
             spi.run_transaction(&mut [Transfer::Both(frame.as_bytes(), &mut response)])?;
 

--- a/sw/host/opentitanlib/src/bootstrap/primitive.rs
+++ b/sw/host/opentitanlib/src/bootstrap/primitive.rs
@@ -129,6 +129,7 @@ impl UpdateProtocol for Primitive {
         container: &Bootstrap,
         transport: &TransportWrapper,
         payload: &[u8],
+        progress: &dyn Fn(u32, u32),
     ) -> Result<()> {
         let spi = container.spi_params.create(transport)?;
 
@@ -144,6 +145,7 @@ impl UpdateProtocol for Primitive {
             );
 
             // Write the frame and read back the hash of the previous frame.
+            progress(frame.header.flash_offset, frame.data.len() as u32);
             let mut prev_hash = [0u8; std::mem::size_of::<Frame>()];
             spi.run_transaction(&mut [Transfer::Both(frame.as_bytes(), &mut prev_hash)])?;
 

--- a/sw/host/opentitanlib/src/bootstrap/rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/rescue.rs
@@ -304,6 +304,7 @@ impl UpdateProtocol for Rescue {
         container: &Bootstrap,
         transport: &TransportWrapper,
         payload: &[u8],
+        progress: &dyn Fn(u32, u32),
     ) -> Result<()> {
         let frames = Frame::from_payload(payload)?;
         let uart = container.uart_params.create(transport)?;
@@ -314,6 +315,7 @@ impl UpdateProtocol for Rescue {
         'next_block: for (idx, frame) in frames.iter().enumerate() {
             for consecutive_errors in 0..Self::MAX_CONSECUTIVE_ERRORS {
                 eprint!("{}.", idx);
+                progress(frame.header.flash_offset, frame.data.len() as u32);
                 uart.write(frame.as_bytes())?;
                 let mut response = [0u8; Frame::HASH_LEN];
                 let mut index = 0;

--- a/sw/host/opentitanlib/src/util/rom_detect.rs
+++ b/sw/host/opentitanlib/src/util/rom_detect.rs
@@ -56,14 +56,14 @@ impl RomDetect {
             .nth(1)
             .ok_or(Error::UsrAccessNotFound)?;
         let usr_access = u32::from_be_bytes(operand.try_into()?);
-        log::info!("Bitstream USR_ACCESS value: {:#x}", usr_access);
+        log::info!("Bitstream file USR_ACCESS value: {:#x}", usr_access);
         Ok(usr_access)
     }
 
     pub fn detect(&mut self, uart: &dyn Uart) -> Result<bool> {
         self.console.interact(uart, None, None)?;
         if let Some(cap) = self.console.captures(ExitStatus::ExitSuccess) {
-            log::info!("Found: {:?}", cap.get(0).unwrap().as_str());
+            log::info!("Current bitstream: {:?}", cap.get(0).unwrap().as_str());
             let romkind = cap.get(1).unwrap().as_str();
             let kind = match RomKind::from_str(romkind) {
                 Ok(k) => k,

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -35,7 +35,6 @@ rust_binary(
         "//third_party/rust/crates:erased_serde",
         "//third_party/rust/crates:hex",
         "//third_party/rust/crates:humantime",
-        "//third_party/rust/crates:indicatif",
         "//third_party/rust/crates:log",
         "//third_party/rust/crates:nix",
         "//third_party/rust/crates:raw_tty",

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use structopt::StructOpt;
 
 use opentitanlib::app::command::CommandDispatch;
-use opentitanlib::app::TransportWrapper;
+use opentitanlib::app::{self, TransportWrapper};
 use opentitanlib::transport::cw310;
 use opentitanlib::util::rom_detect::RomKind;
 
@@ -41,11 +41,18 @@ impl CommandDispatch for LoadBitstream {
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
         log::info!("Loading bitstream: {:?}", self.filename);
-        Ok(transport.dispatch(&cw310::FpgaProgram {
-            bitstream: fs::read(&self.filename)?,
+        let bitstream = fs::read(&self.filename)?;
+        let progress = app::progress_bar(bitstream.len() as u64);
+        let pfunc = Box::new(move |_, chunk| {
+            progress.inc(chunk as u64);
+        });
+        let operation = cw310::FpgaProgram {
+            bitstream: bitstream,
             rom_kind: self.rom_kind,
             rom_reset_pulse: self.rom_reset_pulse,
             rom_timeout: self.rom_timeout,
-        })?)
+            progress: Some(pfunc),
+        };
+        Ok(transport.dispatch(&operation)?)
     }
 }

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -128,16 +128,20 @@ fn parse_command_line(opts: Opts, mut args: ArgsOs) -> Result<Opts> {
 }
 
 // Print the result of a command.
-// If there is an error and `RUST_BACKTRACE=1` _and_ `--logging=debug`, print a backtrace.
+// If there is an error and `RUST_BACKTRACE=1`, print a backtrace.
 fn print_command_result(result: Result<Option<Box<dyn Serialize>>>) -> Result<()> {
     match result {
         Ok(Some(value)) => {
+            log::info!("Command result: success.");
             println!("{}", serde_json::to_string_pretty(&value)?);
             Ok(())
         }
-        Ok(None) => Ok(()),
+        Ok(None) => {
+            log::info!("Command result: success.");
+            Ok(())
+        }
         Err(e) => {
-            log::debug!("{:?}", e);
+            log::info!("Command result: {:?}", e);
             Err(e)
         }
     }


### PR DESCRIPTION
1. Give `bootstrap` a progress bar.
2. Improve logging for `load-bitstream`; add a progress bar.
3. Log success or error for every command.