### PR TITLE
[dif/entropy_src] cleanup existing DIFs and add remaining unit tests

### DIFF
--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -524,7 +524,7 @@ dif_result_t dif_entropy_src_conditioner_start(
   return kDifOk;
 }
 
-dif_result_t dif_entropy_src_conditioner_end(
+dif_result_t dif_entropy_src_conditioner_stop(
     const dif_entropy_src_t *entropy_src) {
   if (entropy_src == NULL) {
     return kDifBadArg;
@@ -548,7 +548,7 @@ dif_result_t dif_entropy_src_get_fifo_depth(
 }
 
 dif_result_t dif_entropy_src_get_main_fsm_state(
-    const dif_entropy_src_t *entropy_src, dif_entropy_main_fsm_t *state) {
+    const dif_entropy_src_t *entropy_src, dif_entropy_src_main_fsm_t *state) {
   if (entropy_src == NULL || state == NULL) {
     return kDifBadArg;
   }

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -54,9 +54,9 @@ typedef enum dif_entropy_src_single_bit_mode {
 } dif_entropy_src_single_bit_mode_t;
 
 /**
- * Main FSM state
+ * Main FSM state.
  */
-typedef enum dif_entropy_main_fsm {
+typedef enum dif_entropy_src_main_fsm {
   kDifEntropySrcMainFsmStateIdle = 0x0f5,
   kDifEntropySrcMainFsmStateBootHTRunning = 0x1d2,
   kDifEntropySrcMainFsmStateBootPostHTChk = 0x16e,
@@ -78,7 +78,7 @@ typedef enum dif_entropy_main_fsm {
   kDifEntropySrcMainFsmStateAlertState = 0x1fb,
   kDifEntropySrcMainFsmStateAlertHang = 0x15c,
   kDifEntropySrcMainFsmStateError = 0x13d
-} dif_entropy_main_fsm_t;
+} dif_entropy_src_main_fsm_t;
 
 /**
  * Firmware override parameters for an entropy source.
@@ -305,7 +305,7 @@ typedef struct dif_entropy_src_alert_fail_counts {
  * This function should only need to be called once for the lifetime of the
  * `entropy` handle.
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @param config Runtime configuration parameters.
  * @param enabled The enablement state of the entropy source.
  * @return The result of the operation.
@@ -321,7 +321,7 @@ dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
  * This function should only need to be called once for the lifetime of the
  * `entropy` handle.
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @param config Runtime configuration parameters for firmware override.
  * @param enabled The enablement state of the firmware override option.
  * @return The result of the operation.
@@ -337,7 +337,7 @@ dif_result_t dif_entropy_src_fw_override_configure(
  * This function should only need to be called once for each health test that
  * requires configuration for the lifetime of the `entropy` handle.
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @param config Runtime configuration parameters for the health test.
  * @return The result of the operation.
  */
@@ -363,7 +363,7 @@ dif_result_t dif_entropy_src_set_enabled(const dif_entropy_src_t *entropy_src,
  * This function is reentrant: calling it while functionality is locked will
  * have no effect and return `kDifEntropySrcOk`.
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -372,7 +372,7 @@ dif_result_t dif_entropy_src_lock(const dif_entropy_src_t *entropy_src);
 /**
  * Checks whether this entropy source is locked.
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @param[out] is_locked Out-param for the locked state.
  * @return The result of the operation.
  */
@@ -381,9 +381,9 @@ dif_result_t dif_entropy_src_is_locked(const dif_entropy_src_t *entropy_src,
                                        bool *is_locked);
 
 /**
- * Queries the entropy source IP for its revision information.
+ * Queries the entropy_src source IP for its revision information.
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @param[out] revision Out-param for revision data.
  * @return The result of the operation.
  */
@@ -394,7 +394,7 @@ dif_result_t dif_entropy_src_get_revision(const dif_entropy_src_t *entropy_src,
 /**
  * Queries the entropy source for health test statistics.
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @param[out] stats Out-param for stats data.
  * @return The result of the operation.
  */
@@ -406,7 +406,7 @@ dif_result_t dif_entropy_src_get_health_test_stats(
 /**
  * Queries the entropy source for health test failure statistics.
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @param[out] counts Out-param for test failure data that triggers alerts.
  * @return The result of the operation.
  */
@@ -475,7 +475,7 @@ dif_result_t dif_entropy_src_observe_fifo_write(
  *
  * Initializes the conditioner. Use the `dif_entropy_src_observe_fifo_write()`
  * function to send data to the conditioner, and
- * `dif_entropy_src_conditioner_end()` once ready to end the conditioner
+ * `dif_entropy_src_conditioner_stop()` once ready to stop the conditioner
  * operation.
  *
  * This function is only available when firmware override mode is enabled. See
@@ -499,17 +499,8 @@ dif_result_t dif_entropy_src_conditioner_start(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_conditioner_end(
+dif_result_t dif_entropy_src_conditioner_stop(
     const dif_entropy_src_t *entropy_src);
-
-/**
- * Get main entropy fsm idle status
- *
- * @param entropy_src An entropy source handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_get_idle(const dif_entropy_src_t *entropy_src);
 
 /**
  * Read the fifo depth.
@@ -523,15 +514,15 @@ dif_result_t dif_entropy_src_get_fifo_depth(
     const dif_entropy_src_t *entropy_src, uint32_t *fifo_depth);
 
 /**
- * Read the current main fsm state.
+ * Reads the current main FSM state.
  *
  * @param entropy_src An entropy source handle.
- * @param[out] state The current state.
+ * @param[out] state The current FSM state.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_entropy_src_get_main_fsm_state(
-    const dif_entropy_src_t *entropy_src, dif_entropy_main_fsm_t *state);
+    const dif_entropy_src_t *entropy_src, dif_entropy_src_main_fsm_t *state);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -416,24 +416,25 @@ dif_result_t dif_entropy_src_get_alert_fail_counts(
     dif_entropy_src_alert_fail_counts_t *counts);
 
 /**
- * Checks to see if entropy is available for software consumption
+ * Checks to see if entropy is available for software consumption.
  *
- * @param entropy An entropy source handle.
+ * @param entropy_src An entropy source handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_avail(const dif_entropy_src_t *entropy_src);
+dif_result_t dif_entropy_src_is_entropy_available(
+    const dif_entropy_src_t *entropy_src);
 
 /**
- * Reads off a word of entropy from the entropy source.
+ * Reads a word of entropy from the entropy source.
  *
- * @param entropy An entropy source handle.
- * @param[out] word Out-param for the entropy.
+ * @param entropy_src An entropy source handle.
+ * @param[out] word Out-param for the entropy word.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_read(const dif_entropy_src_t *entropy_src,
-                                  uint32_t *word);
+dif_result_t dif_entropy_src_non_blocking_read(
+    const dif_entropy_src_t *entropy_src, uint32_t *word);
 
 /**
  * Performs a blocking read from the entropy pipeline through the observe FIFO,

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -436,24 +436,42 @@ TEST_F(GetAlertFailCountsTest, Success) {
   }
 }
 
-class ReadTest : public EntropySrcTest {};
+class IsEntropyAvailableTest : public EntropySrcTest {};
 
-TEST_F(ReadTest, EntropyBadArg) {
+TEST_F(IsEntropyAvailableTest, NullHandle) {
+  EXPECT_DIF_BADARG(dif_entropy_src_is_entropy_available(nullptr));
+}
+
+TEST_F(IsEntropyAvailableTest, Unavailable) {
+  EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                {{ENTROPY_SRC_INTR_STATE_ES_ENTROPY_VALID_BIT, false}});
+  EXPECT_EQ(dif_entropy_src_is_entropy_available(&entropy_src_),
+            kDifUnavailable);
+}
+
+TEST_F(IsEntropyAvailableTest, Available) {
+  EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                {{ENTROPY_SRC_INTR_STATE_ES_ENTROPY_VALID_BIT, true}});
+  EXPECT_DIF_OK(dif_entropy_src_is_entropy_available(&entropy_src_));
+}
+
+class NonBlockingReadTest : public EntropySrcTest {};
+
+TEST_F(NonBlockingReadTest, NullArgs) {
   uint32_t word;
-  EXPECT_DIF_BADARG(dif_entropy_src_read(nullptr, &word));
+  EXPECT_DIF_BADARG(dif_entropy_src_non_blocking_read(nullptr, &word));
+  EXPECT_DIF_BADARG(dif_entropy_src_non_blocking_read(&entropy_src_, nullptr));
+  EXPECT_DIF_BADARG(dif_entropy_src_non_blocking_read(nullptr, nullptr));
 }
 
-TEST_F(ReadTest, WordBadArg) {
-  EXPECT_DIF_BADARG(dif_entropy_src_read(&entropy_src_, nullptr));
-}
-
-TEST_F(ReadTest, ReadDataUnAvailable) {
+TEST_F(NonBlockingReadTest, DataUnavailable) {
   EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET, 0);
-  uint32_t got_word;
-  EXPECT_EQ(dif_entropy_src_read(&entropy_src_, &got_word), kDifUnavailable);
+  uint32_t word;
+  EXPECT_EQ(dif_entropy_src_non_blocking_read(&entropy_src_, &word),
+            kDifUnavailable);
 }
 
-TEST_F(ReadTest, ReadOk) {
+TEST_F(NonBlockingReadTest, Success) {
   const uint32_t expected_word = 0x65585497;
   EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
                 1 << ENTROPY_SRC_INTR_STATE_ES_ENTROPY_VALID_BIT);
@@ -463,9 +481,9 @@ TEST_F(ReadTest, ReadOk) {
   EXPECT_WRITE32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
                  {{ENTROPY_SRC_INTR_STATE_ES_ENTROPY_VALID_BIT, true}});
 
-  uint32_t got_word;
-  EXPECT_DIF_OK(dif_entropy_src_read(&entropy_src_, &got_word));
-  EXPECT_EQ(got_word, expected_word);
+  uint32_t word;
+  EXPECT_DIF_OK(dif_entropy_src_non_blocking_read(&entropy_src_, &word));
+  EXPECT_EQ(word, expected_word);
 }
 
 class ObserveFifoBlockingReadTest : public EntropySrcTest {};

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -59,8 +59,8 @@ void entropy_testutils_boot_mode_init(void) {
 }
 
 void entropy_testutils_wait_for_state(const dif_entropy_src_t *entropy_src,
-                                      dif_entropy_main_fsm_t state) {
-  dif_entropy_main_fsm_t cur_state;
+                                      dif_entropy_src_main_fsm_t state) {
+  dif_entropy_src_main_fsm_t cur_state;
 
   do {
     CHECK_DIF_OK(dif_entropy_src_get_main_fsm_state(entropy_src, &cur_state));

--- a/sw/device/lib/testing/entropy_testutils.h
+++ b/sw/device/lib/testing/entropy_testutils.h
@@ -18,7 +18,7 @@ void entropy_testutils_boot_mode_init(void);
 /**
  * Wait for the entropy_src to reach a certain state.
  */
-void wait_entropy_src_state(const dif_entropy_src_t *entropy_src,
-                            dif_entropy_main_fsm_t state);
+void entropy_testutils_wait_for_state(const dif_entropy_src_t *entropy_src,
+                                      dif_entropy_src_main_fsm_t state);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_ENTROPY_TESTUTILS_H_

--- a/sw/device/tests/entropy_src_fw_ovr_test.c
+++ b/sw/device/tests/entropy_src_fw_ovr_test.c
@@ -38,8 +38,8 @@ static void entropy_data_flush(dif_entropy_src_t *entropy_src) {
   // available in FW override mode.
   const uint32_t kMaxReadCount = 12;
 
-  while (dif_entropy_src_avail(entropy_src) == kDifOk) {
-    CHECK_DIF_OK(dif_entropy_src_read(entropy_src, &entropy_bits));
+  while (dif_entropy_src_is_entropy_available(entropy_src) == kDifOk) {
+    CHECK_DIF_OK(dif_entropy_src_non_blocking_read(entropy_src, &entropy_bits));
     CHECK(entropy_bits != 0);
     read_count++;
     if (read_count >= kMaxReadCount) {
@@ -104,7 +104,7 @@ void test_firmware_override(dif_entropy_src_t *entropy) {
     CHECK_DIF_OK(dif_entropy_src_observe_fifo_write(entropy, buf,
                                                     kEntropyFifoBufferSize));
     word_count += kEntropyFifoBufferSize;
-  } while (dif_entropy_src_avail(entropy) == kDifUnavailable);
+  } while (dif_entropy_src_is_entropy_available(entropy) == kDifUnavailable);
   LOG_INFO("Processed %d words via FIFO_OVR buffer.", word_count);
   entropy_data_flush(entropy);
 }

--- a/sw/device/tests/entropy_src_kat_test.c
+++ b/sw/device/tests/entropy_src_kat_test.c
@@ -73,7 +73,7 @@ void test_sha384_kat(dif_entropy_src_t *entropy) {
   CHECK_DIF_OK(dif_entropy_src_observe_fifo_write(entropy, kInputMsg,
                                                   ARRAYSIZE(kInputMsg)));
 
-  CHECK_DIF_OK(dif_entropy_src_conditioner_end(entropy));
+  CHECK_DIF_OK(dif_entropy_src_conditioner_stop(entropy));
 
   uint32_t got[kEntropyFifoBufferSize];
   for (size_t i = 0; i < ARRAYSIZE(got); ++i) {

--- a/sw/device/tests/entropy_src_kat_test.c
+++ b/sw/device/tests/entropy_src_kat_test.c
@@ -77,7 +77,7 @@ void test_sha384_kat(dif_entropy_src_t *entropy) {
 
   uint32_t got[kEntropyFifoBufferSize];
   for (size_t i = 0; i < ARRAYSIZE(got); ++i) {
-    CHECK_DIF_OK(dif_entropy_src_read(entropy, &got[i]));
+    CHECK_DIF_OK(dif_entropy_src_non_blocking_read(entropy, &got[i]));
   }
 
   const uint32_t kExpectedDigest[kEntropyFifoBufferSize] = {

--- a/sw/device/tests/entropy_src_smoketest.c
+++ b/sw/device/tests/entropy_src_smoketest.c
@@ -49,7 +49,8 @@ bool test_main(void) {
   uint32_t result = 0;
   for (uint32_t i = 0; i < kEntropyDataNumWords; ++i) {
     // wait for entropy to become available
-    while (dif_entropy_src_read(&entropy_src, &entropy_data[i]) != kDifOk)
+    while (dif_entropy_src_non_blocking_read(&entropy_src, &entropy_data[i]) !=
+           kDifOk)
       ;
     LOG_INFO("received 0x%x, expected 0x%x", entropy_data[i],
              kExpectedEntropyData[i]);


### PR DESCRIPTION
This cleans up remaining DIFs to match style guide and naming conventions throughout. Additionally this adds the remaining unit tests for DIFs that had already been implemented.