### PR TITLE
[rv_core_ibex] reset the default crash dump value

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -490,6 +490,7 @@ module rv_core_ibex
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       previous_valid <= '0;
+      crash_dump_previous <= '0;
     end else if (double_fault) begin
       previous_valid <= '1;
       crash_dump_previous <= crash_dump;


### PR DESCRIPTION
This prevents x propagation in DV land when the
crash dump is read in the absence of a double fault.

Signed-off-by: Timothy Chen <timothytim@google.com>