### PR TITLE
[opentitanlib] Remove bail dependency from Uart

### DIFF
--- a/sw/host/opentitanlib/src/transport/ti50emulator/uart.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/uart.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 
 use std::cell::{Cell, RefCell, RefMut};
 use std::io::{Read, Write};


### PR DESCRIPTION
Remove the bail dependency from the opentitanlib Uart. The call to bail was removed in this commit: https://github.com/lowrisc/opentitan/commit/dbc470d2bfcb528a996db9060294207a9ffbdffd