### PR TITLE
[dv,chip,power_glitch] Fix deep_sleep power glitch test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1025,9 +1025,14 @@
       name: chip_sw_pwrmgr_deep_sleep_power_glitch_reset
       desc: '''Verify the effect of a glitch in main power rail in deep sleep.
 
-            The vcmain_supp_i AST input is forced to drop after putting the chip in deep sleep. This
-            triggers a MainPwr reset request, which is checked reading the reset_info CSR when the
-            test restarts and the POR bit is not set.
+            The vcmain_supp_i AST input is forced to drop right after putting the chip in deep
+            sleep. This triggers a MainPwr reset request, which is checked reading the reset_info
+            CSR when the test restarts and the POR bit is not set.
+
+            Note: the glitch has to be sent in a very narrow window:
+            - If sent too early the chip won't have started to process deep sleep.
+            - If too late the hardware won't monitor main power okay so the glitch will have no
+              effect, and the test will timeout.
             '''
       milestone: V2
       tests: ["chip_sw_pwrmgr_deep_sleep_power_glitch_reset"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -561,7 +561,7 @@
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_power_glitch_reset
-      uvm_test_seq: chip_sw_main_power_glitch_vseq
+      uvm_test_seq: chip_sw_deep_power_glitch_vseq
       sw_images: ["sw/device/tests/sim_dv/pwrmgr_deep_sleep_power_glitch_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+bypass_alert_ready_to_end_check=1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -46,6 +46,7 @@ filesets:
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_jtag_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_full_aon_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_deep_power_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_main_power_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_random_sleep_all_reset_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_power_glitch_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_power_glitch_vseq.sv
@@ -2,14 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_sw_main_power_glitch_vseq extends chip_sw_base_vseq;
-  `uvm_object_utils(chip_sw_main_power_glitch_vseq)
+class chip_sw_deep_power_glitch_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_deep_power_glitch_vseq)
 
   `uvm_object_new
-
-  // Cycles to wait for the pwrmgr to start normal sleep processing after trigger.
-  rand int cycles_after_trigger;
-  constraint cycles_after_trigger_c {cycles_after_trigger inside {[5 : 13]};}
 
   virtual task pre_start();
     super.pre_start();
@@ -23,7 +19,7 @@ class chip_sw_main_power_glitch_vseq extends chip_sw_base_vseq;
     super.body();
     // Wait until we reach the SW test state.
     wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-    cfg.ast_supply_vif.glitch_vcmain_pok_on_next_core_sleeping_trigger(cycles_after_trigger);
+    cfg.ast_supply_vif.glitch_vcmain_pok_on_next_low_power_trigger();
 
     // the above glitch should cause the system to reboot, now wait for reset
     // before re-enabling assertion

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -12,6 +12,7 @@
 `include "chip_sw_base_vseq.sv"
 `include "chip_jtag_base_vseq.sv"
 `include "chip_sw_full_aon_reset_vseq.sv"
+`include "chip_sw_deep_power_glitch_vseq.sv"
 `include "chip_sw_main_power_glitch_vseq.sv"
 `include "chip_sw_sysrst_ctrl_vseq.sv"
 `include "chip_sw_random_sleep_all_reset_vseq.sv"

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -80,7 +80,8 @@ module tb;
 
   bind dut ast_supply_if ast_supply_if (
     .clk(top_earlgrey.clk_aon_i),
-    .trigger(top_earlgrey.rv_core_ibex_pwrmgr.core_sleeping)
+    .core_sleeping_trigger(top_earlgrey.rv_core_ibex_pwrmgr.core_sleeping),
+    .low_power_trigger(`PWRMGR_HIER.pwr_rst_o.reset_cause == pwrmgr_pkg::LowPwrEntry)
   );
 
   bind dut ast_ext_clk_if ast_ext_clk_if ();

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_power_glitch_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_power_glitch_test.c
@@ -53,9 +53,11 @@ bool test_main(void) {
     wait_for_interrupt();
   } else {
     LOG_INFO("Checking reset status.");
-    rstmgr_testutils_post_reset(&rstmgr, kDifRstmgrResetInfoPowerUnstable, 0, 0,
-                                0, 0);
-    LOG_INFO("Reset status indicates a main power glitch reset");
+    rstmgr_testutils_post_reset(
+        &rstmgr,
+        kDifRstmgrResetInfoPowerUnstable | kDifRstmgrResetInfoLowPowerExit, 0,
+        0, 0, 0);
+    LOG_INFO("Reset status indicates a power glitch and a deep sleep wakeup");
   }
   return true;
 }


### PR DESCRIPTION
Trigger the glitch when pwrmgr has just set reset_cause to LowPwrEntry.
If the trigger event happens with more relaxed timing the results are
unpredictable: either reset happens before low power entry, or pwrmgr
could have stopped monitoring power glitches.

Signed-off-by: Guillermo Maturana <maturana@google.com>