### PR TITLE
[bazel] mark plic_all_irqs_test as flaky now that it's not broken

### DIFF
--- a/sw/device/tests/autogen/BUILD
+++ b/sw/device/tests/autogen/BUILD
@@ -15,7 +15,8 @@ opentitan_functest(
     srcs = ["plic_all_irqs_test.c"],
     verilator = verilator_params(
         timeout = "eternal",
-        tags = ["broken"],
+        tags = ["flaky"],
+        # often times out in 3600s on 4 cores
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/util/topgen/templates/BUILD.tpl
+++ b/util/topgen/templates/BUILD.tpl
@@ -15,7 +15,8 @@ opentitan_functest(
     srcs = ["plic_all_irqs_test.c"],
     verilator = verilator_params(
         timeout = "eternal",
-        tags = ["broken"],
+        tags = ["flaky"],
+        # often times out in 3600s on 4 cores
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",


### PR DESCRIPTION
The flakiness is just related to the long test time. The flaky and
eternal tags save people from having bad surprises that they can't
filter out

Signed-off-by: Drew Macrae <drewmacrae@google.com>