### PR TITLE
[usbdev] Fix OUT ZLP handling under FIFO errors

### DIFF
--- a/hw/ip/usbdev/rtl/usb_fs_nb_out_pe.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_nb_out_pe.sv
@@ -270,7 +270,7 @@ module usb_fs_nb_out_pe #(
 
         if (current_xact_setup_q) begin
           // SETUP transactions end here
-          if (nak_out_transaction) begin
+          if (nak_out_transaction | out_ep_full_i[out_ep_index]) begin
             // SETUP transactions that fail to be received are dropped without a response.
             tx_pkt_start_o = 1'b0;
             rollback_data = 1'b1;
@@ -283,7 +283,7 @@ module usb_fs_nb_out_pe #(
           // Non-isochronous OUT transactions end here
           if (out_ep_stall_i[out_ep_index]) begin
             tx_pid_o = {UsbPidStall}; // STALL
-          end else if (nak_out_transaction) begin
+          end else if (nak_out_transaction | out_ep_full_i[out_ep_index]) begin
             tx_pid_o = {UsbPidNak}; // NAK -- the endpoint could not accept the data at the moment
             rollback_data = 1'b1;
           end else begin
@@ -298,7 +298,7 @@ module usb_fs_nb_out_pe #(
         // Isochronous OUT transactions end here
         out_xact_state_next = StIdle;
 
-        if (nak_out_transaction) begin
+        if (nak_out_transaction | out_ep_full_i[out_ep_index]) begin
           // We got a valid packet, but can't store it (error that the software must resolve)
           rollback_data = 1'b1;
         end else begin

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -207,7 +207,7 @@ module usbdev_usbif  #(
       out_max_minus1,
       av_rdata_i
   };
-  assign rx_wvalid_o = out_ep_acked & ~all_out_blocked;
+  assign rx_wvalid_o = out_ep_acked;
   // Pop the available fifo after the write that used the previous value
   always_ff @(posedge clk_48mhz_i or negedge rst_ni) begin
     if (!rst_ni) begin


### PR DESCRIPTION
Previously, zero-length packets could elicit an ACK response even when
the AV FIFO is empty or the RX FIFO is full. In the OUT transaction
state machine, the state of the FIFOs was only checked when data would
be written to a buffer. However, in usbdev_usbif, the transaction would
be rejected, so the host would incorrectly think its packet reached the
device.

Fix this up by having the state machine also check FIFO states upon
reaching the decision point for a handshake phase. This will be the
final gate that will reject ZLPs that can't get an entry for the RX
FIFO.

Signed-off-by: Alexander Williams <awill@google.com>