### PR TITLE
[otbn,dv] Fix reference to start secure wipe

### DIFF
--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -437,7 +437,7 @@ module otbn_top_sim (
     end
   end
   always_ff @(negedge IO_CLK or negedge IO_RST_N) begin
-    if (IO_RST_N && u_otbn_core.u_otbn_controller.start_secure_wipe_o) begin
+    if (IO_RST_N && u_otbn_core.u_otbn_controller.start_secure_wipe) begin
       // When OTBN starts a secure wipe this indicates the program has either terminated (executed
       // 'ecall') or hit an error, either way the execution is done. The state must be dumped as the
       // secure wipe is started so we can dump the final execution state not the all zeros state


### PR DESCRIPTION
Ran into this error during an OTBN smoke test on CI because `start_secure_wipe_o` does not exist. Fixed this with the help of @ctopal