### PR TITLE
[dv/alert_handler] Revert the timeout value for ping test

### DIFF
--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -89,7 +89,7 @@
     {
       name: alert_handler_ping_timeout
       uvm_test_seq: alert_handler_ping_timeout_vseq
-      run_opts: ["+test_timeout_ns=1_000_000_000"]
+      run_opts: ["+test_timeout_ns=10_000_000_000"]
     }
 
     {

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -89,7 +89,7 @@
     {
       name: alert_handler_ping_timeout
       uvm_test_seq: alert_handler_ping_timeout_vseq
-      run_opts: ["+test_timeout_ns=1_000_000_000"]
+      run_opts: ["+test_timeout_ns=10_000_000_000"]
     }
 
     {


### PR DESCRIPTION
This PR reverts the timeout value for alert_handler_ping_timeout test.
The previous change causes timeout in nightly regression.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>