### PR TITLE
[sram, dv] Update intg_test_err

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -21,6 +21,9 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // Format: tl_intg_alert_fields[ral.a_reg.a_field] = value
   uvm_reg_data_t      tl_intg_alert_fields[dv_base_reg_field];
 
+  // flag to indicate tl mem acess are gated due to local or global escalation
+  bit                 tl_mem_access_gated;
+
   // Similar as the associative array above, if DUT has shadow registers, these two associative
   // arrays contains register fields related to shadow register's update and storage error status.
   uvm_reg_data_t      shadow_update_err_status_fields[dv_base_reg_field];

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -370,9 +370,10 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
     mem_access_err = !is_tl_mem_access_allowed(item, ral_name, mem_byte_access_err, mem_wo_err,
                                                mem_ro_err, custom_err);
-    if (mem_access_err) begin
+    if (mem_access_err || cfg.tl_mem_access_gated) begin
       // Some memory implementations may not return an error response on invalid accesses.
-      exp_d_error |= mem_byte_access_err | mem_wo_err | mem_ro_err | custom_err;
+      exp_d_error |= mem_byte_access_err | mem_wo_err | mem_ro_err | custom_err |
+                     cfg.tl_mem_access_gated;
     end
 
     bus_intg_err = !item.is_a_chan_intg_ok(.throw_error(0));
@@ -417,9 +418,10 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       `DV_CHECK_EQ(item.d_error, exp_d_error,
           $sformatf({"On interface %0s, TL item: %0s, unmapped_err: %0d, mem_access_err: %0d, ",
                     "bus_intg_err: %0d, byte_wr_err: %0d, csr_size_err: %0d, tl_item_err: %0d, ",
-                    "write_w_instr_type_err: %0d"},
+                    "write_w_instr_type_err: %0d, ", "cfg.tl_mem_access_gated: %0d"},
                     ral_name, item.sprint(uvm_default_line_printer), unmapped_err, mem_access_err,
-                    bus_intg_err, byte_wr_err, csr_size_err, tl_item_err, write_w_instr_type_err))
+                    bus_intg_err, byte_wr_err, csr_size_err, tl_item_err, write_w_instr_type_err,
+                    cfg.tl_mem_access_gated))
 
       // In data read phase, check d_data when d_error = 1.
       if (item.d_error && (item.d_opcode == tlul_pkg::AccessAckData)) begin
@@ -568,6 +570,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       is_fatal_alert[cfg.list_of_alerts[i]]        = 0;
       alert_chk_max_delay[cfg.list_of_alerts[i]]   = 0;
     end
+    cfg.tl_mem_access_gated = 0;
   endfunction
 
   virtual task sample_resets();

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -158,7 +158,8 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
                            bit abort     = 0,
                            bit en_ifetch = 0,
                            bit wait_complete = 1,
-                           bit not_use_last_addr = 0);
+                           bit not_use_last_addr = 0,
+                           bit exp_err_rsp = 0);
     bit [TL_DW-1:0] data;
     bit [TL_AW-1:0] addr;
     mubi4_t instr_type;
@@ -188,6 +189,7 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
                         .write(write),
                         .blocking(blocking),
                         .check_rsp(!en_ifetch),
+                        .exp_err_rsp(exp_err_rsp),
                         .instr_type(instr_type),
                         .tl_sequencer_h(p_sequencer.tl_sequencer_hs[cfg.sram_ral_name]),
                         .req_abort_pct((abort) ? 100 : 0));


### PR DESCRIPTION
Aligned with design that detecting fault injection gates all mem access.
The access after FI won't be blocked but it causes a fatal alert

Signed-off-by: Weicai Yang <weicai@google.com>