### PR TITLE
[usb_testutils] Avoid buffer double-free

### DIFF
--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -313,7 +313,10 @@ static void ctrl_rx(void *ctctx_v, dif_usbdev_rx_packet_info_t packet_info,
     TRC_I(bp[i], 8);
     TRC_C(' ');
   }
-  CHECK_DIF_OK(dif_usbdev_buffer_return(ctx->dev, ctx->buffer_pool, &buffer));
+  if (buffer.type != kDifUsbdevBufferTypeStale) {
+    // Return the unused buffer.
+    CHECK_DIF_OK(dif_usbdev_buffer_return(ctx->dev, ctx->buffer_pool, &buffer));
+  }
   ctctx->ctrlstate = kUsbTestutilsCtIdle;
 }
 


### PR DESCRIPTION
The control endpoint code had a path that would lead to a double return
of the buffer. Check that the buffer is still active before calling the
DIF to return it.

This case is due to the buffer read function automatically returning the
buffer underneath when all data has been read.

Signed-off-by: Alexander Williams <awill@google.com>