### PR TITLE
[top/dv] Add otp_ctrl_program_error test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2399,7 +2399,7 @@
               program error.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_otp_ctrl_program_error"]
     }
     {
       name: chip_sw_otp_ctrl_hw_cfg

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -993,6 +993,13 @@
       run_opts: ["+calibrate_usb_clk=1"]
     }
     {
+      name: chip_sw_otp_ctrl_program_error
+      uvm_test_seq: chip_sw_otp_ctrl_program_error_vseq
+      sw_images: ["sw/device/tests/sim_dv/otp_ctrl_program_error:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
+    }
+    {
       name: chip_sw_pwrmgr_normal_sleep_all_wake_ups
       uvm_test_seq: "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq"
       sw_images: ["sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_wake_ups:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -66,6 +66,7 @@ filesets:
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_otp_ctrl_program_error_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -117,9 +117,10 @@ package chip_env_pkg;
   } chip_tap_type_e;
 
   // Two status for LC JTAG to identify if LC state transition is successful.
-  typedef enum {
+  typedef enum int {
     LcReady,
-    LcTransitionSuccessful
+    LcTransitionSuccessful,
+    LcTransitionCntError
   } lc_ctrl_status_e;
 
   // enumeration for lc_ctrl broadcasts

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_program_error_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_program_error_vseq.sv
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_otp_ctrl_program_error_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_otp_ctrl_program_error_vseq)
+
+  `uvm_object_new
+
+  // Reassign `select_jtag` variable to drive LC JTAG tap at start,
+  // because LC_CTRL's TestLock state can only sample strap once at boot.
+  virtual task pre_start();
+    select_jtag = SelectLCJtagTap;
+    super.pre_start();
+  endtask
+
+  // no need to wait for SW test to complete. As the checks above
+  // imply that software has already done its job.
+  virtual task wait_for_sw_test_done();
+  endtask
+
+  virtual task body();
+    logic [lc_ctrl_state_pkg::NumLcCountValues-1:0][lc_ctrl_state_pkg::LcValueWidth-1:0] lc_max_cnt;
+
+    super.body();
+
+    // Backdoor load life cycle transition count to max
+    lc_max_cnt = lc_ctrl_state_pkg::LcCnt24;
+    for (int i = 0; i < lc_ctrl_state_pkg::NumLcCountValues; i++) begin
+      cfg.mem_bkdr_util_h[Otp].write16(otp_ctrl_reg_pkg::LcTransitionCntOffset + i*2,
+      lc_max_cnt[i]);
+    end
+
+    // Wait for C side to fully stabilize
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Begin life cycle transition");,
+             "timeout waiting for C side acknowledgement",
+             cfg.sw_test_timeout_ns)
+
+    // poll for state to transition to post transition state
+    jtag_csr_spinwait(ral.lc_ctrl.lc_state.get_offset(),
+      p_sequencer.jtag_sequencer_h,
+      {DecLcStateNumRep{DecLcStPostTrans}},
+      cfg.sw_test_timeout_ns);
+
+    // check to ensure that we see a transition count error
+    wait_lc_status(LcTransitionCntError);
+
+  endtask
+
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -45,3 +45,4 @@
 `include "chip_sw_rstmgr_alert_info_vseq.sv"
 `include "chip_rv_dm_ndm_reset_vseq.sv"
 `include "chip_sw_alert_handler_escalation_vseq.sv"
+`include "chip_sw_otp_ctrl_program_error_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -710,3 +710,20 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "otp_ctrl_program_error",
+    srcs = ["otp_ctrl_program_error.c"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/sim_dv/otp_ctrl_program_error.c
+++ b/sw/device/tests/sim_dv/otp_ctrl_program_error.c
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/lc_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/*
+ TO BE FILLED IN
+ */
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_lc_ctrl_t lc_ctrl;
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_lc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc_ctrl));
+
+  // Check lc counter is at max
+  lc_ctrl_testutils_check_transition_count(&lc_ctrl, 24);
+
+  // Initiate transition into scrap
+  dif_lc_ctrl_token_t zero_token = {0, 0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 0};
+
+  // DV sync message
+  LOG_INFO("Begin life cycle transition");
+
+  // Mutex acquire should always succeed, there are no competing agents
+  CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc_ctrl));
+  CHECK_DIF_OK(dif_lc_ctrl_configure(&lc_ctrl, kDifLcCtrlStateScrap, false,
+                                     &zero_token));
+  CHECK_DIF_OK(dif_lc_ctrl_transition(&lc_ctrl));
+
+  return true;
+}


### PR DESCRIPTION
- max out lc count and attempt to transition life cycle state
- check that an error is seen on the life cycle interface

Signed-off-by: Timothy Chen <timothytim@google.com>