### PR TITLE
[staging, sw/silicon_creator] Empty .data section results in a suspicious program header

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -475,7 +475,7 @@ static rom_error_t boot_data_active_page_find(active_page_info_t *page_info,
  * Default boot data to use if the device is in a non-prod state and there is
  * no valid boot data entry in the flash info pages.
  */
-boot_data_t kBootDataDefault = (boot_data_t){
+static const boot_data_t kBootDataDefault = (boot_data_t){
     .digest = {{0x0d044e5c, 0x33ceed53, 0x05aa74a4, 0x57b7017f, 0x574a685d,
                 0x6ec8f5f7, 0x594b0141, 0x656bae85}},
     .is_valid = kBootDataValidEntry,


### PR DESCRIPTION
I'm creating this PR to share the reproduction steps of an issue that I encountered while working on #13081.

Defining `kBootDataDefault` as `static const` in `boot_data.c` places that struct in .rodata and results in an empty .data section (it turns out it was the last mask ROM variable in the .data section).

This, however, causes the build to fail due to the following assertion in `hw/ip/rom_ctrl/util/mem.py`:
```
...
  File "/workspace/worktrees/opentitan/empty-data-section/hw/ip/rom_ctrl/util/mem.py", line 286, in flatten
    assert self.next_addr() <= size
AssertionError
```

I dumped the all the intermediate values and thought the assertion is reasonable. Then, I took a look at the elf files before:

```
...
Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x001000 0x00008000 0x00008000 0x0524c 0x0524c R E 0x1000
  LOAD           0x006650 0x10000650 0x0000d24c 0x00040 0x00538 RW 0x1000
  LOAD           0x000000 0x10000000 0x10000000 0x00000 0x00650 RW 0x1000
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0x10
...
```

and after this change:

```
$ /tools/riscv/bin/riscv32-unknown-elf-readelf -a bazel-out/k8-fastbuild-ST-97f470ee3b14/bin/sw/device/silicon_creator/mask_rom/mask_rom_fpga_cw310
...
Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x001000 0x00008000 0x00008000 0x0528c 0x0528c R E 0x1000
  LOAD           0x000650 0x10000650 0x0000d28c 0x00000 0x004f8 RW 0x1000
  LOAD           0x000000 0x10000000 0x10000000 0x00000 0x00650 RW 0x1000
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0x10
...
```

After this change, there are two `LOAD` program headers with file size = 0 (program headers 2 and 3 above). But the second program header has a non-zero offset and different VMA and LMA values while the third program header's offset is 0 and its VMA is equal to its LMA.

You can reproduce this issue by checking out this branch and
```
$ bazel build //sw/device/silicon_creator/mask_rom
```

@luismarques and @mundaym I'd like to hear what you think: Do these values look OK? Could this be an issue with the linker or our linker script or simply an overly strict assertion in the python script. Thanks a lot!

Signed-off-by: Alphan Ulusoy <alphan@google.com>