### PR TITLE
[cdc] Parse NEW violations only

### DIFF
--- a/hw/cdc/tools/verixcdc/run-cdc.tcl
+++ b/hw/cdc/tools/verixcdc/run-cdc.tcl
@@ -214,7 +214,7 @@ foreach mod $modules {
 }
 
 # Report waived in a separate file
-report_policy -verbose -skip_empty_summary_status -compat -output ../REPORT/vcdc.rpt {NEW TO_BE_FIXED DEFERRED}
+report_policy -verbose -skip_empty_summary_status -compat -output ../REPORT/vcdc.new.rpt {NEW}
 report_policy -verbose -skip_empty_summary_status -compat -output ../REPORT/vcdc.waived.rpt {WAIVED}
 
 # report_messages -output verix_cdc.rpt

--- a/util/dvsim/verixcdc-report-parser.py
+++ b/util/dvsim/verixcdc-report-parser.py
@@ -37,14 +37,14 @@ def extract_rule_patterns(file_path: Path):
     total_msgs = 0
     # extract the summary table
     m = re.findall(
-        r'^Summary of Policy: ALL((?:.|\n|\r\n)*)Rule Details of Policy: ALL',
+        r'^Summary of Policy: NEW((?:.|\n|\r\n)*)Rule Details of Policy: NEW',
         full_file, flags=re.MULTILINE)
     if m:
         # step through the table and identify rule names and their
         # category and severity
         for line in m[0].split('\n'):
-            if re.match(r'^POLICY\s+ALL', line):
-                total = re.findall(r'^POLICY\s+ALL\s+([0-9]+)', line)
+            if re.match(r'^POLICY\s+NEW', line):
+                total = re.findall(r'^POLICY\s+NEW\s+([0-9]+)', line)
                 total_msgs = int(total[0])
             elif re.match(r'^ GROUP\s+SDC_ENV_LINT', line):
                 category = 'sdc'
@@ -217,11 +217,11 @@ def main():
     # This is then used to construct the regex patterns to look for
     # in a second pass to get the actual CDC messages.
     cdc_rule_patterns = extract_rule_patterns(
-        args.repdir.joinpath('syn-icarus/vcdc.rpt'))
+        args.repdir.joinpath('REPORT/vcdc.new.rpt'))
 
     # Patterns for vcdc.rpt
     parser_args.update({
-        args.repdir.joinpath('syn-icarus/vcdc.rpt'): cdc_rule_patterns
+        args.repdir.joinpath('REPORT/vcdc.new.rpt'): cdc_rule_patterns
     })
 
     # Parse logs


### PR DESCRIPTION
This commit revises the CDC flow to parse NEW report not ALL report
file. The result report contains only NEW violations. Previously, the
report has WAIVED list too.

