### PR TITLE
[dv/kmac] improve app interface sequence

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -334,6 +334,18 @@
             '''
     }
     {
+      name: app_sw_cfg_cg
+      desc: '''
+            Covers several scenarios related to the app interface and cfg_shadowed register value:
+            - Hash_mode field value.
+            - Kmac_en field value.
+            - Kstrength field value.
+
+            These sw register settings should not affect kmac app interface calculation.
+            Note that this covergroup will be duplicated once per app interface.
+            '''
+   }
+   {
       name: edn_cg
       desc: '''
             Covers that EDN entropy can be received by KMAC while keccak rounds are active/inactive,

--- a/hw/ip/kmac/dv/env/kmac_env_cov.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cov.sv
@@ -165,16 +165,31 @@ class app_cg_wrap;
     }
   endgroup
 
+  covergroup app_cfg_reg_cg(string name) with function sample(sha3_pkg::sha3_mode_e sw_hash_mode);
+    option.per_instance = 1;
+    option.name = name;
+    sw_configured_hash_mode: coverpoint sw_hash_mode {
+      bins sha3   = {sha3_pkg::Sha3};
+      bins shake  = {sha3_pkg::Shake};
+      bins cshake = {sha3_pkg::CShake};
+    }
+  endgroup
+
   function new(string name = "app_cg");
     app_cg = new(name);
+    app_cfg_reg_cg = new(name);
   endfunction
 
-  function void sample(bit single_beat,
-                       bit [keymgr_pkg::KmacDataIfWidth/8-1:0] strb,
-                       bit err,
-                       bit is_done,
-                       bit in_keccak);
+  function void app_sample(bit single_beat,
+                           bit [keymgr_pkg::KmacDataIfWidth/8-1:0] strb,
+                           bit err,
+                           bit is_done,
+                           bit in_keccak);
     app_cg.sample(single_beat, strb, err, is_done, in_keccak);
+  endfunction
+
+  function void app_cfg_reg_sample(sha3_pkg::sha3_mode_e sw_hash_mode);
+    app_cfg_reg_cg.sample(sw_hash_mode);
   endfunction
 endclass
 
@@ -293,10 +308,6 @@ class kmac_env_cov extends cip_base_env_cov #(.CFG_T(kmac_env_cfg));
       bins app_valid_sideload       = binsof(sideload) intersect {1} && binsof(in_app_keymgr);
       bins app_invalid_sideload     = binsof(sideload) intersect {0} && binsof(in_app_keymgr);
     }
-  endgroup
-
-  covergroup app_cg with function sample();
-
   endgroup
 
   covergroup error_cg with function sample(kmac_pkg::err_code_e kmac_err,

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
@@ -38,9 +38,10 @@ class kmac_app_vseq extends kmac_sideload_vseq;
 
   constraint hash_mode_c {
     if (en_app) {
-      hash_mode == sha3_pkg::CShake;
       if (app_mode == AppKeymgr) {
         kmac_en == 1;
+        // Only enable sideload interface, but does not necessarily need to set
+        // cfg_shadowed.sideload to 1.
         en_sideload == 1;
       } else {
         kmac_en == 0;


### PR DESCRIPTION
Remove the constraint to configure kmac cfg_shadow register hash_mode
field. Kmac should be able to select the correct mode when using the app
interface.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>