### PR TITLE
[sw] Fix clang format errors

### DIFF
--- a/hw/dv/dpi/usbdpi/monitor_usb.c
+++ b/hw/dv/dpi/usbdpi/monitor_usb.c
@@ -185,14 +185,15 @@ void monitor_usb(void *mon_void, FILE *mon_file, int loglevel, int tick,
                   mon->sopAt, tick, mon->driver == M_HOST ? 'H' : 'D',
                   decode_pid[mon->lastpid & 0xf]);
         }
-        fprintf(mon_file, "mon:     %s: ",
-                mon->driver == M_HOST ? "h->d" : "d->h");
+        fprintf(mon_file,
+                "mon:     %s: ", mon->driver == M_HOST ? "h->d" : "d->h");
         comp_crc16 = CRC16(mon->bytes, mon->byte - 2);
         pkt_crc16 = mon->bytes[mon->byte - 2] | mon->bytes[mon->byte - 1] << 8;
         for (i = 0; i < mon->byte; i++) {
           fprintf(mon_file, "%02x%s", mon->bytes[i],
-                  ((i & 0xf) == 0xf) ? "\nmon:           "
-                                     : ((i + 1) == mon->byte) ? "" : ", ");
+                  ((i & 0xf) == 0xf)       ? "\nmon:           "
+                  : ((i + 1) == mon->byte) ? ""
+                                           : ", ");
           if ((mon->bytes[i] == 0x0d) || (mon->bytes[i] == 0x0a)) {
             mon->bytes[i] = '_';
           }

--- a/sw/device/lib/base/mock_mmio_test.cc
+++ b/sw/device/lib/base/mock_mmio_test.cc
@@ -66,7 +66,8 @@ TEST_F(MockMmioTest, ExpectWithBits) {
 
 TEST_F(MockMmioTest, ExpectMask) {
   EXPECT_MASK32(0x8, {
-                         {0x0, 0xfff, 0xabc}, {0x10, 0x1, 0x0},
+                         {0x0, 0xfff, 0xabc},
+                         {0x10, 0x1, 0x0},
                      });
 
   auto value = mmio_region_read32(dev().region(), 0x8);

--- a/sw/device/lib/testing/test_framework/freertos_hooks.c
+++ b/sw/device/lib/testing/test_framework/freertos_hooks.c
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "external/freertos/include/FreeRTOS.h"
+#include "external/freertos/include/task.h"
 #include "sw/device/lib/irq.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
-#include "external/freertos/include/FreeRTOS.h"
-#include "external/freertos/include/task.h"
 
 // NOTE: the function names below do NOT, and cannot, conform to the style
 // guide, since they are specific implementations of FreeRTOS defined functions.

--- a/sw/device/lib/testing/test_framework/freertos_port.c
+++ b/sw/device/lib/testing/test_framework/freertos_port.c
@@ -9,11 +9,11 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 
 // TODO: make this toplevel agnostic.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
-
 #include "external/freertos/include/FreeRTOS.h"
 #include "external/freertos/include/task.h"
 #include "external/freertos/portable/GCC/RISC-V/portmacro.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
 
 // NOTE: some of the function names below do NOT, and cannot, conform to the
 // style guide, since they are specific implementations of FreeRTOS defined

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -170,9 +170,10 @@ void ottf_external_isr(void) {
       top_earlgrey_plic_interrupt_for_peripheral[irq_id];
 
   if (peripheral == kTopEarlgreyPlicPeripheralAonTimerAon) {
-    irq = (dif_aon_timer_irq_t)(
-        irq_id -
-        (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+    irq =
+        (dif_aon_timer_irq_t)(irq_id -
+                              (dif_rv_plic_irq_id_t)
+                                  kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
 
     if (irq_id == kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired) {
       CHECK_DIF_OK(dif_aon_timer_wakeup_stop(&aon_timer));

--- a/sw/device/tests/coverage_test.c
+++ b/sw/device/tests/coverage_test.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/testing/test_framework/coverage.h"
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -9,7 +11,6 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
-#include "sw/device/lib/testing/test_framework/coverage.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 static void spin_45(uint8_t state) {

--- a/sw/device/tests/pwrmgr_sleep_disabled_test.c
+++ b/sw/device/tests/pwrmgr_sleep_disabled_test.c
@@ -54,9 +54,10 @@ void ottf_external_isr(void) {
       top_earlgrey_plic_interrupt_for_peripheral[irq_id];
 
   if (peripheral == kTopEarlgreyPlicPeripheralAonTimerAon) {
-    irq = (dif_aon_timer_irq_t)(
-        irq_id -
-        (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+    irq =
+        (dif_aon_timer_irq_t)(irq_id -
+                              (dif_rv_plic_irq_id_t)
+                                  kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
 
     CHECK_DIF_OK(dif_aon_timer_wakeup_stop(&aon_timer));
     CHECK_DIF_OK(dif_aon_timer_irq_acknowledge(&aon_timer, irq));

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -308,9 +308,10 @@ void ottf_external_isr(void) {
       top_earlgrey_plic_interrupt_for_peripheral[irq_id];
 
   if (peripheral == kTopEarlgreyPlicPeripheralAonTimerAon) {
-    irq = (dif_aon_timer_irq_t)(
-        irq_id -
-        (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+    irq =
+        (dif_aon_timer_irq_t)(irq_id -
+                              (dif_rv_plic_irq_id_t)
+                                  kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
 
     CHECK_DIF_OK(dif_aon_timer_irq_acknowledge(&aon_timer, irq));
   } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
@@ -127,9 +127,10 @@ void ottf_external_isr(void) {
       top_earlgrey_plic_interrupt_for_peripheral[irq_id];
 
   if (peripheral == kTopEarlgreyPlicPeripheralAonTimerAon) {
-    irq = (dif_aon_timer_irq_t)(
-        irq_id -
-        (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+    irq =
+        (dif_aon_timer_irq_t)(irq_id -
+                              (dif_rv_plic_irq_id_t)
+                                  kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
 
     // Stops escalation process.
     CHECK_DIF_OK(dif_alert_handler_escalation_clear(&alert_handler,

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -127,9 +127,10 @@ void ottf_external_isr(void) {
       top_earlgrey_plic_interrupt_for_peripheral[irq_id];
 
   if (peripheral == kTopEarlgreyPlicPeripheralAonTimerAon) {
-    irq = (dif_aon_timer_irq_t)(
-        irq_id -
-        (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+    irq =
+        (dif_aon_timer_irq_t)(irq_id -
+                              (dif_rv_plic_irq_id_t)
+                                  kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
 
     // Stops escalation process.
     CHECK_DIF_OK(dif_alert_handler_escalation_clear(&alert_handler,

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
@@ -128,9 +128,10 @@ void ottf_external_isr(void) {
       top_earlgrey_plic_interrupt_for_peripheral[irq_id];
 
   if (peripheral == kTopEarlgreyPlicPeripheralAonTimerAon) {
-    irq = (dif_aon_timer_irq_t)(
-        irq_id -
-        (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+    irq =
+        (dif_aon_timer_irq_t)(irq_id -
+                              (dif_rv_plic_irq_id_t)
+                                  kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
 
     // Stops escalation process.
     CHECK_DIF_OK(dif_alert_handler_escalation_clear(&alert_handler,


### PR DESCRIPTION
It appears that we have some clang format issues that are breaking CI at the moment. 
This PR intends to correct that.

Signed-off-by: Michael Schaffner <msf@google.com>