### PR TITLE
[formal/script] Add bbox_cmd as an input option

### DIFF
--- a/hw/formal/tools/dvsim/common_formal_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_formal_cfg.hjson
@@ -43,13 +43,15 @@
                         "^ERROR:.*$"]
 
   defines: ""
+  bbox_cmd: ""
 
   // Vars that need to exported to the env
   exports: [
-    { DUT_TOP:  "{dut}" },
-    { COV:      "{cov}" },
-    { sub_flow: "{sub_flow}"},
-    { FPV_DEFINES:  '{defines}'},
+    { DUT_TOP:     "{dut}" },
+    { COV:         "{cov}" },
+    { sub_flow:    "{sub_flow}"},
+    { FPV_DEFINES: "{defines}"},
+    { BBOX_CMD:    "'{bbox_cmd}'"},
   ]
 
   overrides: [

--- a/hw/formal/tools/jaspergold/conn.tcl
+++ b/hw/formal/tools/jaspergold/conn.tcl
@@ -26,11 +26,8 @@ if {$conn_csvs eq ""} {
 # Blackbox ast related modules to avoid compile errors.
 analyze -sv09 \
   +define+SYNTHESIS+$env(FPV_DEFINES) \
-  -f [glob *.scr] \
-  -bbox_m aon_osc \
-  -bbox_m io_osc  \
-  -bbox_m sys_osc \
-  -bbox_m usb_osc
+  $env(BBOX_CMD) \
+  -f [glob *.scr]
 
 # Black-box assistant will blackbox the modules which are not needed by looking at
 # the connectivity csv.

--- a/hw/top_earlgrey/formal/chip_conn_cfg.hjson
+++ b/hw/top_earlgrey/formal/chip_conn_cfg.hjson
@@ -9,6 +9,7 @@
 
   fusesoc_core: lowrisc:systems:chip_earlgrey_asic:0.1
 
+  bbox_cmd: "-bbox_m [list aon_osc io_osc sys_osc usb_osc]"
   conn_csvs_dir: "{proj_root}/hw/top_earlgrey/formal/conn_csvs"
   conn_csvs: ["{conn_csvs_dir}/aon_timer_rst.csv",
               "{conn_csvs_dir}/ast_mem_cfg.csv",


### PR DESCRIPTION
Right now we are trying to support different connectivity tests, so
adding a bbox_cmd as an hjson entry to allow different modules blackbox
different items.

Signed-off-by: Cindy Chen <chencindy@google.com>