### PR TITLE
[dv/alert_handler] Fix multi-thread issue

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_lpg_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_lpg_vseq.sv
@@ -37,10 +37,12 @@ class alert_handler_lpg_vseq extends alert_handler_entropy_vseq;
     fork
       begin : isolation_fork
         trigger_non_blocking_seqs();
-        enable_lpg_group(alert_en);
-        run_smoke_seq();
+        fork
+          enable_lpg_group(alert_en);
+          run_smoke_seq();
+        join
         disable fork; // disable non-blocking seqs for stress_all tests
-      end // end fork
+      end // end isolation_fork
     join
   endtask : body
 endclass : alert_handler_lpg_vseq

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_lpg_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_lpg_vseq.sv
@@ -37,10 +37,12 @@ class alert_handler_lpg_vseq extends alert_handler_entropy_vseq;
     fork
       begin : isolation_fork
         trigger_non_blocking_seqs();
-        enable_lpg_group(alert_en);
-        run_smoke_seq();
+        fork
+          enable_lpg_group(alert_en);
+          run_smoke_seq();
+        join
         disable fork; // disable non-blocking seqs for stress_all tests
-      end // end fork
+      end // end isolation_fork
     join
   endtask : body
 endclass : alert_handler_lpg_vseq


### PR DESCRIPTION
This PR fixes the multi-thread fork join issue.
The current code added an additional begin end within fork join, so the
different threads actually did not run in parallel as I expected.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>