### PR TITLE
[dv] Alert lpg stub clk seq

### DIFF
--- a/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
@@ -107,15 +107,16 @@
             Stimulus:
             - Randomly enabled alert_receivers' `alert_en` but disable their ping response.
             - Turn on their low-power control by either set `lpg_cg_en_i` or `lpg_rst_en_i`.
+              Or pause the alert_handler's clk input for a random period of time.
             - Enable alert ping timeout local alert.
             - Run alert_handler_entropy_vseq.
 
             Checks:
             - Expect no ping timeout error because the alert_receivers are disabled via low-power
-              group.
+              group, or because alert_handler's clk input is paused due to sleep mode.
             '''
       milestone: V2
-      tests: ["alert_handler_lpg"]
+      tests: ["alert_handler_lpg", "alert_handler_lpg_stub_clk"]
     }
     {
       name: stress_all

--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -99,6 +99,12 @@
     }
 
     {
+      name: alert_handler_lpg_stub_clk
+      uvm_test_seq: alert_handler_lpg_stub_clk_vseq
+      run_opts: ["+test_timeout_ns=1_000_000_000"]
+    }
+
+    {
       name: alert_handler_stress_all
       run_opts: ["+test_timeout_ns=15_000_000_000"]
     }

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env.core
@@ -30,6 +30,7 @@ filesets:
       - seq_lib/alert_handler_entropy_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_ping_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_lpg_vseq.sv: {is_include_file: true}
+      - seq_lib/alert_handler_lpg_stub_clk_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -39,6 +39,10 @@ package alert_handler_env_pkg;
   // set the max ping timeout cycle to constrain the simulation run time
   parameter uint MAX_PING_TIMEOUT_CYCLE    = 300;
 
+  // Alert_handler ping timer design should automatically fetch EDN entropy every 500k clock
+  // cycles. We set the threshold to 600k clock cycles.
+  parameter uint MAX_EDN_REQ_WAIT_CYCLES   = 600_000;
+
   parameter uint NUM_CRASHDUMP             = NUM_ALERT_CLASSES * (alert_handler_reg_pkg::AccuCntDw
                                              + alert_handler_reg_pkg::EscCntDw + 3) +
                                              NUM_ALERTS + NUM_LOCAL_ALERTS;

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_lpg_stub_clk_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_lpg_stub_clk_vseq.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence check LPG by randomly turn off alert_handler's clock, and check if ping timer can
+// resume correctly without sending some spurious ping errors.
+class alert_handler_lpg_stub_clk_vseq extends alert_handler_lpg_vseq;
+  `uvm_object_utils(alert_handler_lpg_stub_clk_vseq)
+
+  `uvm_object_new
+
+  constraint loc_alert_en_c {
+    local_alert_en[LocalAlertPingFail] == 1;
+    local_alert_en[LocalEscPingFail] == 1;
+  }
+
+  constraint ping_fail_c {
+    alert_ping_timeout == 0;
+    esc_ping_timeout   == 0;
+  }
+
+  task body();
+    fork begin : isolation_fork
+      trigger_non_blocking_seqs();
+      fork
+        rand_stub_clk();
+        run_smoke_seq();
+      join
+      disable fork; // disable non-blocking seqs for stress_all tests
+    end join
+  endtask : body
+
+  virtual task rand_stub_clk();
+    repeat($urandom_range(1, 5)) begin
+      int clk_stub_ps = cfg.clk_rst_vif.clk_period_ps * $urandom_range(2, 1_000);
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 100_000));
+      cfg.clk_rst_vif.stop_clk();
+      #((clk_stub_ps)*1ps);
+      cfg.clk_rst_vif.start_clk();
+    end
+  endtask
+
+endclass : alert_handler_lpg_stub_clk_vseq

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_vseq_list.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_vseq_list.sv
@@ -13,4 +13,5 @@
 `include "alert_handler_entropy_vseq.sv"
 `include "alert_handler_ping_timeout_vseq.sv"
 `include "alert_handler_lpg_vseq.sv"
+`include "alert_handler_lpg_stub_clk_vseq.sv"
 `include "alert_handler_stress_all_vseq.sv"

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
@@ -107,15 +107,16 @@
             Stimulus:
             - Randomly enabled alert_receivers' `alert_en` but disable their ping response.
             - Turn on their low-power control by either set `lpg_cg_en_i` or `lpg_rst_en_i`.
+              Or pause the alert_handler's clk input for a random period of time.
             - Enable alert ping timeout local alert.
             - Run alert_handler_entropy_vseq.
 
             Checks:
             - Expect no ping timeout error because the alert_receivers are disabled via low-power
-              group.
+              group, or because alert_handler's clk input is paused due to sleep mode.
             '''
       milestone: V2
-      tests: ["alert_handler_lpg"]
+      tests: ["alert_handler_lpg", "alert_handler_lpg_stub_clk"]
     }
     {
       name: stress_all

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -99,6 +99,12 @@
     }
 
     {
+      name: alert_handler_lpg_stub_clk
+      uvm_test_seq: alert_handler_lpg_stub_clk_vseq
+      run_opts: ["+test_timeout_ns=1_000_000_000"]
+    }
+
+    {
       name: alert_handler_stress_all
       run_opts: ["+test_timeout_ns=15_000_000_000"]
     }

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
@@ -30,6 +30,7 @@ filesets:
       - seq_lib/alert_handler_entropy_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_ping_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_lpg_vseq.sv: {is_include_file: true}
+      - seq_lib/alert_handler_lpg_stub_clk_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -39,6 +39,10 @@ package alert_handler_env_pkg;
   // set the max ping timeout cycle to constrain the simulation run time
   parameter uint MAX_PING_TIMEOUT_CYCLE    = 300;
 
+  // Alert_handler ping timer design should automatically fetch EDN entropy every 500k clock
+  // cycles. We set the threshold to 600k clock cycles.
+  parameter uint MAX_EDN_REQ_WAIT_CYCLES   = 600_000;
+
   parameter uint NUM_CRASHDUMP             = NUM_ALERT_CLASSES * (alert_handler_reg_pkg::AccuCntDw
                                              + alert_handler_reg_pkg::EscCntDw + 3) +
                                              NUM_ALERTS + NUM_LOCAL_ALERTS;

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_lpg_stub_clk_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_lpg_stub_clk_vseq.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence check LPG by randomly turn off alert_handler's clock, and check if ping timer can
+// resume correctly without sending some spurious ping errors.
+class alert_handler_lpg_stub_clk_vseq extends alert_handler_lpg_vseq;
+  `uvm_object_utils(alert_handler_lpg_stub_clk_vseq)
+
+  `uvm_object_new
+
+  constraint loc_alert_en_c {
+    local_alert_en[LocalAlertPingFail] == 1;
+    local_alert_en[LocalEscPingFail] == 1;
+  }
+
+  constraint ping_fail_c {
+    alert_ping_timeout == 0;
+    esc_ping_timeout   == 0;
+  }
+
+  task body();
+    fork begin : isolation_fork
+      trigger_non_blocking_seqs();
+      fork
+        rand_stub_clk();
+        run_smoke_seq();
+      join
+      disable fork; // disable non-blocking seqs for stress_all tests
+    end join
+  endtask : body
+
+  virtual task rand_stub_clk();
+    repeat($urandom_range(1, 5)) begin
+      int clk_stub_ps = cfg.clk_rst_vif.clk_period_ps * $urandom_range(2, 1_000);
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 100_000));
+      cfg.clk_rst_vif.stop_clk();
+      #((clk_stub_ps)*1ps);
+      cfg.clk_rst_vif.start_clk();
+    end
+  endtask
+
+endclass : alert_handler_lpg_stub_clk_vseq

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_vseq_list.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_vseq_list.sv
@@ -13,4 +13,5 @@
 `include "alert_handler_entropy_vseq.sv"
 `include "alert_handler_ping_timeout_vseq.sv"
 `include "alert_handler_lpg_vseq.sv"
+`include "alert_handler_lpg_stub_clk_vseq.sv"
 `include "alert_handler_stress_all_vseq.sv"


### PR DESCRIPTION
This PR has two commits:
1). First commit is already review in PR #13473 
2). Second commit adds a alert_handler_lpg_stub_clk sequence that will pause alert_handler's clock,
     and re-enable the clock after a random delay. Then it will check if ping timer functions correctly.