### PR TITLE
[mask_rom] Allow tests to have a `.data` section.

### DIFF
--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -152,6 +152,9 @@ opentitan_functest(
         "mask_rom_epmp_test.c",
         "mask_rom_start.S",
     ],
+    linkopts = [
+        "-Wl,--defsym=mask_rom_test=1",
+    ],
     # This test doesn't use the OTTF.
     targets = ["verilator"],  # Can only run in verilator right now.
     # This test is designed to run and complete entirely in the ROM boot stage.

--- a/sw/device/silicon_creator/mask_rom/mask_rom.ld
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.ld
@@ -149,7 +149,10 @@ SECTIONS {
     *(.data)
     *(.data.*)
 
-    ASSERT(SIZEOF(.data) == 0, "Error: .data section must be empty");
+    /* Tests are an exception to the rule that .data must be empty */
+    ASSERT(
+        (DEFINED(mask_rom_test) ? 0 : SIZEOF(.data)) == 0,
+        "Error: .data section must be empty");
   } > ram_main
 
   /**


### PR DESCRIPTION
The mask_rom_epmp_test fails to build because we forbid the mask_rom from having a .data section.

This restriction should not apply to test programs.

Signed-off-by: Chris Frantz <cfrantz@google.com>