### PR TITLE
[chip-test] Add csrng_kat_test

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -245,16 +245,22 @@
                     value: "<random>",
                 },
                 {
+                    // Cryptolib and chip-level tests require access to the
+                    // CSRNG software interfaces.
                     name:  "EN_CSRNG_SW_APP_READ",
-                    value: false,
+                    value: true,
                 },
                 {
+                    // Cryptolib and chip-level tests require access to the
+                    // entropy_src FW data interface.
                     name:  "EN_ENTROPY_SRC_FW_READ",
                     value: true,
                 },
                 {
+                    // Cryptolib and chip-level tests require access to the
+                    // entropy_src FW override interface.
                     name: "EN_ENTROPY_SRC_FW_OVER",
-                    value: false,
+                    value: true,
                 }
             ],
         }

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1970,13 +1970,15 @@
       name: chip_sw_csrng_known_answer_tests
       desc: '''Verify our ability to run known-answer tests in SW.
 
-            - Configure the software instance with the expected seed
-              (as per the NIST-specified test for CTR_DRBG operation)
-            - Perform several generate operations
+            - Configure the software instance with the expected seed (as per
+              the NIST-specified test for CTR_DRBG operation). Compare the
+              DRBG internal K and V state against the test vector expected
+              values.
+            - Perform generate operations as required by the test vector.
             - Compare the results to test expectations.
             '''
       milestone: V2
-      tests: []
+      tests: ["csrng_kat_test"]
     }
 
     // EDN (pre-verified IP) integration tests:

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -91,6 +91,17 @@ cc_library(
 )
 
 cc_library(
+    name = "csrng_testutils",
+    srcs = ["csrng_testutils.c"],
+    hdrs = ["csrng_testutils.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/testing/test_framework:check",
+    ],
+)
+
+cc_library(
     name = "entropy_testutils",
     srcs = ["entropy_testutils.c"],
     hdrs = ["entropy_testutils.h"],

--- a/sw/device/lib/testing/csrng_testutils.c
+++ b/sw/device/lib/testing/csrng_testutils.c
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/csrng_testutils.h"
+
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+
+void csrng_testutils_cmd_ready_wait(const dif_csrng_t *csrng) {
+  dif_csrng_cmd_status_t cmd_status;
+  do {
+    CHECK_DIF_OK(dif_csrng_get_cmd_interface_status(csrng, &cmd_status));
+    CHECK(cmd_status.kind != kDifCsrngCmdStatusError);
+  } while (cmd_status.kind != kDifCsrngCmdStatusReady);
+}
+
+void csrng_testutils_cmd_generate_run(const dif_csrng_t *csrng,
+                                      uint32_t *output, size_t output_len) {
+  csrng_testutils_cmd_ready_wait(csrng);
+  CHECK_DIF_OK(dif_csrng_generate_start(csrng, output_len));
+
+  dif_csrng_output_status_t output_status;
+  do {
+    CHECK_DIF_OK(dif_csrng_get_output_status(csrng, &output_status));
+  } while (!output_status.valid_data);
+
+  CHECK_DIF_OK(dif_csrng_generate_read(csrng, output, output_len));
+}

--- a/sw/device/lib/testing/csrng_testutils.h
+++ b/sw/device/lib/testing/csrng_testutils.h
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_CSRNG_TESTUTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_CSRNG_TESTUTILS_H_
+
+#include "sw/device/lib/dif/dif_csrng.h"
+
+/**
+ * Wait for the `csrng` instance command interface to be ready to accept
+ * commands. Aborts test execution if an error is found.
+ */
+void csrng_testutils_cmd_ready_wait(const dif_csrng_t *csrng);
+
+/**
+ * Runs CSRNG generate command.
+ *
+ * @param csrng A CSRNG handle.
+ * @param output Output buffer.
+ * @param output_len Number of words of entropy to write to output buffer.
+ */
+void csrng_testutils_cmd_generate_run(const dif_csrng_t *csrng,
+                                      uint32_t *output, size_t output_len);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_CSRNG_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -436,22 +436,27 @@ opentitan_functest(
 )
 
 opentitan_functest(
-    name = "csrng_smoketest",
-    srcs = ["csrng_smoketest.c"],
-    cw310 = cw310_params(
-        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-        tags = ["broken"],
-    ),
-    verilator = verilator_params(
-        tags = [
-            "broken",
-        ],
-    ),
+    name = "csrng_kat_test",
+    srcs = ["csrng_kat_test.c"],
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:csrng",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:csrng_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
+    name = "csrng_smoketest",
+    srcs = ["csrng_smoketest.c"],
+    deps = [
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:csrng_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/csrng_kat_test.c
+++ b/sw/device/tests/csrng_kat_test.c
@@ -1,0 +1,151 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/csrng_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kExpectedOutputLen = 16,
+};
+
+/**
+ * Checks the CSRNG internal state against `expected` values.
+ *
+ * @param csrng A CSRNG handle.
+ * @param expected Expected CSRNG internal state.
+ */
+static void check_internal_state(const dif_csrng_t *csrng,
+                                 const dif_csrng_internal_state_t *expected) {
+  csrng_testutils_cmd_ready_wait(csrng);
+  dif_csrng_internal_state_t got;
+  CHECK_DIF_OK(
+      dif_csrng_get_internal_state(csrng, kCsrngInternalStateIdSw, &got));
+
+  CHECK(got.instantiated == expected->instantiated);
+  CHECK(got.reseed_counter == expected->reseed_counter);
+  CHECK(got.fips_compliance == expected->fips_compliance);
+
+  CHECK_ARRAYS_EQ(got.v, expected->v, ARRAYSIZE(expected->v),
+                  "CSRNG internal V buffer mismatch.");
+
+  CHECK_ARRAYS_EQ(got.key, expected->key, ARRAYSIZE(expected->key),
+                  "CSRNG internal K buffer mismatch.");
+}
+
+/**
+ * CTR DRBG Known-Answer-Test (KAT) for INSTANTIATE command.
+ */
+static void fips_instantiate_kat(const dif_csrng_t *csrng) {
+  LOG_INFO("Instantiate KAT");
+
+  const dif_csrng_seed_material_t kEntropyInput = {
+      .seed_material = {0x73bec010, 0x9262474c, 0x16a30f76, 0x531b51de,
+                        0x2ee494e5, 0xdfec9db3, 0xcb7a879d, 0x5600419c,
+                        0xca79b0b0, 0xdda33b5c, 0xa468649e, 0xdf5d73fa},
+      .seed_material_len = 12,
+  };
+  csrng_testutils_cmd_ready_wait(csrng);
+
+  CHECK_DIF_OK(dif_csrng_instantiate(csrng, kDifCsrngEntropySrcToggleDisable,
+                                     &kEntropyInput));
+  const dif_csrng_internal_state_t kExpectedState = {
+      .reseed_counter = 1,
+      .v = {0x06b8f59e, 0x43c0b2c2, 0x21052502, 0x217b5214},
+      .key = {0x941709fd, 0xd8a25860, 0x861aecf3, 0x98a701a1, 0x0eb2c33b,
+              0x74c08fad, 0x632d5227, 0x8c52f901},
+      .instantiated = true,
+      .fips_compliance = false,
+  };
+  check_internal_state(csrng, &kExpectedState);
+}
+
+/**
+ * CTR DRBG Known-Answer-Test (KAT) for GENERATE command.
+ */
+static void fips_generate_kat(const dif_csrng_t *csrng) {
+  LOG_INFO("Generate KAT");
+
+  uint32_t got[kExpectedOutputLen];
+
+  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
+  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
+  const dif_csrng_internal_state_t kExpectedState = {
+      .reseed_counter = 3,
+      .v = {0xe73e3392, 0x7d2e92b1, 0x1a0bac9d, 0x53c78ac6},
+
+      .key = {0x66d1b85a, 0xc19d4dfd, 0x053b73e3, 0xe9dc0f90, 0x3f015bc8,
+              0x4436e5fd, 0x1cccc697, 0x1a1c6e5f},
+      .instantiated = true,
+      .fips_compliance = false,
+  };
+  check_internal_state(csrng, &kExpectedState);
+
+  // TODO(#13342): csrng does not provide a linear output order. For example,
+  // note the test vector output word order: 12,13,14,15 8,9,10,11 4,5,6,7
+  // 0,1,2,3.
+  const uint32_t kExpectedOutput[kExpectedOutputLen] = {
+      0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9, 0xdf82ab22, 0x771c619b,
+      0xd40fccb1, 0x87189e99, 0x510494b3, 0x64f7ac0c, 0x2581f391, 0x80b1dc2f,
+      0x793e01c5, 0x87b107ae, 0xdb17514c, 0xa43c41b7,
+  };
+
+  CHECK_ARRAYS_EQ(got, kExpectedOutput, kExpectedOutputLen,
+                  "Generate command KAT output mismatch");
+}
+
+/**
+ * Run CTR DRBG Known-Answer-Tests (KATs).
+ *
+ * Test vector sourced from NIST's CAVP website:
+ * https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/random-number-generators
+ *
+ * The number format in this docstring follows the CAVP format to simplify
+ * auditing of this test case.
+ *
+ * Test vector: CTR_DRBG AES-256 no DF.
+ *
+ * - EntropyInput =
+ * df5d73faa468649edda33b5cca79b0b05600419ccb7a879ddfec9db32ee494e5531b51de16a30f769262474c73bec010
+ * - Nonce = EMPTY
+ * - PersonalizationString = EMPTY
+ *
+ * Command: Instantiate
+ * - Key = 8c52f901632d522774c08fad0eb2c33b98a701a1861aecf3d8a25860941709fd
+ * - V   = 217b52142105250243c0b2c206b8f59e
+ *
+ * Command: Generate (first call):
+ * - Key = 72f4af5c93258eb3eeec8c0cacea6c1d1978a4fad44312725f1ac43b167f2d52
+ * - V   = e86f6d07dfb551cebad80e6bf6830ac4
+ *
+ * Command: Generate (second call):
+ * - Key = 1a1c6e5f1cccc6974436e5fd3f015bc8e9dc0f90053b73e3c19d4dfd66d1b85a
+ * - V   = 53c78ac61a0bac9d7d2e92b1e73e3392
+ * - ReturnedBits =
+ * d1c07cd95af8a7f11012c84ce48bb8cb87189e99d40fccb1771c619bdf82ab2280b1dc2f2581f39164f7ac0c510494b3a43c41b7db17514c87b107ae793e01c5
+ */
+void test_ctr_drbg_ctr0(const dif_csrng_t *csrng) {
+  CHECK_DIF_OK(dif_csrng_uninstantiate(csrng));
+  fips_instantiate_kat(csrng);
+  fips_generate_kat(csrng);
+}
+
+bool test_main(void) {
+  dif_csrng_t csrng;
+  CHECK_DIF_OK(dif_csrng_init(
+      mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
+  CHECK_DIF_OK(dif_csrng_configure(&csrng));
+
+  test_ctr_drbg_ctr0(&csrng);
+
+  return true;
+}

--- a/sw/device/tests/csrng_smoketest.c
+++ b/sw/device/tests/csrng_smoketest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_csrng.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/csrng_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -18,46 +19,13 @@ enum {
 };
 
 /**
- * Wait for the `csrng` instance command interface to be ready to accept
- * commands. Aborts test execution if an error is found.
- */
-static void wait_for_csrng_cmd_ready(const dif_csrng_t *csrng) {
-  dif_csrng_cmd_status_t cmd_status;
-  do {
-    CHECK_DIF_OK(dif_csrng_get_cmd_interface_status(csrng, &cmd_status));
-    CHECK(cmd_status.kind != kDifCsrngCmdStatusError);
-  } while (cmd_status.kind != kDifCsrngCmdStatusReady);
-}
-
-/**
- * Checks the CSRNG internal state against `expected` values.
+ * Run CTR DRBG Known-Answer-Tests (KATs).
  *
- * @param csrng A CSRNG handle.
- * @param expected Expected CSRNG internal state.
+ * This is a simplified version of csrng_kat_test. It skips CSRNG internal
+ * state checks to optimize runtime.
  */
-static void check_internal_state(const dif_csrng_t *csrng,
-                                 const dif_csrng_internal_state_t *expected) {
-  wait_for_csrng_cmd_ready(csrng);
-  dif_csrng_internal_state_t got;
-  CHECK_DIF_OK(
-      dif_csrng_get_internal_state(csrng, kCsrngInternalStateIdSw, &got));
-
-  CHECK(got.instantiated == expected->instantiated);
-  CHECK(got.reseed_counter == expected->reseed_counter);
-  CHECK(got.fips_compliance == expected->fips_compliance);
-
-  CHECK_ARRAYS_EQ(got.v, expected->v, ARRAYSIZE(expected->v),
-                  "CSRNG internal V buffer mismatch.");
-
-  CHECK_ARRAYS_EQ(got.key, expected->key, ARRAYSIZE(expected->key),
-                  "CSRNG internal K buffer mismatch.");
-}
-
-/**
- * CTR DRBG Known-Answer-Test (KAT) for INSTANTIATE command.
- */
-static void fips_instantiate_kat(const dif_csrng_t *csrng) {
-  LOG_INFO("Instantiate KAT");
+void test_ctr_drbg_ctr0_smoke(const dif_csrng_t *csrng) {
+  CHECK_DIF_OK(dif_csrng_uninstantiate(csrng));
 
   const dif_csrng_seed_material_t kEntropyInput = {
       .seed_material = {0x73bec010, 0x9262474c, 0x16a30f76, 0x531b51de,
@@ -65,76 +33,21 @@ static void fips_instantiate_kat(const dif_csrng_t *csrng) {
                         0xca79b0b0, 0xdda33b5c, 0xa468649e, 0xdf5d73fa},
       .seed_material_len = 12,
   };
-  wait_for_csrng_cmd_ready(csrng);
+  csrng_testutils_cmd_ready_wait(csrng);
   CHECK_DIF_OK(dif_csrng_instantiate(csrng, kDifCsrngEntropySrcToggleDisable,
                                      &kEntropyInput));
 
-  const dif_csrng_internal_state_t kExpectedState = {
-      .reseed_counter = 1,
-      .v = {0x06b8f59e, 0x43c0b2c2, 0x21052502, 0x217b5214},
-      .key = {0x941709fd, 0xd8a25860, 0x861aecf3, 0x98a701a1, 0x0eb2c33b,
-              0x74c08fad, 0x632d5227, 0x8c52f901},
-      .instantiated = true,
-      .fips_compliance = false,
-  };
-  check_internal_state(csrng, &kExpectedState);
-}
-
-/**
- * Runs CSRNG generate command.
- *
- * @param csrng A CSRNG handle.
- * @param output Output buffer.
- * @param output_len Number of words of entropy to write to output buffer.
- */
-static void run_generate_cmd(const dif_csrng_t *csrng, uint32_t *output,
-                             size_t output_len) {
-  wait_for_csrng_cmd_ready(csrng);
-  CHECK_DIF_OK(dif_csrng_generate_start(csrng, output_len));
-
-  dif_csrng_output_status_t output_status;
-  do {
-    CHECK_DIF_OK(dif_csrng_get_output_status(csrng, &output_status));
-  } while (!output_status.valid_data);
-
-  CHECK_DIF_OK(dif_csrng_generate_read(csrng, output, output_len));
-}
-
-/**
- * CTR DRBG Known-Answer-Test (KAT) for GENERATE command.
- */
-static void fips_generate_kat(const dif_csrng_t *csrng) {
-  LOG_INFO("Generate KAT");
-
   uint32_t got[kExpectedOutputLen];
-  run_generate_cmd(csrng, got, kExpectedOutputLen);
-  run_generate_cmd(csrng, got, kExpectedOutputLen);
-  const dif_csrng_internal_state_t kExpectedState = {
-      .reseed_counter = 3,
-      .v = {0xe73e3392, 0x7d2e92b1, 0x1a0bac9d, 0x53c78ac6},
-      .key = {0x66d1b85a, 0xc19d4dfd, 0x053b73e3, 0xe9dc0f90, 0x3f015bc8,
-              0x4436e5fd, 0x1cccc697, 0x1a1c6e5f},
-      .instantiated = true,
-      .fips_compliance = false,
-  };
-  check_internal_state(csrng, &kExpectedState);
+  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
+  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
 
   const uint32_t kExpectedOutput[kExpectedOutputLen] = {
-      0x793e01c5, 0x87b107ae, 0xdb17514c, 0xa43c41b7, 0x510494b3, 0x64f7ac0c,
-      0x2581f391, 0x80b1dc2f, 0xdf82ab22, 0x771c619b, 0xd40fccb1, 0x87189e99,
-      0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9};
-
+      0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9, 0xdf82ab22, 0x771c619b,
+      0xd40fccb1, 0x87189e99, 0x510494b3, 0x64f7ac0c, 0x2581f391, 0x80b1dc2f,
+      0x793e01c5, 0x87b107ae, 0xdb17514c, 0xa43c41b7,
+  };
   CHECK_ARRAYS_EQ(got, kExpectedOutput, kExpectedOutputLen,
                   "Generate command KAT output mismatch");
-}
-
-/**
- * Run CTR DRBG Known-Answer-Tests (KATs).
- */
-void test_ctr_drbg_ctr0(const dif_csrng_t *csrng) {
-  CHECK_DIF_OK(dif_csrng_uninstantiate(csrng));
-  fips_instantiate_kat(csrng);
-  fips_generate_kat(csrng);
 }
 
 bool test_main(void) {
@@ -143,7 +56,6 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
   CHECK_DIF_OK(dif_csrng_configure(&csrng));
 
-  test_ctr_drbg_ctr0(&csrng);
-
+  test_ctr_drbg_ctr0_smoke(&csrng);
   return true;
 }


### PR DESCRIPTION
Adds basic known answer test based on NIST CAVP test vector. This commit
also simplifies the csrng smoketest, and enables it on FPGA and
verilator test platforms.

Fixes #13223 