### PR TITLE
[otbn] Remove reset from FF-based GPRs and WDRs

### DIFF
--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -228,10 +228,8 @@ module otbn_alu_bignum
     );
     assign mod_no_intg_q[i_word*32+:32] = mod_intg_q[i_word*39+:32];
 
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-      if (!rst_ni) begin
-        mod_intg_q[i_word*39+:39] <= EccZeroWord;
-      end else if (mod_wr_en[i_word]) begin
+    always_ff @(posedge clk_i) begin
+      if (mod_wr_en[i_word]) begin
         mod_intg_q[i_word*39+:39] <= mod_intg_d[i_word*39+:39];
       end
     end

--- a/hw/ip/otbn/rtl/otbn_rf_base_ff.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base_ff.sv
@@ -48,10 +48,8 @@ module otbn_rf_base_ff
   for (genvar i = 1; i < NGpr; i++) begin : g_rf_flops
     logic [BaseIntgWidth-1:0] rf_reg_q;
 
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-      if (!rst_ni) begin
-        rf_reg_q <= WordZeroVal;
-      end else if(we_onehot[i]) begin
+    always_ff @(posedge clk_i) begin
+      if(we_onehot[i]) begin
         rf_reg_q <= wr_data_i;
       end
     end

--- a/hw/ip/otbn/rtl/otbn_rf_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum.sv
@@ -62,9 +62,7 @@ module otbn_rf_bignum
   assign wr_en_internal = wr_en_i & {2{wr_commit_i}};
 
   if (RegFile == RegFileFF) begin : gen_rf_bignum_ff
-    otbn_rf_bignum_ff #(
-      .WordZeroVal(prim_secded_pkg::SecdedInv3932ZeroWord)
-    ) u_otbn_rf_bignum_inner (
+    otbn_rf_bignum_ff u_otbn_rf_bignum_inner (
       .clk_i,
       .rst_ni,
 

--- a/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
@@ -15,9 +15,7 @@
  */
 module otbn_rf_bignum_ff
   import otbn_pkg::*;
-#(
-  parameter logic [BaseIntgWidth-1:0] WordZeroVal = '0
-) (
+(
   input  logic             clk_i,
   input  logic             rst_ni,
 
@@ -53,18 +51,14 @@ module otbn_rf_bignum_ff
     );
 
     // Split registers into halves for clear seperation for the enable terms
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-      if (!rst_ni) begin
-        rf[i][0+:ExtWLEN/2] <= {BaseWordsPerWLEN/2{WordZeroVal}};
-      end else if (rf_predec_bignum_i.rf_we[i] & we_onehot[i][0]) begin
+    always_ff @(posedge clk_i) begin
+      if (rf_predec_bignum_i.rf_we[i] & we_onehot[i][0]) begin
         rf[i][0+:ExtWLEN/2] <= wr_data_blanked[0+:ExtWLEN/2];
       end
     end
 
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-      if (!rst_ni) begin
-        rf[i][ExtWLEN/2+:ExtWLEN/2] <= {BaseWordsPerWLEN/2{WordZeroVal}};
-      end else if (rf_predec_bignum_i.rf_we[i] & we_onehot[i][1]) begin
+    always_ff @(posedge clk_i) begin
+      if (rf_predec_bignum_i.rf_we[i] & we_onehot[i][1]) begin
         rf[i][ExtWLEN/2+:ExtWLEN/2] <= wr_data_blanked[ExtWLEN/2+:ExtWLEN/2];
       end
     end


### PR DESCRIPTION
~**PR Dependency**: This PR depends on #13724 and currently contains duplicate commits from that PR. Please only review the last commit in this PR.~

This removes the reset from the flip-flop-based general purpose registers (GPRs) and wide data registers (WDRs).

This improves security, as [argued by @vogelpi](https://github.com/lowRISC/opentitan/pull/12741#discussion_r893497686):
> [The] OTBN register files are a good example for the use of non-reset flops. The main problem is not the leakage occurring while resetting the register. We are more worried about what's happening afterwards. For example if a register holds a random mask to be applied to some other register (remember that the masking is implemented in SW here) and an attacker manages to reset that register while OTBN is running, the masking is effectively switched off. I believe the integrity bits don't really help here because the reset line is also connected to these. Synthesis will just insert set instead of reset flops for these bits. I am proposing to switch to non-reset flops for the register files and the ISPRs + RND/URND paths (incl. RND cache).

This is part of the work on OTBN D2S (#11019).