### PR TITLE
[dv,rstmgr] Fix rstmgr leaf_rst tests

### DIFF
--- a/hw/ip/rstmgr/dv/env/rstmgr_env.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_env.sv
@@ -50,6 +50,11 @@ class rstmgr_env extends cip_base_env #(
         )) begin
       `uvm_fatal(`gfn, "failed to get pwrmgr_rstmgr_sva_vif from uvm_config_db")
     end
+    if (!uvm_config_db#(virtual rstmgr_cascading_sva_if)::get(
+            this, "", "rstmgr_cascading_sva_vif", cfg.rstmgr_cascading_sva_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get rstmgr_cascading_sva_vif from uvm_config_db")
+    end
     if (!uvm_config_db#(virtual rstmgr_if)::get(this, "", "rstmgr_vif", cfg.rstmgr_vif)) begin
       `uvm_fatal(`gfn, "failed to get rstmgr_vif from uvm_config_db")
     end

--- a/hw/ip/rstmgr/dv/env/rstmgr_env_cfg.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_env_cfg.sv
@@ -13,14 +13,15 @@ class rstmgr_env_cfg extends cip_base_env_cfg #(
 
   `uvm_object_new
 
-  virtual rstmgr_if rstmgr_vif;
-  virtual pwrmgr_rstmgr_sva_if pwrmgr_rstmgr_sva_vif;
   virtual clk_rst_if aon_clk_rst_vif;
   virtual clk_rst_if io_clk_rst_vif;
   virtual clk_rst_if io_div2_clk_rst_vif;
   virtual clk_rst_if io_div4_clk_rst_vif;
   virtual clk_rst_if main_clk_rst_vif;
   virtual clk_rst_if usb_clk_rst_vif;
+  virtual pwrmgr_rstmgr_sva_if pwrmgr_rstmgr_sva_vif;
+  virtual rstmgr_cascading_sva_if rstmgr_cascading_sva_vif;
+  virtual rstmgr_if rstmgr_vif;
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = rstmgr_env_pkg::LIST_OF_ALERTS;

--- a/hw/ip/rstmgr/dv/env/rstmgr_env_pkg.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_env_pkg.sv
@@ -36,30 +36,31 @@ package rstmgr_env_pkg;
 
   // Instances of rstmgr_leaf_rst modules in top_earlgrey's rstmgr.
   parameter string LIST_OF_LEAFS[] = {
-    "u_daon_por",
     "u_daon_por_io",
-    "u_daon_por_io_div2",
-    // The leaf below doesn't implement
-    // consistency checks.
+    // The leaf below doesn't implement consistency checks.
     // "u_daon_por_io_div4",
-    "u_daon_por_usb",
+    "u_daon_lc",
     "u_d0_lc",
+    "u_daon_lc_shadowed",
     "u_d0_lc_shadowed",
+    "u_daon_lc_aon",
+    "u_daon_lc_io",
+    "u_daon_lc_io_div2",
     "u_daon_lc_io_div4",
     "u_d0_lc_io_div4",
     "u_daon_lc_io_div4_shadowed",
     "u_d0_lc_io_div4_shadowed",
-    "u_daon_lc_aon",
+    "u_daon_lc_usb",
     "u_d0_sys",
     "u_d0_sys_shadowed",
     "u_daon_sys_io_div4",
     "u_d0_sys_io_div4",
     "u_daon_sys_aon",
-    "u_d0_sys_aon",
     "u_d0_spi_device",
     "u_d0_spi_host0",
     "u_d0_spi_host1",
     "u_d0_usb",
+    "u_d0_usb_aon",
     "u_d0_i2c0",
     "u_d0_i2c1",
     "u_d0_i2c2"
@@ -67,6 +68,7 @@ package rstmgr_env_pkg;
 
   // Instances of rstmgr_leaf_rst modules which have a shadow pair.
   parameter string LIST_OF_SHADOW_LEAFS[] = {
+    "u_daon_lc",
     "u_d0_lc",
     "u_daon_lc_io_div4",
     "u_d0_lc_io_div4",

--- a/hw/ip/rstmgr/dv/tb.sv
+++ b/hw/ip/rstmgr/dv/tb.sv
@@ -130,6 +130,8 @@ module tb;
 
     uvm_config_db#(virtual pwrmgr_rstmgr_sva_if)::set(null, "*.env", "pwrmgr_rstmgr_sva_vif",
                                                       dut.pwrmgr_rstmgr_sva_if);
+    uvm_config_db#(virtual rstmgr_cascading_sva_if)::set(null, "*.env", "rstmgr_cascading_sva_vif",
+                                                      dut.rstmgr_cascading_sva_if);
     uvm_config_db#(virtual rstmgr_if)::set(null, "*.env", "rstmgr_vif", rstmgr_if);
 
     $timeformat(-12, 0, " ps", 12);


### PR DESCRIPTION
Update the list of rstmgr_leaf_rst instances.
Extend the time to wait on shadow_attack tests.
Disable cascading reset SVAs in shadow_attack tests since they violate
the reset protocol.

Signed-off-by: Guillermo Maturana <maturana@google.com>