### PR TITLE
[bazel/ci] mark e2e mask rom test flaky for better ci runs

### DIFF
--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -30,5 +30,6 @@ ci/bazelisk.sh test \
     --test_output=all \
     --build_tests_only \
     --define cw310=lowrisc \
+    --flaky_test_attempts=2 \
     $(./bazelisk.sh query 'rdeps(//...,@bitstreams//:bitstream_test_rom)') \
     $(./bazelisk.sh query 'rdeps(//...,@bitstreams//:bitstream_mask_rom)')

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -342,6 +342,7 @@ opentitan_functest(
             "--exit-failure='PASS!'",
         ],
         bitstream = "//hw/bitstream:mask_rom",
+        tags = ["flaky"],
     ),
     signed = False,
     targets = [


### PR DESCRIPTION
This should help the cw310 failures, by marking the flaky test as such and letting it rerun if it hits an issue.

Signed-off-by: Drew Macrae <drewmacrae@google.com>