### PR TITLE
[dvsim] Display max CPU time in regression result

### DIFF
--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -268,6 +268,8 @@ class Launcher:
                 context=[],
             )
 
+        self.deploy.extract_runtimes(lines)
+
         if chk_failed or chk_passed:
             for cnt, line in enumerate(lines):
                 if chk_failed:

--- a/util/dvsim/SimResults.py
+++ b/util/dvsim/SimResults.py
@@ -106,6 +106,10 @@ class SimResults:
             row.passing += 1
         row.total += 1
 
+        if item.job_runtime.time > row.job_runtime.time:
+            row.job_runtime = item.job_runtime
+            row.simulated_time = item.simulated_time
+
     def _bucketize(self, fail_msg):
         bucket = fail_msg
         # Remove stuff.

--- a/util/dvsim/sim_utils.py
+++ b/util/dvsim/sim_utils.py
@@ -8,6 +8,7 @@ This script provides common DV simulation specific utilities.
 
 import re
 from collections import OrderedDict
+from typing import List, Tuple
 
 
 # Capture the summary results as a list of lists.
@@ -99,3 +100,135 @@ def vcs_cov_summary_table(buf):
 
     # If we reached here, then we were unable to extract the coverage.
     raise SyntaxError(f"Coverage data not found in {buf.name}!")
+
+
+def get_job_runtime(log_text: List, tool: str) -> Tuple[float, str]:
+    """Returns the job runtime (wall clock time) along with its units.
+
+    EDA tools indicate how long the job ran in terms of CPU time in the log file.
+    This method invokes the tool specific method which parses the log text and
+    returns the runtime as a floating point value followed by its units as a tuple.
+
+    `log_text` is the job's log file contents as a list of lines.
+    `tool` is the EDA tool used to run the job.
+    Returns the runtime, units as a tuple.
+    Raises NotImplementedError exception if the EDA tool is not supported.
+    """
+    if tool == 'xcelium':
+        return xcelium_job_runtime(log_text)
+    elif tool == 'vcs':
+        return vcs_job_runtime(log_text)
+    else:
+        raise NotImplementedError(f"{tool} is unsupported for job runtime extraction.")
+
+
+def vcs_job_runtime(log_text: List) -> Tuple[float, str]:
+    """Capture and return the job_runtime along with its units from VCS simulator.
+
+    Example of VCS job_runtime: 'CPU Time:      1.210 seconds;'
+    Raises SyntaxError exception if we find the specific line but fail to parse the
+    actual number with unit.
+    """
+    # Reverse the log_text because the runtime is usually printed at the end of
+    # the file.
+    for line in reversed(log_text):
+        if "CPU Time" in line:
+            # Find pattern: CPU Time: "XXXX" seconds;.
+            m = re.search(r"(\d+\.\d+)", line)
+            if m:
+                return float(m.group(0)), "s"
+            else:
+                raise SyntaxError("Cannot find job runtime in line: " + line)
+    # We cannot find the job runtime summary line, could due to job killed,
+    # return the default value.
+    return 0, "s"
+
+
+def xcelium_job_runtime(log_text: List) -> Tuple[float, str]:
+    """Capture and return the job_runtime along with its units from Xcelium simulator.
+
+    Example of Xcelium job_runtime:
+      'TOOL: xrun(64) 21.09-s006: Exiting on Jul 22, 2022 at 13:38:48 PDT (total: 00:00:02)'
+    Raises SyntaxError exception if we find the specific line but fail to parse the
+    actual number with unit.
+    """
+    # Reverse the log_text because the runtime is usually printed at the end of
+    # the file.
+    for line in reversed(log_text):
+        if "total:" in line and "TOOL" in line:
+            # Find pattern: TOOL .. (total: "XX":"XX":"XX")
+            m = re.search(r"total:.*(\d+):(\d+):(\d+)", line)
+            if m:
+                # Convert time format: HR:MIN:SEC to seconds.
+                val = re.findall(r"\d+", m.group(0))
+                job_runtime = (int(val[0]) * 60 + int(val[1])) * 60 + int(val[2])
+                return job_runtime, "s"
+            else:
+                raise SyntaxError("Cannot find job runtime in line: " + line)
+    # We cannot find the job runtime summary line, could due to job killed,
+    # return the default value.
+    return 0, "s"
+
+
+def get_simulated_time(log_text: List, tool: str) -> Tuple[float, str]:
+    """Returns the job simulated time along with its units.
+    This method invokes the tool specific method which parses the log text and
+    returns the simulated time as a floating point value followed by its units as a tuple.
+    `log_text` is the job's log file contents as a list of lines.
+    `tool` is the EDA tool used to run the job.
+    Returns the simulated, units as a tuple.
+    Raises NotImplementedError exception if the EDA tool is not supported.
+    """
+
+    if tool == 'xcelium':
+        return xcelium_simulated_time(log_text)
+    elif tool == 'vcs':
+        return vcs_simulated_time(log_text)
+    else:
+        raise NotImplementedError("{tool} is unsupported for run times extraction.")
+
+
+def xcelium_simulated_time(log_text: List) -> Tuple[float, str]:
+    """Capture and return the simulated_time along with its units from Xcelium simulator.
+
+    Example of Xcelium simulated_time:
+      'Simulation complete via $finish(2) at time 43361308 PS + 58'
+    Raises SyntaxError exception if we find the specific line but fail to parse the
+    actual number with unit.
+    """
+
+    # Reverse the log_text because Xcelium does not print out the total
+    # simulation time in summary, so we parse the log in reversed order to get
+    # the last simulation timestamp.
+    for line in reversed(log_text):
+        if "Simulation complete via" in line:
+            m = re.search(r"at time.*(\b\d+).+(\b[A-Z]+)", line)
+            if m:
+                return int(m.group(1)), m.group(2).lower()
+            else:
+                raise SyntaxError("Cannot find the simulation time in line: " + line)
+    # We cannot find the job simulated time summary line, could due to job killed,
+    # return the default value.
+    return 0, "s"
+
+
+def vcs_simulated_time(log_text: List) -> Tuple[float, str]:
+    """Capture and return the simulated_time along with its units from VCS simulator.
+
+    Example of VCS simulated_time: '$finish at simulation time 522104678 ps'
+    Raises SyntaxError exception if we find the specific line but fail to parse the
+    actual number with unit.
+    """
+
+    # Reverse the log_text because the simulation time is usually printed at the end of
+    # the file.
+    for line in reversed(log_text):
+        if "finish at simulation time" in line:
+            m = re.search(r"(\d+).+(\b[a-z]+)", line)
+            if m:
+                return int(m.group(1)), m.group(2)
+            else:
+                raise SyntaxError("Cannot find the simulation time in line: " + line)
+    # We cannot find the job simulated time summary line, could due to job killed,
+    # return the default value.
+    return 0, "s"


### PR DESCRIPTION
This PR displays the max CPU time for each test. Finishes part of TODOs
from issue #13756.
I will implement the sim runtime print out once we think this approach is acceptable.

Here is the latest VCS results:
```
### Simulator: VCS

### Test Results
|  Milestone  |                Name                | Tests          |  Passing  |  Total  |  Pass Rate  |  Max Job Runtime  |  Simulated Time 
 |
|:-----------:|:----------------------------------:|:---------------|:---------:|:-------:|:-----------:|:-----------------:|:----------------
:|
|     V1      |               smoke                | otp_ctrl_smoke |    10     |   10    |  100.00 %   |      6.460s       |    928.288us    
 |
|     V1      |                                    | **TOTAL**      |    10     |   10    |  100.00 %   |                   |                 
 |
|     V2S     |     sec_cm_secret_mem_scramble     | otp_ctrl_smoke |    10     |   10    |  100.00 %   |      6.460s       |    928.288us    
 |
|     V2S     |       sec_cm_part_mem_digest       | otp_ctrl_smoke |    10     |   10    |  100.00 %   |      6.460s       |    928.288us    
 |
|     V2S     |    sec_cm_token_valid_ctrl_mubi    | otp_ctrl_smoke |    10     |   10    |  100.00 %   |      6.460s       |    928.288us    
 |
|     V2S     |      sec_cm_test_bus_lc_gated      | otp_ctrl_smoke |    10     |   10    |  100.00 %   |      6.460s       |    928.288us    
 |
|     V2S     | sec_cm_check_trigger_config_regwen | otp_ctrl_smoke |    10     |   10    |  100.00 %   |      6.460s       |    928.288us    
 |
|     V2S     |     sec_cm_check_config_regwen     | otp_ctrl_smoke |    10     |   10    |  100.00 %   |      6.460s       |    928.288us    
 |
|             |                                    | **TOTAL**      |    10     |   10    |  100.00 %   |                   |                 
 |

```

In xcelium:
```
|  Milestone  |                   Name                    | Tests                |  Passing  |  Total  |  Pass Rate  |  Max Job Runtime  |  Simulated Time  |
|:-----------:|:-----------------------------------------:|:---------------------|:---------:|:-------:|:-----------:|:-----------------:|:----------------:|
|     V1      |                   smoke                   | pattgen_smoke        |    10     |   10    |  100.00 %   |      2.000s       |    155.321us     |
|     V1      |               csr_hw_reset                | pattgen_csr_hw_reset |    10     |   10    |  100.00 %   |      1.000s       |     36.136us     |
|     V1      |                  csr_rw                   | pattgen_csr_rw       |    10     |   10    |  100.00 %   |      1.000s       |     16.695us     |
|     V1      | regwen_csr_and_corresponding_lockable_csr | pattgen_csr_rw       |    10     |   10    |  100.00 %   |      1.000s       |     16.695us     |
|     V1      |                                           | **TOTAL**            |    30     |   30    |  100.00 %   |                   |                  |
|     V2      |          tl_d_outstanding_access          | pattgen_csr_hw_reset |    10     |   10    |  100.00 %   |      1.000s       |     36.136us     |
|             |                                           | pattgen_csr_rw       |    10     |   10    |  100.00 %   |      1.000s       |     16.695us     |
|     V2      |            tl_d_partial_access            | pattgen_csr_hw_reset |    10     |   10    |  100.00 %   |      1.000s       |     36.136us     |
|             |                                           | pattgen_csr_rw       |    10     |   10    |  100.00 %   |      1.000s       |     16.695us     |
|             |                                           | **TOTAL**            |    30     |   30    |  100.00 %   |                   |                  |
```

Signed-off-by: Cindy Chen <chencindy@google.com>