### PR TITLE
[dv/otp_ctrl] Fix lc_dft_en failures

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -35,7 +35,7 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     // once turn on lc_dft_en regiser, will need some time to update the state register
     // two clock cycles for lc_async mode, one clock cycle for driving dft_en, one more clock cycle
     // so there is no racing condition.
-    cfg.clk_rst_vif.wait_clks(3);
+    cfg.clk_rst_vif.wait_clks(4);
   endtask
 
   virtual task post_start();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_test_access_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_test_access_vseq.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO: add support to randomly turn on and off lc_dft_en to fully verify the `prim_lc_gate`
+// module.
 class otp_ctrl_test_access_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_test_access_vseq)
 


### PR DESCRIPTION
This PR fixes the regression failures when lc_dft_en is set to On and DV
did not expect it to return d_error.
This case is hard to align on the scoreboard side because it is timing
sensetive regarding the d_channel and a_channel.
Because this case is not likely to happen in chip level (lc_dft_en
cannot be switched on and off on the fly), I added a TODO to support
checking that in otp_ctrl_test_access sequence.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>