### PR TITLE
[clang-format] Format all covered files

### DIFF
--- a/hw/dv/dpi/dmidpi/dmidpi.c
+++ b/hw/dv/dpi/dmidpi/dmidpi.c
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dmidpi.h"
-#include "tcp_server.h"
 
 #include <assert.h>
 #include <pthread.h>
@@ -11,6 +10,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "tcp_server.h"
 
 // IDCODE register
 // [31:28] 0x0,    - Version

--- a/hw/dv/dpi/jtagdpi/jtagdpi.c
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.c
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "jtagdpi.h"
-#include "tcp_server.h"
 
 #include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "tcp_server.h"
 
 struct jtagdpi_ctx {
   // Server context

--- a/hw/dv/dpi/spidpi/spidpi.h
+++ b/hw/dv/dpi/spidpi/spidpi.h
@@ -35,21 +35,21 @@ struct spidpi_ctx {
 };
 
 // SPI Host States
-#define SP_IDLE    0
-#define SP_CSFALL  1
-#define SP_DMOVE   2
+#define SP_IDLE 0
+#define SP_CSFALL 1
+#define SP_DMOVE 2
 #define SP_LASTBIT 3
-#define SP_CSRISE  4
-#define SP_FINISH  99
+#define SP_CSRISE 4
+#define SP_FINISH 99
 
 // Bits in data to C
-#define D2P_SDO    0x2
+#define D2P_SDO 0x2
 #define D2P_SDO_EN 0x1
 
 // Bits in char from C
-#define P2D_SCK    0x1
-#define P2D_CSB    0x2
-#define P2D_SDI    0x4
+#define P2D_SCK 0x1
+#define P2D_CSB 0x2
+#define P2D_SDI 0x4
 
 void *spidpi_create(const char *name, int mode, int loglevel);
 char spidpi_tick(void *ctx_void, const svLogicVecVal *d2p_data);

--- a/hw/dv/verilator/cpp/ecc32_mem_area.cc
+++ b/hw/dv/verilator/cpp/ecc32_mem_area.cc
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ecc32_mem_area.h"
-#include "secded_enc.h"
 
 #include <cassert>
 #include <cstring>
 #include <stdexcept>
+
+#include "secded_enc.h"
 
 Ecc32MemArea::Ecc32MemArea(const std::string &scope, uint32_t size,
                            uint32_t width_32)

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "aes_model_dpi.h"
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -10,8 +12,6 @@
 #include "aes.h"
 #include "crypto.h"
 #include "svdpi.h"
-
-#include "aes_model_dpi.h"
 
 void c_dpi_aes_crypt_block(const unsigned char impl_i, const unsigned char op_i,
                            const svBitVecVal *mode_i, const svBitVecVal *iv_i,

--- a/hw/ip/aes/model/aes.c
+++ b/hw/ip/aes/model/aes.c
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "aes.h"
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#include "aes.h"
 
 int aes_encrypt_block(const unsigned char *plain_text, const unsigned char *key,
                       const int key_len, unsigned char *cipher_text) {

--- a/hw/ip/aes/model/aes_example.c
+++ b/hw/ip/aes/model/aes_example.c
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "aes_example.h"
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "aes.h"
-#include "aes_example.h"
-
 #include "crypto.h"
 
 #define DEBUG_LEVEL_ENC 0  // 0, 1, 2

--- a/hw/ip/aes/model/aes_modes.c
+++ b/hw/ip/aes/model/aes_modes.c
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "aes_modes.h"
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "aes.h"
-#include "aes_modes.h"
-
 #include "crypto.h"
 
 #ifdef USE_BORING_SSL

--- a/hw/ip/aes/model/crypto.c
+++ b/hw/ip/aes/model/crypto.c
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "crypto.h"
+
 #include <openssl/conf.h>
 #include <openssl/evp.h>
-
-#include "crypto.h"
 
 /**
  * Get EVP_CIPHER type pointer defined by key_len and mode.

--- a/hw/ip/otbn/dv/tracer/cpp/log_trace_listener.cc
+++ b/hw/ip/otbn/dv/tracer/cpp/log_trace_listener.cc
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "log_trace_listener.h"
+
 #include <cassert>
 #include <iomanip>
 #include <ios>
 #include <sstream>
 #include <stdexcept>
 #include <string>
-
-#include "log_trace_listener.h"
 
 LogTraceListener::LogTraceListener(const std::string &log_filename)
     : trace_log(log_filename, std::fstream::out) {

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -203,8 +203,8 @@ void set_up_down_prim_count(PrimCountT *prim_count, uint32_t new_cnt) {
 
 template <typename LoopControllerT>
 auto get_loop_counter(LoopControllerT *loop_controller, uint32_t counter_idx)
-    -> decltype(
-        loop_controller->g_loop_counters__BRA__0__KET____DOT__u_loop_count) {
+    -> decltype(loop_controller
+                    ->g_loop_counters__BRA__0__KET____DOT__u_loop_count) {
   assert(counter_idx < 8);
 
   switch (counter_idx) {

--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.h
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.h
@@ -179,7 +179,9 @@ typedef ee_u32 CORE_TICKS;
 */
 extern ee_u32 default_num_contexts;
 
-typedef struct CORE_PORTABLE_S { ee_u8 portable_id; } core_portable;
+typedef struct CORE_PORTABLE_S {
+  ee_u8 portable_id;
+} core_portable;
 
 /* target specific init/fini */
 void portable_init(core_portable *p, int *argc, char *argv[]);

--- a/sw/device/lib/dif/dif_flash_ctrl.h
+++ b/sw/device/lib/dif/dif_flash_ctrl.h
@@ -13,6 +13,7 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits.h"
+
 #include "sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h"
 
 #ifdef __cplusplus

--- a/sw/device/lib/dif/dif_rom_ctrl.h
+++ b/sw/device/lib/dif/dif_rom_ctrl.h
@@ -13,9 +13,8 @@
 
 #include <stdint.h>
 
-#include "sw/device/lib/dif/autogen/dif_rom_ctrl_autogen.h"
-
 #include "rom_ctrl_regs.h"  // Generated.
+#include "sw/device/lib/dif/autogen/dif_rom_ctrl_autogen.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sw/device/lib/runtime/hart_polyfills.c
+++ b/sw/device/lib/runtime/hart_polyfills.c
@@ -4,10 +4,10 @@
 
 #define _DEFAULT_SOURCE  // Make sure we get usleep() from unistd.h.
 
-#include "sw/device/lib/runtime/hart.h"
-
 #include <stddef.h>
 #include <unistd.h>
+
+#include "sw/device/lib/runtime/hart.h"
 
 void busy_spin_micros(uint32_t usec) { usleep(usec); }
 

--- a/sw/device/lib/runtime/pmp.c
+++ b/sw/device/lib/runtime/pmp.c
@@ -39,7 +39,8 @@ typedef enum pmp_csr_access_type {
 } pmp_csr_access_type_t;
 
 static const bitfield_field32_t kPmpCfgModeField = {
-    .mask = PMP_CFG_CSR_MODE_MASK, .index = PMP_CFG_CSR_A,
+    .mask = PMP_CFG_CSR_MODE_MASK,
+    .index = PMP_CFG_CSR_A,
 };
 
 /**
@@ -191,7 +192,8 @@ static pmp_region_configure_result_t pmp_csr_cfg_field_read(
 
   size_t field_index = (region % PMP_CFG_FIELDS_PER_REG) * PMP_CFG_FIELD_WIDTH;
   bitfield_field32_t pmp_csr_cfg_field = {
-      .mask = PMP_CFG_FIELD_MASK, .index = field_index,
+      .mask = PMP_CFG_FIELD_MASK,
+      .index = field_index,
   };
 
   *field_value = bitfield_field32_read(cfg_csr_original, pmp_csr_cfg_field);
@@ -219,7 +221,8 @@ static pmp_region_configure_result_t pmp_csr_cfg_field_write(
   // Determine the pmpcfg field index based on the `region`.
   size_t field_index = (region % PMP_CFG_FIELDS_PER_REG) * PMP_CFG_FIELD_WIDTH;
   bitfield_field32_t pmp_csr_cfg_field = {
-      .mask = PMP_CFG_FIELD_MASK, .index = field_index,
+      .mask = PMP_CFG_FIELD_MASK,
+      .index = field_index,
   };
 
   uint32_t cfg_csr_new =

--- a/sw/device/lib/testing/aes_testutils.c
+++ b/sw/device/lib/testing/aes_testutils.c
@@ -8,4 +8,3 @@
 // corresponding header a link location.
 
 extern bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t flag);
-

--- a/sw/device/lib/testing/rand_testutils.c
+++ b/sw/device/lib/testing/rand_testutils.c
@@ -2,10 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/testing/rand_testutils.h"
+
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "sw/device/lib/testing/rand_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
 /**

--- a/sw/device/silicon_creator/lib/base/sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.h
@@ -202,7 +202,6 @@ void sec_mmio_write32(uint32_t addr, uint32_t value);
  */
 void sec_mmio_write32_shadowed(uint32_t addr, uint32_t value);
 
-
 /**
  * Checks the expected list of register values.
  *

--- a/sw/device/silicon_creator/mask_rom/keys/test_key_0_rsa_3072_exp_f4.h
+++ b/sw/device/silicon_creator/mask_rom/keys/test_key_0_rsa_3072_exp_f4.h
@@ -30,11 +30,10 @@
             0xd8dc61f4, 0x9404e8bc, 0x0db76fe3, 0x3491d3b0, 0x6ca44e27, \
             0xcda63719,                                                 \
         }},                                                             \
-    .n0_inv =                                                           \
-        {                                                               \
-            0x9c9a176b, 0x44d6fa52, 0x71a63ec4, 0xadc94595,             \
-            0x3fd9bc73, 0xa83cdc95, 0xbe1bc819, 0x2b421fae,             \
-        },                                                              \
+    .n0_inv = {                                                         \
+        0x9c9a176b, 0x44d6fa52, 0x71a63ec4, 0xadc94595,                 \
+        0x3fd9bc73, 0xa83cdc95, 0xbe1bc819, 0x2b421fae,                 \
+    },                                                                  \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_KEYS_TEST_KEY_0_RSA_3072_EXP_F4_H_

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
@@ -5,9 +5,9 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_BOOT_POLICY_PTRS_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_BOOT_POLICY_PTRS_H_
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 
-#include "sw/device/lib/base/macros.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
This should cover moving to the lowrisc toolchain's clang-format.