### PR TITLE
[mask_rom] run E2E tests in DV sim

### DIFF
--- a/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
@@ -7,6 +7,15 @@
 
   # Note: Please maintain alphabetical order.
   tests: [
+    // Mask ROM E2E tests.
+    {
+      name: mask_rom_e2e_bootup_success
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/silicon_creator/mask_rom/e2e_bootup_success:1:signed"]
+      en_run_modes: ["sw_test_mode_mask_rom"]
+      run_opts: ["+sw_test_timeout_ns=20000000"]
+    }
+
     // Signed chip-level tests to be run with mask ROM, instead of test ROM.
     {
       name: chip_sw_uart_smoketest_signed

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -486,7 +486,6 @@ def opentitan_rom_binary(
         name,
         platform = OPENTITAN_PLATFORM,
         per_device_deps = PER_DEVICE_DEPS,
-        extract_sw_logs_db = True,
         **kwargs):
     """A helper macro for generating OpenTitan binary artifacts for ROM.
 
@@ -501,7 +500,6 @@ def opentitan_rom_binary(
       @param name: The name of this rule.
       @param platform: The target platform for the artifacts.
       @param per_device_deps: The deps for each of the hardware target.
-      @param extract_sw_logs_db: Whether to extract SW logs database for DV sim.
       @param **kwargs: Arguments to forward to `opentitan_binary`.
     Emits rules:
       For each device in per_device_deps entry:
@@ -526,7 +524,7 @@ def opentitan_rom_binary(
         targets.extend(opentitan_binary(
             name = devname,
             deps = deps + dev_deps,
-            extract_sw_logs_db = extract_sw_logs_db and device.startswith("sim_"),
+            extract_sw_logs_db = device in ["sim_dv", "sim_verilator"],
             **kwargs
         ))
         elf_name = "{}_{}".format(devname, "elf")
@@ -563,7 +561,6 @@ def opentitan_flash_binary(
             "test_key_0": "@//sw/device/silicon_creator/mask_rom/keys:test_private_key_0",
         },
         per_device_deps = PER_DEVICE_DEPS,
-        extract_sw_logs_db = True,
         output_signed = False,
         **kwargs):
     """A helper macro for generating OpenTitan binary artifacts for flash.
@@ -581,7 +578,6 @@ def opentitan_flash_binary(
       @param platform: The target platform for the artifacts.
       @param signing_keys: The signing keys for to sign each BIN file with.
       @param per_device_deps: The deps for each of the hardware target.
-      @param extract_sw_logs_db: Whether to extract SW logs database for DV sim.
       @param output_signed: Whether or not to emit signed binary/VMEM files.
       @param **kwargs: Arguments to forward to `opentitan_binary`.
     Emits rules:
@@ -611,7 +607,7 @@ def opentitan_flash_binary(
         targets.extend(opentitan_binary(
             name = devname,
             deps = deps + dev_deps,
-            extract_sw_logs_db = extract_sw_logs_db and device.startswith("sim_"),
+            extract_sw_logs_db = device in ["sim_dv", "sim_verilator"],
             **kwargs
         ))
         elf_name = "{}_{}".format(devname, "elf")

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -293,13 +293,14 @@ def opentitan_functest(
         if "manual" not in params.get("tags"):
             all_tests.append(test_name)
 
+        sw_logs_db = []
+
         # Set flash image.
         if target in ["sim_dv", "sim_verilator"]:
             flash = "{}_prog_{}_scr_vmem64".format(name, target)
-            sw_logs_db = ["{}_prog_{}_logs_db".format(name, target)]
+            sw_logs_db.append("{}_prog_{}_logs_db".format(name, target))
         else:
             flash = "{}_prog_{}_bin".format(name, target)
-            sw_logs_db = []
         if signed:
             flash += "_signed_{}".format(key)
 
@@ -319,6 +320,8 @@ def opentitan_functest(
         rom = params.pop("rom")
         if test_in_rom:
             rom = "{}_rom_prog_{}_scr_vmem".format(name, target)
+        if target in ["sim_dv", "sim_verilator"]:
+            sw_logs_db.append(rom.replace("_scr_vmem", "_logs_db"))
 
         bitstream = params.pop("bitstream", None)
         rom_kind = params.pop("rom_kind", None)

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -10,7 +10,7 @@ load(
     "opentitan_functest",
     "verilator_params",
 )
-load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
+load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -78,9 +78,6 @@ opentitan_rom_binary(
         "mask_rom.h",
         "mask_rom_start.S",
     ],
-    # Mask ROM does not permit the DV simulation backdoor logging mechanism that
-    # test ROM does, for obvious security reasons.
-    extract_sw_logs_db = False,
     deps = [
         ":boot_policy",
         ":bootstrap",
@@ -314,10 +311,6 @@ opentitan_functest(
         tags = ["broken"],
     ),
     signed = True,
-    targets = [
-        "verilator",
-        "cw310",
-    ],
     verilator = verilator_params(
         rom = ":mask_rom_sim_verilator_scr_vmem",
         tags = [
@@ -345,10 +338,6 @@ opentitan_functest(
         tags = ["flaky"],
     ),
     signed = False,
-    targets = [
-        "verilator",
-        "cw310",
-    ],
     verilator = verilator_params(
         rom = ":mask_rom_sim_verilator_scr_vmem",
     ),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1248,6 +1248,7 @@ opentitan_functest(
 opentitan_functest(
     name = "uart_smoketest",
     srcs = ["uart_smoketest.c"],
+    signed = True,
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",


### PR DESCRIPTION
This updates the dvsim.py configuration file to demo how to run mask ROM
E2E in DV simulation. additionally, this fixes a bug that was preventing
the software (backdoor) logging database from being generated by Bazel
for the mask ROM.

Signed-off-by: Timothy Trippel <ttrippel@google.com>