### PR TITLE
[chip dv] Fix csrng_kat_test target.

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1989,7 +1989,7 @@
             - Compare the results to test expectations.
             '''
       milestone: V2
-      tests: ["csrng_kat_test"]
+      tests: ["chip_sw_csrng_kat_test"]
     }
 
     // EDN (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -709,6 +709,13 @@
       run_opts: ["+sw_test_timeout_ns=18000000"]
     }
     {
+      name: chip_sw_csrng_kat_test
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/csrng_kat_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=18000000"]
+    }
+    {
       name: chip_sw_hmac_enc_irq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/hmac_enc_irq_test:1"]


### PR DESCRIPTION
Adds test configuration to chip_sim_cfg.hjson and updates test target in
top earlgrey chip_testplan.hjson.
