### PR TITLE
Test EDN in Auto Mode

### DIFF
--- a/sw/device/lib/dif/dif_edn.c
+++ b/sw/device/lib/dif/dif_edn.c
@@ -68,36 +68,78 @@ dif_result_t dif_edn_set_auto_mode(const dif_edn_t *edn,
   }
   DIF_RETURN_IF_ERROR(check_locked(edn));
 
-  uint32_t reg = mmio_region_read32(edn->base_addr, EDN_CTRL_REG_OFFSET);
+  // Check that EDN is disabled.  If it is not disabled (e.g., through a call
+  // to `dif_edn_stop()`), we are not ready to change mode.
+  uint32_t ctrl_reg = mmio_region_read32(edn->base_addr, EDN_CTRL_REG_OFFSET);
+  const uint32_t edn_en =
+      bitfield_field32_read(ctrl_reg, EDN_CTRL_EDN_ENABLE_FIELD);
+  if (dif_multi_bit_bool_to_toggle(edn_en) != kDifToggleDisabled) {
+    return kDifError;
+  }
 
-  // first pulse fifo reset to clear out old fifo contents
-  reg = bitfield_field32_write(reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
-                               kMultiBitBool4True);
-  mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, reg);
+  // Ensure neither automatic nor boot request mode is set.
+  ctrl_reg = bitfield_field32_write(ctrl_reg, EDN_CTRL_AUTO_REQ_MODE_FIELD,
+                                    kMultiBitBool4False);
+  ctrl_reg = bitfield_field32_write(ctrl_reg, EDN_CTRL_BOOT_REQ_MODE_FIELD,
+                                    kMultiBitBool4False);
+  mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, ctrl_reg);
 
-  reg = bitfield_field32_write(reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
-                               kMultiBitBool4False);
-  mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, reg);
+  // Clear the reseed command FIFO and the generate command FIFO.
+  ctrl_reg = bitfield_field32_write(ctrl_reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
+                                    kMultiBitBool4True);
+  mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, ctrl_reg);
 
-  // program ctrl contents
+  // Restore command FIFOs to normal operation mode.  This is a prerequisite
+  // before any further commands can be issued to these FIFOs.
+  ctrl_reg = bitfield_field32_write(ctrl_reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
+                                    kMultiBitBool4False);
+  mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, ctrl_reg);
+
+  // Fill the reseed command FIFO.
   for (size_t i = 0; i < config.reseed_material.len; ++i) {
     mmio_region_write32(edn->base_addr, EDN_RESEED_CMD_REG_OFFSET,
                         config.reseed_material.data[i]);
   }
+
+  // Fill the generate command FIFO.
   for (size_t i = 0; i < config.generate_material.len; ++i) {
     mmio_region_write32(edn->base_addr, EDN_GENERATE_CMD_REG_OFFSET,
                         config.generate_material.data[i]);
   }
 
+  // Set the maximum number of requests between reseeds.
   mmio_region_write32(edn->base_addr,
                       EDN_MAX_NUM_REQS_BETWEEN_RESEEDS_REG_OFFSET,
                       config.reseed_interval);
 
-  reg = bitfield_field32_write(reg, EDN_CTRL_AUTO_REQ_MODE_FIELD,
-                               kMultiBitBool4True);
-  mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, reg);
+  // Re-enable EDN in automatic request mode.
+  ctrl_reg = bitfield_field32_write(ctrl_reg, EDN_CTRL_EDN_ENABLE_FIELD,
+                                    kMultiBitBool4True);
+  ctrl_reg = bitfield_field32_write(ctrl_reg, EDN_CTRL_AUTO_REQ_MODE_FIELD,
+                                    kMultiBitBool4True);
+  mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, ctrl_reg);
 
-  return kDifOk;
+  // Wait until EDN is ready to accept commands.
+  bool ready = false;
+  while (!ready) {
+    DIF_RETURN_IF_ERROR(dif_edn_get_status(edn, kDifEdnStatusReady, &ready));
+  }
+
+  // Command CSRNG Instantiate.  As soon as CSRNG acknowledges this command,
+  // EDN will start automatically sending reseed and generate commands.
+  DIF_RETURN_IF_ERROR(
+      dif_edn_instantiate(edn, kDifEdnEntropySrcToggleEnable, NULL));
+
+  // Wait until CSRNG acknowledges command.
+  ready = false;
+  while (!ready) {
+    DIF_RETURN_IF_ERROR(dif_edn_get_status(edn, kDifEdnStatusReady, &ready));
+  }
+
+  // Read request acknowledge error and return accordingly.
+  bool ack_err;
+  DIF_RETURN_IF_ERROR(dif_edn_get_status(edn, kDifEdnStatusCsrngAck, &ack_err));
+  return ack_err ? kDifError : kDifOk;
 }
 
 dif_result_t dif_edn_get_status(const dif_edn_t *edn, dif_edn_status_t flag,

--- a/sw/device/lib/dif/dif_edn_unittest.cc
+++ b/sw/device/lib/dif/dif_edn_unittest.cc
@@ -93,9 +93,15 @@ TEST_F(SetModeTest, Auto) {
                      {EDN_CTRL_EDN_ENABLE_OFFSET, kMultiBitBool4False},
                      {EDN_CTRL_BOOT_REQ_MODE_OFFSET, kMultiBitBool4False},
                      {EDN_CTRL_AUTO_REQ_MODE_OFFSET, kMultiBitBool4False},
+                     {EDN_CTRL_CMD_FIFO_RST_OFFSET, kMultiBitBool4False},
+                 });
+  EXPECT_WRITE32(EDN_CTRL_REG_OFFSET,
+                 {
+                     {EDN_CTRL_EDN_ENABLE_OFFSET, kMultiBitBool4False},
+                     {EDN_CTRL_BOOT_REQ_MODE_OFFSET, kMultiBitBool4False},
+                     {EDN_CTRL_AUTO_REQ_MODE_OFFSET, kMultiBitBool4False},
                      {EDN_CTRL_CMD_FIFO_RST_OFFSET, kMultiBitBool4True},
                  });
-
   EXPECT_WRITE32(EDN_CTRL_REG_OFFSET,
                  {
                      {EDN_CTRL_EDN_ENABLE_OFFSET, kMultiBitBool4False},
@@ -130,11 +136,19 @@ TEST_F(SetModeTest, Auto) {
 
   EXPECT_WRITE32(EDN_CTRL_REG_OFFSET,
                  {
-                     {EDN_CTRL_EDN_ENABLE_OFFSET, kMultiBitBool4False},
+                     {EDN_CTRL_EDN_ENABLE_OFFSET, kMultiBitBool4True},
                      {EDN_CTRL_BOOT_REQ_MODE_OFFSET, kMultiBitBool4False},
                      {EDN_CTRL_AUTO_REQ_MODE_OFFSET, kMultiBitBool4True},
                      {EDN_CTRL_CMD_FIFO_RST_OFFSET, kMultiBitBool4False},
                  });
+
+  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, 1);
+
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 1);
+
+  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, 1);
+
+  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, 1);
 
   EXPECT_DIF_OK(dif_edn_set_auto_mode(&edn_, params));
 }

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -78,9 +78,7 @@ static void setup_entropy_src(void) {
       .fips_enable = true,
       .route_to_firmware = false,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
-      .health_test_threshold_scope = true,
-      .health_test_window_size =
-          (uint16_t)ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_RESVAL};
+  };
   CHECK_DIF_OK(
       dif_entropy_src_configure(&entropy_src, config, kDifToggleEnabled));
 }
@@ -90,11 +88,10 @@ static void setup_csrng(void) {
   CHECK_DIF_OK(dif_csrng_init(
       mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
 
-  CHECK_DIF_OK(dif_csrng_stop(&csrng));
   CHECK_DIF_OK(dif_csrng_configure(&csrng));
 }
 
-static void setup_edn(bool auto_mode) {
+static void setup_edn() {
   // Temporary solution to configure/enable the EDN and CSRNG to allow OTBN to
   // run before a DIF is available,
   // https://github.com/lowRISC/opentitan/issues/6082
@@ -110,66 +107,27 @@ static void setup_edn(bool auto_mode) {
                                kMultiBitBool4False);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
                       EDN_CTRL_REG_OFFSET, reg);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
+                      EDN_CTRL_REG_OFFSET, reg);
 
-  if (auto_mode) {
-    dif_edn_t edn0, edn1;
-
-    // temporarily declare handle in here, should fix later
-    CHECK_DIF_OK(dif_edn_init(
-        mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));
-    CHECK_DIF_OK(dif_edn_init(
-        mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR), &edn1));
-
-    dif_edn_seed_material_t inst_cmd = {.len = 1,
-                                        .data = {kDifEdnCmdInstantiate}};
-
-    dif_edn_seed_material_t reseed_cmd = {.len = 1, .data = {kDifEdnCmdReseed}};
-
-    dif_edn_seed_material_t generate_cmd = {
-        .len = 1, .data = {0xf000 | kDifEdnCmdGenerate}};
-
-    dif_edn_auto_params_t edn0_params = {.reseed_material = reseed_cmd,
-                                         .generate_material = generate_cmd,
-                                         .reseed_interval = 1 << 31};
-
-    dif_edn_auto_params_t edn1_params = {.reseed_material = reseed_cmd,
-                                         .generate_material = generate_cmd,
-                                         .reseed_interval = 1};
-
-    // setup edn parameters
-    CHECK_DIF_OK(dif_edn_set_auto_mode(&edn0, edn0_params));
-    CHECK_DIF_OK(dif_edn_set_auto_mode(&edn1, edn1_params));
-
-    // enable
-    CHECK_DIF_OK(dif_edn_configure(&edn0));
-    CHECK_DIF_OK(dif_edn_configure(&edn1));
-
-    // instantiate csrng instances
-    CHECK_DIF_OK(
-        dif_edn_instantiate(&edn0, kDifEdnEntropySrcToggleEnable, &inst_cmd));
-    CHECK_DIF_OK(
-        dif_edn_instantiate(&edn1, kDifEdnEntropySrcToggleEnable, &inst_cmd));
-
-  } else {
-    reg = bitfield_field32_write(0, EDN_CTRL_EDN_ENABLE_FIELD,
-                                 kMultiBitBool4True);
-    reg = bitfield_field32_write(reg, EDN_CTRL_BOOT_REQ_MODE_FIELD,
-                                 kMultiBitBool4True);
-    reg = bitfield_field32_write(reg, EDN_CTRL_AUTO_REQ_MODE_FIELD,
-                                 kMultiBitBool4False);
-    reg = bitfield_field32_write(reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
-                                 kMultiBitBool4False);
-    mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
-                        EDN_CTRL_REG_OFFSET, reg);
-    mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
-                        EDN_CTRL_REG_OFFSET, reg);
-  }
+  reg =
+      bitfield_field32_write(0, EDN_CTRL_EDN_ENABLE_FIELD, kMultiBitBool4True);
+  reg = bitfield_field32_write(reg, EDN_CTRL_BOOT_REQ_MODE_FIELD,
+                               kMultiBitBool4True);
+  reg = bitfield_field32_write(reg, EDN_CTRL_AUTO_REQ_MODE_FIELD,
+                               kMultiBitBool4False);
+  reg = bitfield_field32_write(reg, EDN_CTRL_CMD_FIFO_RST_FIELD,
+                               kMultiBitBool4False);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
+                      EDN_CTRL_REG_OFFSET, reg);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
+                      EDN_CTRL_REG_OFFSET, reg);
 }
 
 void entropy_testutils_boot_mode_init(void) {
   setup_entropy_src();
   setup_csrng();
-  setup_edn(false);
+  setup_edn();
 }
 
 void entropy_testutils_wait_for_state(const dif_entropy_src_t *entropy_src,

--- a/sw/device/lib/testing/entropy_testutils.h
+++ b/sw/device/lib/testing/entropy_testutils.h
@@ -8,13 +8,22 @@
 #include "sw/device/lib/dif/dif_entropy_src.h"
 
 /**
+ * Initialize the entropy complex in auto-request mode.
+ *
+ * Initializes the CSRNG, EDN0, and EDN1 in automatic request mode, with EDN1
+ * providing highest-quality entropy and EDN0 providing lower-quality entropy.
+ * The entropy source must have been initialized separately before calling this
+ * function.
+ */
+void entropy_testutils_auto_mode_init(void);
+
+/**
  * Initializes the entropy complex to serve random bits to EDN0 and EDN1.
  *
  * Initializes entropy_src, csrng, EDN0 and EDN1 with default boot time
  * configuration to enable entropy distribution for testing purposes.
  */
 void entropy_testutils_boot_mode_init(void);
-void entropy_testutils_auto_mode_init(void);
 
 /**
  * Wait for the entropy_src to reach a certain state.

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -209,13 +209,10 @@ static void alert_handler_test(entropy_src_test_context_t *ctx) {
 void test_initialize(entropy_src_test_context_t *ctx) {
   LOG_INFO("%s", __func__);
 
+  entropy_testutils_boot_mode_init();
+
   mmio_region_t addr =
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR);
-  CHECK_DIF_OK(dif_entropy_src_init(addr, &ctx->entropy_src));
-
-  entropy_testutils_auto_mode_init();
-  entropy_testutils_wait_for_state(&ctx->entropy_src,
-                                   kDifEntropySrcMainFsmStateContHTRunning);
 
   addr = mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR);
   CHECK_DIF_OK(dif_rv_core_ibex_init(addr, &ctx->ibex));
@@ -241,6 +238,8 @@ void test_initialize(entropy_src_test_context_t *ctx) {
   addr = mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR);
   CHECK_DIF_OK(dif_alert_handler_init(addr, &ctx->alert_handler));
   alert_handler_configure(ctx);
+
+  entropy_testutils_auto_mode_init();
 }
 
 /**

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -177,6 +177,10 @@ bool test_main(void) {
   // verify that the OTBN clk hint status within clkmgr reads 1 (OTBN is not
   // idle).
   CHECK(otbn_load_app(&otbn_ctx, kOtbnAppCfiTest) == kOtbnOk);
+
+  // Re-initialize EDN in auto mode.
+  entropy_testutils_auto_mode_init();
+
   CHECK(otbn_execute(&otbn_ctx) == kOtbnOk);
 
   CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(


### PR DESCRIPTION
This PR solves #7424. It contains the following components:
- EDN DIF: Implement the functionality of `dif_edn_set_auto_mode()` and add a function to check if EDN is idle.
- Chip-level test involving OTBN and EDN: Re-initialize EDN in auto mode before OTBN execution.