### PR TITLE
[util/dv] Fix sec_cm auto-gen in IP template file

### DIFF
--- a/hw/ip_templates/alert_handler/data/alert_handler_sec_cm_testplan.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler_sec_cm_testplan.hjson
@@ -1,0 +1,153 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../alert_handler/data/alert_handler.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../alert_handler/data/alert_handler_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_config_shadow
+      desc: "Verify the countermeasure(s) CONFIG.SHADOW."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ping_timer_config_regwen
+      desc: "Verify the countermeasure(s) PING_TIMER.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_alert_config_regwen
+      desc: "Verify the countermeasure(s) ALERT.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_alert_loc_config_regwen
+      desc: "Verify the countermeasure(s) ALERT_LOC.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_class_config_regwen
+      desc: "Verify the countermeasure(s) CLASS.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_alert_intersig_diff
+      desc: "Verify the countermeasure(s) ALERT.INTERSIG.DIFF."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lpg_intersig_mubi
+      desc: "Verify the countermeasure(s) LPG.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_intersig_diff
+      desc: "Verify the countermeasure(s) ESC.INTERSIG.DIFF."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_alert_rx_intersig_bkgn_chk
+      desc: "Verify the countermeasure(s) ALERT_RX.INTERSIG.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_tx_intersig_bkgn_chk
+      desc: "Verify the countermeasure(s) ESC_TX.INTERSIG.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_rx_intersig_bkgn_chk
+      desc: "Verify the countermeasure(s) ESC_RX.INTERSIG.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_timer_fsm_sparse
+      desc: "Verify the countermeasure(s) ESC_TIMER.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ping_timer_fsm_sparse
+      desc: "Verify the countermeasure(s) PING_TIMER.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_timer_fsm_local_esc
+      desc: "Verify the countermeasure(s) ESC_TIMER.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ping_timer_fsm_local_esc
+      desc: "Verify the countermeasure(s) PING_TIMER.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_timer_fsm_global_esc
+      desc: "Verify the countermeasure(s) ESC_TIMER.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_accu_ctr_redun
+      desc: "Verify the countermeasure(s) ACCU.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_timer_ctr_redun
+      desc: "Verify the countermeasure(s) ESC_TIMER.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ping_timer_ctr_redun
+      desc: "Verify the countermeasure(s) PING_TIMER.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ping_timer_lfsr_redun
+      desc: "Verify the countermeasure(s) PING_TIMER.LFSR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
@@ -11,7 +11,7 @@
                      "hw/dv/sv/alert_esc_agent/data/alert_agent_basic_testplan.hjson",
                      "hw/dv/sv/alert_esc_agent/data/alert_agent_additional_testplan.hjson",
                      "hw/dv/sv/alert_esc_agent/data/esc_agent_basic_testplan.hjson",
-                     "hw/dv/sv/alert_esc_agent/data/esc_agent_additional_testplan.hjson"
+                     "hw/dv/sv/alert_esc_agent/data/esc_agent_additional_testplan.hjson",
                      // Generated in IP gen area (hw/{top}/ip_autogen).
                      "alert_handler_sec_cm_testplan.hjson"]
   testpoints: [

--- a/hw/ip_templates/rv_plic/data/rv_plic_sec_cm_testplan.hjson
+++ b/hw/ip_templates/rv_plic/data/rv_plic_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../rv_plic/data/rv_plic.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../rv_plic/data/rv_plic_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
@@ -11,7 +11,7 @@
                      "hw/dv/sv/alert_esc_agent/data/alert_agent_basic_testplan.hjson",
                      "hw/dv/sv/alert_esc_agent/data/alert_agent_additional_testplan.hjson",
                      "hw/dv/sv/alert_esc_agent/data/esc_agent_basic_testplan.hjson",
-                     "hw/dv/sv/alert_esc_agent/data/esc_agent_additional_testplan.hjson"
+                     "hw/dv/sv/alert_esc_agent/data/esc_agent_additional_testplan.hjson",
                      // Generated in IP gen area (hw/{top}/ip_autogen).
                      "alert_handler_sec_cm_testplan.hjson"]
   testpoints: [

--- a/util/ipgen/renderer.py
+++ b/util/ipgen/renderer.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Optional, Union
 import logging
 
 import reggen.gen_rtl
-import reggen.gen_sec_cm_testplan
 from mako import exceptions as mako_exceptions  # type: ignore
 from mako.lookup import TemplateLookup as MakoTemplateLookup  # type: ignore
 from reggen.ip_block import IpBlock
@@ -296,8 +295,6 @@ class IpBlockRenderer(IpTemplateRendererBase):
             # TODO: Pass on template parameters to reggen? Or enable the user
             # to set a different set of parameters in the renderer?
             reggen.gen_rtl.gen_rtl(obj, str(rtl_path))
-            reggen.gen_sec_cm_testplan.gen_sec_cm_testplan(
-                obj, output_dir_staging / 'data')
 
             # Write IP configuration (to reproduce the generation process).
             # TODO: Should the ipconfig file be written to the instance name,


### PR DESCRIPTION
This PR fixes issue #13560 regarding auto-generated ip_template file
cannot override sec_cm_testplan issue.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>