### PR TITLE
[otbn,rtl] Improve data memory assertions

### DIFF
--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -874,6 +874,7 @@ module otbn_core
   `ASSERT_KNOWN_IF(DmemWriteOKnown_A, dmem_write_o, dmem_req_o)
   `ASSERT_KNOWN_IF(DmemAddrOKnown_A, dmem_addr_o, dmem_req_o)
   `ASSERT_KNOWN_IF(DmemWdataOKnown_A, dmem_wdata_o, dmem_req_o & dmem_write_o)
+  `ASSERT_KNOWN_IF(DmemWmaskOKnown_A, dmem_wmask_o, dmem_req_o & dmem_write_o)
   `ASSERT_KNOWN_IF(DmemRmaskOKnown_A, dmem_rmask_o, dmem_req_o)
   `ASSERT_KNOWN(EdnRndReqOKnown_A, edn_rnd_req_o)
   `ASSERT_KNOWN(EdnUrndReqOKnown_A, edn_urnd_req_o)

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -873,7 +873,7 @@ module otbn_core
   `ASSERT_KNOWN(DmemReqOKnown_A, dmem_req_o)
   `ASSERT_KNOWN_IF(DmemWriteOKnown_A, dmem_write_o, dmem_req_o)
   `ASSERT_KNOWN_IF(DmemAddrOKnown_A, dmem_addr_o, dmem_req_o)
-  `ASSERT_KNOWN_IF(DmemWdataOKnown_A, dmem_wdata_o, dmem_req_o)
+  `ASSERT_KNOWN_IF(DmemWdataOKnown_A, dmem_wdata_o, dmem_req_o & dmem_write_o)
   `ASSERT_KNOWN_IF(DmemRmaskOKnown_A, dmem_rmask_o, dmem_req_o)
   `ASSERT_KNOWN(EdnRndReqOKnown_A, edn_rnd_req_o)
   `ASSERT_KNOWN(EdnUrndReqOKnown_A, edn_urnd_req_o)


### PR DESCRIPTION
- Change assertion that `dmem_wdata_o` is known so that the assertion is active only for writes: Prior to this change, the `DmemWdataOKnown_A` assertion would trigger also on read requests (i.e., when `dmem_req_o` is set but `dmem_write_o` is not).  For read requests, however, no data is written and thus the write data value does not have to be known.  This caused spurious failures of this assertion.
- Add assertion that `dmem_wmask_o` is known if writing.