### PR TITLE
[dv,rstmgr] Fix some sec_cm test failures

### DIFF
--- a/hw/ip/rstmgr/dv/env/rstmgr_env_pkg.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_env_pkg.sv
@@ -34,37 +34,44 @@ package rstmgr_env_pkg;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault", "fatal_cnsty_fault"};
   parameter uint NUM_ALERTS = 2;
 
-  // leaf reset modules for top_earlgrey
-  parameter string LIST_OF_LEAFS[] = {"u_daon_por",
-                                      "u_daon_por_io",
-                                      "u_daon_por_io_div2",
-                                      "u_daon_por_usb",
-                                      "u_daon_sys_aon",
-                                      "u_daon_sys_io_div4",
-                                      "u_d0_lc",
-                                      "u_d0_lc_shadowed",
-                                      "u_d0_lc_io_div4",
-                                      "u_d0_lc_io_div4_shadowed",
-                                      "u_daon_lc_aon",
-                                      "u_daon_lc_io_div4",
-                                      "u_daon_lc_io_div4_shadowed",
-                                      "u_d0_sys",
-                                      "u_d0_sys_shadowed",
-                                      "u_d0_sys_io_div4",
-                                      "u_d0_sys_aon",
-                                      "u_d0_spi_device",
-                                      "u_d0_spi_host0",
-                                      "u_d0_spi_host1",
-                                      "u_d0_usb",
-                                      "u_d0_i2c0",
-                                      "u_d0_i2c1",
-                                      "u_d0_i2c2"};
+  // Instances of rstmgr_leaf_rst modules in top_earlgrey's rstmgr.
+  parameter string LIST_OF_LEAFS[] = {
+    "u_daon_por",
+    "u_daon_por_io",
+    "u_daon_por_io_div2",
+    // The leaf below doesn't implement
+    // consistency checks.
+    // "u_daon_por_io_div4",
+    "u_daon_por_usb",
+    "u_d0_lc",
+    "u_d0_lc_shadowed",
+    "u_daon_lc_io_div4",
+    "u_d0_lc_io_div4",
+    "u_daon_lc_io_div4_shadowed",
+    "u_d0_lc_io_div4_shadowed",
+    "u_daon_lc_aon",
+    "u_d0_sys",
+    "u_d0_sys_shadowed",
+    "u_daon_sys_io_div4",
+    "u_d0_sys_io_div4",
+    "u_daon_sys_aon",
+    "u_d0_sys_aon",
+    "u_d0_spi_device",
+    "u_d0_spi_host0",
+    "u_d0_spi_host1",
+    "u_d0_usb",
+    "u_d0_i2c0",
+    "u_d0_i2c1",
+    "u_d0_i2c2"
+  };
 
-  // leaf reset which has shadow pair
-  parameter string LIST_OF_SHADOW_LEAFS[] = {"u_d0_lc_io_div4",
-                                             "u_daon_lc_io_div4",
-                                             "u_daon_por_io_div4",
-                                             "u_d0_sys"};
+  // Instances of rstmgr_leaf_rst modules which have a shadow pair.
+  parameter string LIST_OF_SHADOW_LEAFS[] = {
+    "u_d0_lc",
+    "u_daon_lc_io_div4",
+    "u_d0_lc_io_div4",
+    "u_d0_sys"
+  };
 
   // types
   typedef logic [NumSwResets-1:0] sw_rst_t;

--- a/hw/ip/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -149,7 +149,7 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
       end
       default: begin
         // add regex match here
-        if (!uvm_re_match("sw_rst_ctrl_n_*",csr.get_name())) begin
+        if (!uvm_re_match("sw_rst_ctrl_n_*", csr.get_name())) begin
           // TODO Check with bitwise enables from sw_rst_regwen.
           do_read_check = 1'b0;
           if (cfg.en_cov && addr_phase_write) begin
@@ -159,7 +159,7 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
               cov.sw_rst_cg_wrap[i].sample(enables[i], item.a_data[i]);
             end
           end
-        end else if (!uvm_re_match("sw_rst_regwen_*",csr.get_name())) begin
+        end else if (!uvm_re_match("sw_rst_regwen_*", csr.get_name())) begin
         end else begin
           `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
         end

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
@@ -275,7 +275,7 @@ class rstmgr_base_vseq extends cip_base_vseq #(
     const sw_rst_t sw_rst_all_ones = '1;
     rstmgr_csr_wr_unpack(.ptr(ral.sw_rst_ctrl_n), .value(sw_rst_all_ones));
     rstmgr_csr_rd_check_unpack(.ptr(ral.sw_rst_ctrl_n), .compare_value(sw_rst_all_ones),
-                 .err_msg("Expected sw_rst_ctrl_n to be set"));
+                               .err_msg("Expected sw_rst_ctrl_n to be set"));
   endtask
 
   virtual protected task clear_sw_rst_ctrl_n_per_entry(int entry);
@@ -299,14 +299,12 @@ class rstmgr_base_vseq extends cip_base_vseq #(
               "regen=%b, ctrl_n=%b, expected=%b", sw_rst_regen, sw_rst_ctrl_n, exp_ctrl_n),
               UVM_MEDIUM)
     rstmgr_csr_rd_check_unpack(.ptr(ral.sw_rst_ctrl_n), .compare_value(exp_ctrl_n),
-                 .err_msg("Expected enabled updates in sw_rst_ctrl_n"));
+                               .err_msg("Expected enabled updates in sw_rst_ctrl_n"));
     if (erase_ctrl_n) clear_sw_rst_ctrl_n();
   endtask
 
-  virtual protected task check_sw_rst_ctrl_n_per_entry(sw_rst_t sw_rst_ctrl_n,
-                                                       sw_rst_t sw_rst_regen,
-                                                       bit erase_ctrl_n,
-                                                       int entry);
+  virtual protected task check_sw_rst_ctrl_n_per_entry(
+      sw_rst_t sw_rst_ctrl_n, sw_rst_t sw_rst_regen, bit erase_ctrl_n, int entry);
     sw_rst_t exp_ctrl_n;
 
     `uvm_info(`gfn, $sformatf("Set sw_rst_ctrl_n[%0d] to 0x%0x", entry, sw_rst_ctrl_n), UVM_MEDIUM)
@@ -315,9 +313,8 @@ class rstmgr_base_vseq extends cip_base_vseq #(
     // Allow for domain crossing delay.
     cfg.io_div2_clk_rst_vif.wait_clks(3);
     exp_ctrl_n = ~sw_rst_regen | sw_rst_ctrl_n;
-    `uvm_info(`gfn,
-              $sformatf("regen=%b, ctrl_n=%b, expected=%b",
-                        sw_rst_regen, sw_rst_ctrl_n, exp_ctrl_n),
+    `uvm_info(`gfn, $sformatf(
+              "regen=%b, ctrl_n=%b, expected=%b", sw_rst_regen, sw_rst_ctrl_n, exp_ctrl_n),
               UVM_MEDIUM)
     csr_rd_check(.ptr(ral.sw_rst_ctrl_n[entry]), .compare_value(exp_ctrl_n[entry]),
                  .err_msg($sformatf("Expected enabled updates in sw_rst_ctrl_n[%0d]", entry)));
@@ -488,16 +485,14 @@ class rstmgr_base_vseq extends cip_base_vseq #(
   endtask
 
   // csr method wrapper for unpacked array registers
-  virtual task rstmgr_csr_rd_check_unpack(input  uvm_object     ptr[],
-                                          input        uvm_reg_data_t compare_value = 0,
-                                          input string err_msg = "");
+  virtual task rstmgr_csr_rd_check_unpack(
+      input uvm_object ptr[], input uvm_reg_data_t compare_value = 0, input string err_msg = "");
     foreach (ptr[i]) begin
-      csr_rd_check(.ptr(ptr[i]), .compare_value(compare_value[i]),
-                   .err_msg(err_msg));
+      csr_rd_check(.ptr(ptr[i]), .compare_value(compare_value[i]), .err_msg(err_msg));
     end
-  endtask // rstmgr_csr_rd_check_unpack
-  virtual task rstmgr_csr_wr_unpack(input uvm_object     ptr[],
-                                    input uvm_reg_data_t value);
+  endtask : rstmgr_csr_rd_check_unpack
+
+  virtual task rstmgr_csr_wr_unpack(input uvm_object ptr[], input uvm_reg_data_t value);
     foreach (ptr[i]) begin
       csr_wr(.ptr(ptr[i]), .value(value[i]));
     end

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
@@ -19,25 +19,26 @@ class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
       leaf_rst_attack(leaf_path, {leaf_path, "_shadowed"});
       leaf_rst_attack({leaf_path, "_shadowed"}, leaf_path);
     end
-  endtask // body
+  endtask : body
 
   task leaf_rst_attack(string npath, string gpath);
-      wait(cfg.rstmgr_vif.resets_o.rst_sys_aon_n == 2'h3);
-      add_glitch(gpath);
-      wait_and_check(npath);
-      remove_glitch(gpath);
+    wait(cfg.rstmgr_vif.resets_o.rst_sys_aon_n == 2'h3);
+    add_glitch(gpath);
+    wait_and_check(npath);
+    remove_glitch(gpath);
 
-      cfg.clk_rst_vif.wait_clks(10);
-      apply_reset();
-  endtask // leaf_rst_attach
+    cfg.clk_rst_vif.wait_clks(10);
+    apply_reset();
+  endtask : leaf_rst_attack
 
 
   function void add_glitch(string path);
     string epath = {path, ".rst_en_o"};
     string opath = {path, ".leaf_rst_o"};
 
-    `DV_CHECK(uvm_hdl_force(epath, prim_mubi_pkg::MuBi4True))
-    `DV_CHECK(uvm_hdl_force(opath, 0))
+    `DV_CHECK(uvm_hdl_force(epath, prim_mubi_pkg::MuBi4True), $sformatf(
+              "Path %0s has problem", epath))
+    `DV_CHECK(uvm_hdl_force(opath, 0), $sformatf("Path %0s has problem", opath))
   endfunction
 
   task wait_and_check(string path);
@@ -48,20 +49,18 @@ class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
 
     cfg.clk_rst_vif.wait_clks(10);
 
-    `DV_CHECK(uvm_hdl_read(epath, rst_en))
-    `DV_CHECK(uvm_hdl_read(opath, leaf_rst))
+    `DV_CHECK(uvm_hdl_read(epath, rst_en), $sformatf("Path %0s has problem", epath))
+    `DV_CHECK(uvm_hdl_read(opath, leaf_rst), $sformatf("Path %0s has problem", opath))
 
-    `DV_CHECK_EQ_FATAL(rst_en, prim_mubi_pkg::MuBi4False,
-                       $sformatf("%s value mismatch",epath))
-    `DV_CHECK_EQ_FATAL(leaf_rst, 1,
-                       $sformatf("%s value mismatch",opath))
-  endtask // wait_and_check
+    `DV_CHECK_EQ_FATAL(rst_en, prim_mubi_pkg::MuBi4False, $sformatf("%s value mismatch", epath))
+    `DV_CHECK_EQ_FATAL(leaf_rst, 1, $sformatf("%s value mismatch", opath))
+  endtask : wait_and_check
 
   function void remove_glitch(string path);
     string epath = {path, ".rst_en_o"};
     string opath = {path, ".leaf_rst_o"};
-    `DV_CHECK(uvm_hdl_release(epath))
-    `DV_CHECK(uvm_hdl_release(opath))
+    `DV_CHECK(uvm_hdl_release(epath), $sformatf("Path %0s has problem", epath))
+    `DV_CHECK(uvm_hdl_release(opath), $sformatf("Path %0s has problem", opath))
   endfunction
 
   // clean up glitch will create reset consistency error
@@ -71,4 +70,4 @@ class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
     super.post_start();
   endtask
 
-endclass // rstmgr_leaf_rst_shadow_attack_vseq
+endclass : rstmgr_leaf_rst_shadow_attack_vseq

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sec_cm_scan_intersig_mubi_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sec_cm_scan_intersig_mubi_vseq.sv
@@ -12,21 +12,23 @@ class rstmgr_sec_cm_scan_intersig_mubi_vseq extends rstmgr_smoke_vseq;
 
   task body();
     disable_assert();
-    fork begin
-      fork
-        super.body();
-        add_noise();
-      join_any
-      disable fork;
-    end join
-  endtask // body
+    fork
+      begin
+        fork
+          super.body();
+          add_noise();
+        join_any
+        disable fork;
+      end
+    join
+  endtask : body
 
   function void disable_assert();
     $assertoff(0, "prim_mubi4_sync");
-  endfunction // disable_assert
+  endfunction : disable_assert
 
   task add_noise();
-    int      delay;
+    int delay;
 
     forever begin
       cfg.clk_rst_vif.wait_clks(1);
@@ -35,5 +37,5 @@ class rstmgr_sec_cm_scan_intersig_mubi_vseq extends rstmgr_smoke_vseq;
       delay = $urandom_range(0, 30);
       cfg.clk_rst_vif.wait_clks(delay);
     end
-  endtask // add_noise
+  endtask : add_noise
 endclass : rstmgr_sec_cm_scan_intersig_mubi_vseq

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -90,16 +90,16 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
       `uvm_info(`gfn, $sformatf("sw_rst_regwen set to 0x%0h", sw_rst_regwen), UVM_LOW)
       rstmgr_csr_rd_check_unpack(.ptr(ral.sw_rst_regwen), .compare_value(sw_rst_regwen));
 
-// XXX: Need a review
-//      // Check sw_rst_regwen can not be set to all ones again because it is rw0c.
-//      rstmgr_csr_wr_unpack(.ptr(ral.sw_rst_regwen), .value({NumSwResets{1'b1}}));
-//      rstmgr_csr_rd_check_unpack(.ptr(ral.sw_rst_regwen), .compare_value(sw_rst_regwen),
-//                   .err_msg("Expected sw_rst_regwen block raising individual bits because rw0c"));
+      // TODO: verify this is tested by common CSR tests.
+      // Check sw_rst_regwen can not be set to all ones again because it is rw0c.
+      // rstmgr_csr_wr_unpack(.ptr(ral.sw_rst_regwen), .value({NumSwResets{1'b1}}));
+      // rstmgr_csr_rd_check_unpack(.ptr(ral.sw_rst_regwen), .compare_value(sw_rst_regwen),
+      //     .err_msg("Expected sw_rst_regwen block raising individual bits because rw0c"));
 
       // Check that the regwen disabled bits block corresponding updated to ctrl_n.
       rstmgr_csr_wr_unpack(.ptr(ral.sw_rst_ctrl_n), .value(sw_rst_regwen));
       rstmgr_csr_rd_check_unpack(.ptr(ral.sw_rst_ctrl_n), .compare_value(sw_rst_all_ones),
-                   .err_msg("Expected sw_rst_ctrl_n not to change"));
+                                 .err_msg("Expected sw_rst_ctrl_n not to change"));
 
       check_sw_rst_ctrl_n(sw_rst_ctrl_n, sw_rst_regwen, 1);
       check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b1);


### PR DESCRIPTION
Update the list of rstmgr_leaf_rst instances for design changes.
Add some messages in check failures for ease of diagnostics.
Formatting changes for verible.

Signed-off-by: Guillermo Maturana <maturana@google.com>