### PR TITLE
[kmac] Relax KeyLen Assertion conditions

### DIFF
--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -452,13 +452,21 @@ module kmac_core
   // Assume configuration is stable during the operation
   `ASSUME(KmacEnStable_M, $changed(kmac_en_i) |-> st inside {StKmacIdle, StTerminalError})
   `ASSUME(ModeStable_M, $changed(mode_i) |-> st inside {StKmacIdle, StTerminalError})
-  `ASSUME(StrengthStable_M, $changed(strength_i) |-> st inside {StKmacIdle, StTerminalError})
-  `ASSUME(KeyLengthStable_M, $changed(key_len_i) |-> st inside {StKmacIdle, StTerminalError})
-  `ASSUME(KeyDataStable_M, $changed(key_data_i) |-> st inside {StKmacIdle, StTerminalError})
+  `ASSUME(StrengthStable_M,
+          $changed(strength_i) |->
+          (st inside {StKmacIdle, StTerminalError}) ||
+          ($past(st) == StKmacIdle))
+  `ASSUME(KeyLengthStable_M,
+          $changed(key_len_i) |->
+          (st inside {StKmacIdle, StTerminalError}) ||
+          ($past(st) == StKmacIdle))
+  `ASSUME(KeyDataStable_M,
+          $changed(key_data_i) |->
+          (st inside {StKmacIdle, StTerminalError}) ||
+          ($past(st) == StKmacIdle))
 
   // no acked to MsgFIFO in StKmacMsg
   `ASSERT(AckOnlyInMessageState_A,
           fifo_valid_i && fifo_ready_o && kmac_en_i |-> st == StKmacMsg)
 
 endmodule : kmac_core
-


### PR DESCRIPTION
@weicaiyang reported an issue
https://github.com/lowRISC/opentitan/issues/13594

When an Application Interface using KMAC initiates the hashing
operation, the `kmac_app` prepares the KMAC configs (strength, mode,
keylen, keydata) for the specific App. At the same time, the App FSM
asserts the `start` signal for KMAC core to run the SHA3 logic.

This violates the KeyLengthStable_M assumption as the kmac_core already
moved to `StKey` state when `key_len_i` is changed.

This commit relaxes the condition by checking the previous value of `st`
is `StKmacIdle`.

