### PR TITLE
[dv/alert_handler] Add timing check for pings

### DIFF
--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -43,6 +43,7 @@ class esc_monitor extends alert_esc_base_monitor;
           int ping_cnter = 1;
           under_esc_ping = 1;
           req.alert_esc_type = AlertEscPingTrans;
+          alert_esc_port.write(req);
           check_esc_resp(.req(req), .is_ping(1));
           while (req.esc_handshake_sta != EscRespComplete &&
                  ping_cnter < cfg.ping_timeout_cycle &&

--- a/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
@@ -238,5 +238,14 @@
       name: num_edn_reqs_cg
       desc: '''Covers if simulation runs long enough to capture more than five EDN requests.'''
     }
+    {
+      name: num_checked_pings_cg
+      desc: '''Covers if simulation runs long enough to capture more than twenty ping requests.'''
+    }
+    {
+      name: cycles_bwtween_pings_cg
+      desc: '''Covers how many cycles are there between two ping requests.'''
+    }
+
   ]
 }

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -114,8 +114,28 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
   // Covergroup to make sure simulation is long enough to fetch more than five EDN requests.
   covergroup num_edn_reqs_cg with function sample(int num_edn_reqs);
     num_edn_reqs_cp: coverpoint num_edn_reqs {
-      bins less_then_five_reqs = {[1:4]};
+      bins less_than_five_reqs = {[1:4]};
       bins five_or_more_reqs   = {[5:$]};
+    }
+  endgroup
+
+  covergroup num_checked_pings_cg with function sample (int num_pings);
+    num_pings_cp: coverpoint num_pings {
+      bins less_than_ten_pings = {[1:9]};
+      bins ten_to_twenty_pings = {[10:19]};
+      bins more_than_twenty_pings = {[20:$]};
+    }
+  endgroup
+
+  covergroup cycles_between_pings_cg with function sample (int num_cycles_between_pings);
+    num_cycles_cp: coverpoint num_cycles_between_pings{
+      bins less_than_5000_cycs = {[1:4_999]};
+      bins less_than_100k_cycs = {[5_000:99_999]};
+      bins less_than_200k_cycs = {[100_000:199_999]};
+      bins less_than_300k_cycs = {[200_000:299_999]};
+      bins less_than_400k_cycs = {[300_000:399_999]};
+      bins less_than_500k_cycs = {[400_000:499_999]};
+      bins more_than_500k_cycs = {[500_000:'hFFFF]};
     }
   endgroup
 
@@ -132,6 +152,8 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     crashdump_trigger_cg = new();
 
     num_edn_reqs_cg = new();
+    num_checked_pings_cg = new();
+    cycles_between_pings_cg = new();
 
   endfunction : new
 

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -13,7 +13,6 @@ package alert_handler_env_pkg;
   import alert_handler_ral_pkg::*;
   import dv_base_reg_pkg::*;
   import cip_base_pkg::*;
-  import sec_cm_pkg::*;
   import push_pull_agent_pkg::*;
   import sec_cm_pkg::*;
 
@@ -46,6 +45,8 @@ package alert_handler_env_pkg;
   parameter uint NUM_CRASHDUMP             = NUM_ALERT_CLASSES * (alert_handler_reg_pkg::AccuCntDw
                                              + alert_handler_reg_pkg::EscCntDw + 3) +
                                              NUM_ALERTS + NUM_LOCAL_ALERTS;
+  parameter bit[15:0] MAX_PING_WAIT_CYCLES = '1;
+
   // types
   typedef enum {
     EscPhase0,

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
@@ -238,5 +238,14 @@
       name: num_edn_reqs_cg
       desc: '''Covers if simulation runs long enough to capture more than five EDN requests.'''
     }
+    {
+      name: num_checked_pings_cg
+      desc: '''Covers if simulation runs long enough to capture more than twenty ping requests.'''
+    }
+    {
+      name: cycles_bwtween_pings_cg
+      desc: '''Covers how many cycles are there between two ping requests.'''
+    }
+
   ]
 }

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -114,8 +114,28 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
   // Covergroup to make sure simulation is long enough to fetch more than five EDN requests.
   covergroup num_edn_reqs_cg with function sample(int num_edn_reqs);
     num_edn_reqs_cp: coverpoint num_edn_reqs {
-      bins less_then_five_reqs = {[1:4]};
+      bins less_than_five_reqs = {[1:4]};
       bins five_or_more_reqs   = {[5:$]};
+    }
+  endgroup
+
+  covergroup num_checked_pings_cg with function sample (int num_pings);
+    num_pings_cp: coverpoint num_pings {
+      bins less_than_ten_pings = {[1:9]};
+      bins ten_to_twenty_pings = {[10:19]};
+      bins more_than_twenty_pings = {[20:$]};
+    }
+  endgroup
+
+  covergroup cycles_between_pings_cg with function sample (int num_cycles_between_pings);
+    num_cycles_cp: coverpoint num_cycles_between_pings{
+      bins less_than_5000_cycs = {[1:4_999]};
+      bins less_than_100k_cycs = {[5_000:99_999]};
+      bins less_than_200k_cycs = {[100_000:199_999]};
+      bins less_than_300k_cycs = {[200_000:299_999]};
+      bins less_than_400k_cycs = {[300_000:399_999]};
+      bins less_than_500k_cycs = {[400_000:499_999]};
+      bins more_than_500k_cycs = {[500_000:'hFFFF]};
     }
   endgroup
 
@@ -132,6 +152,8 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     crashdump_trigger_cg = new();
 
     num_edn_reqs_cg = new();
+    num_checked_pings_cg = new();
+    cycles_between_pings_cg = new();
 
   endfunction : new
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -13,7 +13,6 @@ package alert_handler_env_pkg;
   import alert_handler_ral_pkg::*;
   import dv_base_reg_pkg::*;
   import cip_base_pkg::*;
-  import sec_cm_pkg::*;
   import push_pull_agent_pkg::*;
   import sec_cm_pkg::*;
 
@@ -46,6 +45,8 @@ package alert_handler_env_pkg;
   parameter uint NUM_CRASHDUMP             = NUM_ALERT_CLASSES * (alert_handler_reg_pkg::AccuCntDw
                                              + alert_handler_reg_pkg::EscCntDw + 3) +
                                              NUM_ALERTS + NUM_LOCAL_ALERTS;
+  parameter bit[15:0] MAX_PING_WAIT_CYCLES = '1;
+
   // types
   typedef enum {
     EscPhase0,


### PR DESCRIPTION
This PR adds more timing check to make sure ping is triggered within the
expected timeframe.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>