### PR TITLE
[top,dv,rv_dm] ndm reset request test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -544,7 +544,7 @@
             - Read CSRs / mem in the debug domain to ensure that the values survive the reset.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_rv_dm_ndm_reset_req"]
     }
     // TODO, this could be a block-level test. Put it here since we don't have block-level testplan.
     {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -953,6 +953,13 @@
       run_opts: ["+sw_test_timeout_ns=18000000"]
     }
     {
+      name: chip_rv_dm_ndm_reset_req
+      uvm_test_seq: "chip_rv_dm_ndm_reset_vseq"
+      sw_images: ["sw/device/tests/sim_dv/rv_dm_ndm_reset_req:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+en_scb_tl_err_chk=0", "+use_jtag_dmi=1"]
+    }
+    {
       name: chip_tap_straps_dev
       uvm_test_seq: chip_tap_straps_vseq
       en_run_modes: ["strap_tests_mode"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -42,9 +42,9 @@ filesets:
       - seq_lib/chip_common_vseq.sv: {is_include_file: true}
       - seq_lib/chip_jtag_csr_rw_vseq.sv: {is_include_file: true}
       - seq_lib/chip_jtag_mem_vseq.sv: {is_include_file: true}
-      - seq_lib/chip_jtag_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_tap_straps_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_jtag_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_full_aon_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_main_power_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_vseq.sv: {is_include_file: true}
@@ -73,6 +73,7 @@ filesets:
       - seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_repeat_reset_wkup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rstmgr_alert_info_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_rv_dm_ndm_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - ast_ext_clk_if.sv

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_base_vseq.sv
@@ -2,7 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_jtag_base_vseq extends chip_common_vseq;
+// This is base sequence for rv_dm
+// It runs with actual CPU (not stub) and assumes
+// cpu is in operation at the beginning.
+// So different from rv_dm block sequence,
+// dmcontrol.dmactive needs to be set not in dut_init but
+// another explicit call at any appropriate point in each test.
+class chip_jtag_base_vseq extends chip_sw_base_vseq;
   uvm_mem test_mems[$];
   `uvm_object_utils(chip_jtag_base_vseq)
 
@@ -17,15 +23,22 @@ class chip_jtag_base_vseq extends chip_common_vseq;
   virtual task pre_start();
     select_jtag = SelectRVJtagTap;
     super.pre_start();
+    max_outstanding_accesses = 1;
   endtask
 
-  virtual task dut_init(string reset_kind = "HARD");
-    super.dut_init();
-    // TODO: Randomize the contents of the debug ROM & the program buffer once out of reset.
-
+  task debug_mode_en();
     // "Activate" the DM to facilitate ease of testing.
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(1), .blocking(1), .predict(1));
+    cfg.clk_rst_vif.wait_clks(5);
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(1));
+    cfg.clk_rst_vif.wait_clks(5);
+
   endtask
+
+   task ndm_reset_off();
+      csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(0));
+      cfg.clk_rst_vif.wait_clks(5);
+   endtask
 
   virtual task apply_reset(string kind = "HARD");
     fork

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_ndm_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_ndm_reset_vseq.sv
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence set dmactive, then toggle ndm reset
+class chip_rv_dm_ndm_reset_vseq extends chip_jtag_base_vseq;
+  `uvm_object_utils(chip_rv_dm_ndm_reset_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    super.body();
+    wait(cfg.sw_logger_vif.printed_log == "wait for ndm reset");
+    cfg.clk_rst_vif.wait_clks(10);
+    debug_mode_en();
+    cfg.clk_rst_vif.wait_clks(10);
+    ndm_reset_off();
+    cfg.clk_rst_vif.wait_clks(10);
+  endtask // body
+
+endclass // chip_rv_dm_ndm_reset_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -8,9 +8,9 @@
 `include "chip_common_vseq.sv"
 `include "chip_jtag_csr_rw_vseq.sv"
 `include "chip_jtag_mem_vseq.sv"
-`include "chip_jtag_base_vseq.sv"
 // This needs to be listed prior to all sequences that derive from it.
 `include "chip_sw_base_vseq.sv"
+`include "chip_jtag_base_vseq.sv"
 `include "chip_sw_full_aon_reset_vseq.sv"
 `include "chip_sw_main_power_glitch_vseq.sv"
 `include "chip_sw_sysrst_ctrl_vseq.sv"
@@ -40,3 +40,4 @@
 `include "chip_tap_straps_vseq.sv"
 `include "chip_sw_repeat_reset_wkup_vseq.sv"
 `include "chip_sw_rstmgr_alert_info_vseq.sv"
+`include "chip_rv_dm_ndm_reset_vseq.sv"

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -65,6 +65,10 @@ module tb;
 
   spi_if spi_if(.rst_n);
   tl_if cpu_d_tl_if(.clk(cpu_clk), .rst_n(cpu_rst_n));
+  // Use this until we decide what to do with m_tl_agent_rv_dm_debug_mem_reg_block
+  // TODO reveiw m_tl_agent_rv_dm_debug_mem_reg_block
+  tl_if dmi_tbd_if(.clk(cpu_clk), .rst_n(cpu_rst_n));
+
   uart_if uart_if[NUM_UARTS-1:0]();
   jtag_if jtag_if();
   pwm_if pwm_if[NUM_PWM_CHANNELS]();
@@ -296,17 +300,20 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env*", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env*", "cpu_clk_rst_vif", cpu_clk_rst_if);
+    uvm_config_db#(virtual clk_rst_if)::set(
+        null, "*.env", "clk_rst_vif_rv_dm_debug_mem_reg_block", clk_rst_if);
 
     // IO Interfaces
     uvm_config_db#(virtual pins_if #(NUM_GPIOS))::set(null, "*.env", "gpio_vif", gpio_if);
     uvm_config_db#(virtual jtag_if)::set(null, "*.env.m_jtag_riscv_agent*", "vif", jtag_if);
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_if);
-    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", cpu_d_tl_if);
+    uvm_config_db#(virtual tl_if)::set(
+        null, "*.env.m_tl_agent_chip_reg_block*", "vif", cpu_d_tl_if);
 
     // RV_DM DMI
     uvm_config_db#(virtual clk_rst_if)::set(
         null, "*.env", "clk_rst_vif_rv_dm_debug_mem_reg_block", clk_rst_if);
-
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent_rv_dm*", "vif", dmi_tbd_if);
 
     // Strap pins
     uvm_config_db#(virtual pins_if #(2))::set(

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -862,6 +862,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_7_qs)
@@ -1109,6 +1110,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_ctrl_n_7_qs)

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -458,6 +458,34 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "rv_dm_ndm_reset_req",
+    srcs = ["rv_dm_ndm_reset_req.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/ip/adc_ctrl/data:adc_ctrl_regs",
+        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
+        "//hw/ip/keymgr/data:keymgr_regs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/ip/pinmux/data:pinmux_regs",
+        "//hw/ip/sysrst_ctrl/data:sysrst_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:adc_ctrl",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "sram_ctrl_execution_test_main",
     srcs = ["sram_ctrl_execution_test_main.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/rv_dm_ndm_reset_req.c
+++ b/sw/device/tests/sim_dv/rv_dm_ndm_reset_req.c
@@ -1,0 +1,218 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_adc_ctrl.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_keymgr.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "adc_ctrl_regs.h"
+#include "flash_ctrl_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "keymgr_regs.h"
+#include "otp_ctrl_regs.h"
+#include "pinmux_regs.h"
+#include "sysrst_ctrl_regs.h"
+/*
+   RV_DM NDM RESET REQUEST TEST
+   In top_earlgrey, the CSRs can be devided into 3 groups as below.
+     1. Group1 : Devce under por_reset
+        - pwrmgr, rstmgr
+     2. Group2 : Device under lc_reset
+        - otp_ctrl, pinmux, rv_dm and aontimer
+
+       * clkmgr stay between category 1 and 2.
+     3. Group3 : None of the above
+
+   Upon power up, test programs following registers from Group 2 and 3.
+     Group2:
+                                          RESET    PRGM (ARBITRARY VALUE)
+       OTP_CTRL.DIRECT_ACCESS_WDATA0      0x0      0x0609_2022
+       PINMUX.WKUP_DETECTOR_CNT_TH_1      0X0      0X44 --> move to LC
+       SRAM RET ADDRESS(8)                ?        0xDDAA_55BB
+    Group3:
+                                          RESET    PRGM (ARBITRARY VALUE)
+       ADC_CTRL.ADC_SAMPLE_CTL            0x9B     0x37
+       SYSRST_CTRL.EC_RST_CTL             0x7D0    0x567
+       KEYMGR.MAX_OWNER_KEY_VER_SHADOWED  0x0      0x1600_ABBA
+       FLASH_CTRL.SCRATCH                 0x0      0x3927
+
+   After programming csrs, the test assert NDM reset from RV_DM and de-assert.
+   Read programmed csr to check all Group2 keep programmed value while group 3
+   csrs have reset values.
+
+ */
+OTTF_DEFINE_TEST_CONFIG();
+/**
+ * Test csr struct
+ */
+typedef struct test_register {
+  /**
+   * Name of the device.
+   */
+  const char *name;
+  /**
+   * Base address of the test block
+   */
+  const uintptr_t base;
+  /**
+   * Offset of CSR / MEM of the test block
+   */
+  const ptrdiff_t offset;
+  /**
+   * Arbitrary write value to check register reset.
+   * If the register got reset, then this value will get wiped out.
+   */
+  uint32_t write_val;
+  /**
+   * Expected read value.
+   * For Group 2 registers, it is programmed value - arbitrary, hard coded.
+   * For Group 3 registers, it is reset value.
+   * in the beginning of the test.
+   */
+  uint32_t exp_read_val;
+
+} test_register_t;
+
+static dif_rstmgr_t rstmgr;
+static dif_otp_ctrl_t otp_ctrl;
+static dif_flash_ctrl_t flash_ctrl;
+static dif_adc_ctrl_t adc_ctrl;
+static dif_sysrst_ctrl_t sysrst_ctrl;
+static dif_pinmux_t pinmux;
+static dif_keymgr_t keymgr;
+
+enum {
+  OTP_CTRL,
+  PINMUX,
+  SRAM_CTRL_RET,
+  ADC_CTRL,
+  SYSRST_CTRL,
+  KEYMGR,
+  FLASH_CTRL,
+};
+
+static test_register_t kReg[] = {
+    [OTP_CTRL] =
+        {
+            .name = "OTP_CTRL",
+            .base = TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR,
+            .offset = OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET,
+            .write_val = 0x06092022,
+            .exp_read_val = 0x06092022,
+        },
+    [PINMUX] =
+        {
+            .name = "PINMUX",
+            .base = TOP_EARLGREY_PINMUX_AON_BASE_ADDR,
+            .offset = PINMUX_WKUP_DETECTOR_CNT_TH_1_REG_OFFSET,
+            .write_val = 0x44,
+            .exp_read_val = 0x44,
+
+        },
+    [SRAM_CTRL_RET] =
+        {
+            .name = "SRAM_CTRL_RET",
+            .base = TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR,
+            .offset =
+                8 * sizeof(uint32_t), /* Random location of retention ram */
+            .write_val = 0xddAA55bb,
+            .exp_read_val = 0xddAA55bb,
+        },
+    [ADC_CTRL] =
+        {
+            .name = "ADC_CTRL",
+            .base = TOP_EARLGREY_ADC_CTRL_AON_BASE_ADDR,
+            .offset = ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET,
+            .write_val = 0x37,
+            .exp_read_val = 0x9b,
+
+        },
+    [SYSRST_CTRL] =
+        {
+            .name = "SYSRST_CTRL",
+            .base = TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR,
+            .offset = SYSRST_CTRL_EC_RST_CTL_REG_OFFSET,
+            .write_val = 0x567,
+            .exp_read_val = 0x7d0,
+
+        },
+    [KEYMGR] =
+        {
+            .name = "KEYMGR",
+            .base = TOP_EARLGREY_KEYMGR_BASE_ADDR,
+            .offset = KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET,
+            .write_val = 0x1600ABBA,
+            .exp_read_val = 0x0,
+
+        },
+    [FLASH_CTRL] =
+        {
+            .name = "FLASH_CTRL",
+            .base = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR,
+            .offset = FLASH_CTRL_SCRATCH_REG_OFFSET,
+            .write_val = 0x3927,
+            .exp_read_val = 0x0,
+        },
+};
+
+static void write_test_reg() {
+  for (size_t i = OTP_CTRL; i <= FLASH_CTRL; ++i) {
+    mmio_region_write32(mmio_region_from_addr(kReg[i].base), kReg[i].offset,
+                        kReg[i].write_val);
+  }
+}
+
+bool test_main(void) {
+  // Device init.
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_DIF_OK(dif_flash_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR),
+      &flash_ctrl));
+  CHECK_DIF_OK(dif_adc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_ADC_CTRL_AON_BASE_ADDR), &adc_ctrl));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
+      &sysrst_ctrl));
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_keymgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_KEYMGR_BASE_ADDR), &keymgr));
+
+  if (rstmgr_testutils_is_reset_info(&rstmgr, kDifRstmgrResetInfoPor)) {
+    CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+
+    // Write arbitrary value to each test register.
+    write_test_reg();
+
+    LOG_INFO("wait for ndm reset");
+    wait_for_interrupt();
+  } else {
+    // NDM reset is de-asserted.
+    // Check reset info to be kDifRstmgrResetInfoNdm
+    LOG_INFO("check reset info");
+
+    CHECK(rstmgr_testutils_is_reset_info(&rstmgr, kDifRstmgrResetInfoNdm));
+
+    // Register value check after reset
+    LOG_INFO("Check registers");
+    for (size_t i = 0; i < ARRAYSIZE(kReg); ++i) {
+      uint32_t val = mmio_region_read32(mmio_region_from_addr(kReg[i].base),
+                                        kReg[i].offset);
+      CHECK(val == kReg[i].exp_read_val, "reg[%d]: obs:0x%x  exp:0x%x", i, val,
+            kReg[i].exp_read_val);
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
NDM reset request test
This test does csr write to  lc / sys reset regions. Then it toggles ndm reset.
After toggling reset, it reads back the same csrs to check
 the csr under lc reset region doesn't change the value 
while the csr under sys reset region has reset value.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>

