### PR TITLE
[sw,tests] Verify sysrst_ctrl outputs can be set

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1554,7 +1554,7 @@
               immediately reflect at the outputs, if not intercepted / debounced by sysrst_ctrl.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_sysrst_ctrl_outputs"]
     }
     {
       name: chip_sw_sysrst_ctrl_in_irq

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -592,6 +592,12 @@
       run_opts: ["+sw_test_timeout_ns=36000000"]
     }
     {
+      name: chip_sw_sysrst_ctrl_outputs
+      uvm_test_seq: chip_sw_sysrst_ctrl_outputs_vseq
+      sw_images: ["sw/device/tests/sim_dv/sysrst_ctrl_outputs_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_aon_timer_irq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/aon_timer_irq_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -55,6 +55,7 @@ filesets:
       - seq_lib/chip_sw_uart_rand_baudrate_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_inputs_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -66,6 +66,22 @@ class chip_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get pwrb_in_vif from uvm_config_db")
     end
 
+    if (!uvm_config_db#(virtual pins_if #(1))::get(this, "", "ec_rst_vif", cfg.ec_rst_vif)) begin
+      `uvm_fatal(`gfn, "failed to get ec_rst_vif from uvm_config_db")
+    end
+
+    if (!uvm_config_db#(virtual pins_if #(1))::get(
+            this, "", "flash_wp_vif", cfg.flash_wp_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get flash_wp_vif from uvm_config_db")
+    end
+
+    if (!uvm_config_db#(virtual pins_if #(8))::get(
+            this, "", "sysrst_ctrl_vif", cfg.sysrst_ctrl_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get sysrst_ctrl_vif from uvm_config_db")
+    end
+
     for (chip_mem_e mem = mem.first(), int i = 0; i < mem.num(); mem = mem.next(), i++) begin
       string inst = $sformatf("mem_bkdr_util[%0s]", mem.name());
       bit is_invalid;

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -28,6 +28,9 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   virtual pins_if#(1) pinmux_wkup_vif;
   virtual pins_if#(1) por_rstn_vif;
   virtual pins_if#(1) pwrb_in_vif;
+  virtual pins_if#(1) ec_rst_vif;
+  virtual pins_if#(1) flash_wp_vif;
+  virtual pins_if#(8) sysrst_ctrl_vif;
 
   // pwrmgr probe interface
   virtual pwrmgr_low_power_if   pwrmgr_low_power_vif;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv
@@ -1,0 +1,123 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_sysrst_ctrl_outputs_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_sysrst_ctrl_outputs_vseq)
+
+  `uvm_object_new
+
+  localparam time AON_CYCLE_PERIOD = 5us;
+  localparam bit [7:0] OUTPUT_ALL_SET = 8'b11111111;
+  localparam bit [7:0] OUTPUT_NONE_SET = 8'b00000000;
+  localparam bit [3:0] LOOPBACK_ALL_SET = 4'b1111;
+  localparam bit [3:0] LOOPBACK_PARTIAL_SET = 4'b1010;
+  localparam uint LOOPBACK_PATTERN_LENGTH = 16;
+
+  typedef enum bit [7:0] {
+    PHASE_INITIAL               = 0,
+    PHASE_LOOPBACK              = 1,
+    PHASE_OVERRIDE_SETUP        = 2,
+    PHASE_OVERRIDE_ZEROS        = 3,
+    PHASE_OVERRIDE_ONES         = 4,
+    PHASE_OVERRIDE_RELEASE      = 5,
+    PHASE_OVERRIDE_AND_LOOPBACK = 6,
+    PHASE_DONE                  = 7
+  } test_phases_e;
+
+  logic [3:0] loopback_pad_read_values;
+  logic [7:0] output_pad_read_values;
+
+  virtual function void write_test_phase(input test_phases_e phase);
+    sw_symbol_backdoor_overwrite("kTestPhase", {<<8{phase}});
+  endfunction
+
+  virtual function void set_loopback_pads(input bit [3:0] pad_values);
+    cfg.sysrst_ctrl_vif.drive_pin(0, pad_values[0]);
+    cfg.sysrst_ctrl_vif.drive_pin(1, pad_values[1]);
+    cfg.sysrst_ctrl_vif.drive_pin(2, pad_values[2]);
+    cfg.pwrb_in_vif.drive_pin(0, pad_values[3]);
+  endfunction
+
+  virtual function void read_loopback_pads();
+    loopback_pad_read_values[0] = cfg.sysrst_ctrl_vif.sample_pin(3);
+    loopback_pad_read_values[1] = cfg.sysrst_ctrl_vif.sample_pin(6);
+    loopback_pad_read_values[2] = cfg.sysrst_ctrl_vif.sample_pin(7);
+    loopback_pad_read_values[3] = cfg.sysrst_ctrl_vif.sample_pin(4);
+  endfunction
+
+  virtual task read_output_pads();
+    #(3 * AON_CYCLE_PERIOD);
+    output_pad_read_values[0] = cfg.sysrst_ctrl_vif.sample_pin(3);
+    output_pad_read_values[1] = cfg.sysrst_ctrl_vif.sample_pin(6);
+    output_pad_read_values[2] = cfg.sysrst_ctrl_vif.sample_pin(7);
+    output_pad_read_values[3] = cfg.sysrst_ctrl_vif.sample_pin(4);
+    output_pad_read_values[4] = cfg.sysrst_ctrl_vif.sample_pin(5);
+    output_pad_read_values[5] = cfg.pinmux_wkup_vif.sample_pin(0);
+    output_pad_read_values[6] = cfg.ec_rst_vif.sample_pin(0);
+    output_pad_read_values[7] = cfg.flash_wp_vif.sample_pin(0);
+  endtask
+
+  virtual task sync_with_sw();
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+  endtask
+
+  virtual task check_loopback_pattern();
+    for (int i = 0; i < LOOPBACK_PATTERN_LENGTH; i++) begin
+      set_loopback_pads(i);
+      #1;
+      read_loopback_pads();
+      `DV_CHECK_EQ_FATAL(loopback_pad_read_values, i);
+    end
+  endtask
+
+  virtual task check_loopback_single();
+    set_loopback_pads(LOOPBACK_PARTIAL_SET);
+    #1;
+    read_loopback_pads();
+    `DV_CHECK_EQ_FATAL(loopback_pad_read_values, LOOPBACK_PARTIAL_SET);
+  endtask
+
+  virtual task body();
+    super.body();
+
+    // TODO(lowRISC/opentitan:#13373): Revisit pad assignments.
+    // pinmux_wkup_vif (at Iob7) is re-used for PinZ3WakeupOut
+    // due to lack of unused pins. Disable the default drive
+    // to this pin.
+    cfg.pinmux_wkup_vif.drive_en_pin(0, 0);
+
+    write_test_phase(PHASE_INITIAL);
+    sync_with_sw();
+
+    write_test_phase(PHASE_LOOPBACK);
+    sync_with_sw();
+    check_loopback_pattern();
+
+    write_test_phase(PHASE_OVERRIDE_SETUP);
+    sync_with_sw();
+
+    write_test_phase(PHASE_OVERRIDE_ZEROS);
+    sync_with_sw();
+    read_output_pads();
+    `DV_CHECK_EQ_FATAL(output_pad_read_values, OUTPUT_NONE_SET);
+
+    write_test_phase(PHASE_OVERRIDE_ONES);
+    sync_with_sw();
+    read_output_pads();
+    `DV_CHECK_EQ_FATAL(output_pad_read_values, OUTPUT_ALL_SET);
+
+    write_test_phase(PHASE_OVERRIDE_RELEASE);
+    sync_with_sw();
+    check_loopback_single();
+
+    write_test_phase(PHASE_OVERRIDE_AND_LOOPBACK);
+    sync_with_sw();
+    read_loopback_pads();
+    `DV_CHECK_EQ_FATAL(loopback_pad_read_values, LOOPBACK_ALL_SET);
+
+    write_test_phase(PHASE_DONE);
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -20,6 +20,7 @@
 `include "chip_sw_uart_rand_baudrate_vseq.sv"
 `include "chip_sw_sysrst_ctrl_inputs_vseq.sv"
 `include "chip_sw_sysrst_ctrl_reset_vseq.sv"
+`include "chip_sw_sysrst_ctrl_outputs_vseq.sv"
 `include "chip_sw_gpio_smoke_vseq.sv"
 `include "chip_sw_gpio_vseq.sv"
 `include "chip_sw_flash_ctrl_lc_rw_en_vseq.sv"

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -100,6 +100,21 @@ module tb;
   pins_if #(1) pinmux_wkup_if(.pins(pinmux_wakeup));
   assign (weak0, weak1) pinmux_wakeup = 0;
 
+  // ec_rst if
+  wire ec_rst_l;
+  pins_if #(1) ec_rst_if(.pins(ec_rst_l));
+  assign (weak0, weak1) ec_rst_l = 1;
+
+  // flash_wp if
+  wire flash_wp_l;
+  pins_if #(1) flash_wp_if(.pins(flash_wp_l));
+  assign (weak0, weak1) flash_wp_l = 1;
+
+  // sysrst_ctrl_if
+  wire [7:0] sysrst_ctrl_pins;
+  pins_if #(8) sysrst_ctrl_if(.pins(sysrst_ctrl_pins));
+  assign (weak0, weak1) sysrst_ctrl_pins = '1;
+
   // TODO: Replace with correct interfaces once
   // pinmux/padring and pinout have been updated.
   wire [16:0] tie_off;
@@ -169,13 +184,13 @@ module tb;
     .IOB0(gpio_pins[9]),   // MIO 9
     .IOB1(gpio_pins[10]),  // MIO 10
     .IOB2(gpio_pins[11]),  // MIO 11
-    .IOB3(tie_off[0]),     // MIO 12
+    .IOB3(sysrst_ctrl_pins[0]), // MIO 12
     .IOB4(uart_rx[1]),     // MIO 13
     .IOB5(uart_tx[1]),     // MIO 14
-    .IOB6(tie_off[1]),     // MIO 15
-    .IOB7(pinmux_wakeup),  // MIO 16
-    .IOB8(tie_off[2]),     // MIO 17
-    .IOB9(tie_off[3]),     // MIO 18
+    .IOB6(sysrst_ctrl_pins[1]),     // MIO 15
+    .IOB7(pinmux_wakeup),           // MIO 16
+    .IOB8(sysrst_ctrl_pins[2]),     // MIO 17
+    .IOB9(sysrst_ctrl_pins[3]),     // MIO 18
     .IOB10(iob10),         // MIO 19
     .IOB11(iob11),         // MIO 20
     .IOB12(iob12),         // MIO 21
@@ -187,9 +202,9 @@ module tb;
     .IOC4(ioc4),           // MIO 26
     .IOC5(tap_straps[1]),  // MIO 27
     .IOC6(clk),            // MIO 28 - external clock fed in at a fixed position
-    .IOC7(tie_off[4]),     // MIO 29
-    .IOC8(tap_straps[0]),  // MIO 30
-    .IOC9(tie_off[5]),     // MIO 31
+    .IOC7(sysrst_ctrl_pins[4]),    // MIO 29
+    .IOC8(tap_straps[0]),          // MIO 30
+    .IOC9(sysrst_ctrl_pins[5]),    // MIO 31
     .IOC10(ioc10),         // MIO 32
     .IOC11(ioc11),         // MIO 33
     .IOC12(ioc12),         // MIO 34
@@ -199,15 +214,15 @@ module tb;
     .IOR2(jtag_tdi),       // MIO 37
     .IOR3(jtag_tck),       // MIO 38
     .IOR4(jtag_trst_n),    // MIO 39
-    .IOR5(tie_off[6]),     // MIO 40
-    .IOR6(tie_off[7]),     // MIO 41
-    .IOR7(uart_rx[2]),     // MIO 42
-    .IOR8(tie_off[8]),     // MIO 43, Dedicated sysrst_ctrl output (ec_rst_l)
-    .IOR9(tie_off[9]),     // MIO 44, Dedicated sysrst_ctrl output (pwrb_out)
-    .IOR10(uart_tx[2]),    // MIO 45
-    .IOR11(uart_rx[3]),    // MIO 46
-    .IOR12(uart_tx[3]),    // MIO 47
-    .IOR13(sysrst_ctrl_pwrb),  // MIO 48
+    .IOR5(sysrst_ctrl_pins[6]),     // MIO 40
+    .IOR6(sysrst_ctrl_pins[7]),     // MIO 41
+    .IOR7(uart_rx[2]),       // MIO 42
+    .IOR8(ec_rst_l),         // MIO 43, Dedicated sysrst_ctrl output (ec_rst_l)
+    .IOR9(flash_wp_l),       // MIO 44, Dedicated sysrst_ctrl output (flash_wp_l)
+    .IOR10(uart_tx[2]),      // MIO 45
+    .IOR11(uart_rx[3]),      // MIO 46
+    .IOR12(uart_tx[3]),      // MIO 47
+    .IOR13(sysrst_ctrl_pwrb), // MIO 48
     // DCD (VCC domain)
     .CC1(tie_off[10]),
     .CC2(tie_off[11]),
@@ -357,6 +372,17 @@ module tb;
 
     uvm_config_db#(virtual pins_if #(1))::set(
        null, "*.env", "pwrb_in_vif", pwrb_in_if);
+
+    uvm_config_db#(virtual pins_if #(1))::set(
+        null, "*.env", "ec_rst_vif", ec_rst_if);
+
+    uvm_config_db#(virtual pins_if #(1))::set(
+        null, "*.env", "flash_wp_vif", flash_wp_if);
+
+    uvm_config_db#(virtual pins_if #(8))::set(
+        null, "*.env", "sysrst_ctrl_vif", sysrst_ctrl_if);
+
+
 
     // temp disable pinmux assertion AonWkupReqKnownO_A because driving X in spi_device.sdi and
     // WkupPadSel choose IO_DPS1 in MIO will trigger this assertion

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -162,6 +162,21 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "sysrst_ctrl_outputs_test",
+    srcs = ["sysrst_ctrl_outputs_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "keymgr_key_derivation_test",
     srcs = ["keymgr_key_derivation_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/sysrst_ctrl_outputs_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_outputs_test.c
@@ -1,0 +1,175 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_pinmux_t pinmux;
+static dif_sysrst_ctrl_t sysrst_ctrl;
+
+const uint32_t kTestPhaseTimeoutUsec = 100;
+
+enum {
+  kTestPhaseSetup = 0,
+  kTestPhaseLoopback = 1,
+  kTestPhaseOverrideSetup = 2,
+  kTestPhaseOverrideZeros = 3,
+  kTestPhaseOverrideOnes = 4,
+  kTestPhaseOverrideRelease = 5,
+  kTestPhaseOverrideAndLoopback = 6,
+  kTestPhaseDone = 7,
+};
+
+enum {
+  kAllZero = 0x0,
+  kAllOne = 0xff,
+  kLoopbackPartial = 0x5,
+  kNumMioInputs = 0x4,
+  kNumMioOutputs = 0x6,
+  kOutputNumPads = 0x8,
+};
+
+static const dif_pinmux_index_t kPeripheralInputs[] = {
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey0In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey1In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey2In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonPwrbIn,
+};
+
+static const dif_pinmux_index_t kInputPads[] = {
+    kTopEarlgreyPinmuxInselIob3,
+    kTopEarlgreyPinmuxInselIob6,
+    kTopEarlgreyPinmuxInselIob8,
+    kTopEarlgreyPinmuxInselIor13,
+};
+
+static const dif_pinmux_index_t kPeripheralOutputs[] = {
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonKey0Out,
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonKey1Out,
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonKey2Out,
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonPwrbOut,
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonBatDisable,
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonZ3Wakeup,
+};
+
+static const dif_pinmux_index_t kOutputPads[] = {
+    kTopEarlgreyPinmuxMioOutIob9, kTopEarlgreyPinmuxMioOutIor5,
+    kTopEarlgreyPinmuxMioOutIor6, kTopEarlgreyPinmuxMioOutIoc7,
+    kTopEarlgreyPinmuxMioOutIoc9, kTopEarlgreyPinmuxMioOutIob7,
+};
+
+static const dif_sysrst_ctrl_pin_t kSysrstCtrlOutputs[] = {
+    kDifSysrstCtrlPinKey0Out,           kDifSysrstCtrlPinKey1Out,
+    kDifSysrstCtrlPinKey2Out,           kDifSysrstCtrlPinPowerButtonOut,
+    kDifSysrstCtrlPinBatteryDisableOut, kDifSysrstCtrlPinZ3WakeupOut,
+    kDifSysrstCtrlPinEcResetInOut,      kDifSysrstCtrlPinFlashWriteProtectInOut,
+};
+
+// Test phase written by testbench.
+static volatile const uint8_t kTestPhase = 0;
+
+// Sets up the pinmux to assign input and output pads
+// to the sysrst_ctrl peripheral as required.
+static void pinmux_setup(void) {
+  for (int i = 0; i < kNumMioInputs; ++i) {
+    CHECK_DIF_OK(
+        dif_pinmux_input_select(&pinmux, kPeripheralInputs[i], kInputPads[i]));
+  }
+  for (int i = 0; i < kNumMioOutputs; ++i) {
+    CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kOutputPads[i],
+                                          kPeripheralOutputs[i]));
+  }
+}
+
+// Waits for the kTestPhase variable to be changed by a backdoor overwrite
+// from the testbench in chip_sw_sysrst_ctrl_outputs_vseq.sv. This will
+// indicate that the testbench is ready to proceed with the
+// next phase of the test.
+static void wait_next_test_phase(void) {
+  uint8_t current_phase = kTestPhase;
+  // Set WFI status for testbench synchronization,
+  // no actual WFI instruction is issued.
+  test_status_set(kTestStatusInWfi);
+  test_status_set(kTestStatusInTest);
+  IBEX_SPIN_FOR(current_phase != kTestPhase, kTestPhaseTimeoutUsec);
+  LOG_INFO("Test phase = %0d", kTestPhase);
+}
+
+// Enables the sysrst_ctrl overrides for the output pins. Allows
+// both low and high override values.
+static void override_setup(uint8_t pins_to_override) {
+  for (int i = 0; i < kOutputNumPads; ++i) {
+    if ((pins_to_override >> i) & 0x1) {
+      CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_enabled(
+          &sysrst_ctrl, kSysrstCtrlOutputs[i], kDifToggleEnabled));
+      CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_allowed(
+          &sysrst_ctrl, kSysrstCtrlOutputs[i], true, true));
+    }
+  }
+}
+
+// Disables the overrides. Allows the outputs to pass-through the
+// values from the relevant input pins.
+static void override_disable(void) {
+  for (int i = 0; i < kOutputNumPads; ++i) {
+    CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_enabled(
+        &sysrst_ctrl, kSysrstCtrlOutputs[i], kDifToggleDisabled));
+  }
+}
+
+// Sets the values of the output overrides as required.
+static void set_output_overrides(uint8_t override_value) {
+  for (int i = 0; i < kOutputNumPads; ++i) {
+    CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_set_override(
+        &sysrst_ctrl, kSysrstCtrlOutputs[i], (override_value >> i) & 0x1));
+  }
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
+      &sysrst_ctrl));
+
+  while (kTestPhase < kTestPhaseDone) {
+    switch (kTestPhase) {
+      case kTestPhaseSetup:
+        pinmux_setup();
+        break;
+      case kTestPhaseLoopback:
+        break;
+      case kTestPhaseOverrideSetup:
+        override_setup(kAllOne);
+        break;
+      case kTestPhaseOverrideZeros:
+        set_output_overrides(kAllZero);
+        break;
+      case kTestPhaseOverrideOnes:
+        set_output_overrides(kAllOne);
+        break;
+      case kTestPhaseOverrideRelease:
+        override_disable();
+        break;
+      case kTestPhaseOverrideAndLoopback:
+        override_setup(kLoopbackPartial);
+        set_output_overrides(kLoopbackPartial);
+        break;
+      default:
+        LOG_ERROR("Unexpected test phase : %d", kTestPhase);
+        break;
+    }
+    wait_next_test_phase();
+  }
+  return true;
+}


### PR DESCRIPTION
For test:
chip_sw_sysrst_ctrl_outputs

Checks that sysrst_ctrl loops back signals from input to output without delay.
Checks that output pins can be overriden with known values when configured or otherwise loops back the input.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>