### PR TITLE
[entropy_src, test] - Add the test entropy src ast rng test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1930,6 +1930,7 @@
     // ENTROPY_SRC (pre-verified IP) integration tests:
     {
       name: chip_sw_entropy_src_ast_rng_req
+      //TODO(#13460): A dv enginner should add an assertion to check the connectivity for this test.
       desc: '''Verify the RNG req to ast.
 
             - Program the entropy src in normal RNG mode.
@@ -1939,7 +1940,7 @@
             - Verify the correctness of the received data with assertion based connectivity checks.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_entropy_src_ast_rgn_req"]
     }
     {
       name: chip_sw_entropy_src_ast_fips

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -717,6 +717,13 @@
       run_opts: ["+sw_test_timeout_ns=18000000"]
     }
     {
+      name: chip_sw_entropy_src_ast_rgn_req
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/entropy_src_ast_rng_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=15000000"]
+    }
+    {
       name: chip_sw_hmac_enc_irq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/hmac_enc_irq_test:1"]

--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -265,3 +265,15 @@ dif_result_t dif_entropy_src_disable(const dif_entropy_src_t *entropy_src) {
 
   return kDifOk;
 }
+
+dif_result_t dif_entropy_src_get_fifo_depth(
+    const dif_entropy_src_t *entropy_src, uint32_t *fifo_depth) {
+  if (entropy_src == NULL || fifo_depth == NULL) {
+    return kDifBadArg;
+  }
+
+  *fifo_depth = mmio_region_read32(entropy_src->base_addr,
+                                   ENTROPY_SRC_OBSERVE_FIFO_DEPTH_REG_OFFSET);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -432,7 +432,7 @@ dif_result_t dif_entropy_src_conditioner_end(
 /**
  * Disables the entropy module
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -441,11 +441,22 @@ dif_result_t dif_entropy_src_disable(const dif_entropy_src_t *entropy_src);
 /**
  * Get main entropy fsm idle status
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_entropy_src_get_idle(const dif_entropy_src_t *entropy_src);
+
+/**
+ * Read the fifo depth.
+ *
+ * @param entropy_src An entropy source handle.
+ * @param[out] fifo_depth The fifo depth.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_get_fifo_depth(
+    const dif_entropy_src_t *entropy_src, uint32_t *fifo_depth);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -214,5 +214,23 @@ TEST_F(ReadTest, ReadOk) {
   EXPECT_EQ(got_word, expected_word);
 }
 
+class ReadFifoDepthTest : public EntropySrcTest {};
+
+TEST_F(ReadFifoDepthTest, EntropyBadArg) {
+  uint32_t depth;
+  EXPECT_DIF_BADARG(dif_entropy_src_get_fifo_depth(nullptr, &depth));
+}
+
+TEST_F(ReadFifoDepthTest, DepthBadArg) {
+  EXPECT_DIF_BADARG(dif_entropy_src_get_fifo_depth(&entropy_src_, nullptr));
+}
+
+TEST_F(ReadFifoDepthTest, ReadSuccess) {
+  EXPECT_READ32(ENTROPY_SRC_OBSERVE_FIFO_DEPTH_REG_OFFSET, 6);
+  uint32_t depth;
+  EXPECT_DIF_OK(dif_entropy_src_get_fifo_depth(&entropy_src_, &depth));
+  EXPECT_EQ(depth, 6);
+}
+
 }  // namespace
 }  // namespace dif_entropy_src_unittest

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -479,6 +479,24 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "entropy_src_ast_rng_req_test",
+    srcs = ["entropy_src_ast_rng_req_test.c"],
+    verilator = verilator_params(
+        tags = [
+            "cpu:4",
+        ],
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "example_test_from_flash",
     srcs = ["example_test_from_flash.c"],
     deps = [

--- a/sw/device/tests/entropy_src_ast_rng_req_test.c
+++ b/sw/device/tests/entropy_src_ast_rng_req_test.c
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  /**
+   * The size of the buffer used in firmware to process the entropy bits in
+   * firmware override mode.
+   */
+  kEntropyFifoBufferSize = 32,
+};
+
+static uint32_t read_fifo_depth(dif_entropy_src_t *entropy) {
+  uint32_t fifo_depth = 0;
+  CHECK_DIF_OK(dif_entropy_src_get_fifo_depth(entropy, &fifo_depth));
+  return fifo_depth;
+}
+
+bool test_main() {
+  dif_entropy_src_t entropy_src;
+  CHECK_DIF_OK(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
+
+  CHECK_DIF_OK(dif_entropy_src_disable(&entropy_src));
+
+  const dif_entropy_src_fw_override_config_t fw_override_config = {
+      .entropy_insert_enable = true,
+      .buffer_threshold = kEntropyFifoBufferSize,
+  };
+  CHECK_DIF_OK(dif_entropy_src_fw_override_configure(
+      &entropy_src, fw_override_config, kDifToggleEnabled));
+
+  // Program the entropy src in normal RNG mode.
+  const dif_entropy_src_config_t config = {
+      .fips_enable = true,
+      // Route the entropy data received from RNG to the FIFO.
+      .route_to_firmware = true,
+      .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+  };
+  CHECK_DIF_OK(
+      dif_entropy_src_configure(&entropy_src, config, kDifToggleEnabled));
+
+  // Verify that the FIFO depth is non-zero via SW - indicating the reception of
+  // data over the AST RNG interface.
+  IBEX_SPIN_FOR(read_fifo_depth(&entropy_src) > 0, 1000);
+
+  return true;
+}


### PR DESCRIPTION
## Verify the RNG req to ast.
- Program the entropy src in normal RNG mode.
- Route the entropy data received from RNG to the FIFO.
- Verify that the FIFO depth is non-zero via SW - indicating the reception of data over the AST RNG interface.
- Verify the correctness of the received data with assertion based connectivity checks.

Fixes https://github.com/lowRISC/opentitan/issues/13231