### PR TITLE
Many cw310 tests

### DIFF
--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -23,50 +23,12 @@ export BITSTREAM="--offline --list ${SHA}"
 # in case we've crashed the UART handler on the CW310's SAM3U
 trap 'python3 ./util/fpga/cw310_reboot.py' EXIT
 
-# TODO: remove the --notest_keep_going and --nokeep_going flag after the CW310
-# tests are reliable (#13044)
 ci/bazelisk.sh test \
     --define DISABLE_VERILATOR_BUILD=true \
-    --notest_keep_going \
     --nokeep_going \
     --test_tag_filters=cw310,-broken \
     --test_output=all \
     --build_tests_only \
     --define cw310=lowrisc \
-    //sw/device/tests:aes_smoketest_fpga_cw310 \
-    //sw/device/tests:aon_timer_smoketest_fpga_cw310 \
-    //sw/device/tests:clkmgr_smoketest_fpga_cw310 \
-    //sw/device/tests:crt_test_fpga_cw310 \
-    //sw/device/tests:flash_ctrl_test_fpga_cw310 \
-    //sw/device/tests:gpio_smoketest_fpga_cw310 \
-    //sw/device/tests:kmac_smoketest_fpga_cw310 \
-    //sw/device/tests:kmac_mode_cshake_test_fpga_cw310 \
-    //sw/device/tests:kmac_mode_kmac_test_fpga_cw310 \
-    //sw/device/tests:otbn_randomness_test_fpga_cw310 \
-    //sw/device/tests:otbn_irq_test_fpga_cw310 \
-    //sw/device/tests:otbn_rsa_test_fpga_cw310 \
-    //sw/device/tests:otbn_ecdsa_op_irq_test_fpga_cw310 \
-    //sw/device/tests:otp_ctrl_smoketest_fpga_cw310 \
-    //sw/device/tests:pwrmgr_smoketest_fpga_cw310 \
-    //sw/device/tests:rstmgr_smoketest_fpga_cw310 \
-    //sw/device/tests:rv_plic_smoketest_fpga_cw310 \
-    //sw/device/tests:rv_timer_smoketest_fpga_cw310 \
-    //sw/device/tests:sram_ctrl_smoketest_fpga_cw310 \
-    //sw/device/tests:uart_smoketest_fpga_cw310 \
-    //sw/device/silicon_creator/lib:boot_data_functest_fpga_cw310 \
-    //sw/device/silicon_creator/lib/drivers:hmac_functest_fpga_cw310 \
-    //sw/device/silicon_creator/lib/drivers:retention_sram_functest_fpga_cw310 \
-    //sw/device/silicon_creator/lib/drivers:uart_functest_fpga_cw310 \
-    //sw/device/silicon_creator/lib/drivers:watchdog_functest_fpga_cw310 \
-    //sw/device/silicon_creator/mask_rom:e2e_bootup_no_rom_ext_signature_fpga_cw310 \
-    //sw/device/silicon_creator/lib/sigverify:sigverify_functest_fpga_cw310
-
-    # Note that some tests were included in the original systemtest but are
-    # failing when run under bazel and so are excluded from this run. These
-    # tests are:
-    # - pmp_smoketest_napot
-    # - pmp_smoktetest_tor
-    # TODO: use the following query instead of the list above after the CW310
-    # UART is reliable (#13044)
-    # $(./bazelisk.sh query 'rdeps(//...,@bitstreams//:bitstream_test_rom)') \
-    # All the tests that depend on the test rom
+    $(./bazelisk.sh query 'rdeps(//...,@bitstreams//:bitstream_test_rom)') \
+    $(./bazelisk.sh query 'rdeps(//...,@bitstreams//:bitstream_mask_rom)')

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -179,6 +179,12 @@ opentitan_functest(
 opentitan_functest(
     name = "pwrmgr_wdog_reset_reqs_test",
     srcs = ["pwrmgr_wdog_reset_reqs_test.c"],
+    cw310 = cw310_params(
+        # FIXME #13198 Running
+        # //sw/device/tests:pwrmgr_wdog_reset_reqs_test_fpga_cw310
+        # more than once cause these tests to fail
+        tags = ["broken"],
+    ),
     verilator = verilator_params(
         tags = [
             "broken",
@@ -314,6 +320,10 @@ opentitan_functest(
 opentitan_functest(
     name = "clkmgr_off_peri_test",
     srcs = ["clkmgr_off_peri_test.c"],
+    cw310 = cw310_params(
+        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+        tags = ["broken"],
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
@@ -356,24 +366,42 @@ cc_library(
 opentitan_functest(
     name = "clkmgr_off_aes_trans_test",
     srcs = ["clkmgr_off_aes_trans_test.c"],
+    cw310 = cw310_params(
+        # FIXME #13198 Running
+        # //sw/device/tests:clkmgr_off_aes_trans_test_fpga_cw310
+        # more than once cause these tests to fail
+        tags = ["broken"],
+    ),
     deps = ["clkmgr_off_trans_impl"],
 )
 
 opentitan_functest(
     name = "clkmgr_off_hmac_trans_test",
     srcs = ["clkmgr_off_hmac_trans_test.c"],
+    cw310 = cw310_params(
+        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+        tags = ["broken"],
+    ),
     deps = ["clkmgr_off_trans_impl"],
 )
 
 opentitan_functest(
     name = "clkmgr_off_kmac_trans_test",
     srcs = ["clkmgr_off_kmac_trans_test.c"],
+    cw310 = cw310_params(
+        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+        tags = ["broken"],
+    ),
     deps = ["clkmgr_off_trans_impl"],
 )
 
 opentitan_functest(
     name = "clkmgr_off_otbn_trans_test",
     srcs = ["clkmgr_off_otbn_trans_test.c"],
+    cw310 = cw310_params(
+        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+        tags = ["broken"],
+    ),
     deps = ["clkmgr_off_trans_impl"],
 )
 
@@ -989,6 +1017,10 @@ opentitan_functest(
 opentitan_functest(
     name = "rstmgr_smoketest",
     srcs = ["rstmgr_smoketest.c"],
+    cw310 = cw310_params(
+        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+        tags = ["broken"],
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",

--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -211,7 +211,6 @@ impl Transport for CW310 {
                     return Ok(None);
                 }
             }
-
             // Program the FPGA bitstream.
             log::info!("Programming the FPGA bitstream.");
             let usb = self.device.borrow();

--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -24,7 +24,7 @@ pub struct UartConsole {
     pub newline: bool,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum ExitStatus {
     None,
     CtrlC,

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -30,7 +30,7 @@ pub struct LoadBitstream {
     pub rom_kind: Option<RomKind>,
     #[structopt(long, parse(try_from_str=humantime::parse_duration), default_value="50ms", help = "Duration of the reset pulse.")]
     pub rom_reset_pulse: Duration,
-    #[structopt(long, parse(try_from_str=humantime::parse_duration), default_value="1s", help = "Duration of ROM detection timeout")]
+    #[structopt(long, parse(try_from_str=humantime::parse_duration), default_value="2s", help = "Duration of ROM detection timeout")]
     pub rom_timeout: Duration,
 }
 


### PR DESCRIPTION
Now that the cw310 can reboot after failing tests we can run a lot more tests. This also cleans up the test rom identification so tests take ~2s instead of ~20s.

Fixes #13044