### PR TITLE
[otbn,dv] Fix reset during EDN request

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/edn_client.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/edn_client.py
@@ -62,16 +62,23 @@ class EdnClient:
         self._retry = False
 
     def take_word(self, word: int) -> None:
-        '''Take a 32-bit data word that we've been waiting for'''
+        '''
+        Take a 32-bit data word, which we requested.
+
+        If there is a reset in between an EDN transaction, request flag will
+        drop. In that case, incoming word will be ignored. Otherwise, append
+        it to the internal `_acc` list.
+        '''
         assert 0 <= word < (1 << 32)
-        assert self._acc is not None
-        assert len(self._acc) < ACC_LEN
-        assert self._cdc_counter is None
 
-        self._acc.append(word)
-
-        if len(self._acc) == ACC_LEN:
-            self._cdc_counter = 0
+        if self._acc is None:
+            return
+        else:
+            assert len(self._acc) < ACC_LEN
+            assert self._cdc_counter is None
+            self._acc.append(word)
+            if len(self._acc) == ACC_LEN:
+                self._cdc_counter = 0
 
     def edn_reset(self) -> None:
         '''Called on a reset signal on the EDN clock domain'''

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -208,7 +208,10 @@ class RndReq(RGReg):
         self._client.poison()
 
     def forget(self) -> None:
+        # Clear any pending request in the RND EDN client
         self._client.forget()
+        # Also clear the request flag
+        self.write(0, True)
 
     def take_word(self, word: int) -> None:
         self._client.take_word(word)
@@ -220,7 +223,6 @@ class RndReq(RGReg):
         '''Clear the flag and return the data that we've read from EDN.
 
         Returns the same value as EdnClient.cdc_complete().'''
-        assert self.read(True) == 1
         (data, retry) = self._client.cdc_complete()
         if not retry:
             self.write(0, True)


### PR DESCRIPTION
We were having an assertion saying we shouldn't recieve EDN
words without a request already going. That is not necessarily true
if we are in the middle of a EDN request and resetting OTBN.
Request drops but we still end up with a word to process.

Now we are ignoring the incoming EDN word if we have not initialize
_acc properly.

Also, another bugfix for the `forget` function in RNDReq. Now it also clears
the request flag.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>