### PR TITLE
[dif/entropy_src] add alert threshold config

### DIFF
--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -84,15 +84,27 @@ dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
   mmio_region_write32(entropy_src->base_addr, ENTROPY_SRC_CONF_REG_OFFSET,
                       entropy_conf_reg);
 
-  if (config.health_test_threshold_scope) {
-    // Configure health test window.
-    // Conditioning bypass is hardcoded to disabled (see above). If we want to
-    // expose the ES_TYPE field in the future, we need to also configure the
-    // health test window size for bypass mode.
-    mmio_region_write32(entropy_src->base_addr,
-                        ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_OFFSET,
-                        config.health_test_window_size);
-  }
+  // Configure health test window.
+  // Conditioning bypass is hardcoded to disabled (see above). If we want to
+  // expose the ES_TYPE field in the future, we need to also configure the
+  // health test window size for bypass mode.
+  uint32_t health_test_window_sizes =
+      bitfield_field32_write(ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_RESVAL,
+                             ENTROPY_SRC_HEALTH_TEST_WINDOWS_FIPS_WINDOW_FIELD,
+                             config.health_test_window_size);
+  mmio_region_write32(entropy_src->base_addr,
+                      ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_OFFSET,
+                      health_test_window_sizes);
+
+  // Alert Threshold register configuration.
+  uint32_t alert_threshold = bitfield_field32_write(
+      0, ENTROPY_SRC_ALERT_THRESHOLD_ALERT_THRESHOLD_FIELD,
+      config.alert_threshold);
+  alert_threshold = bitfield_field32_write(
+      alert_threshold, ENTROPY_SRC_ALERT_THRESHOLD_ALERT_THRESHOLD_INV_FIELD,
+      ~config.alert_threshold);
+  mmio_region_write32(entropy_src->base_addr,
+                      ENTROPY_SRC_ALERT_THRESHOLD_REG_OFFSET, alert_threshold);
 
   // MODULE_ENABLE register configuration.
   mmio_region_write32(entropy_src->base_addr,

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -121,6 +121,12 @@ typedef struct dif_entropy_src_config {
    * Units: bits
    */
   uint16_t health_test_window_size;
+
+  /**
+   * The number of health test failures that must occur before an alert is
+   * triggered. When set to 0, alerts are disabled.
+   */
+  uint16_t alert_threshold;
 } dif_entropy_src_config_t;
 
 /**

--- a/sw/device/tests/entropy_src_ast_rng_req_test.c
+++ b/sw/device/tests/entropy_src_ast_rng_req_test.c
@@ -48,6 +48,9 @@ bool test_main() {
       // Route the entropy data received from RNG to the FIFO.
       .route_to_firmware = true,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+      .health_test_threshold_scope = false, /*default*/
+      .health_test_window_size = 0x0200,    /*default*/
+      .alert_threshold = 2,                 /*default*/
   };
   CHECK_DIF_OK(
       dif_entropy_src_configure(&entropy_src, config, kDifToggleEnabled));

--- a/sw/device/tests/entropy_src_fw_ovr_test.c
+++ b/sw/device/tests/entropy_src_fw_ovr_test.c
@@ -68,6 +68,9 @@ static void entropy_with_fw_override_enable(dif_entropy_src_t *entropy_src) {
       .fips_enable = true,
       .route_to_firmware = true,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+      .health_test_threshold_scope = false, /*default*/
+      .health_test_window_size = 0x0200,    /*default*/
+      .alert_threshold = 2,                 /*default*/
   };
   CHECK_DIF_OK(
       dif_entropy_src_configure(entropy_src, config, kDifToggleEnabled));

--- a/sw/device/tests/entropy_src_kat_test.c
+++ b/sw/device/tests/entropy_src_kat_test.c
@@ -42,6 +42,9 @@ static void entropy_with_fw_override_enable(dif_entropy_src_t *entropy_src) {
       .fips_enable = true,
       .route_to_firmware = true,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+      .health_test_threshold_scope = false, /*default*/
+      .health_test_window_size = 0x0200,    /*default*/
+      .alert_threshold = 2,                 /*default*/
   };
   CHECK_DIF_OK(
       dif_entropy_src_configure(entropy_src, config, kDifToggleEnabled));

--- a/sw/device/tests/entropy_src_smoketest.c
+++ b/sw/device/tests/entropy_src_smoketest.c
@@ -38,6 +38,9 @@ bool test_main(void) {
       .fips_enable = true,
       .route_to_firmware = true,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+      .health_test_threshold_scope = false, /*default*/
+      .health_test_window_size = 0x0200,    /*default*/
+      .alert_threshold = 2,                 /*default*/
   };
   CHECK_DIF_OK(
       dif_entropy_src_configure(&entropy_src, config, kDifToggleEnabled));


### PR DESCRIPTION
This updates the main entropy source configuration DIF (and all tests that use this DIF) to set the alert threshold CSR. Additionally, corresponding unit tests are also updated.

**_Note, this depends on #13639._**