### PR TITLE
[fpv/kmac] Fix shadow reg assertion error

### DIFF
--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -1104,7 +1104,7 @@ module kmac
       .rst_src_ni(rst_ni),
       .clk_dst_i (clk_edn_i),
       .rst_dst_ni(rst_edn_ni),
-      .req_chk_i (1'b1),
+      .req_chk_i (kmac_entropy_state_error == 1'b0),
       .src_req_i (entropy_req),
       .src_ack_o (entropy_ack),
       .dst_req_o (entropy_o.edn_req),


### PR DESCRIPTION
When shadow reg assertion error happens, kmac entropy will go to FSM
error state and drop the entropy request without waiting for an entropy
response.
This will cause an assertion error. To avoid this error, I modify the
RTL to disable the assertion check when FSM error state is high.

![image](https://user-images.githubusercontent.com/11466553/179567734-a4757c8c-9168-418f-867c-e86835ddb91e.png)

Signed-off-by: Cindy Chen <chencindy@opentitan.org>