### PR TITLE
[chip/conn] Move a DV testplan entry to connectivity testplan

### DIFF
--- a/hw/top_earlgrey/data/chip_conn_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_conn_testplan.hjson
@@ -510,6 +510,15 @@
       tests: ["rstmgr_rst_sys_src_n"]
       tags: ["conn"]
     }
+    /////////////////////////
+    // TODO: EDN           //
+    /////////////////////////
+    {
+      name: edn_clk_rst_
+      desc: "Check EDN's clock and reset connects correctly to other IPs."
+      milestone: V2
+      tests: []
+      tags: ["conn"]
+    }
   ]
 }
-

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2364,16 +2364,6 @@
       tests: []
     }
     {
-      name: chip_sw_otp_ctrl_edn_reset
-      desc: '''Verify the effect of putting the EDN domain in reset on OTP ctrl.
-
-            Verify that the computed nonce for SRAM is reset?
-            Verify all entropy data used for various things are reset.
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
       name: chip_sw_otp_ctrl_program
       desc: '''Verify the program request from lc_ctrl.
 


### PR DESCRIPTION
This PR removes a DV testplan entry (EDN clock and reset check in OTP)
to a connectivity check. We discussed this topic in one of the DV
meeting and found that there aren't any check points in simulation due
to the clock and reset groups. So we move this to a connectivity check.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>