### PR TITLE
[otbn, dv] Adds otbn_pc_ctrl_flow_redun testcase

### DIFF
--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -115,9 +115,12 @@
     }
     {
       name: sec_cm_pc_ctrl_flow_redun
-      desc: "Verify the countermeasure(s) PC.CTRL_FLOW.REDUN."
+      desc: ''' Verify the countermeasure(s) PC.CTRL_FLOW.REDUN.
+                Wait for a read request and istrn fetch request valid.
+                Corrupt the insn_prefetch_addr.
+            '''
       milestone: V2S
-      tests: []
+      tests: ["otbn_pc_ctrl_flow_redun"]
     }
     {
       name: sec_cm_rnd_bus_consistency

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -52,6 +52,7 @@ filesets:
       - seq_lib/otbn_alu_bignum_mod_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_controller_ispr_rdata_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_mac_bignum_acc_err_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence to verify the countermeasure(s) PC.CTRL_FLOW.REDUN.
+
+class otbn_pc_ctrl_flow_redun_vseq extends otbn_single_vseq;
+  `uvm_object_utils(otbn_pc_ctrl_flow_redun_vseq)
+  `uvm_object_new
+
+  task body();
+    do_end_addr_check = 0;
+    fork
+      begin
+        super.body();
+      end
+      begin
+        corrupt_prefetch_addr();
+      end
+    join
+  endtask: body
+
+  task corrupt_prefetch_addr();
+    bit imem_rvalid;
+    bit insn_fetch_req_valid;
+    bit prefetch_ignore_err;
+    bit [11:0] good_addr;
+    bit [11:0] bad_addr;
+    bit [11:0] mask;
+    bit [31:0] err_val = 32'd1 << 20;
+    string addr_path = "tb.dut.u_otbn_core.u_otbn_instruction_fetch.insn_prefetch_addr";
+
+    do begin
+      @(cfg.clk_rst_vif.cb);
+      uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.imem_rvalid_i", imem_rvalid);
+      uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.insn_fetch_req_valid_raw_i",
+                    insn_fetch_req_valid);
+      uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.prefetch_ignore_errs_i",
+                    prefetch_ignore_err);
+    end while(!(imem_rvalid & insn_fetch_req_valid & !prefetch_ignore_err));
+    uvm_hdl_read(addr_path, good_addr);
+    // Mask to corrupt 1 to 2 bits of the prefetch addr
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
+    bad_addr = good_addr ^ mask;
+    `DV_CHECK_FATAL(uvm_hdl_force(addr_path, bad_addr) == 1);
+    `uvm_info(`gfn, "injecting bad internal state error into ISS", UVM_HIGH)
+    cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+    wait(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
+    `DV_CHECK_FATAL(uvm_hdl_release(addr_path) == 1);
+    reset_if_locked();
+  endtask
+
+endclass : otbn_pc_ctrl_flow_redun_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -20,3 +20,4 @@
 `include "otbn_alu_bignum_mod_err_vseq.sv"
 `include "otbn_controller_ispr_rdata_err_vseq.sv"
 `include "otbn_mac_bignum_acc_err_vseq.sv"
+`include "otbn_pc_ctrl_flow_redun_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -273,6 +273,13 @@ name:
       en_run_modes: ["build_otbn_rig_binary_mode"]
       reseed: 5
     }
+    {
+      name: "otbn_pc_ctrl_flow_redun"
+      uvm_test_seq: "otbn_pc_ctrl_flow_redun_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
+
   ]
 
   // List of regressions.


### PR DESCRIPTION
This commit adds a new testcase to verify OTBN.PC.CTRL_FLOW.REDUN
countermeasure.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>