### PR TITLE
[top/cw310] Add cw310 to lint

### DIFF
--- a/hw/top_earlgrey/chip_earlgrey_cw310.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310.core
@@ -33,6 +33,15 @@ filesets:
       - util/vivado_hook_write_bitstream_pre.tcl: { file_type: user, copyto: vivado_hook_write_bitstream_pre.tcl }
       - util/vivado_hook_opt_design_post.tcl: { file_type: user, copyto: vivado_hook_opt_design_post.tcl }
 
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/chip_earlgrey_cw310.waiver
+    file_type: waiver
+
 parameters:
   # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
   # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
@@ -67,6 +76,7 @@ targets:
   default: &default_target
     filesets:
       - files_rtl_cw310
+      - files_ascentlint_waiver
     toplevel: chip_earlgrey_cw310
     parameters:
       - IBEX_CUSTOM_PMP_RESET_VALUES
@@ -92,6 +102,9 @@ targets:
   lint:
     <<: *default_target
     default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+      - AST_BYPASS_CLK=true
     tools:
       verilator:
         mode: lint-only

--- a/hw/top_earlgrey/lint/chip_earlgrey_cw310.waiver
+++ b/hw/top_earlgrey/lint/chip_earlgrey_cw310.waiver
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for chip_earlgrey_cw310
+
+set ri_blackbox_modules {clkgen_xil7series usr_access_xil7series top_earlgrey ast}

--- a/hw/top_earlgrey/lint/top_earlgrey_fpga_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_fpga_lint_cfgs.hjson
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+
+  // This is the fpga cfg hjson for RTL linting.
+  name: top_earlgrey_fpga_batch
+
+  flow: lint
+
+  import_cfgs:      [// common server configuration for results upload
+                     "{proj_root}/hw/data/common_project_cfg.hjson"
+                     // tool-specific configuration
+                     "{proj_root}/hw/lint/tools/dvsim/{tool}.hjson"]
+
+  // Different dashboard output path for each tool
+  rel_path: "hw/top_earlgrey/lint/{tool}"
+
+  // Severities to be printed in the summary report
+  report_severities: ["warning", "error"]
+
+  use_cfgs: [{    name: chip_earlgrey_cw310
+                  fusesoc_core: lowrisc:systems:chip_earlgrey_cw310
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/chip_earlgrey_asic/lint/{tool}"
+                  overrides: [
+                    {
+                      name: design_level
+                      value: "top"
+                    }
+                  ]
+             },
+            ]
+
+}


### PR DESCRIPTION
- this lint is mainly for integration checking, as it is as
  assumed that top_earlgrey lint is done separately and that
  ast also behaves correctly.

- we've been bitten multiple times by integration mistakes
  that manifest as FPGA test failures, so hopefully this will
  help us address some of the low hanging fruits.

Signed-off-by: Timothy Chen <timothytim@google.com>