### PR TITLE
[test, keymgr] Link sideload aes test in the testplan

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2121,7 +2121,7 @@
                Same as `chip_keymgr_sideload_kmac`, except, sideload to AES.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_aes_sideload"]
     }
     {
       name: chip_sw_keymgr_sideload_otbn


### PR DESCRIPTION
This PR only links the existing aes sideload test to the keymgr test in the testplan