### PR TITLE
[bazel] use --config=riscv32 to build for opentitan_rv32imc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,10 @@ build --incompatible_enable_cc_toolchain_resolution
 # accessed like we do in util/BUILD
 build --workspace_status_command=util/get_workspace_status.sh
 
+# This enables convenient building for opentitan targets with the argument
+# --config=riscv32
+build:riscv32 --platforms=@bazel_embedded//platforms:opentitan_rv32imc
+
 # Generate coverage in lcov format, which can be post-processed by lcov
 # into html-formatted reports.
 coverage --combined_report=lcov --instrument_test_targets --experimental_cc_coverage


### PR DESCRIPTION
This documents and provides easy access to an otherwise hard to recall
invocation to build for the opentitan target

Signed-off-by: Drew Macrae <drewmacrae@google.com>