### PR TITLE
[entropy_src] Implement error-related covergroups

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -119,24 +119,58 @@
     {
       name: err_test_cg
       desc: '''
-            Covers that all health test failures, fatal errors, all counter errors and
-            all error codes of entropy_src have been tested.
-            Individual config settings that will be covered include:
-            - which_ht_fail (0 to 3), 4 possible health test fails, repcnt, adaptp, bucket and
-              markov test fails
-            - which_ht (0 to 1), adaptp and markov health tests have low and high tests
-            - which_fatal_err (0 to 5), 6 fatal errors, esrng, observe, esfinal fifo errors,
-              main state machine, ack state machine errors, and counter error
-            - which_fifo_err (0 to 2), fifo has write, read and state errors
-            - which_fifo (0 to 2), esrng, observe and esfinal fifos
+            Covers that the ERR_CODE_TEST register has been tested for all 9 valid test values:
+            - 0: SFIFO_ESRNG_ERR
+            - 1: SFIFO_OBSERVE_ERR
+            - 2: SFIFO_ESFINAL_ERR
+            - 20: ES_ACK_SM_ERR
+            - 21: ES_MAIN_SM_ERR
+            - 22: ES_CNTR_ERR
+            - 28: FIFO_WRITE_ERR
+            - 29: FIFO_READ_ERR
+            - 30: FIFO_STATE_ERR
+            Each test bit should then trigger the corresponding alerts and error status bits.
+            '''
+    }
+    {
+      name: mubi_err_cg
+      desc: '''
+            Covers that all 11 register fields with built in redundancy (All multi-bit encoded
+            except for ALERT_THRESHOLD) have been programmed with at least one one invalid mubi
+            value, and that the corresponding recoverable alert has been registered.  This
+            includes the 10 boolean register fields which are MultiBit encoded as well as the
+            ALERT_THRESHOLD register, which is a pair of numeric values which must be inverses
+            of each other.
+            '''
+    }
+    {
+       name: sm_err_cg
+       desc: '''
+             Covers that both the MAIN_SM and ACK_SM have been forced into an invalid state,
+             and this state error has been successfully detected, the appropriate alerts have
+             been signalled, and the error has been sucessfully reported in the error CSRs.
+             '''
+    }
+    {
+       name: fifo_err_cg
+       desc: '''
+             Covers that all three fifos (the esrng fifo, the observe fifo, and the esfinal fifo)
+             have all been forced into the three error states (write overflow, read underflow,
+             and invalid state), and the error has sucessfully generated an alert and that
+             the alert is successfully reported in the the ERR_CODE register.
+             '''
+    }
+    {
+      name: cntr_err_cg
+      desc: '''
+            Covers that all counter-related fatal errors have been tested by forcing the
+            respective redundant counters to be mismatched from each other.
             - which_cntr (0 to 5), 6 possible counter errors, window counter, repcnt ht counter,
               repcnts ht counter, adaptive proportion ht counter, bucket ht counter and
               markov ht counter
-            - which_err_code (0 to 17), ERR_CODE has 9 fields, plus 9 ERR_CODE_TEST bits test
-            - which_invalid_mubi (0 to 8), 9 possible invalid mubi value fields
             - which_cntr_replicate (0 to RNG_BUS_WIDTH-1), reptcnt, adaptp, markov health tests
               have RNG_BUS_WIDTH copies of counters
-            - which_bin (0 to 2<sup>RNG_BUS_WIDTH-1</sup>), bucket health test has
+            - which_bin (0 to 2<sup>RNG_BUS_WIDTH</sup>-1), bucket health test has
               2<sup>RNG_BUS_WIDTH</sup> copies of counters
             '''
     }

--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -102,12 +102,12 @@
 
   component_a: "uvm_test_top.env.scoreboard"
   id_a : _ALL_
-  verbosity_a: UVM_FULL
+  verbosity_a: UVM_MEDIUM
   phase_a: run
 
   component_b: "uvm_test_top.env.virtual_sequencer"
   id_b : _ALL_
-  verbosity_b: UVM_FULL
+  verbosity_b: UVM_MEDIUM
   phase_b: run
 
   run_modes: [
@@ -121,7 +121,7 @@
     }
     {
       name: short_run
-      run_opts: ["+test_timeout_ns=10000000"]
+      run_opts: ["+test_timeout_ns=40_000_000"]
     }
   ]
 }

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -40,8 +40,13 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // Mean time before "soft" RNG failure (still functions but less entropy per bit)
   realtime soft_mtbf;
 
-  // Mean time between an unexpected configuration update events
-  realtime mean_rand_reconfig_time;
+  // Mean time between unexpected configuration update events
+  // Default: Negative, meaning no random reconfigs
+  realtime mean_rand_reconfig_time = -1;
+
+  // Mean time ERR_CODE_TEST CSR-driven alert events
+  // Default: Negative, meaning no random reconfigs
+  realtime mean_rand_csr_alert_time = -1;
 
   int      seed_cnt;
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -43,8 +43,10 @@ package entropy_src_env_pkg;
     invalid_rng_bit_enable          = 4,
     invalid_fw_ov_mode              = 5,
     invalid_fw_ov_entropy_insert    = 6,
-    invalid_es_route                = 7,
-    invalid_es_type                 = 8
+    invalid_fw_ov_insert_start      = 7,
+    invalid_es_route                = 8,
+    invalid_es_type                 = 9,
+    invalid_alert_threshold         = 10
   } invalid_mubi_e;
 
   typedef enum int {
@@ -123,6 +125,19 @@ package entropy_src_env_pkg;
     low_test  = 1
   } which_ht_e;
 
+  typedef enum bit [4:0] {
+    sfifo_esrng_err_code   = 0,
+    sfifo_observe_err_code = 1,
+    sfifo_esfinal_err_code = 2,
+    es_ack_sm_err_code     = 20,
+    es_main_sm_err_code    = 21,
+    es_cntr_err_code       = 22,
+    fifo_write_err_code    = 28,
+    fifo_read_err_code     = 29,
+    fifo_state_err_code    = 30
+  } err_code_test_val_e;
+
+
   typedef enum { BOOT, STARTUP, CONTINUOUS, HALTED } entropy_phase_e;
   typedef bit [RNG_BUS_WIDTH-1:0] rng_val_t;
   typedef bit [TL_DW-1:0]         tl_val_t;
@@ -191,6 +206,7 @@ package entropy_src_env_pkg;
   //
   // For more information about the exponential distribution see (for example):
   // https://en.wikipedia.org/wiki/Exponential_distribution
+  //
 
   function automatic realtime randomize_failure_time(realtime mtbf);
     // Random non-zero integer
@@ -198,6 +214,7 @@ package entropy_src_env_pkg;
     // Uniformly distributed random float in range (0, 1].
     // 0 is not included in this range, but 1 is.
     real     rand_r;
+
     realtime now, random_fail_time;
 
     if (!std::randomize(rand_i) with {rand_i > 0;}) begin

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -924,7 +924,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       end
       "err_code": begin
       end
-      "err_code_check": begin
+      "err_code_test": begin
       end
       default: begin
         `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
@@ -1036,6 +1036,17 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
                   package_and_release_entropy();
                 end
               end
+            end
+            "err_code_test": begin
+              uvm_reg_field err_code_test = csr.get_field_by_name("err_code_test");
+              bit [TL_DW - 1:0] err_code = ral.err_code.get_mirrored_value();
+              bit[4:0] bit_num = err_code_test.get_mirrored_value();
+              bit [TL_DW - 1:0] mask = (32'h1 << bit_num);
+              err_code = err_code | mask;
+              `uvm_info(`gfn, "Received write to ERR_CODE_TEST", UVM_LOW)
+              `DV_CHECK_FATAL(ral.err_code.predict(.value(err_code), .kind(UVM_PREDICT_READ)));
+              cov_vif.cg_err_test_sample(bit_num);
+              set_exp_alert(.alert_name("fatal_alert"), .is_fatal(1));
             end
             default: begin
             end

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -19,6 +19,7 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.sim_duration                = 20ms;
     cfg.hard_mtbf                   = 100s;
     cfg.mean_rand_reconfig_time     = 1ms;
+    cfg.mean_rand_csr_alert_time    = 1ms;
 
     cfg.soft_mtbf                   = 7500us;
     // Apply standards ranging from strict to relaxed


### PR DESCRIPTION
This PR updates the test plan to expands the err_test_cg in to several smaller covergroups that are easier to sample.

Since the original err_test_cg covers so many disparate classes of events that happen at different times, it would be hard to write a single sample function that covers them all.   Therefore this CG has been broken into 5 smaller coverpoints:

 - `err_test_cg`: covers that writes to ERR_CODE_TEST generate the expected alerts for all bits
 - `mubi_err_cg`: covers that we've tested that writes to registers that expect redundancy in their values (including both MultiBit Booleans and the AlertThreshold numeric register), and that alerts are seen when bad values are inserted.
 - `sm_err_cg` covers that we've seen alerts when that the MAIN_SM and ACK_SM are forced into invalid values
 - `fifo_err_cg` covers that we've seen alerts when the FIFOs malfunction.
 - `cntr_err_cg` covers that all redundant counters have been forced to mismatching values.

NOTE: Alerts related to health tests (i.e. the main_sm _recoverable_ alert) are mostly covered by other coverpoints.