### PR TITLE
[top/dv] increase test timeout

### DIFF
--- a/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
@@ -22,7 +22,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/silicon_creator/lib/drivers/keymgr_functest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=5000000"]
+      run_opts: ["+sw_test_timeout_ns=10000000"]
     }
   ]
 


### PR DESCRIPTION
- the keymgr functional tests goes through multiple reset cycles
  and thus may incur a larger run-time especially since clocks
  are uncalibrated upon power up

Signed-off-by: Timothy Chen <timothytim@google.com>