### PR TITLE
[opentitanlib] Add rust_doc target

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library", "rust_test")
 load("//rules:ujson.bzl", "ujson_rust")
 
 package(default_visibility = ["//visibility:public"])
@@ -259,4 +259,9 @@ rust_test(
         "gpio": "$(location :gpio)",
         "pinmux_config": "$(location :pinmux_config)",
     },
+)
+
+rust_doc(
+    name = "opentitanlib_doc",
+    crate = ":opentitanlib",
 )


### PR DESCRIPTION
Create build target so users and developers can generate the docs for
local browsing.

Signed-off-by: Alexander Williams <awill@google.com>