### PR TITLE
[alert_handler] Add some more assertions to check wait cycle mask

### DIFF
--- a/hw/ip_templates/alert_handler/rtl/alert_handler.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler.sv
@@ -131,6 +131,8 @@ module alert_handler
     .ping_timeout_cyc_i ( reg2hw_wrap.ping_timeout_cyc   ),
     // set this to the maximum width in the design.
     // can be overridden in DV and FPV to shorten the wait periods.
+    // note however that this needs to be a right-aligned mask.
+    // also, do not set this to a value lower than 0x7.
     .wait_cyc_mask_i    ( {PING_CNT_DW{1'b1}}            ),
     // SEC_CM: ALERT_RX.INTERSIG.BKGN_CHK
     .alert_ping_req_o   ( alert_ping_req                 ),

--- a/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -58,6 +58,13 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   localparam int unsigned ReseedLfsrExtraBits = 3;
   localparam int unsigned ReseedLfsrWidth = PING_CNT_DW + ReseedLfsrExtraBits;
 
+  // A few smoke checks for the DV mask:
+  // 1) make sure the value is a right-aligned mask.
+  //    this can be done by checking that mask+1 is a power of 2.
+  // 2) also make sure that the value is always >= 0x7.
+  `ASSERT(WaitCycMaskMin_A, wait_cyc_mask_i >= 'h7)
+  `ASSERT(WaitCycMaskIsRightAlignedMask_A,
+      2**$clog2(32'(wait_cyc_mask_i) + 1) == 32'(wait_cyc_mask_i) + 1)
   ////////////////////
   // Reseed counter //
   ////////////////////

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler.sv
@@ -131,6 +131,8 @@ module alert_handler
     .ping_timeout_cyc_i ( reg2hw_wrap.ping_timeout_cyc   ),
     // set this to the maximum width in the design.
     // can be overridden in DV and FPV to shorten the wait periods.
+    // note however that this needs to be a right-aligned mask.
+    // also, do not set this to a value lower than 0x7.
     .wait_cyc_mask_i    ( {PING_CNT_DW{1'b1}}            ),
     // SEC_CM: ALERT_RX.INTERSIG.BKGN_CHK
     .alert_ping_req_o   ( alert_ping_req                 ),

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -58,6 +58,13 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   localparam int unsigned ReseedLfsrExtraBits = 3;
   localparam int unsigned ReseedLfsrWidth = PING_CNT_DW + ReseedLfsrExtraBits;
 
+  // A few smoke checks for the DV mask:
+  // 1) make sure the value is a right-aligned mask.
+  //    this can be done by checking that mask+1 is a power of 2.
+  // 2) also make sure that the value is always >= 0x7.
+  `ASSERT(WaitCycMaskMin_A, wait_cyc_mask_i >= 'h7)
+  `ASSERT(WaitCycMaskIsRightAlignedMask_A,
+      2**$clog2(32'(wait_cyc_mask_i) + 1) == 32'(wait_cyc_mask_i) + 1)
   ////////////////////
   // Reseed counter //
   ////////////////////


### PR DESCRIPTION
This ensures that the mask to shorten runtime in DV/FPV is actually a correct mask.

Signed-off-by: Michael Schaffner <msf@opentitan.org>