### PR TITLE
[adc_ctrl] Various D3 cleanup

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -24,8 +24,8 @@
     }
   ],
   interrupt_list: [
-    { name: "debug_cable",
-      desc: "USB-C debug cable is attached or disconnected",
+    { name: "match_done",
+      desc: "ADC match or measurement event done",
     }
   ],
   alert_list: [
@@ -37,7 +37,7 @@
   ],
   wakeup_list: [
     { name: "wkup_req",
-      desc: "USB-C debug cable wakeup request",
+      desc: "ADC wakeup request",
     }
   ],
   param_list: [

--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -312,45 +312,17 @@
     { name: "adc_intr_status",
       desc: "Debug cable internal status",
       swaccess: "rw1c",
-      hwaccess: "hwo",
+      hwaccess: "hrw",
       resval: "0",
       tags: [ // the value of these regs is determined by the
               // value on the pins, hence it cannot be predicted.
               "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
-        { bits: "0",
-          name: "cc_sink_det",
-          desc: "0: filter0 condition is not met; 1: filter0 condition is met",
+        { bits: "NumAdcFilter-1:0",
+          name: "filter_match",
+          desc: "0: filter condition is not met; 1: filter condition is met",
         }
-        { bits: "1",
-          name: "cc_1A5_sink_det",
-          desc: "0: filter1 condition is not met; 1: filter1 condition is met",
-        }
-        { bits: "2",
-          name: "cc_3A0_sink_det",
-          desc: "0: filter2 condition is not met; 1: filter2 condition is met",
-        }
-        { bits: "3",
-          name: "cc_src_det",
-          desc: "0: filter3 condition is not met; 1: filter3 condition is met",
-        }
-        { bits: "4",
-          name: "cc_1A5_src_det",
-          desc: "0: filter4 condition is not met; 1: filter4 condition is met",
-        }
-        { bits: "5",
-          name: "cc_src_det_flip",
-          desc: "0: filter5 condition is not met; 1: filter5 condition is met",
-        }
-        { bits: "6",
-          name: "cc_1A5_src_det_flip",
-          desc: "0: filter6 condition is not met; 1: filter6 condition is met",
-        }
-        { bits: "7",
-          name: "cc_discon",
-          desc: "0: filter7 condition is not met; 1: filter7 condition is met",
-        }
-        { bits: "8",
+        { bits: "NumAdcFilter:NumAdcFilter",
           name: "oneshot",
           desc: "0: oneshot sample is not done ; 1: oneshot sample is done",
         }

--- a/hw/ip/adc_ctrl/doc/_index.md
+++ b/hw/ip/adc_ctrl/doc/_index.md
@@ -53,7 +53,7 @@ Signal                  | Direction | Description
 
 ## Design Details
 
-## Sampling state machine
+### Sampling state machine
 
 The state machine that takes ADC samples follows a very simple pattern:
 
@@ -144,15 +144,28 @@ The list below describes how the counters interpret the filter results:
 Because scanning continues the {{< regref "adc_intr_status" >}} register will reflect any debounced events that are detected between the controller raising an interrupt and the status bits being cleared (by having 1 written to them).
 However, the {{< regref "adc_chn_val[0].adc_chn_value_intr" >}} and {{< regref "adc_chn_val[1].adc_chn_value_intr" >}} registers record the value at the time the interrupt was first raised and thus reflect the filter state from that point.
 
+### ADC_CTRL and ADC Interface
+
+The interface between the ADC controller and the ADC is diagrammed below.
+The interface is from the perspective of the ADC controller.
+Before operation can begin, the ADC controller first powers on the ADC by setting `adc_o.pd` to 0.
+The controller then waits for the ADC to fully power up, as determined by {{< regref "adc_pd_ctl.pwrup_time" >}}.
+
+Once the ADC is ready to go, the controller then selects the channel it wishes to sample by setting `adc_o.channel_sel`.
+The controller holds this value until the ADC responds with `adc_i.data_valid` and `adc_i.data`.
+
+Since there is no request sample signal between the controller and the ADC, the ADC takes a new sample when `adc_o.channel_sel` is changed from 0 to a valid channel.
+To take a new sample then, the controller active sets `adc_o.channel_sel` to 0, before setting it to another valid channel.
+
 {{< wavejson >}}
 {
   signal: [
     {node: '.a..b........', phase:0.2},
-    {name: 'adc_pd_i'     , wave: '10|..|.....|....|..1'},
-    {name: 'clk_ast_adc_i', wave: 'p.|..|.....|....|...'},
-    {name: 'adc_chnsel_i' , wave: '0.|.3|..04.|....|0..'},
-    {name: 'adc_d_val_o'  , wave: '0.|..|.1.0.|.1..|.0.'},
-    {name: 'adc_d_o'      , wave: 'x.|..|.3.x.|.4..|.x.', data: ['ch0', 'ch1', 'ch1']},
+    {name: 'clk_aon_i',         wave: 'p.|..|.....|....|...'},
+    {name: 'adc_o.pd',          wave: '10|..|.....|....|..1'},
+    {name: 'adc_o.channel_sel', wave: '0.|.3|..04.|....|0..'},
+    {name: 'adc_i.data_valid',  wave: '0.|..|.1.0.|.1..|.0.'},
+    {name: 'adc_i.data',        wave: 'x.|..|.3.x.|.4..|.x.', data: ['ch0', 'ch1', 'ch1']},
   ],
   edge: [  'a<->b wakeup time',   ]
 }

--- a/hw/ip/adc_ctrl/doc/_index.md
+++ b/hw/ip/adc_ctrl/doc/_index.md
@@ -37,6 +37,7 @@ The block diagram shows a conceptual view of the ADC controller state machine an
 
 ![ADC_CTRL Block Diagram](adc_overview.svg "image_tooltip")
 
+
 ## Hardware Interface
 
 {{< incGenFromIpDesc "../data/adc_ctrl.hjson" "hwcfg" >}}
@@ -155,7 +156,7 @@ Once the ADC is ready to go, the controller then selects the channel it wishes t
 The controller holds this value until the ADC responds with `adc_i.data_valid` and `adc_i.data`.
 
 Since there is no request sample signal between the controller and the ADC, the ADC takes a new sample when `adc_o.channel_sel` is changed from 0 to a valid channel.
-To take a new sample then, the controller active sets `adc_o.channel_sel` to 0, before setting it to another valid channel.
+To take a new sample then, the controller actively sets `adc_o.channel_sel` to 0, before setting it to another valid channel.
 
 {{< wavejson >}}
 {
@@ -204,9 +205,15 @@ So it is expected that {{< regref "adc_lp_sample_ctl" >}} is configured and low 
 
 If the ADC wakeup is not required then the controller and ADC should both be disabled by clearing {{< regref "adc_en_ctl" >}} prior to the sleep being initiated.
 
-## Use for USB-C debug accessory detection.
+## Use Case
 
-Please see the following diagram for the regions of interest in debug cable detection.
+While the ADC controller is meant to be used generically, it can be configured to satisfy more complex use cases.
+As an illustrative example, the programmers guide uses the [Chrome OS Hardware Debug](https://chromium.googlesource.com/chromiumos/third_party/hdctools/+/HEAD/docs/ccd.md) as an example of how the ADC controller can be used.
+
+The debug setup referred to uses a USB-C debug accessory.
+This insertion of this debug accessory into a system, can be detected by the ADC controller.
+
+The debug accessory voltage range of interest is shown in the diagram below:
 ![Debug Cable Regions](debug_cable_regions.svg "image_tooltip")
 
 The ADC can be used to detect debug cable connection / disconnection in the non-overlapping regions.

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
@@ -464,10 +464,15 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
           inside_range : ~inside_range;
 
       // Combine channel matches for this filter
-      filter_match = 1;
+      filter_match = 0;
       for (int channel_idx = 0; channel_idx < ADC_CTRL_CHANNELS; channel_idx++) begin
-        filter_match &= (m_chn_match[channel_idx][filter_idx] &
-            cfg.filter_cfg[channel_idx][filter_idx].en);
+        filter_match |= cfg.filter_cfg[channel_idx][filter_idx].en;
+      end
+
+      for (int channel_idx = 0; channel_idx < ADC_CTRL_CHANNELS; channel_idx++) begin
+        filter_match &= !cfg.filter_cfg[channel_idx][filter_idx].en |
+			 (m_chn_match[channel_idx][filter_idx] &
+			  cfg.filter_cfg[channel_idx][filter_idx].en);
       end
       m_match[filter_idx] = filter_match;
     end

--- a/hw/ip/adc_ctrl/dv/tb.sv
+++ b/hw/ip/adc_ctrl/dv/tb.sv
@@ -100,7 +100,7 @@ module tb;
     .alert_tx_o        (alert_tx),
     .adc_o             (adc_o),
     .adc_i             (adc_i),
-    .intr_debug_cable_o (interrupts[ADC_CTRL_INTERRUPT_INDEX]),
+    .intr_match_done_o (interrupts[ADC_CTRL_INTERRUPT_INDEX]),
     .wkup_req_o        (wakeup_req)
   );
 

--- a/hw/ip/adc_ctrl/dv/tb.sv
+++ b/hw/ip/adc_ctrl/dv/tb.sv
@@ -100,7 +100,7 @@ module tb;
     .alert_tx_o        (alert_tx),
     .adc_o             (adc_o),
     .adc_i             (adc_i),
-    .intr_debug_cable_o(interrupts[ADC_CTRL_INTERRUPT_INDEX]),
+    .intr_debug_cable_o (interrupts[ADC_CTRL_INTERRUPT_INDEX]),
     .wkup_req_o        (wakeup_req)
   );
 
@@ -267,5 +267,3 @@ module tb;
   `DV_ASSERT_CTRL("ADC_CTRL_FSM_A_CTRL", dut.u_adc_ctrl_core.u_adc_ctrl_fsm)
 
 endmodule
-
-

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
@@ -33,9 +33,8 @@ module adc_ctrl
   // .data_valid: Valid bit(pulse) for adc_d
   input  ast_pkg::adc_ast_rsp_t adc_i,
 
-  // Interrupt interface
-  // Debug cable is detected(attached or disconnected); raise the interrupt to CPU
-  output logic intr_debug_cable_o,
+  // Interrupt indicates a matching or measurement is done
+  output logic intr_match_done_o,
 
   // Pwrmgr interface
   // Debug cable is detected; wake up the chip in normal sleep and deep sleep mode
@@ -91,15 +90,15 @@ module adc_ctrl
     .adc_chn_val_o(hw2reg.adc_chn_val),
     .adc_intr_status_o(hw2reg.adc_intr_status),
     .aon_filter_status_o(hw2reg.filter_status),
-    .debug_cable_wakeup_o(wkup_req_o),
-    .intr_debug_cable_o(intr_debug_cable_o),
+    .wkup_req_o,
+    .intr_o(intr_match_done_o),
     .adc_i(adc_i),
     .adc_o(adc_o)
   );
 
   // All outputs should be known value after reset
-  `ASSERT_KNOWN(IntrDebugCableKnown, intr_debug_cable_o)
-  `ASSERT_KNOWN(WakeDebugCableKnown, wkup_req_o)
+  `ASSERT_KNOWN(IntrKnown, intr_match_done_o)
+  `ASSERT_KNOWN(WakeKnown, wkup_req_o)
   `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown, tl_o.a_ready)
   `ASSERT_KNOWN(AdcKnown_A, adc_o)

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
@@ -169,6 +169,7 @@ module adc_ctrl_core import adc_ctrl_reg_pkg::* ; (
     .intr_enable_i(reg2hw_i.intr_enable),
     .intr_test_i(reg2hw_i.intr_test),
     .intr_state_o,
+    .adc_intr_status_i(reg2hw_i.adc_intr_status),
     .adc_intr_status_o,
     .intr_debug_cable_o
   );

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
@@ -117,8 +117,8 @@ module adc_ctrl_core import adc_ctrl_reg_pkg::* ; (
     assign match_pulse[k] = adc_ctrl_done && match[k];
 
    // Explicitly create assertions for all the matching conditions.
-   // These assertiosn are unwieldly and not suitable for expansion to more channels.
-   // They should be adjusetd eventually.
+   // These assertions are unwieldly and not suitable for expansion to more channels.
+   // They should be adjusted eventually.
    `ASSERT(MatchCheck00_A, !aon_filter_ctl[0][k].en & !aon_filter_ctl[1][k].en |->
            !match[k], clk_aon_i, !rst_aon_ni)
    `ASSERT(MatchCheck01_A, !aon_filter_ctl[0][k].en & aon_filter_ctl[1][k].en  |->

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
@@ -20,8 +20,8 @@ module adc_ctrl_core import adc_ctrl_reg_pkg::* ; (
   output adc_ctrl_hw2reg_filter_status_reg_t aon_filter_status_o,
 
   // interrupt and wakeup outputs
-  output debug_cable_wakeup_o,
-  output intr_debug_cable_o,
+  output wkup_req_o,
+  output intr_o,
 
   // adc interface
   input  ast_pkg::adc_ast_rsp_t adc_i,
@@ -135,8 +135,8 @@ module adc_ctrl_core import adc_ctrl_reg_pkg::* ; (
 
   // generate wakeup to external power manager if filter status
   // and wakeup enable are set.
-  assign debug_cable_wakeup_o = |(reg2hw_i.filter_status.q &
-                                  reg2hw_i.adc_wakeup_ctl.q);
+  assign wkup_req_o = |(reg2hw_i.filter_status.q &
+                      reg2hw_i.adc_wakeup_ctl.q);
 
   //instantiate the main state machine
   adc_ctrl_fsm u_adc_ctrl_fsm (
@@ -191,7 +191,7 @@ module adc_ctrl_core import adc_ctrl_reg_pkg::* ; (
     .intr_state_o,
     .adc_intr_status_i(reg2hw_i.adc_intr_status),
     .adc_intr_status_o,
-    .intr_debug_cable_o
+    .intr_o
   );
 
   // unused register inputs

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_fsm.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_fsm.sv
@@ -149,16 +149,8 @@ module adc_ctrl_fsm
     end
   end
 
-  // At one point the low power periodic scan was supposed to trigger a switch to normal scan
-  // when there is "ANY" match. This does not appear to be the use case anymore, but just in case
-  // keep the code below as a reference.
-  // for (genvar k = 0 ; k < NumAdcFilter ; k++) begin : gen_fst_lp_match
-  //   assign fst_lp_match[k] =
-  //   ((lp_sample_cnt_q == 8'd1) && (fsm_state_q == LP_EVAL)) ? adc_ctrl_match_i[k] : 1'b0;
-  // end
-  //
-  // assign any_fst_lp_match = |fst_lp_match;
-
+  // TODO: #13725
+  // The logic below can be enhanced for better handling in the future
   logic ld_match;
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
     if (!rst_aon_ni) begin

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_intr.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_intr.sv
@@ -22,7 +22,7 @@ module adc_ctrl_intr import adc_ctrl_reg_pkg::*; (
   input  adc_ctrl_reg2hw_adc_intr_status_reg_t adc_intr_status_i,
   output adc_ctrl_hw2reg_adc_intr_status_reg_t adc_intr_status_o,
 
-  output intr_debug_cable_o
+  output intr_o
 );
 
 
@@ -96,7 +96,7 @@ module adc_ctrl_intr import adc_ctrl_reg_pkg::*; (
   assign adc_intr_status_o.filter_match.d = intr_events[7:0] | adc_intr_status_i.filter_match.q;
 
   logic unused_oneshot;
-  assign unused_oneshot = adc_intr_status_i.oneshot.q;   
+  assign unused_oneshot = adc_intr_status_i.oneshot.q;
   assign adc_intr_status_o.oneshot.d = 1'b1;
 
   // instantiate interrupt hardware primitive
@@ -110,7 +110,7 @@ module adc_ctrl_intr import adc_ctrl_reg_pkg::*; (
     .reg2hw_intr_state_q_i  (intr_state_i.q),
     .hw2reg_intr_state_de_o (intr_state_o.de),
     .hw2reg_intr_state_d_o  (intr_state_o.d),
-    .intr_o                 (intr_debug_cable_o)
+    .intr_o
   );
 
 endmodule

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
@@ -112,6 +112,15 @@ package adc_ctrl_reg_pkg;
   } adc_ctrl_reg2hw_adc_intr_ctl_reg_t;
 
   typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } filter_match;
+    struct packed {
+      logic        q;
+    } oneshot;
+  } adc_ctrl_reg2hw_adc_intr_status_reg_t;
+
+  typedef struct packed {
     logic        d;
     logic        de;
   } adc_ctrl_hw2reg_intr_state_reg_t;
@@ -142,37 +151,9 @@ package adc_ctrl_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
+      logic [7:0]  d;
       logic        de;
-    } cc_sink_det;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_1a5_sink_det;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_3a0_sink_det;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_src_det;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_1a5_src_det;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_src_det_flip;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_1a5_src_det_flip;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_discon;
+    } filter_match;
     struct packed {
       logic        d;
       logic        de;
@@ -181,28 +162,29 @@ package adc_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    adc_ctrl_reg2hw_intr_state_reg_t intr_state; // [438:438]
-    adc_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [437:437]
-    adc_ctrl_reg2hw_intr_test_reg_t intr_test; // [436:435]
-    adc_ctrl_reg2hw_alert_test_reg_t alert_test; // [434:433]
-    adc_ctrl_reg2hw_adc_en_ctl_reg_t adc_en_ctl; // [432:431]
-    adc_ctrl_reg2hw_adc_pd_ctl_reg_t adc_pd_ctl; // [430:402]
-    adc_ctrl_reg2hw_adc_lp_sample_ctl_reg_t adc_lp_sample_ctl; // [401:394]
-    adc_ctrl_reg2hw_adc_sample_ctl_reg_t adc_sample_ctl; // [393:378]
-    adc_ctrl_reg2hw_adc_fsm_rst_reg_t adc_fsm_rst; // [377:377]
-    adc_ctrl_reg2hw_adc_chn0_filter_ctl_mreg_t [7:0] adc_chn0_filter_ctl; // [376:201]
-    adc_ctrl_reg2hw_adc_chn1_filter_ctl_mreg_t [7:0] adc_chn1_filter_ctl; // [200:25]
-    adc_ctrl_reg2hw_adc_wakeup_ctl_reg_t adc_wakeup_ctl; // [24:17]
-    adc_ctrl_reg2hw_filter_status_reg_t filter_status; // [16:9]
-    adc_ctrl_reg2hw_adc_intr_ctl_reg_t adc_intr_ctl; // [8:0]
+    adc_ctrl_reg2hw_intr_state_reg_t intr_state; // [447:447]
+    adc_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [446:446]
+    adc_ctrl_reg2hw_intr_test_reg_t intr_test; // [445:444]
+    adc_ctrl_reg2hw_alert_test_reg_t alert_test; // [443:442]
+    adc_ctrl_reg2hw_adc_en_ctl_reg_t adc_en_ctl; // [441:440]
+    adc_ctrl_reg2hw_adc_pd_ctl_reg_t adc_pd_ctl; // [439:411]
+    adc_ctrl_reg2hw_adc_lp_sample_ctl_reg_t adc_lp_sample_ctl; // [410:403]
+    adc_ctrl_reg2hw_adc_sample_ctl_reg_t adc_sample_ctl; // [402:387]
+    adc_ctrl_reg2hw_adc_fsm_rst_reg_t adc_fsm_rst; // [386:386]
+    adc_ctrl_reg2hw_adc_chn0_filter_ctl_mreg_t [7:0] adc_chn0_filter_ctl; // [385:210]
+    adc_ctrl_reg2hw_adc_chn1_filter_ctl_mreg_t [7:0] adc_chn1_filter_ctl; // [209:34]
+    adc_ctrl_reg2hw_adc_wakeup_ctl_reg_t adc_wakeup_ctl; // [33:26]
+    adc_ctrl_reg2hw_filter_status_reg_t filter_status; // [25:18]
+    adc_ctrl_reg2hw_adc_intr_ctl_reg_t adc_intr_ctl; // [17:9]
+    adc_ctrl_reg2hw_adc_intr_status_reg_t adc_intr_status; // [8:0]
   } adc_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    adc_ctrl_hw2reg_intr_state_reg_t intr_state; // [84:83]
-    adc_ctrl_hw2reg_adc_chn_val_mreg_t [1:0] adc_chn_val; // [82:27]
-    adc_ctrl_hw2reg_filter_status_reg_t filter_status; // [26:18]
-    adc_ctrl_hw2reg_adc_intr_status_reg_t adc_intr_status; // [17:0]
+    adc_ctrl_hw2reg_intr_state_reg_t intr_state; // [77:76]
+    adc_ctrl_hw2reg_adc_chn_val_mreg_t [1:0] adc_chn_val; // [75:20]
+    adc_ctrl_hw2reg_filter_status_reg_t filter_status; // [19:11]
+    adc_ctrl_hw2reg_adc_intr_status_reg_t adc_intr_status; // [10:0]
   } adc_ctrl_hw2reg_t;
 
   // Register offsets

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
@@ -222,7 +222,7 @@ package adc_ctrl_reg_pkg;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] ADC_CTRL_INTR_TEST_RESVAL = 1'h 0;
-  parameter logic [0:0] ADC_CTRL_INTR_TEST_DEBUG_CABLE_RESVAL = 1'h 0;
+  parameter logic [0:0] ADC_CTRL_INTR_TEST_MATCH_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] ADC_CTRL_ALERT_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] ADC_CTRL_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
 

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -210,22 +210,8 @@ module adc_ctrl_reg_top (
   logic [8:0] adc_intr_ctl_qs;
   logic [8:0] adc_intr_ctl_wd;
   logic adc_intr_status_we;
-  logic adc_intr_status_cc_sink_det_qs;
-  logic adc_intr_status_cc_sink_det_wd;
-  logic adc_intr_status_cc_1a5_sink_det_qs;
-  logic adc_intr_status_cc_1a5_sink_det_wd;
-  logic adc_intr_status_cc_3a0_sink_det_qs;
-  logic adc_intr_status_cc_3a0_sink_det_wd;
-  logic adc_intr_status_cc_src_det_qs;
-  logic adc_intr_status_cc_src_det_wd;
-  logic adc_intr_status_cc_1a5_src_det_qs;
-  logic adc_intr_status_cc_1a5_src_det_wd;
-  logic adc_intr_status_cc_src_det_flip_qs;
-  logic adc_intr_status_cc_src_det_flip_wd;
-  logic adc_intr_status_cc_1a5_src_det_flip_qs;
-  logic adc_intr_status_cc_1a5_src_det_flip_wd;
-  logic adc_intr_status_cc_discon_qs;
-  logic adc_intr_status_cc_discon_wd;
+  logic [7:0] adc_intr_status_filter_match_qs;
+  logic [7:0] adc_intr_status_filter_match_wd;
   logic adc_intr_status_oneshot_qs;
   logic adc_intr_status_oneshot_wd;
   // Define register CDC handling.
@@ -3636,212 +3622,30 @@ module adc_ctrl_reg_top (
 
 
   // R[adc_intr_status]: V(False)
-  //   F[cc_sink_det]: 0:0
+  //   F[filter_match]: 7:0
   prim_subreg #(
-    .DW      (1),
+    .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_status_cc_sink_det (
+    .RESVAL  (8'h0)
+  ) u_adc_intr_status_filter_match (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (adc_intr_status_we),
-    .wd     (adc_intr_status_cc_sink_det_wd),
+    .wd     (adc_intr_status_filter_match_wd),
 
     // from internal hardware
-    .de     (hw2reg.adc_intr_status.cc_sink_det.de),
-    .d      (hw2reg.adc_intr_status.cc_sink_det.d),
+    .de     (hw2reg.adc_intr_status.filter_match.de),
+    .d      (hw2reg.adc_intr_status.filter_match.d),
 
     // to internal hardware
     .qe     (),
-    .q      (),
+    .q      (reg2hw.adc_intr_status.filter_match.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (adc_intr_status_cc_sink_det_qs)
-  );
-
-  //   F[cc_1a5_sink_det]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_status_cc_1a5_sink_det (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_status_we),
-    .wd     (adc_intr_status_cc_1a5_sink_det_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_intr_status.cc_1a5_sink_det.de),
-    .d      (hw2reg.adc_intr_status.cc_1a5_sink_det.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (adc_intr_status_cc_1a5_sink_det_qs)
-  );
-
-  //   F[cc_3a0_sink_det]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_status_cc_3a0_sink_det (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_status_we),
-    .wd     (adc_intr_status_cc_3a0_sink_det_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_intr_status.cc_3a0_sink_det.de),
-    .d      (hw2reg.adc_intr_status.cc_3a0_sink_det.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (adc_intr_status_cc_3a0_sink_det_qs)
-  );
-
-  //   F[cc_src_det]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_status_cc_src_det (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_status_we),
-    .wd     (adc_intr_status_cc_src_det_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_intr_status.cc_src_det.de),
-    .d      (hw2reg.adc_intr_status.cc_src_det.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (adc_intr_status_cc_src_det_qs)
-  );
-
-  //   F[cc_1a5_src_det]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_status_cc_1a5_src_det (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_status_we),
-    .wd     (adc_intr_status_cc_1a5_src_det_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_intr_status.cc_1a5_src_det.de),
-    .d      (hw2reg.adc_intr_status.cc_1a5_src_det.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (adc_intr_status_cc_1a5_src_det_qs)
-  );
-
-  //   F[cc_src_det_flip]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_status_cc_src_det_flip (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_status_we),
-    .wd     (adc_intr_status_cc_src_det_flip_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_intr_status.cc_src_det_flip.de),
-    .d      (hw2reg.adc_intr_status.cc_src_det_flip.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (adc_intr_status_cc_src_det_flip_qs)
-  );
-
-  //   F[cc_1a5_src_det_flip]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_status_cc_1a5_src_det_flip (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_status_we),
-    .wd     (adc_intr_status_cc_1a5_src_det_flip_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_intr_status.cc_1a5_src_det_flip.de),
-    .d      (hw2reg.adc_intr_status.cc_1a5_src_det_flip.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (adc_intr_status_cc_1a5_src_det_flip_qs)
-  );
-
-  //   F[cc_discon]: 7:7
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_status_cc_discon (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_status_we),
-    .wd     (adc_intr_status_cc_discon_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_intr_status.cc_discon.de),
-    .d      (hw2reg.adc_intr_status.cc_discon.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (adc_intr_status_cc_discon_qs)
+    .qs     (adc_intr_status_filter_match_qs)
   );
 
   //   F[oneshot]: 8:8
@@ -3863,7 +3667,7 @@ module adc_ctrl_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (),
+    .q      (reg2hw.adc_intr_status.oneshot.q),
     .ds     (),
 
     // to register interface (read)
@@ -4061,21 +3865,7 @@ module adc_ctrl_reg_top (
   assign adc_intr_ctl_wd = reg_wdata[8:0];
   assign adc_intr_status_we = addr_hit[30] & reg_we & !reg_error;
 
-  assign adc_intr_status_cc_sink_det_wd = reg_wdata[0];
-
-  assign adc_intr_status_cc_1a5_sink_det_wd = reg_wdata[1];
-
-  assign adc_intr_status_cc_3a0_sink_det_wd = reg_wdata[2];
-
-  assign adc_intr_status_cc_src_det_wd = reg_wdata[3];
-
-  assign adc_intr_status_cc_1a5_src_det_wd = reg_wdata[4];
-
-  assign adc_intr_status_cc_src_det_flip_wd = reg_wdata[5];
-
-  assign adc_intr_status_cc_1a5_src_det_flip_wd = reg_wdata[6];
-
-  assign adc_intr_status_cc_discon_wd = reg_wdata[7];
+  assign adc_intr_status_filter_match_wd = reg_wdata[7:0];
 
   assign adc_intr_status_oneshot_wd = reg_wdata[8];
 
@@ -4215,14 +4005,7 @@ module adc_ctrl_reg_top (
       end
 
       addr_hit[30]: begin
-        reg_rdata_next[0] = adc_intr_status_cc_sink_det_qs;
-        reg_rdata_next[1] = adc_intr_status_cc_1a5_sink_det_qs;
-        reg_rdata_next[2] = adc_intr_status_cc_3a0_sink_det_qs;
-        reg_rdata_next[3] = adc_intr_status_cc_src_det_qs;
-        reg_rdata_next[4] = adc_intr_status_cc_1a5_src_det_qs;
-        reg_rdata_next[5] = adc_intr_status_cc_src_det_flip_qs;
-        reg_rdata_next[6] = adc_intr_status_cc_1a5_src_det_flip_qs;
-        reg_rdata_next[7] = adc_intr_status_cc_discon_qs;
+        reg_rdata_next[7:0] = adc_intr_status_filter_match_qs;
         reg_rdata_next[8] = adc_intr_status_oneshot_qs;
       end
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -13347,7 +13347,7 @@
       module_name: sysrst_ctrl_aon
     }
     {
-      name: adc_ctrl_aon_debug_cable
+      name: adc_ctrl_aon_match_done
       width: 1
       type: interrupt
       module_name: adc_ctrl_aon

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -484,7 +484,7 @@ module top_earlgrey #(
   logic intr_usbdev_link_out_err;
   logic intr_pwrmgr_aon_wakeup;
   logic intr_sysrst_ctrl_aon_sysrst_ctrl;
-  logic intr_adc_ctrl_aon_debug_cable;
+  logic intr_adc_ctrl_aon_match_done;
   logic intr_aon_timer_aon_wkup_timer_expired;
   logic intr_aon_timer_aon_wdog_timer_bark;
   logic intr_sensor_ctrl_io_status_change;
@@ -1849,7 +1849,7 @@ module top_earlgrey #(
   ) u_adc_ctrl_aon (
 
       // Interrupt
-      .intr_debug_cable_o (intr_adc_ctrl_aon_debug_cable),
+      .intr_match_done_o (intr_adc_ctrl_aon_match_done),
       // [26]: fatal_fault
       .alert_tx_o  ( alert_tx[26:26] ),
       .alert_rx_i  ( alert_rx[26:26] ),
@@ -2622,7 +2622,7 @@ module top_earlgrey #(
       intr_sensor_ctrl_io_status_change, // IDs [160 +: 1]
       intr_aon_timer_aon_wdog_timer_bark, // IDs [159 +: 1]
       intr_aon_timer_aon_wkup_timer_expired, // IDs [158 +: 1]
-      intr_adc_ctrl_aon_debug_cable, // IDs [157 +: 1]
+      intr_adc_ctrl_aon_match_done, // IDs [157 +: 1]
       intr_sysrst_ctrl_aon_sysrst_ctrl, // IDs [156 +: 1]
       intr_pwrmgr_aon_wakeup, // IDs [155 +: 1]
       intr_usbdev_link_out_err, // IDs [154 +: 1]

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -169,7 +169,7 @@ const top_earlgrey_plic_peripheral_t
   [kTopEarlgreyPlicIrqIdUsbdevLinkOutErr] = kTopEarlgreyPlicPeripheralUsbdev,
   [kTopEarlgreyPlicIrqIdPwrmgrAonWakeup] = kTopEarlgreyPlicPeripheralPwrmgrAon,
   [kTopEarlgreyPlicIrqIdSysrstCtrlAonSysrstCtrl] = kTopEarlgreyPlicPeripheralSysrstCtrlAon,
-  [kTopEarlgreyPlicIrqIdAdcCtrlAonDebugCable] = kTopEarlgreyPlicPeripheralAdcCtrlAon,
+  [kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone] = kTopEarlgreyPlicPeripheralAdcCtrlAon,
   [kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired] = kTopEarlgreyPlicPeripheralAonTimerAon,
   [kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark] = kTopEarlgreyPlicPeripheralAonTimerAon,
   [kTopEarlgreyPlicIrqIdSensorCtrlIoStatusChange] = kTopEarlgreyPlicPeripheralSensorCtrl,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1172,7 +1172,7 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdUsbdevLinkOutErr = 154, /**< usbdev_link_out_err */
   kTopEarlgreyPlicIrqIdPwrmgrAonWakeup = 155, /**< pwrmgr_aon_wakeup */
   kTopEarlgreyPlicIrqIdSysrstCtrlAonSysrstCtrl = 156, /**< sysrst_ctrl_aon_sysrst_ctrl */
-  kTopEarlgreyPlicIrqIdAdcCtrlAonDebugCable = 157, /**< adc_ctrl_aon_debug_cable */
+  kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone = 157, /**< adc_ctrl_aon_match_done */
   kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired = 158, /**< aon_timer_aon_wkup_timer_expired */
   kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark = 159, /**< aon_timer_aon_wdog_timer_bark */
   kTopEarlgreyPlicIrqIdSensorCtrlIoStatusChange = 160, /**< sensor_ctrl_io_status_change */

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
@@ -54,8 +54,8 @@ dif_result_t dif_adc_ctrl_alert_force(const dif_adc_ctrl_t *adc_ctrl,
 static bool adc_ctrl_get_irq_bit_index(dif_adc_ctrl_irq_t irq,
                                        bitfield_bit32_index_t *index_out) {
   switch (irq) {
-    case kDifAdcCtrlIrqDebugCable:
-      *index_out = ADC_CTRL_INTR_COMMON_DEBUG_CABLE_BIT;
+    case kDifAdcCtrlIrqMatchDone:
+      *index_out = ADC_CTRL_INTR_COMMON_MATCH_DONE_BIT;
       break;
     default:
       return false;

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
@@ -77,9 +77,9 @@ dif_result_t dif_adc_ctrl_alert_force(const dif_adc_ctrl_t *adc_ctrl,
  */
 typedef enum dif_adc_ctrl_irq {
   /**
-   * USB-C debug cable is attached or disconnected
+   * ADC match or measurement event done
    */
-  kDifAdcCtrlIrqDebugCable = 0,
+  kDifAdcCtrlIrqMatchDone = 0,
 } dif_adc_ctrl_irq_t;
 
 /**

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
@@ -91,13 +91,13 @@ TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_is_pending(
-      nullptr, kDifAdcCtrlIrqDebugCable, &is_pending));
+      nullptr, kDifAdcCtrlIrqMatchDone, &is_pending));
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_is_pending(
-      &adc_ctrl_, kDifAdcCtrlIrqDebugCable, nullptr));
+      &adc_ctrl_, kDifAdcCtrlIrqMatchDone, nullptr));
 
   EXPECT_DIF_BADARG(
-      dif_adc_ctrl_irq_is_pending(nullptr, kDifAdcCtrlIrqDebugCable, nullptr));
+      dif_adc_ctrl_irq_is_pending(nullptr, kDifAdcCtrlIrqMatchDone, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
@@ -113,9 +113,9 @@ TEST_F(IrqIsPendingTest, Success) {
   // Get the first IRQ state.
   irq_state = false;
   EXPECT_READ32(ADC_CTRL_INTR_STATE_REG_OFFSET,
-                {{ADC_CTRL_INTR_STATE_DEBUG_CABLE_BIT, true}});
-  EXPECT_DIF_OK(dif_adc_ctrl_irq_is_pending(
-      &adc_ctrl_, kDifAdcCtrlIrqDebugCable, &irq_state));
+                {{ADC_CTRL_INTR_STATE_MATCH_DONE_BIT, true}});
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_is_pending(&adc_ctrl_, kDifAdcCtrlIrqMatchDone,
+                                            &irq_state));
   EXPECT_TRUE(irq_state);
 }
 
@@ -136,7 +136,7 @@ class IrqAcknowledgeTest : public AdcCtrlTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
   EXPECT_DIF_BADARG(
-      dif_adc_ctrl_irq_acknowledge(nullptr, kDifAdcCtrlIrqDebugCable));
+      dif_adc_ctrl_irq_acknowledge(nullptr, kDifAdcCtrlIrqMatchDone));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
@@ -147,15 +147,15 @@ TEST_F(IrqAcknowledgeTest, BadIrq) {
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(ADC_CTRL_INTR_STATE_REG_OFFSET,
-                 {{ADC_CTRL_INTR_STATE_DEBUG_CABLE_BIT, true}});
+                 {{ADC_CTRL_INTR_STATE_MATCH_DONE_BIT, true}});
   EXPECT_DIF_OK(
-      dif_adc_ctrl_irq_acknowledge(&adc_ctrl_, kDifAdcCtrlIrqDebugCable));
+      dif_adc_ctrl_irq_acknowledge(&adc_ctrl_, kDifAdcCtrlIrqMatchDone));
 }
 
 class IrqForceTest : public AdcCtrlTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_force(nullptr, kDifAdcCtrlIrqDebugCable));
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_force(nullptr, kDifAdcCtrlIrqMatchDone));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
@@ -166,8 +166,8 @@ TEST_F(IrqForceTest, BadIrq) {
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(ADC_CTRL_INTR_TEST_REG_OFFSET,
-                 {{ADC_CTRL_INTR_TEST_DEBUG_CABLE_BIT, true}});
-  EXPECT_DIF_OK(dif_adc_ctrl_irq_force(&adc_ctrl_, kDifAdcCtrlIrqDebugCable));
+                 {{ADC_CTRL_INTR_TEST_MATCH_DONE_BIT, true}});
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_force(&adc_ctrl_, kDifAdcCtrlIrqMatchDone));
 }
 
 class IrqGetEnabledTest : public AdcCtrlTest {};
@@ -176,13 +176,13 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_enabled(
-      nullptr, kDifAdcCtrlIrqDebugCable, &irq_state));
+      nullptr, kDifAdcCtrlIrqMatchDone, &irq_state));
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_enabled(
-      &adc_ctrl_, kDifAdcCtrlIrqDebugCable, nullptr));
+      &adc_ctrl_, kDifAdcCtrlIrqMatchDone, nullptr));
 
   EXPECT_DIF_BADARG(
-      dif_adc_ctrl_irq_get_enabled(nullptr, kDifAdcCtrlIrqDebugCable, nullptr));
+      dif_adc_ctrl_irq_get_enabled(nullptr, kDifAdcCtrlIrqMatchDone, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
@@ -198,9 +198,9 @@ TEST_F(IrqGetEnabledTest, Success) {
   // First IRQ is enabled.
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
-                {{ADC_CTRL_INTR_ENABLE_DEBUG_CABLE_BIT, true}});
+                {{ADC_CTRL_INTR_ENABLE_MATCH_DONE_BIT, true}});
   EXPECT_DIF_OK(dif_adc_ctrl_irq_get_enabled(
-      &adc_ctrl_, kDifAdcCtrlIrqDebugCable, &irq_state));
+      &adc_ctrl_, kDifAdcCtrlIrqMatchDone, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 }
 
@@ -210,7 +210,7 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_set_enabled(
-      nullptr, kDifAdcCtrlIrqDebugCable, irq_state));
+      nullptr, kDifAdcCtrlIrqMatchDone, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
@@ -226,9 +226,9 @@ TEST_F(IrqSetEnabledTest, Success) {
   // Enable first IRQ.
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
-                {{ADC_CTRL_INTR_ENABLE_DEBUG_CABLE_BIT, 0x1, true}});
+                {{ADC_CTRL_INTR_ENABLE_MATCH_DONE_BIT, 0x1, true}});
   EXPECT_DIF_OK(dif_adc_ctrl_irq_set_enabled(
-      &adc_ctrl_, kDifAdcCtrlIrqDebugCable, irq_state));
+      &adc_ctrl_, kDifAdcCtrlIrqMatchDone, irq_state));
 }
 
 class IrqDisableAllTest : public AdcCtrlTest {};

--- a/sw/device/tests/autogen/plic_all_irqs_test.c
+++ b/sw/device/tests/autogen/plic_all_irqs_test.c
@@ -164,7 +164,7 @@ void ottf_external_isr(void) {
     case kTopEarlgreyPlicPeripheralAdcCtrlAon: {
       dif_adc_ctrl_irq_t irq = (dif_adc_ctrl_irq_t)(
           plic_irq_id -
-          (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAdcCtrlAonDebugCable);
+          (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone);
       CHECK(irq == adc_ctrl_irq_expected,
             "Incorrect adc_ctrl_aon IRQ triggered: exp = %d, obs = %d",
             adc_ctrl_irq_expected, irq);
@@ -1030,8 +1030,8 @@ static void peripheral_irqs_enable(void) {
  */
 static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralAdcCtrlAon;
-  for (dif_adc_ctrl_irq_t irq = kDifAdcCtrlIrqDebugCable;
-       irq <= kDifAdcCtrlIrqDebugCable; ++irq) {
+  for (dif_adc_ctrl_irq_t irq = kDifAdcCtrlIrqMatchDone;
+       irq <= kDifAdcCtrlIrqMatchDone; ++irq) {
     adc_ctrl_irq_expected = irq;
     LOG_INFO("Triggering adc_ctrl_aon IRQ %d.", irq);
     CHECK_DIF_OK(dif_adc_ctrl_irq_force(&adc_ctrl_aon, irq));


### PR DESCRIPTION
- The current implementation of the filter detection is 2D. This means
  both channels have to match in order for it to be considered a hit.
- This is contrary to the descritpion in the documentation, which suggests
  that filter match should be either or both.

- Update the filter match so that if a filter is disabled, it does not influence
  the match decision. Ie, if channel 0 filter is disabled, then channel 1's
  match status dictates the final result, or vice versa. If both filters are
  enabled, then both influence the final result.  If neither is enabled, then
  the filters can never match.