### PR TITLE
[dv,flash_ctrl] regression fix - rd_buff_evict_test

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
@@ -20,7 +20,6 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
     // enable high endurance
     cfg.seq_cfg.mp_region_he_en_pc      = 50;
     cfg.seq_cfg.default_region_he_en_pc = 50;
-
   endfunction
 
   // Randomized flash ctrl operation.
@@ -387,7 +386,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
     // checking coverpoints for state transitions
     if (cfg.en_cov) begin
-      func_cov_op = cov.control_cg.op_evict_cp.get_inst_coverage();
+      func_cov_op = cov.control_cg.op_evict_cp.get_coverage();
       if (func_cov_op == 100) begin
         `uvm_info(`gfn, $sformatf("Coverage READ/PROGRAM(ERASE)/READ reached!"), UVM_LOW)
       end else begin

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -87,6 +87,7 @@
     {
       name: flash_ctrl_rd_buff_evict
       uvm_test_seq: flash_ctrl_rd_buff_evict_vseq
+      run_opts: ["+en_cov=1"]
       reseed: 5
     }
     {


### PR DESCRIPTION
- Test was using get_inst_coverage() method which does not work properly under current tool. 
- After reviewing test bench, there is only one coverage instance is created overall test. So 
  get_inst_coverage / get_coverage doesn't make any difference in this case.
- Switch to get_coverage(), which work properly in this tool.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>