### PR TITLE
[opentitanlib] Clear UART RX Buffer

### DIFF
--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -50,6 +50,16 @@ pub trait Uart {
 
     /// Writes data from `buf` to the UART.
     fn write(&self, buf: &[u8]) -> Result<()>;
+
+    /// Clears the UART RX buffer.
+    fn clear_rx_buffer(&self) -> Result<()> {
+        // Keep reading while until the RX buffer is empty.
+        // Note: This default implementation is overriden in backends where we can do better.
+        const TIMEOUT: Duration = Duration::from_millis(5);
+        let mut buf = [0u8; 256];
+        while self.read_timeout(&mut buf, TIMEOUT)? > 0 {}
+        Ok(())
+    }
 }
 
 /// Errors related to the UART interface.

--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Context, Result};
+use serialport::ClearBuffer;
 use serialport::SerialPort;
 use std::cell::RefCell;
 use std::io::ErrorKind;
@@ -85,5 +86,10 @@ impl Uart for SerialPortUart {
             buf = &buf[written..];
         }
         Ok(())
+    }
+
+    /// Clears the UART RX buffer.
+    fn clear_rx_buffer(&self) -> Result<()> {
+        Ok(self.port.borrow_mut().clear(ClearBuffer::Input)?)
     }
 }

--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -201,6 +201,8 @@ impl Transport for CW310 {
                 // Reset is active low, sleep, then drive high.
                 reset_pin.write(false)?;
                 std::thread::sleep(fpga_program.rom_reset_pulse);
+                // Also clear the UART RX buffer for improved robustness.
+                uart.clear_rx_buffer()?;
                 reset_pin.write(true)?;
 
                 // Now read the uart until the ROM prints it's version.

--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -220,7 +220,7 @@ impl Transport for CW310 {
                 fpga_program.progress.as_ref().map(Box::as_ref),
             )?;
             Ok(None)
-        } else if let Some(_set_pll) = action.downcast_ref::<SetPll>() {
+        } else if let Some(_) = action.downcast_ref::<SetPll>() {
             const TARGET_FREQ: u32 = 100_000_000;
             let usb = self.device.borrow();
             usb.pll_enable(true)?;

--- a/sw/host/opentitanlib/src/transport/ti50emulator/uart.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/uart.rs
@@ -109,4 +109,14 @@ impl Uart for Ti50Uart {
         self.get_socket()?.write(buf).context("UART read error")?;
         return Ok(());
     }
+
+    /// Clears the UART RX buffer.
+    fn clear_rx_buffer(&self) -> Result<()> {
+        // Iterators are lazy, consume using `count()`.
+        Read::by_ref(&mut *self.get_socket()?)
+            .bytes()
+            .take_while(Result::is_ok)
+            .count();
+        return Ok(());
+    }
 }

--- a/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
@@ -89,4 +89,8 @@ impl Uart for UltradebugUart {
         }
         Ok(())
     }
+
+    // TODO(#13290): Ideally, we would like to call `purge_usb_rx_buffer()` to clear the UART RX
+    // buffer but our `libftdi` is too old:
+    // safe_ftdi::Device::purge_usb_rx_buffer: error: undefined reference to 'ftdi_tciflush'
 }

--- a/sw/host/opentitanlib/src/transport/verilator/uart.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/uart.rs
@@ -8,6 +8,7 @@ use std::fs::File;
 use std::fs::OpenOptions;
 use std::io;
 use std::io::{ErrorKind, Read, Write};
+use std::io::{Seek, SeekFrom};
 use std::time::Duration;
 
 use crate::io::uart::Uart;
@@ -76,5 +77,10 @@ impl Uart for VerilatorUart {
             .borrow_mut()
             .write_all(buf)
             .context("UART write error")?)
+    }
+
+    fn clear_rx_buffer(&self) -> Result<()> {
+        self.file.borrow_mut().seek(SeekFrom::End(0))?;
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR
* Adds the `clear_rx_buffer()` function to the `UART` trait and implements it for all transports except for UltraDebug (please see #13290 for details),
* Adds the `Reset` `dispatch` command to CW310 for clearing the UART RX buffer while holding the board in reset, 
* Adds the capability (enabled by default) to clear the UART RX buffer after bootstrap (can be disabled using the `--no-reset-and-clear-rx` option), and
* Uses the same in rom detection to improve its robustness.

Notes:
* I ended up calling this `clear_buffers()` for the sake of clarity since `flush` and `drain` has other meanings in buffered contexts, e.g. pass all buffered data to kernel.
* The new `Reset` `dispatch` command is limited to CW310 for now since I'm not familiar with and cannot experiment with other transports ATM.

I tried this change locally using the following bazel command
```
bazel test //sw/device/silicon_creator/lib:boot_data_functest_fpga_cw310
```
and observed the following outputs:

* Before (please notice the corruption in the second line and extra output due to multiple resets):
```
Starting interactive console                                                                                                                                                                                                                                                    
[CTRL+C] to exit.                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                
c:118] Test ROM complete, jumping to flash!
I00000 boot_data_functest.c:342] Starting test check_test_data_test...
I00001 boot_data_functest.cúI00000 test_rom.c:81] Version: earlgrey_silver_release_v5-5961-gf6c983f8d, Build Date: 2022-06-17 00:24:02
I00001 test_rom.c:87] TestROM:8b2c1af3
I00000 test_rom.c:81] Version: earlgrey_silver_release_v5-5961-gf6c983f8d, Build Date: 2022-06-17 00:24:02
I00001 test_rom.c:87] TestROM:8b2c1af3
I00002 test_rom.c:118] Test ROM complete, jumping to flash!
I00000 boot_data_functest.c:342] Starting test check_test_data_test...
I00001 boot_data_functest.c:342] Finished test check_test_data_test: ok.
I00002 boot_data_functest.c:343] Starting test read_empty_default_allowed_test...
I00003 boot_data_functest.c:343] Finished test read_empty_default_allowed_test: ok.
I00004 boot_data_functest.c:344] Starting test read_empty_default_not_allowed_test...
I00005 boot_data_functest.c:344] Finished test read_empty_default_not_allowed_test: ok.
I00006 boot_data_functest.c:345] Starting test read_single_page_0_test...
I00007 boot_data_functest.c:345] Finished test read_single_page_0_test: ok.
I00008 boot_data_functest.c:346] Starting test read_single_page_1_test...
I00009 boot_data_functest.c:231] boot_data_read() took 8337 cycles
I00010 boot_data_functest.c:346] Finished test read_single_page_1_test: ok.
I00011 boot_data_functest.c:347] Starting test read_full_page_0_test...
I00012 boot_data_functest.c:347] Finished test read_full_page_0_test: ok.
I00013 boot_data_functest.c:348] Starting test read_full_page_1_test...
I00014 boot_data_functest.c:265] boot_data_read() took 29130 cycles
I00015 boot_data_functest.c:348] Finished test read_full_page_1_test: ok.
I00016 boot_data_functest.c:349] Starting test write_empty_test...
I00017 boot_data_functest.c:349] Finished test write_empty_test: ok.
I00018 boot_data_functest.c:350] Starting test write_page_switch_test...
I00019 boot_data_functest.c:350] Finished test write_page_switch_test: ok.
I00020 status.c:28] PASS!
                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                
Exiting interactive console.
```
* After (updated to reflect the latest changes, includes bootstrap output):
```
Starting interactive console
[CTRL+C] to exit.

I00000 test_rom.c:81] Version: earlgrey_silver_release_v5-6010-g11984ce01, Build Date: 2022-06-21 21:29:24
I00001 test_rom.c:87] TestROM:ab2d6cf9
I00000 test_rom.c:81] Version: earlgrey_silver_release_v5-6010-g11984ce01, Build Date: 2022-06-21 21:29:24
I00001 test_rom.c:87] TestROM:ab2d6cf9
I00002 test_rom.c:118] Test ROM complete, jumping to flash!
I00000 boot_data_functest.c:342] Starting test check_test_data_test...
I00001 boot_data_functest.c:342] Finished test check_test_data_test: ok.
I00002 boot_data_functest.c:343] Starting test read_empty_default_allowed_test...
I00003 boot_data_functest.c:343] Finished test read_empty_default_allowed_test: ok.
I00004 boot_data_functest.c:344] Starting test read_empty_default_not_allowed_test...
I00005 boot_data_functest.c:344] Finished test read_empty_default_not_allowed_test: ok.
I00006 boot_data_functest.c:345] Starting test read_single_page_0_test...
I00007 boot_data_functest.c:345] Finished test read_single_page_0_test: ok.
I00008 boot_data_functest.c:346] Starting test read_single_page_1_test...
I00009 boot_data_functest.c:231] boot_data_read() took 8337 cycles
I00010 boot_data_functest.c:346] Finished test read_single_page_1_test: ok.
I00011 boot_data_functest.c:347] Starting test read_full_page_0_test...
I00012 boot_data_functest.c:347] Finished test read_full_page_0_test: ok.
I00013 boot_data_functest.c:348] Starting test read_full_page_1_test...
I00014 boot_data_functest.c:265] boot_data_read() took 29130 cycles
I00015 boot_data_functest.c:348] Finished test read_full_page_1_test: ok.
I00016 boot_data_functest.c:349] Starting test write_empty_test...
I00017 boot_data_functest.c:349] Finished test write_empty_test: ok.
I00018 boot_data_functest.c:350] Starting test write_page_switch_test...
I00019 boot_data_functest.c:350] Finished test write_page_switch_test: ok.
I00020 status.c:28] PASS!


Exiting interactive console.
```

Signed-off-by: Alphan Ulusoy <alphan@google.com>