### PR TITLE
[otbn,dv] Fix reset during EDN request (again)

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/edn_client.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/edn_client.py
@@ -69,11 +69,14 @@ class EdnClient:
         self._retry = False
 
     def take_word(self, word: int, fips_err: bool) -> None:
-        '''Take a 32-bit data word that we've been waiting for'''
+        '''
+        Take a 32-bit data word, which we requested.
+
+        If there is a reset in between an EDN transaction, request flag will
+        drop. In that case, incoming word will be ignored. Otherwise, append
+        it to the internal `_acc` list.
+        '''
         assert 0 <= word < (1 << 32)
-        assert self._acc is not None
-        assert len(self._acc) < ACC_LEN
-        assert self._cdc_counter is None
 
         if self._acc is None:
             return


### PR DESCRIPTION
This commit reapplies 40dea7f638 (#13294), which had been partially
undone in 3c7192597e (part of #13391).