### PR TITLE
Test rom reset reason reg with difs

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -789,17 +789,21 @@ cc_test(
 )
 
 cc_library(
+    name = "rstmgr_intf",
+    srcs = ["autogen/dif_rstmgr_autogen.h"],
+    hdrs = ["dif_rstmgr.h"],
+    deps = [":base"],
+)
+
+cc_library(
     name = "rstmgr",
     srcs = [
         "autogen/dif_rstmgr_autogen.c",
-        "autogen/dif_rstmgr_autogen.h",
         "dif_rstmgr.c",
-    ],
-    hdrs = [
-        "dif_rstmgr.h",
     ],
     deps = [
         ":base",
+        ":rstmgr_intf",
         "//hw/top_earlgrey/ip/rstmgr/data/autogen:rstmgr_regs",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:macros",

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -31,9 +31,9 @@ opentitan_rom_binary(
 )
 
 # TODO(#12905): Use a slightly hollowed out version of the silicon_creator bootstrap
-# implemention when building the test_rom for the english breakfast top level.
+# and other functions necessary to build the test_rom for the english breakfast top level.
 cc_library(
-    name = "english_breakfast_test_rom_bootstrap",
+    name = "english_breakfast_test_rom_lib",
     srcs = [
         "english_breakfast_fake_driver_funcs.c",
         "//sw/device/silicon_creator/lib/drivers:english_breakfast_test_rom_driver_srcs",
@@ -49,15 +49,24 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:multibits",
+        "//sw/device/lib/dif:rstmgr_intf",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
     ],
 )
 
+cc_library(
+    name = "earl_grey_test_rom_lib",
+    deps = [
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/silicon_creator/mask_rom:bootstrap",
+    ],
+)
+
 alias(
-    name = "test_rom_bootstrap",
+    name = "target_test_rom_lib",
     actual = select({
-        "//sw/device:is_english_breakfast": ":english_breakfast_test_rom_bootstrap",
-        "//conditions:default": "//sw/device/silicon_creator/mask_rom:bootstrap",
+        "//sw/device:is_english_breakfast": ":english_breakfast_test_rom_lib",
+        "//conditions:default": ":earl_grey_test_rom_lib",
     }),
     visibility = ["//visibility:private"],
 )
@@ -106,7 +115,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":chip_info",
-        ":test_rom_bootstrap",
+        ":target_test_rom_lib",
         ":test_rom_manifest",
         "//hw/ip/clkmgr/data:clkmgr_regs",
         "//hw/ip/csrng/data:csrng_regs",

--- a/sw/device/lib/testing/test_rom/english_breakfast_fake_driver_funcs.c
+++ b/sw/device/lib/testing/test_rom/english_breakfast_fake_driver_funcs.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
@@ -23,9 +24,19 @@ void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev) {
 
 uint32_t otp_read32(uint32_t address) { return kHardenedBoolTrue; }
 
-uint32_t rstmgr_reason_get(void) { return 1 << kRstmgrReasonPowerOn; }
+dif_result_t dif_rstmgr_init(mmio_region_t base_addr, dif_rstmgr_t *rstmgr) {
+  return kDifOk;
+}
 
-void rstmgr_reason_clear(uint32_t reasons) {}
+dif_result_t dif_rstmgr_reset_info_get(const dif_rstmgr_t *handle,
+                                       dif_rstmgr_reset_info_bitfield_t *info) {
+  *info = 1 << kRstmgrReasonPowerOn;
+  return kDifOk;
+}
+
+dif_result_t dif_rstmgr_reset_info_clear(const dif_rstmgr_t *handle) {
+  return kDifOk;
+}
 
 void rstmgr_reset(void) {
   while (true) {


### PR DESCRIPTION
This is a followup to [test rom] move RESET_INFO to reset_reason #13536

That uses the rstmgr dif instead of the driver in the test_rom. Doing so complicates the source but should result in simpler, faster tests.

I could either make the commit here in it's entirety or refactor this as a followup PR or drop this PR entirely.