### PR TITLE
[build] clean up old mentions of meson

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,35 +41,27 @@ licence_check(
     """,
 )
 
+clang_format_exclude = [
+    # Vendored source code dirs
+    "./**/vendor/**",
+    # Rust cargo build dirs
+    "./**/target/**",
+    # Directories used exclusively to store build artifacts are still copied into.
+    "./build-out/**",
+    "./build-bin/**",
+    # fusesoc build dir
+    "./build/**",
+]
+
 clang_format_check(
     name = "clang_format_check",
-    exclude_patterns = [
-        # Vendored source code dirs
-        "./**/vendor/**",
-        # Rust cargo build dirs
-        "./**/target/**",
-        # (Old) Meson build dirs that Bazel artifacts are still copied into.
-        "./build-out/**",
-        "./build-bin/**",
-        # fusesoc build dir
-        "./build/**",
-    ],
+    exclude_patterns = clang_format_exclude,
     mode = "diff",
 )
 
 clang_format_check(
     name = "clang_format_fix",
-    exclude_patterns = [
-        # Vendored source code dirs
-        "./**/vendor/**",
-        # Rust cargo build dirs
-        "./**/target/**",
-        # (Old) Meson build dirs that Bazel artifacts are still copied into.
-        "./build-out/**",
-        "./build-bin/**",
-        # fusesoc build dir
-        "./build/**",
-    ],
+    exclude_patterns = clang_format_exclude,
     mode = "fix",
 )
 

--- a/sw/vendor/patches/riscv_compliance/0002-Add-OpenTitan-target.patch
+++ b/sw/vendor/patches/riscv_compliance/0002-Add-OpenTitan-target.patch
@@ -38,139 +38,106 @@ index 0000000..353a9b3
 +designs for silicon root of trust chips.  Please see the [OpenTitan
 +website](https://opentitan.org) for more details.
 +
-+To run on Verilator, set the variables below
++To run on Verilator,
 +
 +```console
-+$ export RISCV_TARGET=opentitan
-+$ export RISCV_DEVICE=rv32imc
-+$ export OT_TARGET=sim_verilator
++$ ${REPO_TOP}/bazelisk.sh test //third_party/riscv-compliance/... \
++  test_tag_filters=verilator
 +```
 +
-+To run on FPGA, set the variables below.  The `OT_FPGA_UART` variable must be
-+set to wherever a valid device is connected.
-+
-+```console
-+$ export RISCV_TARGET=opentitan
-+$ export RISCV_DEVICE=rv32imc
-+$ export OT_TARGET=fpga_nexysvideo
-+$ export OT_FPGA_UART=/dev/tty*
-+```
-+
-+By default, the test assumes there exists a valid Verilator build at
-+`${REPO_TOP}/build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator`.
-+If your Verilator build is at a different location, please set that as well when
-+running with Verilator.
-+
-+```console
-+$ export TARGET_SIM=${PATH_TO_VERILATOR_BUILD}
-+```
-+
-+When running against FPGA, the test assumes the FPGA is already programmed and
-+ready to go with spiflash available at `$BIN_DIR/sw/host/spiflash/spiflash`.
-+To quickly get started with a verilator binary or FPGA bitfile, please see the
-+[OpenTitan quick start guide](https://docs.opentitan.org/doc/ug/quickstart/).
-+
-+Finally the support software must be built, including the test_rom when using
-+the verilator target.
-+
-+```console
-+$ cd $REPO_TOP
-+$ ./meson_init.sh
-+$ ninja -C ./build-out all
-+```
-+
-+Now, run the tests from the riscv_compliance directory.  The following output
++The following output
 +will be seen (software build steps are truncated).  The example below uses
 +Verilator as an example, but the FPGA output is nearly identical.
 +
 +```console
-+$ cd $RISCV_COMPLIANCE_REPO_BASE
-+$ make RISCV_ISA=rv32i
++INFO: Elapsed time: 1071.082s, Critical Path: 1006.91s
++INFO: 249 processes: 1 remote cache hit, 83 internal, 165 local.
++INFO: Build completed successfully, 249 total actions
++//third_party/riscv-compliance:C-ADDI16SP_sim_verilator                  PASSED in 107.6s
++//third_party/riscv-compliance:C-ADDI4SPN_sim_verilator                  PASSED in 107.3s
++//third_party/riscv-compliance:C-ADDI_sim_verilator                      PASSED in 114.9s
++//third_party/riscv-compliance:C-ADD_sim_verilator                       PASSED in 109.7s
++//third_party/riscv-compliance:C-ANDI_sim_verilator                      PASSED in 89.2s
++//third_party/riscv-compliance:C-AND_sim_verilator                       PASSED in 105.3s
++//third_party/riscv-compliance:C-BEQZ_sim_verilator                      PASSED in 113.0s
++//third_party/riscv-compliance:C-BNEZ_sim_verilator                      PASSED in 107.3s
++//third_party/riscv-compliance:C-JALR_sim_verilator                      PASSED in 110.7s
++//third_party/riscv-compliance:C-JAL_sim_verilator                       PASSED in 116.9s
++//third_party/riscv-compliance:C-JR_sim_verilator                        PASSED in 85.9s
++//third_party/riscv-compliance:C-J_sim_verilator                         PASSED in 109.7s
++//third_party/riscv-compliance:C-LI_sim_verilator                        PASSED in 109.9s
++//third_party/riscv-compliance:C-LUI_sim_verilator                       PASSED in 109.1s
++//third_party/riscv-compliance:C-LWSP_sim_verilator                      PASSED in 111.5s
++//third_party/riscv-compliance:C-LW_sim_verilator                        PASSED in 111.5s
++//third_party/riscv-compliance:C-MV_sim_verilator                        PASSED in 108.3s
++//third_party/riscv-compliance:C-OR_sim_verilator                        PASSED in 71.8s
++//third_party/riscv-compliance:C-SLLI_sim_verilator                      PASSED in 108.8s
++//third_party/riscv-compliance:C-SRAI_sim_verilator                      PASSED in 114.2s
++//third_party/riscv-compliance:C-SRLI_sim_verilator                      PASSED in 103.1s
++//third_party/riscv-compliance:C-SUB_sim_verilator                       PASSED in 103.8s
++//third_party/riscv-compliance:C-SWSP_sim_verilator                      PASSED in 104.4s
++//third_party/riscv-compliance:C-SW_sim_verilator                        PASSED in 111.0s
++//third_party/riscv-compliance:C-XOR_sim_verilator                       PASSED in 103.2s
++//third_party/riscv-compliance:DIVU_sim_verilator                        PASSED in 69.2s
++//third_party/riscv-compliance:DIV_sim_verilator                         PASSED in 108.2s
++//third_party/riscv-compliance:I-ADD-01_sim_verilator                    PASSED in 103.0s
++//third_party/riscv-compliance:I-ADDI-01_sim_verilator                   PASSED in 115.8s
++//third_party/riscv-compliance:I-AND-01_sim_verilator                    PASSED in 105.0s
++//third_party/riscv-compliance:I-ANDI-01_sim_verilator                   PASSED in 112.0s
++//third_party/riscv-compliance:I-AUIPC-01_sim_verilator                  PASSED in 105.5s
++//third_party/riscv-compliance:I-BEQ-01_sim_verilator                    PASSED in 109.7s
++//third_party/riscv-compliance:I-BGE-01_sim_verilator                    PASSED in 112.9s
++//third_party/riscv-compliance:I-BGEU-01_sim_verilator                   PASSED in 105.0s
++//third_party/riscv-compliance:I-BLT-01_sim_verilator                    PASSED in 107.5s
++//third_party/riscv-compliance:I-BLTU-01_sim_verilator                   PASSED in 105.7s
++//third_party/riscv-compliance:I-BNE-01_sim_verilator                    PASSED in 108.7s
+++//third_party/riscv-compliance:I-CSRRC-01_sim_verilator                  PASSED in 108.2s
++//third_party/riscv-compliance:I-CSRRCI-01_sim_verilator                 PASSED in 112.2s
++//third_party/riscv-compliance:I-CSRRS-01_sim_verilator                  PASSED in 114.1s
++//third_party/riscv-compliance:I-CSRRSI-01_sim_verilator                 PASSED in 103.8s
++//third_party/riscv-compliance:I-CSRRW-01_sim_verilator                  PASSED in 106.7s
++//third_party/riscv-compliance:I-CSRRWI-01_sim_verilator                 PASSED in 114.3s
++//third_party/riscv-compliance:I-DELAY_SLOTS-01_sim_verilator            PASSED in 105.5s
++//third_party/riscv-compliance:I-ECALL-01_sim_verilator                  PASSED in 103.7s
++//third_party/riscv-compliance:I-ENDIANESS-01_sim_verilator              PASSED in 106.6s
++//third_party/riscv-compliance:I-IO-01_sim_verilator                     PASSED in 125.5s
++//third_party/riscv-compliance:I-JAL-01_sim_verilator                    PASSED in 114.3s
++//third_party/riscv-compliance:I-JALR-01_sim_verilator                   PASSED in 83.2s
++//third_party/riscv-compliance:I-LB-01_sim_verilator                     PASSED in 103.2s
++//third_party/riscv-compliance:I-LBU-01_sim_verilator                    PASSED in 70.8s
++//third_party/riscv-compliance:I-LH-01_sim_verilator                     PASSED in 118.9s
++//third_party/riscv-compliance:I-LHU-01_sim_verilator                    PASSED in 109.7s
++//third_party/riscv-compliance:I-LUI-01_sim_verilator                    PASSED in 85.2s
++//third_party/riscv-compliance:I-LW-01_sim_verilator                     PASSED in 108.6s
++//third_party/riscv-compliance:I-OR-01_sim_verilator                     PASSED in 112.3s
++//third_party/riscv-compliance:I-ORI-01_sim_verilator                    PASSED in 105.2s
++//third_party/riscv-compliance:I-RF_size-01_sim_verilator                PASSED in 104.2s
++//third_party/riscv-compliance:I-RF_width-01_sim_verilator               PASSED in 110.7s
++//third_party/riscv-compliance:I-SB-01_sim_verilator                     PASSED in 111.3s
++//third_party/riscv-compliance:I-SH-01_sim_verilator                     PASSED in 90.4s
++//third_party/riscv-compliance:I-SLL-01_sim_verilator                    PASSED in 106.0s
++//third_party/riscv-compliance:I-SLLI-01_sim_verilator                   PASSED in 117.4s
++//third_party/riscv-compliance:I-SLT-01_sim_verilator                    PASSED in 109.5s
++//third_party/riscv-compliance:I-SLTI-01_sim_verilator                   PASSED in 109.8s
++//third_party/riscv-compliance:I-SLTIU-01_sim_verilator                  PASSED in 102.7s
++//third_party/riscv-compliance:I-SLTU-01_sim_verilator                   PASSED in 110.3s
++//third_party/riscv-compliance:I-SRA-01_sim_verilator                    PASSED in 111.4s
++//third_party/riscv-compliance:I-SRAI-01_sim_verilator                   PASSED in 110.5s
++//third_party/riscv-compliance:I-SRL-01_sim_verilator                    PASSED in 115.5s
++//third_party/riscv-compliance:I-SRLI-01_sim_verilator                   PASSED in 82.3s
++//third_party/riscv-compliance:I-SUB-01_sim_verilator                    PASSED in 107.0s
++//third_party/riscv-compliance:I-SW-01_sim_verilator                     PASSED in 110.2s
++//third_party/riscv-compliance:I-XOR-01_sim_verilator                    PASSED in 101.9s
++//third_party/riscv-compliance:I-XORI-01_sim_verilator                   PASSED in 111.6s
++//third_party/riscv-compliance:MULHSU_sim_verilator                      PASSED in 105.3s
++//third_party/riscv-compliance:MULHU_sim_verilator                       PASSED in 77.2s
++//third_party/riscv-compliance:MULH_sim_verilator                        PASSED in 110.3s
++//third_party/riscv-compliance:MUL_sim_verilator                         PASSED in 113.8s
++//third_party/riscv-compliance:REMU_sim_verilator                        PASSED in 111.9s
++//third_party/riscv-compliance:REM_sim_verilator                         PASSED in 110.3s
 +
-+... verbose test output ...
-+
-+Compare to reference files ...
-+
-+Check         I-ADD-01 ... OK
-+Check        I-ADDI-01 ... OK
-+Check         I-AND-01 ... OK
-+Check        I-ANDI-01 ... OK
-+Check       I-AUIPC-01 ... OK
-+Check         I-BEQ-01 ... OK
-+Check         I-BGE-01 ... OK
-+Check        I-BGEU-01 ... OK
-+Check         I-BLT-01 ... OK
-+Check        I-BLTU-01 ... OK
-+Check         I-BNE-01 ... OK
-+Check I-DELAY_SLOTS-01 ... OK
-+Check      I-EBREAK-01 ... OK
-+Check       I-ECALL-01 ... OK
-+Check   I-ENDIANESS-01 ... OK
-+Check          I-IO-01 ... OK
-+Check         I-JAL-01 ... OK
-+Check        I-JALR-01 ... OK
-+Check          I-LB-01 ... OK
-+Check         I-LBU-01 ... OK
-+Check          I-LH-01 ... OK
-+Check         I-LHU-01 ... OK
-+Check         I-LUI-01 ... OK
-+Check          I-LW-01 ... OK
-+Check I-MISALIGN_JMP-01 ... IGNORE
-+Check I-MISALIGN_LDST-01 ... IGNORE
-+Check         I-NOP-01 ... OK
-+Check          I-OR-01 ... OK
-+Check         I-ORI-01 ... OK
-+Check     I-RF_size-01 ... OK
-+Check    I-RF_width-01 ... OK
-+Check       I-RF_x0-01 ... OK
-+Check          I-SB-01 ... OK
-+Check          I-SH-01 ... OK
-+Check         I-SLL-01 ... OK
-+Check        I-SLLI-01 ... OK
-+Check         I-SLT-01 ... OK
-+Check        I-SLTI-01 ... OK
-+Check       I-SLTIU-01 ... OK
-+Check        I-SLTU-01 ... OK
-+Check         I-SRA-01 ... OK
-+Check        I-SRAI-01 ... OK
-+Check         I-SRL-01 ... OK
-+Check        I-SRLI-01 ... OK
-+Check         I-SUB-01 ... OK
-+Check          I-SW-01 ... OK
-+Check         I-XOR-01 ... OK
-+Check        I-XORI-01 ... OK
-+--------------------------------
-+OK: 48/48
-+```
-+
-+There are several test suites that can be run `rv32i`, `rv32im`, `rv32imc` and
-+`rv32Zicsr`.  Change the `RISCV_ISA` argument passed to `make` to choose between
-+them.
-+
-+## Changing targets
-+When switching between targets (i.e. between FPGA and verilator) the `work`
-+directory in the `riscv_compliance` tree must be remove to force a software
-+rebuild.
-+
-+```console
-+$ cd $RISCV_COMPLIANCE_REPO_BASE
-+$ rm -rf ./work
-+```
-+
-+## Parallel runs
-+When running against the `sim_verilator` target parallel make jobs are used (via
-+passing `-j4` to make internally).  Parallel runs can be disabled by passing
-+`PARALLEL=0` to the `make` command or the `-j` used can be altered with the
-+`JOBS` argument.
-+
-+Disable parallel runs:
-+```console
-+$ make RISCV_ISA=rv32i PARALLEL=0
-+```
-+
-+Use a different `-j` parameter:
-+```console
-+$ make RISCV_ISA=rv32i JOBS=-j8
++Executed 82 out of 82 tests: 82 tests pass.
++INFO: Build completed successfully, 249 total actions
 +```
 +
 +## Removed/Broken Tests


### PR DESCRIPTION
* In BUILD.bazel we mention meson and want to preserve the structure for
other reasons
* Update OpenTitan's riscv_compliance patches to describe how we now run
  them
* The license checker no longer needs to check meson.build files

Signed-off-by: Drew Macrae <drewmacrae@google.com>