### PR TITLE
[flash_ctrl,dv] single bit error test

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -283,11 +283,44 @@
             bit should be fixed. Corrupt randomly either the data or the ECC bits. Randomly corrupt
             2 bits in the same word and ensure that the read results in error. Ensure that pages
             with ECC not enabled reads back corrupted data without any errors. Verify both types,
-            pre-scramble ECC(integrity ESS, 4-bits) and post-scramble ECC(reliability ECC, 8-bits).
+            pre-scramble ECC(integrity ECC, 4-bits) and post-scramble ECC(reliability ECC, 8-bits).
 	    Test status and control ECC bits.
             '''
       milestone: V2
       tests: []
+    }
+    {
+      name: single_bit_err
+      desc: '''
+            Run read only or read write test with randomly injected single bit error.
+            All single bit error should be corrected and all read data should be
+            matched with expected written value.
+            '''
+      milestone: V2
+      tests: ["flash_ctrl_read_word_sweep_serr", "flash_ctrl_read_rand_word_serr",
+              "flash_ctrl_ro_serr", "flash_ctrl_rw_serr", "flash_ctrl_rw_rand_word_serr"]
+    }
+    {
+      name: singlebit_err_counter
+      desc: '''
+            Run read / write test and inject single bit error randomly for read transactions. -
+            both direct and controller read - Adjust error injection ratio s.t. counter is not
+            saturated.
+            Compare counter values for both bank with expected counter values.
+            '''
+      milestone: V2
+      tests: ["flash_ctrl_serr_counter"]
+    }
+    {
+      name: singlebit_err_address
+      desc: '''
+            Run read / write test and inject a single bit error randomly either direct
+            or controller read. Once error is injected a certain transaction, wait for the
+            transaction to be completed and compare ecc_single_err_addr register with the
+            expected value. Do this for multiple rounds for both banks.
+            '''
+      milestone: V2
+      tests: ["flash_ctrl_serr_address"]
     }
     {
       name: scramble

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -63,6 +63,8 @@ filesets:
       - seq_lib/flash_ctrl_read_word_sweep_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_read_rnd_wd_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_serr_counter_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_serr_address_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -69,6 +69,8 @@ class flash_ctrl_env #(
                 m_otf_scb.eg_exp_host_fifo[i].analysis_export);
         m_fpp_agent.monitor.eg_rtl_port[i].connect(
                 m_otf_scb.eg_rtl_fifo[i].analysis_export);
+        m_fpp_agent.monitor.rd_cmd_port[i].connect(
+                m_otf_scb.rd_cmd_fifo[i].analysis_export);
      end
     end
 

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -272,7 +272,9 @@ class flash_ctrl_scoreboard #(
             "intr_test": begin
             end
 
-            "op_status", "status", "erase_suspend": begin
+            "op_status", "status", "erase_suspend",
+            "ecc_single_err_cnt", "ecc_single_err_addr_0",
+            "ecc_single_err_addr_1": begin
               // TODO: FIXME
               do_read_check = 1'b0;
             end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_serr_address_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_serr_address_vseq.sv
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Directed test to check flash_ctrl.single_err_addr
+// Each round test insert one single bit error and capture the address from tb.
+// At the end of each round, compare the captured value with
+// csr read (flash_ctrl.single_err_addr) value.
+class flash_ctrl_serr_address_vseq extends flash_ctrl_otf_base_vseq;
+  `uvm_object_utils(flash_ctrl_serr_address_vseq)
+  `uvm_object_new
+
+  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN := 7, [2:31] :/ 1, CTRL_TRANS_MAX := 2}; }
+  constraint fractions_c {
+       solve ctrl_num before fractions;
+       if (ctrl_num == 1)
+          fractions dist { [1:4] := 4, [5:16] := 1};
+       else
+          fractions == 16;
+  }
+
+  constraint odd_addr_c {
+                         solve fractions before is_addr_odd;
+                         (fractions == 16) -> is_addr_odd == 0;
+                         }
+
+  virtual task body();
+    flash_op_t ctrl;
+    int bank;
+     uvm_reg_data_t addr0, addr1;
+    cfg.serr_once = 1;
+
+    ctrl.partition = FlashPartData;
+    cfg.clk_rst_vif.wait_clks(5);
+
+    repeat(10) begin
+      cfg.serr_created = 0;
+      fork
+        begin
+          repeat(5) begin
+            `DV_CHECK_RANDOMIZE_FATAL(this)
+            bank = $urandom_range(0, 1);
+            ctrl.partition  = FlashPartData;
+            ctrl.otf_addr = is_addr_odd * 4;
+            randcase
+              1:prog_flash(ctrl, bank, ctrl_num, fractions);
+              1:read_flash(ctrl, bank, ctrl_num, fractions);
+            endcase
+          end
+        end
+        begin
+          fork
+            send_rand_host_rd();
+          join_none
+          csr_utils_pkg::wait_no_outstanding_access();
+        end
+      join
+      #1us;
+
+      csr_rd(.ptr(ral.ecc_single_err_addr[0]), .value(addr0));
+      csr_rd(.ptr(ral.ecc_single_err_addr[1]), .value(addr1));
+
+      `DV_CHECK_EQ(addr0, cfg.serr_addr[0])
+      `DV_CHECK_EQ(addr1, cfg.serr_addr[1])
+    end
+  endtask // body
+endclass // flash_ctrl_serr_address_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_serr_counter_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_serr_counter_vseq.sv
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Directed test to check flash_ctrl.single_err_cnt
+// Use low error injection pct to avoid counter saturation.
+// Counter can be saturated but not all the time.
+class flash_ctrl_serr_counter_vseq extends flash_ctrl_otf_base_vseq;
+  `uvm_object_utils(flash_ctrl_serr_counter_vseq)
+  `uvm_object_new
+
+  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN := 7, [2:31] :/ 1, CTRL_TRANS_MAX := 2}; }
+  constraint fractions_c {
+       solve ctrl_num before fractions;
+       if (ctrl_num == 1)
+          fractions dist { [1:4] := 4, [5:16] := 1};
+       else
+          fractions == 16;
+  }
+
+  constraint odd_addr_c {
+      solve fractions before is_addr_odd;
+      (fractions == 16) -> is_addr_odd == 0;
+  }
+
+  virtual task body();
+    flash_op_t ctrl;
+    int bank;
+
+    ctrl.partition = FlashPartData;
+    cfg.clk_rst_vif.wait_clks(5);
+
+    fork
+       begin
+        repeat(50) begin
+          `DV_CHECK_RANDOMIZE_FATAL(this)
+          bank = $urandom_range(0, 1);
+          ctrl.partition  = FlashPartData;
+          ctrl.otf_addr = is_addr_odd * 4;
+          randcase
+            1:prog_flash(ctrl, bank, ctrl_num, fractions);
+            1:read_flash(ctrl, bank, ctrl_num, fractions);
+          endcase
+        end
+      end
+      begin
+         for (int i = 0; i < 5; ++i) begin
+            fork
+              send_rand_host_rd();
+            join_none
+            #0;
+         end
+         csr_utils_pkg::wait_no_outstanding_access();
+      end
+    join
+
+  endtask // body
+  task post_body();
+    uvm_reg_data_t data;
+    csr_rd(.ptr(ral.ecc_single_err_cnt[0]), .value(data));
+    `DV_CHECK_EQ(data[7:0], cfg.serr_cnt[0])
+    `DV_CHECK_EQ(data[15:8], cfg.serr_cnt[1])
+  endtask
+endclass // flash_ctrl_serr_counter_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -35,3 +35,5 @@
 `include "flash_ctrl_read_word_sweep_vseq.sv"
 `include "flash_ctrl_read_rnd_wd_vseq.sv"
 `include "flash_ctrl_rw_rnd_wd_vseq.sv"
+`include "flash_ctrl_serr_counter_vseq.sv"
+`include "flash_ctrl_serr_address_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -259,6 +259,48 @@
       run_opts: ["+scb_otf_en=1", "+ecc_mode=1"]
       reseed: 10
     }
+    {
+      name: flash_ctrl_read_word_sweep_serr
+      uvm_test_seq: flash_ctrl_read_word_sweep_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+serr_pct=3"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_read_rand_word_serr
+      uvm_test_seq: flash_ctrl_read_rnd_wd_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+serr_pct=3"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_ro_serr
+      uvm_test_seq: flash_ctrl_ro_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+serr_pct=3"]
+      reseed: 10
+    }
+    {
+      name: flash_ctrl_rw_serr
+      uvm_test_seq: flash_ctrl_rw_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+serr_pct=3"]
+      reseed: 10
+    }
+    {
+      name: flash_ctrl_rw_rand_word_serr
+      uvm_test_seq: flash_ctrl_rw_rnd_wd_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+serr_pct=3"]
+      reseed: 10
+    }
+    {
+      name: flash_ctrl_serr_counter
+      uvm_test_seq: flash_ctrl_serr_counter_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+serr_pct=1"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_serr_address
+      uvm_test_seq: flash_ctrl_serr_address_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+serr_pct=1"]
+      reseed: 5
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
+++ b/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
@@ -55,5 +55,6 @@ class flash_ctrl_base_test #(
     void'($value$plusargs("scb_otf_en=%0b", cfg.scb_otf_en));
     void'($value$plusargs("multi_alert=%0b", cfg.multi_alert_en));
     void'($value$plusargs("ecc_mode=%0d", cfg.ecc_mode));
+    void'($value$plusargs("serr_pct=%0d", cfg.serr_pct));
   endfunction
 endclass : flash_ctrl_base_test


### PR DESCRIPTION
Single bit error test is created as follows:
All read only, read_write tests are run with cfg.ecc_mode=2 and 
error injection rate (cfg.serr_pct).
Error injection rate is probability to inject error for a single memory word (8byte).

In ecc_mode=2, if sequence issues 'read_flash' or 'otf_direct_read',
the sequence can inject single bit ecc error via bkdr memory read modify write, 
right before the read command is sent.
During the read process, single bit ecc error should be corrected.
single_bit_ecc_cnt / addr are coved with a directed test because
counter can be easily saturated most of the tests and address will be the last single bit error
which is trivial. 
Directed test will cover
 - non saturated  / saturated counter value
 - compare captured address in the middle of the test multiple times

Signed-off-by: Jaedon Kim <jdonjdon@google.com>