### PR TITLE
[bazel] Annotated disassembly

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,10 @@
 build --cxxopt='-std=c++14'
 build --conlyopt='-std=c11'
 
+# Never strip debugging information so that we can produce annotated
+# disassemblies when compilation mode is fastbuild.
+build --strip='never'
+
 # Bazel embedded enables the following feature which along with -std=c11 and
 # our codebase generates a lot of warnings by setting the -Wpedantic flag
 build --features=-all_warnings

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -139,6 +139,9 @@ def _elf_to_disassembly_impl(ctx):
                 ctx.file._cleanup_script.path,
                 disassembly.path,
             ],
+            execution_requirements = {
+                "no-sandbox": "1",
+            },
             command = "$1 --disassemble --headers --line-numbers --disassemble-zeroes --source $2 | $3 > $4",
         )
         return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]

--- a/third_party/bazel_embedded/repos.bzl
+++ b/third_party/bazel_embedded/repos.bzl
@@ -7,12 +7,14 @@ load("@//rules:repo.bzl", "http_archive_or_local")
 def bazel_embedded_repos(bazel_embedded = None, platforms = None):
     # Contains rules that support building SW for embedded targets. Specifically, we
     # maintain a fork to build for RISCV32I.
+    commit = "322dd944eb6b2f1c7736d854ff3026840f3ef8f3"
+    fork = "lowRISC"
     http_archive_or_local(
         name = "bazel_embedded",
         local = bazel_embedded,
         sha256 = "278562634fb0261bc85c9da3ed003eba86430a56bd4668cc742779c3fa085fec",
-        strip_prefix = "bazel-embedded-322dd944eb6b2f1c7736d854ff3026840f3ef8f3",
-        url = "https://github.com/lowRISC/bazel-embedded/archive/322dd944eb6b2f1c7736d854ff3026840f3ef8f3.tar.gz",
+        strip_prefix = "bazel-embedded-{}".format(commit),
+        url = "https://github.com/{}/bazel-embedded/archive/{}.tar.gz".format(fork, commit),
     )
 
     # The platforms repo contains standard cpu/os/disto contraints.

--- a/third_party/bazel_embedded/repos.bzl
+++ b/third_party/bazel_embedded/repos.bzl
@@ -7,12 +7,12 @@ load("@//rules:repo.bzl", "http_archive_or_local")
 def bazel_embedded_repos(bazel_embedded = None, platforms = None):
     # Contains rules that support building SW for embedded targets. Specifically, we
     # maintain a fork to build for RISCV32I.
-    commit = "322dd944eb6b2f1c7736d854ff3026840f3ef8f3"
+    commit = "a274de4b4c51d8a9fb76c153fd66b4b1703ae872"
     fork = "lowRISC"
     http_archive_or_local(
         name = "bazel_embedded",
         local = bazel_embedded,
-        sha256 = "278562634fb0261bc85c9da3ed003eba86430a56bd4668cc742779c3fa085fec",
+        sha256 = "6ccd63a2f71c3dd6b35d2917e903217c20288c162f80578d48ea3a8a14a60c68",
         strip_prefix = "bazel-embedded-{}".format(commit),
         url = "https://github.com/{}/bazel-embedded/archive/{}.tar.gz".format(fork, commit),
     )


### PR DESCRIPTION
This PR disables the sandbox during disassembly to be able to produce annotated disassemblies.

Thanks for the pointers @cfrantz! I'm marking this as ready for review since the flag changes will go in a separate PR to lowRISC/bazel-embedded.

