### PR TITLE
[top, dv] Add checking extclk switch in uart test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -279,7 +279,7 @@
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
       sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+uart_idx=0"]
+      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1"]
       reseed: 5
     }
     {
@@ -287,7 +287,7 @@
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
       sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+uart_idx=1"]
+      run_opts: ["+uart_idx=1", "+calibrate_usb_clk=1"]
       reseed: 5
     }
     {
@@ -295,7 +295,7 @@
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
       sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+uart_idx=2"]
+      run_opts: ["+uart_idx=2", "+calibrate_usb_clk=1"]
       reseed: 5
     }
     {
@@ -303,7 +303,7 @@
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
       sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+uart_idx=3"]
+      run_opts: ["+uart_idx=3", "+calibrate_usb_clk=1"]
       reseed: 5
     }
     {
@@ -311,14 +311,14 @@
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
       sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_spi_load_bootstrap=1"]
+      run_opts: ["+use_spi_load_bootstrap=1", "+calibrate_usb_clk=1"]
     }
     {
       name: chip_sw_uart_rand_baudrate
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=80_000_000"]
+      run_opts: ["+sw_test_timeout_ns=80_000_000", "+calibrate_usb_clk=1"]
       reseed: 20
     }
     {
@@ -327,7 +327,7 @@
       sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000",
-                 "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1"]
+                 "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1", "+calibrate_usb_clk=1"]
       reseed: 5
     }
     {
@@ -335,7 +335,7 @@
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=80_000_000",
+      run_opts: ["+sw_test_timeout_ns=80_000_000", "+calibrate_usb_clk=1",
                  "+ext_clk_type=ExtClkLowSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
       reseed: 5
     }
@@ -349,7 +349,7 @@
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=80_000_000",
+      run_opts: ["+sw_test_timeout_ns=80_000_000", "+calibrate_usb_clk=1",
                  "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
       reseed: 5
     }

--- a/hw/top_earlgrey/dv/env/ast_ext_clk_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_ext_clk_if.sv
@@ -7,7 +7,9 @@
 interface ast_ext_clk_if ();
   import uvm_pkg::*;
 
-  task static detect_io_active_window();
+  string msg_id = "ast_ext_clk_if";
+
+  task automatic detect_io_active_window();
     fork
       wait(u_ast.u_ast_clks_byp.u_clk_src_io_sel.clk_ext_en_o == 1'b1);
       `uvm_info("ast_ext_clk_if", "External clk became active for io clk", UVM_MEDIUM)
@@ -15,5 +17,9 @@ interface ast_ext_clk_if ();
       `uvm_info("ast_ext_clk_if", "External clk back to inactive for io clk", UVM_MEDIUM)
     join
   endtask
+
+  function automatic void check_ext_clk_in_use();
+    `DV_CHECK_EQ(u_ast.u_ast_clks_byp.u_clk_src_io_sel.clk_osc_en_o, 0, , , msg_id)
+  endfunction
 
 endinterface : ast_ext_clk_if

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
@@ -74,5 +74,13 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
     end
   endtask
 
+  // When uart starts to send RX data, check if AST is using extclk if extclk is selected.
+  virtual task send_uart_rx_data(int size = -1, bit random = 0);
+    if (use_extclk) begin
+      cfg.ast_ext_clk_vif.check_ext_clk_in_use();
+    end
+    super.send_uart_rx_data(size, random);
+  endtask
+
 endclass : chip_sw_uart_rand_baudrate_vseq
 `undef CALC_NCO

--- a/sw/device/lib/testing/clkmgr_testutils.c
+++ b/sw/device/lib/testing/clkmgr_testutils.c
@@ -111,3 +111,11 @@ void clkmgr_testutils_check_measurement_counts(const dif_clkmgr_t *clkmgr) {
   // clear recoverable errors
   CHECK_DIF_OK(dif_clkmgr_recov_err_code_clear_codes(clkmgr, ~0u));
 }
+
+void clkmgr_testutils_enable_external_clock_and_wait_for_completion(
+    const dif_clkmgr_t *clkmgr, bool is_low_speed) {
+  LOG_INFO("Configure clkmgr to enable external clock");
+  CHECK_DIF_OK(dif_clkmgr_external_clock_set_enabled(clkmgr, is_low_speed));
+  CHECK_DIF_OK(dif_clkmgr_wait_for_ext_clk_switch(clkmgr));
+  LOG_INFO("Switching to external clock completes");
+}

--- a/sw/device/lib/testing/clkmgr_testutils.h
+++ b/sw/device/lib/testing/clkmgr_testutils.h
@@ -95,6 +95,15 @@ void clkmgr_testutils_check_measurement_counts(const dif_clkmgr_t *clkmgr);
 void clkmgr_testutils_disable_clock_counts(const dif_clkmgr_t *clkmgr);
 
 /**
+ * Switch to use external clock and wait until the switching is done
+ *
+ * @param clkmgr A clkmgr DIF handle.
+ * @param is_low_speed Is external clock in low speed mode or not.
+ */
+void clkmgr_testutils_enable_external_clock_and_wait_for_completion(
+    const dif_clkmgr_t *clkmgr, bool is_low_speed);
+
+/**
  * Verifies the given clock state.
  *
  * @param clkmgr A clkmgr DIF handle.

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -22,6 +22,7 @@ opentitan_functest(
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:clkmgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )


### PR DESCRIPTION
1. Create a testutil to enable SW extclk switch
2. Add a check to ensure uart test uses extclk
Signed-off-by: Weicai Yang <weicai@google.com>