### PR TITLE
[lc_ctrl] Allow clock mux manipulation before initiating a transition

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -659,7 +659,6 @@
     }
     { name: "TRANSITION_CTRL",
       desc: "Control register for state transition requests.",
-      swaccess: "rw",
       hwaccess: "hrw",
       hwqe:     "true",
       hwext:    "true",
@@ -670,9 +669,10 @@
       fields: [
         { bits: "0",
           name: "EXT_CLOCK_EN",
+          swaccess: "rw1s",
           desc: '''
-          When set to 1, the OTP clock will be switched to an externally supplied clock when initiating a life cycle state transition.
-          The clock mux will remain switched until the next system reset.
+          When set to 1, the OTP clock will be switched to an externally supplied clock right away when the
+          device is in a non-PROD life cycle state. The clock mux will remain switched until the next system reset.
           '''
         }
       ]

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -374,7 +374,7 @@ module lc_ctrl
                          tap_reg2hw.transition_cmd.qe;
 
         if (tap_reg2hw.transition_ctrl.qe) begin
-          use_ext_clock_d     = tap_reg2hw.transition_ctrl.q;
+          use_ext_clock_d |= tap_reg2hw.transition_ctrl.q;
         end
 
         for (int k = 0; k < LcTokenWidth/32; k++) begin
@@ -398,7 +398,7 @@ module lc_ctrl
                          reg2hw.transition_cmd.qe;
 
         if (reg2hw.transition_ctrl.qe) begin
-          use_ext_clock_d     = reg2hw.transition_ctrl.q;
+          use_ext_clock_d |= reg2hw.transition_ctrl.q;
         end
 
         for (int k = 0; k < LcTokenWidth/32; k++) begin
@@ -437,7 +437,7 @@ module lc_ctrl
       otp_part_error_q          <= 1'b0;
       fatal_bus_integ_error_q   <= 1'b0;
       otp_vendor_test_ctrl_q    <= '0;
-      use_ext_clock_q           <= '0;
+      use_ext_clock_q           <= 1'b0;
     end else begin
       // All status and error bits are terminal and require a reset cycle.
       trans_success_q           <= trans_success_d         | trans_success_q;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
@@ -217,6 +217,31 @@ module lc_ctrl_fsm
         end else if (trans_cmd_i) begin
           fsm_state_d = ClkMuxSt;
         end
+        // If we are in a non-PROD life cycle state, steer the clock mux if requested. This
+        // action is available in IdleSt so that the mux can be steered without having to initiate
+        // a life cycle transition. If a transition is initiated however, the life cycle controller
+        // will wait for the clock mux acknowledgement in the ClkMuxSt state before proceeding.
+        if (lc_state_q inside {LcStRaw,
+                               LcStTestLocked0,
+                               LcStTestLocked1,
+                               LcStTestLocked2,
+                               LcStTestLocked3,
+                               LcStTestLocked4,
+                               LcStTestLocked5,
+                               LcStTestLocked6,
+                               LcStTestUnlocked0,
+                               LcStTestUnlocked1,
+                               LcStTestUnlocked2,
+                               LcStTestUnlocked3,
+                               LcStTestUnlocked4,
+                               LcStTestUnlocked5,
+                               LcStTestUnlocked6,
+                               LcStTestUnlocked7,
+                               LcStRma}) begin
+          if (use_ext_clock_i) begin
+            lc_clk_byp_req = On;
+          end
+        end
       end
       ///////////////////////////////////////////////////////////////////
       // Clock mux state. If we are in RAW, TEST* or RMA, it is permissible


### PR DESCRIPTION
This allows to steer the clock mux even before initiating a life cycle transition so that the vendor test partition can be exercised during production test before performing a RAW unlock operation.

See also #13175 for more information.

Signed-off-by: Michael Schaffner <msf@google.com>