### PR TITLE
[ottool] Make the uart-clearing behavior optional

### DIFF
--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -147,7 +147,7 @@ def cw310_params(
         # Base Parameters
         args = _BASE_PARAMS["args"] + [
             "--exec=\"load-bitstream --rom-kind={rom_kind} $(location {bitstream})\"",
-            "--exec=\"bootstrap $(location {flash})\"",
+            "--exec=\"bootstrap --clear-uart=true $(location {flash})\"",
             "console",
             "--exit-success={exit_success}",
             "--exit-failure={exit_failure}",

--- a/sw/host/opentitanlib/src/bootstrap/mod.rs
+++ b/sw/host/opentitanlib/src/bootstrap/mod.rs
@@ -95,7 +95,7 @@ pub struct BootstrapOptions {
         long,
         help = "Whether to reset target and clear UART RX buffer after bootstrap. For CW310 only."
     )]
-    pub no_clear_uart_rx: Option<bool>,
+    pub clear_uart: Option<bool>,
     #[structopt(long, parse(try_from_str=parse_duration), help = "Duration of the reset delay")]
     pub reset_delay: Option<Duration>,
     #[structopt(long, parse(try_from_str=parse_duration), help = "Duration of the inter-frame delay")]
@@ -160,7 +160,7 @@ impl<'a> Bootstrap<'a> {
         };
         Bootstrap {
             protocol: options.protocol,
-            clear_uart_rx: !options.no_clear_uart_rx.unwrap_or(false),
+            clear_uart_rx: options.clear_uart.unwrap_or(false),
             uart_params: &options.uart_params,
             spi_params: &options.spi_params,
             reset_pin: transport.gpio_pin("RESET")?,


### PR DESCRIPTION
In #13277, uart-clearing was added to prevent random leftovers in the
host's receive buffer from affecting ROM detection and test pass/fail
detection.  Unfortunately, this changed the behavior of opentitantool in
such a way that one could no longer keep a `opentitantool console` open
in one windows while bootstrapping in another without specifying
`--no-uart-clear-rx=true`.  Since the primary use case for uart buffer
clearing is test automation, test automation should enable its preferred
behavior and not cause an end-user usability change.

1. Do not use a negative-named option. Negatively named options are
   confusing.
2. Add `--uart-clear` to all test-driven invocations of `bootstrap`.

Signed-off-by: Chris Frantz <cfrantz@google.com>