### PR TITLE
[top, otbn] Add RMA req/ack interface to OTBN, daisy chain it with LC / Flash

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -115,6 +115,23 @@
       package: "lc_ctrl_pkg"
     },
 
+    // Lifecycle RMA request and acknowledge
+    { struct:  "lc_tx"
+      type:    "uni"
+      name:    "lc_rma_req"
+      act:     "rcv"
+      default: "lc_ctrl_pkg::Off"
+      package: "lc_ctrl_pkg"
+    },
+
+    { struct:  "lc_tx"
+      type:    "uni"
+      name:    "lc_rma_ack"
+      act:     "req"
+      default: "lc_ctrl_pkg::Off"
+      package: "lc_ctrl_pkg"
+    },
+
     // Key sideload
     { struct:  "otbn_key_req"
       type:    "uni"
@@ -240,18 +257,20 @@
     }
     { name: "DATA.MEM.SEC_WIPE"
       desc: '''
-        Rotate the scrambling key, effectively wiping the dmem, on command
+        Rotate the scrambling key, effectively wiping the dmem.
+        Initiated on command, upon fatal errors and before RMA entry.
       '''
     }
     { name: "INSTRUCTION.MEM.SEC_WIPE"
       desc: '''
-        Rotate the scrambling key, effectively wiping the imem, on command
+        Rotate the scrambling key, effectively wiping the imem.
+        Initiated on command, upon fatal errors and before RMA entry.
       '''
     }
     { name: "DATA_REG_SW.SEC_WIPE"
       desc: '''
-        Securely wipe programmer visible OTBN register (GPRs, WDRs, CSRs, WSRs)
-        state with random data at the end of any OTBN operation.
+        Securely wipe programmer visible OTBN register (GPRs, WDRs, CSRs, WSRs) state with random data.
+        Initiated after reset, at the end of any OTBN operation, upon recoverable and fatal errors, and before RMA entry.
       '''
     }
     { name: "WRITE.MEM.INTEGRITY"

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -475,6 +475,7 @@ The full secure wipe mechanism is split into three parts:
 
 A secure wipe is performed automatically in certain situations, or can be requested manually by the host software.
 The full secure wipe is automatically initiated as a local reaction to a fatal error.
+In addition, it can be triggered by the [Life Cycle Controller]({{<relref "/hw/ip/lc_ctrl/doc" >}}) before RMA entry using the `lc_rma_req/ack` interface.
 A secure wipe of only the internal state is performed after reset, whenever an OTBN operation is complete, and after a recoverable error.
 Finally, host software can manually trigger the data memory and instruction memory secure wipe operations by issuing an appropriate [command](#design-details-commands).
 
@@ -1017,6 +1018,7 @@ The three forms of secure wipe can be triggered in different ways.
 A secure wipe of either the instruction or the data memory can be triggered from from host software by issuing a `SEC_WIPE_DMEM` or `SEC_WIPE_IMEM` [command](#design-details-command).
 
 A secure wipe of instruction memory, data memory, and all internal state is performed automatically when handling a [fatal error](#design-details-fatal-errors).
+In addition, it can be triggered by the [Life Cycle Controller]({{<relref "/hw/ip/lc_ctrl/doc" >}}) before RMA entry using the `lc_rma_req/ack` interface.
 
 A secure wipe of the internal state only is triggered automatically after reset and when OTBN [ends the software execution](#design-details-software-execution), either successfully, or unsuccessfully due to a [recoverable error](#design-details-recoverable-errors).
 

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -129,7 +129,9 @@ module tb;
     .alert_rx_i(alert_rx),
     .alert_tx_o(alert_tx),
 
-    .lc_escalate_en_i (escalate_if.enable),
+    .lc_escalate_en_i(escalate_if.enable),
+    .lc_rma_req_i    (lc_ctrl_pkg::Off),
+    .lc_rma_ack_o    (),
 
     .ram_cfg_i('0),
 

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -115,6 +115,8 @@ module otbn_top_sim (
     .req_sec_wipe_urnd_keys_i    ( 1'b0                       ),
 
     .escalate_en_i               ( prim_mubi_pkg::MuBi4False  ),
+    .rma_req_i                   ( prim_mubi_pkg::MuBi4False  ),
+    .rma_ack_o                   (                            ),
 
     .software_errs_fatal_i       ( 1'b0                       ),
 

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -82,6 +82,11 @@ module otbn_core
   // halt and then enter a locked state.
   input prim_mubi_pkg::mubi4_t escalate_en_i,
 
+  // Indicates an incoming RMA request. The core needs to halt, trigger a secure wipe immediately
+  // and then enter a locked state.
+  input  prim_mubi_pkg::mubi4_t rma_req_i,
+  output prim_mubi_pkg::mubi4_t rma_ack_o,
+
   // When set software errors become fatal errors.
   input logic software_errs_fatal_i,
 
@@ -267,6 +272,8 @@ module otbn_core
 
     .start_i,
     .escalate_en_i(start_stop_escalate_en),
+    .rma_req_i,
+    .rma_ack_o,
 
     .controller_start_o(controller_start),
 
@@ -397,6 +404,7 @@ module otbn_core
 
     .fatal_escalate_en_i(controller_fatal_escalate_en),
     .recov_escalate_en_i(controller_recov_escalate_en),
+    .rma_req_i,
     .err_bits_o         (controller_err_bits),
     .recoverable_err_o,
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5826,6 +5826,28 @@
           index: -1
         }
         {
+          name: lc_rma_req
+          struct: lc_tx
+          package: lc_ctrl_pkg
+          type: uni
+          act: rcv
+          width: 1
+          default: lc_ctrl_pkg::Off
+          inst_name: otbn
+          index: -1
+        }
+        {
+          name: lc_rma_ack
+          struct: lc_tx
+          package: lc_ctrl_pkg
+          type: uni
+          act: req
+          width: 1
+          default: lc_ctrl_pkg::Off
+          inst_name: otbn
+          index: -1
+        }
+        {
           name: keymgr_key
           struct: otbn_key_req
           package: keymgr_pkg
@@ -17551,6 +17573,28 @@
         default: lc_ctrl_pkg::Off
         inst_name: otbn
         top_signame: lc_ctrl_lc_escalate_en
+        index: -1
+      }
+      {
+        name: lc_rma_req
+        struct: lc_tx
+        package: lc_ctrl_pkg
+        type: uni
+        act: rcv
+        width: 1
+        default: lc_ctrl_pkg::Off
+        inst_name: otbn
+        index: -1
+      }
+      {
+        name: lc_rma_ack
+        struct: lc_tx
+        package: lc_ctrl_pkg
+        type: uni
+        act: req
+        width: 1
+        default: lc_ctrl_pkg::Off
+        inst_name: otbn
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1886,7 +1886,9 @@
           width: 1
           default: lc_ctrl_pkg::Off
           inst_name: lc_ctrl
-          top_signame: flash_ctrl_rma_req
+          end_idx: -1
+          top_type: broadcast
+          top_signame: lc_ctrl_lc_flash_rma_req
           index: -1
         }
         {
@@ -1910,7 +1912,7 @@
           width: 1
           default: lc_ctrl_pkg::Off
           inst_name: lc_ctrl
-          top_signame: flash_ctrl_rma_ack
+          top_signame: otbn_lc_rma_ack
           index: -1
         }
         {
@@ -4786,9 +4788,7 @@
           width: 1
           inst_name: flash_ctrl
           default: ""
-          end_idx: -1
-          top_type: broadcast
-          top_signame: flash_ctrl_rma_req
+          top_signame: lc_ctrl_lc_flash_rma_req
           index: -1
         }
         {
@@ -5834,6 +5834,7 @@
           width: 1
           default: lc_ctrl_pkg::Off
           inst_name: otbn
+          top_signame: flash_ctrl_rma_ack
           index: -1
         }
         {
@@ -5845,6 +5846,9 @@
           width: 1
           default: lc_ctrl_pkg::Off
           inst_name: otbn
+          end_idx: -1
+          top_type: broadcast
+          top_signame: otbn_lc_rma_ack
           index: -1
         }
         {
@@ -7779,14 +7783,6 @@
       [
         otp_ctrl.flash_otp_key
       ]
-      flash_ctrl.rma_req:
-      [
-        lc_ctrl.lc_flash_rma_req
-      ]
-      flash_ctrl.rma_ack:
-      [
-        lc_ctrl.lc_flash_rma_ack
-      ]
       flash_ctrl.rma_seed:
       [
         lc_ctrl.lc_flash_rma_seed
@@ -7837,6 +7833,18 @@
       rom_ctrl.keymgr_data:
       [
         keymgr.rom_digest
+      ]
+      lc_ctrl.lc_flash_rma_req:
+      [
+        flash_ctrl.rma_req
+      ]
+      flash_ctrl.rma_ack:
+      [
+        otbn.lc_rma_req
+      ]
+      otbn.lc_rma_ack:
+      [
+        lc_ctrl.lc_flash_rma_ack
       ]
       usbdev.usb_dp_pullup:
       [
@@ -15164,7 +15172,9 @@
         width: 1
         default: lc_ctrl_pkg::Off
         inst_name: lc_ctrl
-        top_signame: flash_ctrl_rma_req
+        end_idx: -1
+        top_type: broadcast
+        top_signame: lc_ctrl_lc_flash_rma_req
         index: -1
       }
       {
@@ -15188,7 +15198,7 @@
         width: 1
         default: lc_ctrl_pkg::Off
         inst_name: lc_ctrl
-        top_signame: flash_ctrl_rma_ack
+        top_signame: otbn_lc_rma_ack
         index: -1
       }
       {
@@ -17045,9 +17055,7 @@
         width: 1
         inst_name: flash_ctrl
         default: ""
-        end_idx: -1
-        top_type: broadcast
-        top_signame: flash_ctrl_rma_req
+        top_signame: lc_ctrl_lc_flash_rma_req
         index: -1
       }
       {
@@ -17584,6 +17592,7 @@
         width: 1
         default: lc_ctrl_pkg::Off
         inst_name: otbn
+        top_signame: flash_ctrl_rma_ack
         index: -1
       }
       {
@@ -17595,6 +17604,9 @@
         width: 1
         default: lc_ctrl_pkg::Off
         inst_name: otbn
+        end_idx: -1
+        top_type: broadcast
+        top_signame: otbn_lc_rma_ack
         index: -1
       }
       {
@@ -20090,28 +20102,6 @@
       }
       {
         package: lc_ctrl_pkg
-        struct: lc_tx
-        signame: flash_ctrl_rma_req
-        width: 1
-        type: uni
-        end_idx: -1
-        act: rcv
-        suffix: ""
-        default: lc_ctrl_pkg::LC_TX_DEFAULT
-      }
-      {
-        package: lc_ctrl_pkg
-        struct: lc_tx
-        signame: flash_ctrl_rma_ack
-        width: 1
-        type: uni
-        end_idx: -1
-        act: req
-        suffix: ""
-        default: lc_ctrl_pkg::LC_TX_DEFAULT
-      }
-      {
-        package: lc_ctrl_pkg
         struct: lc_flash_rma_seed
         signame: flash_ctrl_rma_seed
         width: 1
@@ -20296,6 +20286,39 @@
         act: req
         suffix: ""
         default: rom_ctrl_pkg::KEYMGR_DATA_DEFAULT
+      }
+      {
+        package: lc_ctrl_pkg
+        struct: lc_tx
+        signame: lc_ctrl_lc_flash_rma_req
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: lc_ctrl_pkg::Off
+      }
+      {
+        package: lc_ctrl_pkg
+        struct: lc_tx
+        signame: flash_ctrl_rma_ack
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: lc_ctrl_pkg::LC_TX_DEFAULT
+      }
+      {
+        package: lc_ctrl_pkg
+        struct: lc_tx
+        signame: otbn_lc_rma_ack
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: lc_ctrl_pkg::Off
       }
       {
         package: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -857,8 +857,6 @@
       'csrng.cs_aes_halt'       : ['entropy_src.cs_aes_halt'],
       'flash_ctrl.keymgr'       : ['keymgr.flash'],
       'flash_ctrl.otp'          : ['otp_ctrl.flash_otp_key'],
-      'flash_ctrl.rma_req'      : ['lc_ctrl.lc_flash_rma_req'],
-      'flash_ctrl.rma_ack'      : ['lc_ctrl.lc_flash_rma_ack'],
       'flash_ctrl.rma_seed'     : ['lc_ctrl.lc_flash_rma_seed'],
       'otp_ctrl.sram_otp_key'   : ['sram_ctrl_main.sram_otp_key',
                                    'sram_ctrl_ret_aon.sram_otp_key'
@@ -877,6 +875,11 @@
       'flash_ctrl.keymgr'       : ['keymgr.flash'],
       'alert_handler.crashdump' : ['rstmgr_aon.alert_dump'],
       'csrng.entropy_src_hw_if' : ['entropy_src.entropy_src_hw_if'],
+
+      // Daisy chained LC RMA req/ack interface: LC -> Flash -> OTBN -> LC
+      'lc_ctrl.lc_flash_rma_req' : ['flash_ctrl.rma_req'],
+      'flash_ctrl.rma_ack'       : ['otbn.lc_rma_req'],
+      'otbn.lc_rma_ack'          : ['lc_ctrl.lc_flash_rma_ack'],
 
       // usbdev connection to pinmux
       'usbdev.usb_dp_pullup'      : ['pinmux_aon.usbdev_dppullup_en'],

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -539,8 +539,6 @@ module top_earlgrey #(
   flash_ctrl_pkg::keymgr_flash_t       flash_ctrl_keymgr;
   otp_ctrl_pkg::flash_otp_key_req_t       flash_ctrl_otp_req;
   otp_ctrl_pkg::flash_otp_key_rsp_t       flash_ctrl_otp_rsp;
-  lc_ctrl_pkg::lc_tx_t       flash_ctrl_rma_req;
-  lc_ctrl_pkg::lc_tx_t       flash_ctrl_rma_ack;
   lc_ctrl_pkg::lc_flash_rma_seed_t       flash_ctrl_rma_seed;
   otp_ctrl_pkg::sram_otp_key_req_t [2:0] otp_ctrl_sram_otp_key_req;
   otp_ctrl_pkg::sram_otp_key_rsp_t [2:0] otp_ctrl_sram_otp_key_rsp;
@@ -558,6 +556,9 @@ module top_earlgrey #(
   lc_ctrl_pkg::lc_tx_t       pwrmgr_aon_fetch_en;
   rom_ctrl_pkg::pwrmgr_data_t       rom_ctrl_pwrmgr_data;
   rom_ctrl_pkg::keymgr_data_t       rom_ctrl_keymgr_data;
+  lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_flash_rma_req;
+  lc_ctrl_pkg::lc_tx_t       flash_ctrl_rma_ack;
+  lc_ctrl_pkg::lc_tx_t       otbn_lc_rma_ack;
   logic       usbdev_usb_dp_pullup;
   logic       usbdev_usb_dn_pullup;
   logic       usbdev_usb_aon_suspend_req;
@@ -1491,9 +1492,9 @@ module top_earlgrey #(
       .lc_escalate_en_o(lc_ctrl_lc_escalate_en),
       .lc_clk_byp_req_o(lc_ctrl_lc_clk_byp_req),
       .lc_clk_byp_ack_i(lc_ctrl_lc_clk_byp_ack),
-      .lc_flash_rma_req_o(flash_ctrl_rma_req),
+      .lc_flash_rma_req_o(lc_ctrl_lc_flash_rma_req),
       .lc_flash_rma_seed_o(flash_ctrl_rma_seed),
-      .lc_flash_rma_ack_i(flash_ctrl_rma_ack),
+      .lc_flash_rma_ack_i(otbn_lc_rma_ack),
       .lc_check_byp_en_o(lc_ctrl_lc_check_byp_en),
       .lc_creator_seed_sw_rw_en_o(lc_ctrl_lc_creator_seed_sw_rw_en),
       .lc_owner_seed_sw_rw_en_o(lc_ctrl_lc_owner_seed_sw_rw_en),
@@ -2100,7 +2101,7 @@ module top_earlgrey #(
       .lc_iso_part_sw_wr_en_i(lc_ctrl_lc_iso_part_sw_wr_en),
       .lc_seed_hw_rd_en_i(lc_ctrl_lc_seed_hw_rd_en),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
-      .rma_req_i(flash_ctrl_rma_req),
+      .rma_req_i(lc_ctrl_lc_flash_rma_req),
       .rma_ack_o(flash_ctrl_rma_ack),
       .rma_seed_i(flash_ctrl_rma_seed),
       .pwrmgr_o(pwrmgr_aon_pwr_flash),
@@ -2293,8 +2294,8 @@ module top_earlgrey #(
       .idle_o(clkmgr_aon_idle[3]),
       .ram_cfg_i(ast_ram_1p_cfg),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
-      .lc_rma_req_i(lc_ctrl_pkg::Off),
-      .lc_rma_ack_o(),
+      .lc_rma_req_i(flash_ctrl_rma_ack),
+      .lc_rma_ack_o(otbn_lc_rma_ack),
       .keymgr_key_i(keymgr_otbn_key),
       .tl_i(otbn_tl_req),
       .tl_o(otbn_tl_rsp),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2293,6 +2293,8 @@ module top_earlgrey #(
       .idle_o(clkmgr_aon_idle[3]),
       .ram_cfg_i(ast_ram_1p_cfg),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
+      .lc_rma_req_i(lc_ctrl_pkg::Off),
+      .lc_rma_ack_o(),
       .keymgr_key_i(keymgr_otbn_key),
       .tl_i(otbn_tl_req),
       .tl_o(otbn_tl_rsp),


### PR DESCRIPTION
Please ignore the first two commits, these are part of #13321.

The last two commits of this PR:
1. Add an RMA req/ack interface to OTBN to let OTBN perform a secure wipe before LC can enter RMA.
2. Connects that interface in a daisy chain with LC and Flash.

For details, please refer to the individual commit messages.

This is related to #13499 .