### PR TITLE
[base] Add `status_t` for universal status reporting

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # https://docs.opentitan.org/doc/rm/c_cpp_coding_style/#cxx-version specifies
-build --cxxopt='-std=c++14'
-build --conlyopt='-std=c11'
+build --cxxopt='-std=gnu++14'
+build --conlyopt='-std=gnu11'
 
 # Never strip debugging information so that we can produce annotated
 # disassemblies when compilation mode is fastbuild.

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -13,6 +13,11 @@ cc_library(
 )
 
 cc_library(
+    name = "absl_status",
+    hdrs = ["absl_status.h"],
+)
+
+cc_library(
     name = "stdasm",
     hdrs = ["stdasm.h"],
 )

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -240,3 +240,23 @@ dual_cc_library(
         ],
     ),
 )
+
+cc_library(
+    name = "status",
+    srcs = ["status.c"],
+    hdrs = ["status.h"],
+    deps = [
+        ":absl_status",
+        ":bitfield",
+        ":macros",
+    ],
+)
+
+cc_test(
+    name = "status_unittest",
+    srcs = ["status_unittest.cc"],
+    deps = [
+        ":status",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/sw/device/lib/base/absl_status.h
+++ b/sw/device/lib/base/absl_status.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_ABSL_STATUS_H_
-#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_ABSL_STATUS_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_ABSL_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_ABSL_STATUS_H_
 
 #ifndef USING_ABSL_STATUS
 #error \
@@ -45,7 +45,7 @@ extern "C" {
  * Google by RPC servers, the advice about how to use them and how to
  * categorize errors is generally sound.
  */
-enum absl_status_code {
+typedef enum absl_status_code {
   // StatusCode::kOk
   //
   // kOK (gRPC code "OK") does not indicate an error; this value is returned on
@@ -225,10 +225,10 @@ enum absl_status_code {
   // values, but instead provide a "default:" case. Providing such a default
   // case ensures that code will compile when new codes are added.
   kDoNotUseReservedForFutureExpansionUseDefaultInSwitchInstead_ = 20
-};
+} absl_status_t;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_ABSL_STATUS_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_ABSL_STATUS_H_

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -81,6 +81,116 @@
   n
 
 /**
+ * An argument concatenation macro.
+ *
+ * Because the `##` operator inhibits expansion, we use a level of indirection
+ * to create a macro which concatenates without inhibition.
+ */
+#define OT_CAT(a, ...) OT_PRIMITIVE_CAT(a, __VA_ARGS__)
+#define OT_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
+
+/**
+ * A macro which gets the nth arg from a __VA_LIST__
+ */
+#define OT_GET_ARG(n, ...) OT_CAT(OT_CAT(OT_GET_ARG_, n), _)(__VA_ARGS__)
+
+/**
+ * A macro which gets the last arg from a __VA_LIST__
+ *
+ * Note: we leave out the dummy argument because we want count to
+ * give us the number of args minus one so that the created
+ * OT_GET_ARG_n token will contain the correct integer.
+ */
+#define OT_GET_LAST_ARG(...) \
+  OT_GET_ARG(OT_VA_ARGS_COUNT(__VA_ARGS__), ##__VA_ARGS__)
+
+/**
+ * The following collection of `OT_GET_ARG` macros are used to construct the
+ * generic "get nth arg" macro.
+ */
+#define OT_GET_ARG_0_(x0, ...) x0
+#define OT_GET_ARG_1_(x1, x0, ...) x0
+#define OT_GET_ARG_2_(x2, x1, x0, ...) x0
+#define OT_GET_ARG_3_(x3, x2, x1, x0, ...) x0
+#define OT_GET_ARG_4_(x4, x3, x2, x1, x0, ...) x0
+#define OT_GET_ARG_5_(x5, x4, x3, x2, x1, x0, ...) x0
+#define OT_GET_ARG_6_(x6, x5, x4, x3, x2, x1, x0, ...) x0
+#define OT_GET_ARG_7_(x7, x6, x5, x4, x3, x2, x1, x0, ...) x0
+#define OT_GET_ARG_8_(x8, x7, x6, x5, x4, x3, x2, x1, x0, ...) x0
+#define OT_GET_ARG_9_(x9, x8, x7, x6, x5, x4, x3, x2, x1, x0, ...) x0
+#define OT_GET_ARG_10_(x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, x0, ...) x0
+#define OT_GET_ARG_11_(x11, x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, x0, ...) x0
+#define OT_GET_ARG_12_(x12, x11, x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, x0, \
+                       ...)                                                   \
+  x0
+#define OT_GET_ARG_13_(x13, x12, x11, x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, \
+                       x0, ...)                                                \
+  x0
+#define OT_GET_ARG_14_(x14, x13, x12, x11, x10, x9, x8, x7, x6, x5, x4, x3, \
+                       x2, x1, x0, ...)                                     \
+  x0
+#define OT_GET_ARG_15_(x15, x14, x13, x12, x11, x10, x9, x8, x7, x6, x5, x4, \
+                       x3, x2, x1, x0, ...)                                  \
+  x0
+#define OT_GET_ARG_16_(x16, x15, x14, x13, x12, x11, x10, x9, x8, x7, x6, x5, \
+                       x4, x3, x2, x1, x0, ...)                               \
+  x0
+#define OT_GET_ARG_17_(x17, x16, x15, x14, x13, x12, x11, x10, x9, x8, x7, x6, \
+                       x5, x4, x3, x2, x1, x0, ...)                            \
+  x0
+#define OT_GET_ARG_18_(x18, x17, x16, x15, x14, x13, x12, x11, x10, x9, x8, \
+                       x7, x6, x5, x4, x3, x2, x1, x0, ...)                 \
+  x0
+#define OT_GET_ARG_19_(x19, x18, x17, x16, x15, x14, x13, x12, x11, x10, x9, \
+                       x8, x7, x6, x5, x4, x3, x2, x1, x0, ...)              \
+  x0
+#define OT_GET_ARG_20_(x20, x19, x18, x17, x16, x15, x14, x13, x12, x11, x10, \
+                       x9, x8, x7, x6, x5, x4, x3, x2, x1, x0, ...)           \
+  x0
+#define OT_GET_ARG_21_(x21, x20, x19, x18, x17, x16, x15, x14, x13, x12, x11, \
+                       x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, x0, ...)      \
+  x0
+#define OT_GET_ARG_22_(x22, x21, x20, x19, x18, x17, x16, x15, x14, x13, x12, \
+                       x11, x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, x0, ...) \
+  x0
+#define OT_GET_ARG_23_(x23, x22, x21, x20, x19, x18, x17, x16, x15, x14, x13, \
+                       x12, x11, x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, x0, \
+                       ...)                                                   \
+  x0
+#define OT_GET_ARG_24_(x24, x23, x22, x21, x20, x19, x18, x17, x16, x15, x14,  \
+                       x13, x12, x11, x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, \
+                       x0, ...)                                                \
+  x0
+#define OT_GET_ARG_25_(x25, x24, x23, x22, x21, x20, x19, x18, x17, x16, x15, \
+                       x14, x13, x12, x11, x10, x9, x8, x7, x6, x5, x4, x3,   \
+                       x2, x1, x0, ...)                                       \
+  x0
+#define OT_GET_ARG_26_(x26, x25, x24, x23, x22, x21, x20, x19, x18, x17, x16, \
+                       x15, x14, x13, x12, x11, x10, x9, x8, x7, x6, x5, x4,  \
+                       x3, x2, x1, x0, ...)                                   \
+  x0
+#define OT_GET_ARG_27_(x27, x26, x25, x24, x23, x22, x21, x20, x19, x18, x17, \
+                       x16, x15, x14, x13, x12, x11, x10, x9, x8, x7, x6, x5, \
+                       x4, x3, x2, x1, x0, ...)                               \
+  x0
+#define OT_GET_ARG_28_(x28, x27, x26, x25, x24, x23, x22, x21, x20, x19, x18,  \
+                       x17, x16, x15, x14, x13, x12, x11, x10, x9, x8, x7, x6, \
+                       x5, x4, x3, x2, x1, x0, ...)                            \
+  x0
+#define OT_GET_ARG_29_(x29, x28, x27, x26, x25, x24, x23, x22, x21, x20, x19, \
+                       x18, x17, x16, x15, x14, x13, x12, x11, x10, x9, x8,   \
+                       x7, x6, x5, x4, x3, x2, x1, x0, ...)                   \
+  x0
+#define OT_GET_ARG_30_(x30, x29, x28, x27, x26, x25, x24, x23, x22, x21, x20, \
+                       x19, x18, x17, x16, x15, x14, x13, x12, x11, x10, x9,  \
+                       x8, x7, x6, x5, x4, x3, x2, x1, x0, ...)               \
+  x0
+#define OT_GET_ARG_31_(x31, x30, x29, x28, x27, x26, x25, x24, x23, x22, x21, \
+                       x20, x19, x18, x17, x16, x15, x14, x13, x12, x11, x10, \
+                       x9, x8, x7, x6, x5, x4, x3, x2, x1, x0, ...)           \
+  x0
+
+/**
  * A macro that expands to an assertion for the offset of a struct member.
  *
  * @param type A struct type.

--- a/sw/device/lib/base/status.c
+++ b/sw/device/lib/base/status.c
@@ -1,0 +1,119 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/bitfield.h"
+
+const uint32_t status_module_id = 0;
+
+static const char *basename(const char *file) {
+  const char *f = file;
+  // Go to the end of the string.
+  while (*f)
+    ++f;
+  // Back up to the start of the last filename path component.
+  while (f > file && f[-1] != '/' && f[-1] != '\\')
+    --f;
+  return f;
+}
+
+status_t status_create(absl_status_t code, uint32_t module_id, const char *file,
+                       int32_t arg) {
+  if (code == kOk) {
+    if (arg >= 0) {
+      return (status_t){.value = arg};
+    } else {
+      // If you find yourself here, then someone returned a OK_STATUS
+      // a negative value.
+      arg = __LINE__;
+    }
+  }
+  /**
+   * Our status(error) codes are arranged as a packed bitfield:
+   *
+   * 32  31      26      21      16             5       0
+   *  +---+-------+-------+-------+-------------+-------+
+   *  |   |   15 bit              | 11 bit      | 5 bit |
+   *  | s |   Module Identifier   | Line Number | code  |
+   *  +---+-------+-------+-------+-------------+-------+
+   *
+   * The sign bit is set on all not-Ok statuses, thus proviging a covenient
+   * overloaded return value from functions that may return an error.
+   */
+  if (module_id == 0) {
+    // First three characters of the filename.
+    const char *f = basename(file);
+    module_id = MAKE_MODULE_ID(f[0], f[1], f[2]);
+  }
+  // At this point, the module_id is already packed into the correct bitfield.
+  return (status_t){
+      .value = (int32_t)(module_id |
+                         bitfield_bit32_write(0, STATUS_BIT_ERROR, true) |
+                         bitfield_field32_write(0, STATUS_FIELD_CODE, code) |
+                         bitfield_field32_write(0, STATUS_FIELD_ARG,
+                                                (uint32_t)arg))};
+}
+
+const char *status_codes[] = {
+    "Ok",
+    "Cancelled",
+    "Unknown",
+    "InvalidArgument",
+    "DeadlineExceeded",
+    "NotFound",
+    "AlreadyExists",
+    "PermissionDenied",
+    "ResourceExhausted",
+    "FailedPrecondition",
+    "Aborted",
+    "OutOfRange",
+    "Unimplemented",
+    "Internal",
+    "Unavailable",
+    "DataLoss",
+    "Unauthenticated",
+
+    "Undefined17",
+    "Undefined18",
+    "Undefined19",
+    "Undefined20",
+    "Undefined21",
+    "Undefined22",
+    "Undefined23",
+    "Undefined24",
+    "Undefined25",
+    "Undefined26",
+    "Undefined27",
+    "Undefined28",
+    "Undefined29",
+    "Undefined30",
+    "Undefined31",
+
+    // A "ErrorError" means the error bit is set but the err field is kOk.
+    "ErrorError",
+};
+
+bool status_extract(status_t s, const char **code, int32_t *arg, char *mod_id) {
+  size_t err = (size_t)status_err(s);
+  if (s.value < 0 && err == 0) {
+    err = sizeof(status_codes) / sizeof(status_codes[0]) - 1;
+  }
+  *code = status_codes[err];
+  if (err) {
+    *arg = (int32_t)bitfield_field32_read((uint32_t)s.value, STATUS_FIELD_ARG);
+    uint32_t module_id =
+        bitfield_field32_read((uint32_t)s.value, STATUS_FIELD_MODULE_ID);
+    *mod_id++ = '@' + ((module_id >> 0) & 0x1F);
+    *mod_id++ = '@' + ((module_id >> 5) & 0x1F);
+    *mod_id++ = '@' + ((module_id >> 10) & 0x1F);
+    return true;
+  } else {
+    *arg = s.value;
+    return false;
+  }
+}

--- a/sw/device/lib/base/status.h
+++ b/sw/device/lib/base/status.h
@@ -1,0 +1,169 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_STATUS_H_
+#include <assert.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/macros.h"
+
+#define USING_ABSL_STATUS
+#include "sw/device/lib/base/absl_status.h"
+#undef USING_ABSL_STATUS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * We use the error category codes from absl_status.h.  We build a packed
+ * status value that identifies the source of the error (in the form of the
+ * module identifier and line number).
+ *
+ * By default, the module identifier is the first three letters of the
+ * source filename.  The identifier can be overridden (per-module) with the
+ * DECLARE_MODULE_ID macro.
+ *
+ * Our status codes are arranged as a packed bitfield, with the sign
+ * bit signifying whether the value represents a result or an error.
+ *
+ * All Ok (good) values:
+ * 32  31                                             0
+ *  +---+---------------------------------------------+
+ *  |   |                  31 bit                     |
+ *  | 0 |                  Result                     |
+ *  +---+---------------------------------------------+
+ *
+ * All Error values:
+ * 32  31      26      21      16             5       0
+ *  +---+-------+-------+-------+-------------+-------+
+ *  |   |   15 bit              | 11 bit      | 5 bit |
+ *  | 1 |   Module Identifier   | Line Number | code  |
+ *  +---+-------+-------+-------+-------------+-------+
+ *
+ * The module identifier value is interpreted as three 5-bit fields
+ * representing the characters [0x40..0x5F] (e.g. [@ABC ... _]).
+ */
+
+#define STATUS_FIELD_CODE ((bitfield_field32_t){.mask = 0x1f, .index = 0})
+#define STATUS_FIELD_ARG ((bitfield_field32_t){.mask = 0x7ff, .index = 5})
+#define STATUS_FIELD_MODULE_ID \
+  ((bitfield_field32_t){.mask = 0x7fff, .index = 16})
+#define STATUS_BIT_ERROR 31
+typedef struct status {
+  int32_t value;
+} status_t;
+
+// Uses a GCC statement-expr to embed conrtol-flow inside an expression.
+#define TRY(expr_)            \
+  ({                          \
+    status_t status_ = expr_; \
+    if (status_.value < 0) {  \
+      return status_;         \
+    }                         \
+    status_.value;            \
+  })
+
+// This global constant is available to all modules and is the constant zero.
+extern const uint32_t status_module_id;
+// clang-format off
+#define ASCII_5BIT(v) ( \
+    /*uppercase characters*/  (v) >= '@' && (v) <= '_' ? (v) - '@' \
+    /*lower cvt upper*/     : (v) >= '`' && (v) <= 'z' ? (v) - '`' \
+    /*else cvt underscore*/ : '_' - '@'                            \
+  )
+// clang-format on
+
+#define MAKE_MODULE_ID(a, b, c) \
+  (ASCII_5BIT(a) << 16) | (ASCII_5BIT(b) << 21) | (ASCII_5BIT(c) << 26)
+// A module that uses DECLARE_MODULE_ID shadows the global constant value with
+// its own local value.
+#define DECLARE_MODULE_ID(a, b, c) \
+  static uint32_t status_module_id = MAKE_MODULE_ID(a, b, c)
+
+// Operations on status codes:
+/**
+ * Creates a packed status_t.
+ *
+ * @param code An absl_status code.
+ * @param mod_id The module creating the status code.
+ * @param file The filename of the module creating the code.
+ * @param arg The argument associated with the status.
+ * @return `status_t`.
+ */
+status_t status_create(absl_status_t code, uint32_t mod_id, const char *file,
+                       int32_t arg);
+
+/**
+ * Extracts the packed values from a status code.
+ *
+ * @param s The status code to extract values from.
+ * @param code Pointer to the english name of the status code.
+ * @param arg Pointer to an integer argument.
+ * @param mod_id Pointer to a char[3] buffer for the module id.
+ * @return True if the status represents and error, False if the status
+ * represents Ok.
+ */
+bool status_extract(status_t s, const char **code, int32_t *arg, char *mod_id);
+
+/**
+ * Returns whether the status value represents Ok.
+ *
+ * @param s The status code.
+ * @return True if the status represents Ok.
+ */
+OT_ALWAYS_INLINE bool status_ok(status_t s) { return s.value >= 0; }
+
+/**
+ * Returns the absl status code in the status.
+ *
+ * @param s The status code.
+ * @return `absl_status_t` contained within the status_t.
+ */
+OT_ALWAYS_INLINE absl_status_t status_err(status_t s) {
+  return s.value < 0
+             ? (absl_status_t)bitfield_field32_read(s.value, STATUS_FIELD_CODE)
+             : kOk;
+}
+
+// Create a status with an optional argument.
+// TODO(cfrantz, alphan): Figure out how we want to create statuses in
+// silicon_creator code.
+#define STATUS_CREATE(s_, ...)                            \
+  ({                                                      \
+    static_assert(OT_VA_ARGS_COUNT(_, __VA_ARGS__) <= 2,  \
+                  "status macros take 0 or 1 arguments"); \
+    status_create(s_, status_module_id, __FILE__,         \
+                  OT_GET_LAST_ARG(__VA_ARGS__));          \
+  })
+
+// Helpers for creating statuses of various kinds.
+// clang-format off
+#define OK_STATUS(...)           STATUS_CREATE(kOk,                 0,        ##__VA_ARGS__)
+#define CANCELLED(...)           STATUS_CREATE(kCancelled,          __LINE__, ##__VA_ARGS__)
+#define UNKNOWN(...)             STATUS_CREATE(kUnknown,            __LINE__, ##__VA_ARGS__)
+#define INVALID_ARGUMENT(...)    STATUS_CREATE(kInvalidArgument,    __LINE__, ##__VA_ARGS__)
+#define DEADLINE_EXCEEDED(...)   STATUS_CREATE(kDeadlineExceeded,   __LINE__, ##__VA_ARGS__)
+#define NOT_FOUND(...)           STATUS_CREATE(kNotFound,           __LINE__, ##__VA_ARGS__)
+#define ALREADY_EXISTS(...)      STATUS_CREATE(kAlreadyExists,      __LINE__, ##__VA_ARGS__)
+#define PERMISSION_DENIED(...)   STATUS_CREATE(kPermissionDenied,   __LINE__, ##__VA_ARGS__)
+#define RESOURCE_EXHAUSTED(...)  STATUS_CREATE(kResourceExhausted,  __LINE__, ##__VA_ARGS__)
+#define FAILED_PRECONDITION(...) STATUS_CREATE(kFailedPrecondition, __LINE__, ##__VA_ARGS__)
+#define ABORTED(...)             STATUS_CREATE(kAborted,            __LINE__, ##__VA_ARGS__)
+#define OUT_OF_RANGE(...)        STATUS_CREATE(kOutOfRange,         __LINE__, ##__VA_ARGS__)
+#define UNIMPLEMENTED(...)       STATUS_CREATE(kUnimplemented,      __LINE__, ##__VA_ARGS__)
+#define INTERNAL(...)            STATUS_CREATE(kInternal,           __LINE__, ##__VA_ARGS__)
+#define UNAVAILABLE(...)         STATUS_CREATE(kUnavailable,        __LINE__, ##__VA_ARGS__)
+#define DATA_LOSS(...)           STATUS_CREATE(kDataLoss,           __LINE__, ##__VA_ARGS__)
+#define UNAUTHENTICATED(...)     STATUS_CREATE(kUnauthenticated,    __LINE__, ##__VA_ARGS__)
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_STATUS_H_

--- a/sw/device/lib/base/status_unittest.cc
+++ b/sw/device/lib/base/status_unittest.cc
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+
+#include <ostream>
+#include <stdint.h>
+#include <tuple>
+
+#include "gtest/gtest.h"
+
+namespace status_unittest {
+namespace {
+
+TEST(Status, OkValues) {
+  status_t status;
+
+  // The no-argument form should have a value of zero.
+  status = OK_STATUS();
+  EXPECT_EQ(status_ok(status), true);
+  EXPECT_EQ(status_err(status), absl_status_t::kOk);
+  EXPECT_EQ(status.value, 0);
+
+  // The one-argument form should have the value of the argument.
+  status = OK_STATUS(5);
+  EXPECT_EQ(status_ok(status), true);
+  EXPECT_EQ(status_err(status), absl_status_t::kOk);
+  EXPECT_EQ(status.value, 5);
+
+  // Any negative value for OK is not permitted and will result
+  // in an error value.
+  status = OK_STATUS(-1);
+  EXPECT_EQ(status_ok(status), false);
+}
+
+TEST(Status, ErrorValues) {
+  int32_t arg;
+  status_t status;
+  bool err;
+  const char *message;
+  char mod_id[4]{};
+
+  // The no-argument form should carry the line number on which the error
+  // was created and a module-id of the first three letters of the filename.
+  status = UNKNOWN();
+  int32_t expected_line = __LINE__ - 1;
+  err = status_extract(status, &message, &arg, mod_id);
+  EXPECT_EQ(status_ok(status), false);
+  EXPECT_EQ(status_err(status), absl_status_t::kUnknown);
+  EXPECT_EQ(err, true);
+  EXPECT_EQ(arg, expected_line);
+  EXPECT_EQ(std::string(mod_id), "STA");
+
+  // The one-argument form should carry the value of that argument.
+  status = CANCELLED(1);
+  err = status_extract(status, &message, &arg, mod_id);
+  EXPECT_EQ(status_ok(status), false);
+  EXPECT_EQ(status_err(status), absl_status_t::kCancelled);
+  EXPECT_EQ(err, true);
+  EXPECT_EQ(arg, 1);
+  EXPECT_EQ(std::string(mod_id), "STA");
+}
+
+}  // namespace
+}  // namespace status_unittest

--- a/sw/device/lib/runtime/BUILD
+++ b/sw/device/lib/runtime/BUILD
@@ -89,6 +89,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
         "//sw/device/lib/dif:uart",
     ],
 )
@@ -98,6 +99,7 @@ cc_test(
     srcs = ["print_unittest.cc"],
     deps = [
         ":print",
+        "@com_google_absl//absl/strings:str_format",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -73,6 +73,7 @@ typedef struct buffer_sink {
  *   order (i.e., first byte printed first). This makes sure %!x is consistent
  *   with %x.
  * - %!b, which takes a bool and prints either true or false.
+ * - %r, which takes a status_t and prints the status, argument and module ID.
  *
  * When compiled for a DV testbench, this function will not read any pointers,
  * and as such the specifiers %s, %!s, %!x, %!X, %!y, and %!Y will behave as if

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -105,9 +105,9 @@ cc_library(
 
 cc_library(
     name = "error",
-    srcs = ["absl_status.h"],
     hdrs = ["error.h"],
     deps = [
+        "//sw/device/lib/base:absl_status",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
     ],

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -9,7 +9,7 @@
 #include "sw/device/lib/base/hardened.h"
 
 #define USING_ABSL_STATUS
-#include "sw/device/silicon_creator/lib/absl_status.h"
+#include "sw/device/lib/base/absl_status.h"
 #undef USING_ABSL_STATUS
 
 #ifdef __cplusplus


### PR DESCRIPTION
`status_t` is modelled after `absl::Status` and uses the same error
categories.

- Ok status codes can carry any positive integer value from [0 .. INT_MAX].
- Error status codes carry the error code, the module id that
  created the error (the first 3 letters of the filename) and a
  parameter in the range [0 .. 2047] that, by default, is the
  source line number in the module that created the error.
- A nonstandard printf specifier `%r` prints out a text representation
  of the status value.

The c++ standard is changed from `c++14` to `gnu++14`.  The preprocessor
macro magic used to create the error values is not turned on by
`-std=c++14` (ie: this change needs the comma elision behavior of
`##__VA_ARGS__`).  Lamentably, standard c++20 replacement `__VA_OPT__(,)`
does not work when `-std=c++14`.

Signed-off-by: Chris Frantz <cfrantz@google.com>