### PR TITLE
[dv,chip,hmac_idle] Add chip_sw_hmac_enc_idle test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -774,7 +774,9 @@
             '''
       milestone: V2
       tests: ["chip_sw_aes_idle",
-              "chip_sw_hmac_idle"]
+              "chip_sw_hmac_idle",
+              "chip_sw_kmac_idle",
+              "chip_sw_otbn_randomness"]
     }
     {
       name: chip_sw_clkmgr_off_trans
@@ -1817,9 +1819,11 @@
               (HMAC is enabled), before the HMAC operation is complete.
             - After the HMAC operation is complete, verify the digest for correctness.
               Verify that the HMAC clk hint status within clkmgr now reads 0 again (HMAC is disabled).
+            - This process is repeated for two hmac operations needed to verify the resulting hmac
+              digest.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_hmac_idle"]
     }
 
     // KMAC pre-verified IP) integration tests:
@@ -2161,12 +2165,14 @@
       desc: '''Verify the OTBN idle signal to clkmgr.
 
             - Write the OTBN clk hint to 0 within clkmgr to indicate OTBN clk can be gated
-              and verify that the OTBN clk hint status within clkmgr reads 0 (OTBN is idle).
+              and verify that the OTBN clk hint status within clkmgr reads 0 (OTBN is disabled).
             - Write the OTBN clk hint to 1 within clkmgr to indicate OTBN clk can be enabled.
+              Verify that the OTBN clk hint status within clkmgr reads 1 (OTBN is enabled).
             - Start an OTBN operation, write the OTBN clk hint to 0 within clkmgr and verify that
-              the OTBN clk hint status within clkmgr reads 1 (OTBN is not idle).
+              the OTBN clk hint status within clkmgr reads 1 (OTBN is enabled) before the
+              OTBN operation is complete.
             - After the OTBN operation is complete, verify that the OTBN clk hint status within
-              clkmgr now reads 0 again (OTBN is idle).
+              clkmgr now reads 0 again (OTBN is disabled).
             - Write the OTBN clk hint to 1, read and check the OTBN output for correctness.
             '''
       milestone: V2

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -736,6 +736,12 @@
       run_opts: ["+en_jitter=1"]
     }
     {
+      name: chip_sw_hmac_enc_idle
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/hmac_enc_idle_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_keymgr_key_derivation
       uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
       sw_images: ["sw/device/tests/sim_dv/keymgr_key_derivation_test:1"]

--- a/sw/device/lib/testing/hmac_testutils.c
+++ b/sw/device/lib/testing/hmac_testutils.c
@@ -8,6 +8,54 @@
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+const char kRefData[34] = "Sample message for keylen=blocklen";
+
+const uint8_t kRefHmacLongKey[100] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+    0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+    0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23,
+    0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F,
+    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B,
+    0x3C, 0x3D, 0x3E, 0x3F, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
+    0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53,
+    0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F,
+    0x60, 0x61, 0x62, 0x63};
+
+/**
+ * Big endian representation of the hashed "long" key, which is used as the
+ * input key into the HMAC mode digest generation.
+ */
+const dif_hmac_digest_t kRefExpectedShaDigest = {
+    .digest =
+        {
+            0xBCE0AFF1,
+            0x9CF5AA6A,
+            0x7469A30D,
+            0x61D04E43,
+            0x76E4BBF6,
+            0x381052EE,
+            0x9E7F3392,
+            0x5C954D52,
+        },
+};
+
+/**
+ * Big endian representation of the final HMAC mode digest.
+ */
+const dif_hmac_digest_t kRefExpectedHmacDigest = {
+    .digest =
+        {
+            0xBDCCB6C7,
+            0x2DDEADB5,
+            0x00AE7683,
+            0x86CB38CC,
+            0x41C63DBB,
+            0x0878DDB9,
+            0xC7A38A43,
+            0x1B78378D,
+        },
+};
+
 void hmac_testutils_check_message_length(const dif_hmac_t *hmac,
                                          uint64_t expected_sent_bits) {
   uint64_t sent_bits;
@@ -30,6 +78,7 @@ static bool check_fifo_empty(const dif_hmac_t *hmac) {
   CHECK_DIF_OK(dif_hmac_fifo_count_entries(hmac, &fifo_depth));
   return fifo_depth == 0;
 }
+
 void hmac_testutils_fifo_empty_polled(const dif_hmac_t *hmac) {
   IBEX_SPIN_FOR(check_fifo_empty(hmac), HMAC_TESTUTILS_FIFO_EMPTY_USEC);
 }
@@ -41,6 +90,7 @@ static bool check_finished(const dif_hmac_t *hmac,
 
   return res == kDifOk;
 }
+
 void hmac_testutils_finish_polled(const dif_hmac_t *hmac,
                                   dif_hmac_digest_t *digest_out) {
   IBEX_SPIN_FOR(check_finished(hmac, digest_out),

--- a/sw/device/lib/testing/hmac_testutils.h
+++ b/sw/device/lib/testing/hmac_testutils.h
@@ -44,6 +44,44 @@
   (udiv64_slow((360 + 10) * 1000000, kClockFreqCpuHz, NULL) + 1)
 
 /**
+ * Reference key and tag for testing from NIST.
+ *
+ * https://csrc.nist.gov/CSRC/media/Projects/
+ * Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA256.pdf
+ *
+ * Key Length: 100
+ * Tag length: 32
+ *
+ * When key is > than the block size, it should be hashed to obtain the block
+ * sized key. Please refer to:
+ * https://csrc.nist.gov/csrc/media/publications/fips/198/archive/
+ * 2002-03-06/documents/fips-198a.pdf
+ *
+ * Specifically chapter 3 and 5 (Table 1).
+ */
+
+/**
+ * This should be hashed with SHA-256 to generate the key.
+ */
+extern const uint8_t kRefHmacLongKey[100];
+
+/**
+ * Expected SHA digest for kRefHmacLongKey data above.
+ */
+extern const dif_hmac_digest_t kRefExpectedShaDigest;
+
+/**
+ * This is used as data for the MAC computation, using kRefExpectedShaDigest
+ * as the key.
+ */
+extern const char kRefData[34];
+
+/**
+ * Expected MAC digest for kRefData data above.
+ */
+extern const dif_hmac_digest_t kRefExpectedHmacDigest;
+
+/**
  * Reads and compares the actual sent message length against expected.
  *
  * The message length is provided in bits.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -653,6 +653,21 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "hmac_enc_idle_test",
+    srcs = ["hmac_enc_idle_test.c"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:clkmgr",
+        "//sw/device/lib/dif:hmac",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:clkmgr_testutils",
+        "//sw/device/lib/testing:hmac_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "hmac_smoketest",
     srcs = ["hmac_smoketest.c"],
     deps = [

--- a/sw/device/tests/hmac_enc_idle_test.c
+++ b/sw/device/tests/hmac_enc_idle_test.c
@@ -1,0 +1,123 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/dif/dif_hmac.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/clkmgr_testutils.h"
+#include "sw/device/lib/testing/hmac_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define TIMEOUT (1000 * 1000)
+
+OTTF_DEFINE_TEST_CONFIG();
+static dif_clkmgr_t clkmgr;
+static const dif_clkmgr_hintable_clock_t kHmacClock =
+    kTopEarlgreyHintableClocksMainHmac;
+
+static const dif_hmac_transaction_t kHmacTransactionConfig = {
+    .digest_endianness = kDifHmacEndiannessLittle,
+    .message_endianness = kDifHmacEndiannessLittle,
+};
+
+static bool is_hintable_clock_enabled(const dif_clkmgr_t *clkmgr,
+                                      dif_clkmgr_hintable_clock_t clock) {
+  dif_toggle_t clock_state;
+  CHECK_DIF_OK(
+      dif_clkmgr_hintable_clock_get_enabled(clkmgr, clock, &clock_state));
+  return clock_state == kDifToggleEnabled;
+}
+
+static void initialize_clkmgr(dif_clkmgr_hintable_clock_t clock) {
+  mmio_region_t addr = mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_clkmgr_init(addr, &clkmgr));
+
+  // Get initial hint and enable for AES clock and check both are enabled.
+  dif_toggle_t clock_hint_state;
+  CHECK_DIF_OK(
+      dif_clkmgr_hintable_clock_get_hint(&clkmgr, clock, &clock_hint_state));
+  CHECK(clock_hint_state == kDifToggleEnabled);
+  CLKMGR_TESTUTILS_CHECK_CLOCK_HINT(clkmgr, clock, kDifToggleEnabled);
+}
+
+// This waits for the process to end with a looming hint, checks the hint status
+// shows the clock is disabled, and reanable it. The check for process
+// completion cannot be done using hmac registers since the clock will be
+// disabled as soon as the process ends, so we just wait for the clkmgr hint
+// status to indicate the clock is off, implying the process actually ended.
+static void handle_end_of_process(dif_clkmgr_hintable_clock_t clock) {
+  IBEX_SPIN_FOR(!is_hintable_clock_enabled(&clkmgr, clock), TIMEOUT);
+  LOG_INFO("Done");
+
+  // After the AES operation is complete verify that the AES clk hint status
+  // within clkmgr now reads 0 again (AES is idle).
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(clkmgr, clock, kDifToggleDisabled,
+                                            kDifToggleDisabled);
+
+  // Write the HMAC clk hint to 1, read and check the HMAC output for
+  // correctness.
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(clkmgr, clock, kDifToggleEnabled,
+                                            kDifToggleEnabled);
+}
+
+bool test_main(void) {
+  dif_hmac_t hmac;
+
+  initialize_clkmgr(kHmacClock);
+
+  mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
+  CHECK_DIF_OK(dif_hmac_init(base_addr, &hmac));
+
+  // With the HMAC unit idle, write the HMAC clk hint to 0 within clkmgr to
+  // indicate HMAC clk can be gated and verify that the HMAC clk hint status
+  // within clkmgr reads 0 (HMAC is disabled).
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
+      clkmgr, kHmacClock, kDifToggleDisabled, kDifToggleDisabled);
+
+  // Write the HMAC clk hint to 1 within clkmgr to indicate HMAC clk can be
+  // enabled.
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
+      clkmgr, kHmacClock, kDifToggleEnabled, kDifToggleEnabled);
+
+  // Use HMAC in SHA256 mode to generate a 256bit key from `kRefHmacLongKey`.
+  CHECK_DIF_OK(dif_hmac_mode_sha256_start(&hmac, kHmacTransactionConfig));
+  hmac_testutils_push_message(&hmac, (char *)kRefHmacLongKey,
+                              sizeof(kRefHmacLongKey));
+  LOG_INFO("Pushed message");
+  hmac_testutils_check_message_length(&hmac, sizeof(kRefHmacLongKey) * 8);
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
+      clkmgr, kHmacClock, kDifToggleDisabled, kDifToggleEnabled);
+  LOG_INFO("Cleared hints");
+  CHECK_DIF_OK(dif_hmac_process(&hmac));
+  LOG_INFO("Process");
+
+  handle_end_of_process(kHmacClock);
+
+  dif_hmac_digest_t key_digest;
+  hmac_testutils_finish_polled(&hmac, &key_digest);
+  CHECK_ARRAYS_EQ(key_digest.digest, kRefExpectedShaDigest.digest,
+                  ARRAYSIZE(key_digest.digest));
+
+  // Generate HMAC final digest, using the resulted SHA256 digest over the
+  // `kRefHmacLongKey`.
+  CHECK_DIF_OK(dif_hmac_mode_hmac_start(&hmac, (uint8_t *)&key_digest.digest[0],
+                                        kHmacTransactionConfig));
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
+      clkmgr, kHmacClock, kDifToggleDisabled, kDifToggleEnabled);
+  LOG_INFO("Cleared hints");
+  hmac_testutils_push_message(&hmac, kRefData, sizeof(kRefData));
+  hmac_testutils_check_message_length(&hmac, sizeof(kRefData) * 8);
+  CHECK_DIF_OK(dif_hmac_process(&hmac));
+  LOG_INFO("Process");
+
+  handle_end_of_process(kHmacClock);
+
+  hmac_testutils_finish_and_check_polled(&hmac, &kRefExpectedHmacDigest);
+
+  return true;
+}

--- a/sw/device/tests/hmac_enc_test.c
+++ b/sw/device/tests/hmac_enc_test.c
@@ -18,93 +18,30 @@ static const dif_hmac_transaction_t kHmacTransactionConfig = {
     .message_endianness = kDifHmacEndiannessLittle,
 };
 
-/**
- * https://csrc.nist.gov/CSRC/media/Projects/
- * Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA256.pdf
- *
- * Key Length: 100
- * Tag length: 32
- *
- * When key is > than the block size, it should be hashed to obtain the block
- * sized key. Please refer to:
- * https://csrc.nist.gov/csrc/media/publications/fips/198/archive/
- * 2002-03-06/documents/fips-198a.pdf
- *
- * Specifically chapter 3 and 5 (Table 1).
- */
-
-static const char kData[34] = "Sample message for keylen=blocklen";
-
-static uint8_t kHmacLongKey[100] = {
-    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
-    0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
-    0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23,
-    0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F,
-    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B,
-    0x3C, 0x3D, 0x3E, 0x3F, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
-    0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53,
-    0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F,
-    0x60, 0x61, 0x62, 0x63};
-
-/**
- * Big endian representation of the hashed "long" key, which is used as the
- * input key into the HMAC mode digest generation.
- */
-static const dif_hmac_digest_t kExpectedShaDigest = {
-    .digest =
-        {
-            0xBCE0AFF1,
-            0x9CF5AA6A,
-            0x7469A30D,
-            0x61D04E43,
-            0x76E4BBF6,
-            0x381052EE,
-            0x9E7F3392,
-            0x5C954D52,
-        },
-};
-
-/**
- * Big endian representation of the final HMAC mode digest.
- */
-static const dif_hmac_digest_t kExpectedHmacDigest = {
-    .digest =
-        {
-            0xBDCCB6C7,
-            0x2DDEADB5,
-            0x00AE7683,
-            0x86CB38CC,
-            0x41C63DBB,
-            0x0878DDB9,
-            0xC7A38A43,
-            0x1B78378D,
-        },
-};
-
 bool test_main(void) {
   dif_hmac_t hmac;
   mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
   CHECK_DIF_OK(dif_hmac_init(base_addr, &hmac));
 
-  // Use HMAC in SHA256 mode to generate a 256bit key from `kHmacLongKey`.
+  // Use HMAC in SHA256 mode to generate a 256bit key from `kRefHmacLongKey`.
   CHECK_DIF_OK(dif_hmac_mode_sha256_start(&hmac, kHmacTransactionConfig));
-  hmac_testutils_push_message(&hmac, (char *)kHmacLongKey,
-                              sizeof(kHmacLongKey));
-  hmac_testutils_check_message_length(&hmac, sizeof(kHmacLongKey) * 8);
+  hmac_testutils_push_message(&hmac, (char *)kRefHmacLongKey,
+                              sizeof(kRefHmacLongKey));
+  hmac_testutils_check_message_length(&hmac, sizeof(kRefHmacLongKey) * 8);
   CHECK_DIF_OK(dif_hmac_process(&hmac));
   dif_hmac_digest_t key_digest;
   hmac_testutils_finish_polled(&hmac, &key_digest);
-  CHECK_ARRAYS_EQ(key_digest.digest, kExpectedShaDigest.digest,
+  CHECK_ARRAYS_EQ(key_digest.digest, kRefExpectedShaDigest.digest,
                   ARRAYSIZE(key_digest.digest));
 
   // Generate HMAC final digest, using the resulted SHA256 digest over the
-  // `kHmacLongKey`.
+  // `kRefHmacLongKey`.
   CHECK_DIF_OK(dif_hmac_mode_hmac_start(&hmac, (uint8_t *)&key_digest.digest[0],
                                         kHmacTransactionConfig));
-  hmac_testutils_push_message(&hmac, kData, sizeof(kData));
-  hmac_testutils_check_message_length(&hmac, sizeof(kData) * 8);
+  hmac_testutils_push_message(&hmac, kRefData, sizeof(kRefData));
+  hmac_testutils_check_message_length(&hmac, sizeof(kRefData) * 8);
   CHECK_DIF_OK(dif_hmac_process(&hmac));
-  hmac_testutils_finish_and_check_polled(&hmac, &kExpectedHmacDigest);
+  hmac_testutils_finish_and_check_polled(&hmac, &kRefExpectedHmacDigest);
 
   return true;
 }


### PR DESCRIPTION
Develop this along the line of aes_idle. Check against both hmac
processing steps used in chip_sw_hmac_enc_test.
Share some of the reference data and expected digests between these
two tests via hmac_testutils.
Add this hmac and the otbn idle tests to chip_sw_clkmgr_idle_trans
testpoint.

Signed-off-by: Guillermo Maturana <maturana@google.com>