### PR TITLE
[top,rv_core_ibex] Connect EDN1 to ibex RND

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6499,8 +6499,8 @@
           width: 8
           default: "'0"
           inst_name: edn0
-          end_idx: -1
-          top_type: one-to-N
+          end_idx: 7
+          top_type: partial-one-to-N
           top_signame: edn0_edn
           index: -1
         }
@@ -6581,7 +6581,7 @@
           width: 8
           default: "'0"
           inst_name: edn1
-          end_idx: 1
+          end_idx: 2
           top_type: partial-one-to-N
           top_signame: edn1_edn
           index: -1
@@ -7458,8 +7458,8 @@
           width: 1
           inst_name: rv_core_ibex
           default: ""
-          top_signame: edn0_edn
-          index: 7
+          top_signame: edn1_edn
+          index: 1
         }
         {
           name: icache_otp_key
@@ -7797,11 +7797,11 @@
         alert_handler.edn
         aes.edn
         otbn.edn_urnd
-        rv_core_ibex.edn
       ]
       edn1.edn:
       [
         otbn.edn_rnd
+        rv_core_ibex.edn
       ]
       otp_ctrl.otbn_otp_key:
       [
@@ -17887,8 +17887,8 @@
         width: 8
         default: "'0"
         inst_name: edn0
-        end_idx: -1
-        top_type: one-to-N
+        end_idx: 7
+        top_type: partial-one-to-N
         top_signame: edn0_edn
         index: -1
       }
@@ -17935,7 +17935,7 @@
         width: 8
         default: "'0"
         inst_name: edn1
-        end_idx: 1
+        end_idx: 2
         top_type: partial-one-to-N
         top_signame: edn1_edn
         index: -1
@@ -18307,8 +18307,8 @@
         width: 1
         inst_name: rv_core_ibex
         default: ""
-        top_signame: edn0_edn
-        index: 7
+        top_signame: edn1_edn
+        index: 1
       }
       {
         name: icache_otp_key
@@ -20276,7 +20276,7 @@
         signame: edn0_edn_req
         width: 8
         type: req_rsp
-        end_idx: -1
+        end_idx: 7
         act: rsp
         suffix: req
         default: "'0"
@@ -20287,7 +20287,7 @@
         signame: edn0_edn_rsp
         width: 8
         type: req_rsp
-        end_idx: -1
+        end_idx: 7
         act: rsp
         suffix: rsp
         default: ""
@@ -20298,7 +20298,7 @@
         signame: edn1_edn_req
         width: 8
         type: req_rsp
-        end_idx: 1
+        end_idx: 2
         act: rsp
         suffix: req
         default: "'0"
@@ -20309,7 +20309,7 @@
         signame: edn1_edn_rsp
         width: 8
         type: req_rsp
-        end_idx: 1
+        end_idx: 2
         act: rsp
         suffix: rsp
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -882,9 +882,8 @@
 
       // Edn connections
       'edn0.edn'              : ['keymgr.edn', 'otp_ctrl.edn', 'ast.edn', 'kmac.entropy',
-                                 'alert_handler.edn', 'aes.edn', 'otbn.edn_urnd',
-                                 'rv_core_ibex.edn'],
-      'edn1.edn'              : ['otbn.edn_rnd'],
+                                 'alert_handler.edn', 'aes.edn', 'otbn.edn_urnd'],
+      'edn1.edn'              : ['otbn.edn_rnd', 'rv_core_ibex.edn'],
 
       // OTBN OTP scramble key
       'otp_ctrl.otbn_otp_key' : ['otbn.otbn_otp_key'],

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -748,7 +748,7 @@ module top_earlgrey #(
   assign ast_rom_cfg = rom_cfg_i;
 
   // define partial inter-module tie-off
-  edn_pkg::edn_rsp_t unused_edn1_edn_rsp1;
+  edn_pkg::edn_rsp_t unused_edn0_edn_rsp7;
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp2;
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp3;
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp4;
@@ -757,14 +757,14 @@ module top_earlgrey #(
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp7;
 
   // assign partial inter-module tie-off
-  assign unused_edn1_edn_rsp1 = edn1_edn_rsp[1];
+  assign unused_edn0_edn_rsp7 = edn0_edn_rsp[7];
   assign unused_edn1_edn_rsp2 = edn1_edn_rsp[2];
   assign unused_edn1_edn_rsp3 = edn1_edn_rsp[3];
   assign unused_edn1_edn_rsp4 = edn1_edn_rsp[4];
   assign unused_edn1_edn_rsp5 = edn1_edn_rsp[5];
   assign unused_edn1_edn_rsp6 = edn1_edn_rsp[6];
   assign unused_edn1_edn_rsp7 = edn1_edn_rsp[7];
-  assign edn1_edn_req[1] = '0;
+  assign edn0_edn_req[7] = '0;
   assign edn1_edn_req[2] = '0;
   assign edn1_edn_req[3] = '0;
   assign edn1_edn_req[4] = '0;
@@ -2566,8 +2566,8 @@ module top_earlgrey #(
       .pwrmgr_cpu_en_i(pwrmgr_aon_fetch_en),
       .pwrmgr_o(rv_core_ibex_pwrmgr),
       .nmi_wdog_i(aon_timer_aon_nmi_wdog_timer_bark),
-      .edn_o(edn0_edn_req[7]),
-      .edn_i(edn0_edn_rsp[7]),
+      .edn_o(edn1_edn_req[1]),
+      .edn_i(edn1_edn_rsp[1]),
       .icache_otp_key_o(otp_ctrl_sram_otp_key_req[2]),
       .icache_otp_key_i(otp_ctrl_sram_otp_key_rsp[2]),
       .fpga_info_i(fpga_info_i),


### PR DESCRIPTION
From @andreaskurth, I heard that EDN0 is a low quality entropy source and @engdoreis & @ctopal confirmed that ibex's RND register is connected to EDN0. @GregAC said that it is desirable for EDN1 to be used instead. This PR is meant to fix this issue.