### PR TITLE
[ci] Keep downloaded MMI files in CW310 splice job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -410,6 +410,9 @@ jobs:
     displayName: Splicing bitstream with Vivado
   - template: ci/upload-artifacts-template.yml
     parameters:
+      unconditionalIncludePatterns:
+        - "/hw/top_earlgrey/rom.mmi"
+        - "/hw/top_earlgrey/otp.mmi"
       includePatterns:
         - "/hw/***"
   - ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:

--- a/ci/upload-artifacts-template.yml
+++ b/ci/upload-artifacts-template.yml
@@ -12,8 +12,16 @@
 
 
 parameters:
-  # Rsync-style file patterns to include in the partial BIN_DIR output.
+  # Rsync-style file patterns to include in the partial BIN_DIR output. If a
+  # file is captured by these patterns, but it was previously downloaded via
+  # ci/download-artifacts-template.yml, it will not be uploaded again.
   - name: includePatterns
+    type: object
+    default: []
+  # Rsync-style file patterns to unconditionally include in the partial BIN_DIR
+  # output. If a file is captured by these patterns, it will be uploaded even if
+  # it came from ci/download-artifacts-template.yml.
+  - name: unconditionalIncludePatterns
     type: object
     default: []
 
@@ -23,13 +31,22 @@ steps:
       test -n "$BUILD_ROOT"
       . util/build_consts.sh
 
-      # Write all include patterns to a file used by rsync.
-      echo "${{ join('\n', parameters.includePatterns) }}" > "$BUILD_ROOT/include_patterns.txt"
+      # Write all sets of include patterns to files used by rsync.
+      echo -e "${{ join('\n', parameters.includePatterns) }}" > "$BUILD_ROOT/include_patterns.txt"
+      echo -e "${{ join('\n', parameters.unconditionalIncludePatterns) }}" > "$BUILD_ROOT/unconditional_include_patterns.txt"
 
       echo
-      echo Files matching these patterns will be included in the binary build artifact for this job:
+      echo Files matching these patterns will be included in the binary build
+      echo artifact for this job unless they were downloaded from an upstream job:
       echo vvvvvvvvvvvvvvvvvv
       cat "$BUILD_ROOT/include_patterns.txt"
+      echo ^^^^^^^^^^^^^^^^^^
+
+      echo
+      echo Files matching these patterns will always be included in the binary
+      echo build artifact for this job:
+      echo vvvvvvvvvvvvvvvvvv
+      cat "$BUILD_ROOT/unconditional_include_patterns.txt"
       echo ^^^^^^^^^^^^^^^^^^
 
       # The file upstream_bin_dir_contents.txt lists all files which were part
@@ -49,6 +66,7 @@ steps:
         --verbose \
         --remove-source-files \
         --prune-empty-dirs \
+        --include-from="$BUILD_ROOT/unconditional_include_patterns.txt" \
         --exclude-from="$BUILD_ROOT/upstream_bin_dir_contents.txt" \
         --include="*/" \
         --include-from="$BUILD_ROOT/include_patterns.txt" \


### PR DESCRIPTION
In issue #13603, I noted that MMI files were not being included in
bitstream-latest.tar.gz despite PR #13632.

@a-will correctly pointed out that ci/upload-artifacts-template.yml only
keeps *new* artifacts, intentionally excluding files that came from
ci/download-artifacts-template.yml.

Here's the sequence of relevant events in probably too much detail:

* "chip_earlgrey_cw310" job runs
  - ci/scripts/build-bitstream-vivado.sh generates otp.mmi and rom.mmi
  - ci/upload-artifacts-template.yml uploads otp.mmi and rom.mmi, etc.

* "chip_earlgrey_cw310_splice_mask_rom" job runs
  - ci/download-artifacts-template.yml downloads artifacts from the
    "chip_earlgrey_cw310" job
  - It splices in the Mask ROM to produce the .bit.orig and .bit.splice
    files for the bitstream tarball
  - ci/upload-artifacts-template.yml effectively filters the contents of
    $BIN_DIR. Critically, this drops the MMI files because they were
    downloaded from a previous job!
  - ci/gcp-upload-bitstream-template.yml attempts to include the MMI
    files, but they have already been filtered out.

This commit adds an override parameter, `unconditionalIncludePatterns`,
to the upload template that lets us say "really keep these files".

Signed-off-by: Dan McArdle <dmcardle@google.com>