### PR TITLE
[dv, rtl] Cleanup build errors and warnings thrown by Xcelium

### DIFF
--- a/hw/dv/sv/jtag_dmi_agent/sba_access_monitor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/sba_access_monitor.sv
@@ -224,7 +224,7 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_base_monito
   virtual protected function bit predict_sba_req(input bus_op_e bus_op);
     uvm_reg_addr_t addr = jtag_dmi_ral.sbaddress0.get_mirrored_value();
     uvm_reg_data_t data = jtag_dmi_ral.sbdata0.get_mirrored_value();
-    sba_access_size_e size = jtag_dmi_ral.sbcs.sbaccess.get_mirrored_value();
+    sba_access_size_e size = sba_access_size_e'(jtag_dmi_ral.sbcs.sbaccess.get_mirrored_value());
     sba_access_item item;
 
     // Is the address aligned?
@@ -266,7 +266,7 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_base_monito
   // previous transfer.
   virtual function void predict_autoincr_sba_addr();
     if (jtag_dmi_ral.sbcs.sbautoincrement.get_mirrored_value()) begin
-      sba_access_size_e size = jtag_dmi_ral.sbcs.sbaccess.get_mirrored_value();
+      sba_access_size_e size = sba_access_size_e'(jtag_dmi_ral.sbcs.sbaccess.get_mirrored_value());
       uvm_reg_data_t addr = jtag_dmi_ral.sbaddress0.get_mirrored_value();
       void'(jtag_dmi_ral.sbaddress0.predict(.value(addr + (1 << size)),
                                             .kind(UVM_PREDICT_DIRECT)));

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -150,7 +150,7 @@ class spi_monitor extends dv_base_monitor#(
               if (host_item.data.size == cfg.num_bytes_per_trans_in_mon &&
                   device_item.data.size == cfg.num_bytes_per_trans_in_mon) begin
               if (host_item.first_byte == 1 && cfg.decode_commands == 1)  begin
-                 cmdtmp = host_byte;
+                cmdtmp = spi_cmd_e'(host_byte);
                 `uvm_info(`gfn, $sformatf("spi_monitor: cmdtmp \n%0h", cmdtmp), UVM_DEBUG)
                  end
                  cmd_byte++;

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -123,7 +123,7 @@ from topgen.lib import Name
     .clk_i(clk_${src_name}_i),
     .rst_ni(rst_${src_name}_ni),
     .mubi_i(div_step_down_req_i),
-    .mubi_o(${src_name}_step_down_req)
+    .mubi_o({${src_name}_step_down_req})
   );
 
 % endfor
@@ -152,7 +152,7 @@ from topgen.lib import Name
     .clk_i,
     .rst_ni,
     .mubi_i(scanmode_i),
-    .mubi_o(${src.name}_div_scanmode)
+    .mubi_o({${src.name}_div_scanmode})
   );
 
   prim_clock_div #(

--- a/hw/ip/clkmgr/rtl/clkmgr_byp.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_byp.sv
@@ -47,7 +47,7 @@ module clkmgr_byp
     .clk_i,
     .rst_ni,
     .lc_en_i(en_i),
-    .lc_en_o(en)
+    .lc_en_o({en})
   );
 
   typedef enum logic [1:0] {
@@ -145,7 +145,7 @@ module clkmgr_byp
     .clk_i,
     .rst_ni,
     .mubi_i(all_clk_byp_ack_i),
-    .mubi_o(byp_ack_o)
+    .mubi_o({byp_ack_o})
   );
 
   // the software high speed select is valid only when software requests clock

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -625,7 +625,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .clk_i,
     .rst_ni,
     .mubi_i(otp_en_entropy_src_fw_over_i),
-    .mubi_o(en_entropy_src_fw_over)
+    .mubi_o({en_entropy_src_fw_over})
   );
 
   assign entropy_src_rng_o.rng_enable = es_enable_q_fo[0];
@@ -2507,7 +2507,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .clk_i,
     .rst_ni,
     .mubi_i(otp_en_entropy_src_fw_read_i),
-    .mubi_o(en_entropy_src_fw_read)
+    .mubi_o({en_entropy_src_fw_read})
   );
 
   //--------------------------------------------

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -300,7 +300,7 @@ module flash_ctrl
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_seed_hw_rd_en_i),
-    .lc_en_o(lc_seed_hw_rd_en)
+    .lc_en_o({lc_seed_hw_rd_en})
   );
 
   prim_lfsr #(
@@ -934,7 +934,7 @@ module flash_ctrl
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_escalate_en_i),
-    .lc_en_o(lc_escalate_en)
+    .lc_en_o({lc_escalate_en})
   );
 
   lc_ctrl_pkg::lc_tx_t escalate_en;

--- a/hw/ip/flash_ctrl/data/flash_ctrl_region_cfg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_region_cfg.sv.tpl
@@ -51,7 +51,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_creator_seed_sw_rw_en_i),
-    .lc_en_o(lc_creator_seed_sw_rw_en)
+    .lc_en_o({lc_creator_seed_sw_rw_en})
   );
 
   prim_lc_sync #(
@@ -60,7 +60,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_owner_seed_sw_rw_en_i),
-    .lc_en_o(lc_owner_seed_sw_rw_en)
+    .lc_en_o({lc_owner_seed_sw_rw_en})
   );
 
   prim_lc_sync #(
@@ -69,7 +69,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_iso_part_sw_rd_en_i),
-    .lc_en_o(lc_iso_part_sw_rd_en)
+    .lc_en_o({lc_iso_part_sw_rd_en})
   );
 
   prim_lc_sync #(
@@ -78,7 +78,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_iso_part_sw_wr_en_i),
-    .lc_en_o(lc_iso_part_sw_wr_en)
+    .lc_en_o({lc_iso_part_sw_wr_en})
   );
 
   //////////////////////////////////////

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -301,7 +301,7 @@ module flash_ctrl
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_seed_hw_rd_en_i),
-    .lc_en_o(lc_seed_hw_rd_en)
+    .lc_en_o({lc_seed_hw_rd_en})
   );
 
   prim_lfsr #(
@@ -935,7 +935,7 @@ module flash_ctrl
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_escalate_en_i),
-    .lc_en_o(lc_escalate_en)
+    .lc_en_o({lc_escalate_en})
   );
 
   lc_ctrl_pkg::lc_tx_t escalate_en;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_region_cfg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_region_cfg.sv
@@ -52,7 +52,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_creator_seed_sw_rw_en_i),
-    .lc_en_o(lc_creator_seed_sw_rw_en)
+    .lc_en_o({lc_creator_seed_sw_rw_en})
   );
 
   prim_lc_sync #(
@@ -61,7 +61,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_owner_seed_sw_rw_en_i),
-    .lc_en_o(lc_owner_seed_sw_rw_en)
+    .lc_en_o({lc_owner_seed_sw_rw_en})
   );
 
   prim_lc_sync #(
@@ -70,7 +70,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_iso_part_sw_rd_en_i),
-    .lc_en_o(lc_iso_part_sw_rd_en)
+    .lc_en_o({lc_iso_part_sw_rd_en})
   );
 
   prim_lc_sync #(
@@ -79,7 +79,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_iso_part_sw_wr_en_i),
-    .lc_en_o(lc_iso_part_sw_wr_en)
+    .lc_en_o({lc_iso_part_sw_wr_en})
   );
 
   //////////////////////////////////////

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -627,7 +627,7 @@ module flash_phy_rd
   );
 
   // whenever the response is coming from the buffer, the error is never set
-  assign data_valid_o = flash_rsp_match | |buf_rsp_match;
+  assign data_valid_o = flash_rsp_match | (|buf_rsp_match);
 
   // integrity and reliability ECC errors always cause in band errors
   assign data_err_o   = muxed_err | intg_err;

--- a/hw/ip/keymgr/rtl/keymgr_err.sv
+++ b/hw/ip/keymgr/rtl/keymgr_err.sv
@@ -71,7 +71,7 @@ module keymgr_err
   assign sync_err_d[SyncErrInvalidOp] = err_vld & (invalid_op_i |
                                                    disabled_i |
                                                    invalid_i |
-                                                   |fault_o);
+                                                   (|fault_o));
   assign sync_err_d[SyncErrInvalidIn] = err_vld & kmac_input_invalid_i;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -470,7 +470,7 @@ module otp_ctrl
     fatal_check_error_d |= chk_timeout       |
                            lfsr_fsm_err      |
                            scrmbl_fsm_err    |
-                           |part_fsm_err;
+                           (|part_fsm_err);
   end
 
   // Assign these to the status register.

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -163,7 +163,7 @@ module otp_ctrl
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_creator_seed_sw_rw_en_i),
-    .lc_en_o(lc_creator_seed_sw_rw_en)
+    .lc_en_o({lc_creator_seed_sw_rw_en})
   );
 
   prim_lc_sync #(
@@ -172,7 +172,7 @@ module otp_ctrl
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_seed_hw_rd_en_i),
-    .lc_en_o(lc_seed_hw_rd_en)
+    .lc_en_o({lc_seed_hw_rd_en})
   );
 
   prim_lc_sync #(
@@ -190,7 +190,7 @@ module otp_ctrl
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_check_byp_en_i),
-    .lc_en_o(lc_check_byp_en)
+    .lc_en_o({lc_check_byp_en})
   );
 
   /////////////////////////////////////

--- a/hw/ip/rstmgr/rtl/rstmgr_leaf_rst.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_leaf_rst.sv
@@ -36,7 +36,7 @@ module rstmgr_leaf_rst
     .clk_i,
     .rst_ni,
     .mubi_i(scanmode_i),
-    .mubi_o(scanmode)
+    .mubi_o({scanmode})
  );
 
   logic leaf_rst_sync;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -14,10 +14,10 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
     super.post_apply_reset(reset_kind);
 
     for (int ram_idx = 0; ram_idx < cfg.num_ram_ret_tiles; ram_idx++) begin
-       cfg.mem_bkdr_util_h[RamRet0 + ram_idx].randomize_mem();
+      cfg.mem_bkdr_util_h[int'(RamRet0) + ram_idx].randomize_mem();
     end
     for (int ram_idx = 0; ram_idx < cfg.num_ram_main_tiles; ram_idx++) begin
-       cfg.mem_bkdr_util_h[RamMain0 + ram_idx].randomize_mem();
+      cfg.mem_bkdr_util_h[int'(RamMain0) + ram_idx].randomize_mem();
     end
     wait_rom_check_done();
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -71,7 +71,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     // as early portions of mask ROM will initialize it to the correct value.
     // The randomization here is just to ensure we do not have x's in the memory.
     for (int ram_idx = 0; ram_idx < cfg.num_ram_ret_tiles; ram_idx++) begin
-       cfg.mem_bkdr_util_h[RamRet0 + ram_idx].randomize_mem();
+      cfg.mem_bkdr_util_h[int'(RamRet0) + ram_idx].randomize_mem();
     end
 
     `uvm_info(`gfn, "Initializing ROM", UVM_MEDIUM)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_sleep_all_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_sleep_all_reset_vseq.sv
@@ -14,11 +14,11 @@ class chip_sw_deep_sleep_all_reset_vseq extends chip_sw_base_vseq;
   // ordered using a random variable assa. The last reset does not have to set the next reset type.
 
   // (key rst + pad rst)
+  parameter int NumSleepType = 1;
   parameter int NumPadRstEvent = 2 * NumSleepType;
   // (sw_req + escalation rst + normal watchdog)
   parameter int NumWdogRstEvent = 3 * NumSleepType;
   parameter int NumNormalMode = 1;
-  parameter int NumSleepType = 1;
   parameter int NumRound = NumPadRstEvent + NumWdogRstEvent + NumNormalMode + 1;
 
   rand int cycles_after_trigger;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv
@@ -23,12 +23,12 @@ class chip_sw_flash_ctrl_lc_rw_en_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual function lc_ctrl_pkg::lc_tx_t get_rw_en_signals(int rw_en_index);
-    lc_ctrl_pkg::lc_tx_t read_value;
+    uvm_hdl_data_t read_value;
     `DV_CHECK_EQ_FATAL(uvm_hdl_check_path(RW_EN_PATHS[rw_en_index]), 1, $sformatf(
                        "Hierarchical path %0s appears to be invalid.", RW_EN_PATHS[rw_en_index]))
     `DV_CHECK_EQ_FATAL(uvm_hdl_read(RW_EN_PATHS[rw_en_index], read_value), 1, $sformatf(
                        "uvm_hdl_read failed for %0s", RW_EN_PATHS[rw_en_index]))
-    return read_value;
+    return lc_ctrl_pkg::lc_tx_t'(read_value);
   endfunction
 
   virtual task body();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
@@ -212,7 +212,7 @@ class chip_sw_flash_init_vseq extends chip_sw_base_vseq;
     bit [SEED_WIDTH-1:0] last_creator_seed;
     bit [(SEED_WIDTH*2)-1:0] expected_owner_seed;
     bit [(SEED_WIDTH*2)-1:0] expected_creator_seed;
-    lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
+    uvm_hdl_data_t lc_seed_hw_rd_en;
     forever begin
       @(init_done_event);
       if (do_keymgr_check == 1) begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
@@ -55,9 +55,9 @@ class chip_sw_lc_walkthrough_testunlocks_vseq extends chip_sw_base_vseq;
 
       `uvm_info(`gfn, $sformatf("Current state %0s", curr_state.name), UVM_LOW)
       wait_lc_ready(.allow_err(1));
-      jtag_lc_state_transition(curr_state, curr_state + 1, {<<8{lc_unlock_token}});
+      jtag_lc_state_transition(curr_state, dec_lc_state_e'(curr_state + 1), {<<8{lc_unlock_token}});
       apply_reset();
-      curr_state = curr_state + 2;
+      curr_state = dec_lc_state_e'(curr_state + 2);
     end
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_sleep_all_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_sleep_all_reset_vseq.sv
@@ -13,12 +13,12 @@ class chip_sw_random_sleep_all_reset_vseq extends chip_sw_base_vseq;
   // 12 (NumRound) reset elements where 11 (NumRound-1) random reset sequence is
   // ordered using a random variable assa. The last reset does not have to set the next reset type.
 
+  parameter int NumSleepType = 2;
   // (key rst + pad rst) x 2 (normal sleep/deep sleep)
   parameter int NumPadRstEvent = 2 * NumSleepType;
   // (sw_req + escalation rst + normal watchdog) x 2
   parameter int NumWdogRstEvent = 3 * NumSleepType;
   parameter int NumNormalMode = 1;
-  parameter int NumSleepType = 2;
   parameter int NumRound = NumPadRstEvent + NumWdogRstEvent + NumNormalMode + 1;
 
   rand int cycles_after_trigger;
@@ -65,16 +65,18 @@ class chip_sw_random_sleep_all_reset_vseq extends chip_sw_base_vseq;
     `uvm_info(`gfn, "SW test ready", UVM_MEDIUM)
 
     repeat (loop_num) begin
-      wait (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" |
-            cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by hw por" |
-            cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" |
-            cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by sysrst" |
-            cfg.sw_logger_vif.printed_log == "Last Booting" |
+      wait (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" ||
+            cfg.sw_logger_vif.printed_log ==
+                "Booting and setting normal sleep followed by hw por" ||
+            cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" ||
+            cfg.sw_logger_vif.printed_log ==
+                "Booting and setting normal sleep followed by sysrst" ||
+            cfg.sw_logger_vif.printed_log == "Last Booting" ||
             cfg.sw_logger_vif.printed_log == "Test finish");
 
-       if (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" |
-                cfg.sw_logger_vif.printed_log ==
-                                    "Booting and setting normal sleep followed by sysrst") begin
+       if (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" ||
+           cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by sysrst")
+           begin
          `uvm_info(`gfn, "SW message delivered to TB", UVM_MEDIUM)
          repeat (10) @cfg.pwrmgr_low_power_vif.cb;  //
          repeat (cycles_till_reset) @cfg.pwrmgr_low_power_vif.cb;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_repeat_reset_wkup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_repeat_reset_wkup_vseq.sv
@@ -34,7 +34,7 @@ class chip_sw_repeat_reset_wkup_vseq extends chip_sw_base_vseq;
     super.body();
 
     for (int i = 0; i < num_round; ++i) begin
-      randomize();
+      `DV_CHECK_RANDOMIZE_FATAL(this)
 
       // Wait until we reach the SW test state.
       wait(cfg.sw_logger_vif.printed_log == "ready for power down");

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-`define DUT_HIER              tb.dut
+`ifndef DUT_HIER
+  `define DUT_HIER            tb.dut
+`endif
 `define CHIP_HIER             `DUT_HIER.top_earlgrey
 
 `define ALERT_HANDLER_HIER    `CHIP_HIER.u_alert_handler

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -407,16 +407,15 @@ module tb;
     end
   end
 
-
-
   `undef SIM_SRAM_IF
 
   // Instantitate the memory backdoor util instances.
   if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_generic
     initial begin
+      chip_mem_e    mem;
       mem_bkdr_util m_mem_bkdr_util[chip_mem_e];
 
-      `uvm_info("tb.sv", "Backdoor init flash 0 data", UVM_MEDIUM)
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for flash 0 data", UVM_MEDIUM)
       m_mem_bkdr_util[FlashBank0Data] = new(
           .name  ("mem_bkdr_util[FlashBank0Data]"),
           .path  (`DV_STRINGIFY(`FLASH0_DATA_MEM_HIER)),
@@ -425,7 +424,7 @@ module tb;
           .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank0Data], `FLASH0_DATA_MEM_HIER)
 
-      `uvm_info("tb.sv", "Backdoor init flash 0 info", UVM_MEDIUM)
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for flash 0 info", UVM_MEDIUM)
       m_mem_bkdr_util[FlashBank0Info] = new(
           .name  ("mem_bkdr_util[FlashBank0Info]"),
           .path  (`DV_STRINGIFY(`FLASH0_INFO_MEM_HIER)),
@@ -434,7 +433,7 @@ module tb;
           .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank0Info], `FLASH0_INFO_MEM_HIER)
 
-      `uvm_info("tb.sv", "Backdoor init flash 1 data", UVM_MEDIUM)
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for flash 1 data", UVM_MEDIUM)
       m_mem_bkdr_util[FlashBank1Data] = new(
           .name  ("mem_bkdr_util[FlashBank1Data]"),
           .path  (`DV_STRINGIFY(`FLASH1_DATA_MEM_HIER)),
@@ -443,7 +442,7 @@ module tb;
           .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank1Data], `FLASH0_DATA_MEM_HIER)
 
-      `uvm_info("tb.sv", "Backdoor init flash 0 info", UVM_MEDIUM)
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for flash 0 info", UVM_MEDIUM)
       m_mem_bkdr_util[FlashBank1Info] = new(
           .name  ("mem_bkdr_util[FlashBank1Info]"),
           .path  (`DV_STRINGIFY(`FLASH1_INFO_MEM_HIER)),
@@ -452,7 +451,7 @@ module tb;
           .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank1Info], `FLASH1_INFO_MEM_HIER)
 
-      `uvm_info("tb.sv", "Backdoor init OTP", UVM_MEDIUM)
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTP", UVM_MEDIUM)
       m_mem_bkdr_util[Otp] = new(.name  ("mem_bkdr_util[Otp]"),
                                  .path  (`DV_STRINGIFY(`OTP_MEM_HIER)),
                                  .depth ($size(`OTP_MEM_HIER)),
@@ -460,7 +459,7 @@ module tb;
                                  .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_22_16));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Otp], `OTP_MEM_HIER)
 
-      `uvm_info("tb.sv", "Backdoor init RAM", UVM_MEDIUM)
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for RAM", UVM_MEDIUM)
       m_mem_bkdr_util[RamMain0] = new(.name  ("mem_bkdr_util[RamMain0]"),
                                       .path  (`DV_STRINGIFY(`RAM_MAIN_MEM_HIER)),
                                       .depth ($size(`RAM_MAIN_MEM_HIER)),
@@ -468,7 +467,7 @@ module tb;
                                       .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamMain0], `RAM_MAIN_MEM_HIER)
 
-      `uvm_info("tb.sv", "Backdoor init RAM RET", UVM_MEDIUM)
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for RAM RET", UVM_MEDIUM)
       m_mem_bkdr_util[RamRet0] = new(.name  ("mem_bkdr_util[RamRet0]"),
                                      .path  (`DV_STRINGIFY(`RAM_RET_MEM_HIER)),
                                      .depth ($size(`RAM_RET_MEM_HIER)),
@@ -476,7 +475,7 @@ module tb;
                                      .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamRet0], `RAM_RET_MEM_HIER)
 
-      `uvm_info("tb.sv", "Backdoor init ROM", UVM_MEDIUM)
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for ROM", UVM_MEDIUM)
       m_mem_bkdr_util[Rom] = new(.name  ("mem_bkdr_util[Rom]"),
                                  .path  (`DV_STRINGIFY(`ROM_MEM_HIER)),
                                  .depth ($size(`ROM_MEM_HIER)),
@@ -484,15 +483,18 @@ module tb;
                                  .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom], `ROM_MEM_HIER)
 
-      for (chip_mem_e mem = mem.first(), int i = 0; i < mem.num(); mem = mem.next(), i++) begin
-        if (mem inside {[RamMain1:RamMain15]}) continue;
-        if (mem inside {[RamRet1:RamRet15]}) continue;
+      mem = mem.first();
+      do begin
+        if (mem inside {[RamMain1:RamMain15]} || mem inside {[RamRet1:RamRet15]}) begin
+          mem = mem.next();
+          continue;
+        end
         uvm_config_db#(mem_bkdr_util)::set(
             null, "*.env", m_mem_bkdr_util[mem].get_name(), m_mem_bkdr_util[mem]);
-      end
-
+        mem = mem.next();
+      end while (mem != mem.first());
     end
-  end
+  end : gen_generic
 
   // stub cpu environment
   // if enabled, clock to cpu is forced to 0

--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -614,7 +614,7 @@ prim_mubi4_sync #(
   .clk_i ( clk_sys ),
   .rst_ni ( rst_src_sys_n ),
   .mubi_i ( clk_src_sys_jen_i ),
-  .mubi_o ( clk_src_sys_jen )
+  .mubi_o ( {clk_src_sys_jen} )
 );
 
 // Reset De-Assert Sync

--- a/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
@@ -263,7 +263,7 @@ prim_mubi4_sync #(
   .clk_i ( clk_aon ),
   .rst_ni ( rst_aon_n ),
   .mubi_i ( io_clk_byp_req_i ),
-  .mubi_o ( ot_io_clk_byp_req )
+  .mubi_o ( {ot_io_clk_byp_req} )
 );
 
 prim_mubi4_sync #(
@@ -273,7 +273,7 @@ prim_mubi4_sync #(
   .clk_i ( clk_aon ),
   .rst_ni ( rst_aon_n ),
   .mubi_i ( all_clk_byp_req_i ),
-  .mubi_o ( ot_all_clk_byp_req )
+  .mubi_o ( {ot_all_clk_byp_req} )
 );
 
 prim_mubi4_sync #(
@@ -283,7 +283,7 @@ prim_mubi4_sync #(
   .clk_i ( clk_aon ),
   .rst_ni ( rst_aon_n ),
   .mubi_i ( ext_freq_is_96m_i ),
-  .mubi_o ( ot_ext_freq_is_96m )
+  .mubi_o ( {ot_ext_freq_is_96m} )
 );
 
 // Decode logic

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -123,7 +123,7 @@
     .clk_i(clk_io_i),
     .rst_ni(rst_io_ni),
     .mubi_i(div_step_down_req_i),
-    .mubi_o(io_step_down_req)
+    .mubi_o({io_step_down_req})
   );
 
 
@@ -149,7 +149,7 @@
     .clk_i,
     .rst_ni,
     .mubi_i(scanmode_i),
-    .mubi_o(io_div2_div_scanmode)
+    .mubi_o({io_div2_div_scanmode})
   );
 
   prim_clock_div #(
@@ -172,7 +172,7 @@
     .clk_i,
     .rst_ni,
     .mubi_i(scanmode_i),
-    .mubi_o(io_div4_div_scanmode)
+    .mubi_o({io_div4_div_scanmode})
   );
 
   prim_clock_div #(

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -307,7 +307,7 @@ module flash_ctrl
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_seed_hw_rd_en_i),
-    .lc_en_o(lc_seed_hw_rd_en)
+    .lc_en_o({lc_seed_hw_rd_en})
   );
 
   prim_lfsr #(
@@ -941,7 +941,7 @@ module flash_ctrl
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_escalate_en_i),
-    .lc_en_o(lc_escalate_en)
+    .lc_en_o({lc_escalate_en})
   );
 
   lc_ctrl_pkg::lc_tx_t escalate_en;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_region_cfg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_region_cfg.sv
@@ -58,7 +58,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_creator_seed_sw_rw_en_i),
-    .lc_en_o(lc_creator_seed_sw_rw_en)
+    .lc_en_o({lc_creator_seed_sw_rw_en})
   );
 
   prim_lc_sync #(
@@ -67,7 +67,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_owner_seed_sw_rw_en_i),
-    .lc_en_o(lc_owner_seed_sw_rw_en)
+    .lc_en_o({lc_owner_seed_sw_rw_en})
   );
 
   prim_lc_sync #(
@@ -76,7 +76,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_iso_part_sw_rd_en_i),
-    .lc_en_o(lc_iso_part_sw_rd_en)
+    .lc_en_o({lc_iso_part_sw_rd_en})
   );
 
   prim_lc_sync #(
@@ -85,7 +85,7 @@ module flash_ctrl_region_cfg
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_iso_part_sw_wr_en_i),
-    .lc_en_o(lc_iso_part_sw_wr_en)
+    .lc_en_o({lc_iso_part_sw_wr_en})
   );
 
   //////////////////////////////////////

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl.sv
@@ -288,9 +288,9 @@ module sensor_ctrl
   // be used to trigger wake from low power.
   // Fatal alerts are not used here because they do not ever ack, meaning
   // the originating event can never disappear.
-  assign async_wake = |async_alert_event_p  |
-                      ~&async_alert_event_n |
-                      |reg2hw.recov_alert;
+  assign async_wake = (|async_alert_event_p)  |
+                      (~&async_alert_event_n) |
+                      (|reg2hw.recov_alert);
 
   prim_flop_2sync #(
     .Width(1),


### PR DESCRIPTION
The first 2 commits fix some build warnings in the RTL. The third does the same in some DV code. Warnings fixed include casting operands / values of mismatched types, enclosing logically reduced signals in braces, etc. 

The DV commit also fixes a build error. Not ALL warnings are fixed - there are about 100 more to resolve (subsequent PR). While the build succeeds, all tests fail. The fixes needed to resolve runtime errors will be made in subsequent PRs. 