### PR TITLE
[dv/otp] Fix override test naming

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -218,7 +218,7 @@
             - randomly add reset between each sequence
             '''
       milestone: V2
-      tests: ["otp_ctrl_stress_all"]
+      tests: ["{name}_stress_all"]
     }
     {
       name: sec_cm_additional_check

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -154,7 +154,7 @@
     }
 
     {
-      name: otp_ctrl_stress_all_with_rand_reset
+      name: "{name}_stress_all_with_rand_reset"
       reseed: 100
     }
   ]


### PR DESCRIPTION
This PR fixes an override test naming. The actual name of this tests in
master cfg is {name}_stress_all_with_rand_reset.

Signed-off-by: Cindy Chen <chencindy@google.com>