### PR TITLE
[fpga] Enable splicing OTP images into bitstream

### DIFF
--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -62,3 +62,12 @@ filegroup(
         "//conditions:default": ["@bitstreams//:bitstream_mask_rom"],
     }),
 )
+
+# TODO(lowRISC/opentitan#13603): Use `select` once we're uploading these
+# artifacts to GCP.
+filegroup(
+    name = "mask_rom_otp_dev",
+    srcs = [
+        "//hw/bitstream/vivado:fpga_cw310_mask_rom_otp_dev",
+    ],
+)

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -42,7 +42,8 @@ fusesoc_build(
     ],
     output_groups = {
         "bitstream": ["synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"],
-        "mmi": ["synth-vivado/rom.mmi"],
+        "rom_mmi": ["synth-vivado/rom.mmi"],
+        "otp_mmi": ["synth-vivado/otp.mmi"],
     },
     systems = ["lowrisc:systems:chip_earlgrey_cw310"],
     tags = ["manual"],
@@ -59,7 +60,14 @@ filegroup(
 filegroup(
     name = "rom_mmi",
     srcs = [":fpga_cw310"],
-    output_group = "mmi",
+    output_group = "rom_mmi",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "otp_mmi",
+    srcs = [":fpga_cw310"],
+    output_group = "otp_mmi",
     tags = ["manual"],
 )
 
@@ -68,5 +76,14 @@ bitstream_splice(
     src = ":fpga_cw310_test_rom",
     data = "//sw/device/silicon_creator/mask_rom:mask_rom_fpga_cw310_scr_vmem",
     meminfo = ":rom_mmi",
+    tags = ["manual"],
+)
+
+# Splice in the dev OTP image, replacing the RMA image.
+bitstream_splice(
+    name = "fpga_cw310_mask_rom_otp_dev",
+    src = ":fpga_cw310_mask_rom",
+    data = "//hw/ip/otp_ctrl/data:img_dev",
+    meminfo = ":otp_mmi",
     tags = ["manual"],
 )

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -18,6 +18,11 @@ otp_image(
     src = ":otp_ctrl_img_rma.hjson",
 )
 
+otp_image(
+    name = "img_dev",
+    src = ":otp_ctrl_img_dev.hjson",
+)
+
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Use the gen-otp-img.py script to convert this configuration into
-// a hex file for preloading the OTP in FPGA synthesis or simulation.
+// a MEM file for preloading the OTP in FPGA synthesis or simulation.
 //
 
 {

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_raw.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_raw.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Use the gen-otp-img.py script to convert this configuration into
-// a hex file for preloading the OTP in FPGA synthesis or simulation.
+// a MEM file for preloading the OTP in FPGA synthesis or simulation.
 //
 
 {

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Use the gen-otp-img.py script to convert this configuration into
-// a hex file for preloading the OTP in FPGA synthesis or simulation.
+// a MEM file for preloading the OTP in FPGA synthesis or simulation.
 //
 
 {

--- a/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
@@ -16,67 +16,76 @@ if [expr {$slack_ns < 0}] {
 set_property BITSTREAM.CONFIG.USR_ACCESS TIMESTAMP [current_design]
 
 # Dump MMI for Boot ROM.
-send_msg "Designtask 1-1" INFO "Dumping Boot ROM MMI"
-set workroot [file dirname [info script]]
-set filename "${workroot}/rom.mmi"
-set fileout [open $filename "w"]
+
+proc generate_mmi {filename brams designtask_count} {
+    send_msg "${designtask_count}-1" INFO "Dumping MMI to ${filename}"
+
+    set workroot [file dirname [info script]]
+    set filepath "${workroot}/${filename}"
+    set fileout [open $filepath "w"]
+
+    # Calculate the overall address space.
+    set space 0
+    foreach inst [lsort -dictionary $brams] {
+        set slice_begin [get_property ram_slice_begin [get_cells $inst]]
+        set slice_end [get_property ram_slice_end [get_cells $inst]]
+        if {$slice_begin eq {} || $slice_end eq {}} {
+            send_msg "${designtask_count}-2" ERROR "Extraction of ${filename} information failed."
+        }
+        # The scrambled Boot ROM is actually 39 bits wide but the updatemem tool segfaults
+        # for slice sizes not divisible by 8.
+        if {[expr {($slice_end - $slice_begin + 1) < 8}]} {
+            set slice_end [expr {$slice_begin + 7}]
+        }
+        set addr_begin [get_property ram_addr_begin [get_cells $inst]]
+        set addr_end [get_property ram_addr_end [get_cells $inst]]
+        if {$addr_begin eq {} || $addr_end eq {}} {
+            send_msg "${designtask_count}-3" ERROR "Extraction of ${filename} MMI information failed."
+        }
+        # Calculate total number of bits.
+        set space [expr {$space + ($addr_end - $addr_begin + 1) * ($slice_end - $slice_begin + 1)}]
+    }
+
+    # Generate the MMI.
+    set space [expr {($space / 8) - 1}]
+    puts $fileout "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    puts $fileout "<MemInfo Version=\"1\" Minor=\"0\">"
+    puts $fileout "  <Processor Endianness=\"Little\" InstPath=\"dummy\">"
+    puts $fileout "  <AddressSpace Name=\"rom\" Begin=\"0\" End=\"$space\">"
+    puts $fileout "      <BusBlock>"
+
+    set part [get_property PART [current_design]]
+    foreach inst [lsort -dictionary $brams] {
+        set loc [get_property LOC [get_cells $inst]]
+        set loc [string trimleft $loc RAMB36_]
+        set slice_begin [get_property ram_slice_begin [get_cells $inst]]
+        set slice_end [get_property ram_slice_end [get_cells $inst]]
+        # The scrambled Boot ROM is actually 39 bits wide but the updatemem tool segfaults
+        # for slice sizes not divisible by 4.
+        if {[expr {($slice_end - $slice_begin + 1) < 4}]} {
+            set slice_end [expr {$slice_begin + 3}]
+        }
+        set addr_begin [get_property ram_addr_begin [get_cells $inst]]
+        set addr_end [get_property ram_addr_end [get_cells $inst]]
+        puts $fileout "        <BitLane MemType=\"RAMB32\" Placement=\"$loc\">"
+        puts $fileout "          <DataWidth MSB=\"$slice_end\" LSB=\"$slice_begin\"/>"
+        puts $fileout "          <AddressRange Begin=\"$addr_begin\" End=\"$addr_end\"/>"
+        puts $fileout "          <Parity ON=\"false\" NumBits=\"0\"/>"
+        puts $fileout "        </BitLane>"
+    }
+    puts $fileout "      </BusBlock>"
+    puts $fileout "    </AddressSpace>"
+    puts $fileout "  </Processor>"
+    puts $fileout "<Config>"
+    puts $fileout "  <Option Name=\"Part\" Val=\"$part\"/>"
+    puts $fileout "</Config>"
+    puts $fileout "</MemInfo>"
+    close $fileout
+    send_msg "${designtask_count}-4" INFO "MMI dumped to ${filepath}"
+}
+
 set brams [split [get_cells -hierarchical -filter { PRIMITIVE_TYPE =~ BMEM.bram.* && NAME =~ *u_rom_ctrl*}] " "]
+generate_mmi "rom.mmi" $brams 1
 
-# Calculate the overall address space.
-set space 0
-foreach inst [lsort -dictionary $brams] {
-  set slice_begin [get_property ram_slice_begin [get_cells $inst]]
-  set slice_end [get_property ram_slice_end [get_cells $inst]]
-  if {$slice_begin eq {} || $slice_end eq {}} {
-    send_msg "Designtask 1-2" ERROR "Extraction of Boot ROM MMI information failed."
-  }
-  # The scrambled Boot ROM is actually 39 bits wide but the updatemem tool segfaults
-  # for slice sizes not divisible by 8.
-  if {[expr {($slice_end - $slice_begin + 1) < 8}]} {
-    set slice_end [expr {$slice_begin + 7}]
-  }
-  set addr_begin [get_property ram_addr_begin [get_cells $inst]]
-  set addr_end [get_property ram_addr_end [get_cells $inst]]
-  if {$addr_begin eq {} || $addr_end eq {}} {
-    send_msg "Designtask 1-3" ERROR "Extraction of Boot ROM MMI information failed."
-  }
-  # Calculate total number of bits.
-  set space [expr {$space + ($addr_end - $addr_begin + 1) * ($slice_end - $slice_begin + 1)}]
-}
-
-# Generate the MMI.
-set space [expr {($space / 8) - 1}]
-puts $fileout "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-puts $fileout "<MemInfo Version=\"1\" Minor=\"0\">"
-puts $fileout "  <Processor Endianness=\"Little\" InstPath=\"dummy\">"
-puts $fileout "  <AddressSpace Name=\"rom\" Begin=\"0\" End=\"$space\">"
-puts $fileout "      <BusBlock>"
-
-set part [get_property PART [current_design]]
-foreach inst [lsort -dictionary $brams] {
-  set loc [get_property LOC [get_cells $inst]]
-  set loc [string trimleft $loc RAMB36_]
-  set slice_begin [get_property ram_slice_begin [get_cells $inst]]
-  set slice_end [get_property ram_slice_end [get_cells $inst]]
-  # The scrambled Boot ROM is actually 39 bits wide but the updatemem tool segfaults
-  # for slice sizes not divisible by 4.
-  if {[expr {($slice_end - $slice_begin + 1) < 4}]} {
-    set slice_end [expr {$slice_begin + 3}]
-  }
-  set addr_begin [get_property ram_addr_begin [get_cells $inst]]
-  set addr_end [get_property ram_addr_end [get_cells $inst]]
-  puts $fileout "        <BitLane MemType=\"RAMB32\" Placement=\"$loc\">"
-  puts $fileout "          <DataWidth MSB=\"$slice_end\" LSB=\"$slice_begin\"/>"
-  puts $fileout "          <AddressRange Begin=\"$addr_begin\" End=\"$addr_end\"/>"
-  puts $fileout "          <Parity ON=\"false\" NumBits=\"0\"/>"
-  puts $fileout "        </BitLane>"
-}
-puts $fileout "      </BusBlock>"
-puts $fileout "    </AddressSpace>"
-puts $fileout "  </Processor>"
-puts $fileout "<Config>"
-puts $fileout "  <Option Name=\"Part\" Val=\"$part\"/>"
-puts $fileout "</Config>"
-puts $fileout "</MemInfo>"
-close $fileout
-send_msg "Designtask 1-4" INFO "Boot ROM MMI dumped to ${workroot}/rom.mmi"
+set brams [split [get_cells -hierarchical -filter { PRIMITIVE_TYPE =~ BMEM.bram.* && NAME =~ *u_otp_ctrl*}] " "]
+generate_mmi "otp.mmi" $brams 2

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -332,6 +332,27 @@ opentitan_functest(
     ],
 )
 
+# Same as `:e2e_bootup_success`, but the Dev OTP image is spliced into the
+# bitstream before it's sent to the CW310 FPGA.
+opentitan_functest(
+    name = "e2e_bootup_success_otp_dev",
+    srcs = ["mask_rom_test.c"],
+    cw310 = cw310_params(
+        bitstream = "//hw/bitstream:mask_rom_otp_dev",
+        exit_failure = BOOT_FAILURE_MSG,
+        exit_success = BOOT_SUCCESS_MSG,
+        # TODO(lowRISC/opentitan#13603): Remove this "manual" tag when the
+        # bitstream target can fetch pre-spliced bitstream from GCP.
+        tags = ["manual"],
+    ),
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    signed = True,
+    targets = ["cw310"],
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 opentitan_functest(
     name = "e2e_bootup_no_rom_ext_signature",
     srcs = ["mask_rom_test.c"],


### PR DESCRIPTION
* Generate otp.mmi in vivado_hook_write_bitstream_pre.tcl
* Add otp.mmi to outputs of //hw/bitstream/vivado:fpga_cw310
* Reuse bitstream_splice() macro to splice in the dev OTP image after
  splicing in the Mask ROM.

https://github.com/lowRISC/opentitan/issues/10867