### PR TITLE
[fpga] Make `set_clock_sense` constraint more flexible using a wildcard

### DIFF
--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -25,7 +25,12 @@ create_generated_clock -name clk_io_div4 -source [get_pin ${u_pll}/CLKOUT0] -div
 # therefore, Vivado propagates both clock edges down the clock network.
 # this implementation is not ideal - but we can at least tell Vivado to only honour the rising edge for
 # timing analysis.
-set_clock_sense -positive top_*/u_clkmgr_aon/u_no_scan_io_div2_div/gen_div2.u_div2/gen_fpga_buf.bufg_i_i_1__0/O
+set_clock_sense -positive \
+  [get_pins -filter {DIRECTION == OUT && IS_LEAF} -of_objects \
+    [get_nets -segments -of_objects \
+      [get_pins top_*/u_clkmgr_aon/u_no_scan_io_div2_div/u_clk_div_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.bufg_i/I] \
+    ] \
+  ]
 
 ## JTAG and SPI clocks
 create_clock -add -name lc_jtag_tck -period 100.00 -waveform {0 5} [get_pin top_*/u_pinmux_aon/u_pinmux_strap_sampling/u_pinmux_jtag_buf_lc/prim_clock_buf_tck/gen_xilinx.u_impl_xilinx/gen_fpga_buf.bufg_i/O]


### PR DESCRIPTION
It seems that the name of the target BUFG cell may change as the design evolves. This results in Vivado not being able to apply the constraint and triggering a critical warning instead.