### PR TITLE
[sw/silicon_creator] Remove english breakfast ifdef from lifecycle driver

### DIFF
--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -48,10 +48,7 @@ cc_library(
         "//hw/ip/spi_device/data:spi_device_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
-        "//sw/device/lib/base:bitfield",
-        "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:multibits",
-        "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
     ],
 )
@@ -61,6 +58,42 @@ alias(
     actual = select({
         "//sw/device:is_english_breakfast": ":english_breakfast_test_rom_bootstrap",
         "//conditions:default": "//sw/device/silicon_creator/mask_rom:bootstrap",
+    }),
+    visibility = ["//visibility:private"],
+)
+
+# TODO(#12905): Use a slightly hollowed out version of the silicon_creator manifest
+# implementation when building the test_rom for the english breakfast top level.
+cc_library(
+    name = "english_breakfast_test_rom_manifest",
+    srcs = [
+        "//sw/device/silicon_creator/lib:english_breakfast_test_rom_manifest_srcs",
+        "//sw/device/silicon_creator/lib/drivers:english_breakfast_test_rom_driver_srcs",
+    ],
+    # This should be built only for english breakfast and skipped if using wildcards.
+    tags = ["manual"],
+    deps = [
+        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/ip/spi_device/data:spi_device_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:multibits",
+        "//sw/device/silicon_creator/lib:epmp",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:keymgr_binding",
+        "//sw/device/silicon_creator/lib:manifest_size",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+        "//sw/device/silicon_creator/lib/sigverify:rsa_key",
+    ],
+)
+
+alias(
+    name = "test_rom_manifest",
+    actual = select({
+        "//sw/device:is_english_breakfast": ":english_breakfast_test_rom_manifest",
+        "//conditions:default": "//sw/device/silicon_creator/lib:manifest",
     }),
     visibility = ["//visibility:private"],
 )
@@ -75,6 +108,7 @@ cc_library(
     deps = [
         ":chip_info",
         ":test_rom_bootstrap",
+        ":test_rom_manifest",
         "//hw/ip/clkmgr/data:clkmgr_regs",
         "//hw/ip/csrng/data:csrng_regs",
         "//hw/ip/edn/data:edn_regs",
@@ -101,7 +135,6 @@ cc_library(
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:status",
-        "//sw/device/silicon_creator/lib:manifest",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -238,6 +238,14 @@ cc_test(
     ],
 )
 
+filegroup(
+    name = "english_breakfast_test_rom_manifest_srcs",
+    srcs = [
+        "manifest.c",
+        "manifest.h",
+    ],
+)
+
 cc_library(
     name = "otbn_util",
     srcs = ["otbn_util.c"],

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -12,11 +12,6 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 
-// FIXME(lowRISC/opentitan#12065) Eliminating this dependency from the SW build
-// for englishbreakfast is nontrivial, so we use the IS_ENGLISH_BREAKFAST hack
-// here. This should be removed once the linked bug is resolved.
-#if !OT_IS_ENGLISH_BREAKFAST
-
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "lc_ctrl_regs.h"
 
@@ -94,5 +89,3 @@ void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev) {
       .chip_rev = bitfield_field32_read(reg, LC_CTRL_HW_REV_CHIP_REV_FIELD),
   };
 }
-
-#endif


### PR DESCRIPTION
This PR removes the english breakfast related `ifdef` in the silicon_creator lifecycle driver using the approach in https://github.com/lowRISC/opentitan/pull/12875/commits/40dd7790bc82ebf2e5a1ce625f78cf8ab0dd3025.
