### PR TITLE
[bazel] Remove `ralgen/*` exclusion from `hw/BUILD`

### DIFF
--- a/hw/BUILD
+++ b/hw/BUILD
@@ -85,10 +85,7 @@ genrule(
 # relationships between verilog components.
 filegroup(
     name = "all_files",
-    srcs = glob(
-        ["**"],
-        exclude = ["dv/tools/ralgen/*"],
-    ) + [
+    srcs = glob(["**"]) + [
         "//hw/ip:all_files",
         "//hw/top_earlgrey:all_files",
     ],


### PR DESCRIPTION
This PR reverts #13132 as #13154 has been merged. PR #13154 creates
`FUSESOC_IGNORE` so that the `fusesoc` won't walk the bazel directories.