### PR TITLE
[flash_ctrl] Add Covergroup : error_cg

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * Covergoups that are dependent on run-time parameters that may be available
- * only in build_phase can be defined here
- * Covergroups may also be wrapped inside helper classes if needed.
- */
+//
+// Covergoups that are dependent on run-time parameters that may be available
+// only in build_phase can be defined here
+// Covergroups may also be wrapped inside helper classes if needed.
+//
 
-class flash_ctrl_env_cov extends cip_base_env_cov #(
-  .CFG_T(flash_ctrl_env_cfg)
-);
+`include "dv_fcov_macros.svh"
+
+class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
   `uvm_component_utils(flash_ctrl_env_cov)
 
   // the base class provides the following handles for use:
@@ -28,18 +28,35 @@ class flash_ctrl_env_cov extends cip_base_env_cov #(
       bins read_erase_read = (FlashOpRead => FlashOpErase => FlashOpRead);
     }
     op_part_cross : cross part_cp, op_cp;
-  endgroup  // control_cg
+  endgroup  : control_cg
 
   covergroup erase_susp_cg with function sample (bit erase_req = 0);
     erase_susp_cp: coverpoint erase_req {
       bins erase_susp_true = {1};
     }
-  endgroup  // erase_susp_cg
+  endgroup : erase_susp_cg
+
+  covergroup error_cg with function sample(input bit [NumFlashErrBits-1:0] err_val);
+
+    option.per_instance = 1;
+    option.name         = "error_cg";
+
+    `DV_FCOV_EXPR_SEEN(op_err,          err_val[FlashOpErr])
+    `DV_FCOV_EXPR_SEEN(mp_err,          err_val[FlashMpErr])
+    `DV_FCOV_EXPR_SEEN(rd_err,          err_val[FlashRdErr])
+    `DV_FCOV_EXPR_SEEN(prog_err,        err_val[FlashProgErr])
+    `DV_FCOV_EXPR_SEEN(prog_win_err,    err_val[FlashProgWinErr])
+    `DV_FCOV_EXPR_SEEN(prog_type_err,   err_val[FlashProgTypeErr])
+    `DV_FCOV_EXPR_SEEN(flash_macro_err, err_val[FlashMacroErr])
+    `DV_FCOV_EXPR_SEEN(update_err,      err_val[FlashUpdateErr])
+
+  endgroup : error_cg
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
     control_cg = new();
     erase_susp_cg = new();
+    error_cg = new();
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -122,6 +122,17 @@ package flash_ctrl_env_pkg;
   parameter bit MP_PASS      = 0;
   parameter bit MP_VIOLATION = 1;
 
+  // Flash Error Bits (flash_ctrl.err_code)
+  parameter uint NumFlashErrBits  = 8;
+  parameter uint FlashOpErr       = 0;
+  parameter uint FlashMpErr       = 1;
+  parameter uint FlashRdErr       = 2;
+  parameter uint FlashProgErr     = 3;
+  parameter uint FlashProgWinErr  = 4;
+  parameter uint FlashProgTypeErr = 5;
+  parameter uint FlashMacroErr    = 6;
+  parameter uint FlashUpdateErr   = 7;
+
   // types
   typedef enum int {
     FlashCtrlIntrProgEmpty = 0,

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -283,6 +283,12 @@ class flash_ctrl_scoreboard #(
           if (do_read_check) begin
             `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data, $sformatf(
                          "reg name: %0s", csr.get_full_name()))
+            if (csr.get_name() == "err_code") begin
+              csr_rd(.ptr(ral.err_code), .value(data), .backdoor(1));
+              if (cfg.en_cov) begin
+                cov.error_cg.sample(data);
+              end
+            end
           end
           void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
         end else if (is_mem_addr(item, ral_name) && cfg.scb_check) begin  // rd fifo

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -1011,7 +1011,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     endcase
     csr_rd_check(.ptr(ral.op_status.err), .compare_value(exp_alert));
 
-    // For 'prog_type_err' and 'prog_win_err' check via backdoor ff Pass,
+    // For 'prog_type_err' and 'prog_win_err' check via backdoor if Pass,
     // 'mp_err' is Backdoor checked directly within its own test.
     if ((alert_name inside {"prog_type_err", "prog_win_err"}) && (exp_alert == 0)) begin
       cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);


### PR DESCRIPTION
Adds the covergroup error_cg which covers the fields of FLASH_CTRL.ERR_CODE

Signed-off-by: TIM EWINS <tim.ewins@ensilica.com>