### PR TITLE
[dv/clkmgr] Fix clkmgr_peri tests

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -61,8 +61,8 @@ package clkmgr_env_pkg;
     PeriIo
   } peri_e;
   typedef struct packed {
-    logic io_peri_en;
     logic usb_peri_en;
+    logic io_peri_en;
     logic io_div2_peri_en;
     logic io_div4_peri_en;
   } clk_enables_t;

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -273,10 +273,8 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
       "jitter_regwen": begin
       end
       "jitter_enable": begin
-        if (addr_phase_write) begin
-          if (`gmv(ral.jitter_regwen)) begin
-            `DV_CHECK_EQ(prim_mubi_pkg::mubi4_t'(item.a_data), cfg.clkmgr_vif.jitter_enable_csr)
-          end
+        if (addr_phase_write && `gmv(ral.jitter_regwen)) begin
+          `DV_CHECK_EQ(prim_mubi_pkg::mubi4_t'(item.a_data), cfg.clkmgr_vif.jitter_enable_csr)
         end
       end
       "clk_enables": begin


### PR DESCRIPTION
Fix the layout of struct clk_enables_t to match the RTL. The current mismatch
causes many runs of test clkmgr_peri to fail.

Signed-off-by: Guillermo Maturana <maturana@google.com>