### PR TITLE
[opentitantool] Add transport subcommand

### DIFF
--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -22,6 +22,7 @@ rust_binary(
         "src/command/rsa.rs",
         "src/command/set_pll.rs",
         "src/command/spi.rs",
+        "src/command/transport.rs",
         "src/command/update_usr_access.rs",
         "src/command/version.rs",
         "src/main.rs",

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -13,6 +13,7 @@ pub mod load_bitstream;
 pub mod rsa;
 pub mod set_pll;
 pub mod spi;
+pub mod transport;
 pub mod update_usr_access;
 pub mod version;
 

--- a/sw/host/opentitantool/src/command/transport.rs
+++ b/sw/host/opentitantool/src/command/transport.rs
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use erased_serde::Serialize;
+use std::any::Any;
+use structopt::StructOpt;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
+
+/// Initialize state of a transport debugger device to fit the device under test.  This
+/// typically involves setting pins as input/output, open drain, etc. according to configuration
+/// files.
+#[derive(Debug, StructOpt)]
+pub struct TransportInit {}
+
+impl CommandDispatch for TransportInit {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Serialize>>> {
+        // Configure all GPIO pins to default direction and level, according to
+        // configuration files provided.
+        transport.apply_default_pin_configurations()?;
+        Ok(None)
+    }
+}
+
+/// Commands for interacting with the transport debugger device itself.
+#[derive(Debug, StructOpt, CommandDispatch)]
+pub enum TransportCommand {
+    Init(TransportInit),
+}

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -36,6 +36,7 @@ enum RootCommandHierarchy {
     NoOp(command::NoOp),
     Rsa(command::rsa::Rsa),
     Spi(command::spi::SpiCommand),
+    Transport(command::transport::TransportCommand),
     Version(command::version::Version),
 
     // Flattened because `Greetings` is a subcommand hierarchy.


### PR DESCRIPTION
UltraDebug and the CW310 Atmel chip both have firmware that hard-codes
the functionality of reset, uart, and all other pins, and are therefore
ready for operation upon powering on.

HyperDebug on the other hand, is not hard-coded for any OpenTitan pin
assignments, and all its ports default to high-impedance.  Hence, it
needs some initialization to be told among other things that the reset
pin should be open-drain with pullup, defaulting high, and the boot0
pins should be push-pull defaulting to a low level.  These pin
configurations and defaults are generally declared in configuration
files.  OpenTitan tool cannot blindly apply these defaults at every
invocation, as it would override any previous pin manipulation in the
session.

This PR introduces a new command `transport init`, meant to explicitly
tell the OpenTitan tool to configure all pins according to the
configuration, and set their level to the default (discarding any
previously set levels).  Basically, this command invokes the existing
`TransportWrapper.apply_default_pin_configurations()`.

I have create the `transport` top-level command with the intent that
HyperDebug or other transports may have some special features that do
not fit well into any generic trait, and we could add a channel for
sending arbitrary instructions to the transport, without OpenTitan tool
understanding those instructions.  HyperDebug for instance already has a
textual command line interface, if it had a command for setting e.g. the
slope control on I2C or SPI lines, then OpenTitan tool could be fitted
with a `transport passthrough` command, allowing the sending of a text
string verbatim to the transport for processing.

Change-Id: Ifd004b024a087beb91ae57268a87d02063af8e85