### PR TITLE
[doc] Added inserted header anchors/links.

### DIFF
--- a/site/docs/assets/scss/_markdown.scss
+++ b/site/docs/assets/scss/_markdown.scss
@@ -44,6 +44,15 @@
     margin-bottom: 0.5em;
   }
 
+  .header-link {
+    text-decoration: none;
+  }
+
+  .header-link:hover,
+  .header-link:active {
+    text-decoration: underline;
+  }
+
   p {
     @extend .bodytext;
     font-size: inherit;

--- a/site/docs/layouts/_default/single.html
+++ b/site/docs/layouts/_default/single.html
@@ -13,7 +13,14 @@
         </aside>
         <main id="main" role="main" class="markdown">
           {{ if .Title }}<h1 class="title">{{ .Title }}</h1>{{ end }}
-          {{ .Content }}
+          <!-- The regex finds header tags and converts the content into a link
+            with a link icon appended.
+          -->
+          {{ .Content
+            | replaceRE "(<h[1-6] id=\"(.+)\".*>)(.*)(</h[1-6]>)"
+            `${1}<a class="header-link" href="#${2}">${3}</a>${4}`
+            | safeHTML
+          }}
         </main>
         {{ partial "toc.html" . }}
       </div>


### PR DESCRIPTION
Wrapped the headings in clickable anchors as requested in https://github.com/lowRISC/opentitan/issues/13097 .

The link icon is faded unless the mouse is hovering over the heading. The whole heading is within the anchor not just the link icon, i.e. the whole heading is clickable.

![small](https://user-images.githubusercontent.com/45573837/174621769-cadf8b8a-1477-490e-b4ba-0e351940eafe.png)
