### PR TITLE
[rv_core_ibex] Update to latest crash dump

### DIFF
--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
@@ -167,23 +167,14 @@ class rstmgr_base_vseq extends cip_base_vseq #(
 
   local task check_cpu_dump_info(cpu_crash_dump_t cpu_dump);
     `uvm_info(`gfn, "Checking cpu_info", UVM_MEDIUM)
-    csr_wr(.ptr(ral.cpu_info_ctrl.index), .value(10));
-    csr_rd_check(.ptr(ral.cpu_info), .compare_value(cpu_dump.previous_valid),
-                 .err_msg("checking previous_valid"));
-    csr_wr(.ptr(ral.cpu_info_ctrl.index), .value(9));
-    csr_rd_check(.ptr(ral.cpu_info), .compare_value(cpu_dump.previous.current_pc),
-                 .err_msg("checking previous current_pc"));
-    csr_wr(.ptr(ral.cpu_info_ctrl.index), .value(8));
-    csr_rd_check(.ptr(ral.cpu_info), .compare_value(cpu_dump.previous.next_pc),
-                 .err_msg("checking previous next_pc"));
     csr_wr(.ptr(ral.cpu_info_ctrl.index), .value(7));
-    csr_rd_check(.ptr(ral.cpu_info), .compare_value(cpu_dump.previous.last_data_addr),
-                 .err_msg("checking previous last_data_addr"));
+    csr_rd_check(.ptr(ral.cpu_info), .compare_value(cpu_dump.prev_valid),
+                 .err_msg("checking previous_valid"));
     csr_wr(.ptr(ral.cpu_info_ctrl.index), .value(6));
-    csr_rd_check(.ptr(ral.cpu_info), .compare_value(cpu_dump.previous.exception_pc),
+    csr_rd_check(.ptr(ral.cpu_info), .compare_value(cpu_dump.prev_exception_pc),
                  .err_msg("checking previous exception_pc"));
     csr_wr(.ptr(ral.cpu_info_ctrl.index), .value(5));
-    csr_rd_check(.ptr(ral.cpu_info), .compare_value(cpu_dump.previous.exception_addr),
+    csr_rd_check(.ptr(ral.cpu_info), .compare_value(cpu_dump.prev_exception_addr),
                  .err_msg("checking previous exception_addr"));
     csr_wr(.ptr(ral.cpu_info_ctrl.index), .value(4));
     csr_rd_check(.ptr(ral.cpu_info), .compare_value(cpu_dump.current.current_pc),

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -480,20 +480,24 @@ module rv_core_ibex
 
 
 
-  ibex_pkg::crash_dump_t crash_dump_previous;
-  logic previous_valid;
+  logic prev_valid;
+  logic [31:0] prev_exception_pc;
+  logic [31:0] prev_exception_addr;
 
   assign crash_dump_o.current = crash_dump;
-  assign crash_dump_o.previous = crash_dump_previous;
-  assign crash_dump_o.previous_valid = previous_valid;
+  assign crash_dump_o.prev_valid = prev_valid;
+  assign crash_dump_o.prev_exception_pc = prev_exception_pc;
+  assign crash_dump_o.prev_exception_addr = prev_exception_addr;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      previous_valid <= '0;
-      crash_dump_previous <= '0;
+      prev_valid <= '0;
+      prev_exception_pc <= '0;
+      prev_exception_addr <= '0;
     end else if (double_fault) begin
-      previous_valid <= '1;
-      crash_dump_previous <= crash_dump;
+      prev_valid <= 1'b1;
+      prev_exception_pc <= crash_dump.exception_pc;
+      prev_exception_addr <= crash_dump.exception_addr;
     end
   end
 

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_pkg.sv
@@ -15,8 +15,9 @@ package rv_core_ibex_pkg;
 
   typedef struct packed {
     // previous valid is true only during double fault
-    logic previous_valid;
-    ibex_pkg::crash_dump_t previous;
+    logic prev_valid;
+    logic [31:0] prev_exception_pc;
+    logic [31:0] prev_exception_addr;
     ibex_pkg::crash_dump_t current;
   } cpu_crash_dump_t;
 


### PR DESCRIPTION
Addresses some of the usability issues discovered in #12908
dependent on https://github.com/lowRISC/ibex/pull/1680

The crash dump is now more representative of where the first and second exceptions occurred. 