### PR TITLE
[clkmgr/pwrmgr] Support synchronous resets for lc domain

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -9,14 +9,17 @@
   scan: "true",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
+    {reset: "rst_root_ni"},
 % for src in clocks.srcs.values():
     {clock: "clk_${src.name}_i", reset: "rst_${src.name}_ni"},
 % endfor
 % for src in clocks.derived_srcs.values():
     {clock: "clk_${src.name}_i", reset: "rst_${src.name}_ni", internal: true},
 % endfor
-% for src in clocks.all_derived_srcs():
-    {reset: "rst_por_${src}_ni"},
+% for root, clk_family in typed_clocks.parent_child_clks.items():
+  % for clk in clk_family:
+    {reset: "rst_root_${clk}_ni"},
+  % endfor
 % endfor
   ]
   bus_interfaces: [

--- a/hw/ip/clkmgr/doc/_index.md
+++ b/hw/ip/clkmgr/doc/_index.md
@@ -158,7 +158,7 @@ The following is a high level block diagram of the clock manager.
 
 Since the function of the clock manager is tied closely into the power-up behavior of the device, the reset domain selection must also be purposefully done.
 To ensure that default clocks are available for the [power manager to release resets and initialize memories]({{< relref "hw/ip/pwrmgr/doc/_index.md#fast-clock-domain-fsm" >}}), the clock dividers inside the clock manager directly use `por` (power-on-reset) derived resets.
-This ensures that the root clocks are freely running after power-up, regardless of any other activity in the device.
+This ensures that the root clocks are freely running after power-up and its status can be communicated to the `pwrmgr` regardless of any other activity in the device.
 
 The other functions inside the clock manager operate on the `life cycle reset` domain.
 This ensures that other clock manager functions still release early relative to most functions in the system, and that a user or escalation initiated reset still restores the clock manager to a default clean slate.

--- a/hw/ip/clkmgr/dv/tb.sv
+++ b/hw/ip/clkmgr/dv/tb.sv
@@ -86,15 +86,20 @@ module tb;
     .rst_usb_ni (rst_usb_n),
     .clk_aon_i  (clk_aon),
     .rst_aon_ni (rst_aon_n),
-    // Hack alert: This is not the right reset to use here.
+    .rst_io_div2_ni(rst_io_n),
+    .rst_io_div4_ni(rst_io_n),
+
+    // TODO: This is not the right reset to use here.
     // the "por" reset should de-assert earlier than the
     // the other resets. There should also be scenarios
     // where the other resets assert, but "por" does not,
     // since por resets are upstream of lc resets.
-    .rst_por_io_ni(rst_io_n),
-    .rst_io_div2_ni(rst_io_n),
-    // Setting as above...
-    .rst_io_div4_ni(rst_io_n),
+    .rst_root_ni(rst_io_n),
+    .rst_root_io_ni(rst_io_n),
+    .rst_root_io_div2_ni(rst_io_n),
+    .rst_root_io_div4_ni(rst_io_n),
+    .rst_root_main_ni(rst_main_n),
+    .rst_root_usb_ni(rst_usb_n),
 
     .tl_i(tl_if.h2d),
     .tl_o(tl_if.d2h),

--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -268,15 +268,16 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
 
       FastPwrStateEnableClocks: begin
         ip_clk_en_d = 1'b1;
-        state_d = FastPwrStateReleaseLcRst;
+        if (clks_enabled) begin
+          state_d = FastPwrStateReleaseLcRst;
+        end
       end
 
       FastPwrStateReleaseLcRst: begin
         rst_lc_req_d = '0;  // release rst_lc_n for all power domains
 
-        // once all resets are released and clocks are stable
-        // continue to otp initilization
-        if (&pwr_rst_i.rst_lc_src_n & clks_enabled) begin
+        // once all resets are released continue to otp initilization
+        if (&pwr_rst_i.rst_lc_src_n) begin
           state_d = FastPwrStateOtpInit;
         end
       end

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -223,7 +223,10 @@
         name: por
         gen: true
         type: top
-        domains: []
+        domains:
+        [
+          Aon
+        ]
         shadowed: false
         sw: false
         path: rstmgr_aon_resets.rst_por_n
@@ -245,6 +248,20 @@
         clock: io
       }
       {
+        name: por_io_div2
+        gen: true
+        type: top
+        domains:
+        [
+          Aon
+        ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_por_io_div2_n
+        parent: por_aon
+        clock: io_div2
+      }
+      {
         name: por_io_div4
         gen: true
         type: top
@@ -257,6 +274,20 @@
         path: rstmgr_aon_resets.rst_por_io_div4_n
         parent: por_aon
         clock: io_div4
+      }
+      {
+        name: por_usb
+        gen: true
+        type: top
+        domains:
+        [
+          Aon
+        ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_por_usb_n
+        parent: por_aon
+        clock: usb
       }
       {
         name: lc
@@ -3117,9 +3148,34 @@
           name: lc_usb
           domain: Aon
         }
-        rst_por_io_ni:
+        rst_root_ni:
+        {
+          name: por_io_div4
+          domain: Aon
+        }
+        rst_root_io_ni:
         {
           name: por_io
+          domain: Aon
+        }
+        rst_root_io_div2_ni:
+        {
+          name: por_io_div2
+          domain: Aon
+        }
+        rst_root_io_div4_ni:
+        {
+          name: por_io_div4
+          domain: Aon
+        }
+        rst_root_main_ni:
+        {
+          name: por
+          domain: Aon
+        }
+        rst_root_usb_ni:
+        {
+          name: por_usb
           domain: Aon
         }
       }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -141,7 +141,9 @@
       { name: "sys_src",        gen: false, type: "int",                    clk: "io_div4" }
       { name: "por",            gen: true,  type: "top", parent: "por_aon", clk: "main"    }
       { name: "por_io",         gen: true,  type: "top", parent: "por_aon", clk: "io"      }
+      { name: "por_io_div2",    gen: true , type: "top", parent: "por_aon", clk: "io_div2" }
       { name: "por_io_div4",    gen: true , type: "top", parent: "por_aon", clk: "io_div4" }
+      { name: "por_usb",        gen: true , type: "top", parent: "por_aon", clk: "usb" }
       { name: "lc",             gen: true,  type: "top", parent: "lc_src",  clk: "main"    }
       { name: "lc_aon",         gen: true,  type: "top", parent: "lc_src",  clk: "aon"     }
       { name: "lc_io",          gen: true,  type: "top", parent: "lc_src",  clk: "io"      }
@@ -416,7 +418,12 @@
                           rst_io_div4_ni: "lc_io_div4",
                           rst_main_ni: "lc",
                           rst_usb_ni: "lc_usb",
-                          rst_por_io_ni: "por_io",
+                          rst_root_ni: "por_io_div4",
+                          rst_root_io_ni: "por_io",
+                          rst_root_io_div2_ni: "por_io_div2",
+                          rst_root_io_div4_ni: "por_io_div4",
+                          rst_root_main_ni: "por",
+                          rst_root_usb_ni: "por_usb",
                          },
       domain: ["Aon"],
       base_addr: "0x40420000",

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -15,13 +15,18 @@
   scan: "true",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
+    {reset: "rst_root_ni"},
     {clock: "clk_main_i", reset: "rst_main_ni"},
     {clock: "clk_io_i", reset: "rst_io_ni"},
     {clock: "clk_usb_i", reset: "rst_usb_ni"},
     {clock: "clk_aon_i", reset: "rst_aon_ni"},
     {clock: "clk_io_div2_i", reset: "rst_io_div2_ni", internal: true},
     {clock: "clk_io_div4_i", reset: "rst_io_div4_ni", internal: true},
-    {reset: "rst_por_io_ni"},
+    {reset: "rst_root_main_ni"},
+    {reset: "rst_root_io_ni"},
+    {reset: "rst_root_io_div2_ni"},
+    {reset: "rst_root_io_div4_ni"},
+    {reset: "rst_root_usb_ni"},
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -43,11 +43,13 @@
   input rst_io_div2_ni,
   input rst_io_div4_ni,
 
-  // Sources for derived clocks need both a functional reset (above) and a
-  // por reset. The por reset allows the block to begin
-  // generating the derived clocks immediately, even if other
-  // downstream resets are not yet released
-  input rst_por_io_ni,
+  // Resets for derived clock generation, root clock gating and related status
+  input rst_root_ni,
+  input rst_root_main_ni,
+  input rst_root_io_ni,
+  input rst_root_io_div2_ni,
+  input rst_root_io_div4_ni,
+  input rst_root_usb_ni,
 
   // Bus Interface
   input tlul_pkg::tl_h2d_t tl_i,
@@ -156,7 +158,7 @@
     .Divisor(2)
   ) u_no_scan_io_div2_div (
     .clk_i(clk_io_i),
-    .rst_ni(rst_por_io_ni),
+    .rst_ni(rst_root_io_ni),
     .step_down_req_i(mubi4_test_true_strict(io_step_down_req)),
     .step_down_ack_o(step_down_acks[0]),
     .test_en_i(mubi4_test_true_strict(io_div2_div_scanmode[0])),
@@ -179,7 +181,7 @@
     .Divisor(4)
   ) u_no_scan_io_div4_div (
     .clk_i(clk_io_i),
-    .rst_ni(rst_por_io_ni),
+    .rst_ni(rst_root_io_ni),
     .step_down_req_i(mubi4_test_true_strict(io_step_down_req)),
     .step_down_ack_o(step_down_acks[1]),
     .test_en_i(mubi4_test_true_strict(io_div4_div_scanmode[0])),
@@ -385,7 +387,6 @@
   // clk_main family
   logic pwrmgr_main_en;
   assign pwrmgr_main_en = pwr_i.main_ip_clk_en;
-
   // clk_io family
   logic pwrmgr_io_en;
   logic pwrmgr_io_div2_en;
@@ -393,11 +394,9 @@
   assign pwrmgr_io_en = pwr_i.io_ip_clk_en;
   assign pwrmgr_io_div2_en = pwr_i.io_ip_clk_en;
   assign pwrmgr_io_div4_en = pwr_i.io_ip_clk_en;
-
   // clk_usb family
   logic pwrmgr_usb_en;
   assign pwrmgr_usb_en = pwr_i.usb_ip_clk_en;
-
 
   ////////////////////////////////////////////////////
   // Root gating
@@ -410,7 +409,7 @@
   logic clk_main_root;
   clkmgr_root_ctrl u_main_root_ctrl (
     .clk_i(clk_main_i),
-    .rst_ni(rst_main_ni),
+    .rst_ni(rst_root_main_ni),
     .scanmode_i,
     .async_en_i(pwrmgr_main_en),
     .en_o(clk_main_en),
@@ -423,7 +422,7 @@
     .NumClocks(1)
   ) u_main_status (
     .clk_i,
-    .rst_ni,
+    .rst_ni(rst_root_ni),
     .ens_i(main_ens),
     .status_o(pwr_o.main_status)
   );
@@ -435,7 +434,7 @@
   logic clk_io_root;
   clkmgr_root_ctrl u_io_root_ctrl (
     .clk_i(clk_io_i),
-    .rst_ni(rst_io_ni),
+    .rst_ni(rst_root_io_ni),
     .scanmode_i,
     .async_en_i(pwrmgr_io_en),
     .en_o(clk_io_en),
@@ -447,7 +446,7 @@
   logic clk_io_div2_root;
   clkmgr_root_ctrl u_io_div2_root_ctrl (
     .clk_i(clk_io_div2_i),
-    .rst_ni(rst_io_div2_ni),
+    .rst_ni(rst_root_io_div2_ni),
     .scanmode_i,
     .async_en_i(pwrmgr_io_div2_en),
     .en_o(clk_io_div2_en),
@@ -459,7 +458,7 @@
   logic clk_io_div4_root;
   clkmgr_root_ctrl u_io_div4_root_ctrl (
     .clk_i(clk_io_div4_i),
-    .rst_ni(rst_io_div4_ni),
+    .rst_ni(rst_root_io_div4_ni),
     .scanmode_i,
     .async_en_i(pwrmgr_io_div4_en),
     .en_o(clk_io_div4_en),
@@ -472,7 +471,7 @@
     .NumClocks(3)
   ) u_io_status (
     .clk_i,
-    .rst_ni,
+    .rst_ni(rst_root_ni),
     .ens_i(io_ens),
     .status_o(pwr_o.io_status)
   );
@@ -484,7 +483,7 @@
   logic clk_usb_root;
   clkmgr_root_ctrl u_usb_root_ctrl (
     .clk_i(clk_usb_i),
-    .rst_ni(rst_usb_ni),
+    .rst_ni(rst_root_usb_ni),
     .scanmode_i,
     .async_en_i(pwrmgr_usb_en),
     .en_o(clk_usb_en),
@@ -497,7 +496,7 @@
     .NumClocks(1)
   ) u_usb_status (
     .clk_i,
-    .rst_ni,
+    .rst_ni(rst_root_ni),
     .ens_i(usb_ens),
     .status_o(pwr_o.usb_status)
   );

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -175,12 +175,12 @@ module rstmgr
   ////////////////////////////////////////////////////
 
   // consistency check errors
-  logic [22:0][PowerDomains-1:0] cnsty_chk_errs;
-  logic [22:0][PowerDomains-1:0] shadow_cnsty_chk_errs;
+  logic [24:0][PowerDomains-1:0] cnsty_chk_errs;
+  logic [24:0][PowerDomains-1:0] shadow_cnsty_chk_errs;
 
   // consistency sparse fsm errors
-  logic [22:0][PowerDomains-1:0] fsm_errs;
-  logic [22:0][PowerDomains-1:0] shadow_fsm_errs;
+  logic [24:0][PowerDomains-1:0] fsm_errs;
+  logic [24:0][PowerDomains-1:0] shadow_fsm_errs;
 
   assign hw2reg.err_code.reg_intg_err.d  = 1'b1;
   assign hw2reg.err_code.reg_intg_err.de = reg_intg_err;
@@ -299,12 +299,32 @@ module rstmgr
   // If a reset does not support a particular power domain, that reset is always hard-wired to 0.
 
   // Generating resets for por
-  // Power Domains: []
+  // Power Domains: ['Aon']
   // Shadowed: False
-  assign resets_o.rst_por_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[0][DomainAonSel] = '0;
-  assign fsm_errs[0][DomainAonSel] = '0;
-  assign rst_en_o.por[DomainAonSel] = MuBi4True;
+  rstmgr_leaf_rst #(
+    .SecCheck(SecCheck),
+    .SecMaxSyncDelay(SecMaxSyncDelay),
+    .SwRstReq(1'b0)
+  ) u_daon_por (
+    .clk_i,
+    .rst_ni,
+    .leaf_clk_i(clk_main_i),
+    .parent_rst_ni(rst_por_aon_n[DomainAonSel]),
+    .sw_rst_req_ni(1'b1),
+    .scan_rst_ni,
+    .scanmode_i,
+    .rst_en_o(rst_en_o.por[DomainAonSel]),
+    .leaf_rst_o(resets_o.rst_por_n[DomainAonSel]),
+    .err_o(cnsty_chk_errs[0][DomainAonSel]),
+    .fsm_err_o(fsm_errs[0][DomainAonSel])
+  );
+
+  if (SecCheck) begin : gen_daon_por_assert
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
+    DAonPorFsmCheck_A,
+    u_daon_por.gen_rst_chk.u_rst_chk.u_state_regs,
+    alert_tx_o[0])
+  end
   assign resets_o.rst_por_n[Domain0Sel] = '0;
   assign cnsty_chk_errs[0][Domain0Sel] = '0;
   assign fsm_errs[0][Domain0Sel] = '0;
@@ -346,6 +366,40 @@ module rstmgr
   assign shadow_cnsty_chk_errs[1] = '0;
   assign shadow_fsm_errs[1] = '0;
 
+  // Generating resets for por_io_div2
+  // Power Domains: ['Aon']
+  // Shadowed: False
+  rstmgr_leaf_rst #(
+    .SecCheck(SecCheck),
+    .SecMaxSyncDelay(SecMaxSyncDelay),
+    .SwRstReq(1'b0)
+  ) u_daon_por_io_div2 (
+    .clk_i,
+    .rst_ni,
+    .leaf_clk_i(clk_io_div2_i),
+    .parent_rst_ni(rst_por_aon_n[DomainAonSel]),
+    .sw_rst_req_ni(1'b1),
+    .scan_rst_ni,
+    .scanmode_i,
+    .rst_en_o(rst_en_o.por_io_div2[DomainAonSel]),
+    .leaf_rst_o(resets_o.rst_por_io_div2_n[DomainAonSel]),
+    .err_o(cnsty_chk_errs[2][DomainAonSel]),
+    .fsm_err_o(fsm_errs[2][DomainAonSel])
+  );
+
+  if (SecCheck) begin : gen_daon_por_io_div2_assert
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
+    DAonPorIoDiv2FsmCheck_A,
+    u_daon_por_io_div2.gen_rst_chk.u_rst_chk.u_state_regs,
+    alert_tx_o[0])
+  end
+  assign resets_o.rst_por_io_div2_n[Domain0Sel] = '0;
+  assign cnsty_chk_errs[2][Domain0Sel] = '0;
+  assign fsm_errs[2][Domain0Sel] = '0;
+  assign rst_en_o.por_io_div2[Domain0Sel] = MuBi4True;
+  assign shadow_cnsty_chk_errs[2] = '0;
+  assign shadow_fsm_errs[2] = '0;
+
   // Generating resets for por_io_div4
   // Power Domains: ['Aon']
   // Shadowed: False
@@ -363,16 +417,50 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.por_io_div4[DomainAonSel]),
     .leaf_rst_o(resets_o.rst_por_io_div4_n[DomainAonSel]),
-    .err_o(cnsty_chk_errs[2][DomainAonSel]),
-    .fsm_err_o(fsm_errs[2][DomainAonSel])
+    .err_o(cnsty_chk_errs[3][DomainAonSel]),
+    .fsm_err_o(fsm_errs[3][DomainAonSel])
   );
 
   assign resets_o.rst_por_io_div4_n[Domain0Sel] = '0;
-  assign cnsty_chk_errs[2][Domain0Sel] = '0;
-  assign fsm_errs[2][Domain0Sel] = '0;
+  assign cnsty_chk_errs[3][Domain0Sel] = '0;
+  assign fsm_errs[3][Domain0Sel] = '0;
   assign rst_en_o.por_io_div4[Domain0Sel] = MuBi4True;
-  assign shadow_cnsty_chk_errs[2] = '0;
-  assign shadow_fsm_errs[2] = '0;
+  assign shadow_cnsty_chk_errs[3] = '0;
+  assign shadow_fsm_errs[3] = '0;
+
+  // Generating resets for por_usb
+  // Power Domains: ['Aon']
+  // Shadowed: False
+  rstmgr_leaf_rst #(
+    .SecCheck(SecCheck),
+    .SecMaxSyncDelay(SecMaxSyncDelay),
+    .SwRstReq(1'b0)
+  ) u_daon_por_usb (
+    .clk_i,
+    .rst_ni,
+    .leaf_clk_i(clk_usb_i),
+    .parent_rst_ni(rst_por_aon_n[DomainAonSel]),
+    .sw_rst_req_ni(1'b1),
+    .scan_rst_ni,
+    .scanmode_i,
+    .rst_en_o(rst_en_o.por_usb[DomainAonSel]),
+    .leaf_rst_o(resets_o.rst_por_usb_n[DomainAonSel]),
+    .err_o(cnsty_chk_errs[4][DomainAonSel]),
+    .fsm_err_o(fsm_errs[4][DomainAonSel])
+  );
+
+  if (SecCheck) begin : gen_daon_por_usb_assert
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
+    DAonPorUsbFsmCheck_A,
+    u_daon_por_usb.gen_rst_chk.u_rst_chk.u_state_regs,
+    alert_tx_o[0])
+  end
+  assign resets_o.rst_por_usb_n[Domain0Sel] = '0;
+  assign cnsty_chk_errs[4][Domain0Sel] = '0;
+  assign fsm_errs[4][Domain0Sel] = '0;
+  assign rst_en_o.por_usb[Domain0Sel] = MuBi4True;
+  assign shadow_cnsty_chk_errs[4] = '0;
+  assign shadow_fsm_errs[4] = '0;
 
   // Generating resets for lc
   // Power Domains: ['Aon', '0']
@@ -391,8 +479,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.lc[DomainAonSel]),
     .leaf_rst_o(resets_o.rst_lc_n[DomainAonSel]),
-    .err_o(cnsty_chk_errs[3][DomainAonSel]),
-    .fsm_err_o(fsm_errs[3][DomainAonSel])
+    .err_o(cnsty_chk_errs[5][DomainAonSel]),
+    .fsm_err_o(fsm_errs[5][DomainAonSel])
   );
 
   if (SecCheck) begin : gen_daon_lc_assert
@@ -415,8 +503,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.lc[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_lc_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[3][Domain0Sel]),
-    .fsm_err_o(fsm_errs[3][Domain0Sel])
+    .err_o(cnsty_chk_errs[5][Domain0Sel]),
+    .fsm_err_o(fsm_errs[5][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_lc_assert
@@ -425,8 +513,8 @@ module rstmgr
     u_d0_lc.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[3] = '0;
-  assign shadow_fsm_errs[3] = '0;
+  assign shadow_cnsty_chk_errs[5] = '0;
+  assign shadow_fsm_errs[5] = '0;
 
   // Generating resets for lc_aon
   // Power Domains: ['Aon']
@@ -445,8 +533,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.lc_aon[DomainAonSel]),
     .leaf_rst_o(resets_o.rst_lc_aon_n[DomainAonSel]),
-    .err_o(cnsty_chk_errs[4][DomainAonSel]),
-    .fsm_err_o(fsm_errs[4][DomainAonSel])
+    .err_o(cnsty_chk_errs[6][DomainAonSel]),
+    .fsm_err_o(fsm_errs[6][DomainAonSel])
   );
 
   if (SecCheck) begin : gen_daon_lc_aon_assert
@@ -456,11 +544,11 @@ module rstmgr
     alert_tx_o[0])
   end
   assign resets_o.rst_lc_aon_n[Domain0Sel] = '0;
-  assign cnsty_chk_errs[4][Domain0Sel] = '0;
-  assign fsm_errs[4][Domain0Sel] = '0;
+  assign cnsty_chk_errs[6][Domain0Sel] = '0;
+  assign fsm_errs[6][Domain0Sel] = '0;
   assign rst_en_o.lc_aon[Domain0Sel] = MuBi4True;
-  assign shadow_cnsty_chk_errs[4] = '0;
-  assign shadow_fsm_errs[4] = '0;
+  assign shadow_cnsty_chk_errs[6] = '0;
+  assign shadow_fsm_errs[6] = '0;
 
   // Generating resets for lc_io
   // Power Domains: ['Aon']
@@ -479,8 +567,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.lc_io[DomainAonSel]),
     .leaf_rst_o(resets_o.rst_lc_io_n[DomainAonSel]),
-    .err_o(cnsty_chk_errs[5][DomainAonSel]),
-    .fsm_err_o(fsm_errs[5][DomainAonSel])
+    .err_o(cnsty_chk_errs[7][DomainAonSel]),
+    .fsm_err_o(fsm_errs[7][DomainAonSel])
   );
 
   if (SecCheck) begin : gen_daon_lc_io_assert
@@ -490,11 +578,11 @@ module rstmgr
     alert_tx_o[0])
   end
   assign resets_o.rst_lc_io_n[Domain0Sel] = '0;
-  assign cnsty_chk_errs[5][Domain0Sel] = '0;
-  assign fsm_errs[5][Domain0Sel] = '0;
+  assign cnsty_chk_errs[7][Domain0Sel] = '0;
+  assign fsm_errs[7][Domain0Sel] = '0;
   assign rst_en_o.lc_io[Domain0Sel] = MuBi4True;
-  assign shadow_cnsty_chk_errs[5] = '0;
-  assign shadow_fsm_errs[5] = '0;
+  assign shadow_cnsty_chk_errs[7] = '0;
+  assign shadow_fsm_errs[7] = '0;
 
   // Generating resets for lc_io_div2
   // Power Domains: ['Aon']
@@ -513,8 +601,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.lc_io_div2[DomainAonSel]),
     .leaf_rst_o(resets_o.rst_lc_io_div2_n[DomainAonSel]),
-    .err_o(cnsty_chk_errs[6][DomainAonSel]),
-    .fsm_err_o(fsm_errs[6][DomainAonSel])
+    .err_o(cnsty_chk_errs[8][DomainAonSel]),
+    .fsm_err_o(fsm_errs[8][DomainAonSel])
   );
 
   if (SecCheck) begin : gen_daon_lc_io_div2_assert
@@ -524,11 +612,11 @@ module rstmgr
     alert_tx_o[0])
   end
   assign resets_o.rst_lc_io_div2_n[Domain0Sel] = '0;
-  assign cnsty_chk_errs[6][Domain0Sel] = '0;
-  assign fsm_errs[6][Domain0Sel] = '0;
+  assign cnsty_chk_errs[8][Domain0Sel] = '0;
+  assign fsm_errs[8][Domain0Sel] = '0;
   assign rst_en_o.lc_io_div2[Domain0Sel] = MuBi4True;
-  assign shadow_cnsty_chk_errs[6] = '0;
-  assign shadow_fsm_errs[6] = '0;
+  assign shadow_cnsty_chk_errs[8] = '0;
+  assign shadow_fsm_errs[8] = '0;
 
   // Generating resets for lc_io_div4
   // Power Domains: ['0', 'Aon']
@@ -547,8 +635,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.lc_io_div4[DomainAonSel]),
     .leaf_rst_o(resets_o.rst_lc_io_div4_n[DomainAonSel]),
-    .err_o(cnsty_chk_errs[7][DomainAonSel]),
-    .fsm_err_o(fsm_errs[7][DomainAonSel])
+    .err_o(cnsty_chk_errs[9][DomainAonSel]),
+    .fsm_err_o(fsm_errs[9][DomainAonSel])
   );
 
   if (SecCheck) begin : gen_daon_lc_io_div4_assert
@@ -571,8 +659,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.lc_io_div4[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_lc_io_div4_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[7][Domain0Sel]),
-    .fsm_err_o(fsm_errs[7][Domain0Sel])
+    .err_o(cnsty_chk_errs[9][Domain0Sel]),
+    .fsm_err_o(fsm_errs[9][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_lc_io_div4_assert
@@ -595,8 +683,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.lc_io_div4_shadowed[DomainAonSel]),
     .leaf_rst_o(resets_o.rst_lc_io_div4_shadowed_n[DomainAonSel]),
-    .err_o(shadow_cnsty_chk_errs[7][DomainAonSel]),
-    .fsm_err_o(shadow_fsm_errs[7][DomainAonSel])
+    .err_o(shadow_cnsty_chk_errs[9][DomainAonSel]),
+    .fsm_err_o(shadow_fsm_errs[9][DomainAonSel])
   );
 
   if (SecCheck) begin : gen_daon_lc_io_div4_shadowed_assert
@@ -619,8 +707,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.lc_io_div4_shadowed[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_lc_io_div4_shadowed_n[Domain0Sel]),
-    .err_o(shadow_cnsty_chk_errs[7][Domain0Sel]),
-    .fsm_err_o(shadow_fsm_errs[7][Domain0Sel])
+    .err_o(shadow_cnsty_chk_errs[9][Domain0Sel]),
+    .fsm_err_o(shadow_fsm_errs[9][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_lc_io_div4_shadowed_assert
@@ -647,8 +735,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.lc_usb[DomainAonSel]),
     .leaf_rst_o(resets_o.rst_lc_usb_n[DomainAonSel]),
-    .err_o(cnsty_chk_errs[8][DomainAonSel]),
-    .fsm_err_o(fsm_errs[8][DomainAonSel])
+    .err_o(cnsty_chk_errs[10][DomainAonSel]),
+    .fsm_err_o(fsm_errs[10][DomainAonSel])
   );
 
   if (SecCheck) begin : gen_daon_lc_usb_assert
@@ -658,18 +746,18 @@ module rstmgr
     alert_tx_o[0])
   end
   assign resets_o.rst_lc_usb_n[Domain0Sel] = '0;
-  assign cnsty_chk_errs[8][Domain0Sel] = '0;
-  assign fsm_errs[8][Domain0Sel] = '0;
+  assign cnsty_chk_errs[10][Domain0Sel] = '0;
+  assign fsm_errs[10][Domain0Sel] = '0;
   assign rst_en_o.lc_usb[Domain0Sel] = MuBi4True;
-  assign shadow_cnsty_chk_errs[8] = '0;
-  assign shadow_fsm_errs[8] = '0;
+  assign shadow_cnsty_chk_errs[10] = '0;
+  assign shadow_fsm_errs[10] = '0;
 
   // Generating resets for sys
   // Power Domains: ['0']
   // Shadowed: True
   assign resets_o.rst_sys_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[9][DomainAonSel] = '0;
-  assign fsm_errs[9][DomainAonSel] = '0;
+  assign cnsty_chk_errs[11][DomainAonSel] = '0;
+  assign fsm_errs[11][DomainAonSel] = '0;
   assign rst_en_o.sys[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -685,8 +773,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.sys[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_sys_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[9][Domain0Sel]),
-    .fsm_err_o(fsm_errs[9][Domain0Sel])
+    .err_o(cnsty_chk_errs[11][Domain0Sel]),
+    .fsm_err_o(fsm_errs[11][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_sys_assert
@@ -696,8 +784,8 @@ module rstmgr
     alert_tx_o[0])
   end
   assign resets_o.rst_sys_shadowed_n[DomainAonSel] = '0;
-  assign shadow_cnsty_chk_errs[9][DomainAonSel] = '0;
-  assign shadow_fsm_errs[9][DomainAonSel] = '0;
+  assign shadow_cnsty_chk_errs[11][DomainAonSel] = '0;
+  assign shadow_fsm_errs[11][DomainAonSel] = '0;
   assign rst_en_o.sys_shadowed[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -713,8 +801,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.sys_shadowed[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_sys_shadowed_n[Domain0Sel]),
-    .err_o(shadow_cnsty_chk_errs[9][Domain0Sel]),
-    .fsm_err_o(shadow_fsm_errs[9][Domain0Sel])
+    .err_o(shadow_cnsty_chk_errs[11][Domain0Sel]),
+    .fsm_err_o(shadow_fsm_errs[11][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_sys_shadowed_assert
@@ -728,8 +816,8 @@ module rstmgr
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_sys_io_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[10][DomainAonSel] = '0;
-  assign fsm_errs[10][DomainAonSel] = '0;
+  assign cnsty_chk_errs[12][DomainAonSel] = '0;
+  assign fsm_errs[12][DomainAonSel] = '0;
   assign rst_en_o.sys_io[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -745,8 +833,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.sys_io[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_sys_io_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[10][Domain0Sel]),
-    .fsm_err_o(fsm_errs[10][Domain0Sel])
+    .err_o(cnsty_chk_errs[12][Domain0Sel]),
+    .fsm_err_o(fsm_errs[12][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_sys_io_assert
@@ -755,15 +843,15 @@ module rstmgr
     u_d0_sys_io.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[10] = '0;
-  assign shadow_fsm_errs[10] = '0;
+  assign shadow_cnsty_chk_errs[12] = '0;
+  assign shadow_fsm_errs[12] = '0;
 
   // Generating resets for sys_io_div2
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_sys_io_div2_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[11][DomainAonSel] = '0;
-  assign fsm_errs[11][DomainAonSel] = '0;
+  assign cnsty_chk_errs[13][DomainAonSel] = '0;
+  assign fsm_errs[13][DomainAonSel] = '0;
   assign rst_en_o.sys_io_div2[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -779,8 +867,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.sys_io_div2[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_sys_io_div2_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[11][Domain0Sel]),
-    .fsm_err_o(fsm_errs[11][Domain0Sel])
+    .err_o(cnsty_chk_errs[13][Domain0Sel]),
+    .fsm_err_o(fsm_errs[13][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_sys_io_div2_assert
@@ -789,8 +877,8 @@ module rstmgr
     u_d0_sys_io_div2.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[11] = '0;
-  assign shadow_fsm_errs[11] = '0;
+  assign shadow_cnsty_chk_errs[13] = '0;
+  assign shadow_fsm_errs[13] = '0;
 
   // Generating resets for sys_io_div4
   // Power Domains: ['0', 'Aon']
@@ -809,8 +897,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.sys_io_div4[DomainAonSel]),
     .leaf_rst_o(resets_o.rst_sys_io_div4_n[DomainAonSel]),
-    .err_o(cnsty_chk_errs[12][DomainAonSel]),
-    .fsm_err_o(fsm_errs[12][DomainAonSel])
+    .err_o(cnsty_chk_errs[14][DomainAonSel]),
+    .fsm_err_o(fsm_errs[14][DomainAonSel])
   );
 
   if (SecCheck) begin : gen_daon_sys_io_div4_assert
@@ -833,8 +921,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.sys_io_div4[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_sys_io_div4_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[12][Domain0Sel]),
-    .fsm_err_o(fsm_errs[12][Domain0Sel])
+    .err_o(cnsty_chk_errs[14][Domain0Sel]),
+    .fsm_err_o(fsm_errs[14][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_sys_io_div4_assert
@@ -843,15 +931,15 @@ module rstmgr
     u_d0_sys_io_div4.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[12] = '0;
-  assign shadow_fsm_errs[12] = '0;
+  assign shadow_cnsty_chk_errs[14] = '0;
+  assign shadow_fsm_errs[14] = '0;
 
   // Generating resets for sys_usb
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_sys_usb_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[13][DomainAonSel] = '0;
-  assign fsm_errs[13][DomainAonSel] = '0;
+  assign cnsty_chk_errs[15][DomainAonSel] = '0;
+  assign fsm_errs[15][DomainAonSel] = '0;
   assign rst_en_o.sys_usb[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -867,8 +955,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.sys_usb[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_sys_usb_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[13][Domain0Sel]),
-    .fsm_err_o(fsm_errs[13][Domain0Sel])
+    .err_o(cnsty_chk_errs[15][Domain0Sel]),
+    .fsm_err_o(fsm_errs[15][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_sys_usb_assert
@@ -877,8 +965,8 @@ module rstmgr
     u_d0_sys_usb.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[13] = '0;
-  assign shadow_fsm_errs[13] = '0;
+  assign shadow_cnsty_chk_errs[15] = '0;
+  assign shadow_fsm_errs[15] = '0;
 
   // Generating resets for sys_aon
   // Power Domains: ['Aon']
@@ -897,8 +985,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.sys_aon[DomainAonSel]),
     .leaf_rst_o(resets_o.rst_sys_aon_n[DomainAonSel]),
-    .err_o(cnsty_chk_errs[14][DomainAonSel]),
-    .fsm_err_o(fsm_errs[14][DomainAonSel])
+    .err_o(cnsty_chk_errs[16][DomainAonSel]),
+    .fsm_err_o(fsm_errs[16][DomainAonSel])
   );
 
   if (SecCheck) begin : gen_daon_sys_aon_assert
@@ -908,18 +996,18 @@ module rstmgr
     alert_tx_o[0])
   end
   assign resets_o.rst_sys_aon_n[Domain0Sel] = '0;
-  assign cnsty_chk_errs[14][Domain0Sel] = '0;
-  assign fsm_errs[14][Domain0Sel] = '0;
+  assign cnsty_chk_errs[16][Domain0Sel] = '0;
+  assign fsm_errs[16][Domain0Sel] = '0;
   assign rst_en_o.sys_aon[Domain0Sel] = MuBi4True;
-  assign shadow_cnsty_chk_errs[14] = '0;
-  assign shadow_fsm_errs[14] = '0;
+  assign shadow_cnsty_chk_errs[16] = '0;
+  assign shadow_fsm_errs[16] = '0;
 
   // Generating resets for spi_device
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_spi_device_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[15][DomainAonSel] = '0;
-  assign fsm_errs[15][DomainAonSel] = '0;
+  assign cnsty_chk_errs[17][DomainAonSel] = '0;
+  assign fsm_errs[17][DomainAonSel] = '0;
   assign rst_en_o.spi_device[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -935,8 +1023,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.spi_device[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_spi_device_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[15][Domain0Sel]),
-    .fsm_err_o(fsm_errs[15][Domain0Sel])
+    .err_o(cnsty_chk_errs[17][Domain0Sel]),
+    .fsm_err_o(fsm_errs[17][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_spi_device_assert
@@ -945,15 +1033,15 @@ module rstmgr
     u_d0_spi_device.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[15] = '0;
-  assign shadow_fsm_errs[15] = '0;
+  assign shadow_cnsty_chk_errs[17] = '0;
+  assign shadow_fsm_errs[17] = '0;
 
   // Generating resets for spi_host0
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_spi_host0_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[16][DomainAonSel] = '0;
-  assign fsm_errs[16][DomainAonSel] = '0;
+  assign cnsty_chk_errs[18][DomainAonSel] = '0;
+  assign fsm_errs[18][DomainAonSel] = '0;
   assign rst_en_o.spi_host0[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -969,8 +1057,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.spi_host0[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_spi_host0_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[16][Domain0Sel]),
-    .fsm_err_o(fsm_errs[16][Domain0Sel])
+    .err_o(cnsty_chk_errs[18][Domain0Sel]),
+    .fsm_err_o(fsm_errs[18][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_spi_host0_assert
@@ -979,15 +1067,15 @@ module rstmgr
     u_d0_spi_host0.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[16] = '0;
-  assign shadow_fsm_errs[16] = '0;
+  assign shadow_cnsty_chk_errs[18] = '0;
+  assign shadow_fsm_errs[18] = '0;
 
   // Generating resets for spi_host1
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_spi_host1_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[17][DomainAonSel] = '0;
-  assign fsm_errs[17][DomainAonSel] = '0;
+  assign cnsty_chk_errs[19][DomainAonSel] = '0;
+  assign fsm_errs[19][DomainAonSel] = '0;
   assign rst_en_o.spi_host1[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -1003,8 +1091,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.spi_host1[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_spi_host1_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[17][Domain0Sel]),
-    .fsm_err_o(fsm_errs[17][Domain0Sel])
+    .err_o(cnsty_chk_errs[19][Domain0Sel]),
+    .fsm_err_o(fsm_errs[19][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_spi_host1_assert
@@ -1013,15 +1101,15 @@ module rstmgr
     u_d0_spi_host1.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[17] = '0;
-  assign shadow_fsm_errs[17] = '0;
+  assign shadow_cnsty_chk_errs[19] = '0;
+  assign shadow_fsm_errs[19] = '0;
 
   // Generating resets for usb
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_usb_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[18][DomainAonSel] = '0;
-  assign fsm_errs[18][DomainAonSel] = '0;
+  assign cnsty_chk_errs[20][DomainAonSel] = '0;
+  assign fsm_errs[20][DomainAonSel] = '0;
   assign rst_en_o.usb[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -1037,8 +1125,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.usb[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_usb_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[18][Domain0Sel]),
-    .fsm_err_o(fsm_errs[18][Domain0Sel])
+    .err_o(cnsty_chk_errs[20][Domain0Sel]),
+    .fsm_err_o(fsm_errs[20][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_usb_assert
@@ -1047,15 +1135,15 @@ module rstmgr
     u_d0_usb.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[18] = '0;
-  assign shadow_fsm_errs[18] = '0;
+  assign shadow_cnsty_chk_errs[20] = '0;
+  assign shadow_fsm_errs[20] = '0;
 
   // Generating resets for usb_aon
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_usb_aon_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[19][DomainAonSel] = '0;
-  assign fsm_errs[19][DomainAonSel] = '0;
+  assign cnsty_chk_errs[21][DomainAonSel] = '0;
+  assign fsm_errs[21][DomainAonSel] = '0;
   assign rst_en_o.usb_aon[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -1071,8 +1159,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.usb_aon[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_usb_aon_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[19][Domain0Sel]),
-    .fsm_err_o(fsm_errs[19][Domain0Sel])
+    .err_o(cnsty_chk_errs[21][Domain0Sel]),
+    .fsm_err_o(fsm_errs[21][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_usb_aon_assert
@@ -1081,15 +1169,15 @@ module rstmgr
     u_d0_usb_aon.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[19] = '0;
-  assign shadow_fsm_errs[19] = '0;
+  assign shadow_cnsty_chk_errs[21] = '0;
+  assign shadow_fsm_errs[21] = '0;
 
   // Generating resets for i2c0
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_i2c0_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[20][DomainAonSel] = '0;
-  assign fsm_errs[20][DomainAonSel] = '0;
+  assign cnsty_chk_errs[22][DomainAonSel] = '0;
+  assign fsm_errs[22][DomainAonSel] = '0;
   assign rst_en_o.i2c0[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -1105,8 +1193,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.i2c0[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_i2c0_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[20][Domain0Sel]),
-    .fsm_err_o(fsm_errs[20][Domain0Sel])
+    .err_o(cnsty_chk_errs[22][Domain0Sel]),
+    .fsm_err_o(fsm_errs[22][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_i2c0_assert
@@ -1115,15 +1203,15 @@ module rstmgr
     u_d0_i2c0.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[20] = '0;
-  assign shadow_fsm_errs[20] = '0;
+  assign shadow_cnsty_chk_errs[22] = '0;
+  assign shadow_fsm_errs[22] = '0;
 
   // Generating resets for i2c1
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_i2c1_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[21][DomainAonSel] = '0;
-  assign fsm_errs[21][DomainAonSel] = '0;
+  assign cnsty_chk_errs[23][DomainAonSel] = '0;
+  assign fsm_errs[23][DomainAonSel] = '0;
   assign rst_en_o.i2c1[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -1139,8 +1227,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.i2c1[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_i2c1_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[21][Domain0Sel]),
-    .fsm_err_o(fsm_errs[21][Domain0Sel])
+    .err_o(cnsty_chk_errs[23][Domain0Sel]),
+    .fsm_err_o(fsm_errs[23][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_i2c1_assert
@@ -1149,15 +1237,15 @@ module rstmgr
     u_d0_i2c1.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[21] = '0;
-  assign shadow_fsm_errs[21] = '0;
+  assign shadow_cnsty_chk_errs[23] = '0;
+  assign shadow_fsm_errs[23] = '0;
 
   // Generating resets for i2c2
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_i2c2_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[22][DomainAonSel] = '0;
-  assign fsm_errs[22][DomainAonSel] = '0;
+  assign cnsty_chk_errs[24][DomainAonSel] = '0;
+  assign fsm_errs[24][DomainAonSel] = '0;
   assign rst_en_o.i2c2[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -1173,8 +1261,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.i2c2[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_i2c2_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[22][Domain0Sel]),
-    .fsm_err_o(fsm_errs[22][Domain0Sel])
+    .err_o(cnsty_chk_errs[24][Domain0Sel]),
+    .fsm_err_o(fsm_errs[24][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_i2c2_assert
@@ -1183,8 +1271,8 @@ module rstmgr
     u_d0_i2c2.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[22] = '0;
-  assign shadow_fsm_errs[22] = '0;
+  assign shadow_cnsty_chk_errs[24] = '0;
+  assign shadow_fsm_errs[24] = '0;
 
 
   ////////////////////////////////////////////////////

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
@@ -35,7 +35,9 @@ package rstmgr_pkg;
     logic [PowerDomains-1:0] rst_por_aon_n;
     logic [PowerDomains-1:0] rst_por_n;
     logic [PowerDomains-1:0] rst_por_io_n;
+    logic [PowerDomains-1:0] rst_por_io_div2_n;
     logic [PowerDomains-1:0] rst_por_io_div4_n;
+    logic [PowerDomains-1:0] rst_por_usb_n;
     logic [PowerDomains-1:0] rst_lc_n;
     logic [PowerDomains-1:0] rst_lc_aon_n;
     logic [PowerDomains-1:0] rst_lc_io_n;
@@ -65,7 +67,9 @@ package rstmgr_pkg;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_aon;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_io;
+    prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_io_div2;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_io_div4;
+    prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_usb;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] lc;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] lc_aon;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] lc_io;
@@ -90,7 +94,7 @@ package rstmgr_pkg;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] i2c2;
   } rstmgr_rst_en_t;
 
-  parameter int NumOutputRst = 26 * PowerDomains;
+  parameter int NumOutputRst = 28 * PowerDomains;
 
   // cpu reset requests and status
   typedef struct packed {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -935,69 +935,77 @@ module top_earlgrey #(
     prim_mubi_pkg::mubi4_t unused_rst_en_5;
     assign unused_rst_en_5 = rstmgr_aon_rst_en.por_io[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_6;
-    assign unused_rst_en_6 = rstmgr_aon_rst_en.por_io_div4[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_6 = rstmgr_aon_rst_en.por_io_div2[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_7;
-    assign unused_rst_en_7 = rstmgr_aon_rst_en.lc[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_7 = rstmgr_aon_rst_en.por_io_div2[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_8;
-    assign unused_rst_en_8 = rstmgr_aon_rst_en.lc_aon[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_8 = rstmgr_aon_rst_en.por_io_div4[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_9;
-    assign unused_rst_en_9 = rstmgr_aon_rst_en.lc_aon[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_9 = rstmgr_aon_rst_en.por_usb[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_10;
-    assign unused_rst_en_10 = rstmgr_aon_rst_en.lc_io[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_10 = rstmgr_aon_rst_en.por_usb[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_11;
-    assign unused_rst_en_11 = rstmgr_aon_rst_en.lc_io[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_11 = rstmgr_aon_rst_en.lc[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_12;
-    assign unused_rst_en_12 = rstmgr_aon_rst_en.lc_io_div2[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_12 = rstmgr_aon_rst_en.lc_aon[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_13;
-    assign unused_rst_en_13 = rstmgr_aon_rst_en.lc_io_div2[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_13 = rstmgr_aon_rst_en.lc_aon[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_14;
-    assign unused_rst_en_14 = rstmgr_aon_rst_en.lc_io_div4_shadowed[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_14 = rstmgr_aon_rst_en.lc_io[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_15;
-    assign unused_rst_en_15 = rstmgr_aon_rst_en.lc_io_div4_shadowed[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_15 = rstmgr_aon_rst_en.lc_io[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_16;
-    assign unused_rst_en_16 = rstmgr_aon_rst_en.lc_usb[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_16 = rstmgr_aon_rst_en.lc_io_div2[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_17;
-    assign unused_rst_en_17 = rstmgr_aon_rst_en.lc_usb[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_17 = rstmgr_aon_rst_en.lc_io_div2[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_18;
-    assign unused_rst_en_18 = rstmgr_aon_rst_en.sys_shadowed[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_18 = rstmgr_aon_rst_en.lc_io_div4_shadowed[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_19;
-    assign unused_rst_en_19 = rstmgr_aon_rst_en.sys[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_19 = rstmgr_aon_rst_en.lc_io_div4_shadowed[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_20;
-    assign unused_rst_en_20 = rstmgr_aon_rst_en.sys_shadowed[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_20 = rstmgr_aon_rst_en.lc_usb[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_21;
-    assign unused_rst_en_21 = rstmgr_aon_rst_en.sys_io[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_21 = rstmgr_aon_rst_en.lc_usb[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_22;
-    assign unused_rst_en_22 = rstmgr_aon_rst_en.sys_io[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_22 = rstmgr_aon_rst_en.sys_shadowed[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_23;
-    assign unused_rst_en_23 = rstmgr_aon_rst_en.sys_io_div2[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_23 = rstmgr_aon_rst_en.sys[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_24;
-    assign unused_rst_en_24 = rstmgr_aon_rst_en.sys_io_div2[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_24 = rstmgr_aon_rst_en.sys_shadowed[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_25;
-    assign unused_rst_en_25 = rstmgr_aon_rst_en.sys_usb[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_25 = rstmgr_aon_rst_en.sys_io[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_26;
-    assign unused_rst_en_26 = rstmgr_aon_rst_en.sys_usb[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_26 = rstmgr_aon_rst_en.sys_io[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_27;
-    assign unused_rst_en_27 = rstmgr_aon_rst_en.sys_aon[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_27 = rstmgr_aon_rst_en.sys_io_div2[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_28;
-    assign unused_rst_en_28 = rstmgr_aon_rst_en.sys_aon[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_28 = rstmgr_aon_rst_en.sys_io_div2[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_29;
-    assign unused_rst_en_29 = rstmgr_aon_rst_en.spi_device[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_29 = rstmgr_aon_rst_en.sys_usb[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_30;
-    assign unused_rst_en_30 = rstmgr_aon_rst_en.spi_host0[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_30 = rstmgr_aon_rst_en.sys_usb[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_31;
-    assign unused_rst_en_31 = rstmgr_aon_rst_en.spi_host1[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_31 = rstmgr_aon_rst_en.sys_aon[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_32;
-    assign unused_rst_en_32 = rstmgr_aon_rst_en.usb[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_32 = rstmgr_aon_rst_en.sys_aon[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_33;
-    assign unused_rst_en_33 = rstmgr_aon_rst_en.usb_aon[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_33 = rstmgr_aon_rst_en.spi_device[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_34;
-    assign unused_rst_en_34 = rstmgr_aon_rst_en.usb_aon[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_34 = rstmgr_aon_rst_en.spi_host0[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_35;
-    assign unused_rst_en_35 = rstmgr_aon_rst_en.i2c0[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_35 = rstmgr_aon_rst_en.spi_host1[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_36;
-    assign unused_rst_en_36 = rstmgr_aon_rst_en.i2c1[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_36 = rstmgr_aon_rst_en.usb[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_37;
-    assign unused_rst_en_37 = rstmgr_aon_rst_en.i2c2[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_37 = rstmgr_aon_rst_en.usb_aon[rstmgr_pkg::DomainAonSel];
+    prim_mubi_pkg::mubi4_t unused_rst_en_38;
+    assign unused_rst_en_38 = rstmgr_aon_rst_en.usb_aon[rstmgr_pkg::Domain0Sel];
+    prim_mubi_pkg::mubi4_t unused_rst_en_39;
+    assign unused_rst_en_39 = rstmgr_aon_rst_en.i2c0[rstmgr_pkg::DomainAonSel];
+    prim_mubi_pkg::mubi4_t unused_rst_en_40;
+    assign unused_rst_en_40 = rstmgr_aon_rst_en.i2c1[rstmgr_pkg::DomainAonSel];
+    prim_mubi_pkg::mubi4_t unused_rst_en_41;
+    assign unused_rst_en_41 = rstmgr_aon_rst_en.i2c2[rstmgr_pkg::DomainAonSel];
 
   // Peripheral Instantiation
 
@@ -1792,7 +1800,12 @@ module top_earlgrey #(
       .rst_io_div4_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::DomainAonSel]),
       .rst_main_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::DomainAonSel]),
       .rst_usb_ni (rstmgr_aon_resets.rst_lc_usb_n[rstmgr_pkg::DomainAonSel]),
-      .rst_por_io_ni (rstmgr_aon_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel])
+      .rst_root_ni (rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]),
+      .rst_root_io_ni (rstmgr_aon_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),
+      .rst_root_io_div2_ni (rstmgr_aon_resets.rst_por_io_div2_n[rstmgr_pkg::DomainAonSel]),
+      .rst_root_io_div4_ni (rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]),
+      .rst_root_main_ni (rstmgr_aon_resets.rst_por_n[rstmgr_pkg::DomainAonSel]),
+      .rst_root_usb_ni (rstmgr_aon_resets.rst_por_usb_n[rstmgr_pkg::DomainAonSel])
   );
   sysrst_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[25:25])

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -288,7 +288,12 @@
                           rst_io_div4_ni: "por_io_div4",
                           rst_main_ni: "por",
                           rst_usb_ni: "por_usb",
-                          rst_por_io_ni: "por_io"
+                          rst_root_ni: "por_io_div4",
+                          rst_root_io_ni: "por_io",
+                          rst_root_io_div2_ni: "por_io_div2",
+                          rst_root_io_div4_ni: "por_io_div4",
+                          rst_root_main_ni: "por",
+                          rst_root_usb_ni: "por_usb",
                          },
       domain: ["Aon"],
       base_addr: "0x40420000",


### PR DESCRIPTION
- fixes #13657
- This adds back support for synchronous resets to support
  verilator sims and a specific case inside ast.

- This is done by supplying both por and lc resets to the
  clkmgr.  The por resets are used for clock generation,
  root clock gating and clock status communication.  While
  the lc resets are used for general functionality and error
  checks.

Signed-off-by: Timothy Chen <timothytim@google.com>