### PR TITLE
[dv] Fix ping exclusion

### DIFF
--- a/hw/dv/tools/xcelium/common_cov_excl.tcl
+++ b/hw/dv/tools/xcelium/common_cov_excl.tcl
@@ -8,3 +8,4 @@ exclude -inst $::env(DUT_TOP) -toggle '*tl_o.d_param' -comment "\[UNR\] Follows 
 exclude -inst $::env(DUT_TOP) -toggle '*tl_o.d_sink' -comment "\[UNR\] Based on our Comportability Spec."
 exclude -inst $::env(DUT_TOP) -toggle '*tl_o.d_user.rsp_intg'\[6\] -comment "\[UNR\] Due to the ECC logics"
 exclude -inst $::env(DUT_TOP) -toggle '*alert_rx_*.ping_*' -comment "\[LOW_RISK\] Verified in prim_alert_receiver TB."
+exclude -inst $::env(DUT_TOP).gen_alert_tx*.u_prim_alert_sender -toggle '*alert*.ping_*' -comment "\[LOW_RISK\] Verified in prim_alert_receiver TB."


### PR DESCRIPTION
Since we enable prim_alert_sender toggle coverage, need to apply ping
exclusion to this module too.

Signed-off-by: Weicai Yang <weicai@google.com>