### PR TITLE
[dv/kmac] Fix app_partial_data regression error

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -1618,6 +1618,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
             posedge kmac_err.code == ErrKeyNotValid);
       )
       wait(sha3_idle == 1);
+      num_blocks_filled = 0;
     end
   endtask
 


### PR DESCRIPTION
This PR fixes kmac_*_app_partial_data test failures.
Because this test disabled scb cycle accurate check, so the entropy and
block processing wait time is not accurate in scb. When kmac goes to
idle state, we want to make sure the `num_blocks_filled` variable is
reset to 0.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>