### PR TITLE
[dv/pwm] Two small fixes

### DIFF
--- a/hw/ip/pwm/dv/env/pwm_env_cfg.sv
+++ b/hw/ip/pwm/dv/env/pwm_env_cfg.sv
@@ -34,6 +34,9 @@ class pwm_env_cfg extends cip_base_env_cfg #(.RAL_T(pwm_reg_block));
               create($sformatf("m_pwm_monitor_%0d_cfg", i));
       m_pwm_monitor_cfg[i].if_mode = Device;
     end
+
+    // only support 1 outstanding TL items in tlul_adapter
+    m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 
   // clk_core_freq_mhz is assigned by

--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -28,7 +28,6 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 //"{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",


### PR DESCRIPTION
Fix two TODOs in issue #13476:
1). Fix max outstanding access coverage
2). Fix regression unmapped memory tests.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>