### PR TITLE
[bazel] e2e_bootup_no_rom_ext_signature not broken

### DIFF
--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -340,7 +340,6 @@ opentitan_functest(
             "--exit-failure='PASS!'",
         ],
         bitstream = "//hw/bitstream:mask_rom",
-        tags = ["broken"],
     ),
     signed = False,
     targets = ["cw310"],


### PR DESCRIPTION
With this test marked as broken it wont run on the cw310

Signed-off-by: Drew Macrae <drewmacrae@google.com>