### PR TITLE
[sram/dv] Fix d_error mismatch

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -154,7 +154,6 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
 
   virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
     if (ral_name == cfg.sram_ral_name && get_sram_instr_type_err(item, channel)) begin
-      `DV_CHECK_EQ(item.d_error, 1)
       return 1;
     end
     return super.predict_tl_err(item, channel, ral_name);


### PR DESCRIPTION
Fixed a mistake in #13135
The `d_error` check should be added for chip_scoreboard, but wrongly added in
sram_ctrl_scoreboard. sram_ctrl_scoreboard already checks it in another
function.

Signed-off-by: Weicai Yang <weicai@google.com>