### PR TITLE
[otbn,dv] Illegal Bus Access fixup

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_illegal_mem_acc_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_illegal_mem_acc_vseq.sv
@@ -21,40 +21,57 @@ class otbn_illegal_mem_acc_vseq extends otbn_single_vseq;
 
   task do_mem_acc();
     bit write;
-    uvm_mem mems[$];
-    string ral_name;
+    uvm_mem mem;
     bit [BUS_AW-1:0] offset;
-    bit [BUS_AW-1:0] addr;
     bit [BUS_DW-1:0] data;
-    bit completed, saw_err;
     // Pick either dmem or imem to access randomly
-    bit choose_mem;
+    bit is_imem;
     bit [31:0] err_val = 32'd1 << 21;
 
-    cfg.ral_models["otbn_reg_block"].get_memories(mems);
-    `DV_CHECK_STD_RANDOMIZE_FATAL(choose_mem)
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(is_imem)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(data)
     `DV_CHECK_STD_RANDOMIZE_FATAL(write)
+
+    // Pick on which memory we will be working on
+    mem = is_imem ? ral.imem : ral.dmem;
     wait (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusBusyExecute);
-    offset = $urandom_range(0, mems[choose_mem].get_n_bytes() - 1);
-    addr = mems[choose_mem].get_address(offset);
-    ral_name = mems[choose_mem].get_parent().get_name();
+    offset = $urandom_range(0, mem.get_n_bytes() - 1);
     cfg.en_scb_tl_err_chk = 0;
     fork
       begin
-        string valid_signal_path = "tb.dut.tl_i.a_valid";
-        bit temp_var;
-        do begin
-          cfg.clk_rst_vif.wait_clks(1);
-          `DV_CHECK_FATAL(uvm_hdl_read(valid_signal_path, temp_var) == 1)
-        end while (!temp_var);
-        cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+        string tl_dmem_req_path = "tb.dut.dmem_req_bus";
+        string tl_imem_req_path = "tb.dut.imem_req_bus";
+        bit tl_dmem_req, tl_imem_req;
+        while (1) begin
+          // Check the paths at negedge, any memory accesses from TL bus while executing
+          // regardless of it being driven by this sequence should cause a "ILLEGAL_BUS_ACCESS"
+          // fatal error.
+          `DV_CHECK_FATAL(uvm_hdl_read(tl_dmem_req_path, tl_dmem_req))
+          `DV_CHECK_FATAL(uvm_hdl_read(tl_imem_req_path, tl_imem_req))
+          if (tl_dmem_req | tl_imem_req) begin
+            // This will actually take half-cycle since we are already at a negedge
+            cfg.clk_rst_vif.wait_clks(1);
+            // Let model know we have the fatal error.
+            cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+            break;
+          end
+          cfg.clk_rst_vif.wait_n_clks(1);
+        end
       end
       begin
-        tl_access_w_abort(.addr(addr), .write(0), .data(data), .completed(completed),
-                          .saw_err(saw_err), .check_rsp(1),
-                          .tl_sequencer_h(p_sequencer.tl_sequencer_hs[ral_name]));
-        `DV_CHECK_EQ(completed, 1)
-        `DV_CHECK_EQ(saw_err, 0)
+        if (write) begin
+          csr_utils_pkg::mem_wr(mem, offset, data);
+          `uvm_info(`gfn,
+                    $sformatf("\n\t ----| Writing %d to a memory", data),
+                    UVM_LOW)
+        end else begin
+          csr_utils_pkg::mem_rd(mem, offset, data);
+          `uvm_info(`gfn,
+                    $sformatf("\n\t ----| Reading %d from a memory", data),
+                    UVM_LOW)
+          `DV_CHECK_FATAL(data == '0)
+        end
       end
     join
     reset_if_locked();


### PR DESCRIPTION
This commit includes changes in the do_mem_acc task.
Main idea is to poll TL bus requests for DMEM and IMEM and send relevant
error code to the model right when it happens. 

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>

With #12906 this will clean up +95% failures in this specific test.