### PR TITLE
[dv,chip_sw] Harden external_clk_src_for_lc test

### DIFF
--- a/hw/top_earlgrey/dv/env/ast_ext_clk_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_ext_clk_if.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This interface is used to detect when the external clock is activated and sub sequently
+// deactivated, as part of hardening chip level test(s) enabling the external clock.
+interface ast_ext_clk_if ();
+  import uvm_pkg::*;
+
+  task static detect_io_active_window();
+    fork
+      wait(u_ast.u_ast_clks_byp.u_clk_src_io_sel.clk_ext_en_o == 1'b1);
+      `uvm_info("ast_ext_clk_if", "External clk became active for io clk", UVM_MEDIUM)
+      wait(u_ast.u_ast_clks_byp.u_clk_src_io_sel.clk_osc_en_o == 1'b0);
+      `uvm_info("ast_ext_clk_if", "External clk back to inactive for io clk", UVM_MEDIUM)
+    join
+  endtask
+
+endinterface : ast_ext_clk_if

--- a/hw/top_earlgrey/dv/env/ast_supply_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_supply_if.sv
@@ -28,7 +28,7 @@ interface ast_supply_if (
   // index of key0 input pin in top_earlgrey
   localparam int DioSysrstCtrlAonEcRstL = 10;
   // index of key input pin in top_earlgrey
-  localparam int  MioInSysrstCtrlAonKey0In = 46;
+  localparam int MioInSysrstCtrlAonKey0In = 46;
 
   function static void force_vcaon_pok(bit value);
     force u_ast.u_rglts_pdm_3p3v.vcaon_pok_h_o = value;
@@ -68,12 +68,12 @@ interface ast_supply_if (
     force_vcmain_pok(1'b0);
     repeat (GlitchCycles) @(posedge clk);
     force_vcmain_pok(1'b1);
-  endtask // glitch_vcmain_pok_on_next_trigger
+  endtask : glitch_vcmain_pok_on_next_trigger
 
   // Create pulses in key0 after a trigger transitions high.
   // Since it's top input pin, GLS signal mismatch is not supposed to occur
   task automatic pulse_key0_i_next_trigger(int cycles);
-    `uvm_info("ast_supply_if", $sformatf("sysrst configured, cycles : %0d",cycles), UVM_MEDIUM)
+    `uvm_info("ast_supply_if", $sformatf("sysrst configured, cycles : %0d", cycles), UVM_MEDIUM)
     force_key0_i(1'b0);
     `uvm_info("ast_supply_if", "sysrst key0 input low", UVM_MEDIUM)
     repeat (cycles) @(posedge clk);

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -73,6 +73,7 @@ filesets:
       - seq_lib/chip_sw_rstmgr_alert_info_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
+      - ast_ext_clk_if.sv
       - ast_supply_if.sv
       - pwrmgr_low_power_if.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class chip_env extends cip_base_env #(
-    .CFG_T              (chip_env_cfg),
-    .COV_T              (chip_env_cov),
-    .VIRTUAL_SEQUENCER_T(chip_virtual_sequencer),
-    .SCOREBOARD_T       (chip_scoreboard)
-  );
+  .CFG_T              (chip_env_cfg),
+  .COV_T              (chip_env_cov),
+  .VIRTUAL_SEQUENCER_T(chip_virtual_sequencer),
+  .SCOREBOARD_T       (chip_scoreboard)
+);
   `uvm_component_utils(chip_env)
 
   uart_agent             m_uart_agents[NUM_UARTS];
@@ -26,37 +26,43 @@ class chip_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get gpio_vif from uvm_config_db")
     end
 
-    if (!uvm_config_db#(virtual pins_if#(2))::get(this, "", "tap_straps_vif",
-        cfg.tap_straps_vif)) begin
+    if (!uvm_config_db#(virtual pins_if #(2))::get(
+            this, "", "tap_straps_vif", cfg.tap_straps_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get tap_straps_vif from uvm_config_db")
     end
 
-    if (!uvm_config_db#(virtual pins_if#(2))::get(this, "", "dft_straps_vif",
-        cfg.dft_straps_vif)) begin
+    if (!uvm_config_db#(virtual pins_if #(2))::get(
+            this, "", "dft_straps_vif", cfg.dft_straps_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get dft_straps_vif from uvm_config_db")
     end
 
-    if (!uvm_config_db#(virtual pins_if#(3))::get(this, "", "sw_straps_vif",
-        cfg.sw_straps_vif)) begin
+    if (!uvm_config_db#(virtual pins_if #(3))::get(
+            this, "", "sw_straps_vif", cfg.sw_straps_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get sw_straps_vif from uvm_config_db")
     end
 
-    if (!uvm_config_db#(virtual pins_if#(1))::get(this, "", "rst_n_mon_vif",
-        cfg.rst_n_mon_vif)) begin
+    if (!uvm_config_db#(virtual pins_if #(1))::get(
+            this, "", "rst_n_mon_vif", cfg.rst_n_mon_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get rst_n_mon_vif from uvm_config_db")
     end
 
-    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "cpu_clk_rst_vif",
-                                                 cfg.cpu_clk_rst_vif)) begin
+    if (!uvm_config_db#(virtual clk_rst_if)::get(
+            this, "", "cpu_clk_rst_vif", cfg.cpu_clk_rst_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get cpu_clk_rst_vif from uvm_config_db")
     end
 
-    if (!uvm_config_db#(virtual pins_if#(1))::get(this, "", "pinmux_wkup_vif",
-                                                  cfg.pinmux_wkup_vif)) begin
+    if (!uvm_config_db#(virtual pins_if #(1))::get(
+            this, "", "pinmux_wkup_vif", cfg.pinmux_wkup_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get pinmux_wkup_vif from uvm_config_db")
     end
 
-    if (!uvm_config_db#(virtual pins_if#(1))::get(this, "", "pwrb_in_vif", cfg.pwrb_in_vif)) begin
+    if (!uvm_config_db#(virtual pins_if #(1))::get(this, "", "pwrb_in_vif", cfg.pwrb_in_vif)) begin
       `uvm_fatal(`gfn, "failed to get pwrb_in_vif from uvm_config_db")
     end
 
@@ -80,20 +86,30 @@ class chip_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get sw_logger_vif from uvm_config_db")
     end
 
-    if (!uvm_config_db#(virtual sw_test_status_if)::get(this, "", "sw_test_status_vif",
-        cfg.sw_test_status_vif)) begin
+    if (!uvm_config_db#(virtual sw_test_status_if)::get(
+            this, "", "sw_test_status_vif", cfg.sw_test_status_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get sw_test_status_vif from uvm_config_db")
     end
 
     // get the handle to the ast supply interface.
-    if (!uvm_config_db#(virtual ast_supply_if)::get(this, "", "ast_supply_vif",
-        cfg.ast_supply_vif)) begin
+    if (!uvm_config_db#(virtual ast_supply_if)::get(
+            this, "", "ast_supply_vif", cfg.ast_supply_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get ast_supply_vif from uvm_config_db")
     end
 
+    // get the handle to the ast io_ext_clk interface.
+    if (!uvm_config_db#(ast_ext_clk_vif)::get(
+            this, "", "ast_ext_clk_vif", cfg.ast_ext_clk_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get ast_ext_clk_vif from uvm_config_db")
+    end
+
     // get the handle to the pwrmgr interface
-    if(!uvm_config_db#(virtual pwrmgr_low_power_if)::get(this, "", "pwrmgr_low_power_vif",
-       cfg.pwrmgr_low_power_vif)) begin
+    if (!uvm_config_db#(virtual pwrmgr_low_power_if)::get(
+            this, "", "pwrmgr_low_power_vif", cfg.pwrmgr_low_power_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get pwrmgr_low_power_vif from uvm_config_db")
     end
 
@@ -106,10 +122,11 @@ class chip_env extends cip_base_env #(
 
     m_jtag_riscv_agent = jtag_riscv_agent::type_id::create("m_jtag_riscv_agent", this);
     uvm_config_db#(jtag_riscv_agent_cfg)::set(this, "m_jtag_riscv_agent*", "cfg",
-                   cfg.m_jtag_riscv_agent_cfg);
+                                              cfg.m_jtag_riscv_agent_cfg);
 
-    m_jtag_riscv_reg_adapter = jtag_riscv_reg_adapter::type_id::
-        create("m_jtag_riscv_reg_adapter",null,this.get_full_name());
+    m_jtag_riscv_reg_adapter = jtag_riscv_reg_adapter::type_id::create(
+        "m_jtag_riscv_reg_adapter", null, this.get_full_name()
+    );
     m_jtag_riscv_reg_adapter.cfg = cfg.m_jtag_riscv_agent_cfg;
 
     m_spi_agent = spi_agent::type_id::create("m_spi_agent", this);
@@ -118,17 +135,16 @@ class chip_env extends cip_base_env #(
     // instantiate pwm_monitor
     foreach (m_pwm_monitor[i]) begin
       m_pwm_monitor[i] = pwm_monitor::type_id::create($sformatf("m_pwm_monitor%0d", i), this);
-      uvm_config_db#(pwm_monitor_cfg)::set(this, $sformatf("m_pwm_monitor%0d*", i),
-                                           $sformatf("m_pwm_monitor%0d_cfg", i),
-                                           cfg.m_pwm_monitor_cfg[i]);
+      uvm_config_db#(pwm_monitor_cfg)::set(this, $sformatf("m_pwm_monitor%0d*", i), $sformatf(
+                                           "m_pwm_monitor%0d_cfg", i), cfg.m_pwm_monitor_cfg[i]);
     end
 
     if (!uvm_config_db#(virtual pins_if #(1))::get(
-        this, "", "por_rstn_vif", cfg.por_rstn_vif)) begin
+            this, "", "por_rstn_vif", cfg.por_rstn_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get por_rstn_vif from uvm_config_db")
     end
-    if (!uvm_config_db#(virtual pins_if #(1))::get(
-        this, "", "pwrb_in_vif", cfg.pwrb_in_vif)) begin
+    if (!uvm_config_db#(virtual pins_if #(1))::get(this, "", "pwrb_in_vif", cfg.pwrb_in_vif)) begin
       `uvm_fatal(`gfn, "failed to get pwrb_in_vif from uvm_config_db")
     end
 
@@ -163,8 +179,7 @@ class chip_env extends cip_base_env #(
 
     // Connect pwm_monitor analysis_port to sequencer.
     foreach (m_pwm_monitor[i]) begin
-      m_pwm_monitor[i].item_port.connect(
-          virtual_sequencer.pwm_rx_fifo[i].analysis_export);
+      m_pwm_monitor[i].item_port.connect(virtual_sequencer.pwm_rx_fifo[i].analysis_export);
     end
   endfunction
 

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -81,10 +81,11 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   lc_ctrl_state_pkg::lc_state_e use_otp_image = lc_ctrl_state_pkg::LcStRma;
   string otp_images[lc_ctrl_state_pkg::lc_state_e];
 
-  uint                sw_test_timeout_ns = 12_000_000; // 12ms
-  sw_logger_vif       sw_logger_vif;
-  sw_test_status_vif  sw_test_status_vif;
-  ast_supply_vif      ast_supply_vif;
+  uint               sw_test_timeout_ns = 12_000_000; // 12ms
+  sw_logger_vif      sw_logger_vif;
+  sw_test_status_vif sw_test_status_vif;
+  ast_supply_vif     ast_supply_vif;
+  ast_ext_clk_vif    ast_ext_clk_vif;
 
   // Number of RAM tiles for each RAM instance.
   uint num_ram_main_tiles;

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -70,10 +70,11 @@ package chip_env_pkg;
   localparam uint TokenWidthBit  = kmac_pkg::MsgWidth * 2;
   localparam uint TokenWidthByte = TokenWidthBit / 8;
 
-  typedef virtual pins_if #(NUM_GPIOS)  gpio_vif;
-  typedef virtual sw_logger_if          sw_logger_vif;
-  typedef virtual sw_test_status_if     sw_test_status_vif;
-  typedef virtual ast_supply_if         ast_supply_vif;
+  typedef virtual pins_if #(NUM_GPIOS) gpio_vif;
+  typedef virtual sw_logger_if         sw_logger_vif;
+  typedef virtual sw_test_status_if    sw_test_status_vif;
+  typedef virtual ast_supply_if        ast_supply_vif;
+  typedef virtual ast_ext_clk_if       ast_ext_clk_vif;
 
   // Types of memories in the chip.
   //

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -79,6 +79,8 @@ module tb;
     .trigger(top_earlgrey.rv_core_ibex_pwrmgr.core_sleeping)
   );
 
+  bind dut ast_ext_clk_if ast_ext_clk_if ();
+
   // POR reset if
   pins_if #(1) por_rstn_if();
   assign (weak0, weak1) por_rstn_if.pins = 1;
@@ -330,6 +332,10 @@ module tb;
     // AST supply interface.
     uvm_config_db#(virtual ast_supply_if)::set(
         null, "*.env", "ast_supply_vif", dut.ast_supply_if);
+
+    // AST io clk blocker interface.
+    uvm_config_db#(virtual ast_ext_clk_if)::set(
+        null, "*.env", "ast_ext_clk_vif", dut.ast_ext_clk_if);
 
     // PWRGMR.low_power_o only
     uvm_config_db#(virtual pwrmgr_low_power_if)::set(


### PR DESCRIPTION
Force off AST IO oscillator clock when io_clk_byp_ack raises, and release
it upon reset. If the hardware is not using the external clock the chip
will freeze.

Fixes: #12232

Signed-off-by: Guillermo Maturana <maturana@google.com>