### PR TITLE
[ci] isolate check-generated.sh from previous corruption of repo

### DIFF
--- a/ci/scripts/check-generated.sh
+++ b/ci/scripts/check-generated.sh
@@ -49,6 +49,7 @@ gen_hw_and_check_clean() {
 # Check generated files are up to date
 
 bad=0
+cleanup
 
 gen_hw_and_check_clean "Register headers" regs         || bad=1
 gen_hw_and_check_clean "tops"             top          || bad=1


### PR DESCRIPTION
If we reorder jobs we can find the first step of this test is sensitive
to the state of the git repo and can fail. by cleaning up before we run
it will become more reliable.

Signed-off-by: Drew Macrae <drewmacrae@google.com>