### PR TITLE
[dif, rv_core_ibex]  Add cpu dump and move to S2

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.prj.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.prj.hjson
@@ -11,4 +11,5 @@
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V1",
+    dif_stage:          "S2",
 }

--- a/sw/device/lib/dif/dif_rv_core_ibex.c
+++ b/sw/device/lib/dif/dif_rv_core_ibex.c
@@ -361,3 +361,31 @@ dif_result_t dif_rv_core_ibex_trigger_sw_fatal_err_alert(
                       RV_CORE_IBEX_SW_FATAL_ERR_REG_OFFSET, reg);
   return kDifOk;
 }
+
+enum {
+  kIbexCrashDumpBytesCount = sizeof(dif_rv_core_ibex_crash_dump_info_t),
+  kIbexCrashDumpWordsCount = kIbexCrashDumpBytesCount / sizeof(uint32_t),
+  kIbexCrashDumpStateBytesCount = sizeof(dif_rv_core_ibex_crash_dump_state_t),
+  kIbexCrashDumpStateWordsCount =
+      kIbexCrashDumpStateBytesCount / sizeof(uint32_t),
+  kIbexCrashDumpPreviousStateBytesCount =
+      sizeof(dif_rv_core_ibex_previous_crash_dump_state_t),
+  kIbexCrashDumpPreviousStateWordsCount =
+      kIbexCrashDumpPreviousStateBytesCount / sizeof(uint32_t),
+};
+
+dif_result_t dif_rv_core_ibex_parse_crash_dump(
+    const dif_rv_core_ibex_t *rv_core_ibex, uint32_t *cpu_info,
+    uint32_t cpu_info_len,
+    dif_rv_core_ibex_crash_dump_info_t *crash_dump_info) {
+  if (rv_core_ibex == NULL || cpu_info == NULL || crash_dump_info == NULL ||
+      cpu_info_len < kIbexCrashDumpWordsCount) {
+    return kDifBadArg;
+  }
+
+  memcpy(crash_dump_info, cpu_info, kIbexCrashDumpBytesCount - 1);
+  crash_dump_info->double_fault =
+      dif_bool_to_toggle(cpu_info[kIbexCrashDumpWordsCount - 1] == 1);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_rv_core_ibex.md
+++ b/sw/device/lib/dif/dif_rv_core_ibex.md
@@ -11,9 +11,9 @@ All checklist items refer to the content in the [Checklist]({{< relref "/doc/pro
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | In Progress |
-Implementation | [DIF_USED_IN_TREE][] | In Progress |
-Tests          | [DIF_TEST_SMOKE][]   | In Progress |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
@@ -23,9 +23,9 @@ Tests          | [DIF_TEST_SMOKE][]   | In Progress |
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_FEATURES][]            | In Progress |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
 [DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}


### PR DESCRIPTION
## This PR

- Add a function to parse the CPU dump from the rstmgr.
- Update the dif to S2.

Obs. As soon I receive a positive feedback about the function interface I'll implement the unittest and push to this PR.