### PR TITLE
[sw/silicon_creator] Use `jal` instead of `call` in `mask_rom_start.S`

### DIFF
--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -112,7 +112,7 @@ _mask_rom_shadow_stack:
   // is allocated executable space in ROM by the linker.
   .section .crt, "ax"
 
-  // Linker Relaxation is disabled until `__global_pointer$` is setup, below,
+  // Linker relaxations are disabled until `__global_pointer$` is setup below,
   // because otherwise some sequences may be turned into gp-relative sequences,
   // which is incorrect when `gp` is not initialized.
   .option push
@@ -142,6 +142,15 @@ _mask_rom_start_boot:
   j .L_halt_loop
 
 .L_exec_en:
+  // Set up the global pointer.
+  //
+  // This requires that we disable linker relaxations, or it will be relaxed to
+  // `mv gp, gp`, so we disabled relaxations at the start of `_mask_rom_start_boot`.
+  la gp, __global_pointer$
+
+  // Re-enable linker relaxations.
+  .option pop
+
   // Configure the power manager to enable resets.
   // Note: this enables all types of reset request for simplicity.
   li t0, TOP_EARLGREY_PWRMGR_AON_BASE_ADDR
@@ -232,10 +241,9 @@ _mask_rom_start_boot:
    * State").
    */
 
-  // Zero all writable registers.
+  // Zero all writable registers except for `gp` (`x3`) since it's already initialized.
   li x1,  0x0
   li x2,  0x0
-  li x3,  0x0
   li x4,  0x0
   li x5,  0x0
   li x6,  0x0
@@ -299,11 +307,6 @@ _mask_rom_start_boot:
   // The shadow stack, unlike the regular stack, grows upwards.
   la x18, _mask_rom_shadow_stack
 
-  // Set up global pointer.
-  //
-  // This requires that we disable linker relaxations, or it will be relaxed to
-  // `mv gp, gp`, so we disabled relaxations for all of `_mask_rom_start_boot`.
-  la gp, __global_pointer$
 
   // Set exception/interrupt handlers.
   //
@@ -320,6 +323,3 @@ _mask_rom_start_boot:
    */
   tail mask_rom_main
   .size _mask_rom_start_boot, .-_mask_rom_start_boot
-
-  // Re-enable linker relaxation.
-  .option pop


### PR DESCRIPTION
While looking at the recent RISCV CFI proposal with @tjaychen we noticed that mask ROM has only a handful of `jalr`s and all but one of them come from asm files.

This PR adds an assertion to `mask_rom.ld` and replaces `call`s with `jal`s in `mask_rom_start.S`. Since we know that `.crt` is smaller than 1 MiB, we can use `jal`s which should (slightly) improve our resistance to FI.

After this, the only `jalr` left in mask ROM is the jump to ROM_EXT.

[Disassembly](https://gist.github.com/dfb3a74b16dbe94bf80d2ca1247e7416)

Update: Moving `gp` initialization to earlier and enabling relaxations earlier is simpler and has the same effect.