### PR TITLE
[otbn, dv] Adds otbn_rf_base_glitch_detect testcase

### DIFF
--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -139,9 +139,12 @@
     }
     {
       name: sec_cm_rf_base_data_reg_sw_glitch_detect
-      desc: "Verify the countermeasure(s) RF_BASE.DATA_REG_SW.GLITCH_DETECT."
+      desc: ''' Verify the countermeasure(s) RF_BASE.DATA_REG_SW.GLITCH_DETECT.
+                Wait for a write request to one of the otbn_rf_base registers.
+                Corrupt the we_onehot signal.
+            '''
       milestone: V2S
-      tests: []
+      tests: ["otbn_rf_base_glitch_detect"]
     }
     {
       name: sec_cm_stack_wr_ptr_ctr_redun

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -459,11 +459,13 @@ int OtbnModel::check() const {
     }
   }
 
-  try {
-    good &= check_regs(*iss);
-  } catch (const std::exception &err) {
-    std::cerr << "Failed to check registers: " << err.what() << "\n";
-    return -1;
+  if (!dont_check_regs) {
+    try {
+      good &= check_regs(*iss);
+    } catch (const std::exception &err) {
+      std::cerr << "Failed to check registers: " << err.what() << "\n";
+      return -1;
+    }
   }
 
   try {
@@ -546,6 +548,11 @@ int OtbnModel::set_software_errs_fatal(unsigned char new_val) {
 
 int OtbnModel::set_no_sec_wipe_chk() {
   OtbnTraceChecker::get().set_no_sec_wipe_chk();
+  return 0;
+}
+
+int OtbnModel::disable_reg_checks() {
+  dont_check_regs = true;
   return 0;
 }
 
@@ -991,4 +998,9 @@ int otbn_model_send_err_escalation(OtbnModel *model,
                                    svBitVecVal *err_val /* bit [31:0] */) {
   assert(model);
   return model->send_err_escalation(err_val);
+}
+
+int otbn_disable_reg_checks(OtbnModel *model) {
+  assert(model);
+  return model->disable_reg_checks();
 }

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -17,6 +17,7 @@ struct ISSWrapper;
 class OtbnModel {
  public:
   enum command_t { Execute, DmemWipe, ImemWipe };
+  bool dont_check_regs;
 
   OtbnModel(const std::string &mem_scope, const std::string &design_scope);
   ~OtbnModel();
@@ -113,6 +114,9 @@ class OtbnModel {
   // Returns true if we have an ISS wrapper and it has the START_WIPE flag
   // asserted
   bool is_at_start_of_wipe() const;
+
+  // Tell the model not to execute register integrity checks
+  int disable_reg_checks();
 
  private:
   // Constructs an ISS wrapper if necessary. If something goes wrong, this

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -129,6 +129,9 @@ int otbn_model_reset(OtbnModel *model);
 // React to an error escalation. Returns 0 on success or -1 on failure.
 int otbn_model_send_err_escalation(OtbnModel *model,
                                    svBitVecVal *err_val /* bit [31:0] */);
+
+// Tell the model not to execute register integrity checks
+int otbn_disable_reg_checks(OtbnModel *model);
 }
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_MODEL_DPI_H_

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.svh
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.svh
@@ -62,4 +62,6 @@ import "DPI-C" function int otbn_model_reset(chandle model);
 
 import "DPI-C" function int otbn_model_send_err_escalation(chandle model, bit [31:0] err_val);
 
+import "DPI-C" function int otbn_disable_reg_checks(chandle model);
+
 `endif // SYNTHESIS

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -52,6 +52,7 @@ filesets:
       - seq_lib/otbn_alu_bignum_mod_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_controller_ispr_rdata_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_mac_bignum_acc_err_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_rf_base_glitch_detect_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_glitch_detect_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_glitch_detect_vseq.sv
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence to verify the countermeasure(s) OTBN.RF_BASE.DATA_REG_SW.GLITCH_DETECT.
+
+class otbn_rf_base_glitch_detect_vseq extends otbn_single_vseq;
+  `uvm_object_utils(otbn_rf_base_glitch_detect_vseq)
+  `uvm_object_new
+
+  task body();
+    do_end_addr_check = 0;
+    fork
+      begin
+        super.body();
+      end
+      begin
+        corrupt_oh_bit();
+      end
+    join
+  endtask: body
+
+  task corrupt_oh_bit();
+    bit wr_en;
+    bit [11:0] wr_addr;
+    bit [5:0] oh_bit;
+    bit [31:0] invalid_oh_val;
+    bit [31:0] err_val = 32'd1 << 20;
+    string wr_en_path;
+    string waddr_path;
+    string oh_p;
+
+    wr_en_path = "tb.dut.u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.wr_en_i";
+    waddr_path = "tb.dut.u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.wr_addr_i";
+    oh_p = "tb.dut.u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.we_onehot[31:0]";
+    do begin
+      @(cfg.clk_rst_vif.cb);
+      uvm_hdl_read(wr_en_path, wr_en);
+    end while(!wr_en);
+    uvm_hdl_read(waddr_path, wr_addr);
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(oh_bit, oh_bit != wr_addr;)
+    invalid_oh_val[wr_addr] = 1;
+    invalid_oh_val[oh_bit] = 1;
+    `DV_CHECK_FATAL(uvm_hdl_force(oh_p, invalid_oh_val) == 1);
+    @(cfg.clk_rst_vif.cb);
+    cfg.model_agent_cfg.vif.otbn_disable_reg_checks();
+    cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+    wait(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
+    `DV_CHECK_FATAL(uvm_hdl_release(oh_p) == 1);
+    reset_if_locked();
+  endtask
+
+endclass : otbn_rf_base_glitch_detect_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -20,3 +20,4 @@
 `include "otbn_alu_bignum_mod_err_vseq.sv"
 `include "otbn_controller_ispr_rdata_err_vseq.sv"
 `include "otbn_mac_bignum_acc_err_vseq.sv"
+`include "otbn_rf_base_glitch_detect_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -110,6 +110,11 @@ interface otbn_model_if
                     "Failed to set no_sec_wipe_data_chk", "otbn_model_if")
   endfunction
 
+   function automatic void otbn_disable_reg_checks();
+    `uvm_info("otbn_model_if", "writing to dont_check_regs", UVM_HIGH);
+    `DV_CHECK_FATAL(u_model.otbn_disable_reg_checks(handle) == 0,
+                    "Failed to set dont_check_regs", "otbn_model_if")
+  endfunction
 
   // The err signal is asserted by the model if it fails to find the DUT or if it finds a mismatch
   // in results. It should never go high.

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -273,6 +273,13 @@ name:
       en_run_modes: ["build_otbn_rig_binary_mode"]
       reseed: 5
     }
+    {
+      name: "otbn_rf_base_glitch_detect"
+      uvm_test_seq: "otbn_rf_base_glitch_detect_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
+
   ]
 
   // List of regressions.


### PR DESCRIPTION
This commit adds a testcase called otbn_rf_base_glitch_detect to verify OTBN.RF_BASE.DATA_REG_SW.GLITCH_DETECT countermeasure. 