### PR TITLE
[spi_device/dv] some renames

### DIFF
--- a/hw/ip/spi_device/doc/dv/index.md
+++ b/hw/ip/spi_device/doc/dv/index.md
@@ -88,7 +88,7 @@ The following covergroups have been developed to prove that the test intent has 
 The `spi_device_scoreboard` is primarily used for end to end checking.
 It creates the following analysis fifos to retrieve the data monitored by corresponding interface agents:
 * tl_a_chan_fifo, tl_d_chan_fifo:           These 2 fifos provide transaction items at the end of address channel and data channel respectively
-* host_spi_data_fifo, device_spi_data_fifo: These 2 fifos provides TX/RX words of data from spi_monitor
+* upstream_spi_host_fifo, upstream_spi_device_fifo: These 2 fifos provides TX/RX words of data from spi_monitor
 
 #### Assertions
 * TLUL assertions: The `tb/spi_device_bind.sv` binds the `tlul_assert` [assertions]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}}) to the IP to ensure TileLink interface protocol compliance.

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -127,21 +127,21 @@ class spi_device_base_vseq extends cip_base_vseq #(
   virtual task spi_device_init();
     // set clk period
     if (spi_freq_faster) begin
-      cfg.m_spi_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps / core_spi_freq_ratio;
+      cfg.spi_host_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps / core_spi_freq_ratio;
     end else begin
-      cfg.m_spi_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps * core_spi_freq_ratio;
+      cfg.spi_host_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps * core_spi_freq_ratio;
     end
     // update host agent
-    cfg.m_spi_agent_cfg.sck_polarity[0] = sck_polarity;
-    cfg.m_spi_agent_cfg.sck_phase[0] = sck_phase;
-    cfg.m_spi_agent_cfg.host_bit_dir = host_bit_dir;
-    cfg.m_spi_agent_cfg.device_bit_dir = device_bit_dir;
-    cfg.m_spi_agent_cfg.csb_sel = 0;
-    cfg.m_spi_agent_cfg.partial_byte = 0;
-    cfg.m_spi_agent_cfg.csb_consecutive = 0;
-    cfg.m_spi_agent_cfg.decode_commands = 0;
-    cfg.m_spi_agent_cfg.num_bytes_per_trans_in_mon = 4;
-    cfg.m_spi_agent_cfg.is_flash_mode = 0;
+    cfg.spi_host_agent_cfg.sck_polarity[0] = sck_polarity;
+    cfg.spi_host_agent_cfg.sck_phase[0] = sck_phase;
+    cfg.spi_host_agent_cfg.host_bit_dir = host_bit_dir;
+    cfg.spi_host_agent_cfg.device_bit_dir = device_bit_dir;
+    cfg.spi_host_agent_cfg.csb_sel = 0;
+    cfg.spi_host_agent_cfg.partial_byte = 0;
+    cfg.spi_host_agent_cfg.csb_consecutive = 0;
+    cfg.spi_host_agent_cfg.decode_commands = 0;
+    cfg.spi_host_agent_cfg.num_bytes_per_trans_in_mon = 4;
+    cfg.spi_host_agent_cfg.is_flash_mode = 0;
 
     // update device rtl
     ral.control.mode.set(spi_mode);

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_bit_transfer_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_bit_transfer_vseq.sv
@@ -30,15 +30,15 @@ class spi_device_bit_transfer_vseq extends spi_device_base_vseq;
         write_device_words_to_send({device_data});
         `uvm_info(`gfn, $sformatf("Device Data = 0x%0h", device_data), UVM_LOW)
         cfg.clk_rst_vif.wait_clks(16);
-        cfg.m_spi_agent_cfg.partial_byte = 1;
+        cfg.spi_host_agent_cfg.partial_byte = 1;
         // Randomize number of bits to send before CSN deassert
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bits_num, bits_num > 0;)
-        cfg.m_spi_agent_cfg.bits_to_transfer = bits_num;
+        cfg.spi_host_agent_cfg.bits_to_transfer = bits_num;
         `uvm_info(`gfn, $sformatf("Bits_num = 0x%0h", bits_num), UVM_LOW)
         spi_host_xfer_byte(host_data[7:0], device_data_exp[0]);
         `uvm_info(`gfn, $sformatf("new device data 0 = 0x%0h", device_data_exp[0]), UVM_LOW)
         cfg.clk_rst_vif.wait_clks(4);
-        cfg.m_spi_agent_cfg.partial_byte = 0;
+        cfg.spi_host_agent_cfg.partial_byte = 0;
         spi_host_xfer_byte(host_data[15:8], device_data_exp[1]);
         `uvm_info(`gfn, $sformatf("new device data 1 = 0x%0h", device_data_exp[1]), UVM_LOW)
         spi_host_xfer_byte(host_data[23:16], device_data_exp[2]);
@@ -54,7 +54,7 @@ class spi_device_bit_transfer_vseq extends spi_device_base_vseq;
           `DV_CHECK_CASE_EQ(device_data,
               {device_data_exp[4],device_data_exp[3], device_data_exp[2], device_data_exp[1]})
         end else begin
-          if (cfg.m_spi_agent_cfg.device_bit_dir == 1)  begin
+          if (cfg.spi_host_agent_cfg.device_bit_dir == 1)  begin
             device_data[7] = 0;
           end else begin
             device_data[0] = 0;

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_dual_mode_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_dual_mode_vseq.sv
@@ -32,7 +32,7 @@ class spi_device_dual_mode_vseq extends spi_device_pass_base_vseq;
     /*
     repeat (num_trans) begin
 
-      addr_size = cfg.m_spi_agent_cfg.cmd_infos[READ_DUAL].addr_bytes;
+      addr_size = cfg.spi_host_agent_cfg.cmd_infos[READ_DUAL].addr_bytes;
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(read_size, read_size > 0;)
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cmd_slot, cmd_slot >= 5 && cmd_slot <= 10;)
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(pld, pld.size() == 0;)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_dummy_item_extra_dly_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_dummy_item_extra_dly_vseq.sv
@@ -20,17 +20,17 @@ class spi_device_dummy_item_extra_dly_vseq extends spi_device_txrx_vseq;
     // use more aggressive delay, but if higher than below values, timeout may happen
     randcase
       1: begin
-        cfg.m_spi_agent_cfg.max_extra_dly_ns_btw_sck    = 100;
-        cfg.m_spi_agent_cfg.extra_dly_chance_pc_btw_sck = 20;
+        cfg.spi_host_agent_cfg.max_extra_dly_ns_btw_sck    = 100;
+        cfg.spi_host_agent_cfg.extra_dly_chance_pc_btw_sck = 20;
       end
       1: begin
-        cfg.m_spi_agent_cfg.max_extra_dly_ns_btw_sck    = 50;
-        cfg.m_spi_agent_cfg.extra_dly_chance_pc_btw_sck = 50;
+        cfg.spi_host_agent_cfg.max_extra_dly_ns_btw_sck    = 50;
+        cfg.spi_host_agent_cfg.extra_dly_chance_pc_btw_sck = 50;
       end
     endcase
     // no timeout concern for delay between word
-    cfg.m_spi_agent_cfg.max_extra_dly_ns_btw_word = 10000;
-    cfg.m_spi_agent_cfg.extra_dly_chance_pc_btw_word = 20;
+    cfg.spi_host_agent_cfg.max_extra_dly_ns_btw_word = 10000;
+    cfg.spi_host_agent_cfg.extra_dly_chance_pc_btw_word = 20;
   endtask
 
 endclass : spi_device_dummy_item_extra_dly_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
@@ -18,9 +18,9 @@ class spi_device_fifo_underflow_overflow_vseq extends spi_device_txrx_vseq;
 
     allow_underflow_overflow = 1;
     // when underflow, sio may be unknown, disable checking it
-    cfg.m_spi_agent_cfg.en_monitor_checks = 0;
+    cfg.spi_host_agent_cfg.en_monitor_checks = 0;
     super.body();
-    cfg.m_spi_agent_cfg.en_monitor_checks = 1;
+    cfg.spi_host_agent_cfg.en_monitor_checks = 1;
 
     $asserton(0, "tb.dut.u_s2p.BitcountOverflow_A");
   endtask

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -90,7 +90,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     for (int i = 11; i < 24; i++) begin
       info = spi_flash_cmd_info::type_id::create("info");
       `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
-        foreach (cfg.m_spi_agent_cfg.cmd_infos[j]) {info.op_code != j;})
+        foreach (cfg.spi_host_agent_cfg.cmd_infos[j]) {info.op_code != j;})
       add_cmd_info(info, i);
     end
   endtask : config_all_cmd_infos
@@ -102,20 +102,20 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     `uvm_info(`gfn, "Initialize flash/passthrough mode", UVM_MEDIUM)
     `DV_CHECK_STD_RANDOMIZE_FATAL(use_addr_4b_enable)
     // TODO, fixed config for now
-    cfg.m_spi_agent_cfg.sck_polarity[0] = 0;
-    cfg.m_spi_agent_cfg.sck_phase[0] = 0;
+    cfg.spi_host_agent_cfg.sck_polarity[0] = 0;
+    cfg.spi_host_agent_cfg.sck_phase[0] = 0;
     cfg.spi_device_agent_cfg.sck_polarity[0] = 0;
     cfg.spi_device_agent_cfg.sck_phase[0] = 0;
 
     // bit dir is only supported in fw mode. Need to be 0 for other modes
-    cfg.m_spi_agent_cfg.host_bit_dir = 0;
-    cfg.m_spi_agent_cfg.device_bit_dir = 0;
+    cfg.spi_host_agent_cfg.host_bit_dir = 0;
+    cfg.spi_host_agent_cfg.device_bit_dir = 0;
     cfg.spi_device_agent_cfg.host_bit_dir = 0;
     cfg.spi_device_agent_cfg.device_bit_dir = 0;
 
-    cfg.m_spi_agent_cfg.num_bytes_per_trans_in_mon = 1;
+    cfg.spi_host_agent_cfg.num_bytes_per_trans_in_mon = 1;
     cfg.spi_device_agent_cfg.num_bytes_per_trans_in_mon = 1;
-    cfg.m_spi_agent_cfg.is_flash_mode = 1;
+    cfg.spi_host_agent_cfg.is_flash_mode = 1;
     cfg.spi_device_agent_cfg.is_flash_mode = 1;
     // since tx/rx order are not used in flash mode, randomize them
     `DV_CHECK_RANDOMIZE_FATAL(ral.cfg.tx_order)
@@ -177,7 +177,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
   virtual task add_cmd_info(spi_flash_cmd_info info, bit [4:0] idx);
     bit [3:0] lanes_en;
     addr_mode_e addr_size;
-    cfg.m_spi_agent_cfg.add_cmd_info(info);
+    cfg.spi_host_agent_cfg.add_cmd_info(info);
     cfg.spi_device_agent_cfg.add_cmd_info(info);
 
     `uvm_info(`gfn, $sformatf("Add this cmd_info \n%s", info.sprint()), UVM_MEDIUM)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_cmd_filtering_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_cmd_filtering_vseq.sv
@@ -14,7 +14,7 @@ class spi_device_pass_cmd_filtering_vseq extends spi_device_pass_base_vseq;
     spi_device_flash_pass_init(PassthroughMode);
 
     // cmd_infos index is the opcode, get all opcode
-    opcode_q = cfg.m_spi_agent_cfg.cmd_infos.find_index() with ('1);
+    opcode_q = cfg.spi_host_agent_cfg.cmd_infos.find_index() with ('1);
     for (int i = 0; i < num_trans; ++i) begin
       `uvm_info(`gfn, $sformatf("running iteration %0d", i), UVM_LOW)
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(op,
@@ -30,7 +30,7 @@ class spi_device_pass_cmd_filtering_vseq extends spi_device_pass_base_vseq;
         // Make sure filter is not blocking command opcode
         cfg_cmd_filter(cmd_filter, op);
         // Prepare data for transfer
-        spi_host_xfer_flash_item(op, cfg.m_spi_agent_cfg.cmd_infos[op].addr_bytes, payload_size);
+        spi_host_xfer_flash_item(op, cfg.spi_host_agent_cfg.cmd_infos[op].addr_bytes, payload_size);
       end
     end
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
@@ -21,10 +21,10 @@ class spi_device_tpm_base_vseq extends spi_device_base_vseq;
 
   // Configure clocks and tpm, generate a word.
   virtual task tpm_init();
-    cfg.m_spi_agent_cfg.sck_polarity[0] = 0;
-    cfg.m_spi_agent_cfg.sck_phase[0] = 0;
-    cfg.m_spi_agent_cfg.host_bit_dir = 1;
-    cfg.m_spi_agent_cfg.device_bit_dir = 1;
+    cfg.spi_host_agent_cfg.sck_polarity[0] = 0;
+    cfg.spi_host_agent_cfg.sck_phase[0] = 0;
+    cfg.spi_host_agent_cfg.host_bit_dir = 1;
+    cfg.spi_host_agent_cfg.device_bit_dir = 1;
     ral.cfg.tx_order.set(1);
     ral.cfg.rx_order.set(1);
     ral.cfg.cpol.set(1'b0);
@@ -37,7 +37,7 @@ class spi_device_tpm_base_vseq extends spi_device_base_vseq;
     csr_update(.csr(ral.tpm_cfg));
 
     //Csb select for TPM
-    cfg.m_spi_agent_cfg.csb_sel = 1;
+    cfg.spi_host_agent_cfg.csb_sel = 1;
 
   endtask : tpm_init
 
@@ -94,7 +94,7 @@ class spi_device_tpm_base_vseq extends spi_device_base_vseq;
         pay_num++;
       end
       if ((pay_num == 0  && device_byte_rsp == TPM_START)) pay_num++;
-      if (pay_num == 4) cfg.m_spi_agent_cfg.csb_consecutive = 0;
+      if (pay_num == 4) cfg.spi_host_agent_cfg.csb_consecutive = 0;
     end
   endtask : poll_start_collect_data
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_locality_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_locality_vseq.sv
@@ -47,7 +47,7 @@ class spi_device_tpm_locality_vseq extends spi_device_tpm_base_vseq;
       address_command = {tpm_addr, tpm_cmd};
       `uvm_info(`gfn, $sformatf("Address Command = 0x%0h", address_command), UVM_LOW)
       // send payload
-      cfg.m_spi_agent_cfg.csb_consecutive = 1;
+      cfg.spi_host_agent_cfg.csb_consecutive = 1;
       spi_host_xfer_word(address_command, device_word_rsp);
       // poll START and collect data
       poll_start_collect_data(data_bytes, returned_bytes);

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_vseq.sv
@@ -38,7 +38,7 @@ class spi_device_tpm_read_vseq extends spi_device_tpm_base_vseq;
       tpm_addr = {<<1{tpm_addr}};
       address_command = {tpm_addr, tpm_cmd};
       `uvm_info(`gfn, $sformatf("Address Command = 0x%0h", address_command), UVM_LOW)
-      cfg.m_spi_agent_cfg.csb_consecutive = 1;
+      cfg.spi_host_agent_cfg.csb_consecutive = 1;
       spi_host_xfer_word(address_command, device_word_rsp);
       fork
         begin

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_write_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_write_vseq.sv
@@ -32,7 +32,7 @@ class spi_device_tpm_write_vseq extends spi_device_tpm_base_vseq;
     address_command = {tpm_addr, tpm_cmd};
     `uvm_info(`gfn, $sformatf("Address Command = 0x%0h", address_command), UVM_LOW)
     // send payload
-    cfg.m_spi_agent_cfg.csb_consecutive = 1;
+    cfg.spi_host_agent_cfg.csb_consecutive = 1;
     spi_host_xfer_word(address_command, device_word_rsp);
     while (pay_num < 5) begin
       spi_host_xfer_byte(data_bytes[pay_num], device_byte_rsp);
@@ -40,7 +40,7 @@ class spi_device_tpm_write_vseq extends spi_device_tpm_base_vseq;
       device_byte_rsp = {<<1{device_byte_rsp}};
       if (pay_num > 0) pay_num++;
       if (pay_num == 0  && device_byte_rsp == TPM_START) pay_num++;
-      if (pay_num == 4) cfg.m_spi_agent_cfg.csb_consecutive = 0;
+      if (pay_num == 4) cfg.spi_host_agent_cfg.csb_consecutive = 0;
     end
 
     chk_fifo_contents(address_command, data_bytes);

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
@@ -105,8 +105,8 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
   }
   virtual task spi_device_init();
     super.spi_device_init();
-    cfg.m_spi_agent_cfg.en_extra_dly_btw_sck  = en_extra_dly;
-    cfg.m_spi_agent_cfg.en_extra_dly_btw_word = en_extra_dly;
+    cfg.spi_host_agent_cfg.en_extra_dly_btw_sck  = en_extra_dly;
+    cfg.spi_host_agent_cfg.en_extra_dly_btw_word = en_extra_dly;
   endtask
 
   virtual task body();

--- a/hw/ip/spi_device/dv/env/spi_device_env.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env.sv
@@ -10,7 +10,7 @@ class spi_device_env extends cip_base_env #(
     );
   `uvm_component_utils(spi_device_env)
 
-  spi_agent m_spi_agent;
+  spi_agent spi_host_agent;
   spi_agent spi_device_agent;
 
   `uvm_component_new
@@ -18,26 +18,26 @@ class spi_device_env extends cip_base_env #(
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     // build child components
-    m_spi_agent = spi_agent::type_id::create("m_spi_agent", this);
+    spi_host_agent = spi_agent::type_id::create("spi_host_agent", this);
     spi_device_agent = spi_agent::type_id::create("spi_device_agent", this);
-    uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent", "cfg", cfg.m_spi_agent_cfg);
+    uvm_config_db#(spi_agent_cfg)::set(this, "spi_host_agent", "cfg", cfg.spi_host_agent_cfg);
     uvm_config_db#(spi_agent_cfg)::set(this, "spi_device_agent", "cfg", cfg.spi_device_agent_cfg);
-    cfg.m_spi_agent_cfg.en_cov = cfg.en_cov;
+    cfg.spi_host_agent_cfg.en_cov = cfg.en_cov;
     cfg.spi_device_agent_cfg.en_cov = cfg.en_cov;
   endfunction
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
     if (cfg.en_scb) begin
-      m_spi_agent.monitor.host_analysis_port.connect(
-          scoreboard.host_spi_data_fifo.analysis_export);
-      m_spi_agent.monitor.device_analysis_port.connect(
-          scoreboard.device_spi_data_fifo.analysis_export);
+      spi_host_agent.monitor.host_analysis_port.connect(
+          scoreboard.upstream_spi_host_fifo.analysis_export);
+      spi_host_agent.monitor.device_analysis_port.connect(
+          scoreboard.upstream_spi_device_fifo.analysis_export);
       spi_device_agent.monitor.host_analysis_port.connect(
-          scoreboard.pass_spi_data_fifo.analysis_export);
+          scoreboard.downstream_spi_host_fifo.analysis_export);
     end
-    if (cfg.m_spi_agent_cfg.is_active) begin
-      virtual_sequencer.spi_sequencer_h = m_spi_agent.sequencer;
+    if (cfg.spi_host_agent_cfg.is_active) begin
+      virtual_sequencer.spi_sequencer_h = spi_host_agent.sequencer;
     end
     virtual_sequencer.spi_sequencer_d = spi_device_agent.sequencer;
   endfunction

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block));
-  rand spi_agent_cfg  m_spi_agent_cfg;
+  rand spi_agent_cfg  spi_host_agent_cfg;
   rand spi_agent_cfg  spi_device_agent_cfg;
   bit [TL_AW-1:0]     sram_start_addr;
   bit [TL_AW-1:0]     sram_end_addr;
 
   `uvm_object_utils_begin(spi_device_env_cfg)
-    `uvm_field_object(m_spi_agent_cfg, UVM_DEFAULT)
+    `uvm_field_object(spi_host_agent_cfg, UVM_DEFAULT)
     `uvm_field_object(spi_device_agent_cfg, UVM_DEFAULT)
   `uvm_object_utils_end
 
@@ -19,7 +19,7 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
     list_of_alerts = spi_device_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
     // create spi agent config obj
-    m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");
+    spi_host_agent_cfg = spi_agent_cfg::type_id::create("spi_host_agent_cfg");
     spi_device_agent_cfg = spi_agent_cfg::type_id::create("spi_device_agent_cfg");
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -137,7 +137,7 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
-    uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_if);
+    uvm_config_db#(virtual spi_if)::set(null, "*.env.spi_host_agent*", "vif", spi_if);
     uvm_config_db#(virtual spi_if)::set(null, "*.env.spi_device*", "vif", spi_if_pass);
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
+++ b/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
@@ -12,7 +12,7 @@ class spi_device_base_test extends cip_base_test #(.ENV_T(spi_device_env),
     test_timeout_ns = 1500_000_000; // 1.5s
     super.build_phase(phase);
     // configure the spi agent to be in Host mode
-    cfg.m_spi_agent_cfg.if_mode = Host;
+    cfg.spi_host_agent_cfg.if_mode = Host;
     // configure passthrough agent to be in Device mode
     cfg.spi_device_agent_cfg.if_mode = Device;
     cfg.spi_device_agent_cfg.has_req_fifo = 1'b1;


### PR DESCRIPTION
no functional update, just rename as follows, in order to avoid confusion
1. m_spi_agent -> spi_host_agent
2. in scb, add downstream/upstream prefix for spi variables/functions

Signed-off-by: Weicai Yang <weicai@google.com>