### PR TITLE
[doc] Update secure hw design guidelines

### DIFF
--- a/doc/security/_index.md
+++ b/doc/security/_index.md
@@ -25,6 +25,11 @@ enumerating the range of logical entities supported by the architecture, and
 their mapping into software stages. Runtime isolation properties and baseline
 identity concepts are introduced in this document.
 
+## [Secure Hardware Design Guidelines][implementation_guidelines]
+
+Silicon designs for security devices require special guidelines to protect the designs against myriad attacks.
+To that end, the team established [Secure Hardware Design Guidelines][implementation_guidelines] which are followed when developing OpenTitan security IP.
+
 ## Functional Guarantees
 
 At the functional level OpenTitan aims to provide the following guarantees:
@@ -113,6 +118,7 @@ the assigned severity.
 [hmac]: {{< relref "hw/ip/hmac/doc" >}}
 [keymgr]: {{< relref "hw/ip/keymgr/doc" >}}
 [logical_security_model]: {{< relref "doc/security/logical_security_model" >}}
+[implementation_guidelines]: {{< relref "doc/security/implementation_guidelines/hardware" >}}
 [otbn]: {{< relref "hw/ip/otbn/doc" >}}
 [security_model]: {{< relref "doc/security/specs" >}}
 [use_cases]: {{< relref "doc/security/use_cases" >}}

--- a/doc/security/implementation_guidelines/hardware/index.md
+++ b/doc/security/implementation_guidelines/hardware/index.md
@@ -214,6 +214,16 @@ attacks, see [[12](#ref-12)] and [[13](#ref-13)])
     faulty inputs can have catastrophic consequences. These guidelines cannot
     recommend a default-safe posture, but each decision about handling detected
     faults should be carefully considered.
+16. For request-acknowledge interfaces, monitor the acknowledge line for
+    spurious pulses at all times (not only when pending request) and use this
+    as a glitch/fault detector to escalate locally and/or generate alerts.
+17. When arbitrating between two or more transaction sources with different
+    privilege/access levels, consider how to protect a request from one source
+    being glitched/forged to masquerade as being sourced from another
+    higher-privilege source (for example, to return side-loaded
+    hardware-visible-only data via a software read path). At a minimum,
+    redundant arbitration and multiple-bit encoding of the arbitration "winner"
+    can help to mitigate this type of attack.
 
 ### **Recommendation 4**: Handling of secrets
 

--- a/doc/ug/design.md
+++ b/doc/ug/design.md
@@ -12,6 +12,7 @@ Starting with the language, the strategy is to use the SystemVerilog language, r
 All IP should be developed and delivered under the feature set described by this style guide.
 Inconsistencies or lack of clarity within the style guide should be solved by filing and helping close an issue on the style guide in the
 [lowrisc/style-guides GitHub repo](https://github.com/lowRISC/style-guides).
+Note that when developing OpenTitan security IP, designers should additionally follow the [Secure Hardware Design Guidelines]({{< relref "doc/security/implementation_guidelines/hardware" >}}).
 
 For professional tooling, the team has chosen several industry-grade tools for its design signoff process.
 Wherever possible we attempt to remain tool-agnostic, but we must choose a selection of tools as our ground truth for our own confidence of signoff-level assurances.

--- a/doc/ug/hw_design.md
+++ b/doc/ug/hw_design.md
@@ -44,6 +44,7 @@ The content and the status of the proposal can be shared with the team.
 An example of a canonical detailed specification is the pinmux specification which can be found in the TeamDrive under TechnicalSpecifications --> deprecated, for those that have access to that resource.
 (Google Docs that have been converted into Markdown on GitHub are archived here).
 
+Note that when developing OpenTitan security IP, designers should follow the [Secure Hardware Design Guidelines]({{< relref "doc/security/implementation_guidelines/hardware" >}}).
 
 ## Specification Publication
 


### PR DESCRIPTION
I just realized that we never added these two points that were originally suggested by @cdgori after going through all the D2S revies.

The PR also adds more links pointing to the secure hw design guidelines so that they are more readily discoverable.