### PR TITLE
[entropy_src, dv] Add covergroup sample functions for entropy_src

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
@@ -35,7 +35,7 @@ class entropy_src_dut_cfg extends uvm_object;
   uint          route_software_pct, type_bypass_pct;
 
   // Constraint knobs for Boolean fields in FW_OV_CONTROL register
-  uint          fw_read_pct, fw_over_pct;
+  uint          fw_read_pct, fw_over_pct, fw_ov_insert_start_pct;
 
   // Health test-related knobs
   // Real constraints on sigma ranges (floating point value)
@@ -66,7 +66,7 @@ class entropy_src_dut_cfg extends uvm_object;
 
   rand int                      observe_fifo_thresh;
 
-  rand prim_mubi_pkg::mubi4_t   fw_read_enable, fw_over_enable;
+  rand prim_mubi_pkg::mubi4_t   fw_read_enable, fw_over_enable, fw_ov_insert_start;
 
   // Note: These integer-valued fields are used to derive their real-valued counterparts.
   rand int unsigned adaptp_sigma_i, markov_sigma_i, bucket_sigma_i;
@@ -97,6 +97,10 @@ class entropy_src_dut_cfg extends uvm_object;
   constraint fw_over_enable_c {fw_over_enable dist {
       prim_mubi_pkg::MuBi4True  :/ fw_over_pct,
       prim_mubi_pkg::MuBi4False :/ (100 - fw_over_pct) };}
+
+  constraint fw_ov_insert_start_c {fw_ov_insert_start dist {
+      prim_mubi_pkg::MuBi4True  :/ fw_ov_insert_start_pct,
+      prim_mubi_pkg::MuBi4False :/ (100 - fw_ov_insert_start_pct) };}
 
   constraint module_enable_c {module_enable dist {
       prim_mubi_pkg::MuBi4True  :/ module_enable_pct,
@@ -239,8 +243,11 @@ class entropy_src_dut_cfg extends uvm_object;
         invalid_rng_bit_enable: rng_bit_enable = invalid_mubi_val;
         invalid_fw_ov_mode: fw_read_enable = invalid_mubi_val;
         invalid_fw_ov_entropy_insert: fw_over_enable = invalid_mubi_val;
+        invalid_fw_ov_insert_start: fw_ov_insert_start = invalid_mubi_val;
         invalid_es_route: route_software = invalid_mubi_val;
         invalid_es_type: type_bypass = invalid_mubi_val;
+        invalid_alert_threshold: begin
+        end
         default: begin
           `uvm_fatal(`gfn, "Invalid case! (bug in environment)")
         end

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -21,10 +21,10 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // Configuration for DUT CSRs (held in a separate object for easy re-randomization)
   entropy_src_dut_cfg dut_cfg;
 
-  // handle to csrng assert interface
-  virtual entropy_src_assert_if entropy_src_assert_if;
-  // handle to edn path interface
-  virtual entropy_src_path_if entropy_src_path_vif;
+  // handle to entropy_src assert interface
+  virtual entropy_src_assert_if entropy_src_assert_vif;
+  // handle to entropy_src path interface
+  virtual entropy_src_path_if   entropy_src_path_vif;
   //
   // Variables for controlling test duration.  Depending on the test there are two options:
   // fixed duration in time or total number of seeds.
@@ -150,7 +150,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
 
     // get entropy_src assert interface handle
     if (!uvm_config_db#(virtual entropy_src_assert_if)::
-        get(null, "*.env" , "entropy_src_assert_if", entropy_src_assert_if)) begin
+        get(null, "*.env" , "entropy_src_assert_vif", entropy_src_assert_vif)) begin
       `uvm_fatal(`gfn, $sformatf("FAILED TO GET HANDLE TO ASSERT IF"))
     end
   endfunction

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -99,7 +99,7 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     // If the new configuration is intentionally trying to force bad mubi
     // configurations, disable the alerts before applying the bad configs
     if (newcfg.use_invalid_mubi) begin
-      cfg.entropy_src_assert_if.assert_off_alert();
+      cfg.entropy_src_assert_vif.assert_off_alert();
     end
 
     #50us;

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_intr_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_intr_vseq.sv
@@ -143,7 +143,7 @@ class entropy_src_intr_vseq extends entropy_src_base_vseq;
 
         if (cfg.which_fatal_err == sfifo_esrng_error && cfg.which_fifo_err == write) begin
           //Turn off assertions
-          cfg.entropy_src_assert_if.assert_off_err();
+          cfg.entropy_src_assert_vif.assert_off_err();
           force_fifo_err_exception(fifo_forced_paths, fifo_forced_values,
                                    ral.intr_state.es_fatal_err, 1'b1);
         end else begin

--- a/hw/ip/entropy_src/dv/sva/entropy_src_assert_if.sv
+++ b/hw/ip/entropy_src/dv/sva/entropy_src_assert_if.sv
@@ -128,6 +128,8 @@ interface entropy_src_assert_if
     $assertoff(0, tb.dut.gen_alert_tx[0].u_prim_alert_sender.gen_async_assert.DiffEncoding_A);
     $assertoff(0, `CORE.u_sha3.FsmKnown_A);
     $assertoff(0, `CORE.u_sha3.MuxSelKnown_A);
+    $assertoff(0, `CORE.u_entropy_src_main_sm.u_state_regs_A);
+    $assertoff(0, `CORE.u_entropy_src_ack_sm.u_state_regs_A);
     $assertoff(0, `CORE.u_prim_fifo_sync_esfinal.DepthKnown_A);
     $assertoff(0, `CORE.u_prim_fifo_sync_esfinal.RvalidKnown_A);
     $assertoff(0, `CORE.u_prim_fifo_sync_esfinal.WreadyKnown_A);

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -103,7 +103,7 @@ module tb;
         (null, "*.env.m_rng_agent*", "vif", rng_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)))::
         set(null, "*.env.m_csrng_agent*", "vif", csrng_if);
-    uvm_config_db#(virtual entropy_src_assert_if)::set(null, "*.env", "entropy_src_assert_if",
+    uvm_config_db#(virtual entropy_src_assert_if)::set(null, "*.env", "entropy_src_assert_vif",
         entropy_src_assert_if);
     uvm_config_db#(virtual entropy_src_path_if)::set(null, "*.env", "entropy_src_path_vif",
         entropy_src_path_if);


### PR DESCRIPTION
  - Add covergroup sample functions in the err_vseq for the forced errors that can't be accessed in the scoreboard
  - Update alert_vseq to accommodate the updates in recov_alert_sts register
  - Fix some path reference bugs in the err_vseq

Signed-off-by: Muqing Liu <muqing.liu@wdc.com>