### PR TITLE
[flash/dv] Changes to mid-rst test and add tl_check bit

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -406,7 +406,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       void'(item.is_d_chan_intg_ok(
             .en_data_intg_chk(!is_data_intg_passthru_mem(item, ral_name) ||
                               !cfg.disable_d_user_data_intg_check_for_passthru_mem),
-            .throw_error(1)));
+            .throw_error(cfg.m_tl_agent_cfgs[ral_name].check_tl_errs)));
 
       // sample covergroup
       tl_intg_err_cgs_wrap[ral_name].sample(tl_intg_err_type, num_cmd_err_bits, num_data_err_bits,

--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -130,6 +130,10 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   // return UVM_NOT_OK when the item is aborted without accepted.
   int unsigned csr_access_abort_pct_in_adapter = 0;
 
+  // Indicate whether to check TLUL errors.
+  // Added to allow some TLUL checks to be ignored on certain scenarios.
+  bit check_tl_errs = 1'b1;
+
   `uvm_object_utils_begin(tl_agent_cfg)
     `uvm_field_int(max_outstanding_req,   UVM_DEFAULT)
     `uvm_field_enum(tl_level_e, tl_level, UVM_DEFAULT)

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -61,7 +61,9 @@ class tl_host_driver extends tl_base_driver;
       `DV_CHECK_EQ(pending_a_req.size(), 0)
       `DV_CHECK_EQ(seq_item_port.has_do_available(), 0)
       // Check if the a_source_pend_q maintained in the cfg is empty.
-      `DV_CHECK_EQ(cfg.a_source_pend_q.size(), 0)
+      if (cfg.check_tl_errs) begin
+        `DV_CHECK_EQ(cfg.a_source_pend_q.size(), 0)
+      end
     end
   endtask
 

--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -92,7 +92,9 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
     rw.byte_en = bus_rsp.a_mask;
     `DV_CHECK_EQ(bus_rsp.d_source, bus_rsp.a_source)
     // expect d_error = 0 as we won't drive any error case through RAL
-    `DV_CHECK_EQ(bus_rsp.d_error, 0)
+    if (cfg.check_tl_errs) begin
+      `DV_CHECK_EQ(bus_rsp.d_error, 0)
+    end
     // indicate if the item is completed successfully for upper level to update predict value
     rw.status  = !bus_rsp.req_completed ? UVM_NOT_OK : UVM_IS_OK;
     `uvm_info(`gtn, {"tl_reg_adapter::bus2reg: ", bus_rsp.convert2string()}, UVM_HIGH)


### PR DESCRIPTION
Hi,
In this PR I added and changed some files to improve the flash_ctrl_mid_op_rst test and to make it more flexible so we can make it to pass in the closed-source.
The changes:
* Added a flag that can be set in the tl_agent_cfg in order to skip some checks on specific scenarios.
* Changed the mid-rst test in a way that seems better- Instead of waiting for the done of the interrupted transaction, do random program and read transaction after each power-loss and check that those transactions complete successfully to realy verify the flash recovery from the power-loss.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>