### PR TITLE
[dv,flash_ctrl] sample write / read test

### DIFF
--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_agent_cfg.sv
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_agent_cfg.sv
@@ -12,5 +12,5 @@ class flash_phy_prim_agent_cfg extends dv_base_agent_cfg;
 
   `uvm_object_new
   bit scb_otf_en;
-
+  bit mon_start = 0;
 endclass

--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_agent_pkg.sv
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_agent_pkg.sv
@@ -7,12 +7,15 @@ package flash_phy_prim_agent_pkg;
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
+  import flash_ctrl_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
   // parameters
+  localparam int unsigned PhyAddrW = flash_phy_pkg::BankAddrW;
+  localparam int unsigned PhyDataW = flash_phy_pkg::FullDataWidth;
 
   // local types
   // forward declare classes to allow typedefs below

--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_if.sv
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_if.sv
@@ -10,8 +10,20 @@ interface flash_phy_prim_if (
 
   flash_phy_prim_flash_req_t [NumBanks-1:0] req;
   flash_phy_prim_flash_rsp_t [NumBanks-1:0] rsp;
+  // Inner read request / rdy
+  logic [NumBanks-1:0] rreq;
+  logic [NumBanks-1:0] rdy;
+
+  // Debug tab
+  flash_phy_prim_flash_req_t dreq0, dreq1;
+  flash_phy_prim_flash_rsp_t drsp0, drsp1;
+
+  assign dreq0 = req[0];
+  assign drsp0 = rsp[0];
+  assign dreq1 = req[1];
+  assign drsp1 = rsp[1];
 
   clocking cb @(posedge clk);
-    input     req, rsp;
+    input     req, rsp, rreq, rdy;
   endclocking
 endinterface

--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -286,7 +286,7 @@
             pre-scramble ECC(integrity ESS, 4-bits) and post-scramble ECC(reliability ECC, 8-bits).
 	    Test status and control ECC bits.
             '''
-      milestone: V2S
+      milestone: V2
       tests: []
     }
     {
@@ -299,8 +299,8 @@
             the timing is correct (subsequent reads should be faster). When scrambling is not
             enabled, ensure that the raw data is written and read back.
             '''
-      milestone: V2S
-      tests: []
+      milestone: V2
+      tests: ["flash_ctrl_wo", "flash_ctrl_ro", "flash_ctrl_rw"]
     }
     {
       name: robustness

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -55,6 +55,9 @@ filesets:
       - seq_lib/flash_ctrl_mid_op_rst_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_otf_base_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_wo_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_ro_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_rw_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -47,8 +47,9 @@ class flash_ctrl_env #(
 
     m_fpp_agent = flash_phy_prim_agent::type_id::create("m_fpp_agent", this);
     uvm_config_db#(flash_phy_prim_agent_cfg)::set(this, "m_fpp_agent", "cfg", cfg.m_fpp_agent_cfg);
+    cfg.m_fpp_agent_cfg.mon_start = 0;
     m_otf_scb = flash_ctrl_otf_scoreboard::type_id::create("m_otf_scb", this);
-     uvm_config_db#(flash_ctrl_env_cfg)::set(this, "m_otf_scb", "cfg", cfg);
+    uvm_config_db#(flash_ctrl_env_cfg)::set(this, "m_otf_scb", "cfg", cfg);
   endfunction
 
   virtual function void connect_phase(uvm_phase phase);
@@ -62,11 +63,13 @@ class flash_ctrl_env #(
 
     if (cfg.scb_otf_en) begin
       for (int i = 0; i < flash_ctrl_pkg::NumBanks; ++i) begin
-        virtual_sequencer.eg_exp_port[i].connect(
-                m_otf_scb.eg_exp_fifo[i].analysis_export);
+        virtual_sequencer.eg_exp_ctrl_port[i].connect(
+                m_otf_scb.eg_exp_ctrl_fifo[i].analysis_export);
+        virtual_sequencer.eg_exp_host_port[i].connect(
+                m_otf_scb.eg_exp_host_fifo[i].analysis_export);
         m_fpp_agent.monitor.eg_rtl_port[i].connect(
-                  m_otf_scb.eg_rtl_fifo[i].analysis_export);
-      end
+                m_otf_scb.eg_rtl_fifo[i].analysis_export);
+     end
     end
 
     // scb_otf_en is sampled at the end of build_phase in

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -53,9 +53,10 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // Transaction counters for otf
   int otf_ctrl_wr_sent = 0;
   int otf_ctrl_wr_rcvd = 0;
-
   int otf_ctrl_rd_sent = 0;
   int otf_ctrl_rd_rcvd = 0;
+  int otf_host_rd_sent = 0;
+  int otf_host_rd_rcvd = 0;
 
   // Max delay for alerts in clocks
   uint alert_max_delay;

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -8,14 +8,23 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
 
   // OTF data path fifos
   // Assuming egress (host -> flash) ordering is  maintained per bank.
-  uvm_tlm_analysis_fifo #(flash_otf_item) eg_exp_fifo[flash_ctrl_pkg::NumBanks];
-  uvm_tlm_analysis_fifo #(flash_phy_prim_item) eg_rtl_fifo[flash_ctrl_pkg::NumBanks];
+  uvm_tlm_analysis_fifo #(flash_otf_item) eg_exp_ctrl_fifo[NumBanks];
+  uvm_tlm_analysis_fifo #(flash_otf_item) eg_exp_host_fifo[NumBanks];
+  uvm_tlm_analysis_fifo #(flash_otf_item) eg_rtl_ctrl_fifo[NumBanks];
+  uvm_tlm_analysis_fifo #(flash_otf_item) eg_rtl_host_fifo[NumBanks];
+  uvm_tlm_analysis_fifo #(flash_phy_prim_item) eg_rtl_fifo[NumBanks];
+
   flash_ctrl_env_cfg cfg;
+
+  int eg_exp_cnt = 0;
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    foreach(eg_exp_fifo[i]) begin
-      eg_exp_fifo[i] = new($sformatf("eg_exp_fifo[%0d]", i), this);
+    foreach (eg_exp_ctrl_fifo[i]) begin
+      eg_exp_ctrl_fifo[i] = new($sformatf("eg_exp_ctrl_fifo[%0d]", i), this);
+      eg_exp_host_fifo[i] = new($sformatf("eg_exp_host_fifo[%0d]", i), this);
+      eg_rtl_ctrl_fifo[i] = new($sformatf("eg_rtl_ctrl_fifo[%0d]", i), this);
+      eg_rtl_host_fifo[i] = new($sformatf("eg_rtl_host_fifo[%0d]", i), this);
       eg_rtl_fifo[i] = new($sformatf("eg_rtl_fifo[%0d]", i), this);
     end
   endfunction
@@ -26,58 +35,199 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
   endfunction // connect_phase
 
   task run_phase(uvm_phase phase);
-    flash_otf_item  exp_item[flash_ctrl_pkg::NumBanks];
+    flash_otf_item       exp_ctrl_item[NumBanks];
+    flash_otf_item       exp_host_item[NumBanks];
+    flash_phy_prim_item  phy_item[NumBanks];
+
     fork
-      begin
-        foreach (eg_exp_fifo[i]) begin
-          automatic int j = i;
-          fork begin
-            forever begin
-              eg_exp_fifo[j].get(exp_item[j]);
-              process_eg(exp_item[j], j);
-            end
-          end join_none
-        end
+      forever begin
+        eg_exp_ctrl_fifo[0].get(exp_ctrl_item[0]);
+        process_eg(exp_ctrl_item[0], 0);
+      end
+      forever begin
+        eg_exp_ctrl_fifo[1].get(exp_ctrl_item[1]);
+        process_eg(exp_ctrl_item[1], 1);
+      end
+      forever begin
+        eg_exp_host_fifo[0].get(exp_host_item[0]);
+        process_eg_host(exp_host_item[0], 0);
+      end
+      forever begin
+        eg_exp_host_fifo[1].get(exp_host_item[1]);
+        process_eg_host(exp_host_item[1], 1);
+      end
+      forever begin
+        eg_rtl_fifo[0].get(phy_item[0]);
+        process_phy_item(phy_item[0], 0);
+      end
+      forever begin
+        eg_rtl_fifo[1].get(phy_item[1]);
+        process_phy_item(phy_item[1], 1);
       end
     join_none
   endtask // run_phase
 
-  task process_eg(flash_otf_item exp, int bank);
-    flash_phy_prim_item  item;
-    flash_otf_item       obs;
-    int col_sz = exp.fq.size / 8;
+  task process_eg_host(flash_otf_item exp, int bank);
+    flash_otf_item obs;
+    data_4s_t rcvd_data;
+    fdata_q_t fq;
+    string str = $sformatf("host_read_comp_bank%0d", bank);
 
-    eg_rtl_fifo[bank].get(item);
+    `uvm_info("EXPGET_HOST", $sformatf(" addr %x  data:%x   cnt:%0d  rtlff:%0d  xxx:%0d",
+                                       exp.start_addr, exp.dq[0], eg_exp_cnt++,
+                                       eg_rtl_host_fifo[bank].used(),
+                                       eg_rtl_ctrl_fifo[bank].used()),
+              UVM_MEDIUM)
+
+    // bankdoor read from memory model
+    eg_rtl_host_fifo[bank].get(obs);
+    obs.cmd.addr = exp.start_addr; // tl_addr
+    // descramble needs 2 buswords
+    obs.cmd.addr[2] = 0;
+    obs.cmd.num_words = 2;
+
+    obs.print("RAW");
+    cfg.flash_mem_bkdr_read(obs.cmd, obs.dq);
+    obs.fq = obs.dq2fq(obs.dq);
+
+    obs.is_direct = 1;
+    obs.print("rtl_host: before");
+    obs.descramble(exp.addr_key, exp.data_key);
+    obs.print("rtl_host: after");
+    `uvm_info("process_eg_host", $sformatf(" rcvd:%0d",cfg.otf_host_rd_sent), UVM_MEDIUM)
+
+    if (exp.start_addr[2]) begin
+       rcvd_data = obs.dq[1];
+    end else begin
+       rcvd_data = obs.dq[0];
+    end
+
+     if (rcvd_data == exp.dq[0]) begin
+        `dv_info("data match!!", UVM_MEDIUM, str)
+     end else begin
+        `dv_error($sformatf(" : obs:exp    %8x:%8x mismatch!!", rcvd_data, exp.dq[0]), str)
+     end
+
+    cfg.otf_host_rd_sent++;
+  endtask // process_eg_host
+
+  task process_eg(flash_otf_item item, int bank);
+    `uvm_info("EG_EXPGET", $sformatf("op:%s fq:%0d cnt:%0d rtlff:%0d", item.cmd.op.name(),
+                                     item.fq.size(), eg_exp_cnt++, eg_rtl_fifo[bank].used()),
+              UVM_MEDIUM)
+
+    case (item.cmd.op)
+      FlashOpProgram:begin
+        process_write(item, bank);
+      end
+      FlashOpRead:begin
+        process_read(item, bank);
+      end
+      default:begin
+        // TODO support other commands
+      end
+    endcase
+  endtask
+
+  // Scoreboard process read in following order.
+  //   - Received expected transactions (exp).
+  //   - Pop the same number (col_sz) of transaction from rtl received q.
+  //   - Transform rtl transactions to have the same data format as exp.
+  //   - Compare read data.
+  task process_read(flash_otf_item exp, int bank);
+    flash_otf_item item;
+    flash_otf_item obs;
+    int col_sz = exp.fq.size;
+    `uvm_info("process_read", $sformatf("bank:%0d colsz:%0d ffsz:%0d",
+                                        bank, col_sz, eg_rtl_fifo[bank].used()), UVM_HIGH)
+    exp.print("exp_read");
+
+    eg_rtl_ctrl_fifo[bank].get(obs);
+    obs.cmd = exp.cmd;
+    obs.cmd.addr[OTFBankId] = bank;
+    obs.cmd.num_words = col_sz * 2;
+
+    obs.print("RAW");
+    cfg.flash_mem_bkdr_read(obs.cmd, obs.dq);
+
+    repeat ((2 * col_sz) - 1) begin
+      eg_rtl_ctrl_fifo[bank].get(item);
+    end
+
+    obs.print("rtl_read: enc_data");
+    obs.fq = obs.dq2fq(obs.dq);
+
+    obs.descramble(exp.addr_key, exp.data_key);
+    obs.print("rtl_read: raw_data");
+    `dv_info($sformatf("RDATA size: %d x 8B bank:%0d sent_cnt:%0d",
+                       obs.raw_fq.size(), bank, cfg.otf_ctrl_rd_sent++),
+             UVM_MEDIUM, "process_read")
+    compare_data(obs.raw_fq, exp.fq, bank, "rdata");
+  endtask
+
+  // Scoreboard process write in following order.
+  //   - Received expected transactions (exp).
+  //   - Pop the same number (col_sz) of transaction from rtl received q.
+  //   - Transform rtl transactions to have the same data format as exp.
+  //   - Compare read data.
+  task process_write(flash_otf_item exp, int bank);
+    flash_otf_item item;
+    flash_otf_item obs;
+
+    // Write transactions coalesce upto 8 transactions.
+    // So each pop becomes 8 times of fqs.
+    int col_sz = exp.fq.size / 8;
+    `uvm_info("process_write", $sformatf("process_write:col&comp:bank:%0d colsz:%0d ffsz:%0d",
+                                         bank, col_sz, eg_rtl_ctrl_fifo[bank].used()), UVM_HIGH)
+    eg_rtl_ctrl_fifo[bank].get(item);
     `uvm_create_obj(flash_otf_item, obs)
-    obs.get_wd_from_phy(item);
-    obs.fq = item.fq;
+    obs = item;
 
     repeat(col_sz - 1) begin
-      eg_rtl_fifo[bank].get(item);
+      eg_rtl_ctrl_fifo[bank].get(item);
       obs.fq = {obs.fq, item.fq};
     end
 
-    compare_wdata(obs, exp, bank);
+    `dv_info($sformatf("WDATA size: %d x 8B bank:%0d rcvd_cnt:%0d",
+                       obs.fq.size(), bank, cfg.otf_ctrl_wr_rcvd++), UVM_MEDIUM, "process_write")
+
+    compare_data(obs.fq, exp.fq, bank, "wdata");
   endtask // process_eg
 
   // Compare 64 bit for now
-  task compare_wdata(flash_otf_item obs,
-                     flash_otf_item exp, int bank);
-    string str = $sformatf("wdata_comp_bank%0d", bank);
+  task compare_data(fdata_q_t obs, fdata_q_t exp, int bank, string rw);
+    string str = $sformatf("%s_comp_bank%0d", rw, bank);
     bit    err = 0;
-    `dv_info($sformatf(" Wdata size: %d x 8B  rcvd_cnt:%0d",
-                       obs.fq.size(), cfg.otf_ctrl_wr_rcvd++), UVM_MEDIUM, str)
-    foreach(obs.fq[i]) begin
-      if (obs.fq[i][63:0] != exp.fq[i][63:0]) begin
+
+    foreach (obs[i]) begin
+      if (obs[i][63:0] != exp[i][63:0]) begin
         err = 1;
         `dv_error($sformatf("%4d: obs:exp    %8x_%8x:%8x_%8x  mismatch!!", i,
-                  obs.fq[i][63:32], obs.fq[i][31:0], exp.fq[i][63:32], exp.fq[i][31:0]),
+                  obs[i][63:32], obs[i][31:0], exp[i][63:32], exp[i][31:0]),
                   str)
       end
     end
     if (err == 0) begin
       `dv_info("data match!!", UVM_MEDIUM, str)
     end
-  endtask // compare_wdata
+  endtask // compare_data
 
+  // Transform phy_item to otf_item and
+  // classify to host or ctrl transaction
+  task process_phy_item(flash_phy_prim_item item, int bank);
+    flash_otf_item       obs;
+    `uvm_create_obj(flash_otf_item, obs);
+    if (item.req.prog_req) begin
+      obs.get_from_phy(item, "w");
+      eg_rtl_ctrl_fifo[bank].write(obs);
+    end else begin // read request, guaranteed by monitor
+      obs.get_from_phy(item, "r");
+      if (item.req.addr[flash_ctrl_pkg::BankAddrW-1]) begin // host read
+        obs.start_addr = obs.cmd.addr;
+        eg_rtl_host_fifo[bank].write(obs);
+      end else begin // ctrl read
+        eg_rtl_ctrl_fifo[bank].write(obs);
+      end
+    end
+  endtask // process_phy_item
 endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_virtual_sequencer.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_virtual_sequencer.sv
@@ -8,12 +8,14 @@ class flash_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
 );
   `uvm_component_utils(flash_ctrl_virtual_sequencer)
 
-  uvm_analysis_port #(flash_otf_item) eg_exp_port[flash_ctrl_pkg::NumBanks];
+  uvm_analysis_port #(flash_otf_item) eg_exp_ctrl_port[NumBanks];
+  uvm_analysis_port #(flash_otf_item) eg_exp_host_port[NumBanks];
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    foreach (eg_exp_port[i]) begin
-      eg_exp_port[i] = new($sformatf("eg_exp_port[%0d]", i), this);
+    foreach (eg_exp_ctrl_port[i]) begin
+      eg_exp_ctrl_port[i] = new($sformatf("eg_exp_ctrl_port[%0d]", i), this);
+      eg_exp_host_port[i] = new($sformatf("eg_exp_host_port[%0d]", i), this);
     end
   endfunction // new
 

--- a/hw/ip/flash_ctrl/dv/env/flash_otf_item.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_otf_item.sv
@@ -7,31 +7,59 @@ class flash_otf_item extends uvm_object;
   flash_op_t cmd;
   data_q_t   dq;
   fdata_q_t  raw_fq, fq;
+  bit[flash_ctrl_pkg::BusAddrByteW-1:0] start_addr;
+  bit[flash_phy_pkg::KeySize-1:0]      addr_key, data_key;
+  bit                                  is_direct = 0;
+  bit [flash_ctrl_pkg::BusAddrByteW-2:0] mem_addr;
+
   function new(string name = "flash_otf_item");
     super.new(name);
   endfunction // new
 
   virtual function void print(string name = "flash_otf_item");
-    `dv_info($sformatf("partition : %s", cmd.partition.name()), UVM_MEDIUM, name)
-    `dv_info($sformatf("erase_type: %s", cmd.erase_type.name()), UVM_MEDIUM, name)
-    `dv_info($sformatf("op        : %s", cmd.op.name()), UVM_MEDIUM, name)
-    `dv_info($sformatf("prog_sel  : %s", cmd.prog_sel.name()), UVM_MEDIUM, name)
-    `dv_info($sformatf("num_words : %0d", cmd.num_words), UVM_MEDIUM, name)
-    `dv_info($sformatf("s_addr    : 0x%x", cmd.addr), UVM_MEDIUM, name)
-    flash_otf_print_data64(dq, name);
+    if (is_direct) begin
+      `dv_info($sformatf("host_addr : 0x%x", start_addr), UVM_MEDIUM, name)
+    end else begin
+      `dv_info($sformatf("partition : %s", cmd.partition.name()), UVM_MEDIUM, name)
+      `dv_info($sformatf("erase_type: %s", cmd.erase_type.name()), UVM_MEDIUM, name)
+      `dv_info($sformatf("op        : %s", cmd.op.name()), UVM_MEDIUM, name)
+      `dv_info($sformatf("prog_sel  : %s", cmd.prog_sel.name()), UVM_MEDIUM, name)
+      `dv_info($sformatf("num_words : %0d", cmd.num_words), UVM_MEDIUM, name)
+      `dv_info($sformatf("s_addr    : 0x%x", start_addr), UVM_MEDIUM, name)
+    end
+      `dv_info($sformatf("mem_addr  : 0x%x", mem_addr), UVM_MEDIUM, name)
+
+    if (dq.size() > 0) begin
+      flash_otf_print_data64(dq, name);
+    end else begin // read
+      printfq(fq, name);
+    end
   endfunction // do_print
 
-  function void get_wd_from_phy(flash_phy_prim_item item);
-    // dv has 3 Infos while rtl has 1.
+  function void printfq(fdata_q_t fq, string name = "printfq");
+    foreach (fq[i]) begin
+      `dv_info($sformatf("rdata%0d: %8x_%8x", i, fq[i][63:32], fq[i][31:0]), UVM_MEDIUM, name)
+    end
+  endfunction
+
+  function void get_from_phy(flash_phy_prim_item item, string rw);
+    // TB has 3 Infos while rtl has 1.
     // TODO: align below routine with both dv and rtl data struct.
     this.cmd.partition = flash_dv_part_e'(item.req.part);
     if (item.req.pg_erase_req) this.cmd.erase_type = FlashErasePage;
     if (item.req.bk_erase_req) this.cmd.erase_type = FlashEraseBank;
-    this.cmd.op = FlashOpProgram;
+    if (rw == "w") begin
+      this.cmd.op = FlashOpProgram;
+      this.cmd.num_words = item.fq.size() * 2;
+    end else begin
+      this.cmd.op = FlashOpRead;
+      this.cmd.num_words = 1;
+    end
     this.cmd.prog_sel = flash_prog_sel_e'(item.req.prog_type);
-    this.cmd.num_words = item.fq.size() * 2;
     this.cmd.addr = item.req.addr;
-
+    // cmd.addr can be modified to call bkdr mem access
+    // So we need to exptra copy of mem interface address
+    this.mem_addr = item.req.addr;
     fq = item.fq;
   endfunction // get_from_phy
 
@@ -57,20 +85,45 @@ class flash_otf_item extends uvm_object;
     end
   endfunction // dq2fq
 
+  // Inverse of dq2fq, copy fq to dq.
+  function data_q_t fq2dq(fdata_q_t fq);
+    int size = fq.size();
+
+    for (int i = 0; i < size; ++i) begin
+      fq2dq.push_back(fq[i][31:0]);
+      fq2dq.push_back(fq[i][63:32]);
+    end
+  endfunction
+
+  // Scramble dq data and store result to fq.
+  // Use 'create_flash_data' function from package
   function void scramble(bit[flash_phy_pkg::KeySize-1:0] addr_key,
                          bit[flash_phy_pkg::KeySize-1:0] data_key,
-                         bit[flash_ctrl_pkg::BusAddrW-1:0] addr);
+                         bit[flash_ctrl_pkg::BusAddrByteW-2:0] addr);
     raw_fq = dq2fq(this.dq);
     if (raw_fq.size == 0) begin
       `uvm_error(`gfn, "raw_fq is empty")
       return;
     end
-
-    `uvm_info(`gfn, $sformatf("wr_enc:size:%0d addr:%x  akey:%x  dkey:%x",raw_fq.size(),
+    `uvm_info(`gfn, $sformatf("wr_scr:size:%0d addr:%x  akey:%x  dkey:%x",raw_fq.size(),
                               addr, addr_key, data_key), UVM_MEDIUM)
     foreach (raw_fq[i]) begin
       fq.push_back(create_flash_data(raw_fq[i], addr, addr_key, data_key));
       addr += 8;
     end
-  endfunction
+  endfunction // scramble
+
+  // Descramble fq data and store result to fq and dq.
+  // Use 'create_raw_data' function from package
+  function void descramble(bit[flash_phy_pkg::KeySize-1:0] addr_key,
+                           bit[flash_phy_pkg::KeySize-1:0] data_key);
+    bit[1:0] err72, err76;
+    bit[flash_ctrl_pkg::BusAddrByteW-2:0] addr = mem_addr;
+    `uvm_info(`gfn, $sformatf("rd_scr:size:%0d addr:%x", fq.size(), addr), UVM_MEDIUM)
+    foreach (fq[i]) begin
+      raw_fq.push_back(create_raw_data(fq[i], addr, addr_key, data_key, err72, err76));
+      addr ++;
+    end
+    dq = fq2dq(raw_fq);
+  endfunction // descramble
 endclass // flash_otf_item

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -12,18 +12,37 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   // Used for tracing programmed data
   bit[15:0] global_pat_cnt = 0;
 
-  // Determine post-reset initialization method.
-  flash_mem_init_e otf_flash_init = FlashMemInitSet;
+  // Number of controller transactions
+  // Min: 1 Max:32
+  rand int  ctrl_num;
+
+  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN :=2, [2:31] :/1, CTRL_TRANS_MAX :=2}; }
 
   virtual task pre_start();
-    configure_otf_mode(otf_flash_init);
+    // Erased page doesn't go through descramble.
+    // To maintain high stress rate,
+    // keep flash_init to FlashMemInitRandomize
+    flash_init_c.constraint_mode(0);
+    flash_init = FlashMemInitRandomize;
+    configure_otf_mode();
     super.pre_start();
+    if (cfg.seq_cfg.en_init_keys_seeds == 1) begin
+      `DV_SPINWAIT(while (otp_key_init_done != 2'b11) cfg.clk_rst_vif.wait_clks(1);,
+                   "timeout waiting  otp_key_init_done", 100_000)
+    end
+
+    flash_ctrl_default_region_cfg(,,,MuBi4True);
+
+    // Polling init wip is done
+    csr_spinwait(.ptr(ral.status.init_wip), .exp_data(1'b0));
+
+    cfg.m_fpp_agent_cfg.mon_start = 1;
   endtask
 
   // On the fly scoreboard mode
   // This will disable reference memory check in the end of the test
   // as well as all intermediate transaction update for memory model.
-  function void configure_otf_mode(flash_mem_init_e f_init = "FlashMemInitSet");
+  function void configure_otf_mode();
     cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::On;
     cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::On;
     cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en     = lc_ctrl_pkg::On;
@@ -32,12 +51,23 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     cfg.scb_check                               = 0;
     cfg.check_full_scb_mem_model                = 0;
     cfg.scb_otf_en = 1;
+
+    foreach (cfg.m_tl_agent_cfgs[i]) begin
+      cfg.m_tl_agent_cfgs[i].a_valid_delay_min = 0;
+      cfg.m_tl_agent_cfgs[i].a_valid_delay_max = 0;
+      cfg.m_tl_agent_cfgs[i].d_valid_delay_min = 0;
+      cfg.m_tl_agent_cfgs[i].d_valid_delay_max = 0;
+      cfg.m_tl_agent_cfgs[i].a_ready_delay_min = 0;
+      cfg.m_tl_agent_cfgs[i].a_ready_delay_max = 0;
+      cfg.m_tl_agent_cfgs[i].d_ready_delay_min = 0;
+      cfg.m_tl_agent_cfgs[i].d_ready_delay_max = 0;
+    end
   endfunction
 
   // Program flash in the unit of minimum resolution (8 words).
   // 1 word : 8Byte
   // @arg: flash_op_p : command struct return updated address after write
-  // @arg: bank: band index to access flash
+  // @arg: bank: bank index to access flash
   // @arg: num : number of 8 words range: [1 : 32]
   // @arg: wd  : number of 4byte (TL bus unit) : default : 16
   task prog_flash(ref flash_op_t flash_op, input int bank, int num, int wd = 16);
@@ -45,7 +75,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     flash_otf_item exp_item;
     bit poll_fifo_status = 1;
     bit [15:0] lcnt = 0;
-    bit [flash_ctrl_pkg::BusAddrW-1:0] start_addr, end_addr;
+    bit [flash_ctrl_pkg::BusAddrByteW-1:0] start_addr, end_addr;
 
     flash_op.op = flash_ctrl_pkg::FlashOpProgram;
     flash_op.num_words = wd;
@@ -53,10 +83,10 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end_addr = start_addr + (4 * wd) * num;
     // Check if end_addr overflows.
     // Roll over start address if this is the case.
-    `uvm_info(`gfn, $sformatf("prog_flash: otf_addr:0x%0h, size:%0d x %0d x 4B",
-                              flash_op.otf_addr, num, wd), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("prog_flash: bank:%0d otf_addr:0x%0h, size:%0d x %0d x 4B",
+                              bank, flash_op.otf_addr, num, wd), UVM_MEDIUM)
 
-    if (end_addr[flash_ctrl_pkg::BusAddrW-1]) begin
+    if (end_addr[OTFBankId]) begin
       start_addr = num * 64;
       flash_op.otf_addr = start_addr;
       `uvm_info(`gfn, $sformatf("prog_flash: overflow!, roll over start address to 0x%x",
@@ -72,23 +102,29 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       end
 
       flash_op.addr = flash_op.otf_addr;
+      // Bank : bit[19]
+      flash_op.addr[TL_AW-1:OTFBankId] = bank;
       flash_ctrl_start_op(flash_op);
       flash_ctrl_write(flash_program_data, poll_fifo_status);
       wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
       flash_op.otf_addr = flash_op.otf_addr + (4 * wd);
-
     end // for (int i = 0; i < num; i++)
     flash_otf_print_data64(flash_data_chunk, "wdata");
     `uvm_create_obj(flash_otf_item, exp_item)
+
+    // Set addr to start_addr before exp_time passes
+    // to scoreboard.
+    flash_op.addr = start_addr;
     exp_item.cmd = flash_op;
     exp_item.dq = flash_data_chunk;
+    exp_item.start_addr = start_addr;
 
     // scramble data
-    exp_item.scramble(otp_addr_key, otp_data_key, start_addr);
+    exp_item.scramble(otp_addr_key, otp_data_key, start_addr[flash_ctrl_pkg::BusAddrByteW-2:0]);
 
-    p_sequencer.eg_exp_port[bank].write(exp_item);
+    p_sequencer.eg_exp_ctrl_port[bank].write(exp_item);
     flash_phy_prim_agent_pkg::print_flash_data(exp_item.fq,
-                                               $sformatf("fdata_%0d", cfg.otf_ctrl_wr_sent));
+          $sformatf("fdata_%0d bank%0d", cfg.otf_ctrl_wr_sent, bank));
     global_pat_cnt++;
     cfg.otf_ctrl_wr_sent++;
   endtask // prog_flash
@@ -96,7 +132,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   // Read flash in the unit of minimum resolution (8 words).
   // 1 word : 8Byte
   // @arg: flash_op_p : command struct return updated address after write
-  // @arg: bank: band index to access flash
+  // @arg: bank: bank index to access flash
   // @arg: num : number of 8 words range: [1 : 32]
   // @arg: wd  : number of 4byte (TL bus unit) : default : 16
 
@@ -104,7 +140,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     data_q_t flash_read_data, flash_data_chunk;
     flash_otf_item exp_item;
     bit poll_fifo_status = 1;
-    bit [flash_ctrl_pkg::BusAddrW-1:0] start_addr, end_addr;
+    bit [flash_ctrl_pkg::BusAddrByteW-1:0] start_addr, end_addr;
 
     flash_op.op = flash_ctrl_pkg::FlashOpRead;
     flash_op.num_words = wd;
@@ -112,19 +148,21 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end_addr = start_addr + (4 * wd) * num;
     // Check if end_addr overflows.
     // Roll over start address if this is the case.
-    `uvm_info(`gfn, $sformatf("read_flash: otf_addr:0x%0h, size:%0d x %0d",
-                              flash_op.otf_addr, wd, num), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("read_flash: bank:%0d  otf_addr:0x%0h, size:%0d x %0d x 4B",
+                              bank, flash_op.otf_addr, num, wd), UVM_MEDIUM)
 
-    if (end_addr[flash_ctrl_pkg::BusAddrW-1]) begin
+    // Ctrl read takes lower half of each bank
+    // and host read takes upper half.
+    if (end_addr[OTFHostId]) begin
       start_addr = num * 64;
       flash_op.otf_addr = start_addr;
       `uvm_info(`gfn, $sformatf("read_flash: overflow!, roll over start address to 0x%x",
                                 start_addr), UVM_MEDIUM)
     end
 
-
     for (int i = 0; i < num; i++) begin
       flash_op.addr = flash_op.otf_addr;
+      flash_op.addr[TL_AW-1:OTFBankId] = bank;
       flash_ctrl_start_op(flash_op);
       flash_ctrl_read(flash_op.num_words, flash_read_data, poll_fifo_status);
       wait_flash_op_done();
@@ -132,11 +170,59 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       foreach(flash_read_data[i]) flash_data_chunk.push_back(flash_read_data[i]);
     end // for (int i = 0; i < num; i++)
 
-    flash_otf_print_data64(flash_data_chunk, "rdata");
     `uvm_create_obj(flash_otf_item, exp_item)
+    flash_op.addr = start_addr;
     exp_item.cmd = flash_op;
+    exp_item.start_addr = start_addr;
     exp_item.dq = flash_data_chunk;
-    p_sequencer.eg_exp_port[bank].write(exp_item);
-
+    exp_item.fq = exp_item.dq2fq(flash_data_chunk);
+    exp_item.addr_key = otp_addr_key;
+    exp_item.data_key=  otp_data_key;
+    p_sequencer.eg_exp_ctrl_port[bank].write(exp_item);
+    cfg.otf_ctrl_rd_rcvd++;
   endtask // read_flash
+
+  // Direct access from the host. It returns multiple of
+  // 4bytes of data.
+  // @arg : addr : Direct access address.
+  //               At the phy interface, address_phy = addr >> 3,
+  //               because phy returns data in 8byte.
+  //               At the host interface, addr[2] is used for
+  //               word selector s.t.
+  //               addr[2]? upper 4byte : lower 4byte of phy data.
+  // @arg : bank : bank index to access flash.
+  // @arg : num  : number of 4byte data to read countinuously
+  //               by 4 byte apart.
+  task otf_direct_read(bit [OTFHostId-1:0] addr, int bank, int num);
+    bit[TL_AW-1:0] tl_addr;
+    bit [OTFHostId:0] end_addr;
+    data_4s_t rdata;
+    flash_otf_item exp_item;
+
+    end_addr = addr + num * 4;
+    if (end_addr[OTFHostId]) addr = num * 4;
+
+    tl_addr[OTFHostId-1:2] = addr[OTFHostId-1:2];
+    tl_addr[OTFBankId] = bank;
+    tl_addr[OTFHostId] = 1;
+
+    `uvm_info("direct_read", $sformatf("bank:%0d addr:0x%0h, num: %0d",
+                                       bank, tl_addr, num), UVM_MEDIUM)
+
+    for (int i = 0; i < num ; i++) begin
+      do_direct_read(.addr(tl_addr), .mask('1), .blocking(1), .rdata(rdata));
+      `uvm_create_obj(flash_otf_item, exp_item)
+      exp_item.is_direct = 1;
+      exp_item.start_addr = tl_addr;
+      exp_item.addr_key = otp_addr_key;
+      exp_item.data_key=  otp_data_key;
+      exp_item.dq.push_back(rdata);
+      p_sequencer.eg_exp_host_port[bank].write(exp_item);
+      `uvm_info("direct_read", $sformatf("SEQ: rcvd:%0d    rdata:%x",cfg.otf_host_rd_rcvd, rdata),
+                UVM_MEDIUM)
+      cfg.otf_host_rd_rcvd++;
+      tl_addr += 4;
+    end
+  endtask // otf_direct_read
+
 endclass // flash_ctrl_otf_base_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_ro_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_ro_vseq.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Send read only traffic
+// No protection is applied.
+// TB memory model is disabled.
+class flash_ctrl_ro_vseq extends flash_ctrl_otf_base_vseq;
+  `uvm_object_utils(flash_ctrl_ro_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    flash_op_t ctrl, host;
+    int num, bank;
+    int host_num, host_bank;
+    data_4s_t rdata;
+    bit [OTFHostId:0] end_addr;
+    ctrl.partition  = FlashPartData;
+    cfg.clk_rst_vif.wait_clks(5);
+
+    fork
+      begin
+        repeat(100) begin
+          host.otf_addr[OTFHostId-1:0] = $urandom();
+          host.otf_addr[1:0] = 'h0;
+          host_num = $urandom_range(1,128);
+          host_bank = $urandom_range(0,1);
+          otf_direct_read(host.otf_addr, host_bank, host_num);
+        end
+        csr_utils_pkg::wait_no_outstanding_access();
+      end
+      begin
+        repeat(100) begin
+          num = $urandom_range(CTRL_TRANS_MIN, CTRL_TRANS_MAX);
+          bank = $urandom_range(0, 1);
+          read_flash(ctrl, bank, num);
+        end
+      end
+    join
+
+  endtask
+
+endclass // flash_ctrl_ro_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
+  `uvm_object_utils(flash_ctrl_rw_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    flash_op_t ctrl, host;
+    int bank;
+    int host_num, host_bank;
+    ctrl.partition = FlashPartData;
+    cfg.clk_rst_vif.wait_clks(5);
+
+    fork
+      begin
+        repeat(500) begin
+          `DV_CHECK_RANDOMIZE_FATAL(this)
+          bank = $urandom_range(0, 1);
+          randcase
+            1:prog_flash(ctrl, bank, ctrl_num);
+            1:read_flash(ctrl, bank, ctrl_num);
+          endcase
+        end
+      end
+      begin
+        repeat(100) begin
+          host.otf_addr[OTFHostId-1:0] = $urandom();
+          host.otf_addr[1:0] = 'h0;
+          host_num = $urandom_range(1,128);
+          host_bank = $urandom_range(0,1);
+          otf_direct_read(host.otf_addr, host_bank, host_num);
+        end
+        csr_utils_pkg::wait_no_outstanding_access();
+      end
+    join
+  endtask
+endclass // flash_ctrl_rw_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -27,3 +27,6 @@
 `include "flash_ctrl_mid_op_rst_vseq.sv"
 `include "flash_ctrl_stress_all_vseq.sv"
 `include "flash_ctrl_otf_base_vseq.sv"
+`include "flash_ctrl_wo_vseq.sv"
+`include "flash_ctrl_ro_vseq.sv"
+`include "flash_ctrl_rw_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wo_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wo_vseq.sv
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Send write only traffic
+class flash_ctrl_wo_vseq extends flash_ctrl_otf_base_vseq;
+  `uvm_object_utils(flash_ctrl_wo_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    flash_op_t swcmd;
+    int num, bank;
+    swcmd.partition = FlashPartData;
+
+    repeat(100) begin
+      num = $urandom_range(1, 32);
+      bank = $urandom_range(0, 1);
+      prog_flash(swcmd, bank, num);
+    end
+  endtask
+endclass // flash_ctrl_wo_vseq

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -162,6 +162,24 @@
       uvm_test_seq: flash_ctrl_mid_op_rst_vseq
       reseed: 5
     }
+    {
+      name: flash_ctrl_wo
+      uvm_test_seq: flash_ctrl_wo_vseq
+      run_opts: ["+scb_otf_en=1"]
+      reseed: 1
+    }
+    {
+      name: flash_ctrl_ro
+      uvm_test_seq: flash_ctrl_ro_vseq
+      run_opts: ["+scb_otf_en=1"]
+      reseed: 1
+    }
+    {
+      name: flash_ctrl_rw
+      uvm_test_seq: flash_ctrl_rw_vseq
+      run_opts: ["+scb_otf_en=1"]
+      reseed: 1
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -69,6 +69,10 @@ module tb;
   `define FLASH_DEVICE_HIER tb.dut.u_eflash.u_flash
   assign fpp_if.req = `FLASH_DEVICE_HIER.flash_req_i;
   assign fpp_if.rsp = `FLASH_DEVICE_HIER.flash_rsp_o;
+  assign fpp_if.rreq[0] = tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd.req_i;
+  assign fpp_if.rreq[1] = tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd.req_i;
+  assign fpp_if.rdy[0] = tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd.rdy_o;
+  assign fpp_if.rdy[1] = tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd.rdy_o;
   `undef  FLASH_DEVICE_HIER
 
   `DV_ALERT_IF_CONNECT


### PR DESCRIPTION
read write test through flash controller and host_direct interface.
Enable scramble for default region.
Add more weight to transaction size min and max.
To do
- back to back tlul transaction
- 4byte access from ctrl interface
- MP region, Info partition support

Signed-off-by: Jaedon Kim <jdonjdon@google.com>