### PR TITLE
[otbn,rtl] Connect insn addr mismatch to escalate

### DIFF
--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -577,7 +577,7 @@ module otbn_core
       mubi4_or_hi(escalate_en_i,
                   mubi4_bool_to_mubi(|{start_stop_fatal_error, urnd_all_zero, predec_error,
                                        rf_base_rf_err, lsu_rdata_err, insn_fetch_err,
-                                       non_controller_reg_intg_violation}));
+                                       non_controller_reg_intg_violation, insn_addr_err}));
 
   assign controller_recov_escalate_en =
       mubi4_bool_to_mubi(|{rnd_rep_err, rnd_fips_err});
@@ -587,7 +587,7 @@ module otbn_core
       mubi4_or_hi(escalate_en_i,
                   mubi4_bool_to_mubi(|{urnd_all_zero, rf_base_rf_err, predec_error,
                                        lsu_rdata_err, insn_fetch_err, controller_fatal_err,
-                                       rnd_rep_err, rnd_fips_err}));
+                                       rnd_rep_err, rnd_fips_err, insn_addr_err}));
 
   assign insn_cnt_o = insn_cnt;
 


### PR DESCRIPTION
Although we are still seeing a fatal error in the case of a `instr_addr` mismatch (that's happening because having different instructions on the predecoder and normal decoder generates bunch of other fatal errors (e.g. ALU mismatches)) it's still better to keep this error signal connected since there is a case where the new injected address might have the same instruction! (Thanks @marnovandermaas for coming up with that scenario).

Fixes #13323

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>