### PR TITLE
[bazel] ensure all SW artifacts are generated on a test build

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -561,6 +561,8 @@ def opentitan_rom_binary(
         srcs = targets,
     )
 
+    return targets
+
 def opentitan_flash_binary(
         name,
         platform = OPENTITAN_PLATFORM,
@@ -682,3 +684,5 @@ def opentitan_flash_binary(
         name = name,
         srcs = targets,
     )
+
+    return targets


### PR DESCRIPTION
If you are building an `opentitan_rom_binary` or
`opentitan_flash_binary` Bazel would generate all SW artifacts specified
in the respective macros.

However, if you build an `opentitan_functest`, which subsequently
invoked the `opentitan_rom_binary` and `opentitan_flash_binary` macros,
only the SW artifacts that were dependencies of the `sh_test` rule that
the `opentitan_functest` macro instantiates would get built, because
Bazel would silently prune any unncessary deps, e.g., disassembly files.

This fixes the above scenario so Bazel always generates the SW artifacts
specified by the underlying `opentitan_rom_binary` or
`opentitan_flash_binary` macros that the `opentitan_functest`
instantiates by making these artifacts dependencies of it's sh_test
rule.

Signed-off-by: Timothy Trippel <ttrippel@google.com>