### PR TITLE
[spi_device] Fix an assertion

### DIFF
--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -847,7 +847,7 @@ module spi_passthrough
   // Single mode is used
   `ASSUME(PayloadSwapConstraint_M,
     cmd_info.payload_swap_en |-> (cmd_info.payload_en == 4'b 0001)
-                              && (cmd_info.payload_dir == PayloadOut))
+                              && (cmd_info.payload_dir == PayloadIn))
 
 
 endmodule: spi_passthrough


### PR DESCRIPTION
payload swap constraint should be applied to read command, which is
`PayloadIn` instead of `PayloadOut`

Signed-off-by: Weicai Yang <weicai@google.com>