### PR TITLE
[sca/kmac] Switch off entropy fast process

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -391,7 +391,9 @@
           If 1, entropy logic uses garbage data while not processing the KMAC
           key block. It will re-use previous entropy value and will not
           expand the entropy when it is consumed. Only it refreshes the
-          entropy while processing the secret key block.
+          entropy while processing the secret key block. This process should
+          not be used if SCA resistance is required because it may cause side
+          channel leakage.
           '''
           tags: ["shadowed_reg_path:u_cfg_reg_shadowed.u_cfg_reg_shadowed_entropy_fast_process"]
         } // f: entropy_fast_process

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -150,7 +150,9 @@ typedef struct dif_kmac_config {
 
   /**
    * Entropy fast process mode when enabled prevents the KMAC unit consuming
-   * entropy unless it is processing a secret key.
+   * entropy unless it is processing a secret key. This process should not be
+   * used when resistance against side-channel attacks is required, because
+   * it may lead to leakage of the secret key in the power trace.
    */
   bool entropy_fast_process;
 

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -426,7 +426,7 @@ static void kmac_init(void) {
       .entropy_mode = kDifKmacEntropyModeSoftware,
       .entropy_seed = {0xaa25b4bf, 0x48ce8fff, 0x5a78282a, 0x48465647,
                        0x70410fef},
-      .entropy_fast_process = true,
+      .entropy_fast_process = false,
       .msg_mask = true,
   };
   CHECK_DIF_OK(dif_kmac_configure(&kmac, config));


### PR DESCRIPTION
Entropy fast process should not be used in scenarios which require
side-channel security.
TVLA results with fast entropy process switched on:
![FastEntropy_500k](https://user-images.githubusercontent.com/77437391/179712225-0a276ab8-ed12-4781-b77d-4a70bd8ec887.png)
The analysis shows first order key-leakage at the end of the computation.

Fast entropy process switched off:
![NormalEntropy_500k](https://user-images.githubusercontent.com/77437391/179712357-bddb1ce9-c5a2-459b-9342-fd4d5d68d6ce.png)
No first order leakage.

This commit switches off entropy fast process in sha3_serial.c and
updates documentation.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>