### PR TITLE
[otbn,dv] Add regression for CI

### DIFF
--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -304,6 +304,36 @@ name:
          "otbn_rnd_sec_cm", "otbn_mac_bignum_acc_err",
          "otbn_controller_ispr_rdata_err", "otbn_alu_bignum_mod_err"
       ]
+
+    }
+
+    {
+      name: "ci"
+      tests: [
+        # V1
+        "otbn_smoke", "otbn_single", "otbn_csr_hw_reset", "otbn_csr_rw",
+        "otbn_csr_bit_bash", "otbn_csr_aliasing",
+        "otbn_csr_mem_rw_with_rand_reset",
+        "otbn_mem_partial_access",
+        # V1 but known broken
+        # "otbn_mem_walk",
+        # V2
+        "otbn_reset", "otbn_multi", "otbn_stress_all",
+        "otbn_zero_state_err_urnd", "otbn_sw_errs_fatal_chk", "otbn_alert_test",
+        "otbn_intr_test", "otbn_tl_errors", "otbn_csr_hw_reset",
+        "otbn_same_csr_outstanding"
+        # V2 but known broken
+        # "otbn_multi_err", "otbn_escalate",
+        # V2S
+        "otbn_imem_err", "otbn_dmem_err", "otbn_illegal_mem_acc",
+        "otbn_tl_intg_err", "otbn_sec_cm", "otbn_pc_ctrl_flow_redun",
+        "otbn_rnd_sec_cm", "otbn_pc_ctrl_flow_redun", "otbn_alu_bignum_mod_err",
+        "otbn_controller_ispr_rdata_err", "otbn_mac_bignum_acc_err",
+        # V2S but known broken
+        # "otbn_passthru_mem_tl_intg_err",
+        # V3 thus not yet active
+        # "otbn_stress_all_with_rand_reset",
+      ]
     }
   ]
 }


### PR DESCRIPTION
This commit creates a regression test for OTBN that contains all tests
that are supposed to pass according to the current development stage.

This could be run in CI instead of the `smoke` test.  The problem with
only running the `smoke` test on a PR is that tests that are supposed to
pass are not tested for each PR.  Thus, a PR can break `master` and it
can only be noticed in the next nightly run of regressions.

As all tests with their configured reseed multiplier probably take too
long to run in per-PR CI checks, the reseed multiplier can be reduced
through `dvsim`.  For reference, with `--reseed-multiplier 0.1`, this
commit takes 8 minutes to build and run in VCS on my laptop with 16
threads.