### PR TITLE
[dv/alert_handler] Enhance EDN timing check

### DIFF
--- a/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
@@ -233,5 +233,9 @@
       name: class_phase_cyc_regwen_cg
       desc: '''Covers if regwen is locked for class_phase_cyc registers.'''
     }
- ]
+    {
+      name: num_edn_reqs_cg
+      desc: '''Covers if simulation runs long enough to capture more than five EDN requests.'''
+    }
+  ]
 }

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -278,6 +278,14 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     ping_timer_en_regwen_cp: coverpoint regwen;
   endgroup
 
+  // Covergroup to make sure simulation is long enough to fetch more than five EDN requests.
+  covergroup num_edn_reqs_cg with function sample(int num_edn_reqs);
+    num_edn_reqs_cp: coverpoint num_edn_reqs {
+      bins less_then_five_reqs = {[1:4]};
+      bins five_or_more_reqs   = {[5:$]};
+    }
+  endgroup
+
   alert_handler_alert_en_regwen_cg_wrap        alert_en_regwen_cg_wrap[NUM_ALERTS];
   alert_handler_alert_class_regwen_cg_wrap     alert_class_regwen_cg_wrap[NUM_ALERTS];
   alert_handler_loc_alert_en_regwen_cg_wrap    loc_alert_en_regwen_cg_wrap[NUM_LOCAL_ALERTS];
@@ -306,6 +314,8 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
 
     ping_timeout_cyc_regwen_cg = new();
     ping_timer_en_regwen_cg = new();
+
+    num_edn_reqs_cg = new();
 
     for (int i = 0; i < NUM_ALERTS; i++) begin
       alert_en_regwen_cg_wrap[i] = new($sformatf("alert_en_regwen_cg_wrap[%0d]", i));

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -10,9 +10,11 @@ package alert_handler_env_pkg;
   import csr_utils_pkg::*;
   import tl_agent_pkg::*;
   import alert_esc_agent_pkg::*;
+  import alert_handler_ral_pkg::*;
   import dv_base_reg_pkg::*;
   import cip_base_pkg::*;
-  import alert_handler_ral_pkg::*;
+  import sec_cm_pkg::*;
+  import push_pull_agent_pkg::*;
   import sec_cm_pkg::*;
 
   // macro includes

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
@@ -233,5 +233,9 @@
       name: class_phase_cyc_regwen_cg
       desc: '''Covers if regwen is locked for class_phase_cyc registers.'''
     }
- ]
+    {
+      name: num_edn_reqs_cg
+      desc: '''Covers if simulation runs long enough to capture more than five EDN requests.'''
+    }
+  ]
 }

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -278,6 +278,14 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     ping_timer_en_regwen_cp: coverpoint regwen;
   endgroup
 
+  // Covergroup to make sure simulation is long enough to fetch more than five EDN requests.
+  covergroup num_edn_reqs_cg with function sample(int num_edn_reqs);
+    num_edn_reqs_cp: coverpoint num_edn_reqs {
+      bins less_then_five_reqs = {[1:4]};
+      bins five_or_more_reqs   = {[5:$]};
+    }
+  endgroup
+
   alert_handler_alert_en_regwen_cg_wrap        alert_en_regwen_cg_wrap[NUM_ALERTS];
   alert_handler_alert_class_regwen_cg_wrap     alert_class_regwen_cg_wrap[NUM_ALERTS];
   alert_handler_loc_alert_en_regwen_cg_wrap    loc_alert_en_regwen_cg_wrap[NUM_LOCAL_ALERTS];
@@ -306,6 +314,8 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
 
     ping_timeout_cyc_regwen_cg = new();
     ping_timer_en_regwen_cg = new();
+
+    num_edn_reqs_cg = new();
 
     for (int i = 0; i < NUM_ALERTS; i++) begin
       alert_en_regwen_cg_wrap[i] = new($sformatf("alert_en_regwen_cg_wrap[%0d]", i));

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -10,9 +10,11 @@ package alert_handler_env_pkg;
   import csr_utils_pkg::*;
   import tl_agent_pkg::*;
   import alert_esc_agent_pkg::*;
+  import alert_handler_ral_pkg::*;
   import dv_base_reg_pkg::*;
   import cip_base_pkg::*;
-  import alert_handler_ral_pkg::*;
+  import sec_cm_pkg::*;
+  import push_pull_agent_pkg::*;
   import sec_cm_pkg::*;
 
   // macro includes


### PR DESCRIPTION
The spec specifies that EDN request should be refreshed every 500k clock
cycles.
This PR:
1). Adds a checking in scb to make sure this timing requirement is
  satisfied.
2). Add functional coverage group to make sure we run simulation long
  enough to capture EDN requests at least 5 times.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>