### PR TITLE
[lib] Fix hardened memory functions

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -122,7 +122,6 @@ cc_library(
 cc_test(
     name = "hardened_memory_unittest",
     srcs = ["hardened_memory_unittest.cc"],
-    tags = ["broken"],
     deps = [
         ":hardened_memory",
         ":random_order",


### PR DESCRIPTION
All three functions had the same bug: The second argument of `ct_sltuw()` should have been in bytes not words.

Fixes #12350

Signed-off-by: Alphan Ulusoy <alphan@google.com>