### PR TITLE
[sw,tests] Fix missing sram_ctrl scrambled access test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -756,7 +756,7 @@
     {
       name: chip_sw_sram_ctrl_main_scrambled_access
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
-      sw_images: ["sw/device/tests/sram_ctrl_main_scrambled_access_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/sram_ctrl_main_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+mem_sel=main",
                  "+sw_test_timeout_ns=12000000"]


### PR DESCRIPTION
Fixed incorrect sw_image path in chip_sim_cfg for chip_sw_sram_ctrl_main_scrambled_access test.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>