### PR TITLE
[otbn,dv] Improve FIPS connection for RND in OTBN

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -353,6 +353,7 @@ class otbn_base_vseq extends cip_base_vseq #(
           _run_otbn_cmd(otbn_pkg::CmdExecute);
           _run_loop_warps();
           _run_sideload_sequence();
+          _run_rnd_edn_rsp();
         join_any
 
         // Consumed by _run_sideload_sequence()
@@ -506,6 +507,15 @@ class otbn_base_vseq extends cip_base_vseq #(
     // poll_despite_interrupts_pct percent of the time.
     return $urandom_range(100) > cfg.poll_despite_interrupts_pct;
   endfunction
+
+  // Poll RND EDN request to set some constrained randomness as a response from EDN agent.
+  protected task _run_rnd_edn_rsp();
+    forever begin
+      @(negedge cfg.clk_rst_vif.clk);
+      if (cfg.poll_rnd_edn_req())
+        cfg.gen_rnd_edn_rsp();
+    end
+  endtask
 
   // Monitor the bound-in loop controller interface to take action on loop warp events. Runs
   // forever, but is spawned by run_otbn(), which will kill it when the OTBN run completes or the

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -139,10 +139,9 @@ module tb;
 
     .clk_edn_i (edn_clk),
     .rst_edn_ni(edn_rst_n),
+
     .edn_rnd_o (edn_if[RndEdnIdx].req),
-    // For now, we force the FIPS bit to 1 as the model cannot yet deal with RND FIPS check
-    // failures. For details, see https://github.com/lowRISC/opentitan/issues/11915
-    .edn_rnd_i ({edn_if[RndEdnIdx].ack, 1'b1, edn_if[RndEdnIdx].d_data[31:0]}),
+    .edn_rnd_i ({edn_if[RndEdnIdx].ack, edn_if[RndEdnIdx].d_data}),
 
     .edn_urnd_o(edn_if[UrndEdnIdx].req),
     .edn_urnd_i({edn_if[UrndEdnIdx].ack, edn_if[UrndEdnIdx].d_data}),
@@ -247,7 +246,7 @@ module tb;
 
     .err_bits_o   (model_if.err_bits),
 
-    .edn_rnd_i           ({edn_if[RndEdnIdx].ack, 1'b1, edn_if[RndEdnIdx].d_data[31:0]}),
+    .edn_rnd_i           ({edn_if[RndEdnIdx].ack, edn_if[RndEdnIdx].d_data}),
     .edn_rnd_o           (edn_rnd_req_model),
     .edn_rnd_cdc_done_i  (edn_rnd_cdc_done),
 


### PR DESCRIPTION
Implements a change in how we use EDN agent. Now we are polling
for a request from OTBN to generate a random data with controlled
randomness for its FIPS bit. By default we will always randomize
FIPS bit as 1.

By overwriting the `rnd_fips_pct` variable from
the config, we can allow agent to generate FIPS bits with more
flexibility as well.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>