### PR TITLE
[opentitanlib] Remove unused import in ti50emulator/uart.rs

### DIFF
--- a/sw/host/opentitanlib/src/transport/ti50emulator/uart.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/uart.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 
 use std::cell::{Cell, RefCell, RefMut};
 use std::io::{Read, Write};


### PR DESCRIPTION
This removes the related "unused import" warning.