### PR TITLE
[ci] Install Kythe. Extract and upload Kzips.

### DIFF
--- a/.github/workflows/kythe.yml
+++ b/.github/workflows/kythe.yml
@@ -1,0 +1,67 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install Kythe, extract Kzips, and upload to GCP to enable semantic indexing on
+# https://cs.opensource.google/opentitan
+
+name: kythe
+
+on:
+  # For debugging, it's useful to have the action run whenever the PR is
+  # modified. This can be accomplished by setting a bare `pull_request:` with no
+  # items specified.
+  #
+  # Under normal circumstances, the action should only run when PRs are merged,
+  # and possibly less frequently.
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-when-a-pull-request-merges-1
+  #
+  # TODO(dmcardle) Run only when PRs are merged.
+  pull_request:
+
+jobs:
+  build_and_upload_kzips:
+    name: 'Build and upload kzips for Kythe/Codesearch'
+
+    runs-on: ubuntu-20.04
+    # TODO(dmcardle) Delete environment line before merging. The "Kythe"
+    # environment is specific to the dmcardle/opentitan GitHub repo.
+    environment: Kythe
+    steps:
+      - name: Report glibc version
+        run: |
+          ldd --version
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install packages
+        run: |
+          ci/install-package-dependencies.sh \
+            --verilator-version 4.210 \
+            --openocd-version 0.11.0 \
+            --verible-version v0.0-2135-gb534c1fe \
+            --rust-version 1.60.0
+
+      - name: Generate and Merge Kzips
+        run: |
+          set -ex
+
+          . util/build_consts.sh
+          MERGED_KZIP_PATH="${GITHUB_SHA}_${GITHUB_RUN_ID}.kzip"
+          echo "MERGED_KZIP_PATH=$MERGED_KZIP_PATH" >> $GITHUB_ENV
+
+          ci/scripts/generate_kythe_kzips.sh "${MERGED_KZIP_PATH}"
+
+      - name: Authenticate to GCP
+        # See https://github.com/google-github-actions/auth
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS_KYTHE_UPLOADER }}'
+
+      - name: Upload Merged Kzip to GCS Bucket
+        # See https://github.com/google-github-actions/upload-cloud-storage
+        uses: 'google-github-actions/upload-cloud-storage@v0'
+        with:
+          path: '${{ env.MERGED_KZIP_PATH }}'
+          destination: 'opentitan-kythe'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,9 @@
 
 variables:
   #
-  # If updating VERILATOR_VERSION, OPENOCD_VERSION, TOOLCHAIN_VERSION or RUST_VERSION
-  # update the definitions in util/container/Dockerfile as well.
+  # If updating VERILATOR_VERSION, OPENOCD_VERSION, TOOLCHAIN_VERSION or
+  # RUST_VERSION update the definitions in util/container/Dockerfile as well.
+  # These also must be kept in sync with .github/workflows/kythe.yml.
   #
   VERILATOR_VERSION: 4.210
   OPENOCD_VERSION: 0.11.0

--- a/ci/scripts/generate_kythe_kzips.sh
+++ b/ci/scripts/generate_kythe_kzips.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+print_usage () {
+    cat <<EOF
+Usage: $0 MERGED_KZIP_PATH
+
+This script builds Bazel targets with a special Kythe-infused configuration that
+causes it to generate many "kzip" files along the way. After building, the
+script merges the intermediate kzips and writes the result to MERGED_KZIP_PATH.
+This final kzip is suitable for ingestion by Google's OSS codesearch [0].
+
+By default, the script assumes it's running in GitHub Actions. However, if it
+sees the OT_OUTSIDE_GITHUB_ACTIONS environment variable, it will happily
+simulate the necessary parts of the GitHub Actions environment. For example:
+
+    OT_OUTSIDE_GITHUB_ACTIONS=1 $0 merged.kzip
+
+[0]: https://cs.opensource.google/opentitan
+EOF
+}
+
+MERGED_KZIP_PATH=$1
+
+if [[ -n "${OT_OUTSIDE_GITHUB_ACTIONS}" ]]; then
+    # Simulate the GitHub Action environment when debugging locally.
+    GITHUB_WORKSPACE="$(pwd)"
+    RUNNER_TEMP="/tmp/kythe-kzips"
+    mkdir -p "${RUNNER_TEMP}"
+fi
+
+assert_var_nonempty () {
+    VAR_NAME="$1"
+    if [[ -z "${!VAR_NAME}" ]] ; then
+       echo "Assertion failed: ${VAR_NAME} must be non-empty."
+       echo
+       print_usage
+       exit 1
+    fi
+}
+
+# Assert that script arguments are defined and non-empty.
+assert_var_nonempty MERGED_KZIP_PATH
+# Assert that GitHub Action environment variable are defined and non-empty.
+assert_var_nonempty GITHUB_WORKSPACE
+assert_var_nonempty RUNNER_TEMP
+
+# Release tag from https://github.com/kythe/kythe/releases/
+KYTHE_VERSION="v0.0.60"
+KYTHE_DIR="${RUNNER_TEMP}/kythe-${KYTHE_VERSION}"
+KYTHE_SHA256="8fe1aeb8f514306f26e233077e1156dbe353ef2afa72c37866bebb680b52a10d"
+KYTHE_TAR_GZ="kythe.tar.gz"
+
+set -euxo pipefail
+
+mkdir -p "${KYTHE_DIR}"
+
+cd "${RUNNER_TEMP}"
+
+if [[ ! -e "${KYTHE_TAR_GZ}" ]]; then
+  wget --quiet -O "${KYTHE_TAR_GZ}" \
+    "https://github.com/kythe/kythe/releases/download/${KYTHE_VERSION}/kythe-${KYTHE_VERSION}.tar.gz"
+  echo "${KYTHE_SHA256}  ${KYTHE_TAR_GZ}" | sha256sum --check --quiet
+  mkdir -p "${KYTHE_DIR}"
+  tar --strip-components=1 --no-same-owner -xvzf "${KYTHE_TAR_GZ}" \
+    --directory "${KYTHE_DIR}"
+fi
+
+# TODO(lowRISC/opentitan#13935) Enable Rust extraction.
+#
+# Disable Rust extraction by deleting an action listener line from Kythe's
+# extractors.bazelrc[1]. The problem is that Kythe's bazel_rust_extractor
+# (v0.0.60) has a hardcoded dependency on librustc_driver-3ff8a78cc1a3c248.so,
+# which is not included in the release.
+#
+# [1]:
+#   https://cs.opensource.google/kythe/kythe/+/master:kythe/extractors/bazel/extractors.bazelrc
+#   (Note that this link points to the repo's HEAD, not a particular release.)
+sed -Ei \
+  's%^build --experimental_action_listener=@kythe_release//:extract_kzip_rust$%%' \
+  "${KYTHE_DIR}/extractors.bazelrc"
+
+cd "${GITHUB_WORKSPACE}"
+
+./bazelisk.sh \
+  --bazelrc="${KYTHE_DIR}/extractors.bazelrc" \
+  build \
+  --build_tag_filters="-cw310,-verilator" \
+  --define DISABLE_VERILATOR_BUILD=true \
+  --define bitstream=skip \
+  --override_repository kythe_release="${KYTHE_DIR}" \
+  --define=kythe_corpus=github.com/lowRISC/opentitan \
+  -- //sw/... -//third_party/...
+
+find ./bazel-out/*/extra_actions -name '*.kzip' -print0 \
+  | xargs --null "${KYTHE_DIR}/tools/kzip" merge -output "${MERGED_KZIP_PATH}"


### PR DESCRIPTION
This PR is necessary, but not sufficient, to enable semantic indexing on https://cs.opensource.google/opentitan. Once we get this working, I can update a Google-internal config to start using the uploaded Kzips.

#13935