### PR TITLE
[dv/kmac] Collecting coverage for app interface and sideload

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -90,7 +90,8 @@
       desc: '''
             Same as the smoke test, except we set cfg.sideload and provide a
             valid sideloaded key as well as a valid SW-provided key.
-            KMAC should operate on the sideloaded key.
+            KMAC should operate on the sideloaded key regardless of the cfg_shadowed.sideload field
+            value.
             '''
       milestone: V2
       tests: ["{variant}_sideload"]
@@ -316,8 +317,8 @@
       name: sideload_cg
       desc: '''
             Covers that the KMAC sees scenarios where the sideloaded key is provided and should be
-            used (`en_sideload==1`, `app_mode==AppKeymgr`), and scenarios where the sideloaded key is
-            provided but should not be used.
+            used (`en_sideload==1`, `app_mode==AppKeymgr`), and scenarios where the sideloaded key
+            is provided but should not be used.
             '''
     }
     {

--- a/hw/ip/kmac/dv/env/kmac_env_cov.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cov.sv
@@ -289,11 +289,9 @@ class kmac_env_cov extends cip_base_env_cov #(.CFG_T(kmac_env_cfg));
 
     sideload_cross: cross sideload, kmac_mode, in_app_keymgr {
       bins sw_kmac_valid_sideload   = binsof(sideload) intersect {1} && binsof(kmac_mode);
-      bins sw_kmac_invalid_sideload = binsof(sideload) intersect {1} && binsof(kmac_mode);
+      bins sw_kmac_invalid_sideload = binsof(sideload) intersect {0} && binsof(kmac_mode);
       bins app_valid_sideload       = binsof(sideload) intersect {1} && binsof(in_app_keymgr);
-      bins app_invalid_sideload     = binsof(sideload) intersect {1} && binsof(in_app_keymgr);
-
-      ignore_bins invalid = !binsof(sideload) intersect {1};
+      bins app_invalid_sideload     = binsof(sideload) intersect {0} && binsof(in_app_keymgr);
     }
   endgroup
 


### PR DESCRIPTION
Update fcov to collect coverage where sideload is set to 0, but kmac
keymgr app interface request is sent.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>