### PR TITLE
[flash_ctrl] fixes for hanging transactions

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -66,6 +66,7 @@ package flash_phy_pkg;
     logic part;
     logic [InfoTypesWidth-1:0] info_sel;
     rd_buf_attr_e attr;
+    logic err;
   } rd_buf_t;
 
   typedef struct packed {

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd_buffers.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd_buffers.sv
@@ -25,6 +25,7 @@ module flash_phy_rd_buffers import flash_phy_pkg::*; (
   input en_i,
   input alloc_i,
   input update_i,
+  input err_i,
   input wipe_i,
   input [BankAddrW-1:0] addr_i,
   input part_i,
@@ -40,18 +41,23 @@ module flash_phy_rd_buffers import flash_phy_pkg::*; (
       out_o.part <= flash_ctrl_pkg::FlashPartData;
       out_o.info_sel <= '0;
       out_o.attr <= Invalid;
+      out_o.err <= '0;
     end else if (!en_i && out_o.attr != Invalid) begin
       out_o.attr <= Invalid;
+      out_o.err <= '0;
     end else if (wipe_i && en_i) begin
       out_o.attr <= Invalid;
+      out_o.err <= '0;
     end else if (alloc_i && en_i) begin
       out_o.addr <= addr_i;
       out_o.part <= part_i;
       out_o.info_sel <= info_sel_i;
       out_o.attr <= Wip;
+      out_o.err <= '0;
     end else if (update_i && en_i) begin
       out_o.data <= data_i;
       out_o.attr <= Valid;
+      out_o.err <= err_i;
     end
   end
 


### PR DESCRIPTION
- fixes #13689 
- propagate data error through the read pipeline and store
  it into the buffer if a buffer had been allocated.

- any future reads that match this location will also error
  until evicted.

Signed-off-by: Timothy Chen <timothytim@google.com>