### PR TITLE
[top, dv] Fix chip_csr_mem_rw_with_rand_reset

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -861,8 +861,11 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                 if (mem.get_mem_partial_write_support()) mask = get_rand_contiguous_mask();
                 else                                     mask = '1;
                 data = $urandom;
+                // set check_rsp to 0 to skip checking rsp in sequence, as there could be a mem
+                // which always returns d_error = 1. scb will be overriden to handle it and check
+                // the d_error.
                 tl_access_w_abort(.addr(addr), .write(1), .data(data),
-                                  .completed(write_completed), .saw_err(write_error),
+                                  .completed(write_completed), .saw_err(write_error), .check_rsp(0),
                                   .mask(mask), .blocking(1), .req_abort_pct($urandom_range(0, 100)),
                                   .tl_sequencer_h(p_sequencer.tl_sequencer_hs[ral_name]));
 
@@ -885,9 +888,10 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                 if (get_mem_access_by_addr(local_ral, addr) != "WO") begin
                   bit completed, saw_err;
                   mask = get_rand_contiguous_mask(addr_mask.mask);
+                  // set check_rsp to 0 due to a reason above (in the write section)
                   tl_access_w_abort(.addr(addr), .write(0), .data(data),
                                     .completed(completed), .saw_err(saw_err),
-                                    .mask(mask), .blocking(1),
+                                    .mask(mask), .blocking(1), .check_rsp(0),
                                     .req_abort_pct($urandom_range(0, 100)),
                                     .tl_sequencer_h(p_sequencer.tl_sequencer_hs[ral_name]));
                 end

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -153,7 +153,10 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
   endfunction
 
   virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
-    if (ral_name == cfg.sram_ral_name && get_sram_instr_type_err(item, channel)) return 1;
+    if (ral_name == cfg.sram_ral_name && get_sram_instr_type_err(item, channel)) begin
+      `DV_CHECK_EQ(item.d_error, 1)
+      return 1;
+    end
     return super.predict_tl_err(item, channel, ral_name);
   endfunction
 

--- a/hw/top_earlgrey/dv/env/chip_scoreboard.sv
+++ b/hw/top_earlgrey/dv/env/chip_scoreboard.sv
@@ -65,4 +65,13 @@ class chip_scoreboard #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_b
     // post test checks - ensure that all local fifos and queues are empty
   endfunction
 
+  virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
+    uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_normalized_addr(item.a_addr);
+    uvm_mem mem = cfg.ral_models[ral_name].default_map.get_mem_by_offset(addr);
+
+    // any access to dv_sim_window returns d_error since this is a DV mem
+    if (mem != null && mem.get_name() == "dv_sim_window") return 1;
+    return super.predict_tl_err(item, channel, ral_name);
+  endfunction
+
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -10,8 +10,15 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
   }
   `uvm_object_new
 
-  virtual task apply_reset(string kind = "HARD");
-    super.apply_reset(kind);
+  virtual task post_apply_reset(string kind = "HARD");
+    super.post_apply_reset(kind);
+
+    for (int ram_idx = 0; ram_idx < cfg.num_ram_ret_tiles; ram_idx++) begin
+       cfg.mem_bkdr_util_h[RamRet0 + ram_idx].randomize_mem();
+    end
+    for (int ram_idx = 0; ram_idx < cfg.num_ram_main_tiles; ram_idx++) begin
+       cfg.mem_bkdr_util_h[RamMain0 + ram_idx].randomize_mem();
+    end
     wait_rom_check_done();
   endtask
 


### PR DESCRIPTION
3 fixes
1. initialize sram mem to fix unknown data assert error
2. update scb to return d_error when accessing dv_sim_window
3. disable check_rsp for mem test as accessing dv_sim_window always
   fails
Signed-off-by: Weicai Yang <weicai@google.com>