### PR TITLE
[ci] Skip FPGA/ OTBN tests for CDC

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,7 +117,7 @@ jobs:
 - job: sw_build
   displayName: Build Software for Earl Grey toplevel design
   dependsOn: lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool:
     vmImage: ubuntu-18.04
   steps:
@@ -146,7 +146,7 @@ jobs:
 - job: cw310_sw_build
   displayName: Build Software required for CW310 FPGA synthesis
   dependsOn: lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool:
     vmImage: ubuntu-18.04
   steps:
@@ -175,7 +175,7 @@ jobs:
 - job: chip_englishbreakfast_verilator
   displayName: Build Verilator simulation of the English Breakfast toplevel design
   dependsOn: lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool:
     vmImage: ubuntu-18.04
   steps:
@@ -259,6 +259,7 @@ jobs:
 - job: otbn_standalone_tests
   displayName: Run OTBN Smoke Test
   dependsOn: lint
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool:
     vmImage: ubuntu-18.04
   timeoutInMinutes: 10
@@ -293,7 +294,7 @@ jobs:
     - lint
     # The bootrom is built into the FPGA image at synthesis time.
     - cw310_sw_build
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'))
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public
   timeoutInMinutes: 180
   steps:
@@ -330,7 +331,7 @@ jobs:
   dependsOn:
     - chip_earlgrey_cw310
     - sw_build
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'))
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public
   timeoutInMinutes: 10
   steps:
@@ -370,7 +371,7 @@ jobs:
 - job: chip_englishbreakfast_cw305
   displayName: Build CW305 variant of the English Breakfast toplevel design using Vivado
   dependsOn: build_and_execute_verilated_tests_englishbreakfast
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'))
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public
   timeoutInMinutes: 120 # 2 hours
   steps:
@@ -417,7 +418,7 @@ jobs:
     - sw_build
     - execute_verilated_tests
     - chip_earlgrey_cw310
-  condition: and(eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'))
+  condition: and(eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   steps:
   - template: ci/install-package-dependencies.yml
   - template: ci/download-artifacts-template.yml


### PR DESCRIPTION
This commit let CI skip FPGA, verilator, OTBN tests for CDC only
changes.

The cdconlychange log has been checked after
https://github.com/lowRISC/opentitan/pull/13117 has been merged.

