### PR TITLE
[otbn,dv] Reset model status in scoreboard when reset is released

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -55,7 +55,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
   bit pending_start_tl_trans = 1'b0;
 
   // The mirrored STATUS register from the ISS.
-  bit [7:0] model_status = 8'd0;
+  bit [7:0] model_status;
 
   // The "locked" field is used to track whether OTBN is "locked". For most operational state
   // tracking, we go through the ISS, but OTBN can become locked without actually starting an
@@ -376,6 +376,9 @@ class otbn_scoreboard extends cip_base_scoreboard #(
         OtbnModelStatus: begin
           bit was_executing = model_status inside {otbn_pkg::StatusBusyExecute};
           bit is_busy = otbn_pkg::is_busy_status(item.status);
+
+          // Did the status change happen due to a reset? If so, reset the model status as well.
+          if (item.rst_n !== 1'b1) model_status = item.status;
 
           // Has the status changed from idle to busy? If so, we should have seen a write to the
           // command register on the previous posedge. See comment above pending_start_tl_trans for

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_item.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_item.sv
@@ -11,6 +11,7 @@ class otbn_model_item extends uvm_sequence_item;
   bit [7:0]              status;
   bit                    err;
   otbn_pkg::err_bits_t   err_bits;
+  bit                    rst_n;
 
   // Only valid when item_type == OtbnModelInsn
   bit [31:0]             insn_addr;
@@ -21,6 +22,7 @@ class otbn_model_item extends uvm_sequence_item;
     `uvm_field_int    (status, UVM_DEFAULT)
     `uvm_field_int    (err, UVM_DEFAULT)
     `uvm_field_int    (err_bits, UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int    (rst_n, UVM_DEFAULT)
     `uvm_field_int    (insn_addr, UVM_DEFAULT | UVM_HEX)
     `uvm_field_string (mnemonic, UVM_DEFAULT)
   `uvm_object_utils_end

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
@@ -31,8 +31,13 @@ class otbn_model_monitor extends dv_base_monitor #(
     otbn_model_item trans;
 
     forever begin
+      trans = otbn_model_item::type_id::create("trans");
+
       // Wait until vif signals a change in status (or we are in reset)
       cfg.vif.wait_status();
+
+      // Store value of reset before we wait for it to be released (if it is not already).
+      trans.rst_n = cfg.vif.rst_ni;
 
       if (cfg.vif.rst_ni !== 1'b1) begin
         // We are in reset. Wait until we aren't (we need to do this because wait_status() returns
@@ -40,7 +45,6 @@ class otbn_model_monitor extends dv_base_monitor #(
         wait(cfg.vif.rst_ni);
       end
 
-      trans = otbn_model_item::type_id::create("trans");
       trans.item_type = OtbnModelStatus;
       trans.status    = cfg.vif.status;
       trans.err       = cfg.vif.err;


### PR DESCRIPTION
`otbn_scoreboard` receives status transitions of the OTBN model from
`otbn_model_monitor`.  On a reset, the monitor waits until the reset is
released before sampling the status (as the status is not guaranteed to
have settled directly on the falling reset edge, see 64d77825af).  The
scoreboard thus on a reset only receives a transaction to the initial
status (Idle), and it cannot know if the model entered the Idle state
due to a reset or because OTBN completed execution.

This commit fills this knowledge gap of the scoreboard by adding the
value of the reset signal (before release) to the status transition.  If
the status transitions due to reset, the scoreboard resets its mirror of
the model status as well before using it for checks.

As a bonus side effect, this removes the need to keep the initial value
of the model status in the scoreboard in sync with RTL and model code.