### PR TITLE
[sw,tests] Verify sysrst_ctrl input change interrupts

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1577,7 +1577,7 @@
             - Verify separately, eack key combination sufccessfully generates an interrupt.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_sysrst_ctrl_in_irq"]
     }
     {
       name: chip_sw_sysrst_ctrl_sleep_wakeup

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -579,6 +579,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_sysrst_ctrl_in_irq
+      uvm_test_seq: chip_sw_sysrst_ctrl_in_irq_vseq
+      sw_images: ["sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_sysrst_ctrl_inputs
       uvm_test_seq: chip_sw_sysrst_ctrl_inputs_vseq
       sw_images: ["sw/device/tests/sim_dv/sysrst_ctrl_inputs_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -54,6 +54,7 @@ filesets:
       - seq_lib/chip_sw_pwm_pulses_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_rand_baudrate_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_sysrst_ctrl_in_irq_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_inputs_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_in_irq_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_in_irq_vseq.sv
@@ -1,0 +1,123 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_sysrst_ctrl_in_irq_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_sysrst_ctrl_in_irq_vseq)
+
+  `uvm_object_new
+
+  // Parameters for generation of input pad signals. Using generate_inputs task.
+  // The generate task uses a 1us time step and will generate the required 'valid' inputs and
+  // create random glitches on all other inputs.
+  localparam uint AON_CLK_PERIOD_US = 5;
+  // The number of cycles for the threshold (Talso backdoor written to SW).
+  localparam uint THRESHOLD_CYCLES = 16;
+  // A number of extra cycles to hold the signal past the threshold
+  // to ensure a trigger.
+  localparam uint EXTRA_CYCLES = 5;
+  // A number of cycles before the end of the threshold period to remove any
+  // randomly generated glitchy signals (ensures they will not become valid inputs!)
+  localparam uint END_GLITCH_CYCLES = 2;
+  // The number of time steps to generate signals for.
+  localparam uint GEN_NUM_SAMPLES = (THRESHOLD_CYCLES + EXTRA_CYCLES) * AON_CLK_PERIOD_US;
+  // The maximum sample where the glitched signal can be written.
+  localparam uint MAX_GLITCH_SAMPLE = (THRESHOLD_CYCLES - END_GLITCH_CYCLES) * AON_CLK_PERIOD_US;
+
+  localparam uint NUM_COMBINATIONS = 4;
+  localparam uint NUM_INPUTS = 7;
+
+  // Define combinations of inputs to generate.
+  localparam bit [NUM_INPUTS-1:0] INITIAL_VALUE = 'b0011111;
+  localparam bit [NUM_INPUTS-1:0] COMBO_KEY0_KEY1_VALUE = 'b0000011;
+  localparam bit [NUM_INPUTS-1:0] COMBO_KEY0_KEY2_VALUE = 'b0000101;
+  localparam bit [NUM_INPUTS-1:0] COMBO_KEY1_KEY2_VALUE = 'b0000110;
+  localparam bit [NUM_INPUTS-1:0] COMBO_PWRB_ACPRES_VALUE = 'b0011000;
+
+  virtual function void set_pad(input int index, input bit pad_value);
+    case (index)
+      0: cfg.sysrst_ctrl_vif.drive_pin(0, pad_value);  //IOB3 KEY0
+      1: cfg.sysrst_ctrl_vif.drive_pin(1, pad_value);  //IOB6 KEY1
+      2: cfg.sysrst_ctrl_vif.drive_pin(2, pad_value);  //IOB8 KEY2
+      3: cfg.pwrb_in_vif.drive_pin(0, pad_value);  //IOR13 PWRB
+      4: cfg.sysrst_ctrl_vif.drive_pin(4, pad_value);  //IOC7 ACPRES
+      5: cfg.ec_rst_vif.drive_pin(0, pad_value);  //IOR8 EC_RST
+      default: cfg.flash_wp_vif.drive_pin(0, pad_value);  //IOR9 FLASHWP (case 6 or greater)
+    endcase
+  endfunction
+
+  virtual function void set_pads(bit [NUM_INPUTS-1:0] pad_values);
+    foreach (pad_values[i]) begin
+      set_pad(i, pad_values[i]);
+    end
+  endfunction
+
+  virtual task generate_inputs(input bit [NUM_INPUTS-1:0] combo);
+    int next_transition[NUM_INPUTS] = '{default: 0};
+    bit [NUM_INPUTS-1:0] current_values = INITIAL_VALUE;
+    bit [NUM_INPUTS-1:0] combo_done = '0;
+    for (int sample = 0; sample < GEN_NUM_SAMPLES; sample ++) begin
+      for (int index = 0; index < NUM_INPUTS; index++) begin
+        if (combo[index] == 1) begin
+          if (combo_done[index] == 0) begin
+            set_pad(index, ~INITIAL_VALUE[index]);
+            combo_done[index] = 1;
+          end
+        end else begin
+          if (sample >= MAX_GLITCH_SAMPLE) begin
+            set_pad(index, INITIAL_VALUE[index]);
+          end else begin
+            if (next_transition[index] == sample) begin
+              if (sample == 0) begin
+                next_transition[index] = $urandom_range(1, GEN_NUM_SAMPLES);
+              end else begin
+                set_pad(index, ~current_values[index]);
+                current_values[index]  = ~current_values[index];
+                next_transition[index] = sample + $urandom_range(1, GEN_NUM_SAMPLES);
+              end
+            end
+          end
+        end
+      end
+      #1us;
+    end
+    set_pads(INITIAL_VALUE);
+    #1;
+  endtask
+
+  virtual task do_combo_tests();
+    bit [NUM_INPUTS-1:0] combo;
+    for (int i = 0; i < NUM_COMBINATIONS; i++) begin
+      wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+      wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+      #20us;
+      case (i)
+        0: combo = COMBO_KEY0_KEY1_VALUE;
+        1: combo = COMBO_KEY0_KEY2_VALUE;
+        2: combo = COMBO_KEY1_KEY2_VALUE;
+        3: combo = COMBO_PWRB_ACPRES_VALUE;
+        default: combo = 'b0000000;
+      endcase
+      generate_inputs(combo);
+    end
+  endtask
+
+  virtual task do_input_tests();
+    for (int i = 0; i < NUM_INPUTS; i++) begin
+      wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+      wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+      #20us;
+      generate_inputs(1 << i);
+    end
+  endtask
+
+  virtual task body();
+    bit [7:0] threshold_backdoor[1] = '{default: THRESHOLD_CYCLES[7:0]};
+    super.body();
+    sw_symbol_backdoor_overwrite("kThreshold", threshold_backdoor);
+    set_pads(INITIAL_VALUE);
+    do_input_tests();
+    do_combo_tests();
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -19,6 +19,7 @@
 `include "chip_sw_deep_sleep_all_reset_vseq.sv"
 `include "chip_sw_uart_tx_rx_vseq.sv"
 `include "chip_sw_uart_rand_baudrate_vseq.sv"
+`include "chip_sw_sysrst_ctrl_in_irq_vseq.sv"
 `include "chip_sw_sysrst_ctrl_inputs_vseq.sv"
 `include "chip_sw_sysrst_ctrl_reset_vseq.sv"
 `include "chip_sw_sysrst_ctrl_outputs_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -132,6 +132,25 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "sysrst_ctrl_in_irq_test",
+    srcs = ["sysrst_ctrl_in_irq_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib:irq",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "sysrst_ctrl_inputs_test",
     srcs = ["sysrst_ctrl_inputs_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test.c
@@ -1,0 +1,185 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+#include "sw/device/lib/irq.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_sysrst_ctrl_t sysrst_ctrl;
+static dif_rv_plic_t plic;
+
+static plic_isr_ctx_t plic_ctx = {
+    .rv_plic = &plic,
+    .hart_id = kTopEarlgreyPlicTargetIbex0,
+};
+
+static sysrst_ctrl_isr_ctx_t sysrst_ctrl_ctx = {
+    .sysrst_ctrl = &sysrst_ctrl,
+    .plic_sysrst_ctrl_start_irq_id =
+        kTopEarlgreyPlicIrqIdSysrstCtrlAonSysrstCtrl,
+    .expected_irq = kDifSysrstCtrlIrqSysrstCtrl,
+    .is_only_irq = true,
+};
+
+static top_earlgrey_plic_peripheral_t peripheral_serviced;
+static dif_sysrst_ctrl_irq_t irq_serviced;
+
+enum {
+  kNumPads = 0x7,
+  kNunMioPads = 0x6,
+  kNumCombinations = 0x4,
+  kNumInputs = 0x7,
+};
+
+static const dif_pinmux_index_t kPeripheralInputs[] = {
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey0In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey1In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey2In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonPwrbIn,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonAcPresent,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonLidOpen,
+};
+
+static const dif_pinmux_index_t kInputPads[] = {
+    kTopEarlgreyPinmuxInselIob3, kTopEarlgreyPinmuxInselIob6,
+    kTopEarlgreyPinmuxInselIob8, kTopEarlgreyPinmuxInselIor13,
+    kTopEarlgreyPinmuxInselIoc7, kTopEarlgreyPinmuxInselIoc9,
+};
+
+static const uint32_t kExpectedIntrCauses[] = {2, 4, 8, 1, 16, 4096, 8192};
+
+// Threshold for debouce and combo detection written by testbench.
+static volatile const uint8_t kThreshold = 0;
+
+void ottf_external_isr(void) {
+  isr_testutils_sysrst_ctrl_isr(plic_ctx, sysrst_ctrl_ctx, &peripheral_serviced,
+                                &irq_serviced);
+}
+
+static void enable_irqs(void) {
+  // Enable the sysrst_ctrl interrupt.
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      &plic, kTopEarlgreyPlicIrqIdSysrstCtrlAonSysrstCtrl,
+      kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      &plic, kTopEarlgreyPlicIrqIdSysrstCtrlAonSysrstCtrl,
+      kDifRvPlicMaxPriority));
+  CHECK_DIF_OK(dif_rv_plic_target_set_threshold(
+      &plic, kTopEarlgreyPlicTargetIbex0, 0x0));
+  // Enable the external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+}
+
+static void setup_input_change_detect_configs(void) {
+  CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_enabled(
+      &sysrst_ctrl, kDifSysrstCtrlPinEcResetInOut, kDifToggleDisabled));
+  CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_enabled(
+      &sysrst_ctrl, kDifSysrstCtrlPinFlashWriteProtectInOut,
+      kDifToggleDisabled));
+
+  CHECK_DIF_OK(dif_sysrst_ctrl_input_change_detect_configure(
+      &sysrst_ctrl,
+      (dif_sysrst_ctrl_input_change_config_t){
+          .debounce_time_threshold = kThreshold,
+          .input_changes =
+              kDifSysrstCtrlInputKey0H2L | kDifSysrstCtrlInputKey1H2L |
+              kDifSysrstCtrlInputKey2H2L | kDifSysrstCtrlInputAcPowerPresetH2L |
+              kDifSysrstCtrlInputPowerButtonH2L |
+              kDifSysrstCtrlInputEcResetL2H |
+              kDifSysrstCtrlInputFlashWriteProtectL2H,
+      }));
+}
+
+static void setup_key_combinations(void) {
+  CHECK_DIF_OK(dif_sysrst_ctrl_input_change_detect_configure(
+      &sysrst_ctrl, (dif_sysrst_ctrl_input_change_config_t){
+                        .debounce_time_threshold = 0, .input_changes = 0}));
+
+  dif_sysrst_ctrl_key_combo_config_t combo_config = {
+      .actions = kDifSysrstCtrlKeyComboActionInterrupt,
+      .detection_time_threshold = kThreshold,
+      .embedded_controller_reset_duration = 0,
+      .keys = kDifSysrstCtrlKey0 | kDifSysrstCtrlKey1,
+  };
+  CHECK_DIF_OK(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl, kDifSysrstCtrlKeyCombo0, combo_config));
+
+  combo_config.keys = kDifSysrstCtrlKey0 | kDifSysrstCtrlKey2;
+  CHECK_DIF_OK(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl, kDifSysrstCtrlKeyCombo1, combo_config));
+
+  combo_config.keys = kDifSysrstCtrlKey1 | kDifSysrstCtrlKey2;
+  CHECK_DIF_OK(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl, kDifSysrstCtrlKeyCombo2, combo_config));
+
+  combo_config.keys =
+      kDifSysrstCtrlKeyPowerButton | kDifSysrstCtrlKeyAcPowerPresent;
+  CHECK_DIF_OK(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl, kDifSysrstCtrlKeyCombo3, combo_config));
+}
+
+static void do_test(bool is_input_test) {
+  uint32_t loop_size = is_input_test ? kNumInputs : kNumCombinations;
+  for (int i = 0; i < loop_size; ++i) {
+    test_status_set(kTestStatusInWfi);
+    wait_for_interrupt();
+    test_status_set(kTestStatusInTest);
+    busy_spin_micros(20);
+
+    uint32_t int_causes;
+    CHECK_DIF_OK(
+        dif_sysrst_ctrl_key_combo_irq_get_causes(&sysrst_ctrl, &int_causes));
+    CHECK_DIF_OK(
+        dif_sysrst_ctrl_key_combo_irq_clear_causes(&sysrst_ctrl, int_causes));
+    CHECK(int_causes == (is_input_test ? 0 : 1 << i));
+    CHECK_DIF_OK(
+        dif_sysrst_ctrl_input_change_irq_get_causes(&sysrst_ctrl, &int_causes));
+    CHECK_DIF_OK(dif_sysrst_ctrl_input_change_irq_clear_causes(&sysrst_ctrl,
+                                                               int_causes));
+    CHECK(int_causes == (is_input_test ? kExpectedIntrCauses[i] : 0));
+  }
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
+      &sysrst_ctrl));
+  CHECK_DIF_OK(dif_sysrst_ctrl_irq_set_enabled(
+      &sysrst_ctrl, kDifSysrstCtrlIrqSysrstCtrl, kDifToggleEnabled));
+  rv_plic_testutils_irq_range_enable(
+      &plic, plic_ctx.hart_id, kTopEarlgreyPlicIrqIdSysrstCtrlAonSysrstCtrl,
+      kTopEarlgreyPlicIrqIdSysrstCtrlAonSysrstCtrl);
+
+  dif_pinmux_t pinmux;
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+
+  for (int i = 0; i < kNunMioPads; ++i) {
+    CHECK_DIF_OK(
+        dif_pinmux_input_select(&pinmux, kPeripheralInputs[i], kInputPads[i]));
+  }
+
+  enable_irqs();
+  setup_input_change_detect_configs();
+  do_test(true);
+  setup_key_combinations();
+  do_test(false);
+
+  return true;
+}


### PR DESCRIPTION
For test:
chip_sw_sysrst_ctrl_in_irq

Tests that transitions on the input pins to sysrst_ctrl generate appropriate interrupt requests.
Tests indivdual pins and combinations.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>