### PR TITLE
[build] Add dependent data files to generate an otp image.

### DIFF
--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -24,6 +24,10 @@ py_binary(
     name = "gen-otp-img",
     srcs = ["gen-otp-img.py"],
     imports = ["."],
+    data = [
+        "//hw/ip/lc_ctrl/data:all_files",
+        "//hw/ip/otp_ctrl/data:all_files",
+    ],
     deps = [
         "//util/design/lib:common",
         "//util/design/lib:otp_mem_img",


### PR DESCRIPTION
Command to generate an otp image is broken.
`bazel run //util/design:gen-otp-img`

After adding the dependent data files, an opt image could be generated.
```find `bazel info bazel-genfiles` -name "otp-img*vmem"```