### PR TITLE
[sw/silicon_creator] Specialize FPGA version print for target platform

### DIFF
--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -12,13 +12,21 @@ cc_library(
 cc_library(
     name = "fpga_nexysvideo",
     srcs = ["device_fpga_nexysvideo.c"],
-    deps = [":device"],
+    deps = [
+        ":device",
+        "//sw/device/silicon_creator/lib:rom_print",
+        "//sw/device/silicon_creator/lib/drivers:ibex",
+    ],
 )
 
 cc_library(
     name = "fpga_cw310",
     srcs = ["device_fpga_cw310.c"],
-    deps = [":device"],
+    deps = [
+        ":device",
+        "//sw/device/silicon_creator/lib:rom_print",
+        "//sw/device/silicon_creator/lib/drivers:ibex",
+    ],
 )
 
 cc_library(

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -175,4 +175,11 @@ extern const bool kJitterEnabled;
  */
 uint64_t to_cpu_cycles(uint64_t usec);
 
+/**
+ * Prints the FPGA version.
+ *
+ * This function is a NOP unless we are building for an FPGA.
+ */
+void device_fpga_version_print(void);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_ARCH_DEVICE_H_

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/rom_print.h"
 
 /**
  * @file
@@ -41,3 +43,11 @@ const uintptr_t kDeviceTestStatusAddress = 0;
 const uintptr_t kDeviceLogBypassUartAddress = 0;
 
 const bool kJitterEnabled = false;
+
+void device_fpga_version_print(void) {
+  // This value is guaranteed to be zero on all non-FPGA implementations.
+  uint32_t fpga = ibex_fpga_version();
+  // The cast to unsigned int stops GCC from complaining about uint32_t
+  // being a `long unsigned int` while the %x specifier takes `unsigned int`.
+  rom_printf("MaskROM:%x\r\n", (unsigned int)fpga);
+}

--- a/sw/device/lib/arch/device_fpga_nexysvideo.c
+++ b/sw/device/lib/arch/device_fpga_nexysvideo.c
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/rom_print.h"
 
 /**
  * @file
@@ -41,3 +43,11 @@ const uintptr_t kDeviceTestStatusAddress = 0;
 const uintptr_t kDeviceLogBypassUartAddress = 0;
 
 const bool kJitterEnabled = false;
+
+void device_fpga_version_print(void) {
+  // This value is guaranteed to be zero on all non-FPGA implementations.
+  uint32_t fpga = ibex_fpga_version();
+  // The cast to unsigned int stops GCC from complaining about uint32_t
+  // being a `long unsigned int` while the %x specifier takes `unsigned int`.
+  rom_printf("MaskROM:%x\r\n", (unsigned int)fpga);
+}

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -45,3 +45,5 @@ const uintptr_t kDeviceTestStatusAddress = 0x411f0080;
 const uintptr_t kDeviceLogBypassUartAddress = 0x411f0084;
 
 const bool kJitterEnabled = false;
+
+void device_fpga_version_print(void) {}

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -51,3 +51,5 @@ const uintptr_t kDeviceTestStatusAddress = 0x411f0080;
 const uintptr_t kDeviceLogBypassUartAddress = 0;
 
 const bool kJitterEnabled = false;
+
+void device_fpga_version_print(void) {}

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -112,7 +112,6 @@ opentitan_rom_binary(
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:irq_asm",
         "//sw/device/silicon_creator/lib:manifest",
-        "//sw/device/silicon_creator/lib:rom_print",
         "//sw/device/silicon_creator/lib:shutdown",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/base:static_critical_boot_measurements",

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -30,7 +30,6 @@
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 #include "sw/device/silicon_creator/lib/drivers/watchdog.h"
 #include "sw/device/silicon_creator/lib/error.h"
-#include "sw/device/silicon_creator/lib/rom_print.h"
 #include "sw/device/silicon_creator/lib/shutdown.h"
 #include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
 #include "sw/device/silicon_creator/mask_rom/boot_policy.h"
@@ -149,14 +148,8 @@ static rom_error_t mask_rom_init(void) {
   retention_sram_get()->reset_reasons = reset_reasons;
   rstmgr_reason_clear(reset_reasons);
 
-  // If running on an FPGA, print the FPGA version-id.
-  // This value is guaranteed to be zero on all non-FPGA implementations.
-  uint32_t fpga = ibex_fpga_version();
-  if (fpga != 0) {
-    // The cast to unsigned int stops GCC from complaining about uint32_t
-    // being a `long unsigned int` while the %x specifier takes `unsigned int`.
-    rom_printf("MaskROM:%x\r\n", (unsigned int)fpga);
-  }
+  // This function is a NOP unless mask ROM is built for an fpga.
+  device_fpga_version_print();
 
   // Read boot data from flash
   HARDENED_RETURN_IF_ERROR(boot_data_read(lc_state, &boot_data));


### PR DESCRIPTION
This PR ~adds a new platform called `chip` to `sw/device/lib/arch` and~ moves the FPGA version printing to the device library so that we can specialize it for target platform, i.e. NOP unless building for an FPGA.

This change removes `rom_printf` and the related call site from mask ROM, reducing its size by 288 bytes (21132 -> 20844).

@cfrantz I also considered a test/debug version for this change but this approach felt more intuitive. I'll try to do something similar for fake/prod key definitions.