### PR TITLE
[sw/silicon_creator] Fix and enable `e2e_bootup_success` test

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -84,6 +84,31 @@ cc_library(
     ],
 )
 
+# TODO(#12905): Use a slightly hollowed out version of the silicon_creator manifest_def
+# implementation when building the test_framework for the english breakfast top level.
+cc_library(
+    name = "english_breakfast_test_framework_manifest_def",
+    srcs = [
+        "//sw/device/silicon_creator/lib:english_breakfast_test_framework_manifest_def_srcs",
+    ],
+    # This should be built only for english breakfast and skipped if using wildcards.
+    tags = ["manual"],
+    deps = [
+        "//sw/device/lib/testing/test_rom:english_breakfast_test_rom_manifest",
+    ],
+    # The manifest section should be populated anytime this is added as a
+    # dependency, even if kManifest is not referenced by software.
+    alwayslink = True,
+)
+
+alias(
+    name = "test_framework_manifest_def",
+    actual = select({
+        "//sw/device:is_english_breakfast": ":english_breakfast_test_framework_manifest_def",
+        "//conditions:default": "//sw/device/silicon_creator/lib:manifest_def",
+    }),
+)
+
 cc_library(
     name = "ottf_main",
     srcs = ["ottf_main.c"],
@@ -96,6 +121,7 @@ cc_library(
         ":ottf_start",
         ":ottf_test_config",
         ":status",
+        ":test_framework_manifest_def",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/dif:uart",

--- a/sw/device/lib/testing/test_framework/ottf.ld
+++ b/sw/device/lib/testing/test_framework/ottf.ld
@@ -24,6 +24,22 @@ _stack_start = _stack_end - _stack_size;
  */
 _dv_log_offset = 0x10000;
 
+/*
+ * The start of the .text section relative to the beginning of the associated
+ * slot for use in the manifest.
+ */
+_manifest_code_start = _text_start - ORIGIN(eflash);
+/*
+ * The end of the .text section relative to the beginning of the associated slot
+ * for use in the manifest.
+ */
+_manifest_code_end = _text_end - ORIGIN(eflash);
+/*
+ * The location of the entry point relative to the beginning of the associated
+ * slot for use in the manifest.
+ */
+_manifest_entry_point = _ottf_start - ORIGIN(eflash);
+
 OUTPUT_ARCH(riscv)
 
 /**
@@ -66,6 +82,7 @@ SECTIONS {
    * Ibex.
    */
   .vectors : ALIGN (256){
+    _text_start = .;
     *(.vectors)
   } > eflash
 
@@ -105,6 +122,7 @@ SECTIONS {
 
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
+    _text_end = .;
   } > eflash
 
   /**

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -7,6 +7,9 @@
 #include <assert.h>
 #include <stddef.h>
 
+#include "external/freertos/include/FreeRTOS.h"
+#include "external/freertos/include/queue.h"
+#include "external/freertos/include/task.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/dif/dif_base.h"
@@ -18,13 +21,10 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/coverage.h"
 #include "sw/device/lib/testing/test_framework/status.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
 
 // TODO: make this toplevel agnostic.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
-#include "external/freertos/include/FreeRTOS.h"
-#include "external/freertos/include/queue.h"
-#include "external/freertos/include/task.h"
 
 // Check layout of test configuration struct since OTTF ISR asm code requires a
 // specific layout.

--- a/sw/device/lib/testing/test_framework/ottf_start.S
+++ b/sw/device/lib/testing/test_framework/ottf_start.S
@@ -2,28 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/silicon_creator/lib/manifest_size.h"
-
-  /**
-   * Manifest for boot stages stored in flash.
-   *
-   * Note, we set the default entry point field (which is the last field in the
-   * manifest struct) to `_ottf_start`. We do this to enable running unsigned test
-   * images with the test ROM, since these images will not be processed by our
-   * signing tool which would otherwise populate this entry point field.
-   */
-  .section .manifest, "a"
-  .global kManifest
-  .type kManifest, @object
-kManifest:
-  .rept MANIFEST_SIZE - 4
-  .byte 0x0
-  .endr
-  .4byte _ottf_start
-  .size kManifest, .-kManifest
-
-// -----------------------------------------------------------------------------
-
 /**
  * OTTF Interrupt Vector.
  */

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -95,7 +95,6 @@ alias(
         "//sw/device:is_english_breakfast": ":english_breakfast_test_rom_manifest",
         "//conditions:default": "//sw/device/silicon_creator/lib:manifest",
     }),
-    visibility = ["//visibility:private"],
 )
 
 cc_library(

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -32,7 +32,7 @@
  * by the flash binary: see `sw/device/lib/testing/test_framework/ottf.ld`
  * for that.
  */
-extern manifest_t _manifest;
+extern const char _manifest[];
 
 /**
  * Type alias for the OTTF entry point.
@@ -114,9 +114,10 @@ bool rom_test_main(void) {
 
   // Jump to the OTTF in flash. Within the flash binary, it is the responsibily
   // of the OTTF to set up its own stack, and to never return.
-  uintptr_t manifest_entry_point = _manifest.entry_point;
+  uintptr_t entry_point =
+      manifest_entry_point_get((const manifest_t *)_manifest);
   LOG_INFO("Test ROM complete, jumping to flash!");
-  ((ottf_entry *)manifest_entry_point)();
+  ((ottf_entry *)entry_point)();
 
   // If the flash image returns, we should abort anyway.
   abort();

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -231,6 +231,14 @@ dual_cc_library(
     alwayslink = True,
 )
 
+filegroup(
+    name = "english_breakfast_test_framework_manifest_def_srcs",
+    srcs = [
+        "manifest_def.c",
+        "manifest_def.h",
+    ],
+)
+
 cc_test(
     name = "manifest_unittest",
     srcs = ["manifest_unittest.cc"],

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -311,7 +311,6 @@ opentitan_functest(
         bitstream = "//hw/bitstream:mask_rom",
         exit_failure = BOOT_FAILURE_MSG,
         exit_success = BOOT_SUCCESS_MSG,
-        tags = ["broken"],
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
@@ -319,6 +318,8 @@ opentitan_functest(
         exit_failure = BOOT_FAILURE_MSG,
         exit_success = BOOT_SUCCESS_MSG,
         rom = ":mask_rom_sim_verilator_scr_vmem",
+        # Note: Leaving as broken since this test takes a long time and
+        # we don't really need it as long as the CI runs the FPGA version.
         tags = [
             "broken",
         ],
@@ -341,7 +342,6 @@ opentitan_functest(
         exit_failure = BOOT_SUCCESS_MSG,
         exit_success = BOOT_FAILURE_MSG,
         rom = ":mask_rom_sim_verilator_scr_vmem",
-        tags = ["broken"],
     ),
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -309,6 +309,7 @@ opentitan_functest(
         bitstream = "//hw/bitstream:mask_rom",
         tags = ["broken"],
     ),
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
     verilator = verilator_params(
         rom = ":mask_rom_sim_verilator_scr_vmem",

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -300,18 +300,24 @@ cc_test(
 # MASK ROM E2E TESTS
 
 # Bootup tests
-BOOT_FAILURE_MSG = "BFV:[0-9a-z]{{8}}\r\nLCV:[0-9a-z]{{8}}\r\n"
+BOOT_FAILURE_MSG = "BFV:[0-9a-f]{8}"
+
+BOOT_SUCCESS_MSG = "PASS!"
 
 opentitan_functest(
     name = "e2e_bootup_success",
     srcs = ["mask_rom_test.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:mask_rom",
+        exit_failure = BOOT_FAILURE_MSG,
+        exit_success = BOOT_SUCCESS_MSG,
         tags = ["broken"],
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
     verilator = verilator_params(
+        exit_failure = BOOT_FAILURE_MSG,
+        exit_success = BOOT_SUCCESS_MSG,
         rom = ":mask_rom_sim_verilator_scr_vmem",
         tags = [
             "broken",
@@ -326,18 +332,14 @@ opentitan_functest(
     name = "e2e_bootup_no_rom_ext_signature",
     srcs = ["mask_rom_test.c"],
     cw310 = cw310_params(
-        args = [
-            "--exec=\"load-bitstream --rom-kind={rom_kind} $(location {bitstream})\"",
-            "--exec=\"bootstrap $(location {flash})\"",
-            "console",
-            "--timeout=30s",
-            "--exit-success='{}'".format(BOOT_FAILURE_MSG),
-            "--exit-failure='PASS!'",
-        ],
         bitstream = "//hw/bitstream:mask_rom",
+        exit_failure = BOOT_SUCCESS_MSG,
+        exit_success = BOOT_FAILURE_MSG,
     ),
     signed = False,
     verilator = verilator_params(
+        exit_failure = BOOT_SUCCESS_MSG,
+        exit_success = BOOT_FAILURE_MSG,
         rom = ":mask_rom_sim_verilator_scr_vmem",
         tags = ["broken"],
     ),

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -136,6 +136,7 @@ manifest(
     name = "manifest_standard",
     address_translation = CONST.FALSE,
     identifier = CONST.ROM_EXT,
+    visibility = ["//visibility:public"],
 )
 
 manifest(

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -390,6 +390,7 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_start",
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 

--- a/sw/device/tests/crt_test.c
+++ b/sw/device/tests/crt_test.c
@@ -15,6 +15,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/lib/testing/test_framework/status.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 


### PR DESCRIPTION
This PR
* Updates OTTF to use `manifest_def` (thanks @jon-flatley!) for populating the code start, end, and size fields of the manifest,
* Updates the `e2e_bootup_success` target to use the standard ROM_EXT manifest, and
* Adds exit string parameters to `verilator_params` and `cw310_params`.

With this change we now have both a positive and a negative mask_rom boot test in the CI.