### PR TITLE
[CDC][SPI] added synchronizer between sys_clk and spi_clk

### DIFF
--- a/hw/ip/prim/prim_edge_detector_gp.core
+++ b/hw/ip/prim/prim_edge_detector_gp.core
@@ -1,0 +1,44 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+name: "lowrisc:prim:edge_detector_gp:0.1"
+description: "Positive/ Negative Edge detector with glitch protection"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:flop_2sync
+    files:
+      - rtl/prim_edge_detector_gp.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_edge_detector_gp.sv
+++ b/hw/ip/prim/rtl/prim_edge_detector_gp.sv
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Edge Detector
+
+module prim_edge_detector_gp #(
+  parameter int unsigned Width = 1,
+  parameter int PosWindow = 16,
+  parameter int NegWindow = 8,
+  parameter int TabSize = PosWindow + NegWindow,
+  parameter logic [Width-1:0] ResetValue = '0,
+
+  // EnSync
+  //
+  // Enable Synchronizer to the input signal.
+  // It is assumed that the input signal is glitch free (registered input).
+  parameter bit EnSync  = 1'b 1
+) (
+  input clk_i,
+  input rst_ni,
+
+  input        [Width-1:0] d_i,
+  output logic [Width-1:0] q_sync_o,
+
+  output logic [Width-1:0] q_posedge_pulse_o,
+  output logic [Width-1:0] q_negedge_pulse_o
+);
+
+  logic [Width-1:0] q_sync_d;
+  logic [TabSize-1:0][Width-1:0] q_sync_q;
+
+  if (EnSync) begin : g_sync
+    prim_flop_2sync #(
+      .Width (Width),
+      .ResetValue (ResetValue)
+    ) u_sync (
+      .clk_i,
+      .rst_ni,
+      .d_i,
+      .q_o (q_sync_d)
+    );
+  end : g_sync
+  else begin : g_nosync
+    assign q_sync_d = d_i;
+  end : g_nosync
+
+  assign q_sync_o = q_sync_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) q_sync_q <= {TabSize{ResetValue}};
+    else         q_sync_q <= {q_sync_q[TabSize-2:0], q_sync_d};
+  end
+
+  assign q_posedge_pulse_o = q_sync_d &
+                            (q_sync_q == {{NegWindow{!ResetValue}}, {PosWindow{ResetValue}}});
+  assign q_negedge_pulse_o = ~q_sync_d &
+                            (q_sync_q == {{PosWindow{ResetValue}}, {NegWindow{!ResetValue}}});
+
+endmodule : prim_edge_detector_gp

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -79,8 +79,20 @@ package spi_device_pkg;
   localparam int unsigned AddrCntW = $clog2(MaxAddrBit);
 
   // Dummy
+
   localparam int unsigned MaxDummyBit = 8;
   localparam int unsigned DummyCntW = $clog2(MaxDummyBit);
+
+  // TPM
+  localparam int unsigned AccessRegSize    = 8; // times Locality
+  localparam int unsigned IntEnRegSize     = 32;
+  localparam int unsigned IntVectorRegSize = 8;
+  localparam int unsigned IntStsRegSize    = 32;
+  localparam int unsigned IntfCapRegSize   = 32;
+  localparam int unsigned StatusRegSize    = 32;
+  localparam int unsigned IdRegSize        = 32; // {DID; VID}
+  localparam int unsigned RidRegSize       = 8;
+  localparam int unsigned ActiveLocalityBitPos = 5; // Access[5
 
   typedef enum logic {
     PayloadIn  = 1'b 0,

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -16,6 +16,7 @@ filesets:
       - lowrisc:prim:mubi
       - lowrisc:prim:ram_2p_adv
       - lowrisc:prim:edge_detector
+      - lowrisc:prim:edge_detector_gp
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:prim:lc_sync
       - lowrisc:ip:spi_device_pkg


### PR DESCRIPTION
Data capture logic is moved from spi_clk domain to sys_clk domain to handle SW data changing during data capture in spi_clk based on recent discussion on https://github.com/lowRISC/opentitan/issues/13286.

spi regression results are the same as before this fix.

Signed-off-by: Joshua Park <jeoong@google.com>