### PR TITLE
[dv] Add build rule for sensor_ctrl_status

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -812,7 +812,7 @@
     {
       name: chip_sw_sensor_ctrl_status
       uvm_test_seq: chip_sw_sensor_ctrl_status_intr_vseq
-      sw_images: ["sw/device/tests/sensor_ctrl_status_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/sensor_ctrl_status_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=40000000"]
     }

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -602,3 +602,26 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "sensor_ctrl_status_test",
+    srcs = ["sensor_ctrl_status.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib:irq",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:sensor_ctrl",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/sim_dv/sensor_ctrl_status.c
+++ b/sw/device/tests/sim_dv/sensor_ctrl_status.c
@@ -16,6 +16,8 @@
 #include "sensor_ctrl_regs.h"  // Generated.
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 
+OTTF_DEFINE_TEST_CONFIG();
+
 /* In this test, the IO POK status is randomly change by an
  * an external source (user or dv).
  * Only 1 IO change is made at a time.


### PR DESCRIPTION
- also move to sim_dv directory since this test does not work
  for fpga / verilator natively

Signed-off-by: Timothy Chen <timothytim@google.com>