### PR TITLE
[dif, rv_core_ibex] Add fatal and recoverable alert functions

### DIFF
--- a/sw/device/lib/dif/dif_rv_core_ibex.c
+++ b/sw/device/lib/dif/dif_rv_core_ibex.c
@@ -309,3 +309,55 @@ dif_result_t dif_rv_core_ibex_read_fpga_info(
                              RV_CORE_IBEX_FPGA_INFO_REG_OFFSET);
   return kDifOk;
 }
+
+dif_result_t dif_rv_core_ibex_get_sw_recov_err_alert(
+    const dif_rv_core_ibex_t *rv_core_ibex, bool *enabled) {
+  if (rv_core_ibex == NULL || enabled == NULL) {
+    return kDifBadArg;
+  }
+  uint32_t reg = mmio_region_read32(rv_core_ibex->base_addr,
+                                    RV_CORE_IBEX_SW_RECOV_ERR_REG_OFFSET);
+  *enabled = reg != kMultiBitBool4False;
+  return kDifOk;
+}
+
+dif_result_t dif_rv_core_ibex_trigger_sw_recov_err_alert(
+    const dif_rv_core_ibex_t *rv_core_ibex) {
+  if (rv_core_ibex == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg = 0;
+  reg = bitfield_field32_write(reg, RV_CORE_IBEX_SW_RECOV_ERR_VAL_FIELD,
+                               kMultiBitBool4True);
+
+  mmio_region_write32(rv_core_ibex->base_addr,
+                      RV_CORE_IBEX_SW_RECOV_ERR_REG_OFFSET, reg);
+  return kDifOk;
+}
+
+dif_result_t dif_rv_core_ibex_get_sw_fatal_err_alert(
+    const dif_rv_core_ibex_t *rv_core_ibex, bool *enabled) {
+  if (rv_core_ibex == NULL || enabled == NULL) {
+    return kDifBadArg;
+  }
+  uint32_t reg = mmio_region_read32(rv_core_ibex->base_addr,
+                                    RV_CORE_IBEX_SW_FATAL_ERR_REG_OFFSET);
+  *enabled = reg != kMultiBitBool4False;
+  return kDifOk;
+}
+
+dif_result_t dif_rv_core_ibex_trigger_sw_fatal_err_alert(
+    const dif_rv_core_ibex_t *rv_core_ibex) {
+  if (rv_core_ibex == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg = 0;
+  reg = bitfield_field32_write(reg, RV_CORE_IBEX_SW_FATAL_ERR_VAL_FIELD,
+                               kMultiBitBool4True);
+
+  mmio_region_write32(rv_core_ibex->base_addr,
+                      RV_CORE_IBEX_SW_FATAL_ERR_REG_OFFSET, reg);
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_rv_core_ibex.h
+++ b/sw/device/lib/dif/dif_rv_core_ibex.h
@@ -293,8 +293,57 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_core_ibex_read_fpga_info(
     const dif_rv_core_ibex_t *rv_core_ibex, dif_rv_core_ibex_fpga_info_t *info);
 
+/**
+ * Software fatal alert. When triggered,
+ * a fatal alert is sent. Note, this alert once cleared cannot be set and
+ * will continuously cause alert events.
+ */
+
+/**
+ * Get the software recoverable alert sate.
+ *
+ * @param rv_core_ibex Handle.
+ * @param[out] enabled Returns `true` if enabled.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT dif_result_t dif_rv_core_ibex_get_sw_recov_err_alert(
+    const dif_rv_core_ibex_t *rv_core_ibex, bool *enabled);
+
+/**
+ * Software recoverable alert. When triggered, a recoverable alert is sent. Once
+ * the alert is sent, the register is then reset to disabled.
+ *
+ * @param rv_core_ibex Handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_trigger_sw_recov_err_alert(
+    const dif_rv_core_ibex_t *rv_core_ibex);
+
+/**
+ * Get the software fatal alert trigger status.
+ *
+ * @param rv_core_ibex Handle.
+ * @param[out] enabled Returns `true` if enabled.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_get_sw_fatal_err_alert(
+    const dif_rv_core_ibex_t *rv_core_ibex, bool *enabled);
+
+/**
+ * Software fatal alert. When triggered, a fatal alert is sent. Note, once this
+ * alert is triggered it cannot be reset and will continuously cause alert
+ * events.
+ *
+ * @param rv_core_ibex Handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_trigger_sw_fatal_err_alert(
+    const dif_rv_core_ibex_t *rv_core_ibex);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
-
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_RV_CORE_IBEX_H_

--- a/sw/device/lib/dif/dif_rv_core_ibex_unittest.cc
+++ b/sw/device/lib/dif/dif_rv_core_ibex_unittest.cc
@@ -499,4 +499,79 @@ TEST_F(FpgaInfoTest, ReadBadArg) {
   EXPECT_DIF_BADARG(dif_rv_core_ibex_read_fpga_info(nullptr, &info));
   EXPECT_DIF_BADARG(dif_rv_core_ibex_read_fpga_info(&ibex_, nullptr));
 }
+
+class FatalErrorAlertTest : public RvCoreIbexTestInitialized {};
+
+TEST_F(FatalErrorAlertTest, ReadAlertEnabled) {
+  bool enabled;
+
+  EXPECT_READ32(RV_CORE_IBEX_SW_FATAL_ERR_REG_OFFSET, 0x01);
+  EXPECT_DIF_OK(dif_rv_core_ibex_get_sw_fatal_err_alert(&ibex_, &enabled));
+  EXPECT_TRUE(enabled);
+
+  EXPECT_READ32(RV_CORE_IBEX_SW_FATAL_ERR_REG_OFFSET, kMultiBitBool4True);
+  EXPECT_DIF_OK(dif_rv_core_ibex_get_sw_fatal_err_alert(&ibex_, &enabled));
+  EXPECT_TRUE(enabled);
+}
+
+TEST_F(FatalErrorAlertTest, ReadAlertDisabled) {
+  bool enabled;
+
+  EXPECT_READ32(RV_CORE_IBEX_SW_FATAL_ERR_REG_OFFSET, kMultiBitBool4False);
+  EXPECT_DIF_OK(dif_rv_core_ibex_get_sw_fatal_err_alert(&ibex_, &enabled));
+  EXPECT_FALSE(enabled);
+}
+
+TEST_F(FatalErrorAlertTest, TriggerSuccess) {
+  EXPECT_WRITE32(RV_CORE_IBEX_SW_FATAL_ERR_REG_OFFSET, kMultiBitBool4True);
+  EXPECT_DIF_OK(dif_rv_core_ibex_trigger_sw_fatal_err_alert(&ibex_));
+}
+
+TEST_F(FatalErrorAlertTest, ReadBadArg) {
+  bool enabled;
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_get_sw_fatal_err_alert(nullptr, &enabled));
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_get_sw_fatal_err_alert(&ibex_, nullptr));
+}
+
+TEST_F(FatalErrorAlertTest, TriggerBadArg) {
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_trigger_sw_fatal_err_alert(nullptr));
+}
+
+class RecoverableErrorAlertTest : public RvCoreIbexTestInitialized {};
+
+TEST_F(RecoverableErrorAlertTest, ReadAlertEnabled) {
+  bool enabled;
+
+  EXPECT_READ32(RV_CORE_IBEX_SW_RECOV_ERR_REG_OFFSET, 0x01);
+  EXPECT_DIF_OK(dif_rv_core_ibex_get_sw_recov_err_alert(&ibex_, &enabled));
+  EXPECT_TRUE(enabled);
+
+  EXPECT_READ32(RV_CORE_IBEX_SW_RECOV_ERR_REG_OFFSET, kMultiBitBool4True);
+  EXPECT_DIF_OK(dif_rv_core_ibex_get_sw_recov_err_alert(&ibex_, &enabled));
+  EXPECT_TRUE(enabled);
+}
+
+TEST_F(RecoverableErrorAlertTest, ReadAlertDisabled) {
+  bool enabled;
+
+  EXPECT_READ32(RV_CORE_IBEX_SW_RECOV_ERR_REG_OFFSET, kMultiBitBool4False);
+  EXPECT_DIF_OK(dif_rv_core_ibex_get_sw_recov_err_alert(&ibex_, &enabled));
+  EXPECT_FALSE(enabled);
+}
+
+TEST_F(RecoverableErrorAlertTest, TriggerSuccess) {
+  EXPECT_WRITE32(RV_CORE_IBEX_SW_RECOV_ERR_REG_OFFSET, kMultiBitBool4True);
+  EXPECT_DIF_OK(dif_rv_core_ibex_trigger_sw_recov_err_alert(&ibex_));
+}
+
+TEST_F(RecoverableErrorAlertTest, ReadBadArg) {
+  bool enabled;
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_get_sw_recov_err_alert(nullptr, &enabled));
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_get_sw_recov_err_alert(&ibex_, nullptr));
+}
+
+TEST_F(RecoverableErrorAlertTest, TriggerBadArg) {
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_trigger_sw_recov_err_alert(nullptr));
+}
+
 }  // namespace dif_rv_core_ibex_test


### PR DESCRIPTION
This PR only add:
- Functions to trigger and check the status of errors alerts.
- Unittest for those functions.