### PR TITLE
[dv,chip,clkmgr] Make expected cycle counts device-independent

### DIFF
--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -22,6 +22,14 @@ uint32_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds) {
   return (uint32_t)cycles;
 }
 
+uint32_t aon_timer_testutils_get_us_from_aon_cycles(uint64_t cycles) {
+  uint64_t uss = udiv64_slow(cycles * 1000000, kClockFreqAonHz, NULL);
+  CHECK(uss < UINT32_MAX,
+        "The value 0x%08x%08x can't fit into the 32 bits timer counter.",
+        (uss >> 32), (uint32_t)uss);
+  return (uint32_t)uss;
+}
+
 void aon_timer_testutils_wakeup_config(const dif_aon_timer_t *aon_timer,
                                        uint32_t cycles) {
   // Make sure that wake-up timer is stopped.

--- a/sw/device/lib/testing/aon_timer_testutils.h
+++ b/sw/device/lib/testing/aon_timer_testutils.h
@@ -15,6 +15,11 @@
 uint32_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds);
 
 /**
+ * Returns the number of microseconds corresponding to the given AON cycles.
+ */
+uint32_t aon_timer_testutils_get_us_from_aon_cycles(uint64_t cycles);
+
+/**
  * Configure wakeup counter for a number of AON clock cycles.
  * @param cycles The number of AON clock cycles.
  */

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -228,6 +228,7 @@ cc_library(
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aon_timer_testutils",
         "//sw/device/lib/testing:clkmgr_testutils",
         "//sw/device/lib/testing/test_framework:check",
     ],

--- a/sw/device/tests/clkmgr_external_clk_src_for_sw_impl.c
+++ b/sw/device/tests/clkmgr_external_clk_src_for_sw_impl.c
@@ -12,6 +12,7 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
 #include "sw/device/lib/testing/clkmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
@@ -19,8 +20,8 @@
 
 // Switching to external clocks causes the clocks to be unstable for some time.
 // This is used to delay further action when the switch happens.
-static const int kSettleDelayMicros = 35;
-static const int kMeasurementDelayMicros = 100;
+static const int kSettleDelayMicros = 200;
+static const int kMeasurementsPerRound = 100;
 
 // For passing into `IBEX_SPIN_FOR`.
 static bool did_extclk_settle(const dif_clkmgr_t *clkmgr) {
@@ -32,6 +33,9 @@ static bool did_extclk_settle(const dif_clkmgr_t *clkmgr) {
 void execute_clkmgr_external_clk_src_for_sw_test(bool fast_ext_clk) {
   dif_clkmgr_t clkmgr;
   dif_clkmgr_recov_err_codes_t err_codes;
+
+  uint32_t kMeasurementDelayMicros =
+      aon_timer_testutils_get_us_from_aon_cycles(kMeasurementsPerRound);
 
   CHECK_DIF_OK(dif_clkmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));


### PR DESCRIPTION
Compute the expected cycle counts from the device frequencies. This was
formerly done so it predicted sim_dv counts only, and other devices
(like fpga or verilator) would get wrong predictions.

Signed-off-by: Guillermo Maturana <maturana@google.com>