### PR TITLE
[util/design] Generate MEM instead of hexfile in gen-otp-img.py

### DIFF
--- a/util/design/gen-otp-img.py
+++ b/util/design/gen-otp-img.py
@@ -24,7 +24,7 @@ LC_STATE_DEFINITION_FILE = 'hw/ip/lc_ctrl/data/lc_ctrl_state.hjson'
 IMAGE_DEFINITION_FILE = 'hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson'
 # Default output path (can be overridden on the command line). Note that
 # "BITWIDTH" will be replaced with the architecture's bitness.
-MEMORY_HEX_FILE = 'otp-img.BITWIDTH.vmem'
+MEMORY_MEM_FILE = 'otp-img.BITWIDTH.vmem'
 
 
 def _override_seed(args, name, config):
@@ -144,11 +144,11 @@ def main():
                         '--out',
                         type=str,
                         metavar='<path>',
-                        default=MEMORY_HEX_FILE,
+                        default=MEMORY_MEM_FILE,
                         help='''
-                        Custom output path for generated hex file.
+                        Custom output path for generated MEM file.
                         Defaults to {}
-                        '''.format(MEMORY_HEX_FILE))
+                        '''.format(MEMORY_MEM_FILE))
     parser.add_argument('--lc-state-def',
                         type=Path,
                         metavar='<path>',
@@ -195,7 +195,7 @@ def main():
                         default='',
                         help='''
                         This is a post-processing option and allows permuting
-                        the bit positions before writing the hexfile.
+                        the bit positions before writing the memfile.
                         The bit mapping needs to be supplied as a comma separated list
                         of bit slices, where the numbers refer to the bit positions in
                         the original data word before remapping, for example:
@@ -247,7 +247,7 @@ def main():
         log.error(err)
         exit(1)
 
-    # Print all defined args into header comment for referqence
+    # Print all defined args into header comment for reference
     argstr = ''
     for arg, argval in sorted(vars(args).items()):
         if argval:
@@ -264,14 +264,14 @@ def main():
     memfile_header = '// Generated on {} with\n// $ gen-otp-img.py {}\n//\n'.format(
         dtstr, argstr)
 
-    hexfile_content, bitness = otp_mem_img.streamout_hexfile()
-    hexfile_content = memfile_header + hexfile_content
+    memfile_body, bitness = otp_mem_img.streamout_memfile()
 
     # If the out argument does not contain "BITWIDTH", it will not be changed.
-    hexfile_path = Path(args.out.replace('BITWIDTH', str(bitness)))
+    memfile_path = Path(args.out.replace('BITWIDTH', str(bitness)))
 
-    with open(hexfile_path, 'w') as outfile:
-        outfile.write(hexfile_content)
+    with open(memfile_path, 'w') as outfile:
+        outfile.write(memfile_header)
+        outfile.write(memfile_body)
 
 
 if __name__ == "__main__":

--- a/util/design/lib/OtpMemImg.py
+++ b/util/design/lib/OtpMemImg.py
@@ -77,11 +77,11 @@ def _present_64bit_digest(data_blocks, iv, const):
     return state
 
 
-def _to_hexfile_with_ecc(data, annotation, config,
+def _to_memfile_with_ecc(data, annotation, config,
                          data_perm) -> Tuple[str, int]:
-    '''Compute ECC and convert into memory hexfile'''
+    '''Compute ECC and convert into MEM file'''
 
-    log.info('Convert to HEX file.')
+    log.info('Convert to MEM file.')
 
     data_width = config['secded']['data_width']
     ecc_width = config['secded']['ecc_width']
@@ -98,25 +98,22 @@ def _to_hexfile_with_ecc(data, annotation, config,
     bin_format_str = '0' + str(data_width) + 'b'
     hex_format_str = '0' + str(bytes_per_word_ecc * 2) + 'x'
     bitness = bytes_per_word_ecc * 8
-    memory_words = '// OTP memory hexfile with {} x {}bit layout\n'.format(
-        num_words, bitness)
+    mem_lines = [
+        '// OTP MEM file with {} x {}bit layout'.format(num_words, bitness),
+    ]
+
     log.info('Memory layout is {} x {}bit (with ECC)'.format(
         num_words, bitness))
 
-    for k in range(num_words):
+    for i_word in range(num_words):
         # Assemble native OTP word and uniquify annotation for comments
+        word_address = i_word * bytes_per_word
         word = 0
-        word_ann = {}
-        for j in range(bytes_per_word):
-            idx = k * bytes_per_word + j
-            word += data[idx] << (j * 8)
-            if annotation[idx] not in word_ann:
-                word_ann.update({annotation[idx]: "1"})
-
-        # This prints the byte offset of the corresponding
-        # payload data in the memory map (excluding ECC bits)
-        annotation_str = ' // {:06x}: '.format(k * bytes_per_word) + ', '.join(
-            word_ann.keys())
+        word_annotations = set()
+        for i_byte in range(bytes_per_word):
+            byte_address = word_address + i_byte
+            word += data[byte_address] << (i_byte * 8)
+            word_annotations.add(annotation[byte_address])
 
         # ECC encode
         word_bin = format(word, bin_format_str)
@@ -125,11 +122,19 @@ def _to_hexfile_with_ecc(data, annotation, config,
         word_bin = ('0' * bit_padding) + word_bin
         word_bin = permute_bits(word_bin, data_perm)
         word_hex = format(int(word_bin, 2), hex_format_str)
-        memory_words += word_hex + annotation_str + '\n'
+
+        # Build a MEM line containing this word's address in the memory map and
+        # its value. Because this file will be read by Verilog's $readmemh, the
+        # address is a *word* offset, not a byte offset. The address does not
+        # count ECC bits. In a comment, we also include any annotations
+        # associated with the word.
+        line = '@{:06x} {} // {}'.format(i_word, word_hex,
+                                         ', '.join(word_annotations))
+        mem_lines.append(line)
 
     log.info('Done.')
 
-    return (memory_words, bitness)
+    return ('\n'.join(mem_lines), bitness)
 
 
 def _check_unused_keys(dict_to_check, msg_postfix=""):
@@ -142,12 +147,8 @@ def _check_unused_keys(dict_to_check, msg_postfix=""):
 
 class OtpMemImg(OtpMemMap):
 
-    # LC state object
-    lc_state = []
-
     def __init__(self, lc_state_config, otp_mmap_config, img_config,
                  data_perm):
-
         # Initialize memory map
         super().__init__(otp_mmap_config)
 
@@ -354,7 +355,7 @@ class OtpMemImg(OtpMemMap):
 
         # First chop up all items into individual bytes.
         data_bytes = [0] * part_size
-        # Annotation is propagated into the hexfile as comments
+        # Annotation is propagated into the MEM file as comments
         annotation = ['unallocated'] * part_size
         # Need to keep track of defined items for the scrambling.
         # Undefined regions are left blank (0x0) in the memory.
@@ -469,8 +470,8 @@ class OtpMemImg(OtpMemMap):
                 'Data permutation "{}" is not bijective,'
                 'since it contains duplicated indices.'.format(data_perm))
 
-    def streamout_hexfile(self) -> Tuple[str, int]:
-        '''Streamout of memory image in hex file format
+    def streamout_memfile(self) -> Tuple[str, int]:
+        '''Streamout of memory image in MEM file format
 
         Returns a tuple of the file contents and architecture bitness.
         '''
@@ -497,5 +498,5 @@ class OtpMemImg(OtpMemMap):
         assert len(annotation) <= otp_size, 'Annotation size mismatch'
         assert len(data) == len(annotation), 'Data/Annotation size mismatch'
 
-        return _to_hexfile_with_ecc(data, annotation, self.lc_state.config,
+        return _to_memfile_with_ecc(data, annotation, self.lc_state.config,
                                     self.data_perm)

--- a/util/design/lib/OtpMemMap.py
+++ b/util/design/lib/OtpMemMap.py
@@ -11,8 +11,8 @@ import random
 from math import ceil, log2
 
 from lib.common import check_bool, check_int, random_or_hexvalue
-from tabulate import tabulate
 from mubi.prim_mubi import is_width_valid, mubi_value_as_int
+from tabulate import tabulate
 
 DIGEST_SUFFIX = "_DIGEST"
 DIGEST_SIZE = 8
@@ -200,8 +200,8 @@ def _validate_item(item):
     # defaults are handled differently in case of mubi
     if item["ismubi"]:
         if not is_width_valid(item_width):
-            raise RuntimeError("Mubi value {} has invalid width"
-                               .format(item["name"]))
+            raise RuntimeError("Mubi value {} has invalid width".format(
+                item["name"]))
         # Convert default to correct mubi value
         item.setdefault("inv_default", "false")
         item["inv_default"] = check_bool(item["inv_default"])
@@ -244,8 +244,9 @@ def _validate_mmap(config):
 
         part['offset'] = offset
         if check_int(part['offset']) % SCRAMBLE_BLOCK_WIDTH:
-            raise RuntimeError("Partition {} offset must be 64bit aligned".format(
-                part['name']))
+            raise RuntimeError(
+                "Partition {} offset must be 64bit aligned".format(
+                    part['name']))
 
         log.info("Partition {} at offset {} size {}".format(
             part["name"], part["offset"], part["size"]))
@@ -277,9 +278,12 @@ def _validate_mmap(config):
                 "offset":
                 check_int(part["offset"]) + check_int(part["size"]) -
                 DIGEST_SIZE,
-                "ismubi": False,
-                "isdigest": True,
-                "inv_default": "<random>"
+                "ismubi":
+                False,
+                "isdigest":
+                True,
+                "inv_default":
+                "<random>"
             })
             # Randomize the digest default.
             random_or_hexvalue(part["items"][-1], "inv_default",
@@ -311,10 +315,7 @@ def _validate_mmap(config):
 
         offset = check_int(part["offset"]) + check_int(part["size"])
 
-        part_dict.setdefault(part['name'], {
-            'index': j,
-            'items': item_dict
-        })
+        part_dict.setdefault(part['name'], {'index': j, 'items': item_dict})
 
     if offset > config["otp"]["size"]:
         raise RuntimeError(
@@ -322,7 +323,8 @@ def _validate_mmap(config):
             "Bytes available {}, bytes required {}", config["otp"]["size"],
             offset)
 
-    log.info("Total number of partitions: {}".format(len(config["partitions"])))
+    log.info("Total number of partitions: {}".format(len(
+        config["partitions"])))
     log.info("Bytes available in OTP: {}".format(config["otp"]["size"]))
     log.info("Bytes required for partitions: {}".format(offset))
 


### PR DESCRIPTION
With this PR, [gen-otp-img.py](https://cs.opensource.google/opentitan/opentitan/+/master:util/design/gen-otp-img.py;l=85;drc=961b2cdd2044ebaf354b2960aa0951e0ce353e33) emits OTP images in a format that [gen_vivado_mem_image.py](https://cs.opensource.google/opentitan/opentitan/+/master:hw/ip/rom_ctrl/util/gen_vivado_mem_image.py;l=1;drc=961b2cdd2044ebaf354b2960aa0951e0ce353e33) can understand. This is a prerequisite for using Vivado to splice OTP images into FPGA bitstreams.

See https://github.com/lowRISC/opentitan/issues/10867