### PR TITLE
[entropy_src/rtl] Fixes to ERR_CODE_TEST Register

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1469,7 +1469,6 @@
       swaccess: "rw",
       hwaccess: "hro",
       hwqe: "true",
-      regwen: "REGWEN",
       tags: [// Setting this register will force an unwanted fatal alert.
                  "excl:CsrNonInitTests:CsrExclWrite"]
       fields: [

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -367,6 +367,10 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     sfifo_esrng_err_sum;
   logic                     sfifo_observe_err_sum;
   logic                     sfifo_esfinal_err_sum;
+  // For fifo errors that are generated through the
+  // ERR_CODE_TEST register, but are not associated
+  // with any errors:
+  logic                     sfifo_test_err_sum;
   logic                     es_ack_sm_err_sum;
   logic                     es_ack_sm_err;
   logic                     es_main_sm_err_sum;
@@ -713,6 +717,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
                                              sfifo_esrng_err_sum ||
                                              sfifo_observe_err_sum ||
                                              sfifo_esfinal_err_sum ||
+                                             sfifo_test_err_sum ||
                                              es_ack_sm_err_sum ||
                                              es_main_sm_err_sum)) ||
                                              es_cntr_err_sum || // prim_count err is always active
@@ -725,6 +730,16 @@ module entropy_src_core import entropy_src_pkg::*; #(
          err_code_test_bit[1];
   assign sfifo_esfinal_err_sum = (|sfifo_esfinal_err) ||
          err_code_test_bit[2];
+
+  // The following test bits help normally diagnose the _type_ of
+  // error when they are triggred by the fifo. However when
+  // they are triggered by softwre they are not linked to a
+  // particular sfifo and do not trigger an alert, unless
+  // we capture them here.
+  assign sfifo_test_err_sum = err_code_test_bit[28] ||
+                              err_code_test_bit[29] ||
+                              err_code_test_bit[30];
+
   assign es_ack_sm_err_sum = es_ack_sm_err ||
          err_code_test_bit[20];
   assign es_main_sm_err_sum = es_main_sm_err ||
@@ -2514,7 +2529,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   // unused signals
   //--------------------------------------------
 
-  assign unused_err_code_test_bit = (|{err_code_test_bit[27:22],err_code_test_bit[19:3]});
+  assign unused_err_code_test_bit = (|{err_code_test_bit[27:23],err_code_test_bit[19:3]});
   assign unused_sha3_state = (|sha3_state[0][sha3_pkg::StateW-1:SeedLen]);
   assign unused_entropy_data = (|reg2hw.entropy_data.q);
   assign unused_fw_ov_rd_data = (|reg2hw.fw_ov_rd_data.q);

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -3004,9 +3004,6 @@ module entropy_src_reg_top (
     .d_i(&err_code_test_flds_we),
     .q_o(err_code_test_qe)
   );
-  // Create REGWEN-gated WE signal
-  logic err_code_test_gated_we;
-  assign err_code_test_gated_we = err_code_test_we & regwen_qs;
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3016,7 +3013,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_test_gated_we),
+    .we     (err_code_test_we),
     .wd     (err_code_test_wd),
 
     // from internal hardware
@@ -3442,7 +3439,7 @@ module entropy_src_reg_top (
     reg_we_check[52] = 1'b0;
     reg_we_check[53] = recov_alert_sts_we;
     reg_we_check[54] = 1'b0;
-    reg_we_check[55] = err_code_test_gated_we;
+    reg_we_check[55] = err_code_test_we;
     reg_we_check[56] = 1'b0;
   end
 


### PR DESCRIPTION
1. ERR_CODE_TEST is no longer under REGWEN.  Writes to this
   register are only effective when the module is active.
   Since the module automatically activates REGWEN when
   enabled, having ERR_CODE_TEST under REGWEN makes the
   test null.

2. Makes sure that any writes to ERR_CODE_TEST will create
   an alert.
   We add a new signal sfifo_test_err_sum to accumulate
   artificial FIFO error events, that are not associated
   with any real FIFO.  These events can be caused by
   writes to bits 28-30 of ERR_CODE_TEST

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>