### PR TITLE
[sw/silicon_creator, bazel] Test updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -417,13 +417,14 @@ jobs:
   timeoutInMinutes: 30
   dependsOn:
     - chip_earlgrey_cw310
+    - chip_earlgrey_cw310_splice_mask_rom
     - sw_build
   steps:
   - template: ci/install-package-dependencies.yml
   - template: ci/download-artifacts-template.yml
     parameters:
       downloadPartialBuildBinFrom:
-        - chip_earlgrey_cw310
+        - chip_earlgrey_cw310_splice_mask_rom
         - sw_build
   - bash: |
       set -e

--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -54,6 +54,8 @@ ci/bazelisk.sh test \
     //sw/device/silicon_creator/lib/drivers:hmac_functest_fpga_cw310 \
     //sw/device/silicon_creator/lib/drivers:retention_sram_functest_fpga_cw310 \
     //sw/device/silicon_creator/lib/drivers:uart_functest_fpga_cw310 \
+    //sw/device/silicon_creator/lib/drivers:watchdog_functest_fpga_cw310 \
+    //sw/device/silicon_creator/mask_rom:e2e_bootup_no_rom_ext_signature_fpga_cw310 \
     //sw/device/silicon_creator/lib/sigverify:sigverify_functest_fpga_cw310
 
     # Note that some tests were included in the original systemtest but are

--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -7,13 +7,16 @@ set -x
 set -e
 
 . util/build_consts.sh
-SHA=$(git rev-parse HEAD)
-BITCACHE_DIR=~/.cache/opentitan-bitstreams/cache/${SHA}
-mkdir -p $BITCACHE_DIR
-BITCACHE_FILE=$BITCACHE_DIR/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig
-cp $BIN_DIR/hw/top_earlgrey/lowrisc_systems_chip_earlgrey_cw310_0.1.bit ${BITCACHE_FILE}
-echo "" >> ${BITCACHE_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice
-echo -n ${SHA} > ${BITCACHE_DIR}/../../latest.txt
+readonly SHA=$(git rev-parse HEAD)
+readonly BIT_CACHE_DIR="${HOME}/.cache/opentitan-bitstreams/cache/${SHA}"
+readonly BIT_SRC_PREFIX="${BIN_DIR}/hw/top_earlgrey/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+readonly BIT_DST_PREFIX="${BIT_CACHE_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+
+mkdir -p ${BIT_CACHE_DIR}
+for suffix in orig splice; do
+  cp "${BIT_SRC_PREFIX}.${suffix}" "${BIT_DST_PREFIX}.${suffix}"
+done
+echo -n ${SHA} > ${BIT_CACHE_DIR}/../../latest.txt
 export BITSTREAM="--offline --list ${SHA}"
 
 # We will lose serial access when we reboot, but if tests fail we should reboot

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -141,7 +141,7 @@ def cw310_params(
         # Base Parameters
         args = _BASE_PARAMS["args"] + [
             "--exec=\"load-bitstream --rom-kind={rom_kind} $(location {bitstream})\"",
-            "--exec=\"bootstrap --protocol {bootstrap_protocol} $(location {flash})\"",
+            "--exec=\"bootstrap $(location {flash})\"",
             "console",
             "--exit-failure=" + shell.quote(_EXIT_FAILURE),
             "--exit-success=" + shell.quote(_EXIT_SUCCESS),
@@ -157,7 +157,6 @@ def cw310_params(
         # CW310-specific Parameters
         bitstream = "@//hw/bitstream:test_rom",
         rom_kind = None,
-        bootstrap_protocol = "eeprom",
         # None
         **kwargs):
     """A macro to create CW310 parameters for OpenTitan functional tests.
@@ -356,7 +355,6 @@ def opentitan_functest(
             rom = rom,
             rom_kind = rom_kind,
             bitstream = bitstream,
-            bootstrap_protocol = "eeprom",
         )
         if target == "fpga_cw310":
             # We attach the uarts configuration to the front of the command

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -631,12 +631,6 @@ cc_test(
 opentitan_functest(
     name = "watchdog_functest",
     srcs = ["watchdog_functest.c"],
-    cw310 = cw310_params(
-        # (lowRISC/opentitan#6965) This test resets the chip and appears to
-        # cause a test failure on FPGA boards.  Restrict this test to
-        # verilator for now.
-        tags = ["broken"],
-    ),
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/lib/drivers/watchdog_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/watchdog_functest.c
@@ -87,9 +87,6 @@ bool test_main(void) {
   // next reset.
   rstmgr_reason_clear(reason);
 
-  // This test assumes the reset reason is unique.
-  CHECK(bitfield_popcount32(reason) == 1, "Expected exactly 1 reset reason.");
-
   // Use the part of the retention SRAM reserved for the silicon owner to
   // store the test phase.
   volatile uint32_t *phase = &retention_sram_get()->reserved_owner[0];

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -326,7 +326,6 @@ opentitan_functest(
     ],
 )
 
-# TODO: Add verilator test
 opentitan_functest(
     name = "e2e_bootup_no_rom_ext_signature",
     srcs = ["mask_rom_test.c"],
@@ -335,15 +334,20 @@ opentitan_functest(
             "--exec=\"load-bitstream --rom-kind={rom_kind} $(location {bitstream})\"",
             "--exec=\"bootstrap $(location {flash})\"",
             "console",
-            "--timeout=3600s",
+            "--timeout=30s",
             "--exit-success='{}'".format(BOOT_FAILURE_MSG),
             "--exit-failure='PASS!'",
         ],
         bitstream = "//hw/bitstream:mask_rom",
-        tags = ["broken"],
     ),
     signed = False,
-    targets = ["cw310"],
+    targets = [
+        "verilator",
+        "cw310",
+    ],
+    verilator = verilator_params(
+        rom = ":mask_rom_sim_verilator_scr_vmem",
+    ),
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -333,7 +333,7 @@ opentitan_functest(
     cw310 = cw310_params(
         args = [
             "--exec=\"load-bitstream --rom-kind={rom_kind} $(location {bitstream})\"",
-            "--exec=\"bootstrap --protocol {bootstrap_protocol} $(location {flash})\"",
+            "--exec=\"bootstrap $(location {flash})\"",
             "console",
             "--timeout=3600s",
             "--exit-success='{}'".format(BOOT_FAILURE_MSG),


### PR DESCRIPTION
This PR
* Removes the bootstrap protocol argument from test definitions in bazel,
* Fixes and enables watchdog_functest on cw310, and
* Enables e2e_bootup_no_rom_ext_signature test on cw310 and verilator.
* Adds watchdog_functest and e2e_bootup_no_rom_ext_signature to the set of cw310 tests that are run in CI.