### PR TITLE
Revert "[dv/entropy_src] temp disable entropy_rng_test"

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -54,12 +54,11 @@
       uvm_test_seq: entropy_src_smoke_vseq
     }
 
-//    TODO: #13741
-//    {
-//      name: entropy_src_rng
-//      uvm_test: entropy_src_rng_test
-//      uvm_test_seq: entropy_src_rng_vseq
-//    }
+    {
+      name: entropy_src_rng
+      uvm_test: entropy_src_rng_test
+      uvm_test_seq: entropy_src_rng_vseq
+    }
 
     {
       name: entropy_src_stress_all

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_stress_all_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_stress_all_vseq.sv
@@ -11,9 +11,8 @@ class entropy_src_stress_all_vseq extends entropy_src_base_vseq;
 
   task body();
     string seq_names[] = {"entropy_src_smoke_vseq",
-                          "entropy_src_common_vseq"}; //, // for intr_test
-                          // TODO: #13741
-                          // "entropy_src_rng_vseq"};
+                          "entropy_src_common_vseq", // for intr_test
+                          "entropy_src_rng_vseq"};
 
     for (int i = 1; i <= num_trans; i++) begin
       uvm_sequence            seq;


### PR DESCRIPTION
Reverts lowRISC/opentitan#13742
Because PR #13748 provides a temp fix for this sequence.
And issue #13741 records the issue.

Signed-off-by: Cindy Chen [chencindy@opentitan.org](mailto:chencindy@opentitan.org)