### PR TITLE
[entropy_src/dv] Redefine bins for cntr coverpoints

### DIFF
--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -81,13 +81,26 @@ interface entropy_src_cov_if
     option.name         = "entropy_src_cntr_err_cg";
     option.per_instance = 1;
 
-    cp_which_cntr: coverpoint which_cntr;
+    // coverpoint for counters with only one instance
+    cp_which_cntr: coverpoint which_cntr {
+       bins single_cntrs[] = {window_cntr, repcnts_ht_cntr};
+    }
 
-    cp_which_line: coverpoint which_line iff(which_cntr inside {repcnt_ht_cntr,
-                                                                adaptp_ht_cntr,
-                                                                markov_ht_cntr});
+    cp_which_repcnt_line: coverpoint which_line iff(which_cntr == repcnt_ht_cntr) {
+      bins repcnt_cntrs[] = { [0:3] };
+    }
 
-    cp_which_bucket: coverpoint which_bucket iff(which_cntr == bucket_ht_cntr);
+    cp_which_adaptp_line: coverpoint which_line iff(which_cntr == adaptp_ht_cntr) {
+      bins adaptp_cntrs[] = { [0:3] };
+    }
+
+    cp_which_markov_line: coverpoint which_line iff(which_cntr == markov_ht_cntr) {
+      bins markov_cntrs[] = { [0:3] };
+    }
+
+    cp_which_bucket: coverpoint which_bucket iff(which_cntr == bucket_ht_cntr) {
+      bins bucket_cntrs[] = { [0:15] };
+    }
 
   endgroup : entropy_src_cntr_err_cg
 


### PR DESCRIPTION
Creates:
- A coverpoint with two bins for the counter types with only one
  instance.
- Three cps with four bins each for the HT's that have one cntr
  instance per line.
- A coverpoint with 16 bins for the bucket test counters.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>