### PR TITLE
[csrng/dv] Add deposit to force states when disabled

### DIFF
--- a/hw/dv/tools/xcelium/common.ccf
+++ b/hw/dv/tools/xcelium/common.ccf
@@ -29,7 +29,6 @@ set_branch_scoring
 // Scores statements within a block.
 set_statement_scoring
 
-
 // Enables Toggle scoring and reporting of SystemVerilog enumerations and multidimensional static
 // arrays , vectors, packed union, modport and generate blocks.
 set_toggle_scoring -sv_enum enable_mda -sv_struct_with_enum -sv_modport -sv_mda 16 -sv_mda_of_struct -sv_generate -sv_packed_union

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -24,13 +24,14 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
 
   // Knobs & Weights
   uint   otp_en_cs_sw_app_read_pct, lc_hw_debug_en_pct, regwen_pct,
-         enable_pct, sw_app_enable_pct, read_int_state_pct,
+         enable_pct, sw_app_enable_pct, read_int_state_pct, force_state_pct,
          check_int_state_pct, num_cmds_min, num_cmds_max, aes_halt_pct,
          min_aes_halt_clks, max_aes_halt_clks;
 
   bit    use_invalid_mubi;
 
-  rand bit       check_int_state, regwen, hw_app[NUM_HW_APPS], sw_app, aes_halt;
+  rand bit       check_int_state, regwen, hw_app[NUM_HW_APPS],
+                 sw_app, aes_halt, force_state;
   rand mubi4_t   enable, sw_app_enable, read_int_state;
   rand lc_tx_t   lc_hw_debug_en;
   rand mubi8_t   otp_en_cs_sw_app_read;
@@ -86,6 +87,10 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   constraint aes_halt_c { aes_halt dist {
                           1 :/ aes_halt_pct,
                           0 :/ (100 - aes_halt_pct) };}
+
+  constraint force_state_c { force_state dist {
+                             1 :/ force_state_pct,
+                             0 :/ (100 - force_state_pct) };}
 
   // Functions
   function void post_randomize();
@@ -208,6 +213,8 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
            regwen)};
     str = {str,  $sformatf("\n\t |***** check_int_state           : %10d *****| \t",
            check_int_state)};
+    str = {str,  $sformatf("\n\t |***** force_state               : %10d *****| \t",
+           force_state)};
     str = {str,  $sformatf("\n\t |---------------- knobs ---------------------------| \t")};
     str = {str,  $sformatf("\n\t |***** otp_en_cs_sw_app_read_pct : %10d *****| \t",
            otp_en_cs_sw_app_read_pct) };
@@ -223,6 +230,8 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
            regwen_pct)};
     str = {str,  $sformatf("\n\t |***** check_int_state_pct       : %10d *****| \t",
            check_int_state_pct)};
+    str = {str,  $sformatf("\n\t |***** force_state_pct           : %10d *****| \t",
+           force_state_pct)};
     str = {str,  $sformatf("\n\t |***** num_cmds_min              : %10d *****| \t",
            num_cmds_min)};
     str = {str,  $sformatf("\n\t |***** num_cmds_max              : %10d *****| \t",

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -45,6 +45,15 @@ class csrng_base_vseq extends cip_base_vseq #(
 
   // setup basic csrng features
   virtual task csrng_init();
+    state_e   state;
+    string    path;
+
+    // Force into random state while disabled
+    if (cfg.force_state) begin
+      path = "tb.dut.u_csrng_core.u_csrng_main_sm.state_d";
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(state, !(state inside { Error });)
+      `DV_CHECK(uvm_hdl_deposit(path, state));
+    end
 
     // In cases where we are testing alert scenarios using invalid register configurations
     // we must first disable the DUT assertions to allow the environment to catch the alerts

--- a/hw/ip/csrng/dv/tests/csrng_cmds_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_cmds_test.sv
@@ -15,6 +15,7 @@ class csrng_cmds_test extends csrng_base_test;
     cfg.aes_halt_pct      = 80;
     cfg.min_aes_halt_clks = 400;
     cfg.max_aes_halt_clks = 600;
+    cfg.force_state_pct   = 100;
 
     for (int i = 0; i < NUM_HW_APPS; i++) begin
       cfg.m_edn_agent_cfg[i].min_genbits_rdy_dly = 0;

--- a/hw/ip/csrng/dv/tests/csrng_smoke_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_smoke_test.sv
@@ -10,7 +10,8 @@ class csrng_smoke_test extends csrng_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.use_invalid_mubi          = 0;
+    cfg.use_invalid_mubi = 0;
+    cfg.force_state_pct  = 100;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -190,7 +190,7 @@ module csrng_core import csrng_pkg::*; #(
   logic                   cmd_stage_sm_err_sum;
   logic                   main_sm_err_sum;
   logic                   cs_main_sm_err;
-  logic [7:0]             cs_main_sm_state;
+  logic [StateWidth-1:0]  cs_main_sm_state;
   logic                   drbg_gen_sm_err_sum;
   logic                   drbg_gen_sm_err;
   logic                   drbg_updbe_sm_err_sum;
@@ -1056,7 +1056,7 @@ module csrng_core import csrng_pkg::*; #(
   // sm to process all instantiation requests
   // SEC_CM: MAIN_SM.CTR.LOCAL_ESC
   // SEC_CM: MAIN_SM.FSM.SPARSE
-  csrng_main_sm u_csrng_main_sm (
+  csrng_main_sm#(StateWidth) u_csrng_main_sm (
     .clk_i                  (clk_i),
     .rst_ni                 (rst_ni),
     .enable_i               (cs_enable_fo[36]),


### PR DESCRIPTION
Coverage Modifications:

Add deposit to force random states before enabling csrng
Moved state_e typedef from csrng_main_sm to csrng_pkg so dv can use it also
Removed "set_fsm_reset_scoring" from common.ccf since sm is a primitive

Signed-off-by: Steve Nelson <steve.nelson@wdc.com>