### PR TITLE
[csrng/rtl] detect unsupported CSRNG commands

### DIFF
--- a/hw/ip/csrng/csrng.core
+++ b/hw/ip/csrng/csrng.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:prim:count
+      - lowrisc:prim:edge_detector
       - lowrisc:prim:assert
       - lowrisc:prim:lc_sync
       - lowrisc:prim:sparse_fsm

--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -408,6 +408,14 @@
                 Writing a zero resets this status bit.
                 '''
         }
+        { bits: "13",
+          name: "CS_MAIN_SM_ALERT",
+          desc: '''
+                This bit is set when an unsupported CSRNG command is being processed.
+                The main FSM will hang unless the module enable field is set to the disabled state.
+                Writing a zero resets this status bit.
+                '''
+        }
       ]
     },
     {

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -49,7 +49,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
 
   localparam int GenBitsFifoWidth = 1+128;
   localparam int GenBitsFifoDepth = 1;
-  localparam int GenBitsCntrWidth = 19;
+  localparam int GenBitsCntrWidth = 13;
 
   // signals
   // command fifo
@@ -80,7 +80,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   logic                    cmd_gen_inc_req;
   logic                    cmd_gen_cnt_last;
   logic                    cmd_final_ack;
-  logic [GenBitsCntrWidth-1:0] cmd_gen_cnt; // max_number_of_bits_per_request = 2^19
+  logic [GenBitsCntrWidth-1:0] cmd_gen_cnt; // max_number_of_bits_per_request = 2^13
   logic                        genbits_fips;
 
   // flops
@@ -186,7 +186,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
     .rst_ni,
     .clr_i(!cs_enable_i),
     .set_i(cmd_gen_1st_req),
-    .set_cnt_i(sfifo_cmd_rdata[30:12]),
+    .set_cnt_i(sfifo_cmd_rdata[24:12]),
     .en_i(cmd_gen_cnt_dec),
     .step_i(GenBitsCntrWidth'(1)),
     .cnt_o(cmd_gen_cnt),
@@ -267,7 +267,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
         cmd_gen_1st_req = 1'b1;
         cmd_arb_sop_o = 1'b1;
         cmd_fifo_pop = 1'b1;
-        if (sfifo_cmd_rdata[30:12] == GenBitsCntrWidth'(1)) begin
+        if (sfifo_cmd_rdata[24:12] == GenBitsCntrWidth'(1)) begin
           cmd_gen_cnt_last = 1'b1;
         end
         if (cmd_len == '0) begin

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -30,6 +30,7 @@ module csrng_main_sm import csrng_pkg::*; #(
   input logic                   cmd_complete_i,
   input logic                   local_escalate_i,
   output logic [StateWidth-1:0] main_sm_state_o,
+  output logic                  main_sm_alert_o,
   output logic                  main_sm_err_o
 );
 
@@ -48,6 +49,7 @@ module csrng_main_sm import csrng_pkg::*; #(
     update_req_o = 1'b0;
     uninstant_req_o = 1'b0;
     clr_adata_packer_o = 1'b0;
+    main_sm_alert_o = 1'b0;
     main_sm_err_o = 1'b0;
     unique case (state_q)
       Idle: begin
@@ -86,6 +88,9 @@ module csrng_main_sm import csrng_pkg::*; #(
               if (acmd_eop_i) begin
                 state_d = UninstantPrep;
               end
+            end else begin
+              // command was not supported
+              main_sm_alert_o = 1'b1;
             end
           end
         end

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -182,6 +182,10 @@ package csrng_reg_pkg;
       logic        d;
       logic        de;
     } cs_bus_cmp_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cs_main_sm_alert;
   } csrng_hw2reg_recov_alert_sts_reg_t;
 
   typedef struct packed {
@@ -312,13 +316,13 @@ package csrng_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [163:156]
-    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [155:152]
-    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [151:150]
-    csrng_hw2reg_genbits_reg_t genbits; // [149:118]
-    csrng_hw2reg_int_state_val_reg_t int_state_val; // [117:86]
-    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [85:69]
-    csrng_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [68:61]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [165:158]
+    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [157:154]
+    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [153:152]
+    csrng_hw2reg_genbits_reg_t genbits; // [151:120]
+    csrng_hw2reg_int_state_val_reg_t int_state_val; // [119:88]
+    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [87:71]
+    csrng_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [70:61]
     csrng_hw2reg_err_code_reg_t err_code; // [60:9]
     csrng_hw2reg_main_sm_state_reg_t main_sm_state; // [8:0]
   } csrng_hw2reg_t;

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -183,6 +183,8 @@ module csrng_reg_top (
   logic recov_alert_sts_read_int_state_field_alert_wd;
   logic recov_alert_sts_cs_bus_cmp_alert_qs;
   logic recov_alert_sts_cs_bus_cmp_alert_wd;
+  logic recov_alert_sts_cs_main_sm_alert_qs;
+  logic recov_alert_sts_cs_main_sm_alert_wd;
   logic err_code_sfifo_cmd_err_qs;
   logic err_code_sfifo_genbits_err_qs;
   logic err_code_sfifo_cmdreq_err_qs;
@@ -969,6 +971,32 @@ module csrng_reg_top (
 
     // to register interface (read)
     .qs     (recov_alert_sts_cs_bus_cmp_alert_qs)
+  );
+
+  //   F[cs_main_sm_alert]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_recov_alert_sts_cs_main_sm_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_cs_main_sm_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.cs_main_sm_alert.de),
+    .d      (hw2reg.recov_alert_sts.cs_main_sm_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_cs_main_sm_alert_qs)
   );
 
 
@@ -1830,6 +1858,8 @@ module csrng_reg_top (
   assign recov_alert_sts_read_int_state_field_alert_wd = reg_wdata[2];
 
   assign recov_alert_sts_cs_bus_cmp_alert_wd = reg_wdata[12];
+
+  assign recov_alert_sts_cs_main_sm_alert_wd = reg_wdata[13];
   assign err_code_test_we = addr_hit[15] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
@@ -1931,6 +1961,7 @@ module csrng_reg_top (
         reg_rdata_next[1] = recov_alert_sts_sw_app_enable_field_alert_qs;
         reg_rdata_next[2] = recov_alert_sts_read_int_state_field_alert_qs;
         reg_rdata_next[12] = recov_alert_sts_cs_bus_cmp_alert_qs;
+        reg_rdata_next[13] = recov_alert_sts_cs_main_sm_alert_qs;
       end
 
       addr_hit[14]: begin


### PR DESCRIPTION
Unsupported CSRNG commands will now hang the main FSM.
A recoverable alert status bit will be set.

Also, recoverable alerts will now generate a single pulse.

Also, the CSRNG command GLEN is now sized to the specification size.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>