### PR TITLE
[otbn,data] Fix synopsis of `bn.mulqacc.wo` instruction

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -207,7 +207,7 @@
       wrd: bxxxxx
 
 - mnemonic: bn.mulqacc.wo
-  synopsis: Quarter-word Multiply and Accumulate with half-word writeback
+  synopsis: Quarter-word Multiply and Accumulate with full-word writeback
   operands:
     - *mulqacc-zero-acc
     - &mulqacc-wrd


### PR DESCRIPTION
This instruction writes the full 256-bit accumulator value to the
destination WDR, not just the lower 128 bit (which `bn.mulqacc.so` does).
Prior to this commit, the synopsis of the `bn.mulqacc.wo` instruction was
incorrect in this regard.