### PR TITLE
[csrng/rtl] fix bug where cmd ack sts is always being set

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -357,7 +357,7 @@
       swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
-        { bits: "14:0",
+        { bits: "15:0",
           name: "HW_EXC_STS",
           desc: '''
                 Reading this register indicates whether one of the CSRNG HW instances has

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -324,7 +324,7 @@ module csrng_core import csrng_pkg::*; #(
   logic [31:0]             genbits_stage_bus_sw;
   logic                    genbits_stage_fips_sw;
 
-  logic [14:0]             hw_exception_sts;
+  logic [15:0]             hw_exception_sts;
   logic [LcHwDebugCopies-1:0] lc_hw_debug_on_fo;
   logic                    state_db_is_dump_en;
   logic                    state_db_reg_rd_sel;
@@ -953,12 +953,12 @@ module csrng_core import csrng_pkg::*; #(
   end : gen_app_if
 
   // set ack status for configured instances
-  for (genvar i = 0; i < NHwApps; i = i+1) begin : gen_app_if_sts
-    assign hw_exception_sts[i] = cmd_stage_ack[i] && !cmd_stage_ack_sts[i];
+  for (genvar i = 0; i < NApps; i = i+1) begin : gen_app_if_sts
+    assign hw_exception_sts[i] = cmd_stage_ack[i] && cmd_stage_ack_sts[i];
   end : gen_app_if_sts
 
   // set ack status to zero for un-configured instances
-  for (genvar i = NHwApps; i < 15; i = i+1) begin : gen_app_if_zero_sts
+  for (genvar i = NApps; i < 16; i = i+1) begin : gen_app_if_zero_sts
     assign hw_exception_sts[i] = 1'b0;
   end : gen_app_if_zero_sts
 

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -161,7 +161,7 @@ package csrng_reg_pkg;
   } csrng_hw2reg_int_state_val_reg_t;
 
   typedef struct packed {
-    logic [14:0] d;
+    logic [15:0] d;
     logic        de;
   } csrng_hw2reg_hw_exc_sts_reg_t;
 
@@ -312,12 +312,12 @@ package csrng_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [162:155]
-    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [154:151]
-    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [150:149]
-    csrng_hw2reg_genbits_reg_t genbits; // [148:117]
-    csrng_hw2reg_int_state_val_reg_t int_state_val; // [116:85]
-    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [84:69]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [163:156]
+    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [155:152]
+    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [151:150]
+    csrng_hw2reg_genbits_reg_t genbits; // [149:118]
+    csrng_hw2reg_int_state_val_reg_t int_state_val; // [117:86]
+    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [85:69]
     csrng_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [68:61]
     csrng_hw2reg_err_code_reg_t err_code; // [60:9]
     csrng_hw2reg_main_sm_state_reg_t main_sm_state; // [8:0]

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -172,8 +172,8 @@ module csrng_reg_top (
   logic int_state_val_re;
   logic [31:0] int_state_val_qs;
   logic hw_exc_sts_we;
-  logic [14:0] hw_exc_sts_qs;
-  logic [14:0] hw_exc_sts_wd;
+  logic [15:0] hw_exc_sts_qs;
+  logic [15:0] hw_exc_sts_wd;
   logic recov_alert_sts_we;
   logic recov_alert_sts_enable_field_alert_qs;
   logic recov_alert_sts_enable_field_alert_wd;
@@ -841,9 +841,9 @@ module csrng_reg_top (
 
   // R[hw_exc_sts]: V(False)
   prim_subreg #(
-    .DW      (15),
+    .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (15'h0)
+    .RESVAL  (16'h0)
   ) u_hw_exc_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1820,7 +1820,7 @@ module csrng_reg_top (
   assign int_state_val_re = addr_hit[11] & reg_re & !reg_error;
   assign hw_exc_sts_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign hw_exc_sts_wd = reg_wdata[14:0];
+  assign hw_exc_sts_wd = reg_wdata[15:0];
   assign recov_alert_sts_we = addr_hit[13] & reg_we & !reg_error;
 
   assign recov_alert_sts_enable_field_alert_wd = reg_wdata[0];
@@ -1923,7 +1923,7 @@ module csrng_reg_top (
       end
 
       addr_hit[12]: begin
-        reg_rdata_next[14:0] = hw_exc_sts_qs;
+        reg_rdata_next[15:0] = hw_exc_sts_qs;
       end
 
       addr_hit[13]: begin


### PR DESCRIPTION
The event logic that captures hw_exceptions was inverting
the sts bit for all cases, causing false interrupts to fire.
Fixes #13633.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>