### PR TITLE
[test] Remove entropy_src initialization from uneeded tests

### DIFF
--- a/sw/device/tests/aes_entropy_test.c
+++ b/sw/device/tests/aes_entropy_test.c
@@ -60,9 +60,6 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   dif_aes_t aes;
 
-  // First of all, we need to get the entropy complex up and running.
-  entropy_testutils_boot_mode_init();
-
   // Initialise AES.
   CHECK_DIF_OK(
       dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));

--- a/sw/device/tests/aes_idle_test.c
+++ b/sw/device/tests/aes_idle_test.c
@@ -80,11 +80,6 @@ bool test_main(void) {
 
   initialize_clkmgr();
 
-#if !OT_IS_ENGLISH_BREAKFAST
-  // First of all, we need to get the entropy complex up and running.
-  entropy_testutils_boot_mode_init();
-#endif
-
   // Initialise AES.
   CHECK_DIF_OK(
       dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));

--- a/sw/device/tests/aes_smoketest.c
+++ b/sw/device/tests/aes_smoketest.c
@@ -61,11 +61,6 @@ bool test_main(void) {
 
   LOG_INFO("Running AES test");
 
-#if !OT_IS_ENGLISH_BREAKFAST
-  // First of all, we need to get the entropy complex up and running.
-  entropy_testutils_boot_mode_init();
-#endif
-
   // Initialise AES.
   CHECK_DIF_OK(
       dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));


### PR DESCRIPTION
 Besides the OTB that uses de EDN1, any other IP requires the reset of the entropy src.
 By removing entropy initialization from the unecessary tests we save a few minutes in the nightly regression.
