### PR TITLE
[spi_device] Check CmdInfo valid condition

### DIFF
--- a/hw/ip/spi_device/rtl/spi_cmdparse.sv
+++ b/hw/ip/spi_device/rtl/spi_cmdparse.sv
@@ -171,10 +171,14 @@ module spi_cmdparse
                           && (data_i == cmd_info_i[CmdInfoReadJedecId].opcode);
   assign opcode_readsfdp = cmd_info_i[CmdInfoReadSfdp].valid
                          && (data_i == cmd_info_i[CmdInfoReadSfdp].opcode);
-  assign opcode_en4b = (data_i == cmd_info_i[CmdInfoEn4B].opcode);
-  assign opcode_ex4b = (data_i == cmd_info_i[CmdInfoEx4B].opcode);
-  assign opcode_wren = (data_i == cmd_info_i[CmdInfoWrEn].opcode);
-  assign opcode_wrdi = (data_i == cmd_info_i[CmdInfoWrDi].opcode);
+  assign opcode_en4b = cmd_info_i[CmdInfoEn4B].valid
+                     && (data_i == cmd_info_i[CmdInfoEn4B].opcode);
+  assign opcode_ex4b = cmd_info_i[CmdInfoEx4B].valid
+                     && (data_i == cmd_info_i[CmdInfoEx4B].opcode);
+  assign opcode_wren = cmd_info_i[CmdInfoWrEn].valid
+                     && (data_i == cmd_info_i[CmdInfoWrEn].opcode);
+  assign opcode_wrdi = cmd_info_i[CmdInfoWrDi].valid
+                     && (data_i == cmd_info_i[CmdInfoWrDi].opcode);
 
   always_comb begin
     opcode_readcmd = 1'b 0;


### PR DESCRIPTION
`En4B`, `Ex4B`, `WrEn`, `WrDi` are opcode-only commands. They provide
`valid` and `opcode` fields in the SPI_DEVICE CSR. They are different
from other command information slots.

When the command information slots are configured as:

- slots between idx 11 to 23 has same opcode as one of the command
  above and valid bit is set and upload bit is not set.
- above four commands do not have valid bit set in their command
  information CSRs

The command parse activates the datapath.

The fix is to check the four commands' valid field for `opcode_*`
signals.

This issue is reported by @weicaiyang