### PR TITLE
[dif/entropy_src] implement locking/enable DIFs and locked checks

### DIFF
--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -22,6 +22,11 @@ dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
     return kDifBadArg;
   }
 
+  if (!mmio_region_read32(entropy_src->base_addr,
+                          ENTROPY_SRC_REGWEN_REG_OFFSET)) {
+    return kDifLocked;
+  }
+
   // ENTROPY_CONTROL register configuration.
 
   // Conditioning bypass is hardcoded to disabled. Conditioning bypass is not
@@ -107,6 +112,11 @@ dif_result_t dif_entropy_src_fw_override_configure(
     return kDifBadArg;
   }
 
+  if (!mmio_region_read32(entropy_src->base_addr,
+                          ENTROPY_SRC_REGWEN_REG_OFFSET)) {
+    return kDifLocked;
+  }
+
   mmio_region_write32(entropy_src->base_addr,
                       ENTROPY_SRC_OBSERVE_FIFO_THRESH_REG_OFFSET,
                       config.buffer_threshold);
@@ -128,6 +138,11 @@ dif_result_t dif_entropy_src_health_test_configure(
     dif_entropy_src_health_test_config_t config) {
   if (entropy_src == NULL) {
     return kDifBadArg;
+  }
+
+  if (!mmio_region_read32(entropy_src->base_addr,
+                          ENTROPY_SRC_REGWEN_REG_OFFSET)) {
+    return kDifLocked;
   }
 
   ptrdiff_t high_thresholds_reg_offset = -1;

--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -182,6 +182,24 @@ dif_result_t dif_entropy_src_health_test_configure(
   return kDifOk;
 }
 
+dif_result_t dif_entropy_src_set_enabled(const dif_entropy_src_t *entropy_src,
+                                         dif_toggle_t enabled) {
+  if (entropy_src == NULL || !dif_is_valid_toggle(enabled)) {
+    return kDifBadArg;
+  }
+
+  if (!mmio_region_read32(entropy_src->base_addr,
+                          ENTROPY_SRC_ME_REGWEN_REG_OFFSET)) {
+    return kDifLocked;
+  }
+
+  mmio_region_write32(entropy_src->base_addr,
+                      ENTROPY_SRC_MODULE_ENABLE_REG_OFFSET,
+                      dif_toggle_to_multi_bit_bool4(enabled));
+
+  return kDifOk;
+}
+
 dif_result_t dif_entropy_src_get_health_test_stats(
     const dif_entropy_src_t *entropy_src,
     dif_entropy_src_health_test_stats_t *stats) {
@@ -443,19 +461,6 @@ dif_result_t dif_entropy_src_conditioner_end(
   mmio_region_write32(entropy_src->base_addr,
                       ENTROPY_SRC_FW_OV_SHA3_START_REG_OFFSET,
                       kMultiBitBool4False);
-  return kDifOk;
-}
-
-dif_result_t dif_entropy_src_disable(const dif_entropy_src_t *entropy_src) {
-  if (entropy_src == NULL) {
-    return kDifBadArg;
-  }
-
-  // TODO: should first check if entropy is locked and return error if it is.
-  mmio_region_write32(entropy_src->base_addr,
-                      ENTROPY_SRC_MODULE_ENABLE_REG_OFFSET,
-                      kMultiBitBool4False);
-
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -277,9 +277,10 @@ typedef struct dif_entropy_src_alert_fail_counts {
  * @param enabled The enablement state of the entropy source.
  * @return The result of the operation.
  */
-OT_WARN_UNUSED_RESULT dif_result_t dif_entropy_src_configure(
-    const dif_entropy_src_t *entropy_src, dif_entropy_src_config_t config,
-    dif_toggle_t enabled);
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
+                                       dif_entropy_src_config_t config,
+                                       dif_toggle_t enabled);
 
 /**
  * Configures entropy source firmware override feature with runtime information.
@@ -311,6 +312,17 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_entropy_src_health_test_configure(
     const dif_entropy_src_t *entropy_src,
     dif_entropy_src_health_test_config_t config);
+
+/**
+ * Enables/Disables the entropy source.
+ *
+ * @param entropy_src An entropy source handle.
+ * @param enabled The enablement state to configure the entropy source in.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_set_enabled(const dif_entropy_src_t *entropy_src,
+                                         dif_toggle_t enabled);
 
 /**
  * Queries the entropy source IP for its revision information.
@@ -454,15 +466,6 @@ dif_result_t dif_entropy_src_conditioner_start(
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_entropy_src_conditioner_end(
     const dif_entropy_src_t *entropy_src);
-
-/**
- * Disables the entropy module
- *
- * @param entropy_src An entropy source handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_disable(const dif_entropy_src_t *entropy_src);
 
 /**
  * Get main entropy fsm idle status

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -325,6 +325,29 @@ dif_result_t dif_entropy_src_set_enabled(const dif_entropy_src_t *entropy_src,
                                          dif_toggle_t enabled);
 
 /**
+ * Locks out entropy source functionality.
+ *
+ * This function is reentrant: calling it while functionality is locked will
+ * have no effect and return `kDifEntropySrcOk`.
+ *
+ * @param entropy An entropy source handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_lock(const dif_entropy_src_t *entropy_src);
+
+/**
+ * Checks whether this entropy source is locked.
+ *
+ * @param entropy An entropy source handle.
+ * @param[out] is_locked Out-param for the locked state.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_is_locked(const dif_entropy_src_t *entropy_src,
+                                       bool *is_locked);
+
+/**
  * Queries the entropy source IP for its revision information.
  *
  * @param entropy An entropy source handle.
@@ -358,29 +381,6 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_entropy_src_get_alert_fail_counts(
     const dif_entropy_src_t *entropy_src,
     dif_entropy_src_alert_fail_counts_t *counts);
-
-/**
- * Locks out entropy source functionality.
- *
- * This function is reentrant: calling it while functionality is locked will
- * have no effect and return `kDifEntropySrcOk`.
- *
- * @param entropy An entropy source handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_lock(const dif_entropy_src_t *entropy_src);
-
-/**
- * Checks whether this entropy source is locked.
- *
- * @param entropy An entropy source handle.
- * @param[out] is_locked Out-param for the locked state.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_is_locked(const dif_entropy_src_t *entropy_src,
-                                       bool *is_locked);
 
 /**
  * Checks to see if entropy is available for software consumption

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -225,6 +225,35 @@ TEST_F(HealthTestConfigTest, SuccessTwoThresholds) {
   EXPECT_DIF_OK(dif_entropy_src_health_test_configure(&entropy_src_, config_));
 }
 
+class SetEnabledTest : public EntropySrcTest {};
+
+TEST_F(SetEnabledTest, NullHandle) {
+  EXPECT_DIF_BADARG(dif_entropy_src_set_enabled(nullptr, kDifToggleEnabled));
+}
+
+TEST_F(SetEnabledTest, BadToggle) {
+  EXPECT_DIF_BADARG(
+      dif_entropy_src_set_enabled(nullptr, static_cast<dif_toggle_t>(1)));
+}
+
+TEST_F(SetEnabledTest, Locked) {
+  EXPECT_READ32(ENTROPY_SRC_ME_REGWEN_REG_OFFSET, 0);
+  EXPECT_EQ(dif_entropy_src_set_enabled(&entropy_src_, kDifToggleEnabled),
+            kDifLocked);
+}
+
+TEST_F(SetEnabledTest, Success) {
+  // Enable.
+  EXPECT_READ32(ENTROPY_SRC_ME_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32(ENTROPY_SRC_MODULE_ENABLE_REG_OFFSET, kMultiBitBool4True);
+  EXPECT_DIF_OK(dif_entropy_src_set_enabled(&entropy_src_, kDifToggleEnabled));
+
+  // Disable.
+  EXPECT_READ32(ENTROPY_SRC_ME_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32(ENTROPY_SRC_MODULE_ENABLE_REG_OFFSET, kMultiBitBool4False);
+  EXPECT_DIF_OK(dif_entropy_src_set_enabled(&entropy_src_, kDifToggleDisabled));
+}
+
 class HealthTestStatsGetTest : public EntropySrcTest {};
 
 TEST_F(HealthTestStatsGetTest, NullArgs) {

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -16,7 +16,7 @@ static void setup_entropy_src(void) {
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
 
   // Disable entropy for test purpose, as it has been turned on by ROM
-  CHECK_DIF_OK(dif_entropy_src_disable(&entropy_src));
+  CHECK_DIF_OK(dif_entropy_src_set_enabled(&entropy_src, kDifToggleDisabled));
 
   const dif_entropy_src_config_t config = {
       .fips_enable = true,

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -190,7 +190,7 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
     dif_entropy_src_t entropy;
     OT_DISCARD(dif_entropy_src_init(
         mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy));
-    OT_DISCARD(dif_entropy_src_disable(&entropy));
+    OT_DISCARD(dif_entropy_src_set_enabled(&entropy, kDifToggleDisabled));
   }
 #endif
 

--- a/sw/device/tests/entropy_src_ast_rng_req_test.c
+++ b/sw/device/tests/entropy_src_ast_rng_req_test.c
@@ -33,7 +33,7 @@ bool test_main() {
   CHECK_DIF_OK(dif_entropy_src_init(
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
 
-  CHECK_DIF_OK(dif_entropy_src_disable(&entropy_src));
+  CHECK_DIF_OK(dif_entropy_src_set_enabled(&entropy_src, kDifToggleDisabled));
 
   const dif_entropy_src_fw_override_config_t fw_override_config = {
       .entropy_insert_enable = true,

--- a/sw/device/tests/entropy_src_fw_ovr_test.c
+++ b/sw/device/tests/entropy_src_fw_ovr_test.c
@@ -58,6 +58,12 @@ static void entropy_data_flush(dif_entropy_src_t *entropy_src) {
  * @param entropy An entropy source instance.
  */
 static void entropy_with_fw_override_enable(dif_entropy_src_t *entropy_src) {
+  const dif_entropy_src_fw_override_config_t fw_override_config = {
+      .entropy_insert_enable = true,
+      .buffer_threshold = kEntropyFifoBufferSize,
+  };
+  CHECK_DIF_OK(dif_entropy_src_fw_override_configure(
+      entropy_src, fw_override_config, kDifToggleEnabled));
   const dif_entropy_src_config_t config = {
       .fips_enable = true,
       .route_to_firmware = true,
@@ -65,12 +71,6 @@ static void entropy_with_fw_override_enable(dif_entropy_src_t *entropy_src) {
   };
   CHECK_DIF_OK(
       dif_entropy_src_configure(entropy_src, config, kDifToggleEnabled));
-  const dif_entropy_src_fw_override_config_t fw_override_config = {
-      .entropy_insert_enable = true,
-      .buffer_threshold = kEntropyFifoBufferSize,
-  };
-  CHECK_DIF_OK(dif_entropy_src_fw_override_configure(
-      entropy_src, fw_override_config, kDifToggleEnabled));
 }
 
 /**
@@ -84,7 +84,7 @@ static void entropy_with_fw_override_enable(dif_entropy_src_t *entropy_src) {
  * @param entropy An Entropy handle.
  */
 void test_firmware_override(dif_entropy_src_t *entropy) {
-  CHECK_DIF_OK(dif_entropy_src_disable(entropy));
+  CHECK_DIF_OK(dif_entropy_src_set_enabled(entropy, kDifToggleDisabled));
   entropy_with_fw_override_enable(entropy);
   entropy_data_flush(entropy);
 

--- a/sw/device/tests/entropy_src_kat_test.c
+++ b/sw/device/tests/entropy_src_kat_test.c
@@ -48,7 +48,7 @@ static void entropy_with_fw_override_enable(dif_entropy_src_t *entropy_src) {
 }
 
 /**
- * Runds known answer test for the entropy_src SHA-3 conditioner.
+ * Runs known answer test for the entropy_src SHA-3 conditioner.
  *
  * This test uses the following SHA3 CAVP test vector:
  *
@@ -59,7 +59,7 @@ static void entropy_with_fw_override_enable(dif_entropy_src_t *entropy_src) {
  * https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/secure-hashing
  */
 void test_sha384_kat(dif_entropy_src_t *entropy) {
-  CHECK_DIF_OK(dif_entropy_src_disable(entropy));
+  CHECK_DIF_OK(dif_entropy_src_set_enabled(entropy, kDifToggleDisabled));
   entropy_with_fw_override_enable(entropy);
   CHECK_DIF_OK(dif_entropy_src_conditioner_start(entropy));
 

--- a/sw/device/tests/entropy_src_smoketest.c
+++ b/sw/device/tests/entropy_src_smoketest.c
@@ -32,7 +32,7 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
 
   // Disable entropy for test purpose, as it has been turned on by ROM
-  CHECK_DIF_OK(dif_entropy_src_disable(&entropy_src));
+  CHECK_DIF_OK(dif_entropy_src_set_enabled(&entropy_src, kDifToggleDisabled));
 
   const dif_entropy_src_config_t config = {
       .fips_enable = true,


### PR DESCRIPTION
This PR contains three commits that adds the following features (and corresponding unit tests): 
1. implement a DIF that enables the entropy_src module (to match the disable DIF)
2. implements REGWEN checks across all configuration DIFs to let the user know when the IP's configurability has been locked
3. implement the locking DIFs

**_Note: this depends on #13637_**