### PR TITLE
[dv/verilator] Fix numeric base of simulation statistics

### DIFF
--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -305,7 +305,7 @@ void VerilatorSimCtrl::PrintStatistics() const {
   std::cout << std::endl
             << "Simulation statistics" << std::endl
             << "=====================" << std::endl
-            << "Executed cycles:  " << time_ / 2 << std::endl
+            << "Executed cycles:  " << std::dec << time_ / 2 << std::endl
             << "Wallclock time:   " << GetExecutionTimeMs() / 1000.0 << " s"
             << std::endl
             << "Simulation speed: " << speed_hz << " cycles/s "


### PR DESCRIPTION
Verilator currently prints integer simulation statistics, such as the number of executed cycles or the size of the trace file, as hexadecimal numbers.  Since these numbers are intended for humans, I think this makes little sense.  This commit changes the base of those numbers to decimal.