### PR TITLE
[top/dv] Add lc_ctrl_program_error test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2383,13 +2383,12 @@
       name: chip_sw_otp_ctrl_program_error
       desc: '''Verify the otp program error.
 
-            - Initiate an illegal program request from LC ctrl to OTP ctrl (example: issue program
-            request when the lc_cnt is at max value).
+            - Initiate an illegal program request from LC ctrl to OTP ctrl.
             - Verify that the LC ctrl triggers an alert when the OTP ctrl responds back with a
               program error.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_lc_ctrl_program_error"]
     }
     {
       name: chip_sw_otp_ctrl_hw_cfg

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -987,6 +987,13 @@
       run_opts: ["+calibrate_usb_clk=1"]
     }
     {
+      name: chip_sw_lc_ctrl_program_error
+      uvm_test_seq: chip_sw_lc_ctrl_program_error_vseq
+      sw_images: ["sw/device/tests/sim_dv/lc_ctrl_program_error:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
+    }
+    {
       name: chip_sw_pwrmgr_normal_sleep_all_wake_ups
       uvm_test_seq: "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq"
       sw_images: ["sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_wake_ups:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -66,6 +66,7 @@ filesets:
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -117,9 +117,14 @@ package chip_env_pkg;
   } chip_tap_type_e;
 
   // Two status for LC JTAG to identify if LC state transition is successful.
-  typedef enum {
+  typedef enum int {
     LcReady,
-    LcTransitionSuccessful
+    LcTransitionSuccessful,
+    LcTransitionCntError,
+    LcTransitionError,
+    LcTokenError,
+    LcFlashRmaError,
+    LcOtpError
   } lc_ctrl_status_e;
 
   // enumeration for lc_ctrl broadcasts

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_lc_ctrl_program_error_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_lc_ctrl_program_error_vseq)
+
+  `uvm_object_new
+
+  // Reassign `select_jtag` variable to drive LC JTAG tap at start,
+  // because LC_CTRL's TestLock state can only sample strap once at boot.
+  virtual task pre_start();
+    select_jtag = SelectLCJtagTap;
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    bit [TL_DW-1:0] status_val;
+    string otp_path = {`DV_STRINGIFY(`OTP_CTRL_HIER),
+                       ".u_otp_ctrl_lci.lc_err_o"};
+
+    super.body();
+
+    // Wait for C side to fully stabilize
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Begin life cycle transition");,
+             "timeout waiting for C side acknowledgement",
+             cfg.sw_test_timeout_ns)
+
+    // force lc_ctrl program path to error
+    `DV_CHECK_FATAL(uvm_hdl_force(otp_path, 1'b1));
+
+    // poll for state to transition to post transition state
+    jtag_csr_spinwait(ral.lc_ctrl.lc_state.get_offset(),
+      p_sequencer.jtag_sequencer_h,
+      {DecLcStateNumRep{DecLcStEscalate}},
+      cfg.sw_test_timeout_ns);
+
+    `uvm_info(`gfn, $sformatf("post trans observed"), UVM_LOW)
+
+    // check to ensure that we see an otp error
+    jtag_read_csr(ral.lc_ctrl.status.get_offset(),
+      p_sequencer.jtag_sequencer_h,
+      status_val);
+
+    `DV_CHECK_FATAL(status_val & (1 << LcOtpError));
+  endtask
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -45,3 +45,4 @@
 `include "chip_sw_rstmgr_alert_info_vseq.sv"
 `include "chip_rv_dm_ndm_reset_vseq.sv"
 `include "chip_sw_alert_handler_escalation_vseq.sv"
+`include "chip_sw_lc_ctrl_program_error_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -710,3 +710,24 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "lc_ctrl_program_error",
+    srcs = ["lc_ctrl_program_error.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/sim_dv/lc_ctrl_program_error.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_program_error.c
@@ -1,0 +1,103 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/lc_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/*
+ TO BE FILLED IN
+ */
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_alert_handler_t alert_handler;
+static dif_lc_ctrl_t lc_ctrl;
+static dif_rstmgr_t rstmgr;
+
+static const dif_alert_handler_escalation_phase_t kEscProfiles[] = {
+    // TODO:
+    // this duration must be long enough to
+    // accommodate a few jtag transactions
+    // how can this be done in a non-hardcoded way?
+    {.phase = kDifAlertHandlerClassStatePhase0,
+     .signal = 1,
+     .duration_cycles = 10000},
+    {.phase = kDifAlertHandlerClassStatePhase1,
+     .signal = 3,
+     .duration_cycles = 10000}};
+
+static const dif_alert_handler_class_config_t kConfigProfiles[] = {{
+    .auto_lock_accumulation_counter = kDifToggleDisabled,
+    .accumulator_threshold = 0,
+    .irq_deadline_cycles = 0,
+    .escalation_phases = kEscProfiles,
+    .escalation_phases_len = 2,
+    .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase0,
+}};
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_lc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc_ctrl));
+
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  CHECK_DIF_OK(dif_alert_handler_init(
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
+      &alert_handler));
+
+  // Check if there was a HW reset caused by the escalation.
+  dif_rstmgr_reset_info_bitfield_t rst_info;
+  CHECK_DIF_OK(dif_rstmgr_reset_info_get(&rstmgr, &rst_info));
+  CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+
+  if (rst_info & kDifRstmgrResetInfoPor) {
+    // set the alert we care about to class A
+    CHECK_DIF_OK(dif_alert_handler_configure_alert(
+        &alert_handler, kTopEarlgreyAlertIdLcCtrlFatalProgError,
+        kDifAlertHandlerClassA, /*enabled=*/kDifToggleEnabled,
+        /*locked=*/kDifToggleEnabled));
+
+    // configurate class A
+    CHECK_DIF_OK(dif_alert_handler_configure_class(
+        &alert_handler, kDifAlertHandlerClassA, kConfigProfiles[0],
+        /*enabled=*/kDifToggleEnabled,
+        /*locked=*/kDifToggleEnabled));
+
+    // Initiate transition into scrap
+    dif_lc_ctrl_token_t zero_token = {0, 0, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 0};
+
+    // DV sync message
+    LOG_INFO("Begin life cycle transition");
+
+    // Mutex acquire should always succeed, there are no competing agents
+    CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc_ctrl));
+    CHECK_DIF_OK(dif_lc_ctrl_configure(&lc_ctrl, kDifLcCtrlStateScrap, false,
+                                       &zero_token));
+    CHECK_DIF_OK(dif_lc_ctrl_transition(&lc_ctrl));
+
+    // halt execution
+    wait_for_interrupt();
+
+  } else if (rst_info & kDifRstmgrResetInfoEscalation) {
+    LOG_INFO("Reset due to alert escalation");
+    return true;
+  } else {
+    LOG_FATAL("unexpected reset info %d", rst_info);
+  }
+
+  return false;
+}


### PR DESCRIPTION
- force otp to respond with an error during lc transition
- check that an error is seen on the life cycle interface and
  that an alert is triggered.

Signed-off-by: Timothy Chen <timothytim@google.com>