### PR TITLE
Fix the example programs to work with the test_rom

### DIFF
--- a/sw/device/examples/hello_usbdev/BUILD
+++ b/sw/device/examples/hello_usbdev/BUILD
@@ -18,6 +18,7 @@ opentitan_flash_binary(
     deps = [
         ":hello_usbdev_lib",
         "//sw/device/lib/base:mmio",
+        "//sw/device/lib/testing/test_framework:test_framework_manifest_def",
     ],
 )
 

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -18,6 +18,7 @@ opentitan_flash_binary(
     deps = [
         ":hello_world_lib",
         "//sw/device/lib/base:mmio",
+        "//sw/device/lib/testing/test_framework:test_framework_manifest_def",
     ],
 )
 


### PR DESCRIPTION
The test_rom recently changed how it interprets the manifest.
Fix the example programs to include the correct unsigned manifest.

Signed-off-by: Chris Frantz <cfrantz@google.com>