### PR TITLE
[dv/kmac] Fix unmasked_error code failure

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -2083,6 +2083,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
           end else begin
             case (kmac_cmd_e'(kmac_cmd))
               CmdStart: begin
+                bit en_unsupported_modestrength = 1;
 
                 // Mode/Strength configuration error
                 if ((hash_mode inside {sha3_pkg::Shake, sha3_pkg::CShake} &&
@@ -2098,10 +2099,11 @@ class kmac_scoreboard extends cip_base_scoreboard #(
                   // If the mode/strength are mis-configured, the IP will finish running a hash
                   // with the incorrect configuration, producing a garbage digest that should not
                   // be checked.
-                  do_check_digest = 1'b0;
+                  if (`gmv(ral.cfg_shadowed.en_unsupported_modestrength)) do_check_digest = 1'b0;
+                  else en_unsupported_modestrength = 0;
                 end
 
-                if (checked_kmac_cmd == CmdNone) begin
+                if (checked_kmac_cmd == CmdNone && en_unsupported_modestrength) begin
                   // the first 6B of the prefix (function name),
                   // need to check that it is "KMAC" when `kmac_en == 1`
                   bit [47:0] function_name_6B;

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -71,6 +71,9 @@ class kmac_base_vseq extends cip_base_vseq #(
   // entropy ready
   rand bit entropy_ready;
 
+  // process the digest when mode strength does not match
+  rand bit en_unsupported_modestrength;
+
   // Message masking
   rand bit msg_mask;
 
@@ -315,6 +318,7 @@ class kmac_base_vseq extends cip_base_vseq #(
     ral.cfg_shadowed.entropy_ready.set(entropy_ready);
     ral.cfg_shadowed.msg_mask.set(msg_mask);
     ral.cfg_shadowed.err_processed.set(1'b0);
+    ral.cfg_shadowed.en_unsupported_modestrength.set(en_unsupported_modestrength);
     // It is not required to set up sideload bit when keymgr app interface is requesting a hash
     // operation, because it will always use sideload key regardless of the cfg settings.
     if (keymgr_app_intf) ral.cfg_shadowed.sideload.set($urandom_range(0, 1));
@@ -407,7 +411,8 @@ class kmac_base_vseq extends cip_base_vseq #(
             $sformatf("custom_str: %0s\n", str_utils_pkg::bytes_to_str(custom_str_arr)),
             $sformatf("entropy_mode: %0s\n", entropy_mode.name()),
             $sformatf("entropy_fast_process: %0b\n", entropy_fast_process),
-            $sformatf("entropy_ready: %0b\n", entropy_ready)};
+            $sformatf("entropy_ready: %0b\n", entropy_ready),
+            $sformatf("en_unsupported_modestrength %0b\n", en_unsupported_modestrength)};
   endfunction
 
   // This function implements the bulk of integer encoding specified by NIST.SP.800-185

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
@@ -29,6 +29,7 @@ class kmac_error_vseq extends kmac_app_vseq;
   }
 
   constraint kmac_err_type_c {
+    kmac_err_type != ErrUnexpectedModeStrength;
     if (en_kmac_err) {
       (kmac_err_type inside
           {kmac_pkg::ErrNone,
@@ -39,6 +40,8 @@ class kmac_error_vseq extends kmac_app_vseq;
     } else {
       kmac_err_type == kmac_pkg::ErrNone;
     }
+    // TODO: remove this constraint when scb error found.
+    (kmac_err_type == kmac_pkg:: ErrUnexpectedModeStrength) -> (en_unsupported_modestrength == 1);
 
     (kmac_err_type == kmac_pkg::ErrSwPushedMsgFifo) -> (en_app == 1);
 


### PR DESCRIPTION
This PR fixes the regression failure at error sequence.
The issue is due to newly support field `en_unsupported_modestrength`.
Current randomization only allow this field to be 1. There is still a
testbench(scb) error when value is set to 0.
I will work on fixing this issue asap.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>