### PR TITLE
[entropy_src/dv] Temporarily disable some stressors

### DIFF
--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -18,8 +18,8 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.dut_cfg.boot_mode_retry_limit       = 10;
     cfg.sim_duration                = 20ms;
     cfg.hard_mtbf                   = 100s;
-    cfg.mean_rand_reconfig_time     = 1ms;
-    cfg.mean_rand_csr_alert_time    = 1ms;
+    cfg.mean_rand_reconfig_time     = -1;
+    cfg.mean_rand_csr_alert_time    = -1;
 
     cfg.soft_mtbf                   = 7500us;
     // Apply standards ranging from strict to relaxed


### PR DESCRIPTION
THe entropy_src_rng sequence is currenly hanging dues to frequent
fatal errors and an unreliable reset sequence.   This commit
disables the events causing these fatal errors until the reset
mechanism can be made more robust.

Fixes #13741 

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>