### PR TITLE
[dv/kmac] Fix escalation regression failure

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -127,8 +127,6 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
 
   task post_start();
     super.post_start();
-    void'($value$plusargs("do_clear_all_interrupts=%0b", do_clear_all_interrupts));
-    if (do_clear_all_interrupts) clear_all_interrupts();
 
     if (expect_fatal_alerts) begin
       // Fatal alert is triggered in this seq. Wait 10_000ns so the background check
@@ -139,6 +137,11 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
     end else begin
       check_no_fatal_alerts();
     end
+
+    // Some fatal alerts might trigger interrupt as well, so only check interrupt after fatal alert
+    // is cleared.
+    void'($value$plusargs("do_clear_all_interrupts=%0b", do_clear_all_interrupts));
+    if (do_clear_all_interrupts) clear_all_interrupts();
   endtask
 
   virtual task apply_reset(string kind = "HARD");

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
@@ -60,6 +60,7 @@ class kmac_lc_escalation_vseq extends kmac_app_vseq;
 
   virtual task post_start();
     expect_fatal_alerts = 1;
+    cfg.kmac_vif.drive_lc_escalate(lc_ctrl_pkg::Off);
     super.post_start();
   endtask
 


### PR DESCRIPTION
This PR fixes KMAC lc_escalation test failure in nightly regression.
The main issue is that now that lc_escalation triggers a fatal alert and
also interrupt. So before reset, the interrupt will continously fire.
To avoid this issue, I moved the interrupt checking after fatal alert
stops firing. Also fixes an issue that the test does not revert back
lc_escalation_en signal.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>