### PR TITLE
[top] autogen

### DIFF
--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -862,6 +862,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_regwen_7_qs)
@@ -1109,6 +1110,7 @@ module rstmgr_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[7].q),
+    .ds     (),
 
     // to register interface (read)
     .qs     (sw_rst_ctrl_n_7_qs)


### PR DESCRIPTION
Fixes the CI autogen check failure [here](https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=84688&view=logs&j=3a559e2a-952e-58d2-b8db-2e604a9266d7&t=6030b3ab-5c40-5687-1411-a3f06314fb10&l=180)

Signed-off-by: Alphan Ulusoy <alphan@google.com>