### PR TITLE
[otbn,rtl,dv] Replace zeroing in secure wipe with writing random data

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -937,7 +937,7 @@ unsigned otbn_model_step(OtbnModel *model, unsigned model_state,
 
     case 1:
       // Finished
-      model_state = (model_state & ~RUNNING_BIT) | CHECK_DUE_BIT;
+      model_state = (model_state & ~RUNNING_BIT);
       break;
 
     default:

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.cc
@@ -31,7 +31,36 @@ bool OtbnTraceBodyLine::fill_from_string(const std::string &src,
 }
 
 bool OtbnTraceBodyLine::operator==(const OtbnTraceBodyLine &other) const {
-  return raw_ == other.raw_;
+  // If the raw lines are identical, the two objects are identical and no
+  // further checks are required.
+  if (raw_ == other.raw_) {
+    return true;
+  }
+
+  // If the raw lines are not identical, the two objects can be identical if one
+  // of them contains unknown values.
+
+  // Type and location have to be identical, though.
+  if (type_ != other.type_ || loc_ != other.loc_) {
+    return false;
+  }
+
+  // The values have to be of identical length.
+  if (value_.size() != other.value_.size()) {
+    return false;
+  }
+
+  // Compare values digit by digit and treat `x` as unknown value, which is
+  // identical to any other value.
+  std::string::const_iterator other_it = other.value_.begin();
+  for (std::string::const_iterator it = value_.begin(); it != value_.end();
+       it++) {
+    if (*it != *other_it && !(*it == 'x' || *other_it == 'x')) {
+      return false;
+    }
+    other_it++;
+  }
+  return true;
 }
 
 bool OtbnTraceEntry::from_rtl_trace(const std::string &trace) {

--- a/hw/ip/otbn/dv/otbnsim/sim/gpr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/gpr.py
@@ -119,4 +119,4 @@ class GPRs(RegFile):
         # TODO: Check that we wipe the call stack in the RTL and make sure it
         #       appears in a trace entry, then match that here.
         for idx in range(2, 32):
-            self.get_reg(idx).write_unsigned(0)
+            self.get_reg(idx).write_invalid()

--- a/hw/ip/otbn/dv/otbnsim/sim/reg.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/reg.py
@@ -138,4 +138,4 @@ class RegFile:
 
     def wipe(self) -> None:
         for r in self._registers:
-            r.write_unsigned(0)
+            r.write_invalid()

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -289,7 +289,8 @@ class OTBNSim:
             self.state._fsm_state = FsmState.WIPING_BAD
 
         # Reflect wiping in STATUS register if it has not been updated yet.
-        if self.state.ext_regs.read('STATUS', True) == Status.BUSY_EXECUTE:
+        if (self.state.ext_regs.read('STATUS', True) not in
+            [Status.BUSY_SEC_WIPE_INT, Status.LOCKED]):
             self.state.ext_regs.write('STATUS', Status.BUSY_SEC_WIPE_INT, True)
 
         is_good = self.state.get_fsm_state() == FsmState.WIPING_GOOD

--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -2,11 +2,15 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+from itertools import cycle
 from typing import Optional, TextIO
 from .sim import OTBNSim
 
-_TEST_RND_DATA = \
-    0xAAAAAAAA_99999999_AAAAAAAA_99999999_AAAAAAAA_99999999_AAAAAAAA_99999999
+_TEST_RND_DATA = cycle([
+    0xAAAAAAAA_99999999_AAAAAAAA_99999999_AAAAAAAA_99999999_AAAAAAAA_99999999,
+    0xCCCCCCCC_BBBBBBBB_CCCCCCCC_BBBBBBBB_CCCCCCCC_BBBBBBBB_CCCCCCCC_BBBBBBBB,
+])
+
 
 # This is the default seed for URND PRNG. Note that the actualy URND value will
 # be random since we are modelling PRNG inside the URND register model.
@@ -32,7 +36,8 @@ class StandaloneSim(OTBNSim):
         while self.state.executing():
             # If there's a RND request, respond immediately
             if self.state.ext_regs.read('RND_REQ', True):
-                self.state.wsrs.RND.set_unsigned(_TEST_RND_DATA, False, False)
+                self.state.wsrs.RND.set_unsigned(next(_TEST_RND_DATA), False,
+                                                 False)
 
             self.step(verbose)
             insn_count += 1

--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -38,6 +38,9 @@ class StandaloneSim(OTBNSim):
             if self.state.ext_regs.read('RND_REQ', True):
                 self.state.wsrs.RND.set_unsigned(next(_TEST_RND_DATA), False,
                                                  False)
+            # If there's a URND request, respond immediately.
+            if not self.state.wsrs.URND.running:
+                self.state.wsrs.URND.set_seed(_TEST_URND_DATA)
 
             self.step(verbose)
             insn_count += 1

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -19,9 +19,9 @@ from .reg import RegFile
 from .trace import Trace, TracePC
 from .wsr import WSRFile
 
-# The number of cycles spent in the 'WIPE' state. This takes constant time in
-# the RTL, mirrored here.
-_WIPE_CYCLES = 98
+# The number of cycles spent per round of a secure wipe. This takes constant
+# time in the RTL, mirrored here.
+_WIPE_CYCLES = 67
 
 
 class FsmState(IntEnum):
@@ -98,6 +98,8 @@ class OTBNState:
         self._next_fsm_state = FsmState.IDLE
 
         self._init_sec_wipe_state = InitSecWipeState.NOT_DONE
+
+        self.first_round_of_wipe = True
 
         self.loop_stack = LoopStack()
 

--- a/hw/ip/otbn/dv/otbnsim/sim/trace.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/trace.py
@@ -27,16 +27,22 @@ class Trace:
         return None
 
     @staticmethod
-    def hex_value(value: int, bit_width: int) -> str:
+    def hex_value(value: Optional[int], bit_width: int) -> str:
         '''Render a hex value in the format expected by RTL tracing'''
         if bit_width == 32:
-            return '{:#010x}'.format(value)
+            if value is None:
+                return '0x' + 'x' * 8
+            else:
+                return '{:#010x}'.format(value)
 
         num_words = (bit_width + 31) // 32
         mask32 = (1 << 32) - 1
         # Collect up words, LSB first
         words = []
         for idx in range(num_words):
+            if value is None:
+                words.append('x' * 8)
+                continue
             lsb = 32 * idx
             word = (value >> lsb) & mask32
             top_width = (bit_width - lsb + 3) // 4

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -448,5 +448,5 @@ class WSRFile:
         self.KeyS1.set_unsigned(key1)
 
     def wipe(self) -> None:
-        self.MOD.write_unsigned(0)
-        self.ACC.write_unsigned(0)
+        self.MOD.write_invalid()
+        self.ACC.write_invalid()

--- a/hw/ip/otbn/dv/smoke/smoke_test.s
+++ b/hw/ip/otbn/dv/smoke/smoke_test.s
@@ -241,6 +241,7 @@ bn.wsrw 0x3 /* ACC */, w26
 
 bn.mulqacc           w27.0, w28.0, 0
 bn.mulqacc           w27.1, w28.0, 64
+bn.xor        w29,   w29,   w29
 bn.mulqacc.so w29.L, w27.0, w28.1, 64
 bn.mulqacc           w27.2, w28.0, 0
 bn.mulqacc           w27.1, w28.1, 0
@@ -253,6 +254,7 @@ bn.mulqacc           w27.3, w28.1, 0
 bn.mulqacc           w27.2, w28.2, 0
 bn.mulqacc           w27.1, w28.3, 0
 bn.mulqacc           w27.3, w28.2, 64
+bn.xor        w30,   w30,   w30
 bn.mulqacc.so w30.L, w27.2, w28.3, 64
 bn.mulqacc.so w30.U, w27.3, w28.3, 0
 

--- a/hw/ip/otbn/dv/smoke/smoke_test.s
+++ b/hw/ip/otbn/dv/smoke/smoke_test.s
@@ -340,6 +340,10 @@ bn.add w2, w2, w1
 bn.wsrr w1, 0x7
 bn.add w2, w2, w1
 
+# Set unused registers to zero. Without this, they would keep the random value assigned during
+# secure wipe, which cannot be compared against an expected value.
+xor x30, x30, x30
+
 ecall
 
 test_fn_1:

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -558,12 +558,13 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     end
     else `uvm_fatal(`gfn, $sformatf("Bad alert name: %0s", alert_name));
 
-    // Wait up to 100 cycles for the a prediction to come through (giving up on reset). This is a
+    // Wait up to 400 cycles for the prediction to come through (giving up on reset).  This is a
     // long time, but that's needed because an error that comes in when we're running will cause an
-    // immediate alert but the status change will only appear after secure wipe is done. Note that
-    // this might be here already, in which case wait_for_expected_alert will take zero time.
+    // immediate alert but the status change will only appear after secure wipe is done.  A secure
+    // wipe includes a reseed of the URND, and the time for that depends on the EDN.  Note that
+    // the alert might be here already, in which case `wait_for_expected_alert` will take zero time.
     fork
-      wait_for_expected_alert(alert_name, 100);
+      wait_for_expected_alert(alert_name, 400);
     join_none
   endfunction
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -347,11 +347,11 @@ class otbn_base_vseq extends cip_base_vseq #(
     `DV_CHECK_FATAL(!cfg.under_reset)
 
     // Wait for OTBN to be idle. After a reset, getting an URND value from EDN and performing an
-    // initial secure wipe can take up to 300 cycles if the EDN is held in reset for much longer
+    // initial secure wipe can take up to 500 cycles if the EDN is held in reset for much longer
     // than OTBN, so use that as timeout.  Stop waiting on a reset.
     fork: wait_for_idle_fork
       wait (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusIdle);
-      repeat (300) @(cfg.clk_rst_vif.cbn);
+      repeat (500) @(cfg.clk_rst_vif.cbn);
       wait (cfg.under_reset);
     join_any
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_intg_err_vseq.sv
@@ -90,8 +90,10 @@ class otbn_intg_err_vseq extends otbn_base_vseq;
     @(cfg.clk_rst_vif.cbn);
     release_force();
 
-    // OTBN should now do a secure wipe. Give it some cycles to do so.
-    repeat (100) @(cfg.clk_rst_vif.cbn);
+    // OTBN should now do a secure wipe. Give it up to 400 cycles to do so (because it needs to go
+    // twice over all registers and reseed URND in between, the time of which depends on the delay
+    // configured in the EDN model).
+    repeat (400) @(cfg.clk_rst_vif.cbn);
 
     // We should now be in a locked state after the secure wipe.
     `DV_CHECK_FATAL(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -122,7 +122,9 @@ module otbn_top_sim (
     .sideload_key_shares_valid_i ( 2'b11                      )
   );
 
-  localparam logic [WLEN-1:0] FixedEdnVal = {{4{64'hAAAA_AAAA_9999_9999}}};
+  // The values returned by the mock EDN must match those set in `standalonesim.py`.
+  localparam logic [1:0][WLEN-1:0] FixedEdnVals = {{4{64'hCCCC_CCCC_BBBB_BBBB}},
+                                                   {4{64'hAAAA_AAAA_9999_9999}}};
 
   edn_req_t rnd_req;
   edn_rsp_t rnd_rsp;
@@ -130,8 +132,8 @@ module otbn_top_sim (
   assign rnd_req.edn_req = edn_rnd_req;
 
   otbn_mock_edn #(
-    .Width       ( WLEN        ),
-    .FixedEdnVal ( FixedEdnVal )
+    .Width        ( WLEN         ),
+    .FixedEdnVals ( FixedEdnVals )
   ) u_mock_rnd_edn(
     .clk_i      ( IO_CLK       ),
     .rst_ni     ( IO_RST_N     ),
@@ -151,8 +153,8 @@ module otbn_top_sim (
   assign urnd_req.edn_req = edn_urnd_req;
 
   otbn_mock_edn #(
-    .Width       ( WLEN        ),
-    .FixedEdnVal ( FixedEdnVal )
+    .Width        ( WLEN         ),
+    .FixedEdnVals ( FixedEdnVals )
   ) u_mock_urnd_edn(
     .clk_i      ( IO_CLK       ),
     .rst_ni     ( IO_RST_N     ),

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -248,7 +248,6 @@ module otbn_alu_bignum
           mod_intg_d[i_word*39+:39]  = mod_intg_calc[i_word*39+:39];
         end
         // Pre-encoded inputs can directly be written to the register.
-        sec_wipe_zero_i: mod_intg_d[i_word*39+:39] = EccZeroWord;
         default: mod_intg_d[i_word*39+:39] = ispr_mod_bignum_wdata_intg_blanked[i_word*39+:39];
       endcase
 
@@ -262,7 +261,6 @@ module otbn_alu_bignum
       endcase
     end
 
-    `ASSERT(ModSecWipeSelOneHot, $onehot0({sec_wipe_mod_urnd_i, sec_wipe_zero_i}))
     `ASSERT(ModWrSelOneHot, $onehot0({ispr_init_i, ispr_base_wr_en_i[i_word]}))
 
     assign mod_ispr_wr_en[i_word] = (ispr_addr_i == IsprMod)                          &
@@ -271,8 +269,7 @@ module otbn_alu_bignum
 
     assign mod_wr_en[i_word] = ispr_init_i            |
                                mod_ispr_wr_en[i_word] |
-                               sec_wipe_mod_urnd_i    |
-                               sec_wipe_zero_i;
+                               sec_wipe_mod_urnd_i;
   end
 
   assign ispr_acc_wr_en_o   =

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -807,7 +807,6 @@ module otbn_core
 
     .urnd_data_i        (urnd_data),
     .sec_wipe_acc_urnd_i(sec_wipe_acc_urnd),
-    .sec_wipe_zero_i    (sec_wipe_zero),
 
     .mac_en_i    (mac_bignum_en),
     .mac_commit_i(mac_bignum_commit),
@@ -904,13 +903,21 @@ module otbn_core
           mubi4_test_true_loose(start_stop_escalate_en) && mubi4_test_false_strict(escalate_en_i)
           |=> err_bits_q)
 
+  // The following assertions allow up to 400 cycles from escalation until the start/stop FSM locks.
+  // This is a long time, but it's necessary because following an escalation the start/stop FSM goes
+  // through two rounds of secure wiping with random data with an URND reseed in between.  Depending
+  // on the delay configured in the EDN model, the reseed alone can take 200 cycles.
+
   `ASSERT(OtbnStartStopGlobalEscCntrMeasure_A, err_bits_q && mubi4_test_true_loose(escalate_en_i)
-          && mubi4_test_true_loose(start_stop_escalate_en)|=> ##[1:100]
+          && mubi4_test_true_loose(start_stop_escalate_en)|=> ##[1:400]
           u_otbn_start_stop_control.state_q == otbn_pkg::OtbnStartStopStateLocked)
 
   `ASSERT(OtbnStartStopLocalEscCntrMeasure_A, err_bits_q && mubi4_test_false_strict(escalate_en_i)
-          && mubi4_test_true_loose(start_stop_escalate_en) |=>  ##[1:100]
+          && mubi4_test_true_loose(start_stop_escalate_en) |=>  ##[1:400]
           u_otbn_start_stop_control.state_q == otbn_pkg::OtbnStartStopStateLocked)
+
+  // In contrast to the start/stop FSM, the controller FSM should lock quickly after an escalation,
+  // independent of the secure wipe.
 
   `ASSERT(OtbnControllerGlobalEscCntrMeasure_A, err_bits_q && mubi4_test_true_loose(escalate_en_i)
           && mubi4_test_true_loose(controller_fatal_escalate_en)|=> ##[1:100]

--- a/hw/ip/otbn/rtl/otbn_mac_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_mac_bignum.sv
@@ -24,7 +24,6 @@ module otbn_mac_bignum
 
   input logic [WLEN-1:0] urnd_data_i,
   input logic            sec_wipe_acc_urnd_i,
-  input logic            sec_wipe_zero_i,
 
   output logic [ExtWLEN-1:0] ispr_acc_intg_o,
   input  logic [ExtWLEN-1:0] ispr_acc_wr_data_intg_i,
@@ -192,8 +191,6 @@ module otbn_mac_bignum
         acc_no_intg_d = urnd_data_i;
         acc_intg_d = acc_intg_calc;
       end
-      // Pre-encoded values can be written directly to the register.
-      sec_wipe_zero_i: acc_intg_d = EccWideZeroWord;
       default: begin
         // If performing an ACC ISPR write the next accumulator value is taken from the ISPR write
         // data, otherwise it is drawn from the adder result. The new accumulator can be optionally
@@ -211,8 +208,7 @@ module otbn_mac_bignum
 
   // Only write to accumulator if the MAC is enabled or an ACC ISPR write is occuring or secure
   // wipe of the internal state is occuring.
-  assign acc_en = (mac_en_i & mac_commit_i) | ispr_acc_wr_en_i | sec_wipe_acc_urnd_i |
-    sec_wipe_zero_i;
+  assign acc_en = (mac_en_i & mac_commit_i) | ispr_acc_wr_en_i | sec_wipe_acc_urnd_i;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin


### PR DESCRIPTION
As reasoned in https://github.com/lowRISC/opentitan/issues/13499, the second round of a secure wipe should not
write zeroes but PRNG-provided values.  This should make FI attacks that
rely on a known (or even zero) register state much more difficult.
Before that second round using PRNG-provided values, the PRNG has to be
reseeded.  This is needed so the PRNG state that provided the values for
the first wipe cannot be inferred from reading out registers after the
wipe.

The main commit in this PR (the last one) adds an URND reseed between
the two rounds of a secure wipe and changes the second round from zeroing
to using URND-provided values, like the first round.  This is mainly implemented
in `otbn_start_stop_control`, which controls the secure wipe.
Additionally, the bignum ALU and MAC are slightly modified as follows:
- In `otbn_alu_bignum`, the `sec_wipe_zero_i` input is no longer used to
  zero the `MOD` register.  It is still used to zero the flags, though.
- In `otbn_mac_bignum`, the `sec_wipe_zero_i` input has been removed.
  The MAC only used that input to zero the `ACC` register, which no
  longer happens.

On OTBN DV, the main commit makes the following changes:
- Extend `otbn_core_model`, which models the URND request, to perform
  the URND reseed between the two rounds of a secure wipe.  This
  significantly increases the complexity of that part of the model, but
  the behavior is still coded independently from RTL (except the number
  of cycles for one wipe round, which is dictated by the RTL).
- Change `otbn_scoreboard` to wait for an expected alert for up to 150
  cycles, as the URND reseed in the middle of a secure wipe potentially
  delays the raising of an alert.
- Modify the registers in `otbnsim` to be *invalid* after a secure wipe.
  This is required because the registers are no longer zero after the
  secure wipe, yet the simulator does not know the random values written
  during secure wipe.
- Modify and extend the `_step_wiping()` function of `otbnsim` to model
  two rounds of secure wipe with an URND refresh between them.

## To be discussed

OTBN's simulator does not model the random values that are written during secure wipe. (Before this change, this was not an issue because each secure wipe ended with zeros in all registers.) This creates two practical problems described below.

A solution to both problems could be to model the random values in the simulator precisely as in RTL. This would further increase the complexity of the simulator and reduce its abstraction level, though, so I would refrain from doing this unless we consider this to be the only viable solution.

### Checks after secure wipe

One check to ensure the secure wipe works as intended was to compare the registers of the simulator and the RTL for equality after a secure wipe. This no longer works with this change, because after a secure wipe RTL registers contain random values that the simulator does not know. *Some* checks on the outcome of a secure wipe are required, though.

This PR:
- removes the equality comparison of the registers *after* the secure wipe. (The registers are still compared after *program execution* and thus *before* the secure wipe.)
- modifies the comparison of the register write traces: A value of `x` now compares equal to any value. This is used to compare the traces produced during secure wipe, where the *set* of written registers must be equal between RTL and simulator but the *value* written to registers that are wiped non-zero is ignored.

### Instructions that write only part of a register

Some instructions, such as `bn.mulqacc.so` (are there more?), write only one half of a register. When such an instruction writes a register that has not been set to a value in a way that is independent of the initial value of any register that is wiped non-zero, the outcome will differ between simulator and RTL. This is usually a transient issue, because a program will eventually write the entire register. However, it would cause a mismatch in the traces.

This PR initializes the destination WDRs of the `bn.mulqacc.so` instructions in `smoke_test`, so that this problem does not surface in the smoke test.

In the long run, we may want to model partially unknown registers in the simulator, so that a simulator register could be partially unknown, appear as such in the trace, and compare equal to the RTL register provided the known part matches.