### PR TITLE
[bazel] rom_ext_image_test isn't broken

### DIFF
--- a/sw/host/rom_ext_image_tools/signer/image/BUILD
+++ b/sw/host/rom_ext_image_tools/signer/image/BUILD
@@ -23,5 +23,4 @@ rust_library(
 rust_test(
     name = "rom_ext_image_test",
     crate = ":rom_ext_image",
-    tags = ["broken"],
 )


### PR DESCRIPTION
We can run this in CI by marking it as no longer broken

Signed-off-by: Drew Macrae <drewmacrae@google.com>