### PR TITLE
[otbn,rtl,dv] Add status for internal secure wipe

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -383,6 +383,11 @@
                   <td>OTBN is busy securely wiping the instruction memory.</td>
                 </tr>
                 <tr>
+                  <td>0x04</td>
+                  <td>BUSY_SEC_WIPE_INT</td>
+                  <td>OTBN is busy securely wiping the internal state.</td>
+                </tr>
+                <tr>
                   <td>0xFF</td>
                   <td>LOCKED</td>
                   <td>

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -37,6 +37,7 @@ int otbn_stack_element_peek(int index, svBitVecVal *val);
 #define STATUS_BUSY_EXECUTE 0x01
 #define STATUS_BUSY_SEC_WIPE_DMEM 0x02
 #define STATUS_BUSY_SEC_WIPE_IMEM 0x03
+#define STATUS_BUSY_SEC_WIPE_INT 0x04
 #define STATUS_LOCKED 0xFF
 
 // Read (the start of) the contents of a file at path as a vector of bytes.

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -18,6 +18,7 @@ class Status(IntEnum):
     BUSY_EXECUTE = 0x01
     BUSY_SEC_WIPE_DMEM = 0x02
     BUSY_SEC_WIPE_IMEM = 0x03
+    BUSY_SEC_WIPE_INT = 0x04
     LOCKED = 0xFF
 
 

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -262,6 +262,10 @@ class OTBNSim:
         assert self.state.wipe_cycles > 0
         self.state.wipe_cycles -= 1
 
+        # Reflect wiping in STATUS register if it has not been updated yet.
+        if self.state.ext_regs.read('STATUS', True) == Status.BUSY_EXECUTE:
+            self.state.ext_regs.write('STATUS', Status.BUSY_SEC_WIPE_INT, True)
+
         is_good = self.state.get_fsm_state() == FsmState.WIPING_GOOD
 
         # Clear the WIPE_START register if it was set.

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -117,7 +117,8 @@ package otbn_env_pkg;
     unique case (status)
       otbn_pkg::StatusBusyExecute,
       otbn_pkg::StatusBusySecWipeDmem,
-      otbn_pkg::StatusBusySecWipeImem:
+      otbn_pkg::StatusBusySecWipeImem,
+      otbn_pkg::StatusBusySecWipeInt:
         return OperationalStateBusy;
 
       otbn_pkg::StatusLocked:

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -374,7 +374,8 @@ class otbn_scoreboard extends cip_base_scoreboard #(
 
       case (item.item_type)
         OtbnModelStatus: begin
-          bit was_executing = model_status inside {otbn_pkg::StatusBusyExecute};
+          bit was_executing = model_status inside {otbn_pkg::StatusBusyExecute,
+                                                   otbn_pkg::StatusBusySecWipeInt};
           bit is_busy = otbn_pkg::is_busy_status(item.status);
 
           // Has the status changed from idle to busy? If so, we should have seen a write to the

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
@@ -43,7 +43,8 @@ class otbn_dmem_err_vseq extends otbn_base_vseq;
 
     cfg.model_agent_cfg.vif.invalidate_dmem();
 
-    wait (cfg.model_agent_cfg.vif.status != otbn_pkg::StatusBusyExecute);
+    wait (!(cfg.model_agent_cfg.vif.status inside {otbn_pkg::StatusBusyExecute,
+                                                   otbn_pkg::StatusBusySecWipeInt}));
 
     // At this point, our status has changed. We're probably actually seeing the alert now, but make
     // sure that it has gone out in at most 100 cycles.

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -74,6 +74,7 @@ module otbn_top_sim (
     .start_i                     ( otbn_start                 ),
     .done_o                      ( otbn_done                  ),
     .locking_o                   (                            ),
+    .secure_wipe_running_o       (                            ),
 
     .err_bits_o                  ( core_err_bits              ),
     .recoverable_err_o           (                            ),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -92,6 +92,7 @@ module otbn
   logic start_d, start_q;
   logic busy_execute_d, busy_execute_q;
   logic done, done_core, locking, locking_q;
+  logic busy_secure_wipe;
   logic illegal_bus_access_d, illegal_bus_access_q;
   logic missed_gnt_error_d, missed_gnt_error_q;
   logic dmem_sec_wipe;
@@ -791,6 +792,7 @@ module otbn
   // combinatorially on the cycle that an error is injected. The STATUS register change, done
   // interrupt and any change to the idle signal will be delayed by 2 cycles.
   assign status_d = locking                         ? StatusLocked          :
+                    busy_secure_wipe                ? StatusBusySecWipeInt  :
                     busy_execute_d                  ? StatusBusyExecute     :
                     otbn_dmem_scramble_key_req_busy ? StatusBusySecWipeDmem :
                     otbn_imem_scramble_key_req_busy ? StatusBusySecWipeImem :
@@ -1038,6 +1040,7 @@ module otbn
     .start_i                     (start_q),
     .done_o                      (done_core),
     .locking_o                   (locking),
+    .secure_wipe_running_o       (busy_secure_wipe),
 
     .err_bits_o                  (core_err_bits),
     .recoverable_err_o           (core_recoverable_err),

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -32,6 +32,7 @@ module otbn_core
   input  logic start_i,   // start the operation
   output logic done_o,    // operation done
   output logic locking_o, // The core is in or is entering the locked state
+  output logic secure_wipe_running_o, // the core is securely wiping its internal state
 
   output core_err_bits_t err_bits_o,  // valid when done_o is asserted
   output logic           recoverable_err_o,
@@ -272,6 +273,7 @@ module otbn_core
 
     .secure_wipe_req_i (secure_wipe_req),
     .secure_wipe_ack_o (secure_wipe_ack),
+    .secure_wipe_running_o,
     .done_o,
 
     .sec_wipe_wdr_o      (sec_wipe_wdr_d),

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -71,11 +71,15 @@ package otbn_pkg;
     StatusBusyExecute     = 8'h01,
     StatusBusySecWipeDmem = 8'h02,
     StatusBusySecWipeImem = 8'h03,
+    StatusBusySecWipeInt  = 8'h04,
     StatusLocked          = 8'hFF
   } status_e;
 
   function automatic logic is_busy_status(status_e status);
-    return status inside {StatusBusyExecute, StatusBusySecWipeDmem, StatusBusySecWipeImem};
+    return status inside {StatusBusyExecute,
+                          StatusBusySecWipeDmem,
+                          StatusBusySecWipeImem,
+                          StatusBusySecWipeInt};
   endfunction
 
   // Error bits

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -40,6 +40,7 @@ module otbn_start_stop_control
 
   input   logic secure_wipe_req_i,
   output  logic secure_wipe_ack_o,
+  output  logic secure_wipe_running_o,
   output  logic done_o,
 
   output logic       sec_wipe_wdr_o,
@@ -111,6 +112,7 @@ module otbn_start_stop_control
     sec_wipe_zero_o         = 1'b0;
     addr_cnt_inc            = 1'b0;
     secure_wipe_ack_o       = 1'b0;
+    secure_wipe_running_o   = 1'b0;
     state_error             = 1'b0;
     allow_secure_wipe       = 1'b0;
     expect_secure_wipe      = 1'b0;
@@ -145,12 +147,13 @@ module otbn_start_stop_control
       end
       // Writing random numbers to the wide data registers.
        OtbnStartStopSecureWipeWdrUrnd: begin
-        urnd_advance_o      = 1'b1;
-        addr_cnt_inc        = 1'b1;
-        sec_wipe_wdr_o      = 1'b1;
-        sec_wipe_wdr_urnd_o = 1'b1;
-        allow_secure_wipe   = 1'b1;
-        expect_secure_wipe  = 1'b1;
+        urnd_advance_o        = 1'b1;
+        addr_cnt_inc          = 1'b1;
+        sec_wipe_wdr_o        = 1'b1;
+        sec_wipe_wdr_urnd_o   = 1'b1;
+        allow_secure_wipe     = 1'b1;
+        expect_secure_wipe    = 1'b1;
+        secure_wipe_running_o = 1'b1;
 
         if (addr_cnt_q == 5'b11111) begin
           state_d = OtbnStartStopSecureWipeAccModBaseUrnd;
@@ -164,6 +167,7 @@ module otbn_start_stop_control
         addr_cnt_inc          = 1'b1;
         allow_secure_wipe     = 1'b1;
         expect_secure_wipe    = 1'b1;
+        secure_wipe_running_o = 1'b1;
         // The first two clock cycles are used to write random data to accumulator and modulus.
         sec_wipe_acc_urnd_o   = (addr_cnt_q == 5'b00000);
         sec_wipe_mod_urnd_o   = (addr_cnt_q == 5'b00001);
@@ -177,12 +181,13 @@ module otbn_start_stop_control
       // Writing zeros to the accumulator, modulus and the registers.
       // Resetting stack
        OtbnStartStopSecureWipeAllZero: begin
-        sec_wipe_zero_o    = (addr_cnt_q == 5'b00000);
-        sec_wipe_wdr_o     = 1'b1;
-        sec_wipe_base_o    = (addr_cnt_q > 5'b00001);
-        addr_cnt_inc       = 1'b1;
-        allow_secure_wipe  = 1'b1;
-        expect_secure_wipe = 1'b1;
+        sec_wipe_zero_o       = (addr_cnt_q == 5'b00000);
+        sec_wipe_wdr_o        = 1'b1;
+        sec_wipe_base_o       = (addr_cnt_q > 5'b00001);
+        addr_cnt_inc          = 1'b1;
+        allow_secure_wipe     = 1'b1;
+        expect_secure_wipe    = 1'b1;
+        secure_wipe_running_o = 1'b1;
 
         if (addr_cnt_q == 5'b11111) begin
           state_d = OtbnStartStopSecureWipeComplete;

--- a/sw/device/lib/crypto/drivers/otbn.h
+++ b/sw/device/lib/crypto/drivers/otbn.h
@@ -40,6 +40,7 @@ typedef enum otbn_status {
   kOtbnStatusBusyExecute = 0x01,
   kOtbnStatusBusySecWipeDmem = 0x02,
   kOtbnStatusBusySecWipeImem = 0x03,
+  kOtbnStatusBusySecWipeInt = 0x04,
   kOtbnStatusLocked = 0xFF,
 } otbn_status_t;
 

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -39,6 +39,7 @@ typedef enum dif_otbn_status {
   kDifOtbnStatusBusyExecute = 0x01,
   kDifOtbnStatusBusySecWipeDmem = 0x02,
   kDifOtbnStatusBusySecWipeImem = 0x03,
+  kDifOtbnStatusBusySecWipeInt = 0x04,
   kDifOtbnStatusLocked = 0xFF,
 } dif_otbn_status_t;
 

--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -42,6 +42,7 @@ typedef enum otbn_status {
   kOtbnStatusBusyExecute = 0x01,
   kOtbnStatusBusySecWipeDmem = 0x02,
   kOtbnStatusBusySecWipeImem = 0x03,
+  kOtbnStatusBusySecWipeInt = 0x04,
   kOtbnStatusLocked = 0xFF,
 } otbn_status_t;
 


### PR DESCRIPTION
After execution OTBN securely wipes its internal state.  Prior to this
commit, OTBN remained in the `BUSY_EXECUTE` status during this secure
wipe.  The `BUSY_EXECUTE` status, however, is defined as "OTBN is busy
executing software", which is not accurate: when performing a secure
wipe, OTBN no longer executes software.  Additionally, there is work in
progress to perform an internal secure wipe after reset as well as on a
software command (the latter is already possible for the instruction and
the data memories).  The newly added status will be used to represent
those operations as well.