### PR TITLE
[dvsim] Add support for SW (bazel) build opts

### DIFF
--- a/hw/dv/tools/dvsim/bazel.hjson
+++ b/hw/dv/tools/dvsim/bazel.hjson
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  sw_build_cmd: "bazel"
+  sw_build_opts: []
+}

--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -10,6 +10,7 @@
   import_cfgs:      ["{proj_root}/hw/data/common_project_cfg.hjson",
                      "{dv_root}/tools/dvsim/common_modes.hjson",
                      "{dv_root}/tools/dvsim/fusesoc.hjson",
+                     "{dv_root}/tools/dvsim/bazel.hjson",
                      "{dv_root}/tools/dvsim/{tool}.hjson"]
 
   // Default directory structure for the output

--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -88,13 +88,13 @@ ifneq (${sw_images},)
 			if [[ $$index == "1" ]]; then \
 				bazel_label+="_sim_dv"; \
 			fi; \
-			bazel_opts="--define DISABLE_VERILATOR_BUILD=true"; \
+			bazel_opts="${sw_build_opts} --define DISABLE_VERILATOR_BUILD=true"; \
 			if [[ -z $${BAZEL_PYTHON_WHEELS_REPO} ]]; then \
 				echo "Building \"$${bazel_label}\" on network connected machine."; \
 				bazel_cmd="./bazelisk.sh"; \
 			else \
 				echo "Building \"$${bazel_label}\" on air-gapped machine."; \
-				bazel_opts+=" --distdir=$${BAZEL_DISTDIR} --repository_cache=$${BAZEL_CACHE}"; \
+				bazel_opts+="${sw_build_opts} --distdir=$${BAZEL_DISTDIR} --repository_cache=$${BAZEL_CACHE}"; \
 				bazel_cmd="bazel"; \
 			fi; \
 			$${bazel_cmd} build $${bazel_opts} $${bazel_label}; \

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -424,6 +424,8 @@ class RunTest(Deploy):
             "sw_images": False,
             "sw_build_device": False,
             "sw_build_dir": False,
+            "sw_build_cmd": False,
+            "sw_build_opts": False,
             "run_dir": False,
             "pre_run_cmds": False,
             "run_cmd": False,

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -270,6 +270,7 @@ class BuildModes(Modes):
         self.post_run_cmds = []
         self.run_opts = []
         self.sw_images = []
+        self.sw_build_opts = []
 
         super().__init__(bdict)
         self.en_build_modes = list(set(self.en_build_modes))
@@ -302,6 +303,7 @@ class RunModes(Modes):
         self.build_mode = ""
         self.sw_images = []
         self.sw_build_device = ""
+        self.sw_build_opts = []
 
         super().__init__(rdict)
         self.en_run_modes = list(set(self.en_run_modes))
@@ -328,6 +330,7 @@ class Tests(RunModes):
         "build_mode": "",
         "sw_images": [],
         "sw_build_device": "",
+        "sw_build_opts": []
     }
 
     def __init__(self, tdict):
@@ -419,6 +422,7 @@ class Tests(RunModes):
             test_obj.post_run_cmds.extend(test_obj.build_mode.post_run_cmds)
             test_obj.run_opts.extend(test_obj.build_mode.run_opts)
             test_obj.sw_images.extend(test_obj.build_mode.sw_images)
+            test_obj.sw_build_opts.extend(test_obj.build_mode.sw_build_opts)
 
         # Return the list of tests
         return tests_objs
@@ -426,7 +430,8 @@ class Tests(RunModes):
     @staticmethod
     def merge_global_opts(tests, global_pre_build_cmds, global_post_build_cmds,
                           global_build_opts, global_pre_run_cmds,
-                          global_post_run_cmds, global_run_opts, global_sw_images):
+                          global_post_run_cmds, global_run_opts,
+                          global_sw_images, global_sw_build_opts):
         processed_build_modes = []
         for test in tests:
             if test.build_mode.name not in processed_build_modes:
@@ -438,6 +443,7 @@ class Tests(RunModes):
             test.post_run_cmds.extend(global_post_run_cmds)
             test.run_opts.extend(global_run_opts)
             test.sw_images.extend(global_sw_images)
+            test.sw_build_opts.extend(global_sw_build_opts)
 
 
 class Regressions(Modes):

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -60,7 +60,8 @@ class SimCfg(FlowCfg):
     # TODO: Find a way to set these in sim cfg instead
     ignored_wildcards = [
         "build_mode", "index", "test", "seed", "uvm_test", "uvm_test_seq",
-        "cov_db_dirs", "sw_images", "sw_build_device"
+        "cov_db_dirs", "sw_images", "sw_build_device", "sw_build_cmd",
+        "sw_build_opts"
     ]
 
     def __init__(self, flow_cfg_file, hjson_data, args, mk_config):
@@ -121,6 +122,7 @@ class SimCfg(FlowCfg):
         self.run_dir = ""
         self.sw_build_dir = ""
         self.sw_images = []
+        self.sw_build_opts = []
         self.pass_patterns = []
         self.fail_patterns = []
         self.name = ""
@@ -271,6 +273,7 @@ class SimCfg(FlowCfg):
                 self.post_run_cmds.extend(build_mode_obj.post_run_cmds)
                 self.run_opts.extend(build_mode_obj.run_opts)
                 self.sw_images.extend(build_mode_obj.sw_images)
+                self.sw_build_opts.extend(build_mode_obj.sw_build_opts)
             else:
                 log.error(
                     "Mode \"%s\" enabled on the the command line is not defined",
@@ -285,6 +288,7 @@ class SimCfg(FlowCfg):
                 self.post_run_cmds.extend(run_mode_obj.post_run_cmds)
                 self.run_opts.extend(run_mode_obj.run_opts)
                 self.sw_images.extend(run_mode_obj.sw_images)
+                self.sw_build_opts.extend(run_mode_obj.sw_build_opts)
             else:
                 log.error(
                     "Mode \"%s\" enabled on the the command line is not defined",
@@ -374,7 +378,8 @@ class SimCfg(FlowCfg):
         Tests.merge_global_opts(self.run_list, self.pre_build_cmds,
                                 self.post_build_cmds, self.build_opts,
                                 self.pre_run_cmds, self.post_run_cmds,
-                                self.run_opts, self.sw_images)
+                                self.run_opts, self.sw_images,
+                                self.sw_build_opts)
 
         # Process reseed override and create the build_list
         build_list_names = []


### PR DESCRIPTION
This commit adds native support to set additional bazel command args via
`sw_build_opts`, which can be set in test specifications, `run_modes`,
`build_modes` and regressions in the Hjson spec.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>