### PR TITLE
[dv/otp] Update prim_tl agent

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -18,9 +18,6 @@ class otp_ctrl_env #(
 
   `uvm_component_new
 
-  // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
-  tl_agent prim_tl_agent;
-
   push_pull_agent#(.DeviceDataWidth(SRAM_DATA_SIZE))  m_sram_pull_agent[NumSramKeyReqSlots];
   push_pull_agent#(.DeviceDataWidth(OTBN_DATA_SIZE))  m_otbn_pull_agent;
   push_pull_agent#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_addr_pull_agent;
@@ -61,14 +58,6 @@ class otp_ctrl_env #(
     uvm_config_db#(push_pull_agent_cfg#(.HostDataWidth(LC_PROG_DATA_SIZE), .DeviceDataWidth(1)))::
         set(this, "m_lc_prog_pull_agent", "cfg", cfg.m_lc_prog_pull_agent_cfg);
 
-    // TODO: reggen tool optimization.
-    // Temp build the prim_tl_agent.should be auto-generated via otp_ctrl_env_cfg once the reggen
-    // tool is optimized.NCurrently this is an empty RAL so dv_base_reg_block will return an error.
-    if (cfg.create_prim_tl_agent) begin
-      prim_tl_agent = tl_agent::type_id::create({"prim_tl_agent"}, this);
-      uvm_config_db#(tl_agent_cfg)::set(this, "prim_tl_agent", "cfg", cfg.prim_tl_agent_cfg);
-    end
-
     // config mem virtual interface
     if (!uvm_config_db#(mem_bkdr_util)::get(this, "", "mem_bkdr_util", cfg.mem_bkdr_util_h)) begin
       `uvm_fatal(`gfn, "failed to get mem_bkdr_util from uvm_config_db")
@@ -100,10 +89,7 @@ class otp_ctrl_env #(
     virtual_sequencer.flash_addr_pull_sequencer_h = m_flash_addr_pull_agent.sequencer;
     virtual_sequencer.flash_data_pull_sequencer_h = m_flash_data_pull_agent.sequencer;
     virtual_sequencer.lc_prog_pull_sequencer_h    = m_lc_prog_pull_agent.sequencer;
-    // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
-    if (cfg.create_prim_tl_agent) begin
-      virtual_sequencer.prim_tl_sequencer_h = prim_tl_agent.sequencer;
-    end
+
     if (cfg.en_scb) begin
       m_otbn_pull_agent.monitor.analysis_port.connect(scoreboard.otbn_fifo.analysis_export);
       m_flash_addr_pull_agent.monitor.analysis_port.connect(

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -30,6 +30,8 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
   // ext interfaces
   otp_ctrl_vif otp_ctrl_vif;
+  virtual clk_rst_if clk_rst_vif_otp_ctrl_prim_reg_block;
+
   bit backdoor_clear_mem;
 
   // Check ECC errors
@@ -37,9 +39,6 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
   // values for otp_ctrl_if signals connected to DUT
   rand otp_ctrl_ast_inputs_cfg dut_cfg;
-
-  // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
-  rand tl_agent_cfg prim_tl_agent_cfg;
 
   // Introduce this flag to avoid close source conflict.
   bit create_prim_tl_agent = 1;
@@ -57,11 +56,9 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
   }
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
-    // TODO: reggen tool optimization.
-    // Enable these codes once prim_reg_block has register place holders.
-    // string prim_ral_name = "otp_ctrl_prim_reg_block";
-    // ral_model_names.push_back(prim_ral_name);
-    // clk_freqs_mhz[prim_ral_name] = clk_freq_mhz;
+    string prim_ral_name = "otp_ctrl_prim_reg_block";
+    ral_model_names.push_back(prim_ral_name);
+    clk_freqs_mhz[prim_ral_name] = clk_freq_mhz;
 
     list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;
     num_edn = 1;
@@ -93,14 +90,6 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
                                .DeviceDataWidth(1))::type_id::create("m_lc_prog_pull_agent_cfg");
     m_lc_prog_pull_agent_cfg.agent_type = PullAgent;
 
-    // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
-    if (create_prim_tl_agent) begin
-      prim_tl_agent_cfg = tl_agent_cfg::type_id::create("prim_tl_agent_cfg");
-      prim_tl_agent_cfg.if_mode = dv_utils_pkg::Host;
-      prim_tl_agent_cfg.host_can_stall_rsp_when_a_valid_high = $urandom_range(0, 1);
-      prim_tl_agent_cfg.allow_a_valid_drop_wo_a_ready = $urandom_range(0, 1);
-    end
-
     // set num_interrupts & num_alerts
     begin
       uvm_reg rg = ral.get_reg_by_name("intr_state");
@@ -111,7 +100,6 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
     // only support 1 outstanding TL items in tlul_adapter
     m_tl_agent_cfg.max_outstanding_req = 1;
-    if (create_prim_tl_agent) prim_tl_agent_cfg.max_outstanding_req = 1;
 
     // create the inputs cfg instance
     dut_cfg = otp_ctrl_ast_inputs_cfg::type_id::create("dut_cfg");

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -14,6 +14,7 @@ package otp_ctrl_env_pkg;
   import csr_utils_pkg::*;
   import push_pull_agent_pkg::*;
   import otp_ctrl_core_ral_pkg::*;
+  import otp_ctrl_prim_ral_pkg::*;
   import otp_ctrl_reg_pkg::*;
   import otp_ctrl_pkg::*;
   import otp_ctrl_part_pkg::*;
@@ -38,8 +39,6 @@ package otp_ctrl_env_pkg;
   parameter uint DIGEST_SIZE             = 8;
   parameter uint SW_WINDOW_BASE_ADDR     = 'h1000;
   parameter uint SW_WINDOW_SIZE          = 512 * 4;
-  // Address size for prim_tl_i/o.
-  parameter uint PRIM_ADDR_SIZE          = 32 * 4;
 
   // convert byte into TLUL width size
   parameter uint VENDOR_TEST_START_ADDR  = VendorTestOffset / (TL_DW / 8);
@@ -76,6 +75,8 @@ package otp_ctrl_env_pkg;
                                    / (TL_DW / 8);
 
   parameter int OTP_ADDR_WIDTH = 11;
+
+  parameter uint NUM_PRIM_REG = 8;
 
   // Total num of valid dai address, secret partitions have a granularity of 8, the rest have
   // a granularity of 4. Subtract 8 for each digest.

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -33,7 +33,8 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     // drive dft_en pins to access the test_access memory
     cfg.otp_ctrl_vif.drive_lc_dft_en(lc_ctrl_pkg::On);
     // once turn on lc_dft_en regiser, will need some time to update the state register
-    // two clock cycles for lc_async mode, one clock cycle for driving dft_en
+    // two clock cycles for lc_async mode, one clock cycle for driving dft_en, one more clock cycle
+    // so there is no racing condition.
     cfg.clk_rst_vif.wait_clks(3);
   endtask
 

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -244,9 +244,12 @@ module tb;
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env",
+                                            "clk_rst_vif_otp_ctrl_prim_reg_block", clk_rst_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent_otp_ctrl_core_reg_block*",
                                        "vif", tl_if);
-    uvm_config_db#(virtual tl_if)::set(null, "*.env.prim_tl_agent*","vif", prim_tl_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent_otp_ctrl_prim_reg_block",
+                                       "vif", prim_tl_if);
     uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(OTBN_DATA_SIZE)))::set(null,
                    "*env.m_otbn_pull_agent*", "vif", otbn_if);
     uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(FLASH_DATA_SIZE)))::set(null,


### PR DESCRIPTION
As design supports alias register in open/close source for tl_prim_i/o,
in open source DV, we switch to use this tl_prim_i/o agent.

This PR only updates the open source version of the DV, another PR will come
soon in the close source domain to update the DV env.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>