### PR TITLE
[bazel] Add @ to test_harness path

### DIFF
--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -232,7 +232,7 @@ def opentitan_functest(
         data = [],
         test_in_rom = False,
         signed = False,
-        test_harness = "//sw/host/opentitantool",
+        test_harness = "@//sw/host/opentitantool",
         key = "test_key_0",
         dv = None,
         verilator = None,


### PR DESCRIPTION
Signed-off-by: Sharon Topaz <sharon.topaz@nuvoton.com>

Following issue https://github.com/lowRISC/opentitan/issues/13723 fix typo in test_harness path.