### PR TITLE
fix(bazel): Exclude ralgen from copying over

### DIFF
--- a/hw/BUILD
+++ b/hw/BUILD
@@ -76,7 +76,10 @@ alias(
 # relationships between verilog components.
 filegroup(
     name = "all_files",
-    srcs = glob(["**"]) + [
+    srcs = glob(
+        ["**"],
+        exclude = ["dv/tools/ralgen/*"],
+    ) + [
         "//hw/ip:all_files",
         "//hw/top_earlgrey:all_files",
     ],


### PR DESCRIPTION
Discussed in #13088 . This commit excludes ralgen related files from bazel copying over under `bazel-out/`
This ensures the fusesoc to not pick ralgen under that directory.

Better way is for bazel to create `FUSESOC_IGNORE` under `bazel-out/`