### PR TITLE
[bazel] Add --config=asan and --config=ubsan

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,3 +31,30 @@ coverage --combined_report=lcov --instrument_test_targets --experimental_cc_cove
 # 1 test per 4 cores to avoid verilator performance falloff and timeouts we'd
 # otherwise see on machines with fewer than 40 cores.
 test --local_test_jobs=HOST_CPUS*0.25
+
+# AddressSanitizer (ASan) catches runtime out-of-bounds accesses to globals, the
+# stack, and (less importantly for OpenTitan) the heap. ASan instruments
+# programs at compile time and also requires a runtime library.
+#
+# ASan documentation: https://clang.llvm.org/docs/AddressSanitizer.html
+#
+# Enable ASan with --config=asan.
+build:asan --copt -fsanitize=address
+build:asan --copt -g
+build:asan --strip=never
+build:asan --copt -fno-omit-frame-pointer
+build:asan --linkopt -fsanitize=address
+
+# UndefinedBehaviorSanitizer (UBSan) catches C/C++ undefined behavior at
+# runtime, e.g. signed integer overflow. UBSan instruments programs at compile
+# time and also requires a runtime library.
+#
+# UBSan documentation:
+# https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
+#
+# Enable UBSan with --config=ubsan.
+build:ubsan --copt -fsanitize=undefined
+build:ubsan --copt -g
+build:ubsan --strip=never
+build:ubsan --copt -fno-omit-frame-pointer
+build:ubsan --linkopt -fsanitize=undefined


### PR DESCRIPTION
[bazel] Add --config=asan and --config=ubsan

These new config flags are intended to be applied to cc_test() targets
that run on the host machine. For example, the following runs a test
binary with ASan enabled:

  $ ./bazelisk.sh test --config=asan \
    //sw/device/lib/base:status_unittest

Caveat 1: ASan is not implemented for riscv32.

  $ ./bazelisk.sh build \
    --platforms=@bazel_embedded//platforms:opentitan_rv32imc \
    --config=asan //sw/device/lib/base:status
  ...
  clang-13: error: unsupported option '-fsanitize=address' for target 'riscv32-unknown-unknown-elf'
  ...

Caveat 2: UBSan is platform-independent, but the linker portion of
--config=ubsan (-fsanitize=undefined) will not be picked up by custom
linker scripts.

  * This works because :status does not have a custom linker script:
    $ ./bazelisk.sh build \
      --platforms=@bazel_embedded//platforms:opentitan_rv32imc \
      --config=ubsan //sw/device/lib/base:status

  * This fails with a linker error:
    $ ./bazelisk.sh test \
      --platforms=@bazel_embedded//platforms:opentitan_rv32imc \
      --config=ubsan //sw/device/lib/testing/test_rom:test_rom
    ...
    /proc/self/cwd/sw/device/silicon_creator/mask_rom/bootstrap.c:320: undefined reference to `__ubsan_handle_builtin_unreachable'
    ...

Issue #13754