### PR TITLE
[otbn/doc] Clarify the expected behavior around RND_REP/FIPS_CHK_FAIL

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -791,14 +791,15 @@ This way, no alert is generated without setting an error code somewhere.
       <td><code>RND_REP_CHK_FAIL</code></td>
       <td>recoverable</td>
       <td>
-        The RND END interface returned identical random numbers on two subsequent entropy requests.
+        The random number obtained from the last read of the RND register failed the repetition check.
+        The RND EDN interface returned identical random numbers on two subsequent entropy requests.
       </td>
     </tr>
     <tr>
       <td><code>RND_FIPS_CHK_FAIL</code></td>
       <td>recoverable</td>
       <td>
-        The random numbers received via the RND EDN interface have been generated from entropy that at least partially failed the FIPS health checks in the entropy source.
+        The random number obtained from the last read of the RND register has been generated from entropy that at least partially failed the FIPS health checks in the entropy source.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
These are both recoverable errors that are only triggered when OTBN uses the random numbers during program execution by reading RND register and not when the entropy is received from EDN.

This resolves lowRISC/OpenTitan#13325.