### PR TITLE
[otbn,sw] Use app symbols for parameter addresses

### DIFF
--- a/sw/otbn/code-snippets/barrett384.s
+++ b/sw/otbn/code-snippets/barrett384.s
@@ -231,23 +231,60 @@ wrap_barrett384:
 
   /* load first operand from dmem to [w9, w8] */
   li x4, 8
-  bn.lid x4++, 0(x0)
-  bn.lid x4++, 32(x0)
+  la x5, inp_a
+  bn.lid x4++, 0(x5)
+  bn.lid x4++, 32(x5)
   /* load second operand from dmem to [w11, w10] */
-  bn.lid x4++, 64(x0)
-  bn.lid x4++, 96(x0)
+  la x5, inp_b
+  bn.lid x4++, 0(x5)
+  bn.lid x4++, 32(x5)
   /* load modulus from dmem to [w13, w12] */
-  bn.lid x4++, 256(x0)
-  bn.lid x4++, 288(x0)
+  la x5, inp_m
+  bn.lid x4++, 0(x5)
+  bn.lid x4++, 32(x5)
   /* load barrett precomputed parameter u from dmem to [w15, w14] */
-  bn.lid x4++, 320(x0)
-  bn.lid x4++, 352(x0)
+  la x5, inp_u
+  bn.lid x4++, 0(x5)
+  bn.lid x4++, 32(x5)
 
   jal x1, barrett384
 
   /* store result from [w30, w29] to dmem */
   li x4, 29
-  bn.sid x4++, 512(x0)
-  bn.sid x4++, 544(x0)
+  la x5, oup_c
+  bn.sid x4++, 0(x5)
+  bn.sid x4++, 32(x5)
 
   ecall
+
+.bss
+
+/* First operand for Barrett modular multiplication. */
+.globl inp_a
+.balign 32
+inp_a:
+  .zero 64
+
+/* Second operand for Barrett modular multiplication. */
+.globl inp_b
+.balign 32
+inp_b:
+  .zero 64
+
+/* Modulus. */
+.globl inp_m
+.balign 32
+inp_m:
+  .zero 64
+
+/* Low 256 bits of Barrett constant u = floor(2^512 / modulus). */
+.globl inp_u
+.balign 32
+inp_u:
+  .zero 64
+
+/* Output buffer. */
+.globl oup_c
+.balign 32
+oup_c:
+  .zero 64


### PR DESCRIPTION
`otbn_smoketest` runs the `barrett384` OTBN application.  Before and after OTBN execution, data is copied to and from OTBN data memory, respectively.  Prior to this commit, `otbn_smoketest` had hard-coded offsets for the input and output data.  Instead of hard-coded offsets, the OTBN DIF can extract the address of a symbol in data memory from an OTBN object file.  This commit replaces the hard-coded offsets with symbol-derived addresses.

The instruction count of `barrett384` increases by 10:  Before running the actual algorithm, OTBN now loads four operands from symbol-defined addresses instead of a hard-coded offset.  This code uses one `la` per operand, which is a pseudo-instruction implemented as two real instructions.  After running the algorithm, OTBN now stores one operand using the same method.  That sums up to 8 additional instructions for loading and 2 additional instructions for storing.  For repeated invocations of `barrett384`, the code could be optimized so that the additional instructions don't reduce the overall performance.