### PR TITLE
[test,rv_core_ibex] Chip-level test Ibex random number generator

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2676,7 +2676,7 @@
                  polling to check read when invalid doesn't block.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_rv_core_ibex_rnd"]
     }
     {
       name: chip_sw_rv_core_ibex_address_translation

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2669,7 +2669,7 @@
                - Enable entropy complex so `RND_DATA` can get entropy.
                - Perform multiple reads from `RND_DATA` polling `RND_STATUS` in
                  between to only read valid data. Check different random bits
-                 are provided each time.
+                 are provided each time and that the random data is never zero or all ones.
                - Ensure `RND_STATUS` indicate invalid data immediately after
                  `RND_DATA` read.
                - Perform repeated reads from `RND_DATA` without `RND_STATUS`

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -258,6 +258,13 @@
   // For example, if the Bazel label for a test is:
   // `//sw/device/tests:example_test_from_flash`, then you would specify this as
   // `//sw/device/tests:example_test_from_flash:1`.
+  //
+  // To calculate the value of `+sw_test_timeout_ns` run dvsim by:
+  // $ util/dvsim/dvsim.py hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson \
+  //       -i TEST_NAME --fixed-seed=1
+  // Run this a few times and take the worst case runtime, then  increase this
+  // value by 20% and use the relationship that 5 minutes of runtime is roughly
+  // 4 milliseconds of timeout.
   tests: [
     {
       // Reused from hw/dv/tools/dvsim/tests/csr_tests.hjson.

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -419,7 +419,7 @@
       uvm_test_seq: chip_sw_flash_init_vseq
       sw_images: ["//sw/device/tests/sim_dv:flash_init_test:0:test_in_rom"]
       en_run_modes: ["sw_test_mode_common"]
-      run_opts: ["+sw_test_timeout_ns=25000000"]
+      run_opts: ["+sw_test_timeout_ns=25_000_000"]
     }
     {
       name: chip_sw_flash_rma_unlocked
@@ -597,7 +597,7 @@
       uvm_test_seq: chip_sw_sysrst_ctrl_reset_vseq
       sw_images: ["//sw/device/tests/sim_dv:sysrst_ctrl_reset_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=36000000"]
+      run_opts: ["+sw_test_timeout_ns=36_000_000"]
     }
     {
       name: chip_sw_sysrst_ctrl_outputs
@@ -610,70 +610,70 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aon_timer_irq_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_sw_aon_timer_sleep_wdog_sleep_pause
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aon_timer_sleep_wdog_sleep_pause_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_sw_aon_timer_wdog_bite_reset
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aon_timer_wdog_bite_reset_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_sw_pwrmgr_wdog_reset
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:pwrmgr_wdog_reset_reqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_sw_aon_timer_wdog_lc_escalate
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aon_timer_wdog_lc_escalate_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_sw_adc_ctrl_sleep_debug_cable_wakeup
       uvm_test_seq: chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq
       sw_images: ["//sw/device/tests/sim_dv:adc_ctrl_sleep_debug_cable_wakeup_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_sw_otbn_randomness
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_randomness_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_sw_otbn_ecdsa_op_irq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_ecdsa_op_irq_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=28000000"]
+      run_opts: ["+sw_test_timeout_ns=28_000_000"]
     }
     {
       name: chip_sw_otbn_ecdsa_op_irq_jitter_en
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_ecdsa_op_irq_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=35000000", "+en_jitter=1"]
+      run_opts: ["+sw_test_timeout_ns=35_000_000", "+en_jitter=1"]
     }
     {
       name: chip_sw_otbn_mem_scramble
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_mem_scramble_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15000000"]
+      run_opts: ["+sw_test_timeout_ns=15_000_000"]
     }
     {
       name: chip_sw_rv_core_ibex_rnd
@@ -681,28 +681,28 @@
       sw_images: ["sw/device/tests/rv_core_ibex_rnd_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       // Timeout based on a 10min dvsim runtime.
-      run_opts: ["+sw_test_timeout_ns=10000000"]
+      run_opts: ["+sw_test_timeout_ns=10_000_000"]
     }
     {
       name: chip_sw_aes_enc
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aes_smoketest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=22000000"]
+      run_opts: ["+sw_test_timeout_ns=22_000_000"]
     }
     {
       name: chip_sw_aes_enc_jitter_en
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aes_smoketest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=26000000", "+en_jitter=1"]
+      run_opts: ["+sw_test_timeout_ns=26_000_000", "+en_jitter=1"]
     }
     {
       name: chip_sw_aes_idle
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aes_idle_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=25000000"]
+      run_opts: ["+sw_test_timeout_ns=25_000_000"]
     }
     {
       name: chip_sw_aes_sideload
@@ -736,28 +736,28 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aes_entropy_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15000000"]
+      run_opts: ["+sw_test_timeout_ns=15_000_000"]
     }
     {
       name: chip_sw_entropy_src_kat_test
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_kat_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_sw_csrng_kat_test
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:csrng_kat_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_sw_entropy_src_ast_rng_req
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_ast_rng_req_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15000000"]
+      run_opts: ["+sw_test_timeout_ns=15_000_000"]
     }
     {
       name: chip_sw_edn_entropy_reqs
@@ -796,14 +796,14 @@
       uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
       sw_images: ["//sw/device/tests/sim_dv:keymgr_key_derivation_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=20000000"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000"]
     }
     {
       name: chip_sw_keymgr_key_derivation_jitter_en
       uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
       sw_images: ["//sw/device/tests/sim_dv:keymgr_key_derivation_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=20000000", "+en_jitter=1"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000", "+en_jitter=1"]
     }
     {
       name: chip_sw_kmac_mode_cshake
@@ -855,7 +855,7 @@
       sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_main_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+mem_sel=main",
-                 "+sw_test_timeout_ns=12000000"]
+                 "+sw_test_timeout_ns=12_000_000"]
     }
     {
       name: chip_sw_sram_ctrl_main_scrambled_access_jitter_en
@@ -863,7 +863,7 @@
       sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_main_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+mem_sel=main",
-                 "+sw_test_timeout_ns=12000000",
+                 "+sw_test_timeout_ns=12_000_000",
                  "+en_jitter=1"]
     }
     {
@@ -877,28 +877,28 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=20000000"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000"]
     }
     {
       name: chip_sw_sensor_ctrl_alert
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:sensor_ctrl_alert_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=40000000"]
+      run_opts: ["+sw_test_timeout_ns=40_000_000"]
     }
     {
       name: chip_sw_sensor_ctrl_status
       uvm_test_seq: chip_sw_sensor_ctrl_status_intr_vseq
       sw_images: ["//sw/device/tests/sim_dv:sensor_ctrl_status_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=40000000"]
+      run_opts: ["+sw_test_timeout_ns=40_000_000"]
     }
     {
       name: chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:sensor_ctrl_wakeup_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=8000000"]
+      run_opts: ["+sw_test_timeout_ns=8_000_000"]
     }
     {
       name: chip_sw_coremark
@@ -906,7 +906,7 @@
       sw_images: ["//sw/device/benchmarks/coremark/coremark_top_earlgrey:1:external"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_uart_logger=1",
-                 "+sw_test_timeout_ns=22000000"]
+                 "+sw_test_timeout_ns=22_000_000"]
     }
     {
       name: chip_sw_pwrmgr_b2b_sleep_reset_req
@@ -1042,14 +1042,14 @@
       uvm_test_seq: "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq"
       sw_images: ["//sw/device/tests/sim_dv:pwrmgr_normal_sleep_all_wake_ups:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_all_wake_ups
       uvm_test_seq: "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq"
       sw_images: ["//sw/device/tests/sim_dv:pwrmgr_deep_sleep_all_wake_ups:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18000000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
       name: chip_rv_dm_ndm_reset_req

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -676,6 +676,14 @@
       run_opts: ["+sw_test_timeout_ns=15000000"]
     }
     {
+      name: chip_sw_rv_core_ibex_rnd
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/rv_core_ibex_rnd_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      // Timeout based on a 10min dvsim runtime.
+      run_opts: ["+sw_test_timeout_ns=10000000"]
+    }
+    {
       name: chip_sw_aes_enc
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aes_smoketest:1"]

--- a/sw/device/lib/dif/dif_rv_core_ibex.c
+++ b/sw/device/lib/dif/dif_rv_core_ibex.c
@@ -310,11 +310,6 @@ dif_result_t dif_rv_core_ibex_read_rnd_data(
   if (rv_core_ibex == NULL || data == NULL) {
     return kDifBadArg;
   }
-  uint32_t reg = mmio_region_read32(rv_core_ibex->base_addr,
-                                    RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
-  if (!bitfield_bit32_read(reg, RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT)) {
-    return kDifError;
-  }
 
   *data = mmio_region_read32(rv_core_ibex->base_addr,
                              RV_CORE_IBEX_RND_DATA_REG_OFFSET);

--- a/sw/device/lib/dif/dif_rv_core_ibex.h
+++ b/sw/device/lib/dif/dif_rv_core_ibex.h
@@ -356,17 +356,6 @@ dif_result_t dif_rv_core_ibex_clear_nmi_state(
     const dif_rv_core_ibex_t *rv_core_ibex, dif_rv_core_ibex_nmi_source_t nmi);
 
 /**
- * Reads a random word from the RISC-V Ibex core wrapper.
- *
- * @param rv_core_ibex Handle.
- * @param[out] data Pointer to be filled with the random word.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_rv_core_ibex_read_rnd_data(
-    const dif_rv_core_ibex_t *rv_core_ibex, uint32_t *data);
-
-/**
  * Gets whether the rnd data is either valid or is FIPS compliant.
  *
  * @param rv_core_ibex Handle.
@@ -377,6 +366,17 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_core_ibex_get_rnd_status(
     const dif_rv_core_ibex_t *rv_core_ibex,
     dif_rv_core_ibex_rnd_status_t *status);
+
+/**
+ * Reads a random word from the RISC-V Ibex core wrapper.
+ *
+ * @param rv_core_ibex Handle.
+ * @param[out] data Pointer to be filled with the random word.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_read_rnd_data(
+    const dif_rv_core_ibex_t *rv_core_ibex, uint32_t *data);
 
 typedef uint32_t dif_rv_core_ibex_fpga_info_t;
 

--- a/sw/device/lib/dif/dif_rv_core_ibex_unittest.cc
+++ b/sw/device/lib/dif/dif_rv_core_ibex_unittest.cc
@@ -464,8 +464,6 @@ TEST_F(NMITest, ClearBadArg) {
 class RndTest : public RvCoreIbexTestInitialized {};
 
 TEST_F(RndTest, ReadSuccess) {
-  EXPECT_READ32(RV_CORE_IBEX_RND_STATUS_REG_OFFSET,
-                {{RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT, true}});
   EXPECT_READ32(RV_CORE_IBEX_RND_DATA_REG_OFFSET, 0xf55ef65e);
 
   uint32_t data;
@@ -477,13 +475,6 @@ TEST_F(RndTest, ReadBadArg) {
   uint32_t data;
   EXPECT_DIF_BADARG(dif_rv_core_ibex_read_rnd_data(nullptr, &data));
   EXPECT_DIF_BADARG(dif_rv_core_ibex_read_rnd_data(&ibex_, nullptr));
-}
-
-TEST_F(RndTest, ReadNotValid) {
-  EXPECT_READ32(RV_CORE_IBEX_RND_STATUS_REG_OFFSET,
-                {{RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT, false}});
-  uint32_t data;
-  EXPECT_EQ(dif_rv_core_ibex_read_rnd_data(&ibex_, &data), kDifError);
 }
 
 TEST_F(RndTest, StatusValid) {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1412,6 +1412,25 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "rv_core_ibex_rnd_test",
+    srcs = [
+        "rv_core_ibex_rnd_test.S",
+        "rv_core_ibex_rnd_test.c",
+    ],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:edn",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "ast_clk_outs_test",
     srcs = ["ast_clk_outs_test.c"],
     cw310 = cw310_params(

--- a/sw/device/tests/rv_core_ibex_rnd_test.S
+++ b/sw/device/tests/rv_core_ibex_rnd_test.S
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/* These assembly functions are used in the rv_core_ibex_rnd_test chip-level
+ * test. Writing these functions in assembly guarantees that the memory reads
+ * are a fixed number of instructions apart, independent of how the compiler
+ * optimizes code. This is important because the RND status is low for only a
+ * small number of cycles (10 cycles in the Verilator simulator). If we do not
+ * write these in assembly, changes to the test, implementation or compiler
+ * could affect whether the tests pass or not, which is de-risked to a certain
+ * extent by using the assembly versions.
+ */
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "rv_core_ibex_regs.h"
+
+/**
+ * Read RND Data and immediately read RND status afterwards.
+ *
+ * @return the value of the RND status.
+ */
+  .globl rv_core_ibex_rnd_read_and_immediately_check_status
+  .type rv_core_ibex_rnd_read_and_immediately_check_status, @function
+rv_core_ibex_rnd_read_and_immediately_check_status:
+  li t0, TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR // Load ibex base address
+  lw t1, RV_CORE_IBEX_RND_DATA_REG_OFFSET(t0) // Read RND data
+  lw a0, RV_CORE_IBEX_RND_STATUS_REG_OFFSET(t0) // Get RND status
+  ret // Return status
+
+/**
+ * Read RND data to invalidate status, read status then read RND again,
+ * followed by read status. If both status reads are low and you read the same
+ * data then it means read data does not block when status is invalid. Check
+ * that the RND status reads are equal and the invalid RND data read is zero.
+ *
+ * @return -1 if the second load does not equal the fourth or if the
+ * intermediate RND read is not zero. Otherwise return the value of the RND
+ * status.
+ */
+  .globl rv_core_ibex_check_rnd_read_possible_while_status_invalid
+  .type rv_core_ibex_check_rnd_read_possible_while_status_invalid, @function
+rv_core_ibex_check_rnd_read_possible_while_status_invalid:
+  li t0, TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR // Load ibex base address
+  lw t1, RV_CORE_IBEX_RND_DATA_REG_OFFSET(t0) // Read RND to invalidate status
+  lw t2, RV_CORE_IBEX_RND_STATUS_REG_OFFSET(t0) // Get RND status
+  lw t3, RV_CORE_IBEX_RND_DATA_REG_OFFSET(t0) // Read RND data
+  lw a0, RV_CORE_IBEX_RND_STATUS_REG_OFFSET(t0) // Get RND status
+  sub t2, t2, a0 // Calculate difference between first and last status
+  or t2, t2, t3 // Check whether intermediate RND data is 0
+  bnez t2, error_return // Check whether to return -1
+  ret // Return status value
+error_return:
+  addi a0, x0, -1 // Put -1 in a0
+  ret // Return -1

--- a/sw/device/tests/rv_core_ibex_rnd_test.c
+++ b/sw/device/tests/rv_core_ibex_rnd_test.c
@@ -46,13 +46,16 @@ bool test_main(void) {
       &rv_core_ibex));
 
   // Perform multiple reads from `RND_DATA` polling `RND_STATUS` in between to
-  // only read valid data. Check different random bits are provided each time.
+  // only read valid data. Check different random bits are provided each time
+  // and that the random data is never zero or all ones.
   uint32_t rnd_data;
   uint32_t previous_rnd_data = 0;
   for (int i = 0; i < RANDOM_DATA_READS; i++) {
     IBEX_SPIN_FOR(get_rnd_status(&rv_core_ibex), MAX_STATUS_CHECKS);
     CHECK_DIF_OK(dif_rv_core_ibex_read_rnd_data(&rv_core_ibex, &rnd_data));
     CHECK(rnd_data != previous_rnd_data);
+    CHECK(rnd_data != 0);
+    CHECK(rnd_data != UINT32_MAX);
     previous_rnd_data = rnd_data;
   }
 

--- a/sw/device/tests/rv_core_ibex_rnd_test.c
+++ b/sw/device/tests/rv_core_ibex_rnd_test.c
@@ -1,0 +1,77 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "rv_core_ibex_regs.h"
+
+// Initialize OTTF.
+OTTF_DEFINE_TEST_CONFIG();
+
+// Declare two assembly function defined in `rv_core_ibex_rnd_test.S`.
+extern volatile uint32_t rv_core_ibex_rnd_read_and_immediately_check_status();
+extern volatile uint32_t
+rv_core_ibex_check_rnd_read_possible_while_status_invalid();
+
+#define RANDOM_DATA_READS 32
+#define MAX_STATUS_CHECKS 1024
+
+static bool get_rnd_status(const dif_rv_core_ibex_t *rv_core_ibex) {
+  dif_rv_core_ibex_rnd_status_t rnd_status;
+  CHECK_DIF_OK(dif_rv_core_ibex_get_rnd_status(rv_core_ibex, &rnd_status));
+  return rnd_status != 0;
+}
+
+bool test_main(void) {
+  // Verify the functionality of the random number generation CSRs.
+
+  // Enable entropy complex, CSRNG and EDN so Ibex can get entropy.
+  // No code is necessary for this because EDN0 is automatically initialized
+  // by the ROM.
+
+  // Initialize Ibex.
+  dif_rv_core_ibex_t rv_core_ibex;
+  CHECK_DIF_OK(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  // Perform multiple reads from `RND_DATA` polling `RND_STATUS` in between to
+  // only read valid data. Check different random bits are provided each time.
+  uint32_t rnd_data;
+  uint32_t previous_rnd_data = 0;
+  for (int i = 0; i < RANDOM_DATA_READS; i++) {
+    IBEX_SPIN_FOR(get_rnd_status(&rv_core_ibex), MAX_STATUS_CHECKS);
+    CHECK_DIF_OK(dif_rv_core_ibex_read_rnd_data(&rv_core_ibex, &rnd_data));
+    CHECK(rnd_data != previous_rnd_data);
+    previous_rnd_data = rnd_data;
+  }
+
+  // Ensure `RND_STATUS` indicate invalid data immediately after `RND_DATA`
+  // read.
+  CHECK(rv_core_ibex_rnd_read_and_immediately_check_status() == 0);
+
+  // Perform repeated reads from `RND_DATA` without `RND_STATUS` polling to
+  // check read when invalid doesn't block.
+  for (int i = 0; i < RANDOM_DATA_READS; i++) {
+    CHECK_DIF_OK(dif_rv_core_ibex_read_rnd_data(&rv_core_ibex, &rnd_data));
+  }
+
+  // Check to see that we can really do an RND while status is invalid before
+  // and after.
+  IBEX_SPIN_FOR(get_rnd_status(&rv_core_ibex), MAX_STATUS_CHECKS);
+  uint32_t status_value =
+      rv_core_ibex_check_rnd_read_possible_while_status_invalid();
+  CHECK(status_value == 0);
+
+  return true;
+}


### PR DESCRIPTION
Added new chip-level test named `chip_sw_rv_core_ibex_rnd`, which:
- Initializes the EDN and Ibex
- Checks whether random data changes after each request
- Checks that status becomes invalid immediately after reading random data
- Checks that random data can be read even without checking the status first

Closes https://github.com/lowRISC/opentitan/issues/13217