### PR TITLE
[otbn] Enable secure FIFO pointers in TLUL adapters

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -276,6 +276,9 @@
     { name: "KEY.SIDELOAD"
       desc: "Keys can be sideloaded without exposing them to the CPU"
     }
+    { name: "TLUL_FIFO.CTR.REDUN",
+      desc: "The TL-UL response FIFO pointers are implemented with duplicate counters."
+    }
   ]
 
   regwidth: "32"

--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -249,5 +249,11 @@
       milestone: V2S
       tests: []
     }
+    {
+      name: sec_cm_tlul_fifo_ctr_redun
+      desc: "Verify the countermeasure(s) TLUL_FIFO.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -342,7 +342,8 @@ module otbn
     .Outstanding     (1),
     .ByteAccess      (0),
     .ErrOnRead       (0),
-    .EnableDataIntgPt(1)
+    .EnableDataIntgPt(1),
+    .SecFifoPtr      (1)  // SEC_CM: TLUL_FIFO.CTR.REDUN
   ) u_tlul_adapter_sram_imem (
     .clk_i,
     .rst_ni      (rst_n),
@@ -578,7 +579,8 @@ module otbn
     .Outstanding     (1),
     .ByteAccess      (0),
     .ErrOnRead       (0),
-    .EnableDataIntgPt(1)
+    .EnableDataIntgPt(1),
+    .SecFifoPtr      (1)  // SEC_CM: TLUL_FIFO.CTR.REDUN
   ) u_tlul_adapter_sram_dmem (
     .clk_i,
     .rst_ni      (rst_n),
@@ -734,6 +736,7 @@ module otbn
   );
 
   // SEC_CM: BUS.INTEGRITY
+  // SEC_CM: TLUL_FIFO.CTR.REDUN
   logic bus_intg_violation;
   assign bus_intg_violation = (imem_bus_intg_violation | dmem_bus_intg_violation |
                                reg_bus_intg_violation);
@@ -1215,5 +1218,19 @@ module otbn
       alert_tx_o[AlertFatal])
   `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT(RfBignumOnehotCheck_A,
       u_otbn_core.u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.u_prim_onehot_check,
+      alert_tx_o[AlertFatal])
+
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(DmemFifoWptrCheck_A,
+      u_tlul_adapter_sram_dmem.u_rspfifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_wptr,
+      alert_tx_o[AlertFatal])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(DmemFifoRptrCheck_A,
+      u_tlul_adapter_sram_dmem.u_rspfifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
+      alert_tx_o[AlertFatal])
+
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(ImemFifoWptrCheck_A,
+      u_tlul_adapter_sram_imem.u_rspfifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_wptr,
+      alert_tx_o[AlertFatal])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(ImemFifoRptrCheck_A,
+      u_tlul_adapter_sram_imem.u_rspfifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
       alert_tx_o[AlertFatal])
 endmodule


### PR DESCRIPTION
See https://github.com/lowRISC/opentitan/issues/9438 for context.

Signed-off-by: Michael Schaffner <msf@google.com>