### PR TITLE
[dv/alert_handler] Fix alert_handler ping timeout

### DIFF
--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -90,7 +90,7 @@
     {
       name: alert_handler_ping_timeout
       uvm_test_seq: alert_handler_ping_timeout_vseq
-      run_opts: ["+test_timeout_ns=10_000_000_000"]
+      run_opts: ["+test_timeout_ns=1_000_000_000"]
     }
 
     {

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -17,7 +17,8 @@ class alert_handler_entropy_vseq extends alert_handler_smoke_vseq;
   // increase the possibility to enable more alerts, because alert_handler only sends ping on
   // enabled alerts
   constraint enable_one_alert_c {
-    alert_en dist {'1 :/ 9, [0:('1-1)] :/ 1};
+    alert_en        dist {'1 :/ 9, [0:('1-1)] :/ 1};
+    (~alert_regwen) dist {'1 :/ 9, [0:('1-1)] :/ 1};
   }
 
   constraint sig_int_c {

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_ping_timeout_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_ping_timeout_vseq.sv
@@ -14,7 +14,7 @@ class alert_handler_ping_timeout_vseq extends alert_handler_entropy_vseq;
   `uvm_object_new
 
   constraint num_trans_c {
-    num_trans inside {[1:10]};
+    num_trans inside {[5:30]};
   }
 
   constraint alert_trigger_c {
@@ -32,7 +32,8 @@ class alert_handler_ping_timeout_vseq extends alert_handler_entropy_vseq;
   }
 
   constraint loc_alert_en_c {
-    local_alert_en[LocalEscPingFail:LocalAlertPingFail] > 0;
+    local_alert_en[LocalEscPingFail] == 1;
+    local_alert_en[LocalAlertPingFail] == 1;
   }
 
   constraint ping_fail_c {
@@ -40,9 +41,13 @@ class alert_handler_ping_timeout_vseq extends alert_handler_entropy_vseq;
     esc_ping_timeout   == '1;
   }
 
-  // At least enable `NUM_ALERTS-4` alerts to avoid this sequence running too long.
+  // At least enable and lock `NUM_ALERTS-4` alerts to avoid this sequence running too long.
+  // This constraint also ensures at least one alert is locked and enabled so that we can ensure at
+  // least one alert ping will fire.
   constraint enable_one_alert_c {
-    $countones(alert_en) dist {NUM_ALERTS :/ 8, [NUM_ALERTS-4 : NUM_ALERTS-1] :/ 2};
+    $countones(alert_en)      dist {NUM_ALERTS :/ 8, [NUM_ALERTS-4 : NUM_ALERTS-1] :/ 2};
+    $countones(~alert_regwen) dist {NUM_ALERTS :/ 5, [NUM_ALERTS-4 : NUM_ALERTS-1] :/ 5};
+    (~alert_regwen) & alert_en > 0;
   }
 
   constraint ping_timeout_cyc_c {

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -90,7 +90,7 @@
     {
       name: alert_handler_ping_timeout
       uvm_test_seq: alert_handler_ping_timeout_vseq
-      run_opts: ["+test_timeout_ns=10_000_000_000"]
+      run_opts: ["+test_timeout_ns=1_000_000_000"]
     }
 
     {

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -17,7 +17,8 @@ class alert_handler_entropy_vseq extends alert_handler_smoke_vseq;
   // increase the possibility to enable more alerts, because alert_handler only sends ping on
   // enabled alerts
   constraint enable_one_alert_c {
-    alert_en dist {'1 :/ 9, [0:('1-1)] :/ 1};
+    alert_en        dist {'1 :/ 9, [0:('1-1)] :/ 1};
+    (~alert_regwen) dist {'1 :/ 9, [0:('1-1)] :/ 1};
   }
 
   constraint sig_int_c {

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_ping_timeout_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_ping_timeout_vseq.sv
@@ -14,7 +14,7 @@ class alert_handler_ping_timeout_vseq extends alert_handler_entropy_vseq;
   `uvm_object_new
 
   constraint num_trans_c {
-    num_trans inside {[1:10]};
+    num_trans inside {[5:30]};
   }
 
   constraint alert_trigger_c {
@@ -32,7 +32,8 @@ class alert_handler_ping_timeout_vseq extends alert_handler_entropy_vseq;
   }
 
   constraint loc_alert_en_c {
-    local_alert_en[LocalEscPingFail:LocalAlertPingFail] > 0;
+    local_alert_en[LocalEscPingFail] == 1;
+    local_alert_en[LocalAlertPingFail] == 1;
   }
 
   constraint ping_fail_c {
@@ -40,9 +41,13 @@ class alert_handler_ping_timeout_vseq extends alert_handler_entropy_vseq;
     esc_ping_timeout   == '1;
   }
 
-  // At least enable `NUM_ALERTS-4` alerts to avoid this sequence running too long.
+  // At least enable and lock `NUM_ALERTS-4` alerts to avoid this sequence running too long.
+  // This constraint also ensures at least one alert is locked and enabled so that we can ensure at
+  // least one alert ping will fire.
   constraint enable_one_alert_c {
-    $countones(alert_en) dist {NUM_ALERTS :/ 8, [NUM_ALERTS-4 : NUM_ALERTS-1] :/ 2};
+    $countones(alert_en)      dist {NUM_ALERTS :/ 8, [NUM_ALERTS-4 : NUM_ALERTS-1] :/ 2};
+    $countones(~alert_regwen) dist {NUM_ALERTS :/ 5, [NUM_ALERTS-4 : NUM_ALERTS-1] :/ 5};
+    (~alert_regwen) & alert_en > 0;
   }
 
   constraint ping_timeout_cyc_c {


### PR DESCRIPTION
The alert_handler ping timeout sequence is running too long that nightly
regression was affected.
This PR reduces the length by enabling and locking more alerts, also
enabling escalation ping timeout to fasten the process.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>