### PR TITLE
[ci] Remove Verilator test's dependency on pre-fetched Bazel dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,6 +95,7 @@ jobs:
 
 - job: download_bazel_dependencies
   displayName: Download Bazel fetched dependencies
+  continueOnError: True
   pool:
     vmImage: ubuntu-18.04
   steps:
@@ -211,9 +212,7 @@ jobs:
   displayName: Build and run fast tests on sim_verilator
   pool: ci-public
   timeoutInMinutes: 120
-  dependsOn:
-    - lint
-    - download_bazel_dependencies
+  dependsOn: lint
   steps:
   - template: ci/install-package-dependencies.yml
   - task: DownloadSecureFile@1
@@ -224,14 +223,8 @@ jobs:
   - bash: echo "##vso[task.setvariable variable=bazelCacheGcpKeyPath]$(bazelCacheGcpKey.secureFilePath)"
     condition: eq(variables['Build.SourceBranchName'], 'master')
     displayName: Set the remote cache GCP key path
-  - download: current
-    artifact: bazel-dependencies
-    displayName: Download Bazel dependencies
   - bash: |
-      tar -xf $(Pipeline.Workspace)/bazel-dependencies/bazel-airgapped.tar.gz
-      export BAZEL_CACHE=$(pwd)/bazel-airgapped/bazel-cache
-      export BAZEL_DISTDIR=$(pwd)/bazel-airgapped/bazel-distdir
-      export BAZEL_PYTHON_WHEELS_REPO=$(pwd)/bazel-airgapped/ot_python_wheels
+      set -x -e
       export GCP_BAZEL_CACHE_KEY=$(bazelCacheGcpKeyPath)
       ci/scripts/run-verilator-tests.sh
     displayName: Build and execute tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,6 +99,7 @@ jobs:
     vmImage: ubuntu-18.04
   steps:
   - bash: |
+      set -x -e
       util/prep-bazel-airgapped-build.sh
       rm -rf bazel-airgapped/bitstreams-cache
       tar -cf bazel-airgapped.tar.gz bazel-airgapped

--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -6,13 +6,9 @@
 set -e
 
 # Increase the test_timeout due to slow performance on CI
-# In CI, this script uses pre-downloaded bazel dependencies located in
-# $BAZEL_CACHE and $BAZEL_DISTDIR
 
 ./bazelisk.sh query "filter('sim_verilator\_.*\_smoketest', tests(//sw/device/...))" | \
 xargs ci/bazelisk.sh test \
-    --repository_cache=$BAZEL_CACHE \
-    --distdir=$BAZEL_DISTDIR \
     --build_tests_only=true \
     --test_timeout=2400,2400,3600,-1 \
     --local_test_jobs=4 \


### PR DESCRIPTION
This PR removes the Verilator test's dependency on the prefetched Bazel dependencies step. As explained in #13246, we're seeing some failures every so often in the prefetching, and until we can determine what's going on there, we'll just let this run in CI without blocking anything else.

This PR also adds `set -e` to the prefetching step to cause it to throw an error.