### PR TITLE
[edn,entropy_src,csrng] VCS compatibility

### DIFF
--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -93,7 +93,6 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
       prim_mubi_pkg::mubi4_t invalid_mubi_val;
       invalid_mubi_val = get_rand_mubi4_val(.t_weight(0), .f_weight(0), .other_weight(1));
 
-      csrng_assert_vif.assert_off_alert();
       case (which_invalid_mubi)
         invalid_enable: enable = invalid_mubi_val;
         invalid_sw_app_enable: sw_app_enable = invalid_mubi_val;

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -46,6 +46,12 @@ class csrng_base_vseq extends cip_base_vseq #(
   // setup basic csrng features
   virtual task csrng_init();
 
+    // In cases where we are testing alert scenarios using invalid register configurations
+    // we must first disable the DUT assertions to allow the environment to catch the alerts
+    if (cfg.use_invalid_mubi) begin
+      cfg.csrng_assert_vif.assert_off_alert();
+    end
+
     // Enables
     csr_wr(.ptr(ral.regwen), .value(cfg.regwen));
     ral.ctrl.enable.set(cfg.enable);

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -67,8 +67,6 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
     if (use_invalid_mubi) begin
       prim_mubi_pkg::mubi4_t invalid_mubi_val;
       invalid_mubi_val = get_rand_mubi4_val(.t_weight(0), .f_weight(0), .other_weight(1));
-      // Turn off assertions
-      edn_assert_vif.assert_off_alert();
       case (which_invalid_mubi)
         invalid_edn_enable: enable = invalid_mubi_val;
         invalid_boot_req_mode: boot_req_mode = invalid_mubi_val;

--- a/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
@@ -75,6 +75,11 @@ class edn_alert_vseq extends edn_base_vseq;
     uvm_reg       csr;
     uvm_reg_field fld;
 
+    if (cfg.use_invalid_mubi) begin
+      // Turn off DUT assertions so that the corresponding alert can fire
+      cfg.edn_assert_vif.assert_off_alert();
+    end
+
     // Depending on the value of cfg.which_invalid_mubi, one of the following ctrl register fields
     // will be set to an invalid MuBI value.
     // Apply the bad settings, and confirm the corresponding alert is fired.

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -48,6 +48,12 @@ class edn_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task edn_init(string reset_kind = "HARD");
+
+    if (cfg.use_invalid_mubi) begin
+      // Turn off DUT assertions so that the corresponding alert can fire
+      cfg.edn_assert_vif.assert_off_alert();
+    end
+
     if (cfg.boot_req_mode == MuBi4True) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
       `DV_CHECK_STD_RANDOMIZE_FATAL(glen)

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -183,11 +183,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
     return str;
   endfunction
 
-  function post_randomize();
+  function void post_randomize();
     dut_cfg.randomize();
-    if (dut_cfg.use_invalid_mubi) begin
-      entropy_src_assert_if.assert_off_alert();
-    end
   endfunction
 
 endclass

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1168,7 +1168,10 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       fork : isolation_fork
         begin
           fork
-            wait(!rng_fifo.is_empty());
+            // Exploit the fact that peek is a blocking task to check the rng_fifo depth without
+            // modifying it.
+            // Note that the alternate approach: wait(!rng_fifo.is_empty()) does not work with VCS
+            rng_fifo.peek(rng_item);
             begin
               wait(!dut_pipeline_enabled);
               `uvm_info(`gfn, "Disable detected", UVM_MEDIUM);

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -96,6 +96,12 @@ class entropy_src_base_vseq extends cip_base_vseq #(
   // setup basic entropy_src features
   virtual task entropy_src_init(entropy_src_dut_cfg newcfg=cfg.dut_cfg);
 
+    // If the new configuration is intentionally trying to force bad mubi
+    // configurations, disable the alerts before applying the bad configs
+    if (newcfg.use_invalid_mubi) begin
+      cfg.entropy_src_assert_if.assert_off_alert();
+    end
+
     #50us;
 
     // Controls
@@ -134,7 +140,6 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     csr_wr(.ptr(ral.sw_regupd), .value(newcfg.sw_regupd));
 
     #50us;
-
 
     // Module_enables (should be done last)
     ral.module_enable.set(newcfg.module_enable);


### PR DESCRIPTION
Fixes various issues that were preventing compiliation under VCS

- Entropy_src scoreboarding functions no longer waits for virtual
  function tlm_analysis_fifo::is_empty
- All post_randomize functions in the env cfg clases are now
  declared with a return type of void
- Config post_randomize methods no longer call $assertoff tasks
  (calling tasks within a function is strictly prohibited by VCS)
  - When needed, calls to <IP>_assert_vif.assert_off_alert have been
    moved to the appropriate virtual sequences.  Any vseq which
    uses a potentially invalid mubi checks to see if invalid mubis
    are enabled.

Fixes #13516

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>