### PR TITLE
[dif/entropy_src] implement last DIF and move to S2

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.prj.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.prj.hjson
@@ -12,5 +12,5 @@
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V1",
-    dif_stage:          "S0",
+    dif_stage:          "S2",
 }

--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -592,6 +592,35 @@ dif_result_t dif_entropy_src_get_fifo_depth(
   return kDifOk;
 }
 
+dif_result_t dif_entropy_src_get_debug_state(
+    const dif_entropy_src_t *entropy_src,
+    dif_entropy_src_debug_state_t *debug_state) {
+  if (entropy_src == NULL || debug_state == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t debug_state_reg = mmio_region_read32(
+      entropy_src->base_addr, ENTROPY_SRC_DEBUG_STATUS_REG_OFFSET);
+  debug_state->entropy_fifo_depth = bitfield_field32_read(
+      debug_state_reg, ENTROPY_SRC_DEBUG_STATUS_ENTROPY_FIFO_DEPTH_FIELD);
+  debug_state->sha3_fsm_state = bitfield_field32_read(
+      debug_state_reg, ENTROPY_SRC_DEBUG_STATUS_SHA3_FSM_FIELD);
+  debug_state->sha3_block_processed = bitfield_bit32_read(
+      debug_state_reg, ENTROPY_SRC_DEBUG_STATUS_SHA3_BLOCK_PR_BIT);
+  debug_state->sha3_squeezing = bitfield_bit32_read(
+      debug_state_reg, ENTROPY_SRC_DEBUG_STATUS_SHA3_SQUEEZING_BIT);
+  debug_state->sha3_absorbed = bitfield_bit32_read(
+      debug_state_reg, ENTROPY_SRC_DEBUG_STATUS_SHA3_ABSORBED_BIT);
+  debug_state->sha3_error = bitfield_bit32_read(
+      debug_state_reg, ENTROPY_SRC_DEBUG_STATUS_SHA3_ERR_BIT);
+  debug_state->main_fsm_is_idle = bitfield_bit32_read(
+      debug_state_reg, ENTROPY_SRC_DEBUG_STATUS_MAIN_SM_IDLE_BIT);
+  debug_state->main_fsm_boot_done = bitfield_bit32_read(
+      debug_state_reg, ENTROPY_SRC_DEBUG_STATUS_MAIN_SM_BOOT_DONE_BIT);
+
+  return kDifOk;
+}
+
 dif_result_t dif_entropy_src_get_recoverable_alerts(
     const dif_entropy_src_t *entropy_src, uint32_t *alerts) {
   if (entropy_src == NULL || alerts == NULL) {

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -282,6 +282,62 @@ typedef struct dif_entropy_src_alert_fail_counts {
 } dif_entropy_src_alert_fail_counts_t;
 
 /**
+ * SHA3 state machine states.
+ *
+ * See `hw/ip/kmac/rtl/sha3_pkg.sv` for more details.
+ */
+typedef enum dif_entropy_src_sha3_state {
+  kDifEntropySrcSha3StateIdle = 0,
+  kDifEntropySrcSha3StateAbsorb = 1,
+  kDifEntropySrcSha3StateSqueeze = 2,
+  kDifEntropySrcSha3StateManualRun = 3,
+  kDifEntropySrcSha3StateFlush = 4,
+  kDifEntropySrcSha3StateError = 5,
+} dif_entropy_src_sha3_state_t;
+
+/**
+ * Debug status information.
+ */
+typedef struct dif_entropy_src_debug_state {
+  /**
+   * Depth of the entropy source FIFO.
+   *
+   * Valid range: [0, 7]
+   */
+  uint8_t entropy_fifo_depth;
+  /**
+   * The current state of the SHA3 preconditioner state machine.
+   *
+   * See `dif_entropy_src_sha3_state_t` for more details.
+   */
+  dif_entropy_src_sha3_state_t sha3_fsm_state;
+  /**
+   * Whether the SHA3 preconditioner has completed processing the current block.
+   */
+  bool sha3_block_processed;
+  /**
+   * Whether the SHA3 preconditioner is in the squeezing state.
+   */
+  bool sha3_squeezing;
+  /**
+   * Whether the SHA3 preconditioner is in the absorbed state.
+   */
+  bool sha3_absorbed;
+  /**
+   * Whether the SHA3 preconditioner has is in an error state.
+   */
+  bool sha3_error;
+  /**
+   * Whether the main FSM is in the idle state.
+   */
+  bool main_fsm_is_idle;
+  /**
+   * Whether the main FSM is in the boot done state.
+   */
+  bool main_fsm_boot_done;
+} dif_entropy_src_debug_state_t;
+
+/**
  * Recoverable alerts.
  */
 typedef enum dif_entropy_src_alert_cause {
@@ -658,6 +714,18 @@ dif_result_t dif_entropy_src_clear_fifo_overflow(
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_entropy_src_get_fifo_depth(
     const dif_entropy_src_t *entropy_src, uint32_t *fifo_depth);
+
+/**
+ * Reads the debug status register.
+ *
+ * @param entropy_src An entropy source handle.
+ * @param[out] debug_state The current debug state of the IP.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_get_debug_state(
+    const dif_entropy_src_t *entropy_src,
+    dif_entropy_src_debug_state_t *debug_state);
 
 /**
  * Reads the recoverable alert status register.

--- a/sw/device/lib/dif/dif_entropy_src.md
+++ b/sw/device/lib/dif/dif_entropy_src.md
@@ -13,7 +13,7 @@ Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
 Implementation | [DIF_EXISTS][]       | Done        |
 Implementation | [DIF_USED_IN_TREE][] | Done        |
-Tests          | [DIF_TEST_SMOKE][]   | In Progress |
+Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
@@ -24,8 +24,8 @@ Tests          | [DIF_TEST_SMOKE][]   | In Progress |
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_FEATURES][]            | In Progress |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
 [DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
@@ -39,7 +39,7 @@ Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
 Documentation  | [DIF_DOC_HW][]                   | Not Started |
 Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
-Tests          | [DIF_TEST_UNIT][]                | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -718,6 +718,38 @@ TEST_F(ReadFifoDepthTest, ReadSuccess) {
   EXPECT_EQ(depth, 6);
 }
 
+class GetDebugStateTest : public EntropySrcTest {};
+
+TEST_F(GetDebugStateTest, NullArgs) {
+  dif_entropy_src_debug_state_t debug_state;
+  EXPECT_DIF_BADARG(dif_entropy_src_get_debug_state(nullptr, &debug_state));
+  EXPECT_DIF_BADARG(dif_entropy_src_get_debug_state(&entropy_src_, nullptr));
+  EXPECT_DIF_BADARG(dif_entropy_src_get_debug_state(nullptr, nullptr));
+}
+
+TEST_F(GetDebugStateTest, Success) {
+  dif_entropy_src_debug_state_t debug_state;
+  EXPECT_READ32(
+      ENTROPY_SRC_DEBUG_STATUS_REG_OFFSET,
+      {{ENTROPY_SRC_DEBUG_STATUS_MAIN_SM_BOOT_DONE_BIT, 1},
+       {ENTROPY_SRC_DEBUG_STATUS_MAIN_SM_IDLE_BIT, 1},
+       {ENTROPY_SRC_DEBUG_STATUS_SHA3_ERR_BIT, 1},
+       {ENTROPY_SRC_DEBUG_STATUS_SHA3_ABSORBED_BIT, 1},
+       {ENTROPY_SRC_DEBUG_STATUS_SHA3_SQUEEZING_BIT, 1},
+       {ENTROPY_SRC_DEBUG_STATUS_SHA3_BLOCK_PR_BIT, 1},
+       {ENTROPY_SRC_DEBUG_STATUS_SHA3_FSM_OFFSET, kDifEntropySrcSha3StateFlush},
+       {ENTROPY_SRC_DEBUG_STATUS_ENTROPY_FIFO_DEPTH_OFFSET, 4}});
+  EXPECT_DIF_OK(dif_entropy_src_get_debug_state(&entropy_src_, &debug_state));
+  EXPECT_EQ(debug_state.entropy_fifo_depth, 4);
+  EXPECT_EQ(debug_state.sha3_fsm_state, kDifEntropySrcSha3StateFlush);
+  EXPECT_EQ(debug_state.sha3_block_processed, true);
+  EXPECT_EQ(debug_state.sha3_squeezing, true);
+  EXPECT_EQ(debug_state.sha3_absorbed, true);
+  EXPECT_EQ(debug_state.sha3_error, true);
+  EXPECT_EQ(debug_state.main_fsm_is_idle, true);
+  EXPECT_EQ(debug_state.main_fsm_boot_done, true);
+}
+
 class GetRecoverableAlertsTest : public EntropySrcTest {};
 
 TEST_F(GetRecoverableAlertsTest, NullArgs) {


### PR DESCRIPTION
This implements the last DIF for the entropy_src (that reads the debug status register) and moves the DIF library to S2.