### PR TITLE
[spi/dv] Update spi_agent and seq to test flash passthrough

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_device_flash_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_device_flash_seq.sv
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class spi_device_flash_seq extends dv_base_seq #(
+    .REQ         (spi_item),
+    .CFG_T       (spi_agent_cfg),
+    .SEQUENCER_T (spi_sequencer)
+  );
+  `uvm_object_utils(spi_device_flash_seq)
+  `uvm_object_new
+
+  // return the data in this queue if it's provided, otherwise, random data will be used
+  bit[7:0] byte_data_q[$];
+  // allow user to have forever loop to auto respond the req
+  bit is_forever_rsp_seq;
+
+  task body();
+    do begin
+      spi_item req;
+      p_sequencer.req_analysis_fifo.get(req);
+      `downcast(rsp, req.clone());
+      rsp.payload_q = byte_data_q;
+      start_item(rsp);
+      finish_item(rsp);
+    end while (is_forever_rsp_seq);
+  endtask
+
+endclass

--- a/hw/dv/sv/spi_agent/seq_lib/spi_host_flash_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_host_flash_seq.sv
@@ -3,32 +3,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class spi_host_flash_seq extends spi_base_seq;
-  `uvm_object_utils(spi_host_flash_seq)
-  `uvm_object_new
 
-  rand bit write_command;
-  rand bit [7:0] opcode;
+  rand bit [7:0] op_code;
   rand bit [7:0] address_q[$];
   rand bit [7:0] payload_q[$];
-  rand bit [7:0] read_bsize;
-  rand bit [2:0] num_lanes;
+  rand int          read_size;
+
+  `uvm_object_utils_begin(spi_host_flash_seq)
+    `uvm_field_int(op_code,         UVM_DEFAULT)
+    `uvm_field_int(read_size,       UVM_DEFAULT)
+    `uvm_field_queue_int(payload_q, UVM_DEFAULT)
+    `uvm_field_queue_int(address_q, UVM_DEFAULT)
+  `uvm_object_utils_end
+  `uvm_object_new
 
   virtual task body();
     req = spi_item::type_id::create("req");
     start_item(req);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
                                    item_type == SpiFlashTrans;
-                                   write_command == local::write_command;
-                                   opcode == local::opcode;
-                                   address_q.size() == local::address_q.size();
+                                   opcode == local::op_code;
+                                   write_command == cfg.cmd_infos[op_code].write_command;
+                                   address_q.size() == cfg.cmd_infos[op_code].addr_bytes;
                                    foreach (address_q[i]) {
                                      address_q[i] == local::address_q[i];
                                    }
-                                   read_bsize == local::read_bsize;
-                                   num_lanes == local::num_lanes;
-                                   payload_q.size() == local::payload_q.size();
-                                   foreach (payload_q[i]) {
-                                     payload_q[i] == local::payload_q[i];
+                                   num_lanes == cfg.cmd_infos[op_code].num_lanes;
+                                   if (write_command) {
+                                     read_size == 0;
+                                     payload_q.size() == local::payload_q.size();
+                                     foreach (payload_q[i]) {
+                                       payload_q[i] == local::payload_q[i];
+                                     }
+                                   } else { // read
+                                     read_size == local::read_size;
+                                     payload_q.size() == 0;
                                    })
     finish_item(req);
     get_response(rsp);

--- a/hw/dv/sv/spi_agent/seq_lib/spi_seq_list.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_seq_list.sv
@@ -5,6 +5,7 @@
 `include "spi_base_seq.sv"
 `include "spi_host_seq.sv"
 `include "spi_host_flash_seq.sv"
+`include "spi_device_flash_seq.sv"
 `include "spi_host_dummy_seq.sv"
 `include "spi_device_seq.sv"
 `include "spi_device_cmd_rsp_seq.sv"

--- a/hw/dv/sv/spi_agent/spi_agent.core
+++ b/hw/dv/sv/spi_agent/spi_agent.core
@@ -13,6 +13,7 @@ filesets:
       - spi_agent_pkg.sv
       - spi_if.sv
       - spi_item.sv: {is_include_file: true}
+      - spi_flash_cmd_info.sv: {is_include_file: true}
       - spi_agent_cfg.sv: {is_include_file: true}
       - spi_agent_cov.sv: {is_include_file: true}
       - spi_driver.sv: {is_include_file: true}
@@ -26,6 +27,7 @@ filesets:
       - seq_lib/spi_host_seq.sv: {is_include_file: true}
       - seq_lib/spi_host_dummy_seq.sv: {is_include_file: true}
       - seq_lib/spi_host_flash_seq.sv: {is_include_file: true}
+      - seq_lib/spi_device_flash_seq.sv: {is_include_file: true}
       - seq_lib/spi_device_seq.sv: {is_include_file: true}
       - seq_lib/spi_device_cmd_rsp_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/dv/sv/spi_agent/spi_agent.sv
+++ b/hw/dv/sv/spi_agent/spi_agent.sv
@@ -28,6 +28,7 @@ class spi_agent extends dv_base_agent#(
     end else begin
       `uvm_info(`gfn, "spi agent is configure in Host mode", UVM_HIGH)
     end
+    cfg.has_req_fifo = 1;
   endfunction : build_phase
 
 endclass

--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -20,6 +20,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   bit [3:0] bits_to_transfer; // Bits to transfer if using less than byte
   bit csb_consecutive;            // Don't deassert CSB
   bit decode_commands;  // Used in monitor if decoding of commands needed
+  bit [2:0] cmd_addr_size = 4; //Address size for command
 
   //-------------------------
   // spi_host regs
@@ -35,6 +36,9 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   bit [3:0]        csn_idle[MAX_CS];
   // command register fields
   spi_mode_e       spi_mode;
+  // Cmd info configs
+  spi_flash_cmd_info cmd_infos[bit[7:0]];
+  bit              is_flash_mode;
 
 
   // address width in bytes (default is 4 bytes)
@@ -66,6 +70,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int (partial_byte,   UVM_DEFAULT)
     `uvm_field_int (csb_consecutive,    UVM_DEFAULT)
     `uvm_field_int (decode_commands,    UVM_DEFAULT)
+    `uvm_field_int (cmd_addr_size,      UVM_DEFAULT)
     `uvm_field_int (bits_to_transfer,             UVM_DEFAULT)
     `uvm_field_int (en_extra_dly_btw_sck,         UVM_DEFAULT)
     `uvm_field_int (max_extra_dly_ns_btw_sck,     UVM_DEFAULT)
@@ -81,6 +86,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_sarray_int(csn_trail,       UVM_DEFAULT)
     `uvm_field_sarray_int(csn_idle,        UVM_DEFAULT)
     `uvm_field_enum(spi_mode_e, spi_mode, UVM_DEFAULT)
+    `uvm_field_int(is_flash_mode, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
@@ -128,5 +134,11 @@ class spi_agent_cfg extends dv_base_agent_cfg;
       default:  return 0;
     endcase
   endfunction : get_sio_size
+
+  virtual function void add_cmd_info(spi_flash_cmd_info info);
+    // op_code must be unique
+    `DV_CHECK_EQ(cmd_infos.exists(info.op_code), 0)
+    cmd_infos[info.op_code] = info;
+  endfunction  : add_cmd_info
 
 endclass : spi_agent_cfg

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -60,6 +60,7 @@ package spi_agent_pkg;
   typedef class spi_agent_cfg;
 
   // package sources
+  `include "spi_flash_cmd_info.sv"
   `include "spi_agent_cfg.sv"
   `include "spi_agent_cov.sv"
   `include "spi_item.sv"

--- a/hw/dv/sv/spi_agent/spi_flash_cmd_info.sv
+++ b/hw/dv/sv/spi_agent/spi_flash_cmd_info.sv
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// this object stores the cfg info for a command, so that when a driver/monitor receives a flash
+// cmd, it knows how many addr_bytes, direction, dummy_cycles etc
+class spi_flash_cmd_info extends uvm_sequence_item;
+  rand bit [7:0] op_code;
+  rand bit [2:0] addr_bytes;
+  rand bit write_command;
+  rand bit [2:0] dummy_cycles; // TODO add support in driver and monitor
+  rand bit [2:0] num_lanes;
+  rand bit addr_swap;
+  rand bit data_swap;
+
+  constraint addr_bytes_c {
+    addr_bytes inside {0, 3, 4};
+    // for dual/quad mode, it always contains address
+    num_lanes > 1 -> addr_bytes > 0;
+  }
+
+  constraint num_lanes_c {
+    write_command -> num_lanes == 1;
+    num_lanes inside {1, 2, 4};
+  }
+
+  // payload_swap_en only works with write data and SingleIO mode
+  constraint data_swap_c {
+    data_swap -> num_lanes == 1 &&  write_command == 1;
+  }
+
+  // TODO, simplify setting. Remove this later
+  constraint simplify_c {
+    addr_swap == 0;
+    data_swap == 0;
+    dummy_cycles == 0;
+  }
+  `uvm_object_utils_begin(spi_flash_cmd_info)
+    `uvm_field_int(op_code,       UVM_DEFAULT)
+    `uvm_field_int(addr_bytes,    UVM_DEFAULT)
+    `uvm_field_int(write_command, UVM_DEFAULT)
+    `uvm_field_int(dummy_cycles,  UVM_DEFAULT)
+    `uvm_field_int(num_lanes,     UVM_DEFAULT)
+    `uvm_field_int(addr_swap,     UVM_DEFAULT)
+    `uvm_field_int(data_swap,     UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+endclass

--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -92,7 +92,7 @@ class spi_host_driver extends spi_driver;
       end else begin
         num_bits = 8;
       end
-      host_byte = req.data[i];
+      host_byte = transfer_data[i];
       for (int j = 0; j < num_bits; j++) begin
         // drive sio early so that it is stable at the sampling edge
         which_bit = cfg.host_bit_dir ? j : 7 - j;
@@ -131,14 +131,15 @@ class spi_host_driver extends spi_driver;
 
   task drive_flash_item();
     bit [7:0] drive_data[$];
+
+    `uvm_info(`gfn, $sformatf("Driving flash item: \n%s", req.sprint()), UVM_MEDIUM)
     cfg.vif.csb[cfg.csb_sel] <= 1'b0;
-    if (!req.write_command) begin
-      `DV_CHECK_EQ(req.payload_q.size, 0)
-    end
+
     drive_data = {req.opcode, req.address_q, req.payload_q};
     sck_pulses = drive_data.size() * 8;
     if (!req.write_command) begin
-      sck_pulses = sck_pulses + req.read_bsize * (8 / req.num_lanes);
+      `DV_CHECK_EQ(req.payload_q.size, 0)
+      sck_pulses = sck_pulses + req.read_size * (8 / req.num_lanes);
     end
 
     // for mode 1 and 3, get the leading edges out of the way

--- a/hw/dv/sv/spi_agent/spi_item.sv
+++ b/hw/dv/sv/spi_agent/spi_item.sv
@@ -11,13 +11,12 @@ class spi_item extends uvm_sequence_item;
   // start of transaction
   bit first_byte;
   // flash command constraints
-  rand bit [7:0] read_bsize;
+  rand int read_size;
   rand bit [7:0] payload_q[$];
   rand bit write_command;
   rand bit [7:0] address_q[$];
   rand bit [7:0] opcode;
   rand bit [2:0] num_lanes; // 1,2 or 4 lanes for read response
-
 
   rand uint dummy_clk_cnt;
   rand uint dummy_sck_length_ns;
@@ -40,6 +39,12 @@ class spi_item extends uvm_sequence_item;
     `uvm_field_int(first_byte,                   UVM_DEFAULT)
     `uvm_field_int(dummy_clk_cnt,                UVM_DEFAULT)
     `uvm_field_int(dummy_sck_length_ns,          UVM_DEFAULT)
+    `uvm_field_int(read_size,                    UVM_DEFAULT)
+    `uvm_field_int(write_command,                UVM_DEFAULT)
+    `uvm_field_int(opcode,                       UVM_DEFAULT)
+    `uvm_field_int(num_lanes,                    UVM_DEFAULT)
+    `uvm_field_queue_int(payload_q,              UVM_DEFAULT)
+    `uvm_field_queue_int(address_q,              UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_dual_mode_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_dual_mode_vseq.sv
@@ -19,20 +19,24 @@ class spi_device_dual_mode_vseq extends spi_device_pass_base_vseq;
     bit [31:0] device_word_rsp;
     bit [31:0] cmd_addr;
     bit [31:0] address_command;
-    bit [7:0] read_size;
+    int read_size;
     bit rx_order;
     bit [7:0] addr [$];
+    bit [7:0] pld [$];
     bit [4:0]  cmd_slot;
     addr_mode_e addr_size;
     spi_device_flash_pass_init(FlashMode);
     cfg.clk_rst_vif.wait_clks(100);
-    prepare_buffer(); // Randomize buffer data
 
+    // TODO need to re-write this seq
+    /*
     repeat (num_trans) begin
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(read_size, read_size%4 == 0 && read_size < 65;)
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(addr_size, addr_size >= Addr3B;)
+
+      addr_size = cfg.m_spi_agent_cfg.cmd_infos[READ_DUAL].addr_bytes;
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(read_size, read_size > 0;)
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cmd_slot, cmd_slot >= 5 && cmd_slot <= 10;)
-      config_cmd_info(op_cmd, cmd_slot, addr_size, num_lanes); // Configure dual read in slot 5 - 10
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(pld, pld.size() == 0;)
+      //config_cmd_info(op_cmd, cmd_slot, addr_size, num_lanes); // Configure dual read in slot 5 - 10
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cmd_addr, cmd_addr[15:0] == 0;)
       // Prepare data for transfer
       csr_rd(.ptr(ral.cfg.rx_order), .value(rx_order));
@@ -44,10 +48,10 @@ class spi_device_dual_mode_vseq extends spi_device_pass_base_vseq;
         addr[i] = cmd_addr[i*8 + 7 -: 8];
       end
       // Issue command - opcode - address 3B - read size in bytes - 2 lanes
-      spi_host_xfer_cmd_out(op_cmd, addr, read_size, num_lanes);
+      //spi_host_xfer_flash_item(op_cmd, addr, read_size, pld);
       cfg.clk_rst_vif.wait_clks(1000);
     end
-
+  */
   endtask : body
 
 endclass : spi_device_dual_mode_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -7,16 +7,120 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
   `uvm_object_utils(spi_device_pass_base_vseq)
   `uvm_object_new
 
+  // Task for adding cmd info
+  virtual task config_all_cmd_infos();
+    spi_flash_cmd_info info = spi_flash_cmd_info::type_id::create("info");
+    // Configure the first 11 commands which are fixed
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes == 0 &&
+      info.op_code == READ_STATUS_1 &&
+      info.num_lanes == 1 &&
+      info.write_command == 0;)
+    add_cmd_info(info, 0);
+    info = spi_flash_cmd_info::type_id::create("info");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes == 0 &&
+      info.op_code == READ_STATUS_2;
+      info.num_lanes == 1 &&
+      info.write_command == 0;)
+    add_cmd_info(info, 1);
+    info = spi_flash_cmd_info::type_id::create("info");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes == 0 &&
+      info.op_code == READ_STATUS_3 &&
+      info.num_lanes == 1 &&
+      info.write_command == 0;)
+    add_cmd_info(info, 2);
+    info = spi_flash_cmd_info::type_id::create("info");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes == 0 &&
+      info.op_code == READ_JEDEC &&
+      info.num_lanes == 1 &&
+      info.write_command == 0;)
+    add_cmd_info(info, 3);
+    info = spi_flash_cmd_info::type_id::create("info");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes == 0 &&
+      info.op_code == READ_SFDP;
+      info.num_lanes == 1 &&
+      info.write_command == 0;)
+    add_cmd_info(info, 4);
+    info = spi_flash_cmd_info::type_id::create("info");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes > 0 &&
+      info.op_code == READ_NORMAL &&
+      info.num_lanes == 1 &&
+      info.write_command == 0;)
+    add_cmd_info(info, 5);
+    info = spi_flash_cmd_info::type_id::create("info");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes > 0 &&
+      info.op_code == READ_FAST &&
+      info.num_lanes == 1 &&
+      info.write_command == 0;)
+    add_cmd_info(info, 6);
+    info = spi_flash_cmd_info::type_id::create("info");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes > 0 &&
+      info.op_code == READ_DUAL &&
+      info.write_command == 0 &&
+      info.num_lanes == 2;)
+    add_cmd_info(info, 7);
+    info = spi_flash_cmd_info::type_id::create("info");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes > 0 &&
+      info.op_code == READ_QUAD &&
+      info.write_command == 0 &&
+      info.num_lanes == 4;)
+    add_cmd_info(info, 8);
+    info = spi_flash_cmd_info::type_id::create("info");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes > 0 &&
+      info.op_code == READ_DUALIO &&
+      info.write_command == 0 &&
+      info.num_lanes == 2;)
+    add_cmd_info(info, 9);
+    info = spi_flash_cmd_info::type_id::create("info");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+      info.addr_bytes > 0 &&
+      info.op_code == READ_QUADIO &&
+      info.write_command == 0 &&
+      info.num_lanes == 4;)
+    add_cmd_info(info, 10);
+    for (int i = 11; i < 24; i++) begin
+      info = spi_flash_cmd_info::type_id::create("info");
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
+        foreach (cfg.m_spi_agent_cfg.cmd_infos[j]) {info.op_code != j;})
+      add_cmd_info(info, i);
+    end
+  endtask : config_all_cmd_infos
+
   // Task for flash or pass init
   virtual task spi_device_flash_pass_init(device_mode_e mode);
+    bit use_addr_4b_enable; // Mode of config
     spi_device_init();
-    // Fixed config for this scenario
+    `uvm_info(`gfn, "Initialize flash/passthrough mode", UVM_MEDIUM)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(use_addr_4b_enable)
+    // TODO, fixed config for now
     cfg.m_spi_agent_cfg.sck_polarity[0] = 0;
     cfg.m_spi_agent_cfg.sck_phase[0] = 0;
-    cfg.m_spi_agent_cfg.host_bit_dir = 1;
-    cfg.m_spi_agent_cfg.device_bit_dir = 1;
-    ral.cfg.tx_order.set(1);
-    ral.cfg.rx_order.set(1);
+    cfg.spi_device_agent_cfg.sck_polarity[0] = 0;
+    cfg.spi_device_agent_cfg.sck_phase[0] = 0;
+
+    // bit dir is only supported in fw mode. Need to be 0 for other modes
+    cfg.m_spi_agent_cfg.host_bit_dir = 0;
+    cfg.m_spi_agent_cfg.device_bit_dir = 0;
+    cfg.spi_device_agent_cfg.host_bit_dir = 0;
+    cfg.spi_device_agent_cfg.device_bit_dir = 0;
+
+    cfg.m_spi_agent_cfg.num_bytes_per_trans_in_mon = 1;
+    cfg.spi_device_agent_cfg.num_bytes_per_trans_in_mon = 1;
+    cfg.m_spi_agent_cfg.is_flash_mode = 1;
+    cfg.spi_device_agent_cfg.is_flash_mode = 1;
+    // since tx/rx order are not used in flash mode, randomize them
+    `DV_CHECK_RANDOMIZE_FATAL(ral.cfg.tx_order)
+    `DV_CHECK_RANDOMIZE_FATAL(ral.cfg.rx_order)
+    ral.cfg.addr_4b_en.set(use_addr_4b_enable);
     ral.cfg.cpol.set(1'b0);
     ral.cfg.cpha.set(1'b0);
     csr_update(.csr(ral.cfg)); // TODO check if randomization possible
@@ -29,6 +133,10 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
       ral.control.mode.set(PassthroughMode);
     end
     csr_update(.csr(ral.control));
+    config_all_cmd_infos();
+
+    spi_device_flash_auto_rsp_nonblocking();
+    randomize_mem();
   endtask : spi_device_flash_pass_init
 
   // Task for configuring enable/disable of command opcode
@@ -56,31 +164,51 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
   endtask : order_cmd_bits
 
   // Task for preparing memory buffer for read commands
-  virtual task prepare_buffer();
+  virtual task randomize_mem();
     bit [31:0] buffer_data [1024];
     `DV_CHECK_STD_RANDOMIZE_FATAL(buffer_data)
     // Prepare Buffer
     for (int i = 0; i < 1024; i++) begin // Fill buffer with random data
       mem_wr(.ptr(ral.buffer), .offset(i), .data(buffer_data[i]));
     end
-  endtask : prepare_buffer
+  endtask : randomize_mem
 
   // Task for configuring cmd info slot
-  virtual task config_cmd_info(bit [7:0] opcode, bit [4:0] idx, addr_mode_e addr_size,
-                                     bit [2:0] num_lanes);
+  virtual task add_cmd_info(spi_flash_cmd_info info, bit [4:0] idx);
     bit [3:0] lanes_en;
-    case (num_lanes)
+    addr_mode_e addr_size;
+    cfg.m_spi_agent_cfg.add_cmd_info(info);
+    cfg.spi_device_agent_cfg.add_cmd_info(info);
+
+    `uvm_info(`gfn, $sformatf("Add this cmd_info \n%s", info.sprint()), UVM_MEDIUM)
+    case (info.num_lanes)
       1 : lanes_en = 4'h2;
       2 : lanes_en = 4'h3;
       4 : lanes_en = 4'hF;
-      default : `uvm_fatal(`gfn, $sformatf("Unsupported lanes num 0x%0h", num_lanes))
+      default : `uvm_fatal(`gfn, $sformatf("Unsupported lanes num 0x%0h", info.num_lanes))
     endcase
-    ral.cmd_info[idx].valid.set(1'b1); // Enable this OPCODE
-    ral.cmd_info[idx].opcode.set(opcode);// Read Dual
+    case (info.addr_bytes)
+      0: addr_size = AddrDisabled;
+      3: addr_size = Addr3B;
+      4: addr_size = Addr4B;
+      default : `uvm_fatal(`gfn, $sformatf("Unsupported addr bytes 0x%0h", info.addr_bytes))
+    endcase
     ral.cmd_info[idx].addr_mode.set(addr_size);
+    // if addr_size is aligned with addr_4b_en, we could use AddrCfg instead of Addr4B/Addr3B
+    if (`gmv(ral.cfg.addr_4b_en) == 1 && addr_size == Addr4B ||
+         `gmv(ral.cfg.addr_4b_en) == 0 && addr_size == Addr3B) begin
+        if ($urandom_range(0, 1)) addr_size = AddrCfg;
+    end
+    ral.cmd_info[idx].addr_mode.set(addr_size);
+
+    ral.cmd_info[idx].valid.set(1'b1); // Enable this OPCODE
+    ral.cmd_info[idx].opcode.set(info.op_code);// Read Dual
     ral.cmd_info[idx].payload_en.set(lanes_en);
-    ral.cmd_info[idx].payload_dir.set(PayloadOut);
+    ral.cmd_info[idx].payload_dir.set(!info.write_command);
+    ral.cmd_info[idx].mbyte_en.set(info.num_lanes > 1);
+    ral.cmd_info[idx].addr_swap_en.set(info.addr_swap);
+    ral.cmd_info[idx].payload_swap_en.set(info.data_swap);
     csr_update(.csr(ral.cmd_info[idx]));
-  endtask : config_cmd_info
+  endtask : add_cmd_info
 
 endclass : spi_device_pass_base_vseq

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -52,7 +52,7 @@ package spi_device_env_pkg;
     PassthroughMode
   } device_mode_e;
 
-  typedef enum {
+  typedef enum bit [1:0] {
     AddrDisabled,
     AddrCfg,
     Addr3B,

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -69,10 +69,9 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
     spi_item item;
     forever begin
       pass_spi_data_fifo.get(item);
-      `uvm_info(`gfn, $sformatf("received pass spi item:\n%0s", item.sprint()), UVM_HIGH)
-      if (`gmv(ral.control.mode) == PassthroughMode) begin
-        compare_pass_opcode_addr({item.data[3], item.data[2], item.data[1], item.data[0]});
-      end
+      `uvm_info(`gfn, $sformatf("received pass spi item:\n%0s", item.sprint()), UVM_MEDIUM)
+      `DV_CHECK_EQ(`gmv(ral.control.mode), PassthroughMode)
+      // TODO, check downstream items
     end
   endtask
 

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -27,7 +27,7 @@ module tb;
   wire [3:0] sd_out_en;
   wire [3:0] sd_in;
   spi_device_pkg::passthrough_req_t pass_out;
-  spi_device_pkg::passthrough_req_t pass_in;
+  spi_device_pkg::passthrough_rsp_t pass_in;
 
   wire intr_rxf;
   wire intr_rxlvl;
@@ -110,7 +110,8 @@ module tb;
   `CONNECT_SPI_IO(spi_if, sd_in, sd_out, sd_out_en, 3)
 
   assign spi_if_pass.sck = pass_out.sck;
-  assign spi_if_pass.csb = pass_out.csb;
+  // if passthrough_en is low, set csb inactive as the whole passthrough interface is off
+  assign spi_if_pass.csb = pass_out.csb ||  !pass_out.passthrough_en;
   `CONNECT_SPI_IO_PASS(spi_if_pass, pass_in.s, pass_out.s, pass_out.s_en, 0)
   `CONNECT_SPI_IO_PASS(spi_if_pass, pass_in.s, pass_out.s, pass_out.s_en, 1)
   `CONNECT_SPI_IO_PASS(spi_if_pass, pass_in.s, pass_out.s, pass_out.s_en, 2)


### PR DESCRIPTION
Sorry for making such large PR. This consolidates the updates in this PR #12594 and solves
unaddressed comments, as well as making cmd_filter test pass

1. agent update
  - add spi_flash_cmd_info so that driver/monitor understands addr
    length, direction etc from the received opcode
  - update device driver, monitor to handle flash item
  - add flash seq
2. seq update
  - update base vseq to configure all cmd_infos
  - update spi_device_pass_cmd_filtering_vseq to randomly test opcodes

Will update scb to compare items from both spi interface, depending
on the filter enabled or not

Signed-off-by: Kosta Kojdic <kosta.kojdic@ensilica.com>
Signed-off-by: Weicai Yang <weicai@google.com>