### PR TITLE
[sigverify] Update OTBN instruction count range.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.h
+++ b/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.h
@@ -26,8 +26,8 @@ extern "C" {
  * IMPORTANT: This may need to be modified if the modexp routine is changed!
  */
 enum {
-  kModExpOtbnInsnCountMin = 182578,
-  kModExpOtbnInsnCountMax = 197207,
+  kModExpOtbnInsnCountMin = 181147,
+  kModExpOtbnInsnCountMax = 198397,
 };
 
 /**


### PR DESCRIPTION
The original range was off because I missed a branch in the computation of R^2 when I calculated it manually, and it happened to be close enough that none of the tests fell outside the range. Exactly the kind of human error that automatic checks should be created to avoid! This range has been confirmed locally both by a manual check and also a new automatic script (see #13699). CI test to follow once the script is merged, which should prevent future errors.