### PR TITLE
[top/dv] Enhance alert_handler_escalation_test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1246,7 +1246,7 @@
             - Ensure that all escalation handshakes complete without errors.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_alert_handler_escalation"]
     }
     {
       name: chip_sw_alert_handler_irqs
@@ -1367,23 +1367,19 @@
 
             - Trigger an alert to initiate the escalations.
             - Check that the escalation signals are connected to the LC ctrl:
-              - First escalation has no effect on the LC ctrl
-              - Second escalation should cause the `lc_escalation_en` output to be asserted. Read
-                the LC_STATE CSR to confirm that it is in the escalate state.
-                - Verify that the escalate_en and check_bypass_en signals are asserted. X-ref'ed
-                  with the respective IP tests that consume these signals.
-              - Third escalation should cause the LC ctrl to transition to the virtual scrap state.
-                At this stage, the CPU is not operational. Read the LC_STATE CSR via backdoor and
-                confirm that it is is in the scrap state.
-                - Verify that all decoded outputs except for escalate_en and check_bypass_en are
-                  disabled. X-ref'ed with the respective IP tests that consume these signals.
+              - First escalation has no effect on the LC ctrl.  Read LC_STATE CSR to confirm
+                this is the case.
+              - Second escalation should cause the `lc_escalation_en` output to be asserted and for
+                the LC_STATE to transition to scrap state.  Confirm by reading the LC_STATE CSR
+              - Verify that all decoded outputs except for escalate_en are
+                disabled. X-ref'ed with the respective IP tests that consume these signals.
 
             X-ref'ed with chip_lc_ctrl_broadcast test, which verifies the connectivity of the LC
             decoded outputs to other IPs.
             X-ref'ed with alert_handler's escalation test.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_alert_handler_escalation"]
     }
     {
       name: chip_sw_lc_ctrl_jtag_access

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -122,6 +122,40 @@ package chip_env_pkg;
     LcTransitionSuccessful
   } lc_ctrl_status_e;
 
+  // enumeration for lc_ctrl broadcasts
+  typedef enum int {
+    DftEn = 0,
+    NvmDebugEn,
+    HwDebugEn,
+    CpuEn,
+    CreatorSeedEn,
+    OwnerSeedEn,
+    IsoRdEn,
+    IsoWrEn,
+    SeedRdEn,
+    KeyMgrEn,
+    EscEn,
+    CheckBypEn,
+    LcBroadcastLast
+  } lc_broadcast_e;
+
+  // hierarchy paths for lc_ctrl broadcast signals
+  string lc_broadcast_paths[LcBroadcastLast] = '{
+    0  : "lc_dft_en_o",
+    1  : "lc_nvm_debug_en_o",
+    2  : "lc_hw_debug_en_o",
+    3  : "lc_cpu_en_o",
+    4  : "lc_creator_seed_sw_rw_en_o",
+    5  : "lc_owner_seed_sw_rw_en_o",
+    6  : "lc_iso_part_sw_rd_en_o",
+    7  : "lc_iso_part_sw_wr_en_o",
+    8  : "lc_seed_hw_rd_en_o",
+    9  : "lc_keymgr_en_o",
+    10 : "lc_escalate_en_o",
+    11 : "lc_check_byp_en_o"
+  };
+
+
   // Extracts the address and size of a const symbol in a SW test (supplied as an ELF file).
   //
   // Used by a testbench to modify the given symbol in an executable (elf) generated for an embedded

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -15,6 +15,7 @@
 `define EFLASH_HIER           `CHIP_HIER.u_flash_ctrl.u_eflash.u_flash
 `define GPIO_HIER             `CHIP_HIER.u_gpio
 `define KEYMGR_HIER           `CHIP_HIER.u_keymgr
+`define LC_CTRL_HIER          `CHIP_HIER.u_lc_ctrl
 `define OTP_CTRL_HIER         `CHIP_HIER.u_otp_ctrl
 `define RAM_MAIN_HIER         `CHIP_HIER.u_sram_ctrl_main.u_prim_ram_1p_scr
 `define RAM_RET_HIER          `CHIP_HIER.u_sram_ctrl_ret_aon.u_prim_ram_1p_scr

--- a/sw/device/tests/sim_dv/alert_handler_escalation.c
+++ b/sw/device/tests/sim_dv/alert_handler_escalation.c
@@ -51,13 +51,13 @@ typedef struct node {
 
 static volatile uint32_t global_alert_called;
 static const dif_alert_handler_escalation_phase_t kEscProfiles[] = {
-    {.phase = kDifAlertHandlerClassStatePhase0,
-     .signal = 0,
-     .duration_cycles = 5000},
     // TODO:
-    // this second duration must be long enough to
+    // this first/second duration must be long enough to
     // accommodate a jtag transaction
     // how can this be done in a non-hardcoded way?
+    {.phase = kDifAlertHandlerClassStatePhase0,
+     .signal = 0,
+     .duration_cycles = 10000},
     {.phase = kDifAlertHandlerClassStatePhase1,
      .signal = 1,
      .duration_cycles = 10000},


### PR DESCRIPTION
- The enhanced test should now also cover chip_sw_lc_ctrl_alert_handler_escalation
- Added lc_ctrl broadcast check that can be re-used by other tests

Signed-off-by: Timothy Chen <timothytim@google.com>