### PR TITLE
[sw, ottf] Enable chip level tests to boot with mask_rom and rom_ext

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -4,6 +4,7 @@
 
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 load("//rules:linker.bzl", "ld_library")
+load("//rules:manifest.bzl", "CONST", "manifest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -41,11 +42,38 @@ cc_library(
 )
 
 ld_library(
-    name = "linker_script",
-    script = "ottf.ld",
+    name = "ld_common",
+    fragments = ["ottf_common.ld"],
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
         "//sw/device:info_sections",
+        "//sw/device/silicon_creator/lib/base:static_critical_sections",
+    ],
+)
+
+ld_library(
+    name = "ld_test_rom",
+    script = "ottf_test_rom.ld",
+    deps = [
+        ":ld_common",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+    ],
+)
+
+ld_library(
+    name = "ld_silicon_creator_stage",
+    script = "ottf_silicon_creator_stage.ld",
+    deps = [
+        ":ld_common",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+    ],
+)
+
+ld_library(
+    name = "ld_silicon_owner_stage",
+    script = "ottf_silicon_owner_stage.ld",
+    deps = [
+        ":ld_common",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
     ],
 )
 
@@ -67,13 +95,12 @@ cc_library(
     ],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
-        ":linker_script",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crt",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
-        "//sw/device/silicon_creator/lib:manifest_size",
+        "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 
@@ -109,6 +136,25 @@ alias(
     }),
 )
 
+
+manifest(
+    name = "ottf_manifest_creator",
+    address_translation = CONST.TRUE,
+    identifier = CONST.ROM_EXT,
+)
+
+manifest(
+    name = "ottf_manifest_owner",
+    address_translation = CONST.TRUE,
+    identifier = CONST.OWNER,
+)
+
+manifest(
+    name = "ottf_manifest_test_rom",
+    address_translation = CONST.FALSE,
+    identifier = CONST.ROM_EXT,
+)
+
 cc_library(
     name = "ottf_main",
     srcs = ["ottf_main.c"],
@@ -121,7 +167,6 @@ cc_library(
         ":ottf_start",
         ":ottf_test_config",
         ":status",
-        ":test_framework_manifest_def",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/dif:uart",

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -3,14 +3,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /**
- * Linker script for OpenTitan OTTF-launched test binaries.
- *
- * Portions of this file are Ibex-specific.
- */
-
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
-
-/**
  * Reserving space at the top of the RAM for the stack.
  */
 _stack_size = 0x2000;
@@ -28,17 +20,17 @@ _dv_log_offset = 0x10000;
  * The start of the .text section relative to the beginning of the associated
  * slot for use in the manifest.
  */
-_manifest_code_start = _text_start - ORIGIN(eflash);
+_manifest_code_start = _text_start - _ottf_ext_start_address;
 /*
  * The end of the .text section relative to the beginning of the associated slot
  * for use in the manifest.
  */
-_manifest_code_end = _text_end - ORIGIN(eflash);
+_manifest_code_end = _text_end - _ottf_ext_start_address;
 /*
  * The location of the entry point relative to the beginning of the associated
  * slot for use in the manifest.
  */
-_manifest_entry_point = _ottf_start - ORIGIN(eflash);
+_manifest_entry_point = _ottf_start - _ottf_ext_start_address;
 
 OUTPUT_ARCH(riscv)
 
@@ -60,9 +52,9 @@ ENTRY(_ottf_start);
  * s19->slm conversion scripts are not able to handle non-word aligned sections.
  */
 SECTIONS {
-  .manifest ORIGIN(eflash) : {
+  .manifest _ottf_ext_start_address : {
     KEEP(*(.manifest))
-  } > eflash
+  } > ottf_flash
 
   /**
    * Non-volatile Scratch area in flash.
@@ -73,7 +65,7 @@ SECTIONS {
   .non_volatile_scratch : ALIGN(2048){
     _non_volatile_scratch_start = .;
     KEEP(*(.non_volatile_scratch))
-  } > eflash
+  } > ottf_flash
 
   /**
    * Ibex interrupt vector. See 'ottf_start.S' for more information.
@@ -84,14 +76,14 @@ SECTIONS {
   .vectors : ALIGN (256){
     _text_start = .;
     *(.vectors)
-  } > eflash
+  } > ottf_flash
 
   /**
    * C runtime (CRT) section, containing program initialization code.
    */
   .crt : ALIGN(4) {
     KEEP(*(.crt))
-  } > eflash
+  } > ottf_flash
 
   /**
    * For LLVM profiling. This contains a pointer to the runtime initialization
@@ -105,7 +97,7 @@ SECTIONS {
       *(.init_array.*)
       . = ALIGN(4);
       _init_array_end = .;
-  } > eflash
+  } > ottf_flash
 
   /**
    * Standard text section, containing program code.
@@ -123,7 +115,7 @@ SECTIONS {
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _text_end = .;
-  } > eflash
+  } > ottf_flash
 
   /**
    * Read-only data section, containing all large compile-time constants, like
@@ -141,7 +133,7 @@ SECTIONS {
     KEEP(*(__llvm_covfun))
     KEEP(*(__llvm_covmap))
     KEEP(*(__llvm_prf_names))
-  } > eflash
+  } > ottf_flash
 
   /**
    * "Intitial data" section, the initial values of the mutable data section
@@ -149,7 +141,7 @@ SECTIONS {
    */
   .idata : ALIGN(4) {
     _data_init_start = .;
-  } > eflash
+  } > ottf_flash
 
   /**
    * Standard mutable data section, at the bottom of RAM. This will be

--- a/sw/device/lib/testing/test_framework/ottf_silicon_creator_stage.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_creator_stage.ld
@@ -1,0 +1,23 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for OpenTitan OTTF-launched test binaries.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * This linker script generates a binary to run mask_rom.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/**
+ * Symbols to be used in the setup of the address translation for ROM_EXT.
+ */
+_ottf_ext_start_address = ORIGIN(rom_ext_virtual);
+_ottf_ext_size = LENGTH(rom_ext_virtual);
+
+REGION_ALIAS("ottf_flash", rom_ext_virtual);
+
+INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/lib/testing/test_framework/ottf_silicon_owner_stage.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_owner_stage.ld
@@ -1,0 +1,23 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for OpenTitan OTTF-launched test binaries.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * This linker script generates a binary to run mask_rom.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/**
+ * Symbols to be used in the setup of the address translation for ROM_EXT.
+ */
+_ottf_ext_start_address = ORIGIN(owner_virtual) + 64K;
+_ottf_ext_size = LENGTH(owner_virtual) - 64K;
+
+REGION_ALIAS("ottf_flash", owner_virtual);
+
+INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/lib/testing/test_framework/ottf_test_rom.ld
+++ b/sw/device/lib/testing/test_framework/ottf_test_rom.ld
@@ -1,0 +1,23 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for OpenTitan OTTF-launched test binaries.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * This linker script generates a binary to run with the test rom.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/**
+ * Symbols to be used in the setup of the address translation for ROM_EXT.
+ */
+_ottf_ext_start_address = ORIGIN(eflash);
+_ottf_ext_size = LENGTH(eflash);
+
+REGION_ALIAS("ottf_flash", eflash);
+
+INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -48,6 +48,7 @@ cc_library(
     srcs = ["bare_metal_example.c"],
     hdrs = ["bare_metal_example.h"],
     deps = [
+        "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/lib:rom_print",
     ],
@@ -73,8 +74,6 @@ opentitan_flash_binary(
     deps = [
         ":bare_metal_example",
         ":ld_slot_a",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 
@@ -86,8 +85,6 @@ opentitan_flash_binary(
     deps = [
         ":bare_metal_example",
         ":ld_slot_b",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 
@@ -99,8 +96,6 @@ opentitan_flash_binary(
     deps = [
         ":bare_metal_example",
         ":ld_virtual_addr",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -16,13 +16,8 @@ exports_files(glob([
     "*.h",
 ]))
 
-opentitan_functest(
+cc_library(
     name = "aes_entropy_test",
-    srcs = ["aes_entropy_test.c"],
-    cw310 = cw310_params(
-        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-        tags = ["broken"],
-    ),
     deps = [
         "//hw/ip/aes:model",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -34,6 +29,39 @@ opentitan_functest(
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
+)
+
+opentitan_functest(
+    name = "aes_entropy_test_creator",
+    srcs = ["aes_entropy_test.c"],
+    deps = [
+        ":aes_entropy_test",
+        "//sw/device/lib/testing/test_framework:ld_silicon_creator_stage",
+    ],
+    manifest = "//sw/device/lib/testing/test_framework:ottf_manifest_creator",
+    signed = True,
+)
+
+opentitan_functest(
+    name = "aes_entropy_test_owner",
+    srcs = ["aes_entropy_test.c"],
+    deps = [
+        ":aes_entropy_test",
+        "//sw/device/lib/testing/test_framework:ld_silicon_owner_stage",
+    ],
+    manifest = "//sw/device/lib/testing/test_framework:ottf_manifest_owner",
+    signed = True,
+)
+
+opentitan_functest(
+    name = "aes_entropy_test_rom",
+    srcs = ["aes_entropy_test.c"],
+    deps = [
+        ":aes_entropy_test",
+        "//sw/device/lib/testing/test_framework:ld_test_rom",
+    ],
+    manifest = "//sw/device/lib/testing/test_framework:ottf_manifest_test_rom",
+    signed = False,
 )
 
 opentitan_functest(


### PR DESCRIPTION
This PR enables the chip level test to boot with mask_rom and rom_ext.
#### Executing in the 2nd stage
```
bazel-bin/sw/host/opentitantool/opentitantool load-bitstream /tmp/bitstream-latest/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice

bazel run //sw/host/opentitantool -- --exec "bootstrap /home/doreis/lowrisc/git/opentitan/bazel-bin/sw/device/tests/aes_entropy_test_creator_prog_fpga_cw310.test_key_0.signed.bin" console
```
#### Executing in the 3nd stage
```
bazel-bin/sw/host/opentitantool/opentitantool load-bitstream /tmp/bitstream-latest/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice

bazel run //sw/host/opentitantool -- --exec "bootstrap /home/doreis/lowrisc/git/opentitan/bazel-bin/sw/device/silicon_creator/rom_ext/virtual_addr_fpga_cw310.test_key_0.signed.bin@0 /home/doreis/lowrisc/git/opentitan/bazel-bin/sw/device/tests/aes_entropy_test_owner_prog_fpga_cw310.test_key_0.signed.bin@0x10000" console
```

Fixes: #10712 