### PR TITLE
[bazel] Create FUSESOC_IGNORE

### DIFF
--- a/hw/BUILD
+++ b/hw/BUILD
@@ -71,6 +71,15 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "fusesoc_ignore",
+    outs = ["FUSESOC_IGNORE"],
+    cmd = """
+        touch $@
+    """,
+    visibility = ["//visibility:public"],
+)
+
 # TODO(lowRISC/opentitan#7972): Globbing all of the //hw/... hierarchy together
 # is a bit of a hack.  Longer term, we need proper rules for expressing the
 # relationships between verilog components.

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -60,6 +60,7 @@ def dv_params(
         dvsim_config,
         "@//util/dvsim",
         "@//hw:all_files",
+        "@//hw:fusesoc_ignore",
     ]
     required_tags = ["dv"]
     kwargs.update(
@@ -121,6 +122,7 @@ def verilator_params(
     required_data = [
         "@//sw/host/opentitantool:test_resources",
         "@//hw:verilator",
+        "@//hw:fusesoc_ignore",
     ]
     required_tags = ["verilator"]
     kwargs.update(


### PR DESCRIPTION
This commit defines `fusesoc_ignore` rule to create FUSESOC_IGNORE for
hw copied files.

