### PR TITLE
[sw,tests] Verify sysrst_ctrl inputs can be read using CSRs

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1477,7 +1477,7 @@
             - Read the pin_in_value CSR to check for correctness.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_sysrst_ctrl_inputs"]
     }
     {
       name: chip_sw_sysrst_ctrl_outputs

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -578,6 +578,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_sysrst_ctrl_inputs
+      uvm_test_seq: chip_sw_sysrst_ctrl_inputs_vseq
+      sw_images: ["sw/device/tests/sim_dv/sysrst_ctrl_inputs_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_sysrst_ctrl_reset
       uvm_test_seq: chip_sw_sysrst_ctrl_reset_vseq
       sw_images: ["sw/device/tests/sim_dv/sysrst_ctrl_reset_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -53,6 +53,7 @@ filesets:
       - seq_lib/chip_sw_pwm_pulses_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_rand_baudrate_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_sysrst_ctrl_inputs_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_inputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_inputs_vseq.sv
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_sysrst_ctrl_inputs_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_sysrst_ctrl_inputs_vseq)
+
+  `uvm_object_new
+
+  localparam string PAD_KEY0_PATH = "tb.dut.IOB3";
+  localparam string PAD_KEY1_PATH = "tb.dut.IOB6";
+  localparam string PAD_KEY2_PATH = "tb.dut.IOB8";
+  localparam string PAD_PWRB_PATH = "tb.dut.IOR13";
+  localparam string PAD_ACPRES_PATH = "tb.dut.IOC7";
+  localparam string PAD_LIDOPEN_PATH = "tb.dut.IOC9";
+  localparam string PAD_ECRST_PATH = "tb.dut.IOR8";
+  localparam string PAD_FLASHWP_PATH = "tb.dut.IOR9";
+  localparam uint NUM_TEST_PHASES = 10;
+
+  virtual function void set_pads(input bit [7:0] pad_values);
+    `DV_CHECK(uvm_hdl_force(PAD_KEY0_PATH, pad_values[0]));
+    `DV_CHECK(uvm_hdl_force(PAD_KEY1_PATH, pad_values[1]));
+    `DV_CHECK(uvm_hdl_force(PAD_KEY2_PATH, pad_values[2]));
+    `DV_CHECK(uvm_hdl_force(PAD_PWRB_PATH, pad_values[3]));
+    `DV_CHECK(uvm_hdl_force(PAD_ACPRES_PATH, pad_values[4]));
+    `DV_CHECK(uvm_hdl_force(PAD_LIDOPEN_PATH, pad_values[5]));
+    `DV_CHECK(uvm_hdl_force(PAD_ECRST_PATH, pad_values[6]));
+    `DV_CHECK(uvm_hdl_force(PAD_FLASHWP_PATH, pad_values[7]));
+  endfunction
+
+  virtual function void write_test_phase_and_expected(input int phase, input bit [7:0] expected);
+    bit [7:0] test_phase[1];
+    bit [7:0] test_expected[1];
+    test_phase[0] = phase;
+    test_expected[0] = expected;
+    sw_symbol_backdoor_overwrite("kTestPhase", test_phase);
+    sw_symbol_backdoor_overwrite("kTestExpected", test_expected);
+  endfunction
+
+  virtual task body();
+    bit [7:0] pads_to_set = '0;
+    super.body();
+
+    for (int current_phase = 0; current_phase < NUM_TEST_PHASES; current_phase++) begin
+      // set each pad individually then all together.
+      case (current_phase)
+        1: pads_to_set = 8'b00000001;
+        2: pads_to_set = 8'b00000010;
+        3: pads_to_set = 8'b00000100;
+        4: pads_to_set = 8'b00001000;
+        5: pads_to_set = 8'b00010000;
+        6: pads_to_set = 8'b00100000;
+        7: pads_to_set = 8'b01000000;
+        8: pads_to_set = 8'b10000000;
+        9: pads_to_set = 8'b11111111;
+        default: pads_to_set = 8'b00000000;
+      endcase
+
+      set_pads(pads_to_set);
+      #1us;
+      write_test_phase_and_expected(current_phase, pads_to_set);
+
+      wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+      wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+    end
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -18,6 +18,7 @@
 `include "chip_sw_deep_sleep_all_reset_vseq.sv"
 `include "chip_sw_uart_tx_rx_vseq.sv"
 `include "chip_sw_uart_rand_baudrate_vseq.sv"
+`include "chip_sw_sysrst_ctrl_inputs_vseq.sv"
 `include "chip_sw_sysrst_ctrl_reset_vseq.sv"
 `include "chip_sw_gpio_smoke_vseq.sv"
 `include "chip_sw_gpio_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -128,6 +128,21 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "sysrst_ctrl_inputs_test",
+    srcs = ["sysrst_ctrl_inputs_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "sysrst_ctrl_reset_test",
     srcs = ["sysrst_ctrl_reset_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/sysrst_ctrl_inputs_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_inputs_test.c
@@ -1,0 +1,88 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_sysrst_ctrl_t sysrst_ctrl;
+const uint32_t kTestPhaseTimeoutUsec = 10;
+const uint32_t kNumPhases = 10;
+
+// Test phase and expected values written by testbench.
+static volatile const uint8_t kTestPhase = 0;
+static volatile const uint8_t kTestExpected = 0;
+
+enum {
+  kOutputNumPads = 0x8,
+  kOutputNunMioPads = 0x6,
+};
+
+static const dif_pinmux_index_t kPeripheralInputs[] = {
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey0In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey1In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey2In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonPwrbIn,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonAcPresent,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonLidOpen,
+};
+
+static const dif_pinmux_index_t kInputPads[] = {
+    kTopEarlgreyPinmuxInselIob3, kTopEarlgreyPinmuxInselIob6,
+    kTopEarlgreyPinmuxInselIob8, kTopEarlgreyPinmuxInselIor13,
+    kTopEarlgreyPinmuxInselIoc7, kTopEarlgreyPinmuxInselIoc9,
+};
+
+static const dif_sysrst_ctrl_pin_t kSysrstCtrlInputs[] = {
+    kDifSysrstCtrlPinKey0In,           kDifSysrstCtrlPinKey1In,
+    kDifSysrstCtrlPinKey2In,           kDifSysrstCtrlPinPowerButtonIn,
+    kDifSysrstCtrlPinAcPowerPresentIn, kDifSysrstCtrlPinLidOpenIn,
+    kDifSysrstCtrlPinEcResetInOut,     kDifSysrstCtrlPinFlashWriteProtectInOut,
+};
+
+static uint8_t read_input_pins(void) {
+  bool input_value;
+  uint8_t inputs = 0;
+  for (int i = 0; i < kOutputNumPads; ++i) {
+    CHECK_DIF_OK(dif_sysrst_ctrl_input_pin_read(
+        &sysrst_ctrl, kSysrstCtrlInputs[i], &input_value));
+    inputs |= input_value << i;
+  }
+  return inputs;
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_sysrst_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
+      &sysrst_ctrl));
+
+  dif_pinmux_t pinmux;
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+
+  for (int i = 0; i < kOutputNunMioPads; ++i) {
+    CHECK_DIF_OK(
+        dif_pinmux_input_select(&pinmux, kPeripheralInputs[i], kInputPads[i]));
+  }
+  for (int i = 0; i < kNumPhases; ++i) {
+    IBEX_SPIN_FOR(i == kTestPhase, kTestPhaseTimeoutUsec);
+    uint8_t input_pins = read_input_pins();
+    CHECK(kTestExpected == input_pins);
+    // Test status set to InTest then Wfi for testbench synchronization,
+    // an actual WFI instruction is not issued.
+    test_status_set(kTestStatusInTest);
+    test_status_set(kTestStatusInWfi);
+  }
+
+  test_status_set(kTestStatusInTest);
+  return true;
+}


### PR DESCRIPTION
For test:
chip_sw_sysrst_ctrl_inputs

Checks that known values driven at the chip inputs by the testbench
can be read using the sysrst_ctrl CSRs in software. The values read
are verified against the expected values.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>