### PR TITLE
[bazel] Remove flaky tag from e2e_bootup_no_rom_ext_signature

### DIFF
--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -341,7 +341,6 @@ opentitan_functest(
             "--exit-failure='PASS!'",
         ],
         bitstream = "//hw/bitstream:mask_rom",
-        tags = ["flaky"],
     ),
     signed = False,
     targets = [


### PR DESCRIPTION
Signed-off-by: Alphan Ulusoy <alphan@google.com>
