### PR TITLE
[dv/kmac] Allow randomly write sideload and key_len in keymgr_app_intf

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -185,7 +185,7 @@ package kmac_env_pkg;
       Key256: return 32;
       Key384: return 48;
       Key512: return 64;
-      default: `uvm_fatal("kmac_env_pkg", $sformatf("%0s is an invalid key length", len.name()))
+      default: `uvm_fatal("kmac_env_pkg", $sformatf("%0d is an invalid key length", len))
     endcase
   endfunction
 

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -112,7 +112,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
 
       `DV_CHECK_RANDOMIZE_FATAL(this)
 
-      kmac_init();
+      kmac_init(.keymgr_app_intf(en_app && (app_mode == AppKeymgr)));
       `uvm_info(`gfn, "kmac_init done", UVM_HIGH)
 
       if (cfg.enable_masking && kmac_err_type == kmac_pkg::ErrWaitTimerExpired &&


### PR DESCRIPTION
In issue #13606, keymgr_app_intf request always uses sideload keys
regardless of the cfg_shadowed register settings.
This PR relaxes the sequence to allow this to happen.

Next PR will work on collecting coverage of random settings when
keymgr_app_intf request is completed.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>