### PR TITLE
[dif/entropy_src] cleanup/add unit tests for observe FIFO DIFs

### DIFF
--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -409,45 +409,46 @@ dif_result_t dif_entropy_src_read(const dif_entropy_src_t *entropy_src,
                                   uint32_t *word);
 
 /**
- * Performs an override read from the entropy pipeline.
+ * Performs a blocking read from the entropy pipeline through the observe FIFO,
+ * which contains post-test, unconditioned entropy.
  *
- * Entropy source must be configured with firmware override mode enabled, and
- * the `len` parameter must be strictly less than the FIFO threshold set in the
- * firmware override parameters.
+ * The entropy source must be configured with firmware override mode enabled,
+ * and the `len` parameter must be less than or equal to the FIFO threshold set
+ * in the firmware override parameters (that is, the threshold that triggers an
+ * interrupt). Additionally, `buf` may be `NULL`; in this case, reads will be
+ * discarded.
  *
- * `buf` may be `NULL`; in this case, reads will be discarded.
- *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @param[out] buf A buffer to fill with words from the pipeline.
  * @param len The number of words to read into `buf`.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_fifo_read(const dif_entropy_src_t *entropy_src,
-                                       uint32_t *buf, size_t len);
+dif_result_t dif_entropy_src_observe_fifo_blocking_read(
+    const dif_entropy_src_t *entropy_src, uint32_t *buf, size_t len);
 
 /**
- * Performs an override write to the entropy pipeline.
+ * Performs a write to the entropy pipeline through the observe FIFO.
  *
  * Entropy source must be configured with firmware override and insert mode
- * enabled, otherwise the function will return
- * `kDifBadArg`.
+ * enabled, otherwise the function will return `kDifError`.
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @param buf A buffer to push words from into the pipeline.
  * @param len The number of words to write from `buf`.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_fifo_write(const dif_entropy_src_t *entropy_src,
-                                        const uint32_t *buf, size_t len);
+dif_result_t dif_entropy_src_observe_fifo_write(
+    const dif_entropy_src_t *entropy_src, const uint32_t *buf, size_t len);
 
 /**
  * Starts conditioner operation.
  *
- * Initializes the conditioner. Use the `dif_entropy_src_fifo_write()` function
- * to send data to the conditioner, and `dif_entropy_src_conditioner_end()` once
- * ready to end the conditioner operation.
+ * Initializes the conditioner. Use the `dif_entropy_src_observe_fifo_write()`
+ * function to send data to the conditioner, and
+ * `dif_entropy_src_conditioner_end()` once ready to end the conditioner
+ * operation.
  *
  * This function is only available when firmware override mode is enabled. See
  * `dif_entropy_src_fw_override_configure()` for more details.

--- a/sw/device/tests/entropy_src_fw_ovr_test.c
+++ b/sw/device/tests/entropy_src_fw_ovr_test.c
@@ -91,18 +91,18 @@ void test_firmware_override(dif_entropy_src_t *entropy) {
   entropy_with_fw_override_enable(entropy);
   entropy_data_flush(entropy);
 
-  // Read data from the obeservation and write it back into the pre conditioner
-  // until there is data available in the output buffer.
+  // Read data from the observation FIFO and write it back into the
+  // pre-conditioner until there is data available in the output buffer.
   uint32_t buf[kEntropyFifoBufferSize] = {0};
   uint32_t word_count = 0;
   do {
-    CHECK_DIF_OK(
-        dif_entropy_src_fifo_read(entropy, buf, kEntropyFifoBufferSize));
+    CHECK_DIF_OK(dif_entropy_src_observe_fifo_blocking_read(
+        entropy, buf, kEntropyFifoBufferSize));
     for (size_t i = 0; i < kEntropyFifoBufferSize; ++i) {
       CHECK(buf[i] != 0);
     }
-    CHECK_DIF_OK(
-        dif_entropy_src_fifo_write(entropy, buf, kEntropyFifoBufferSize));
+    CHECK_DIF_OK(dif_entropy_src_observe_fifo_write(entropy, buf,
+                                                    kEntropyFifoBufferSize));
     word_count += kEntropyFifoBufferSize;
   } while (dif_entropy_src_avail(entropy) == kDifUnavailable);
   LOG_INFO("Processed %d words via FIFO_OVR buffer.", word_count);

--- a/sw/device/tests/entropy_src_kat_test.c
+++ b/sw/device/tests/entropy_src_kat_test.c
@@ -70,8 +70,8 @@ void test_sha384_kat(dif_entropy_src_t *entropy) {
       0xa52a0da9, 0xcae141b2, 0x6d5bab9d, 0x2c3e5cc0, 0x225afc93, 0x5d31a610,
       0x91b7f960, 0x0d566bb3, 0xef35e170, 0x94ba7d8e, 0x534eb741, 0x6b60b0da,
   };
-  CHECK_DIF_OK(
-      dif_entropy_src_fifo_write(entropy, kInputMsg, ARRAYSIZE(kInputMsg)));
+  CHECK_DIF_OK(dif_entropy_src_observe_fifo_write(entropy, kInputMsg,
+                                                  ARRAYSIZE(kInputMsg)));
 
   CHECK_DIF_OK(dif_entropy_src_conditioner_end(entropy));
 


### PR DESCRIPTION
This cleans up the DIFs that read/write from/to the observe FIFO and
adds corresponding unit tests for these DIFs.

Signed-off-by: Timothy Trippel <ttrippel@google.com>