### PR TITLE
[test, entropy_src] Fix nightly regression tests

### DIFF
--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -79,13 +79,15 @@ dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
   mmio_region_write32(entropy_src->base_addr, ENTROPY_SRC_CONF_REG_OFFSET,
                       entropy_conf_reg);
 
-  // Configure health test window.
-  // Conditioning bypass is hardcoded to disabled (see above). If we want to
-  // expose the ES_TYPE field in the future, we need to also configure the
-  // health test window size for bypass mode.
-  mmio_region_write32(entropy_src->base_addr,
-                      ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_OFFSET,
-                      config.health_test_window_size);
+  if (config.health_test_threshold_scope) {
+    // Configure health test window.
+    // Conditioning bypass is hardcoded to disabled (see above). If we want to
+    // expose the ES_TYPE field in the future, we need to also configure the
+    // health test window size for bypass mode.
+    mmio_region_write32(entropy_src->base_addr,
+                        ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_OFFSET,
+                        config.health_test_window_size);
+  }
 
   // MODULE_ENABLE register configuration.
   mmio_region_write32(entropy_src->base_addr,

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -101,8 +101,10 @@ TEST_P(ConfigTestAllParams, ValidConfigurationMode) {
           {ENTROPY_SRC_CONF_RNG_BIT_SEL_OFFSET, rng_bit_sel},
       });
 
-  EXPECT_WRITE32(ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_OFFSET,
-                 test_param.health_test_window_size);
+  if (config_.health_test_threshold_scope) {
+    EXPECT_WRITE32(ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_OFFSET,
+                   test_param.health_test_window_size);
+  }
 
   EXPECT_WRITE32(ENTROPY_SRC_MODULE_ENABLE_REG_OFFSET,
                  {


### PR DESCRIPTION
 All the tests that initialize the `entropy_src` were failing when executed with `dvsim`.
Log
```
UVM_INFO @ 3657.038560 us: (sw_logger_if.sv:362) [tb.u_sim_sram.u_sim_sram_if.u_sw_logger_if.construct_log_and_print.unnamed$$_0.unnamed$$_1.unnamed$$_2.isolation_thread.unnamed$$_0.unnamed$$_1] String arg at addr ff60: ff60
UVM_INFO @ 3657.038560 us: (sw_logger_if.sv:516) [test_rom_sim_dv(sw/device/lib/testing/test_rom/test_rom.c:81)] ff60
UVM_INFO @ 3660.208560 us: (sw_logger_if.sv:516) [test_rom_sim_dv(sw/device/lib/testing/test_rom/test_rom.c:119)] Test ROM complete, jumping to flash!
UVM_INFO @ 3665.868560 us: (sw_test_status_if.sv:51) [tb.u_sim_sram.u_sim_sram_if.u_sw_test_status_if] SW test transitioned to SwTestStatusInTest.
"../src/lowrisc_prim_count_0/rtl/prim_count.sv", 180: tb.dut.top_earlgrey.u_entropy_src.u_entropy_src_core.u_prim_count_window_cntr.SimulClrSet_A: started at 3668498560ps failed at 3668498560ps
	Offending '(clr_i != set_i)'
UVM_ERROR @ 3668.498560 us: (prim_count.sv:180) [ASSERT FAILED] SimulClrSet_A
UVM_INFO @ 3668.498560 us: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER] 
--- UVM Report catcher Summary ---
```
 The problem was the entropy_src dif setting the health test windows when it is disable.
