### PR TITLE
[dv] Update xcelium coverage config file

### DIFF
--- a/hw/dv/tools/xcelium/cover.ccf
+++ b/hw/dv/tools/xcelium/cover.ccf
@@ -25,6 +25,11 @@ deselect_coverage -betfs -module prim_cdc_rand_delay
 // csr_assert_fpv is an auto-generated csr read assertion module. So only assertion coverage is
 // meaningful to collect.
 deselect_coverage -betf -module *csr_assert_fpv...
+select_coverage -assert -module *csr_assert_fpv
+
+// Only enable assertion coverage
+deselect_coverage -betf -module *tlul_assert...
+select_coverage -assert -module *tlul_assert
 
 // Only collect toggle coverage on the DUT and the black-boxed IP (above) ports.
 deselect_coverage -toggle -module ${DUT_TOP}...

--- a/hw/dv/tools/xcelium/cover_reg_top.ccf
+++ b/hw/dv/tools/xcelium/cover_reg_top.ccf
@@ -8,8 +8,15 @@ include_ccf ${dv_root}/tools/xcelium/common.ccf
 // Only collect code coverage on the *_reg_top instance.
 deselect_coverage -betfs -module ${DUT_TOP}...
 select_coverage -befs -module *_reg_top...
-select_coverage -assert -module tlul_assert
-select_coverage -assert -module *_csr_assert_fpv
+
+// csr_assert_fpv is an auto-generated csr read assertion module. So only assertion coverage is
+// meaningful to collect.
+deselect_coverage -betf -module *csr_assert_fpv...
+select_coverage -assert -module *csr_assert_fpv
+
+// Only enable assertion coverage
+deselect_coverage -betf -module *tlul_assert...
+select_coverage -assert -module *tlul_assert
 
 // Include toggle coverage on `prim_alert_sender` because the `alert_test` task under
 // `cip_base_vseq` drives `alert_test_i` and verifies `alert_rx/tx` handshake in each IP.


### PR DESCRIPTION
Excluded statement coverage for tlul_assert, only enabled assertion
coverage.
Signed-off-by: Weicai Yang <weicai@google.com>