### PR TITLE
[dv/alert_handler] Add missing mubi coverage bind instance

### DIFF
--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -33,6 +33,7 @@
 
   // Add additional tops for simulation.
   sim_tops: ["alert_handler_bind",
+             "alert_handler_cov_bind",
              "sec_cm_prim_sparse_fsm_flop_bind",
              "sec_cm_prim_count_bind",
              "sec_cm_prim_double_lfsr_bind",

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -33,6 +33,7 @@
 
   // Add additional tops for simulation.
   sim_tops: ["alert_handler_bind",
+             "alert_handler_cov_bind",
              "sec_cm_prim_sparse_fsm_flop_bind",
              "sec_cm_prim_count_bind",
              "sec_cm_prim_double_lfsr_bind",


### PR DESCRIPTION
I think this change might be missed when solving merging conflict.
This PR adds the alert_handler_cov_bind instance to
alert_handler_sim_cfg so the coverage results will be collected in
nightly regression.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>