### PR TITLE
[dv,chip,sva] Fix SVA checking pwrmgr to rstmgs reset requests

### DIFF
--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
@@ -41,13 +41,13 @@ interface pwrmgr_rstmgr_sva_if
   localparam int MAX_RST_CYCLES = 4;
   `define RST_CYCLES ##[MIN_RST_CYCLES:MAX_RST_CYCLES]
 
-  // output reset cycle with a clk enalbe disable
+  // output reset cycle with a clk enable disable
   localparam int MIN_MAIN_RST_CYCLES = 0;
   localparam int MAX_MAIN_RST_CYCLES = pwrmgr_clk_ctrl_common_pkg::MAIN_CLK_DELAY_MAX;
   `define MAIN_RST_CYCLES ##[MIN_MAIN_RST_CYCLES:MAX_MAIN_RST_CYCLES]
 
   localparam int MIN_ESC_RST_CYCLES = 0;
-  localparam int MAX_ESC_RST_CYCLES = pwrmgr_clk_ctrl_common_pkg::ESC_CLK_DELAY_MAX * 8;
+  localparam int MAX_ESC_RST_CYCLES = 4;
   `define ESC_RST_CYCLES ##[MIN_ESC_RST_CYCLES:MAX_ESC_RST_CYCLES]
 
   bit disable_sva;
@@ -137,12 +137,12 @@ interface pwrmgr_rstmgr_sva_if
   `ASSERT(EscRstOn_A,
           $rose(
               esc_rst_req_i
-          ) |-> `ESC_RST_CYCLES rstreqs[ResetEscIdx], clk_i,
+          ) |-> `ESC_RST_CYCLES rstreqs[ResetEscIdx], clk_slow_i,
           reset_or_disable || !check_rstreqs_en)
   `ASSERT(EscRstOff_A,
           $fell(
               esc_rst_req_i
-          ) |-> `ESC_RST_CYCLES !rstreqs[ResetEscIdx], clk_i,
+          ) |-> `ESC_RST_CYCLES !rstreqs[ResetEscIdx], clk_slow_i,
           reset_or_disable || !check_rstreqs_en)
   // Software initiated resets are not sent to rstmgr since they originated there.
   `undef RST_CYCLES

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -2,16 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base_vseq #(
-    .CFG_T               (chip_env_cfg),
-    .RAL_T               (RAL_T),
-    .COV_T               (chip_env_cov),
-    .VIRTUAL_SEQUENCER_T (chip_virtual_sequencer)
-  );
+class chip_base_vseq #(
+  type RAL_T = chip_ral_pkg::chip_reg_block
+) extends cip_base_vseq #(
+  .CFG_T              (chip_env_cfg),
+  .RAL_T              (RAL_T),
+  .COV_T              (chip_env_cov),
+  .VIRTUAL_SEQUENCER_T(chip_virtual_sequencer)
+);
   `uvm_object_utils(chip_base_vseq)
 
   // knobs to enable pre_start routines
-  bit do_strap_pins_init = 1'b1; // initialize the strap
+  bit do_strap_pins_init = 1'b1;  // initialize the strap
 
   // knobs to enable post_start routines
 
@@ -33,7 +35,6 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
   task post_start();
     do_clear_all_interrupts = 0;
     super.post_start();
-    set_sva_check_rstreqs(0);
   endtask
 
   virtual task apply_reset(string kind = "HARD");
@@ -136,9 +137,8 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
     // Use otbn mod_exp implementation for signature
     // verification. See the definition of `hardened_bool_t` in
     // sw/device/lib/base/hardened.h.
-    cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgUseSwRsaVerifyOffset,
-                                     32'h1d4);
-  endfunction // initialize_otp_sig_verify
+    cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgUseSwRsaVerifyOffset, 32'h1d4);
+  endfunction : initialize_otp_sig_verify
 
   // Initialize the OTP creator SW cfg region with AST configuration data.
   virtual function void initialize_otp_creator_sw_cfg_ast_cfg();
@@ -152,28 +152,30 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
     // registers to be programmed.
     `DV_CHECK_EQ_FATAL(otp_ctrl_reg_pkg::CreatorSwCfgAstCfgSize, ast_pkg::AstRegsNum * 4)
     foreach (cfg.creator_sw_cfg_ast_cfg_data[i]) begin
-      `uvm_info(`gfn, $sformatf({"OTP: Preloading creator_sw_cfg_ast_cfg_data[%0d] with 0x%0h ",
-                                 "via backdoor"}, i, cfg.creator_sw_cfg_ast_cfg_data[i]),
-                UVM_MEDIUM)
-      cfg.mem_bkdr_util_h[Otp].write32(
-          otp_ctrl_reg_pkg::CreatorSwCfgAstCfgOffset + i * 4, cfg.creator_sw_cfg_ast_cfg_data[i]);
+      `uvm_info(`gfn, $sformatf(
+                "OTP: Preloading creator_sw_cfg_ast_cfg_data[%0d] with 0x%0h via backdoor",
+                i,
+                cfg.creator_sw_cfg_ast_cfg_data[i]
+                ), UVM_MEDIUM)
+      cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgAstCfgOffset + i * 4,
+                                       cfg.creator_sw_cfg_ast_cfg_data[i]);
     end
   endfunction
 
   task test_mem_rw(uvm_mem mem, int max_access = 2048);
     uvm_reg_data_t rdata;
-    int wdata, exp_data[$]; // cause all data is 32bit wide in this test
+    int wdata, exp_data[$];  // Because all data is 32bit wide in this test.
     int offmax = mem.get_size() - 1;
     int sizemax = offmax / 4;
     int st, sz;
     int byte_addr;
     st = $urandom_range(0, offmax);
-    // set the maximum transaction
+    // Set the maximum transaction.
     if (sizemax > max_access) sizemax = max_access;
 
     sz = $urandom_range(1, sizemax);
-    `uvm_info(`gfn, $sformatf("Mem write to %s  offset:%0d size: %0d",
-                              mem.get_full_name(), st, sz), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("Mem write to %s  offset:%0d size: %0d", mem.get_full_name(), st, sz),
+              UVM_MEDIUM)
 
     for (int i = 0; i < sz; ++i) begin
       wdata = $urandom();
@@ -181,26 +183,23 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
 
       if (mem.get_access() == "RW") begin
         mem_wr(.ptr(mem), .offset((st + i) % (offmax + 1)), .data(wdata));
-      end else begin // if (mem.get_access() == "RW")
+      end else begin  // if (mem.get_access() == "RW")
         // deposit random data to rom
         byte_addr = ((st + i) % (offmax + 1)) * 4;
-        cfg.mem_bkdr_util_h[Rom].rom_encrypt_write32_integ(.addr(byte_addr), .data(wdata),
-                                                           .key(RndCnstRomCtrlScrKey),
-                                                           .nonce(RndCnstRomCtrlScrNonce),
-                                                           .scramble_data(1));
+        cfg.mem_bkdr_util_h[Rom].rom_encrypt_write32_integ(
+            .addr(byte_addr), .data(wdata), .key(RndCnstRomCtrlScrKey),
+            .nonce(RndCnstRomCtrlScrNonce), .scramble_data(1));
       end
     end
 
-    `uvm_info(`gfn, $sformatf("write to %s is complete, read back start...",
-                                mem.get_full_name()), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("write to %s is complete, read back start...", mem.get_full_name()),
+              UVM_MEDIUM)
     for (int i = 0; i < sz; ++i) begin
       mem_rd(.ptr(mem), .offset((st + i) % (offmax + 1)), .data(rdata));
-      `DV_CHECK_EQ((int'(rdata)), exp_data[i],
-                   $sformatf("read back check for offset:%0d failed",
-                             ((st + i) % (offmax + 1))))
+      `DV_CHECK_EQ((int'(rdata)), exp_data[i], $sformatf(
+                   "read back check for offset:%0d failed", ((st + i) % (offmax + 1))))
     end
-    `uvm_info(`gfn, $sformatf("read check from %s is complete",
-                              mem.get_full_name()), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("read check from %s is complete", mem.get_full_name()), UVM_MEDIUM)
 
   endtask : test_mem_rw
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_sleep_all_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_sleep_all_reset_vseq.sv
@@ -98,13 +98,7 @@ class chip_sw_random_sleep_all_reset_vseq extends chip_sw_base_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    set_sva_check_rstreqs(0);
   endtask
-
-  virtual function void set_sva_check_rstreqs(bit enable);
-    `uvm_info(`gfn, $sformatf("Remote setting check_rstreqs_en=%b", enable), UVM_MEDIUM)
-    uvm_config_db#(bit)::set(null, "pwrmgr_rstmgr_sva_if", "check_rstreqs_en", enable);
-  endfunction
 
   task execute_reset();
     `uvm_info(`gfn, "wait for low power entry", UVM_MEDIUM)


### PR DESCRIPTION
The escalation request assertion needs to use the slow clock, since using
other clocks makes it prone to timing out.
Remove calls to disable these assertions, since they don't fail with this
change.
Make many formatting changes for verible.

Signed-off-by: Guillermo Maturana <maturana@google.com>