### PR TITLE
[formal/tool] Move define to common formal script

### DIFF
--- a/hw/formal/tools/dvsim/common_formal_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_formal_cfg.hjson
@@ -42,11 +42,14 @@
   build_fail_patterns: [// FuseSoC build error
                         "^ERROR:.*$"]
 
+  defines: ""
+
   // Vars that need to exported to the env
   exports: [
     { DUT_TOP:  "{dut}" },
     { COV:      "{cov}" },
-    { sub_flow: "{sub_flow}"}
+    { sub_flow: "{sub_flow}"},
+    { FPV_DEFINES:  '{defines}'},
   ]
 
   overrides: [

--- a/hw/formal/tools/dvsim/common_fpv_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_fpv_cfg.hjson
@@ -6,12 +6,10 @@
   import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_formal_cfg.hjson"]
   stopats: []
   task: ""
-  defines: ""
 
   // Optional vars that need to exported to the env
   exports: [
     {STOPATS: "'{stopats}'"},
     {TASK:    '{task}'},
-    {FPV_DEFINES:  '{defines}'},
   ]
 }

--- a/hw/formal/tools/jaspergold/conn.tcl
+++ b/hw/formal/tools/jaspergold/conn.tcl
@@ -25,7 +25,7 @@ if {$conn_csvs eq ""} {
 # only one scr file exists in this folder
 # Blackbox ast related modules to avoid compile errors.
 analyze -sv09 \
-  +define+SYNTHESIS \
+  +define+SYNTHESIS+$env(FPV_DEFINES) \
   -f [glob *.scr] \
   -bbox_m aon_osc \
   -bbox_m io_osc  \


### PR DESCRIPTION
The keyword define was previously only used for fpv script.
Now we want to support more connectivity tests, and want to expand the
usage of `defines`.
So this PR moves the `define` related logic to common formal script.

Signed-off-by: Cindy Chen <chencindy@google.com>