### PR TITLE
[bazel] mark cw310 tests as short, making them timeout in 60s

### DIFF
--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -152,12 +152,12 @@ def cw310_params(
         otp = _BASE_PARAMS["otp"],
         rom = _BASE_PARAMS["rom"].format("fpga_cw310"),
         tags = _BASE_PARAMS["tags"],
-        timeout = _BASE_PARAMS["timeout"],
         test_runner = _BASE_PARAMS["test_runner"],
         # CW310-specific Parameters
         bitstream = "@//hw/bitstream:test_rom",
         rom_kind = None,
         # None
+        timeout = "short",
         **kwargs):
     """A macro to create CW310 parameters for OpenTitan functional tests.
 


### PR DESCRIPTION
There's variability in the time they take but they're consistently less
than 20s, but with 137 of them a timeout that allows the slower
iterations (which appear stochastic) will not prevent the whole set from
timing out against the 30minute limit. The only thing I can think of
that gives us timout headroom on the cw310 tests at this stage is to use
--notests_keep_going.

Signed-off-by: Drew Macrae <drewmacrae@google.com>