### PR TITLE
[ottool] Handle line endings in the console

### DIFF
--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -87,10 +87,14 @@ impl UartConsole {
                     .map_or(Ok(()), |out| out.write_fmt(format_args!("[{}]", t)))?;
                 self.newline = false;
             }
-            stdout
-                .as_mut()
-                .map_or(Ok(()), |out| out.write_all(&buf[i..i + 1]))?;
             self.newline = buf[i] == b'\n';
+            stdout.as_mut().map_or(Ok(()), |out| {
+                out.write_all(if self.newline {
+                    b"\r\n"
+                } else {
+                    &buf[i..i + 1]
+                })
+            })?;
         }
         stdout.as_mut().map_or(Ok(()), |out| out.flush())?;
 


### PR DESCRIPTION
Code running in the OpenTitan cpu may not always emit CRLF at the end of
lines.  Convert instances of LF to CRLF in the client.

Signed-off-by: Chris Frantz <cfrantz@google.com>