### PR TITLE
[alert_handler/fpv] Fix local_alert index for reg WE error

### DIFF
--- a/hw/ip_templates/alert_handler/rtl/alert_handler.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler.sv
@@ -328,5 +328,5 @@ module alert_handler
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ERR(RegWeOnehotCheck_A,
-      u_reg_wrap.u_reg, loc_alert_trig[2])
+      u_reg_wrap.u_reg, loc_alert_trig[4])
 endmodule

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler.sv
@@ -328,5 +328,5 @@ module alert_handler
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ERR(RegWeOnehotCheck_A,
-      u_reg_wrap.u_reg, loc_alert_trig[2])
+      u_reg_wrap.u_reg, loc_alert_trig[4])
 endmodule


### PR DESCRIPTION
This PR fixes the alert_handler_sec_cm failure where we expect to see
loc_alert[2] to fire when reg WE failed. But from the spec, loc_alert[2]
is alert integfail but loc_alert[4] is for bus integrity failure.
So this PR fixes this typo.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>