### PR TITLE
[bazel] clear the broken tag from the following passing tests

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -23,11 +23,6 @@ opentitan_functest(
         # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
         tags = ["broken"],
     ),
-    verilator = verilator_params(
-        tags = [
-            "broken",
-        ],
-    ),
     deps = [
         "//hw/ip/aes:model",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -592,10 +587,6 @@ opentitan_functest(
     name = "flash_ctrl_ops_test",
     srcs = ["flash_ctrl_ops_test.c"],
     cw310 = cw310_params(
-        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-        tags = ["broken"],
-    ),
-    verilator = verilator_params(
         # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
         tags = ["broken"],
     ),


### PR DESCRIPTION
//sw/device/tests:flash_ctrl_ops_test_sim_verilator
//sw/device/tests:aes_entropy_test_sim_verilator

Signed-off-by: Drew Macrae <drewmacrae@google.com>