### PR TITLE
[opentitanlib] Add support for Emulator in Proxy transport.

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -65,6 +65,7 @@ rust_library(
         "src/transport/hyperdebug/mod.rs",
         "src/transport/hyperdebug/spi.rs",
         "src/transport/mod.rs",
+        "src/transport/proxy/emu.rs",
         "src/transport/proxy/gpio.rs",
         "src/transport/proxy/i2c.rs",
         "src/transport/proxy/mod.rs",

--- a/sw/host/opentitanlib/src/transport/proxy/emu.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/emu.rs
@@ -35,7 +35,7 @@ impl Emulator for ProxyEmu {
     fn get_state(&self) -> Result<EmuState> {
         match self.execute_command(EmuRequest::GetState)? {
             EmuResponse::GetState { state } => Ok(state),
-            _ => bail!(ProxyError::UnexpectedReply()),
+            _ => Err(ProxyError::UnexpectedReply().into()),
         }
     }
 
@@ -45,14 +45,14 @@ impl Emulator for ProxyEmu {
             args: args.clone(),
         })? {
             EmuResponse::Start => Ok(()),
-            _ => bail!(ProxyError::UnexpectedReply()),
+            _ => Err(ProxyError::UnexpectedReply().into()),
         }
     }
 
     fn stop(&self) -> Result<()> {
         match self.execute_command(EmuRequest::Stop)? {
             EmuResponse::Stop => Ok(()),
-            _ => bail!(ProxyError::UnexpectedReply()),
+            _ => Err(ProxyError::UnexpectedReply().into()),
         }
     }
 }

--- a/sw/host/opentitanlib/src/transport/proxy/emu.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/emu.rs
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use super::ProxyError;
+use crate::io::emu::{EmuState, EmuValue, Emulator};
+use crate::proxy::protocol::{EmuRequest, EmuResponse, Request, Response};
+use crate::transport::proxy::{Inner, Proxy};
+
+pub struct ProxyEmu {
+    inner: Rc<Inner>,
+}
+
+impl ProxyEmu {
+    pub fn open(proxy: &Proxy) -> Result<Self> {
+        Ok(Self {
+            inner: Rc::clone(&proxy.inner),
+        })
+    }
+
+    // Convenience method for issuing EMU commands via proxy protocol.
+    fn execute_command(&self, command: EmuRequest) -> Result<EmuResponse> {
+        match self.inner.execute_command(Request::Emu { command })? {
+            Response::Emu(resp) => Ok(resp),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+}
+
+impl Emulator for ProxyEmu {
+    fn get_state(&self) -> Result<EmuState> {
+        match self.execute_command(EmuRequest::GetState)? {
+            EmuResponse::GetState { state } => Ok(state),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn start(&self, factory_reset: bool, args: &HashMap<String, EmuValue>) -> Result<()> {
+        match self.execute_command(EmuRequest::Start {
+            factory_reset,
+            args: args.clone(),
+        })? {
+            EmuResponse::Start => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn stop(&self) -> Result<()> {
+        match self.execute_command(EmuRequest::Stop)? {
+            EmuResponse::Stop => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+}

--- a/sw/host/opentitanlib/src/transport/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/mod.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 
 use crate::bootstrap::BootstrapOptions;
 use crate::impl_serializable_error;
+use crate::io::emu::Emulator;
 use crate::io::gpio::GpioPin;
 use crate::io::i2c::Bus;
 use crate::io::spi::Target;
@@ -20,6 +21,7 @@ use crate::io::uart::Uart;
 use crate::proxy::protocol::{Message, ProxyRequest, ProxyResponse, Request, Response};
 use crate::transport::{Capabilities, Capability, ProxyOps, Transport, TransportError};
 
+mod emu;
 mod gpio;
 mod i2c;
 mod spi;
@@ -167,6 +169,11 @@ impl Transport for Proxy {
     // Create GpioPin instance, or return one from a cache of previously created instances.
     fn gpio_pin(&self, pinname: &str) -> Result<Rc<dyn GpioPin>> {
         Ok(Rc::new(gpio::ProxyGpioPin::open(self, pinname)?))
+    }
+
+    // Create Emulator instance, or return one from a cache of previously created instances.
+    fn emulator(&self) -> Result<Rc<dyn Emulator>> {
+        Ok(Rc::new(emu::ProxyEmu::open(self)?))
     }
 
     // Create ProxyOps instance.

--- a/sw/host/opentitanlib/src/transport/ti50emulator/emu.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/emu.rs
@@ -258,6 +258,11 @@ impl EmulatorProcess {
                     )));
                 }
             }
+        } else {
+            if self.state == EmuState::Error {
+                log::warn!("Stop sub-process don't exist clean error state");
+                self.state = EmuState::Off;
+            }
         }
         Ok(())
     }
@@ -379,7 +384,6 @@ impl Emulator for Ti50SubProcess {
             }
             _ => {}
         };
-        process.state = EmuState::Busy;
         process.update_args(factory_reset, args)?;
         process.spawn_process()?;
         process.state = EmuState::On;


### PR DESCRIPTION
[opentitanlib] Add support for Emulator in Proxy transport.

Implementations of transparent Emulator for Proxy backend.
Also adds minor fix in Ti50Emulator state handling.

Part of the issue: https://github.com/lowRISC/opentitan/issues/10217

Signed-off-by: Michał Mazurek <maz@semihalf.com>