### PR TITLE
[dv/top] Add alert_handler_escalation test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1234,9 +1234,8 @@
 
             Verify all escalation paths triggered by an alert.
             - Verify the first escalation results in NMI interrupt serviced by the CPU.
-            - Verify the second results in device secrets to be wiped - read via SW to confirm.
-            - Verify the third results in device being put in scrap state, via the LC JTAG TAP.
-            - Verify the fourth results in chip reset.
+            - Verify the second results in device being put in scrap state, via the LC JTAG TAP.
+            - Verify the third results in chip reset.
             - Ensure that all escalation handshakes complete without errors.
             '''
       milestone: V2

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -689,6 +689,13 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_alert_handler_escalation
+      uvm_test_seq: chip_sw_alert_handler_escalation_vseq
+      sw_images: ["sw/device/tests/sim_dv/alert_handler_escalation_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=5000000", "+bypass_alert_ready_to_end_check=1"]
+    }
+    {
       name: chip_sw_alert_handler_ping_timeout
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/alert_handler_ping_timeout_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -45,6 +45,7 @@ filesets:
       - seq_lib/chip_tap_straps_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_jtag_base_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_alert_handler_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_full_aon_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_main_power_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_escalation_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_escalation_vseq.sv
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_alert_handler_escalation_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_alert_handler_escalation_vseq)
+
+  `uvm_object_new
+
+  lc_ctrl_state_pkg::dec_lc_state_e state_val = lc_ctrl_state_pkg::DecLcStRaw;
+
+  // Reassign `select_jtag` variable to drive LC JTAG tap at start,
+  // because LC_CTRL's TestLock state can only sample strap once at boot.
+  virtual task pre_start();
+    select_jtag = SelectLCJtagTap;
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    string keymgr_path = {`DV_STRINGIFY(`KEYMGR_HIER),
+                        ".u_ctrl.key_state_q"};
+    logic [1023:0] curr_key, prev_key;
+    super.body();
+
+    // ensure we see NMI handler trigger from C side
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Keymgr entered Init State");,
+             "timeout waiting for C side keymgr init acknowledgement",
+             cfg.sw_test_timeout_ns)
+
+    if (!uvm_hdl_read(keymgr_path, curr_key)) begin
+       `uvm_fatal(`gfn, $sformatf("uvm_hdl_read failed for %0s", keymgr_path))
+    end
+
+
+    // ensure we see NMI handler trigger from C side
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "You are experiencing an NMI");,
+             "timeout waiting for C side NMI acknowledgement",
+             cfg.sw_test_timeout_ns)
+
+    // poll for state to transition into scrap
+    jtag_csr_spinwait(ral.lc_ctrl.lc_state.get_offset(),
+      p_sequencer.jtag_sequencer_h,
+      {DecLcStateNumRep{DecLcStEscalate}},
+      cfg.sw_test_timeout_ns);
+
+    prev_key = curr_key;
+    uvm_hdl_read(keymgr_path, curr_key);
+    if (curr_key == prev_key) begin
+      `uvm_fatal(`gfn, $sformatf("something is very wrong"))
+    end
+
+
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -42,3 +42,4 @@
 `include "chip_sw_repeat_reset_wkup_vseq.sv"
 `include "chip_sw_rstmgr_alert_info_vseq.sv"
 `include "chip_rv_dm_ndm_reset_vseq.sv"
+`include "chip_sw_alert_handler_escalation_vseq.sv"

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -12,6 +12,7 @@
 `define CPU_TL_ADAPT_D_HIER   `CPU_HIER.tl_adapter_host_d_ibex
 `define EFLASH_HIER           `CHIP_HIER.u_flash_ctrl.u_eflash.u_flash
 `define GPIO_HIER             `CHIP_HIER.u_gpio
+`define KEYMGR_HIER           `CHIP_HIER.u_keymgr
 `define OTP_CTRL_HIER         `CHIP_HIER.u_otp_ctrl
 `define RAM_MAIN_HIER         `CHIP_HIER.u_sram_ctrl_main.u_prim_ram_1p_scr
 `define RAM_RET_HIER          `CHIP_HIER.u_sram_ctrl_ret_aon.u_prim_ram_1p_scr

--- a/sw/device/lib/testing/test_framework/ottf_isrs.h
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.h
@@ -29,7 +29,7 @@ typedef enum ottf_exc_id {
  */
 typedef enum ottf_internal_irq_id {
   kInternalIrqLoadInteg = 0xffffffe0,
-  kInternalIrqNmi = 0x0000001f
+  kInternalIrqNmi = 0x8000001f
 } ottf_internal_irq_id_t;
 
 /**

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -672,3 +672,26 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "alert_handler_escalation_test",
+    srcs = ["alert_handler_escalation.c"],
+    deps = [
+        "//hw/top_earlgrey:alert_handler_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:clkmgr",
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing:keymgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/sim_dv/alert_handler_escalation.c
+++ b/sw/device/tests/sim_dv/alert_handler_escalation.c
@@ -1,0 +1,163 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/dif/dif_keymgr.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/keymgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "alert_handler_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "rv_core_ibex_regs.h"  // Generated.
+
+/*
+  - Verify the first escalation results in NMI interrupt serviced by the CPU.
+  - Verify the second results in device being put in escalate state, via the LC
+  JTAG TAP.
+  - Verify the third results in chip reset.
+  - Ensure that all escalation handshakes complete without errors.
+
+  The first escalation is checked via the entry of the NMI handler and polling
+  by dv. The second escalation is directly checked by dv. The third escalation
+  is checked via reset reason.
+ */
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_clkmgr_t clkmgr;
+static dif_keymgr_t keymgr;
+static dif_rstmgr_t rstmgr;
+static dif_alert_handler_t alert_handler;
+static dif_rv_core_ibex_t rv_core_ibex;
+static dif_uart_t uart;
+
+typedef struct node {
+  const char *name;
+  dif_alert_handler_alert_t alert;
+  dif_alert_handler_class_t class;
+} node_t;
+
+static volatile uint32_t global_alert_called;
+static const dif_alert_handler_escalation_phase_t kEscProfiles[] = {
+    {.phase = kDifAlertHandlerClassStatePhase0,
+     .signal = 0,
+     .duration_cycles = 5000},
+    // TODO:
+    // this second duration must be long enough to
+    // accommodate a jtag transaction
+    // how can this be done in a non-hardcoded way?
+    {.phase = kDifAlertHandlerClassStatePhase1,
+     .signal = 1,
+     .duration_cycles = 10000},
+    {.phase = kDifAlertHandlerClassStatePhase2,
+     .signal = 3,
+     .duration_cycles = 3000}};
+
+static const dif_alert_handler_class_config_t kConfigProfiles[] = {{
+    .auto_lock_accumulation_counter = kDifToggleDisabled,
+    .accumulator_threshold = 0,
+    .irq_deadline_cycles = 0,
+    .escalation_phases = kEscProfiles,
+    .escalation_phases_len = 3,
+    .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase1,
+}};
+
+/**
+ * External ISR.
+ *
+ * Handles all peripheral interrupts on Ibex. PLIC asserts an external interrupt
+ * line to the CPU, which results in a call to this OTTF ISR. This ISR
+ * overrides the default OTTF implementation.
+ */
+void ottf_external_nmi_handler(void) {
+  // DO NOT REMOVE, DV sync message
+  LOG_INFO("You are experiencing an NMI");
+
+  // Now intentionally hang the device
+  CHECK_DIF_OK(dif_clkmgr_gateable_clock_set_enabled(
+      &clkmgr, kTopEarlgreyGateableClocksIoDiv4Peri, kDifToggleDisabled));
+
+  // access uart after clocks have been disabled
+  CHECK_DIF_OK(dif_uart_disable_rx_timeout(&uart));
+  LOG_FATAL("This message should never be seen");
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_clkmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  CHECK_DIF_OK(dif_alert_handler_init(
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
+      &alert_handler));
+
+  CHECK_DIF_OK(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
+
+  CHECK_DIF_OK(dif_keymgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_KEYMGR_BASE_ADDR), &keymgr));
+
+  // Check if there was a HW reset caused by the escalation.
+  dif_rstmgr_reset_info_bitfield_t rst_info;
+  CHECK_DIF_OK(dif_rstmgr_reset_info_get(&rstmgr, &rst_info));
+  CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+
+  if (rst_info & kDifRstmgrResetInfoPor) {
+    // set the alert we care about to class A
+    CHECK_DIF_OK(dif_alert_handler_configure_alert(
+        &alert_handler, kTopEarlgreyAlertIdRvCoreIbexRecovSwErr,
+        kDifAlertHandlerClassA, /*enabled=*/kDifToggleEnabled,
+        /*locked=*/kDifToggleEnabled));
+
+    // configurate class A
+    CHECK_DIF_OK(dif_alert_handler_configure_class(
+        &alert_handler, kDifAlertHandlerClassA, kConfigProfiles[0],
+        /*enabled=*/kDifToggleEnabled,
+        /*locked=*/kDifToggleEnabled));
+
+    // Initialize keymgr with otp contents
+    keymgr_testutils_advance_state(&keymgr, NULL);
+
+    // DO NOT REMOVE, DV sync message
+    LOG_INFO("Keymgr entered Init State");
+
+    // Enable NMI
+    CHECK_DIF_OK(dif_rv_core_ibex_enable_nmi(&rv_core_ibex,
+                                             kDifRvCoreIbexNmiSourceAlert));
+
+    // force trigger the alert
+    CHECK_DIF_OK(dif_rv_core_ibex_alert_force(&rv_core_ibex,
+                                              kDifRvCoreIbexAlertRecovSwErr));
+
+    // Stop execution here and just wait for something to happen
+    wait_for_interrupt();
+    CHECK(false, "Should have reset before this line");
+
+  } else if (rst_info & kDifRstmgrResetInfoEscalation) {
+    LOG_INFO("Reset due to alert escalation");
+    return true;
+
+  } else {
+    LOG_FATAL("unexpected reset info %d", rst_info);
+  }
+
+  return false;
+}


### PR DESCRIPTION
- this test goes through the full escalation path from a single
  alert.
- the secret checking portion during escalation can be further
  enhanced.

Signed-off-by: Timothy Chen <timothytim@google.com>