### PR TITLE
[top/dv] update test to pass for DV

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -46,6 +46,7 @@ package chip_env_pkg;
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
+  `include "chip_hier_macros.svh"
 
   // include auto-generated alert related parameters
   `include "autogen/chip_env_pkg__params.sv"

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -71,6 +71,7 @@ class chip_base_vseq #(
     cfg.mem_bkdr_util_h[Rom].randomize_mem();
     // Bring the chip out of reset.
     super.dut_init(reset_kind);
+    alert_ping_en_shorten();
     callback_vseq.post_dut_init();
   endtask
 
@@ -129,6 +130,18 @@ class chip_base_vseq #(
       p_sequencer.uart_tx_fifos[uart_idx].get(item);
       `uvm_info(`gfn, $sformatf("Received UART data over TX:\n%0h", item.data), UVM_HIGH)
       uart_tx_data_q.push_back(item.data);
+    end
+  endtask
+
+  // shorten alert ping timer enable wait time
+  task alert_ping_en_shorten();
+    string mask_path = {`DV_STRINGIFY(`ALERT_HANDLER_HIER),
+                        ".u_ping_timer.wait_cyc_mask_i"};
+    bit shorten_ping_en;
+    `uvm_info(`gfn, $sformatf("ping enable path: %s", mask_path), UVM_HIGH)
+    void'($value$plusargs("shorten_ping_en=%0d", shorten_ping_en));
+    if (shorten_ping_en) begin
+       `DV_CHECK_FATAL(uvm_hdl_force(mask_path, 16'h3F))
     end
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rstmgr_alert_info_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rstmgr_alert_info_vseq.sv
@@ -9,7 +9,9 @@ class chip_sw_rstmgr_alert_info_vseq extends chip_sw_base_vseq;
 
   virtual task body();
     super.body();
-    wait(cfg.sw_logger_vif.printed_log == "wait round3 3ms");
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Disable ping timer alert check");,
+                "timeout waiting for C side synchronization",
+                cfg.sw_test_timeout_ns)
     cfg.en_scb_ping_chk = 0;
   endtask
 endclass

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -707,6 +707,9 @@ module chip_earlgrey_asic (
   otp_ctrl_pkg::otp_ast_req_t otp_ctrl_otp_ast_pwr_seq;
   otp_ctrl_pkg::otp_ast_rsp_t otp_ctrl_otp_ast_pwr_seq_h;
 
+  // otp alert
+  ast_pkg::ast_dif_t otp_alert;
+
   logic usb_ref_pulse;
   logic usb_ref_val;
 
@@ -732,6 +735,7 @@ module chip_earlgrey_asic (
   prim_mubi_pkg::mubi4_t flash_bist_enable;
   logic flash_power_down_h;
   logic flash_power_ready_h;
+  ast_pkg::ast_dif_t flash_alert;
 
   // clock bypass req/ack
   prim_mubi_pkg::mubi4_t io_clk_byp_req;
@@ -836,9 +840,6 @@ module chip_earlgrey_asic (
 
   logic unused_pwr_clamp;
   assign unused_pwr_clamp = base_ast_pwr.pwr_clamp;
-
-  ast_pkg::ast_dif_t flash_alert;
-  ast_pkg::ast_dif_t otp_alert;
   logic ast_init_done;
   logic usb_diff_rx_obs;
 

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -669,6 +669,9 @@ module chip_earlgrey_cw310 #(
   otp_ctrl_pkg::otp_ast_req_t otp_ctrl_otp_ast_pwr_seq;
   otp_ctrl_pkg::otp_ast_rsp_t otp_ctrl_otp_ast_pwr_seq_h;
 
+  // otp alert
+  ast_pkg::ast_dif_t otp_alert;
+
   logic usb_ref_pulse;
   logic usb_ref_val;
 
@@ -694,6 +697,7 @@ module chip_earlgrey_cw310 #(
   prim_mubi_pkg::mubi4_t flash_bist_enable;
   logic flash_power_down_h;
   logic flash_power_ready_h;
+  ast_pkg::ast_dif_t flash_alert;
 
   // clock bypass req/ack
   prim_mubi_pkg::mubi4_t io_clk_byp_req;
@@ -1015,6 +1019,7 @@ module chip_earlgrey_cw310 #(
     .flash_power_down_h_i         ( 1'b0                  ),
     .flash_power_ready_h_i        ( 1'b1                  ),
     .flash_obs_o                  ( flash_obs             ),
+    .flash_alert_o                ( flash_alert           ),
     .io_clk_byp_req_o             ( io_clk_byp_req        ),
     .io_clk_byp_ack_i             ( io_clk_byp_ack        ),
     .all_clk_byp_req_o            ( all_clk_byp_req       ),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1299,6 +1299,7 @@ opentitan_functest(
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/dif:rv_timer",
         "//sw/device/lib/dif:spi_host",

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -486,6 +486,9 @@ module chip_${top["name"]}_${target["name"]} (
   otp_ctrl_pkg::otp_ast_req_t otp_ctrl_otp_ast_pwr_seq;
   otp_ctrl_pkg::otp_ast_rsp_t otp_ctrl_otp_ast_pwr_seq_h;
 
+  // otp alert
+  ast_pkg::ast_dif_t otp_alert;
+
   logic usb_ref_pulse;
   logic usb_ref_val;
 
@@ -511,6 +514,7 @@ module chip_${top["name"]}_${target["name"]} (
   prim_mubi_pkg::mubi4_t flash_bist_enable;
   logic flash_power_down_h;
   logic flash_power_ready_h;
+  ast_pkg::ast_dif_t flash_alert;
 
   // clock bypass req/ack
   prim_mubi_pkg::mubi4_t io_clk_byp_req;
@@ -621,9 +625,6 @@ module chip_${top["name"]}_${target["name"]} (
 
   logic unused_pwr_clamp;
   assign unused_pwr_clamp = base_ast_pwr.pwr_clamp;
-
-  ast_pkg::ast_dif_t flash_alert;
-  ast_pkg::ast_dif_t otp_alert;
   logic ast_init_done;
   logic usb_diff_rx_obs;
 
@@ -1105,6 +1106,7 @@ module chip_${top["name"]}_${target["name"]} (
     .flash_power_down_h_i         ( 1'b0                  ),
     .flash_power_ready_h_i        ( 1'b1                  ),
     .flash_obs_o                  ( flash_obs             ),
+    .flash_alert_o                ( flash_alert           ),
     .io_clk_byp_req_o             ( io_clk_byp_req        ),
     .io_clk_byp_ack_i             ( io_clk_byp_ack        ),
     .all_clk_byp_req_o            ( all_clk_byp_req       ),


### PR DESCRIPTION
- remove usage of ping timeout. This is because ping timeout
  can actually manifest as normal alerts when the ping timeout
  length is set very short.  This makes it difficult for the test
  to match an exact value.  On FPGA for example this turned into
  over 4000 events.

- fix minor bugs with alert field dump disaggregation. This really
  should be made into its own testutil so that it can be re-used.
  That will be done as a separate commit.  There were some minor issues
  with how the upper portion was calculated.

- add print alert cause for easier debug.

- shorten ping enable time to speed up test.