### PR TITLE
[dv/rstmgr] Fix sec_cm_scan_intersig_mubi failure

### DIFF
--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sec_cm_scan_intersig_mubi_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sec_cm_scan_intersig_mubi_vseq.sv
@@ -32,7 +32,12 @@ class rstmgr_sec_cm_scan_intersig_mubi_vseq extends rstmgr_smoke_vseq;
 
     forever begin
       cfg.clk_rst_vif.wait_clks(1);
-      cfg.rstmgr_vif.scanmode_i = get_rand_mubi4_val(0, 0, 1);
+      // If scan_rst_ni is active we assume super is doing a scan reset, so keep scanmode_i True.
+      if (cfg.rstmgr_vif.scan_rst_ni == 1'b1) begin
+        cfg.rstmgr_vif.scanmode_i = get_rand_mubi4_val(0, 0, 1);
+      end else begin
+        cfg.rstmgr_vif.scanmode_i = prim_mubi_pkg::MuBi4True;
+      end
       cfg.io_div4_clk_rst_vif.wait_clks(scanmode_to_scan_rst_cycles);
       delay = $urandom_range(0, 30);
       cfg.clk_rst_vif.wait_clks(delay);


### PR DESCRIPTION
Block wiggling scanmode_i while scan_rst_ni is active, or the smoke
sequence will fail to generate a scan reset, and fail.

Signed-off-by: Guillermo Maturana <maturana@google.com>