### PR TITLE
[dv/cip_base] Add checking in stress_all_with_rand_reset seq

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -710,6 +710,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
               do_read_and_check_all_csrs = 1'b1;
               ongoing_reset = 1'b0;
             end
+          `DV_CHECK_EQ(has_outstanding_access(),  0, "No CSR outstanding items after reset!")
           join_any
           disable fork;
           `uvm_info(`gfn, $sformatf("\nStress w/ reset is done for run %0d/%0d", i, num_times),

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -39,6 +39,10 @@ package csr_utils_pkg;
     outstanding_accesses = 0;
   endfunction
 
+  function automatic bit has_outstanding_access();
+    return outstanding_accesses > 0;
+  endfunction
+
   // timeout may happen if we issue too many non-blocking accesses at once
   // limit the nonblocking items to be up to max outstanding
   task automatic wait_if_max_outstanding_accesses_reached(int max = max_outstanding_accesses);


### PR DESCRIPTION
This PR adds a checking after reset is issued to check if there are
still any outstanding csr items. If so, the following csr checks or
sequences are unlikely to pass due to the hanging outstanding item.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>