### PR TITLE
[ujson] Json implementation for firmware

### DIFF
--- a/rules/ujson.bzl
+++ b/rules/ujson.bzl
@@ -1,0 +1,67 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+
+"""Rust generation rules for `ujson`."""
+
+def _ujson_rust(ctx):
+    cc_toolchain = find_cc_toolchain(ctx).cc
+    module = ctx.actions.declare_file("{}.rs".format(ctx.label.name))
+    ujson_lib = ctx.attr.ujson_lib[CcInfo].compilation_context.headers.to_list()
+
+    srcs = []
+    for src in ctx.attr.srcs:
+        srcs.extend(src[CcInfo].compilation_context.direct_public_headers)
+
+    # TODO(cfrantz): Is there a better way to find the `rustfmt` binary?
+    rustfmt_files = ctx.attr._rustfmt.data_runfiles.files.to_list()
+    rustfmt = [f for f in rustfmt_files if f.basename == "rustfmt"][0]
+
+    # The pipeline for generating rust code from a ujson header file:
+    # 1. Preprocess the file with RUST_PREPROCESSOR_EMIT
+    # 2. Grep out all the preprocessor noise (which starts with `#`).
+    # 3. Substitute all `rust_attr` for `#`, thus creating rust attributes.
+    # 4. Format it with `rustfmt` so it looks nice and can be inspected.
+    command = """
+        {preprocessor} -nostdinc -I. -DRUST_PREPROCESSOR_EMIT=1 -DNOSTDINC=1 $@ \
+        | grep -v '#' \
+        | sed -e "s/rust_attr/#/g" \
+        | {rustfmt} > {module}""".format(
+        preprocessor = cc_toolchain.preprocessor_executable,
+        module = module.path,
+        rustfmt = rustfmt.path,
+    )
+
+    ctx.actions.run_shell(
+        outputs = [module],
+        inputs = ujson_lib + srcs,
+        tools = cc_toolchain.all_files.to_list() + rustfmt_files,
+        arguments = [src.path for src in srcs],
+        command = command,
+    )
+    return [
+        DefaultInfo(files = depset([module]), runfiles = ctx.runfiles([module])),
+    ]
+
+ujson_rust = rule(
+    implementation = _ujson_rust,
+    attrs = {
+        "srcs": attr.label_list(
+            providers = [CcInfo],
+            doc = "ujson cc_library targets to generate Rust for",
+        ),
+        "ujson_lib": attr.label(
+            default = "//sw/device/lib/ujson",
+            doc = "Location of the ujson library",
+            providers = [CcInfo],
+        ),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+        "_rustfmt": attr.label(
+            default = "@rules_rust//rust/toolchain:current_exec_rustfmt_files",
+            cfg = "exec",
+        ),
+    },
+    toolchains = ["@rules_cc//cc:toolchain_type"],
+)

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -29,7 +29,10 @@ cc_library(
 
 cc_library(
     name = "macros",
-    hdrs = ["macros.h"],
+    hdrs = [
+        "adv_macros.h",
+        "macros.h",
+    ],
 )
 
 cc_library(

--- a/sw/device/lib/base/adv_macros.h
+++ b/sw/device/lib/base/adv_macros.h
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_ADV_MACROS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_ADV_MACROS_H_
+
+#include "sw/device/lib/base/macros.h"
+
+// The preprocessor techniques below are explained at
+// https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
+
+#define OT_IIF(c) OT_PRIMITIVE_CAT(OT_IIF_, c)
+#define OT_IIF_0(t, ...) __VA_ARGS__
+#define OT_IIF_1(t, ...) t
+
+#define OT_CHECK_N(x, n, ...) n
+#define OT_CHECK(...) OT_CHECK_N(__VA_ARGS__, 0, )
+#define OT_PROBE(x) x, 1,
+
+#define OT_NOT(x) OT_CHECK(OT_PRIMITIVE_CAT(OT_NOT_, x))
+#define OT_NOT_0 OT_PROBE(~)
+
+#define OT_EMPTY()
+#define OT_DEFER(id) id OT_EMPTY()
+#define OT_OBSTRUCT(...) __VA_ARGS__ OT_DEFER(OT_EMPTY)()
+#define OT_EXPAND(...) __VA_ARGS__
+
+#define OT_EVAL(...) OT_EVAL1(OT_EVAL1(OT_EVAL1(__VA_ARGS__)))
+#define OT_EVAL1(...) OT_EVAL2(OT_EVAL2(OT_EVAL2(__VA_ARGS__)))
+#define OT_EVAL2(...) OT_EVAL3(OT_EVAL3(OT_EVAL3(__VA_ARGS__)))
+#define OT_EVAL3(...) OT_EVAL4(OT_EVAL4(OT_EVAL4(__VA_ARGS__)))
+#define OT_EVAL4(...) OT_EVAL5(OT_EVAL5(OT_EVAL5(__VA_ARGS__)))
+#define OT_EVAL5(...) __VA_ARGS__
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_ADV_MACROS_H_

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -7,7 +7,7 @@
 
 // This file may be used in .S files, in which case standard library includes
 // should be elided.
-#ifndef __ASSEMBLER__
+#if !defined(__ASSEMBLER__) && !defined(NOSTDINC)
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -55,6 +55,12 @@
  * It only needs to be used in headers; .c files can use `restrict` directly.
  */
 #define OT_RESTRICT __restrict__
+
+/**
+ * An argument stringification macro.
+ */
+#define OT_STRINGIFY(a) OT_STRINGIFY_(a)
+#define OT_STRINGIFY_(a) #a
 
 /**
  * A variable-argument macro that expands to the number of arguments passed into

--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -275,7 +275,7 @@ static size_t write_digits(buffer_sink_t out, uint32_t value, uint32_t width,
   return out.sink(out.data, buffer + (kWordBits - len), len);
 }
 
-static size_t write_status(buffer_sink_t out, status_t value) {
+static size_t write_status(buffer_sink_t out, status_t value, bool as_json) {
   // The module id is defined to be 3 chars long.
   char mod[] = {'"', 0, 0, 0, '"', ','};
   int32_t arg;
@@ -286,7 +286,11 @@ static size_t write_status(buffer_sink_t out, status_t value) {
   const char *end = start;
   while (*end)
     end++;
-  size_t len = out.sink(out.data, start, end - start);
+  size_t len = 0;
+
+  len += out.sink(out.data, "{\"", as_json ? 2 : 0);
+  len += out.sink(out.data, start, end - start);
+  len += out.sink(out.data, "\"", as_json ? 1 : 0);
 
   // print the module id and arg.
   len += out.sink(out.data, ":[", 2);
@@ -296,6 +300,7 @@ static size_t write_status(buffer_sink_t out, status_t value) {
   }
   len += write_digits(out, arg, 0, 0, 10, kDigitsLow);
   len += out.sink(out.data, "]", 1);
+  len += out.sink(out.data, "}", as_json ? 1 : 0);
   return len;
 }
 
@@ -511,7 +516,7 @@ static void process_specifier(buffer_sink_t out, format_specifier_t spec,
     }
     case kStatusResult: {
       status_t value = va_arg(*args, status_t);
-      *bytes_written += write_status(out, value);
+      *bytes_written += write_status(out, value, spec.is_nonstd);
       break;
     }
     bad_spec:  // Used with `goto` to bail out early.

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -74,6 +74,8 @@ typedef struct buffer_sink {
  *   with %x.
  * - %!b, which takes a bool and prints either true or false.
  * - %r, which takes a status_t and prints the status, argument and module ID.
+ * - %!r, which takes a status_t and prints the status, argument and module ID
+ *        as JSON.
  *
  * When compiled for a DV testbench, this function will not read any pointers,
  * and as such the specifiers %s, %!s, %!x, %!X, %!y, and %!Y will behave as if

--- a/sw/device/lib/runtime/print_unittest.cc
+++ b/sw/device/lib/runtime/print_unittest.cc
@@ -295,6 +295,13 @@ TEST_F(PrintfTest, StatusError) {
   EXPECT_EQ(buf_, absl::StrFormat("Hello, Unknown:[\"PRI\",%d]\n", line));
 }
 
+TEST_F(PrintfTest, StatusErrorAsJson) {
+  status_t value = UNKNOWN();
+  int line = __LINE__ - 1;
+  EXPECT_EQ(base_printf("Hello, %!r\n", value), 31);
+  EXPECT_EQ(buf_, absl::StrFormat("Hello, {\"Unknown\":[\"PRI\",%d]}\n", line));
+}
+
 TEST_F(PrintfTest, StatusErrorWithArg) {
   status_t value = INVALID_ARGUMENT(2);
   EXPECT_EQ(base_printf("Hello, %r\n", value), 33);

--- a/sw/device/lib/ujson/BUILD
+++ b/sw/device/lib/ujson/BUILD
@@ -1,0 +1,83 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:ujson.bzl", "ujson_rust")
+
+cc_library(
+    name = "ujson",
+    srcs = ["ujson.c"],
+    hdrs = [
+        "ujson.h",
+        "ujson_derive.h",
+        "ujson_rust.h",
+    ],
+    deps = [
+        ":private_status",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:math",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:print",
+    ],
+)
+
+cc_library(
+    name = "private_status",
+    srcs = [
+        "private_status.c",
+        "ujson.h",
+        "ujson_derive.h",
+    ],
+    hdrs = ["private_status.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:status",
+    ],
+)
+
+cc_library(
+    name = "test_helpers",
+    hdrs = ["test_helpers.h"],
+)
+
+cc_test(
+    name = "ujson_test",
+    srcs = ["ujson_test.cc"],
+    deps = [
+        ":test_helpers",
+        ":ujson",
+        "//sw/device/lib/base:status",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "example",
+    srcs = ["example.c"],
+    hdrs = ["example.h"],
+    deps = [":ujson"],
+)
+
+cc_test(
+    name = "example_test",
+    srcs = ["example_test.cc"],
+    deps = [
+        ":example",
+        ":test_helpers",
+        ":ujson",
+        "//sw/device/lib/base:status",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_binary(
+    name = "example_roundtrip",
+    srcs = ["example_roundtrip.c"],
+    deps = [
+        ":example",
+        "//sw/device/lib/base:status",
+    ],
+)

--- a/sw/device/lib/ujson/example.c
+++ b/sw/device/lib/ujson/example.c
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/////////////////////////////////////////////////////////////////////////////
+// The corresponding C file to a `ujson` header file should simply define
+// the preprocessor token `UJSON_SERDE_IMPL` and then include the header
+// file.  This will cause the preprocessor to emit the `serialize` and
+// `deserialize` implementations for the data structures.
+#define UJSON_SERDE_IMPL
+#include "sw/device/lib/ujson/example.h"

--- a/sw/device/lib/ujson/example.h
+++ b/sw/device/lib/ujson/example.h
@@ -1,0 +1,99 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_UJSON_EXAMPLE_H_
+#define OPENTITAN_SW_DEVICE_LIB_UJSON_EXAMPLE_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+/////////////////////////////////////////////////////////////////////////////
+// Automatic generation of structs with serialize/deserialize functions:
+//
+// The follow creates a `struct Foo`:
+// typedef struct Foo {
+//     int32_t foo;
+//     uint32_t bar;
+//     char message[20];
+// } foo;
+// status_t ujson_serialize_foo(ujson_t *context, const foo *self);
+// status_t ujson_deserialize_foo(ujson_t *context, foo *self);
+#define STRUCT_FOO(field, string) \
+    field(foo, int32_t) \
+    field(bar, uint32_t) \
+    string(message, 20)
+UJSON_SERDE_STRUCT(Foo, foo, STRUCT_FOO);
+
+// The next two structs demonstrate struct nesting:
+// typedef struct Coord { int32_t x; int32_t y; } coord;
+//
+// typedef struct Rect {
+//     coord top_left;
+//     coord bottom_right;
+// } rect;
+// status_t ujson_serialize_rect(ujson_t *context, const rect *self);
+// status_t ujson_deserialize_rect(ujson_t *context, rect *self);
+// (and yes: `coord` has serialize and deserialize functions as well).
+#define STRUCT_COORD(field, string) \
+    field(x, int32_t) \
+    field(y, int32_t)
+UJSON_SERDE_STRUCT(Coord, coord, STRUCT_COORD);
+
+#define STRUCT_RECT(field, string) \
+    field(top_left, coord) \
+    field(bottom_right, coord)
+UJSON_SERDE_STRUCT(Rect, rect, STRUCT_RECT);
+
+// The next example demonstrates arrays within struct fields:
+// struct Matrix {
+//     int32_t k[3][5];
+// } matrix;
+// (and serialize/deserialize functions).
+//
+// Arrays may have arbitrary dimension.  However, ujson has no concept
+// of a variable sized array:
+//   - Serialize will always emit _all_ elements.
+//   - Deserialize will _not_ initialize absent elements.
+#define STRUCT_MATRIX(field, string) \
+    field(k, int32_t, 3, 5)
+UJSON_SERDE_STRUCT(Matrix, matrix, STRUCT_MATRIX);
+
+/////////////////////////////////////////////////////////////////////////////
+// Automatic generation of enums with serialize/deserialize functions:
+//
+// The following creates an `enum Direction`:
+// typedef enum Direction {
+//     kDirectionNorth,
+//     kDirectionEast,
+//     kDirectionSouth,
+//     kDirectionWest,
+// } direction;
+// status_t ujson_serialize_direction(ujson_t *context, const direction *self);
+// status_t ujson_deserialize_direction(ujson_t *context, direction *self);
+#define ENUM_DIRECTION(_, value) \
+    value(_, North) \
+    value(_, East) \
+    value(_, South) \
+    value(_, West)
+UJSON_SERDE_ENUM(Direction, direction, ENUM_DIRECTION);
+
+
+/////////////////////////////////////////////////////////////////////////////
+// Other miscellaneous supported types: bool and status_t
+//
+// status_t ujson_serialize_misc_t(ujson_t *context, const misc_t *self);
+// status_t ujson_deserialize_misc_t(ujson_t *context, misc_t *self);
+#define STRUCT_MISC(field, string) \
+    field(value, bool) \
+    field(status, status_t)
+UJSON_SERDE_STRUCT(Misc, misc_t, STRUCT_MISC);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_UJSON_EXAMPLE_H_

--- a/sw/device/lib/ujson/example_roundtrip.c
+++ b/sw/device/lib/ujson/example_roundtrip.c
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/example.h"
+
+status_t stdio_getc(void *context) {
+  int ch = fgetc(stdin);
+  return ch == EOF ? RESOURCE_EXHAUSTED() : OK_STATUS(ch);
+}
+
+status_t stdio_putbuf(void *context, const char *buf, size_t len) {
+  fwrite(buf, 1, len, stdout);
+  return OK_STATUS();
+}
+
+status_t roundtrip(const char *name) {
+  ujson_t uj = ujson_init(NULL, stdio_getc, stdio_putbuf);
+  if (!strcmp(name, "foo")) {
+    foo x = {0};
+    TRY(ujson_deserialize_foo(&uj, &x));
+    TRY(ujson_serialize_foo(&uj, &x));
+  } else if (!strcmp(name, "rect")) {
+    rect x = {0};
+    TRY(ujson_deserialize_rect(&uj, &x));
+    TRY(ujson_serialize_rect(&uj, &x));
+  } else if (!strcmp(name, "matrix")) {
+    matrix x = {0};
+    TRY(ujson_deserialize_matrix(&uj, &x));
+    TRY(ujson_serialize_matrix(&uj, &x));
+  } else if (!strcmp(name, "direction")) {
+    direction x = {0};
+    TRY(ujson_deserialize_direction(&uj, &x));
+    TRY(ujson_serialize_direction(&uj, &x));
+  } else if (!strcmp(name, "misc")) {
+    misc_t x = {0};
+    TRY(ujson_deserialize_misc_t(&uj, &x));
+    TRY(ujson_serialize_misc_t(&uj, &x));
+  } else {
+    return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    fprintf(stderr, "%s [struct-name]", argv[0]);
+    return EXIT_FAILURE;
+  }
+  status_t s = roundtrip(argv[1]);
+
+  return status_ok(s) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/sw/device/lib/ujson/example_test.cc
+++ b/sw/device/lib/ujson/example_test.cc
@@ -1,0 +1,153 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/ujson/example.h"
+
+#include <cstring>
+#include <gtest/gtest.h>
+#include <string>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/test_helpers.h"
+#include "sw/device/lib/ujson/ujson.h"
+namespace {
+using test_helpers::SourceSink;
+
+TEST(Derive, FooSerialize) {
+  foo foo = {-5, 150000, "Kilroy was here"};
+  SourceSink ss;
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_serialize_foo(&uj, &foo)));
+  EXPECT_EQ(ss.Sink(),
+            R"json({"foo":-5,"bar":150000,"message":"Kilroy was here"})json");
+}
+
+TEST(Derive, FooDeserialize) {
+  foo expected = {-5, 150000, "Kilroy was here"};
+  foo foo{};
+  SourceSink ss(
+      R"json({"foo":-5,"bar":150000,"message":"Kilroy was here"})json");
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_deserialize_foo(&uj, &foo)));
+  EXPECT_EQ(memcmp(&foo, &expected, sizeof(foo)), 0);
+}
+
+TEST(Derive, FooDeserializeNoFoo) {
+  foo expected = {0, 150000, "Kilroy was here"};
+  foo foo{};
+  SourceSink ss(R"json({"bar":150000,"message":"Kilroy was here"})json");
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_deserialize_foo(&uj, &foo)));
+  EXPECT_EQ(memcmp(&foo, &expected, sizeof(foo)), 0);
+}
+
+TEST(Derive, FooDeserializeNoMessage) {
+  foo expected = {
+      -5,
+      150000,
+  };
+  foo foo{};
+  SourceSink ss(R"json({"foo":-5,"bar":150000})json");
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_deserialize_foo(&uj, &foo)));
+  EXPECT_EQ(memcmp(&foo, &expected, sizeof(foo)), 0);
+}
+
+TEST(Derive, FooDeserializeMessageToLong) {
+  foo expected = {-5, 150000, "abcdefghijklmnopqrs"};
+  foo foo{};
+  SourceSink ss(
+      R"json({"foo":-5,"bar":150000,"message":"abcdefghijklmnopqrstuvwxyz"})json");
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_deserialize_foo(&uj, &foo)));
+  EXPECT_EQ(memcmp(&foo, &expected, sizeof(foo)), 0);
+}
+
+TEST(Derive, FooDeserializeBogusKey) {
+  foo foo{};
+  SourceSink ss(
+      R"json({"bar":150000,"message":"Kilroy was here","bogus":99})json");
+  ujson_t uj = ss.UJson();
+  EXPECT_EQ(status_err(ujson_deserialize_foo(&uj, &foo)), kInvalidArgument);
+}
+
+TEST(Derive, RectSerialize) {
+  rect r = {{10, 10}, {60, 40}};
+  SourceSink ss;
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_serialize_rect(&uj, &r)));
+  EXPECT_EQ(
+      ss.Sink(),
+      R"json({"top_left":{"x":10,"y":10},"bottom_right":{"x":60,"y":40}})json");
+}
+
+TEST(Derive, RectDeserialize) {
+  rect expected = {{10, 20}, {30, 40}};
+  rect r{};
+  SourceSink ss(
+      R"json({"top_left":{"x":10,"y":20},"bottom_right":{"x":30,"y":40}})json");
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_deserialize_rect(&uj, &r)));
+  EXPECT_EQ(memcmp(&r, &expected, sizeof(r)), 0);
+}
+
+TEST(Derive, MatrixSerialize) {
+  matrix m = {
+      {{0, 1, 2, 3, 4}, {5, 6, 7, 8, 9}, {-1, -2, -3, -4, -5}},
+  };
+  SourceSink ss;
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_serialize_matrix(&uj, &m)));
+  EXPECT_EQ(ss.Sink(),
+            R"json({"k":[[0,1,2,3,4],[5,6,7,8,9],[-1,-2,-3,-4,-5]]})json");
+}
+
+TEST(Derive, MatrixDeserialize) {
+  matrix expected = {
+      {{0, 1, 0, 0, 0}, {2, 3, 4, 5, 0}, {-1, 0, 0, 0, 0}},
+  };
+  matrix m{};
+  SourceSink ss(R"json({"k":[[0,1],[2, 3, 4, 5],[-1]]})json");
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_deserialize_matrix(&uj, &m)));
+  ujson_serialize_matrix(&uj, &m);
+  std::cout << ss.Sink() << "\n\n";
+  EXPECT_EQ(memcmp(&m, &expected, sizeof(m)), 0);
+}
+
+TEST(Derive, DirectionSerialize) {
+  direction d = kDirectionEast;
+  SourceSink ss;
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_serialize_direction(&uj, &d)));
+  EXPECT_EQ(ss.Sink(), R"json("East")json");
+
+  ss.Reset();
+  d = kDirectionSouth;
+  EXPECT_TRUE(status_ok(ujson_serialize_direction(&uj, &d)));
+  EXPECT_EQ(ss.Sink(), R"json("South")json");
+
+  ss.Reset();
+  d = static_cast<direction>(120);
+  EXPECT_TRUE(status_ok(ujson_serialize_direction(&uj, &d)));
+  EXPECT_EQ(ss.Sink(), R"json({"IntValue":120})json");
+}
+
+TEST(Derive, DirectionDeserialize) {
+  direction d;
+  SourceSink ss(R"json("West")json");
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_deserialize_direction(&uj, &d)));
+  EXPECT_EQ(d, kDirectionWest);
+
+  ss.Reset(R"json("North")json");
+  EXPECT_TRUE(status_ok(ujson_deserialize_direction(&uj, &d)));
+  EXPECT_EQ(d, kDirectionNorth);
+
+  ss.Reset(R"json({"IntValue":35})json");
+  EXPECT_TRUE(status_ok(ujson_deserialize_direction(&uj, &d)));
+  EXPECT_EQ(d, static_cast<direction>(35));
+}
+
+}  // namespace

--- a/sw/device/lib/ujson/private_status.c
+++ b/sw/device/lib/ujson/private_status.c
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod bootstrap;
-pub mod init;
-pub mod load_bitstream;
-pub mod status;
+#define UJSON_SERDE_IMPL
+#include "sw/device/lib/ujson/private_status.h"

--- a/sw/device/lib/ujson/private_status.h
+++ b/sw/device/lib/ujson/private_status.h
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_UJSON_PRIVATE_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_UJSON_PRIVATE_STATUS_H_
+
+#include "sw/device/lib/ujson/ujson_derive.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Note: the PrivateStatus enum values must be in the same order as the
+// values in //sw/device/lib/base/absl_status.h.
+
+// clang-format off
+#define ENUM_PRIVATE_STATUS(_, value) \
+    value(_, Ok) \
+    value(_, Cancelled) \
+    value(_, Unknown) \
+    value(_, InvalidArgument) \
+    value(_, DeadlineExceeded) \
+    value(_, NotFound) \
+    value(_, AlreadyExists) \
+    value(_, PermissionDenied) \
+    value(_, ResourceExhausted) \
+    value(_, FailedPrecondition) \
+    value(_, Aborted) \
+    value(_, OutOfRange) \
+    value(_, Unimplemented) \
+    value(_, Internal) \
+    value(_, Unavailable) \
+    value(_, DataLoss) \
+    value(_, Unauthenticated)
+
+// We don't need a serialize implementation because the printf extension for
+// status_t already serializes in a JSON-compatible form.
+UJSON_DECLARE_ENUM(PrivateStatus, private_status_t, ENUM_PRIVATE_STATUS);
+UJSON_DESERIALIZE_ENUM(PrivateStatus, private_status_t, ENUM_PRIVATE_STATUS);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_UJSON_PRIVATE_STATUS_H_

--- a/sw/device/lib/ujson/rust/BUILD
+++ b/sw/device/lib/ujson/rust/BUILD
@@ -1,0 +1,35 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_test")
+load("//rules:ujson.bzl", "ujson_rust")
+
+package(default_visibility = ["//visibility:public"])
+
+ujson_rust(
+    name = "example",
+    srcs = ["//sw/device/lib/ujson:example"],
+)
+
+rust_test(
+    name = "roundtrip_test",
+    srcs = [
+        "roundtrip_test.rs",
+        ":example",
+    ],
+    data = ["//sw/device/lib/ujson:example_roundtrip"],
+    env = {
+        "ROUNDTRIP_CLIENT": "$(rootpath //sw/device/lib/ujson:example_roundtrip)",
+        "RUST_BACKTRACE": "1",
+    },
+    rustc_env = {
+        "example": "$(location :example)",
+    },
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:serde",
+        "//third_party/rust/crates:serde_json",
+    ],
+)

--- a/sw/device/lib/ujson/rust/roundtrip_test.rs
+++ b/sw/device/lib/ujson/rust/roundtrip_test.rs
@@ -1,0 +1,108 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use opentitanlib::test_utils::status::Status;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+
+mod example {
+    // Bring in the auto-generated sources.
+    include!(env!("example"));
+}
+
+fn roundtrip(name: &str, data: &str) -> Result<String> {
+    let mut command = Command::new(&std::env::var("ROUNDTRIP_CLIENT")?);
+    command.args(&[name]);
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+
+    let mut stdin = child.stdin.take().unwrap();
+    eprintln!("sent: {}", data);
+    stdin.write_all(data.as_bytes())?;
+
+    let mut s = String::new();
+    let mut stdout = child.stdout.take().unwrap();
+    stdout.read_to_string(&mut s)?;
+    eprintln!("recv: {}", s);
+    Ok(s)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_foo() -> Result<()> {
+        let before = example::Foo {
+            foo: 5,
+            bar: 10,
+            message: "Hello".into(),
+        };
+        let after = roundtrip("foo", &serde_json::to_string_pretty(&before)?)?;
+        let after = serde_json::from_str::<example::Foo>(&after)?;
+        assert_eq!(before, after);
+        Ok(())
+    }
+
+    #[test]
+    fn test_rect() -> Result<()> {
+        let before = example::Rect {
+            top_left: example::Coord { x: 10, y: 20 },
+            bottom_right: example::Coord { x: 30, y: 40 },
+        };
+        let after = roundtrip("rect", &serde_json::to_string(&before)?)?;
+        let after = serde_json::from_str::<example::Rect>(&after)?;
+        assert_eq!(before, after);
+        Ok(())
+    }
+
+    #[test]
+    fn test_matrix() -> Result<()> {
+        let before = example::Matrix {
+            k: [
+                [0, 1, 2, 3, 4],
+                [100, 200, 300, 400, 500],
+                [-1, -2, -3, -4, -5],
+            ],
+        };
+        let after = roundtrip("matrix", &serde_json::to_string(&before)?)?;
+        let after = serde_json::from_str::<example::Matrix>(&after)?;
+        assert_eq!(before, after);
+        Ok(())
+    }
+
+    #[test]
+    fn test_direction() -> Result<()> {
+        let before = example::Direction::North;
+        let after = roundtrip("direction", &serde_json::to_string(&before)?)?;
+        let after = serde_json::from_str::<example::Direction>(&after)?;
+        assert_eq!(before, after);
+        Ok(())
+    }
+
+    #[test]
+    fn test_direction_intvalue() -> Result<()> {
+        let before = example::Direction::IntValue(45);
+        let after = roundtrip("direction", &serde_json::to_string(&before)?)?;
+        let after = serde_json::from_str::<example::Direction>(&after)?;
+        assert_eq!(before, after);
+        Ok(())
+    }
+
+    #[test]
+    fn test_misc() -> Result<()> {
+        let before = example::Misc {
+            value: true,
+            status: Status::InvalidArgument("FOO".into(), 5),
+        };
+        let after = roundtrip("misc", &serde_json::to_string(&before)?)?;
+        let after = serde_json::from_str::<example::Misc>(&after)?;
+        assert_eq!(before, after);
+        Ok(())
+    }
+}

--- a/sw/device/lib/ujson/test_helpers.h
+++ b/sw/device/lib/ujson/test_helpers.h
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_UJSON_TEST_HELPERS_H_
+#define OPENTITAN_SW_DEVICE_LIB_UJSON_TEST_HELPERS_H_
+
+#include <string>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+namespace test_helpers {
+class SourceSink {
+ public:
+  SourceSink() {}
+  SourceSink(const std::string &source) : source_(source) {}
+
+  const std::string &Sink() { return sink_; }
+
+  ujson_t UJson() {
+    return ujson_init((void *)this, &SourceSink::getc, &SourceSink::putbuf);
+  }
+
+  void Reset() {
+    pos_ = 0;
+    sink_.clear();
+  }
+
+  void Reset(const std::string &source) {
+    Reset();
+    source_ = source;
+  }
+
+  status_t GetChar() {
+    if (pos_ < source_.size()) {
+      return OK_STATUS(static_cast<uint8_t>(source_[pos_++]));
+    } else {
+      return RESOURCE_EXHAUSTED();
+    }
+  }
+
+  status_t PutBuf(const char *buf, size_t len) {
+    sink_.append(buf, len);
+    return OK_STATUS();
+  }
+
+ private:
+  static status_t getc(void *self) {
+    return static_cast<SourceSink *>(self)->GetChar();
+  }
+
+  static status_t putbuf(void *self, const char *buf, size_t len) {
+    return static_cast<SourceSink *>(self)->PutBuf(buf, len);
+  }
+
+  size_t pos_ = 0;
+  std::string source_;
+  std::string sink_;
+};
+}  // namespace test_helpers
+#endif  // OPENTITAN_SW_DEVICE_LIB_UJSON_TEST_HELPERS_H_

--- a/sw/device/lib/ujson/ujson.c
+++ b/sw/device/lib/ujson/ujson.c
@@ -1,0 +1,390 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/ujson/ujson.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/ujson/private_status.h"
+
+static bool is_space(int c) { return c == ' ' || (unsigned)c - '\t' < 5; }
+
+ujson_t ujson_init(void *context, status_t (*getc)(void *),
+                   status_t (*putbuf)(void *, const char *, size_t)) {
+  ujson_t u = UJSON_INIT(context, getc, putbuf);
+  return u;
+}
+
+status_t ujson_putbuf(ujson_t *uj, const char *buf, size_t len) {
+  return uj->putbuf(uj->io_context, buf, len);
+}
+
+status_t ujson_getc(ujson_t *uj) {
+  int16_t buffer = uj->buffer;
+  if (buffer >= 0) {
+    uj->buffer = -1;
+    return OK_STATUS(buffer);
+  } else {
+    return uj->getc(uj->io_context);
+  }
+}
+
+status_t ujson_ungetc(ujson_t *uj, char ch) {
+  if (uj->buffer >= 0) {
+    return FAILED_PRECONDITION();
+  }
+  uj->buffer = ch;
+  return OK_STATUS();
+}
+
+bool ujson_streq(const char *a, const char *b) {
+  while (*a && *b && *a == *b) {
+    ++a;
+    ++b;
+  }
+  return *a == *b;
+}
+
+// Consumes whitespace returning first non-whitepsace character found.
+static status_t consume_whitespace(ujson_t *uj) {
+  int ch;
+  do {
+    ch = TRY(ujson_getc(uj));
+  } while (is_space(ch));
+  return OK_STATUS(ch);
+}
+
+static status_t consume_hexdigit(ujson_t *uj) {
+  int ch = TRY(ujson_getc(uj));
+  if (ch >= '0' && ch <= '9') {
+    return OK_STATUS(ch - '0');
+  } else if (ch >= 'A' && ch <= 'F') {
+    return OK_STATUS(ch - 'A' + 10);
+  } else if (ch >= 'a' && ch <= 'f') {
+    return OK_STATUS(ch - 'a' + 10);
+  } else {
+    return OUT_OF_RANGE();
+  }
+}
+
+static status_t consume_hex(ujson_t *uj) {
+  int a = TRY(consume_hexdigit(uj));
+  int b = TRY(consume_hexdigit(uj));
+  int c = TRY(consume_hexdigit(uj));
+  int d = TRY(consume_hexdigit(uj));
+  return OK_STATUS((a << 12) | (b << 8) | (c << 4) | d);
+}
+
+status_t ujson_consume(ujson_t *uj, char ch) {
+  if (ch != TRY(consume_whitespace(uj))) {
+    return NOT_FOUND();
+  }
+  return OK_STATUS();
+}
+
+status_t ujson_consume_maybe(ujson_t *uj, char ch) {
+  char got = TRY(consume_whitespace(uj));
+  if (ch != got) {
+    ujson_ungetc(uj, got);
+    return OK_STATUS(0);
+  }
+  return OK_STATUS(1);
+}
+
+status_t ujson_parse_qs(ujson_t *uj, char *str, size_t len) {
+  int ch;
+  int n = 0;
+  len--;  // One char for the nul terminator.
+  TRY(ujson_consume(uj, '"'));
+  while (true) {
+    ch = TRY(ujson_getc(uj));
+    if (ch == '\"')
+      break;
+    if (ch == '\\') {
+      ch = TRY(ujson_getc(uj));
+      switch (ch) {
+        case '"':
+        case '\\':
+        case '/':
+          break;
+        case 'b':
+          ch = '\b';
+          break;
+        case 'f':
+          ch = '\f';
+          break;
+        case 'n':
+          ch = '\n';
+          break;
+        case 'r':
+          ch = '\r';
+          break;
+        case 't':
+          ch = '\t';
+          break;
+        case 'u':
+          ch = TRY(consume_hex(uj));
+          break;
+        default:
+          return OUT_OF_RANGE();
+      }
+    }
+    if (len > 0) {
+      *str++ = ch;
+      --len;
+      n++;
+    }
+  }
+  *str = '\0';
+  return OK_STATUS(n);
+}
+
+status_t ujson_parse_integer(ujson_t *uj, void *result, size_t rsz) {
+  char ch = TRY(consume_whitespace(uj));
+  bool neg = false;
+
+  if (ch == '-') {
+    neg = true;
+    ch = TRY(ujson_getc(uj));
+  }
+  int64_t value = 0;
+  status_t s;
+  while (ch >= '0' && ch <= '9') {
+    value *= 10;
+    value += ch - '0';
+    s = ujson_getc(uj);
+    if (status_err(s))
+      break;
+    ch = (char)s.value;
+  }
+  if (status_ok(s))
+    TRY(ujson_ungetc(uj, ch));
+  if (neg)
+    value = -value;
+  memcpy(result, &value, rsz);
+  return OK_STATUS();
+}
+
+status_t ujson_deserialize_bool(ujson_t *uj, bool *value) {
+  char got = TRY(consume_whitespace(uj));
+  if (got == 't') {
+    TRY(ujson_consume(uj, 'r'));
+    TRY(ujson_consume(uj, 'u'));
+    TRY(ujson_consume(uj, 'e'));
+    *value = true;
+  } else if (got == 'f') {
+    TRY(ujson_consume(uj, 'a'));
+    TRY(ujson_consume(uj, 'l'));
+    TRY(ujson_consume(uj, 's'));
+    TRY(ujson_consume(uj, 'e'));
+    *value = false;
+  } else {
+    ujson_ungetc(uj, got);
+    return NOT_FOUND();
+  }
+  return OK_STATUS();
+}
+
+status_t ujson_deserialize_uint64_t(ujson_t *uj, uint64_t *value) {
+  return ujson_parse_integer(uj, (void *)value, sizeof(*value));
+}
+status_t ujson_deserialize_uint32_t(ujson_t *uj, uint32_t *value) {
+  return ujson_parse_integer(uj, (void *)value, sizeof(*value));
+}
+status_t ujson_deserialize_uint16_t(ujson_t *uj, uint16_t *value) {
+  return ujson_parse_integer(uj, (void *)value, sizeof(*value));
+}
+status_t ujson_deserialize_uint8_t(ujson_t *uj, uint8_t *value) {
+  return ujson_parse_integer(uj, (void *)value, sizeof(*value));
+}
+status_t ujson_deserialize_size_t(ujson_t *uj, size_t *value) {
+  return ujson_parse_integer(uj, (void *)value, sizeof(*value));
+}
+status_t ujson_deserialize_int64_t(ujson_t *uj, int64_t *value) {
+  return ujson_parse_integer(uj, (void *)value, sizeof(*value));
+}
+status_t ujson_deserialize_int32_t(ujson_t *uj, int32_t *value) {
+  return ujson_parse_integer(uj, (void *)value, sizeof(*value));
+}
+status_t ujson_deserialize_int16_t(ujson_t *uj, int16_t *value) {
+  return ujson_parse_integer(uj, (void *)value, sizeof(*value));
+}
+status_t ujson_deserialize_int8_t(ujson_t *uj, int8_t *value) {
+  return ujson_parse_integer(uj, (void *)value, sizeof(*value));
+}
+
+static const char hex[] = "0123456789abcdef";
+
+status_t ujson_serialize_string(ujson_t *uj, const char *buf) {
+  uint8_t ch;
+  TRY(ujson_putbuf(uj, "\"", 1));
+  while ((ch = (uint8_t)*buf) != '\0') {
+    if (ch < 0x20 || ch == '"' || ch == '\\' || ch >= 0x7f) {
+      switch (ch) {
+        case '"':
+          TRY(ujson_putbuf(uj, "\\\"", 2));
+          break;
+        case '\\':
+          TRY(ujson_putbuf(uj, "\\\\", 2));
+          break;
+        case '\b':
+          TRY(ujson_putbuf(uj, "\\b", 2));
+          break;
+        case '\f':
+          TRY(ujson_putbuf(uj, "\\f", 2));
+          break;
+        case '\n':
+          TRY(ujson_putbuf(uj, "\\n", 2));
+          break;
+        case '\r':
+          TRY(ujson_putbuf(uj, "\\r", 2));
+          break;
+        case '\t':
+          TRY(ujson_putbuf(uj, "\\t", 2));
+          break;
+        default: {
+          char esc[] = {'\\', 'u', '0', '0', hex[ch >> 4], hex[ch & 0xF]};
+          TRY(ujson_putbuf(uj, esc, sizeof(esc)));
+        }
+      }
+    } else {
+      TRY(ujson_putbuf(uj, buf, 1));
+    }
+    ++buf;
+  }
+  TRY(ujson_putbuf(uj, "\"", 1));
+  return OK_STATUS();
+}
+
+static status_t ujson_serialize_integer64(ujson_t *uj, uint64_t value,
+                                          bool neg) {
+  char buf[24];
+  char *end = buf + sizeof(buf);
+  size_t len = 0;
+  *--end = '\0';
+
+  // If negative, two's complement for the absolute value.
+  if (neg)
+    value = ~value + 1;
+  do {
+    // We've banned __udivdi3; do division with the replacement function.
+    uint64_t remainder;
+    value = udiv64_slow(value, 10, &remainder);
+    *--end = '0' + remainder;
+    ++len;
+  } while (value);
+  if (neg) {
+    *--end = '-';
+    ++len;
+  }
+  TRY(ujson_putbuf(uj, end, len));
+  return OK_STATUS();
+}
+
+static status_t ujson_serialize_integer32(ujson_t *uj, uint32_t value,
+                                          bool neg) {
+  char buf[24];
+  char *end = buf + sizeof(buf);
+  size_t len = 0;
+  *--end = '\0';
+
+  // If negative, two's complement for the absolute value.
+  if (neg)
+    value = ~value + 1;
+  do {
+    *--end = '0' + value % 10;
+    value /= 10;
+    ++len;
+  } while (value);
+  if (neg) {
+    *--end = '-';
+    ++len;
+  }
+  TRY(ujson_putbuf(uj, end, len));
+  return OK_STATUS();
+}
+
+status_t ujson_serialize_bool(ujson_t *uj, const bool *value) {
+  if (*value) {
+    TRY(ujson_putbuf(uj, "true", 4));
+  } else {
+    TRY(ujson_putbuf(uj, "false", 5));
+  }
+  return OK_STATUS();
+}
+
+status_t ujson_serialize_uint64_t(ujson_t *uj, const uint64_t *value) {
+  return ujson_serialize_integer64(uj, *value, false);
+}
+status_t ujson_serialize_uint32_t(ujson_t *uj, const uint32_t *value) {
+  return ujson_serialize_integer32(uj, *value, false);
+}
+
+status_t ujson_serialize_uint16_t(ujson_t *uj, const uint16_t *value) {
+  return ujson_serialize_integer32(uj, *value, false);
+}
+
+status_t ujson_serialize_uint8_t(ujson_t *uj, const uint8_t *value) {
+  return ujson_serialize_integer32(uj, *value, false);
+}
+
+status_t ujson_serialize_size_t(ujson_t *uj, const size_t *value) {
+  if (sizeof(size_t) == sizeof(uint64_t)) {
+    return ujson_serialize_integer64(uj, *value, false);
+  } else {
+    return ujson_serialize_integer32(uj, *value, false);
+  }
+}
+
+status_t ujson_serialize_int64_t(ujson_t *uj, const int64_t *value) {
+  return ujson_serialize_integer64(uj, (uint64_t)*value, *value < 0);
+}
+
+status_t ujson_serialize_int32_t(ujson_t *uj, const int32_t *value) {
+  return ujson_serialize_integer32(uj, (uint32_t)*value, *value < 0);
+}
+
+status_t ujson_serialize_int16_t(ujson_t *uj, const int16_t *value) {
+  return ujson_serialize_integer32(uj, (uint32_t)*value, *value < 0);
+}
+
+status_t ujson_serialize_int8_t(ujson_t *uj, const int8_t *value) {
+  return ujson_serialize_integer32(uj, (uint32_t)*value, *value < 0);
+}
+
+status_t ujson_deserialize_status_t(ujson_t *uj, status_t *value) {
+  private_status_t code;
+  uint32_t module_id = 0;
+  uint32_t arg = 0;
+  TRY(ujson_consume(uj, '{'));
+  TRY(ujson_deserialize_private_status_t(uj, &code));
+  TRY(ujson_consume(uj, ':'));
+  TRY(ujson_consume(uj, '['));
+  if (code != kPrivateStatusOk) {
+    char module[4];
+    TRY(ujson_parse_qs(uj, module, sizeof(module)));
+    module_id = MAKE_MODULE_ID(module[0], module[1], module[2]);
+    TRY(ujson_consume(uj, ','));
+  }
+  TRY(ujson_deserialize_uint32_t(uj, &arg));
+  TRY(ujson_consume(uj, ']'));
+  TRY(ujson_consume(uj, '}'));
+
+  *value = status_create((absl_status_t)code, module_id, __FILE__, arg);
+  return OK_STATUS();
+}
+
+status_t ujson_serialize_status_t(ujson_t *uj, const status_t *value) {
+  buffer_sink_t out = {
+      .data = uj->io_context,
+      .sink = (size_t(*)(void *, const char *, size_t))uj->putbuf,
+  };
+  base_fprintf(out, "%!r", *value);
+  return OK_STATUS();
+}

--- a/sw/device/lib/ujson/ujson.h
+++ b/sw/device/lib/ujson/ujson.h
@@ -1,0 +1,214 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_UJSON_UJSON_H_
+#define OPENTITAN_SW_DEVICE_LIB_UJSON_UJSON_H_
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Input/Output context for ujson.
+ */
+typedef struct ujson {
+  /** A generic pointer holding context for the IO routines. */
+  void *io_context;
+  /** A pointer to an IO function for writing data to the output. */
+  status_t (*putbuf)(void *, const char *, size_t);
+  /** A pointer to an IO function for reading data from the input. */
+  status_t (*getc)(void *);
+  /** An internal single character buffer for ungetting a character. */
+  int16_t buffer;
+} ujson_t;
+
+// clang-format off
+#define UJSON_INIT(context_, getc_, putbuf_) \
+  {                                          \
+    .io_context = (void*)(context_),         \
+    .putbuf_ = (putbuf_),                    \
+    .getc = (getc_),                         \
+    .buffer = -1,                            \
+  }
+// clang-format on
+
+/**
+ * Initializes and returns a ujson context.
+ *
+ * @param context An IO context for the `getc` and `putbuf` functions.
+ * @param getc A function to read a character from the input.
+ * @param putbuf A function to write a buffer to the output.
+ * @return An initialized ujson_t context.
+ */
+ujson_t ujson_init(void *context, status_t (*getc)(void *),
+                   status_t (*putbuf)(void *, const char *, size_t));
+
+/**
+ * Gets a single character from the input.
+ *
+ * @param uj A ujson IO context.
+ * @return The next character or an error.
+ */
+status_t ujson_getc(ujson_t *uj);
+
+/**
+ * Pushes a single character back to the input.
+ *
+ * @param uj A ujson IO context.
+ * @param ch The character to put back to the input buffer.
+ * @return OK or an error.
+ */
+status_t ujson_ungetc(ujson_t *uj, char ch);
+
+/**
+ * Writes a buffer to the output.
+ *
+ * @param uj A ujson IO context.
+ * @param buf The buffer to write to the output.
+ * @param len The length of the buffer.
+ * @return OK or an error.
+ */
+status_t ujson_putbuf(ujson_t *uj, const char *buf, size_t len);
+
+/**
+ * Compares two strings for equality.
+ *
+ * @param a A string.
+ * @param b A string.
+ * @return true of the strings are equal; false otherwise.
+ */
+bool ujson_streq(const char *a, const char *b);
+
+/**
+ * Consumes a character from the input.
+ *
+ * Consume all whitespace until a non-whitespace character is found.
+ * The non-whitespace character must be `ch`.
+ *
+ * @param uj A ujson IO context.
+ * @param ch The character to consume.
+ * @return OK or an error.
+ */
+status_t ujson_consume(ujson_t *uj, char ch);
+
+/**
+ * Find and consume a character from the input.
+ *
+ * Consume all whitespace until a non-whitespace character is found.
+ * If the character is `ch`, return OK(1).
+ * If the character is not `ch`, unget the character and return OK(0).
+ *
+ * @param uj A ujson IO context.
+ * @param ch The character to consume.
+ * @return OK or an error.
+ */
+status_t ujson_consume_maybe(ujson_t *uj, char ch);
+
+/**
+ * Parse a JSON quoted string.
+ *
+ * Consume whitespace until finding a double-quote.  Consume all characters
+ * (obeying json escape sequences) until the next double-quote.  If the
+ * input string exceeds the length of the user buffer, the the user
+ * buffer will contain a truncated string and the entire input json string
+ * will be consumed.
+ *
+ * @param uj A ujson IO context.
+ * @param str A buffer to write the string into.
+ * @param len The length of the target buffer.
+ * @return OK or an error.
+ */
+status_t ujson_parse_qs(ujson_t *uj, char *str, size_t len);
+
+/**
+ * Parse a JSON integer.
+ *
+ * @param uj A ujson IO context.
+ * @param result: The parsed integer.
+ * @param rsz: The size of the integer (in bytes).
+ * @return OK or an error.
+ */
+status_t ujson_parse_integer(ujson_t *uj, void *result, size_t rsz);
+
+/**
+ * The following functions parse integers of specific sizes.
+ */
+status_t ujson_deserialize_uint64_t(ujson_t *uj, uint64_t *value);
+status_t ujson_deserialize_uint32_t(ujson_t *uj, uint32_t *value);
+status_t ujson_deserialize_uint16_t(ujson_t *uj, uint16_t *value);
+status_t ujson_deserialize_uint8_t(ujson_t *uj, uint8_t *value);
+status_t ujson_deserialize_size_t(ujson_t *uj, size_t *value);
+status_t ujson_deserialize_int64_t(ujson_t *uj, int64_t *value);
+status_t ujson_deserialize_int32_t(ujson_t *uj, int32_t *value);
+status_t ujson_deserialize_int16_t(ujson_t *uj, int16_t *value);
+status_t ujson_deserialize_int8_t(ujson_t *uj, int8_t *value);
+
+/**
+ * Deserialize a boolean.
+ *
+ * @param uj A ujson IO context.
+ * @param value Pointer to the value to deserialize into.
+ * @return OK or an error.
+ */
+status_t ujson_deserialize_bool(ujson_t *uj, bool *value);
+
+/**
+ * Deserialize a status_t.
+ *
+ * @param uj A ujson IO context.
+ * @param value Pointer to the value to deserialize into.
+ * @return OK or an error.
+ */
+status_t ujson_deserialize_status_t(ujson_t *uj, status_t *value);
+
+/**
+ * Serialize a string.
+ *
+ * @param uj A ujson IO context.
+ * @param buf The string to serialize.
+ * @return OK or an error.
+ */
+status_t ujson_serialize_string(ujson_t *uj, const char *buf);
+
+/**
+ * Serialize an integer.
+ *
+ * @param uj A ujson IO context.
+ * @param value A pointer to the integer to serialize.
+ * @return OK or an error.
+ */
+status_t ujson_serialize_uint64_t(ujson_t *uj, const uint64_t *value);
+status_t ujson_serialize_uint32_t(ujson_t *uj, const uint32_t *value);
+status_t ujson_serialize_uint16_t(ujson_t *uj, const uint16_t *value);
+status_t ujson_serialize_uint8_t(ujson_t *uj, const uint8_t *value);
+status_t ujson_serialize_size_t(ujson_t *uj, const size_t *value);
+status_t ujson_serialize_int64_t(ujson_t *uj, const int64_t *value);
+status_t ujson_serialize_int32_t(ujson_t *uj, const int32_t *value);
+status_t ujson_serialize_int16_t(ujson_t *uj, const int16_t *value);
+status_t ujson_serialize_int8_t(ujson_t *uj, const int8_t *value);
+
+/**
+ * Serialize a boolean.
+ *
+ * @param uj A ujson IO context.
+ * @param value Pointer to the value to serialize.
+ * @return OK or an error.
+ */
+status_t ujson_serialize_bool(ujson_t *uj, const bool *value);
+
+/**
+ * Serialize a status_t.
+ *
+ * @param uj A ujson IO context.
+ * @param value Pointer to the value to serialize.
+ * @return OK or an error.
+ */
+status_t ujson_serialize_status_t(ujson_t *uj, const status_t *value);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_UJSON_UJSON_H_

--- a/sw/device/lib/ujson/ujson_derive.h
+++ b/sw/device/lib/ujson/ujson_derive.h
@@ -1,0 +1,264 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_UJSON_UJSON_DERIVE_H_
+#define OPENTITAN_SW_DEVICE_LIB_UJSON_UJSON_DERIVE_H_
+// This is what we'll use as the Rust enumeration name for C-enum values
+// that do not have a symbolic name.
+#define RUST_ENUM_INTVALUE IntValue
+
+#ifndef RUST_PREPROCESSOR_EMIT
+#include <stdint.h>
+
+#include "sw/device/lib/base/adv_macros.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+#define RUST_ENUM_INTVALUE_STR OT_STRINGIFY(RUST_ENUM_INTVALUE)
+// clang-format off
+// clang-format is turned off; as scary as these macros look, they look
+// even scarier after clang-format is done with them.
+#define ujson_struct_field_array_indirect() ujson_struct_field_array
+#define ujson_struct_field_array(nt_, sz_, ...) \
+    OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+    ( /*then*/ \
+        nt_[sz_] \
+    , /*else*/ \
+        OT_OBSTRUCT(ujson_struct_field_array_indirect)()(nt_[sz_], __VA_ARGS__) \
+    ) /*endif*/
+
+#define ujson_struct_field(name_, type_, ...) \
+    OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+    ( /*then*/ \
+        type_ name_; \
+    , /*else*/ \
+        OT_EVAL(ujson_struct_field_array(type_ name_, __VA_ARGS__)); \
+    ) /*endif*/
+
+#define ujson_struct_string(name_, size_, ...) \
+    ujson_struct_field(name_, char, ##__VA_ARGS__, size_)
+
+#define UJSON_DECLARE_STRUCT(formal_name_, name_, decl_, ...) \
+    typedef struct formal_name_ { \
+        decl_(ujson_struct_field, ujson_struct_string) \
+    } name_
+
+#define ujson_enum_value(formal_name_, name_, ...) \
+    OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+    ( /*then*/ \
+        k ##formal_name_ ## name_ \
+    , /*else*/ \
+        k ##formal_name_ ## name_ = __VA_ARGS__ \
+    ) /*endif*/ ,
+
+#define UJSON_DECLARE_ENUM(formal_name_, name_, decl_, ...) \
+    typedef enum formal_name_ { \
+        decl_(formal_name_, ujson_enum_value) \
+    } name_
+
+#ifdef UJSON_SERDE_IMPL
+
+// Helper to count number of fields.
+#define ujson_count(name_, type_, ...) +1
+
+//////////////////////////////////////////////////////////////////////
+// Serialize Implementation
+//////////////////////////////////////////////////////////////////////
+#define ujson_ser_loop_indirect() ujson_ser_loop
+#define ujson_ser_loop(expr, count, ...) \
+    TRY(ujson_putbuf(uj, "[", 1)); \
+    for(size_t x=0; x < count; ++x) { \
+        if (x) TRY(ujson_putbuf(uj, ",", 1)); \
+        OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+        ( /*then*/ \
+            expr; \
+        , /*else*/ \
+            OT_OBSTRUCT(ujson_ser_loop_indirect)()(expr, __VA_ARGS__) \
+        ) /*endif*/ \
+    } \
+    TRY(ujson_putbuf(uj, "]", 1));
+
+#define ujson_ser_field(name_, type_, ...) { \
+        TRY(ujson_serialize_string(uj, #name_)); \
+        TRY(ujson_putbuf(uj, ":", 1)); \
+        OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+        ( /*then*/ \
+            TRY(ujson_serialize_##type_(uj, &self->name_)); \
+        , /*else*/ \
+            const type_ *p = (const type_*)self->name_; \
+            OT_EVAL(ujson_ser_loop( \
+                    TRY(ujson_serialize_##type_(uj, p++)), __VA_ARGS__)) \
+        ) /*endif*/ \
+        if (--nfield) TRY(ujson_putbuf(uj, ",", 1)); \
+    }
+
+#define ujson_ser_string(name_, size_, ...) { \
+        TRY(ujson_serialize_string(uj, #name_)); \
+        TRY(ujson_putbuf(uj, ":", 1)); \
+        OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+        ( /*then*/ \
+            TRY(ujson_serialize_string(uj, self->name_)); \
+        , /*else*/ \
+            const char *p = (const char*)self->name_; \
+            OT_EVAL(ujson_ser_loop( \
+                    TRY(ujson_serialize_string(uj, p)); p+=size_, __VA_ARGS__)) \
+        ) /*endif*/ \
+        if (--nfield) TRY(ujson_putbuf(uj, ",", 1)); \
+    }
+
+#define UJSON_SERIALIZE_STRUCT(name_, decl_) \
+    status_t ujson_serialize_##name_(ujson_t *uj, const name_ *self) { \
+        size_t nfield = decl_(ujson_count, ujson_count); \
+        TRY(ujson_putbuf(uj, "{", 1)); \
+        decl_(ujson_ser_field, ujson_ser_string) \
+        TRY(ujson_putbuf(uj, "}", 1)); \
+        return OK_STATUS(); \
+    } \
+    extern const int __never_referenced___here_to_eat_a_semicolon[]
+
+#define ujson_ser_enum(formal_name_, name_, ...) \
+    case k ##formal_name_ ## name_: \
+        TRY(ujson_serialize_string(uj, #name_)); break;
+
+#define UJSON_SERIALIZE_ENUM(formal_name_, name_, decl_) \
+    status_t ujson_serialize_##name_(ujson_t *uj, const name_ *self) { \
+        switch(*self) { \
+            decl_(formal_name_, ujson_ser_enum) \
+            default: \
+                TRY(ujson_putbuf(uj, \
+                    "{\"" RUST_ENUM_INTVALUE_STR "\":", \
+                    sizeof("{\"" RUST_ENUM_INTVALUE_STR "\":") - 1)); \
+                TRY(ujson_serialize_uint32_t(uj, (const uint32_t*)self)); \
+                TRY(ujson_putbuf(uj, "}", 1)); \
+        } \
+        return OK_STATUS(); \
+    } \
+    extern const int __never_referenced___here_to_eat_a_semicolon[]
+
+//////////////////////////////////////////////////////////////////////
+// Deserialize Implementation
+//////////////////////////////////////////////////////////////////////
+#define ujson_de_loop_indirect() ujson_de_loop
+#define ujson_de_loop(mult, expr, count, ...) \
+    TRY(ujson_consume(uj, '[')); \
+    OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+    ( /*then*/ \
+        size_t i = 0; \
+        while(true) { \
+            if (TRY(ujson_consume_maybe(uj, ']'))) break; \
+            if (i) TRY(ujson_consume(uj, ',')); \
+            if (i < count) {  expr; ++i; } \
+        } \
+        if (i < count) { p += (count - i) * mult; } \
+    , /*else*/ \
+        for(size_t x=0;; ++x) { \
+            if (TRY(ujson_consume_maybe(uj, ']'))) break; \
+            if (x) TRY(ujson_consume(uj, ',')); \
+            OT_OBSTRUCT(ujson_de_loop_indirect)()(mult, expr, __VA_ARGS__) \
+        } \
+    ) /*endif*/ \
+
+#define ujson_de_field(name_, type_, ...) \
+    else if (ujson_streq(key, #name_)) { \
+        OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+        ( /*then*/ \
+            TRY(ujson_deserialize_##type_(uj, &self->name_)); \
+        , /*else*/ \
+            type_ *p = (type_*)self->name_; \
+            OT_EVAL(ujson_de_loop(1, \
+                TRY(ujson_deserialize_##type_(uj, p++)), __VA_ARGS__)) \
+        ) /*endif*/ \
+    }
+
+#define ujson_de_string(name_, size_, ...) \
+    else if (ujson_streq(key, #name_)) { \
+        OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+        ( /*then*/ \
+            TRY(ujson_parse_qs(uj, self->name_, sizeof(self->name_))); \
+        , /*else*/ \
+            char *p = (char*)self->name_; \
+            OT_EVAL(ujson_de_loop(size_, \
+                TRY(ujson_parse_qs(uj, p, sizeof(self->name_))); p+=size_, __VA_ARGS__)) \
+        ) /*endif*/ \
+    }
+
+#define UJSON_DESERIALIZE_STRUCT(name_, decl_) \
+    status_t ujson_deserialize_##name_(ujson_t *uj, name_ *self) { \
+        size_t nfield = 0; \
+        char key[128]; \
+        TRY(ujson_consume(uj, '{')); \
+        while(TRY(ujson_consume_maybe(uj, '}')) == 0) { \
+            if (nfield++ > 0) { \
+                TRY(ujson_consume(uj, ',')); \
+            } \
+            TRY(ujson_parse_qs(uj, key, sizeof(key))); \
+            TRY(ujson_consume(uj, ':')); \
+            if (0) {} \
+            decl_(ujson_de_field, ujson_de_string) \
+            else { \
+                return INVALID_ARGUMENT(); \
+            } \
+        } \
+        return OK_STATUS(); \
+    } \
+    extern const int __never_referenced___here_to_eat_a_semicolon[]
+
+#define ujson_de_enum(formal_name_, name_, ...) \
+    else if (ujson_streq(value, #name_)) { *self = k ##formal_name_ ## name_; }
+
+#define UJSON_DESERIALIZE_ENUM(formal_name_, name_, decl_) \
+    status_t ujson_deserialize_##name_(ujson_t *uj, name_ *self) { \
+        char value[128]; \
+        if (TRY(ujson_consume_maybe(uj, '"'))) { \
+            TRY(ujson_ungetc(uj, '"')); \
+            TRY(ujson_parse_qs(uj, value, sizeof(value))); \
+            if (0) {} \
+            decl_(formal_name_, ujson_de_enum) \
+            else { \
+                return INVALID_ARGUMENT(); \
+            } \
+        } else { \
+            TRY(ujson_consume(uj, '{')); \
+            TRY(ujson_parse_qs(uj, value, sizeof(value))); \
+            TRY(ujson_consume(uj, ':')); \
+            if (ujson_streq(value, RUST_ENUM_INTVALUE_STR)) { \
+                TRY(ujson_deserialize_uint32_t(uj, (uint32_t*)self)); \
+            } else { \
+                return INVALID_ARGUMENT(); \
+            } \
+            TRY(ujson_consume(uj, '}')); \
+        } \
+        return OK_STATUS(); \
+    } \
+    extern const int __never_referenced___here_to_eat_a_semicolon[]
+// clang-format on
+#else  // UJSON_SERDE_IMPL
+#define UJSON_SERIALIZE_STRUCT(name_, decl_) \
+  status_t ujson_serialize_##name_(ujson_t *uj, const name_ *self)
+#define UJSON_SERIALIZE_ENUM(formal_name_, name_, decl_) \
+  status_t ujson_serialize_##name_(ujson_t *uj, const name_ *self)
+
+#define UJSON_DESERIALIZE_STRUCT(name_, decl_) \
+  status_t ujson_deserialize_##name_(ujson_t *uj, name_ *self);
+#define UJSON_DESERIALIZE_ENUM(formal_name_, name_, decl_) \
+  status_t ujson_deserialize_##name_(ujson_t *uj, name_ *self);
+
+#endif  // UJSON_SERDE_IMPL
+//////////////////////////////////////////////////////////////////////
+// Combined build-everything macros
+//////////////////////////////////////////////////////////////////////
+#define UJSON_SERDE_STRUCT(formal_name_, name_, decl_, ...)        \
+  UJSON_DECLARE_STRUCT(formal_name_, name_, decl_, ##__VA_ARGS__); \
+  UJSON_SERIALIZE_STRUCT(name_, decl_);                            \
+  UJSON_DESERIALIZE_STRUCT(name_, decl_)
+
+#define UJSON_SERDE_ENUM(formal_name_, name_, decl_, ...)        \
+  UJSON_DECLARE_ENUM(formal_name_, name_, decl_, ##__VA_ARGS__); \
+  UJSON_SERIALIZE_ENUM(formal_name_, name_, decl_);              \
+  UJSON_DESERIALIZE_ENUM(formal_name_, name_, decl_)
+
+#else  // RUST_PREPROCESSOR_EMIT
+#include "sw/device/lib/ujson/ujson_rust.h"
+#endif  // RUST_PREPROCESSOR_EMIT
+#endif  // OPENTITAN_SW_DEVICE_LIB_UJSON_UJSON_DERIVE_H_

--- a/sw/device/lib/ujson/ujson_rust.h
+++ b/sw/device/lib/ujson/ujson_rust.h
@@ -1,0 +1,110 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_UJSON_UJSON_RUST_H_
+#define OPENTITAN_SW_DEVICE_LIB_UJSON_UJSON_RUST_H_
+
+// Definitions of the UJSON macros that emit code that can be trivially
+// transformed into rust code:
+//
+// Preprocess the input, grep out all the preprocessor noise,
+// translate `rust_attr` into `#` (rust attributes) and finally format the code:
+//      gcc -nostdinc -I. -E -DRUST_PREPROCESSOR_EMIT <input_file> \
+//          | grep -v '#' \
+//          | sed -e "s/rust_attr/#/g" \
+//          | rustfmt > output_file
+
+#ifndef RUST_PREPROCESSOR_EMIT
+#error "Do not include this file directly.  Include ujson_derive.h instead."
+#endif  // RUST_PREPROCESSOR_EMIT
+#include "sw/device/lib/base/adv_macros.h"
+
+#define uint64_t u64
+#define uint32_t u32
+#define uint16_t u16
+#define uint8_t u8
+#define size_t usize
+
+#define int64_t i64
+#define int32_t i32
+#define int16_t i16
+#define int8_t i8
+
+#define RUST_DEFAULT_DERIVE Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq
+
+// clang-format off
+rust_attr[allow(unused_imports)]
+use opentitanlib::test_utils::status::status_t;
+
+// clang-format is turned off; as scary as these macros look, they look
+// even scarier after clang-format is done with them.
+#define ujson_struct_field_array_indirect() ujson_struct_field_array
+#define ujson_struct_field_array(t_, sz_, ...) \
+    OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+    ( /*then*/ \
+        [t_; sz_]\
+    , /*else*/ \
+        [OT_OBSTRUCT(ujson_struct_field_array_indirect)()(t_, __VA_ARGS__); sz_] \
+    ) /*endif*/
+
+#define ujson_struct_field(name_, type_, ...) \
+    pub OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+    ( /*then*/ \
+        name_: type_ \
+    , /*else*/ \
+        name_: OT_EVAL(ujson_struct_field_array(type_, __VA_ARGS__)) \
+    ) /*endif*/,
+
+#define ujson_struct_string(name_, size_, ...) \
+    ujson_struct_field(name_, String, ##__VA_ARGS__)
+
+#define UJSON_DECLARE_STRUCT(formal_name_, name_, decl_, ...) \
+    OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+    ( /*then*/ \
+        rust_attr[derive(RUST_DEFAULT_DERIVE)] /*transform into #[...] */ \
+    , /*else*/ \
+        rust_attr[derive(__VA_ARGS__)] /*transform into #[...] */ \
+    ) /*endif*/ \
+    rust_attr[allow(non_camel_case_types)] \
+    pub struct name_ { \
+        decl_(ujson_struct_field, ujson_struct_string) \
+    } \
+    rust_attr[allow(dead_code)] \
+    pub type formal_name_ = name_ /*eat_semicolon*/
+
+#define ujson_enum_value(formal_name_, name_, ...) \
+    pub OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+    ( /*then*/ \
+        name_ \
+    , /*else*/ \
+        name_ = __VA_ARGS__ \
+    ) /*endif*/,
+
+#define UJSON_DECLARE_ENUM(formal_name_, name_, decl_, ...) \
+    OT_IIF(OT_NOT(OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__))) \
+    ( /*then*/ \
+        rust_attr[derive(RUST_DEFAULT_DERIVE)] /*transform into #[...] */ \
+    , /*else*/ \
+        rust_attr[derive(__VA_ARGS__)] /*transform into #[...] */ \
+    ) /*endif*/ \
+    rust_attr[repr(u32)] /* transform into #[...] */ \
+    rust_attr[allow(non_camel_case_types)] \
+    pub enum name_ { \
+        decl_(formal_name_, ujson_enum_value) \
+        RUST_ENUM_INTVALUE (u32), \
+    } \
+    rust_attr[allow(dead_code)] \
+    pub type formal_name_ = name_ /*eat_semicolon*/
+// clang-format on
+
+//////////////////////////////////////////////////////////////////////
+// Combined build-everything macro
+//////////////////////////////////////////////////////////////////////
+#define UJSON_SERDE_STRUCT(formal_name_, name_, decl_, ...) \
+  UJSON_DECLARE_STRUCT(formal_name_, name_, decl_, ##__VA_ARGS__)
+
+#define UJSON_SERDE_ENUM(formal_name_, name_, decl_, ...) \
+  UJSON_DECLARE_ENUM(formal_name_, name_, decl_, ##__VA_ARGS__)
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_UJSON_UJSON_RUST_H_

--- a/sw/device/lib/ujson/ujson_test.cc
+++ b/sw/device/lib/ujson/ujson_test.cc
@@ -1,0 +1,235 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/ujson/ujson.h"
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/test_helpers.h"
+
+namespace {
+using test_helpers::SourceSink;
+
+TEST(UJson, GetC) {
+  SourceSink ss("abc123");
+  ujson_t uj = ss.UJson();
+
+  EXPECT_EQ(ujson_getc(&uj).value, 'a');
+  EXPECT_EQ(ujson_getc(&uj).value, 'b');
+  EXPECT_EQ(ujson_getc(&uj).value, 'c');
+  EXPECT_EQ(status_err(ujson_ungetc(&uj, 'd')), kOk);
+  EXPECT_EQ(ujson_getc(&uj).value, 'd');
+  EXPECT_EQ(ujson_getc(&uj).value, '1');
+  EXPECT_EQ(ujson_getc(&uj).value, '2');
+  EXPECT_EQ(ujson_getc(&uj).value, '3');
+  EXPECT_EQ(status_err(ujson_getc(&uj)), kResourceExhausted);
+}
+
+TEST(UJson, PutBuf) {
+  SourceSink ss;
+  ujson_t uj = ss.UJson();
+
+  EXPECT_TRUE(status_ok(ujson_putbuf(&uj, "abc", 3)));
+  EXPECT_TRUE(status_ok(ujson_putbuf(&uj, "123", 3)));
+  EXPECT_EQ(ss.Sink(), "abc123");
+}
+
+TEST(UJson, Consume) {
+  SourceSink ss("  \t\r\nax");
+  ujson_t uj = ss.UJson();
+
+  EXPECT_EQ(status_err(ujson_consume(&uj, 'a')), kOk);
+  EXPECT_EQ(status_err(ujson_consume(&uj, 'b')), kNotFound);
+}
+
+TEST(UJson, ParseQuotedString) {
+  SourceSink ss(R"json(
+        "Hello World\r\n"
+    )json");
+  ujson_t uj = ss.UJson();
+  char buf[256];
+  status_t s;
+
+  s = ujson_parse_qs(&uj, buf, sizeof(buf));
+  EXPECT_TRUE(status_ok(s));
+  EXPECT_EQ(s.value, 13);
+  std::string vala(buf);
+  EXPECT_EQ(vala, "Hello World\r\n");
+
+  ss.Reset();
+  s = ujson_parse_qs(&uj, buf, 6);
+  EXPECT_TRUE(status_ok(s));
+  EXPECT_EQ(s.value, 5);
+  std::string valb(buf);
+  EXPECT_EQ(valb, "Hello");
+}
+
+TEST(UJson, ParseQuotedStringInvalidString) {
+  SourceSink ss("abc");
+  ujson_t uj = ss.UJson();
+  char buf[256];
+  status_t s;
+
+  s = ujson_parse_qs(&uj, buf, sizeof(buf));
+  EXPECT_EQ(status_err(s), kNotFound);
+}
+
+TEST(UJson, ParseQuotedStringShortBuffer) {
+  SourceSink ss("\"abc");
+  ujson_t uj = ss.UJson();
+  char buf[256];
+  status_t s;
+
+  s = ujson_parse_qs(&uj, buf, sizeof(buf));
+  EXPECT_EQ(status_err(s), kResourceExhausted);
+}
+
+TEST(UJson, ParseBoolean) {
+  SourceSink ss("true");
+  ujson_t uj = ss.UJson();
+  status_t s;
+  bool val = false;
+
+  // Parse the token "true".
+  s = ujson_deserialize_bool(&uj, &val);
+  EXPECT_TRUE(status_ok(s));
+  EXPECT_TRUE(val);
+
+  // Parse the token "false".
+  ss.Reset("false");
+  val = true;
+  s = ujson_deserialize_bool(&uj, &val);
+  EXPECT_TRUE(status_ok(s));
+  EXPECT_FALSE(val);
+
+  // Check various non-true/false values.
+  ss.Reset("xyz");
+  s = ujson_deserialize_bool(&uj, &val);
+  EXPECT_FALSE(status_ok(s));
+  ss.Reset("trust");
+  s = ujson_deserialize_bool(&uj, &val);
+  EXPECT_FALSE(status_ok(s));
+  ss.Reset("fast");
+  s = ujson_deserialize_bool(&uj, &val);
+  EXPECT_FALSE(status_ok(s));
+}
+
+#define INT(type_, str_, value_)                                  \
+  do {                                                            \
+    SourceSink ss(str_);                                          \
+    ujson_t uj = ss.UJson();                                      \
+    type_ t;                                                      \
+    status_t s = ujson_parse_integer(&uj, (void *)&t, sizeof(t)); \
+    EXPECT_EQ(status_err(s), kOk);                                \
+    EXPECT_EQ(t, value_);                                         \
+  } while (0)
+
+#define SIMPLE_INT(type_, value_) INT(type_, #value_, value_)
+
+TEST(UJson, ParseInteger) {
+  SIMPLE_INT(int64_t, -1);
+  SIMPLE_INT(uint64_t, 9223372036854775808);
+  SIMPLE_INT(uint32_t, 12345678);
+  SIMPLE_INT(int32_t, -12345678);
+  SIMPLE_INT(int16_t, -1);
+  SIMPLE_INT(int8_t, -1);
+
+  // Won't fit, we should get zero.
+  INT(uint8_t, "256", 0);
+  // This value overflows int64 and becomes its own negative.
+  INT(int64_t, "9223372036854775808", -9223372036854775808);
+}
+#undef INT
+#undef SIMPLE_INT
+
+TEST(UJson, SerializeString) {
+  SourceSink ss;
+  ujson uj = ss.UJson();
+
+  EXPECT_TRUE(status_ok(ujson_serialize_string(&uj, "abc123")));
+  EXPECT_EQ(ss.Sink(), R"json("abc123")json");
+
+  ss.Reset();
+  EXPECT_TRUE(status_ok(ujson_serialize_string(&uj, "\"\\\b\f\n\r\t")));
+  EXPECT_EQ(ss.Sink(), R"json("\"\\\b\f\n\r\t")json");
+
+  ss.Reset();
+  EXPECT_TRUE(status_ok(ujson_serialize_string(&uj, "\xFF\x01\x99")));
+  EXPECT_EQ(ss.Sink(), R"json("\u00ff\u0001\u0099")json");
+}
+
+TEST(UJson, SerializeBool) {
+  SourceSink ss;
+  ujson uj = ss.UJson();
+  bool val;
+
+  val = true;
+  EXPECT_TRUE(status_ok(ujson_serialize_bool(&uj, &val)));
+  EXPECT_EQ(ss.Sink(), R"json(true)json");
+
+  ss.Reset();
+  val = false;
+  EXPECT_TRUE(status_ok(ujson_serialize_bool(&uj, &val)));
+  EXPECT_EQ(ss.Sink(), R"json(false)json");
+}
+
+#define INT(type_, str_, value_)                   \
+  do {                                             \
+    SourceSink ss;                                 \
+    ujson_t uj = ss.UJson();                       \
+    type_ t = value_;                              \
+    status_t s = ujson_serialize_##type_(&uj, &t); \
+    EXPECT_EQ(status_err(s), kOk);                 \
+    EXPECT_EQ(ss.Sink(), str_);                    \
+  } while (0)
+
+TEST(UJson, SerializeIntegers) {
+  INT(uint64_t, "9223372036854775808", 1UL << 63);
+  INT(uint32_t, "4294967295", 0xFFFFFFFF);
+  INT(uint16_t, "32768", 0x8000);
+  INT(uint8_t, "129", 129);
+
+  INT(int64_t, "-9223372036854775808", 1UL << 63);
+  INT(int32_t, "-1", 0xFFFFFFFF);
+  INT(int16_t, "-32768", 0x8000);
+  INT(int8_t, "-2", 0xfe);
+}
+
+TEST(UJson, SerializeStatus) {
+  SourceSink ss;
+  ujson uj = ss.UJson();
+  status_t val;
+
+  val = OK_STATUS(1234);
+  EXPECT_TRUE(status_ok(ujson_serialize_status_t(&uj, &val)));
+  EXPECT_EQ(ss.Sink(), R"json({"Ok":[1234]})json");
+}
+
+TEST(UJson, DeerializeStatus) {
+  SourceSink ss(R"json({"Ok":[1234]})json");
+  ujson uj = ss.UJson();
+  status_t val;
+  const char *code;
+  char mod_id[4] = {0};
+  int32_t arg;
+
+  // Parse an Ok value with an argument.
+  EXPECT_TRUE(status_ok(ujson_deserialize_status_t(&uj, &val)));
+  status_extract(val, &code, &arg, mod_id);
+  EXPECT_EQ(status_err(val), kOk);
+  EXPECT_EQ(arg, 1234);
+
+  // Parse an error value with a module and argument.
+  // The module_id should get truncated to 3 characters.
+  ss.Reset(R"json({"InvalidArgument": ["foobar", 77]})json");
+  EXPECT_TRUE(status_ok(ujson_deserialize_status_t(&uj, &val)));
+  status_extract(val, &code, &arg, mod_id);
+  EXPECT_EQ(status_err(val), kInvalidArgument);
+  EXPECT_EQ(std::string(mod_id), "FOO");
+  EXPECT_EQ(arg, 77);
+}
+
+}  // namespace

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -62,6 +62,7 @@ rust_library(
         "src/test_utils/init.rs",
         "src/test_utils/load_bitstream.rs",
         "src/test_utils/mod.rs",
+        "src/test_utils/status.rs",
         "src/transport/common/mod.rs",
         "src/transport/common/uart.rs",
         "src/transport/cw310/gpio.rs",

--- a/sw/host/opentitanlib/src/test_utils/status.rs
+++ b/sw/host/opentitanlib/src/test_utils/status.rs
@@ -1,0 +1,87 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Status {
+    #[error("Not an error ({0})!")]
+    Ok(u32),
+    #[error("Cancelled (module={0} line={1})")]
+    Cancelled(String, u32),
+    #[error("Unknown (module={0} line={1})")]
+    Unknown(String, u32),
+    #[error("Invalid Argument (module={0} line={1})")]
+    InvalidArgument(String, u32),
+    #[error("Deadline Exceeded (module={0} line={1})")]
+    DeadlineExceeded(String, u32),
+    #[error("Not Found (module={0} line={1})")]
+    NotFound(String, u32),
+    #[error("Already Exists (module={0} line={1})")]
+    AlreadyExists(String, u32),
+    #[error("Permission Denied (module={0} line={1})")]
+    PermissionDenied(String, u32),
+    #[error("Resource Exhausted (module={0} line={1})")]
+    ResourceExhausted(String, u32),
+    #[error("Failed Precondition (module={0} line={1})")]
+    FailedPrecondition(String, u32),
+    #[error("Aborted (module={0} line={1})")]
+    Aborted(String, u32),
+    #[error("Out Of Range (module={0} line={1})")]
+    OutOfRange(String, u32),
+    #[error("Unimplemented (module={0} line={1})")]
+    Unimplemented(String, u32),
+    #[error("Internal (module={0} line={1})")]
+    Internal(String, u32),
+    #[error("Unavailable (module={0} line={1})")]
+    Unavailable(String, u32),
+    #[error("Data Loss (module={0} line={1})")]
+    DataLoss(String, u32),
+    #[error("Unauthenticated (module={0} line={1})")]
+    Unauthenticated(String, u32),
+}
+
+#[allow(non_camel_case_types)]
+pub type status_t = Status;
+
+macro_rules! ok_status_to_integer {
+    () => { };
+
+    ($t:ty, $($ts:ty),* $(,)?) => {
+        impl TryFrom<Status> for $t {
+            type Error = Status;
+            fn try_from(value: Status) -> Result<Self, Self::Error> {
+                match value {
+                    Status::Ok(v) => Ok(v as $t),
+                    _ => Err(value),
+                }
+            }
+        }
+        ok_status_to_integer!($($ts,)*);
+    };
+}
+
+// Facilitate easy conversion of Status::Ok(_) to integer types.
+ok_status_to_integer!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn test_convert_ok() -> Result<()> {
+        let status = Status::Ok(123);
+        assert_eq!(123, i32::try_from(status)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_convert_err() -> Result<()> {
+        let status = Status::Cancelled("foo".into(), 123);
+        assert!(u32::try_from(status).is_err());
+        Ok(())
+    }
+}


### PR DESCRIPTION
The `ujson` library represents a command/control/status interface
between Rust-based test harnesses and riscv32-based test programs.  The
library allows one to define structs and enums in a C-preprocessor
domain-specific-language and automatically generate:

- The C language structs and enums.
- The C language serializer and deserializer for those structs/enums.
- The Rust language struct/enum definitions with appropriate `serde`
  attributes to enable serialization and deserialization.

The files `example.[ch]` provide a basic guide showing how to declare
structs and enums.  The files `example_roundtrip.c` and
`rust/roundtrip_test.rs` demonstrate data exchange between C and Rust
programs.

The preprocessor techniques used to generate the parser and emitter code
are somewhat advanced, but well known techniques. See the page
[C Preprocessor tricks, tips, and idioms](https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms).
Because these techniques rely on the comma elision with variadic macros,
we must use the `gnu` compiler extensions (`-std=gnu11` and
`-std=gnu++14`).

Signed-off-by: Chris Frantz <cfrantz@google.com>