### PR TITLE
[ci] Avoid running clang-format when no .c/.cc files are changed.

### DIFF
--- a/ci/scripts/clang-format.sh
+++ b/ci/scripts/clang-format.sh
@@ -26,4 +26,4 @@ trap 'echo "code failed clang_format_check fix with ./bazelisk.sh run //:clang_f
 
 set -o pipefail
 git diff --name-only "$merge_base" -- "*.cpp" "*.cc" "*.c" "*.h" ':!*/vendor/*' | \
-    xargs ./bazelisk.sh run //:clang_format_check --
+    xargs -r ./bazelisk.sh run //:clang_format_check --


### PR DESCRIPTION
When no .cpp, .cc, .c. or .h files have changed, the diff is empty, but
piping the empty diff into `bazel run` causes `//:clang_format_check` to run
on the whole repo.
We add the -r flag to avoid this.

Signed-off-by: Miles Dai <milesdai@google.com>