### PR TITLE
[edn/doc,rtl] update doc to reflect system hang

### DIFF
--- a/hw/ip/edn/doc/_index.md
+++ b/hw/ip/edn/doc/_index.md
@@ -118,6 +118,12 @@ Once firmware initialization is complete, it is important to exit this mode if t
 This is done by either *clearing* the `EDN_ENABLE` field or *clearing* the `BOOT_REQ_MODE` field in {{< regref "CTRL" >}} to halt the boot-time request state machine.
 Firmware must then wait for successful the shutdown of the state machine by polling the `REQ_MODE_SM_STS` field of the {{< regref "SUM_STS" >}} register.
 
+It should be noted that when in boot-time request mode, no status will be updated that is used for the software port operation.
+If some hang condition were to occur when in this mode, the main state machine debug register should be read to determine if a hang condition is present.
+There is a limit to how much entropy can be requested in the boot-time request mode BOOT_GEN_CMD command (GLEN = 4K).
+It is the responsibility of software to switch to the software mode of operation before the command has completed.
+If the BOOT_GEN_CMD command ends while an endpoint is requesting, EDN will never ack and the endpoint bus will hang.
+
 #### Note on Security Considerations when Using Boot-time Request Mode
 
 Boot-time request mode is not intended for normal operation, as it tolerates the potential use of preliminary seeds for the attached CSRNG instance.
@@ -154,6 +160,9 @@ Note that if BOOT_REQ_MODE is asserted the state machine will enter boot-time re
 To issue any new commands other than those stored in the generate or reseed FIFOs, it is important to disable auto request mode, by deasserting the `AUTO_REQ_MODE` field in the {{< regref "CTRL" >}} register.
 Firmware must then wait until the current command is completed by polling the `REQ_MODE_SM_STS` bit in the {{< regref "SUM_STS" >}} register
 Once `REQ_MODE_SM_STS` reads zero, the state machine is idle and new firmware-driven commands can be passed to the CSRNG via the {{< regref "SW_CMD_REQ" >}} register.
+
+It should be noted that when in auto request mode, no status will be updated that is used for the software port operation once the `instantiate` command has completed.
+If some hang condition were to occur when in this mode, the main state machine debug register should be read to determine if a hang condition is present.
 
 ### Note on State Machine Shutdown Delays
 

--- a/hw/ip/edn/edn.core
+++ b/hw/ip/edn/edn.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:prim:count
+      - lowrisc:prim:edge_detector
       - lowrisc:prim:assert
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:tlul

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -734,7 +734,20 @@ module edn_core import edn_pkg::*;
   assign edn_bus_cmp_alert = cs_rdata_capt_vld && cs_rdata_capt_vld_q &&
          (cs_rdata_capt_q == packer_cs_rdata[63:0]);
 
-  assign recov_alert_o = edn_bus_cmp_alert;
+
+
+  prim_edge_detector #(
+    .Width(1),
+    .ResetValue(0),
+    .EnSync(0)
+  ) u_prim_edge_detector_recov_alert (
+    .clk_i,
+    .rst_ni,
+    .d_i(edn_bus_cmp_alert),
+    .q_sync_o(),
+    .q_posedge_pulse_o(recov_alert_o),
+    .q_negedge_pulse_o()
+  );
 
   assign hw2reg.recov_alert_sts.edn_bus_cmp_alert.de = edn_bus_cmp_alert;
   assign hw2reg.recov_alert_sts.edn_bus_cmp_alert.d  = edn_bus_cmp_alert;


### PR DESCRIPTION
Because of how EDN has different modes that may hang when in operation,
an update to the documentation has been made to watch for that condition.

Also, recoverable alerts have been changed to pulses.
Fixes #13716.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>