### PR TITLE
[otbn] Save one datapath mux input in bignum ALU by leveraging blanking

### DIFF
--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -721,7 +721,10 @@ module otbn_alu_bignum
   );
 
   always_comb begin
-    logical_res = '0;
+    // Drive logical_res to zero unless it's actually used. When used,
+    // alu_predec_bignum_i.logic_shifter_en is set. Otherwise logical_op_shifter_res_blanked is
+    // blanked to zero.
+    logical_res = ~logical_op_shifter_res_blanked;
 
     unique case (operation_i.op)
       AluOpBignumXor: logical_res = logical_op_a_blanked ^ logical_op_shifter_res_blanked;


### PR DESCRIPTION
Whenever logical_res is actually used, alu_predec_bignum_i.logic_shifter_en is set to 1 and the blanking disabled. Otherwise, logical_op_shifter_res_blanked is blanked to zero. This can be leveraged to drive logical_res to 0 whenever it's not used.
