### PR TITLE
[opentitantool] resolve a warning by avoiding unused dependence on "bail"

### DIFF
--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{anyhow, ensure, Result};
 use erased_serde::Serialize;
 use std::any::Any;
 use std::convert::TryInto;


### PR DESCRIPTION
We get a warning for including unused code here and it's crowding out other output

Signed-off-by: Drew Macrae <drewmacrae@google.com>