### PR TITLE
[formal/conn] Update chip level connectivity csvs

### DIFF
--- a/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
@@ -28,10 +28,10 @@ CONNECTION, AST_DFT_OTBN_IMEM_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_r
 CONNECTION, AST_DFT_OTBN_DMEM_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_otbn.u_dmem.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic, cfg_i
 
 # To rv_core_ibex.
-CONNECTION, AST_DFT_RV_CORE_IBEX_TAG0_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].tag_bank.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic, cfg_i
-CONNECTION, AST_DFT_RV_CORE_IBEX_TAG1_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].tag_bank.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic, cfg_i
-CONNECTION, AST_DFT_RV_CORE_IBEX_DATA0_RAM_1P_CFG, u_ast.u_ast_dft,"{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].data_bank.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic, cfg_i
-CONNECTION, AST_DFT_RV_CORE_IBEX_DATA1_RAM_1P_CFG, u_ast.u_ast_dft,"{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].data_bank.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic, cfg_i
+CONNECTION, AST_DFT_RV_CORE_IBEX_TAG0_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic, cfg_i
+CONNECTION, AST_DFT_RV_CORE_IBEX_TAG1_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic, cfg_i
+CONNECTION, AST_DFT_RV_CORE_IBEX_DATA0_RAM_1P_CFG, u_ast.u_ast_dft,"{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic, cfg_i
+CONNECTION, AST_DFT_RV_CORE_IBEX_DATA1_RAM_1P_CFG, u_ast.u_ast_dft,"{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic, cfg_i
 
 # To sram_ctrl (main).
 CONNECTION, AST_DFT_SRAM_MAIN_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_sram_ctrl_main.u_prim_ram_1p_scr.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic, cfg_i

--- a/hw/top_earlgrey/formal/conn_csvs/clkmgr_peri.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/clkmgr_peri.csv
@@ -29,7 +29,7 @@ CONNECTION, CLKMGR_PERI_CLK_UART1_CLK, top_earlgrey.u_clkmgr_aon, clocks_o.clk_i
 CONNECTION, CLKMGR_PERI_CLK_UART2_CLK, top_earlgrey.u_clkmgr_aon, clocks_o.clk_io_div4_peri, top_earlgrey.u_uart2, clk_i
 CONNECTION, CLKMGR_PERI_CLK_UART3_CLK, top_earlgrey.u_clkmgr_aon, clocks_o.clk_io_div4_peri, top_earlgrey.u_uart3, clk_i
 
-CONNECTION, CLKMGR_PERI_CLK_USBDEV_CLK,     top_earlgrey.u_clkmgr_aon, clocks_o.clk_io_div4_peri, top_earlgrey.u_usbdev, clk_i
+CONNECTION, CLKMGR_PERI_CLK_USBDEV_CLK,     top_earlgrey.u_clkmgr_aon, clocks_o.clk_usb_peri, top_earlgrey.u_usbdev, clk_i
 CONNECTION, CLKMGR_PERI_CLK_USBDEV_USB_CLK, top_earlgrey.u_clkmgr_aon, clocks_o.clk_usb_peri,     top_earlgrey.u_usbdev, clk_usb_48mhz_i
 
 # TODO: check with design - this is a questionable classification: an aon clock in the peri group seems wrong.


### PR DESCRIPTION
This PR updates two mismatches in connectivity test:
1). Fix an ibex memory path
2). Fix usb clock connection

Signed-off-by: Cindy Chen <chencindy@opentitan.org>