### PR TITLE
[spi_device/dv] Enable testing SFDP command

### DIFF
--- a/hw/dv/sv/mem_model/mem_model.sv
+++ b/hw/dv/sv/mem_model/mem_model.sv
@@ -27,7 +27,7 @@ class mem_model #(int AddrWidth = bus_params_pkg::BUS_AW,
 
   function bit [7:0] read_byte(mem_addr_t addr);
     bit [7:0] data;
-    if (system_memory.exists(addr)) begin
+    if (addr_exists(addr)) begin
       data = system_memory[addr];
       `uvm_info(`gfn, $sformatf("Read Mem  : Addr[0x%0h], Data[0x%0h]", addr, data), UVM_HIGH)
     end else begin
@@ -77,7 +77,7 @@ class mem_model #(int AddrWidth = bus_params_pkg::BUS_AW,
     for (int i = 0; i < DataWidth / 8; i++) begin
       mem_addr_t byte_addr = addr + i;
       byte_data = act_data[7:0];
-      if (mask[0] && (!compare_exist_addr_only || system_memory.exists(byte_addr))) begin
+      if (mask[0] && (!compare_exist_addr_only || addr_exists(byte_addr))) begin
         compare_byte(byte_addr, byte_data);
       end else begin
         // Nothing to do here: since this byte wasn't selected by the mask, there are no
@@ -88,4 +88,7 @@ class mem_model #(int AddrWidth = bus_params_pkg::BUS_AW,
     end
   endfunction
 
+  function bit addr_exists(mem_addr_t addr);
+    return system_memory.exists(addr);
+  endfunction
 endclass

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_intercept_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_intercept_vseq.sv
@@ -8,7 +8,8 @@ class spi_device_intercept_vseq extends spi_device_pass_cmd_filtering_vseq;
   `uvm_object_utils(spi_device_intercept_vseq)
   `uvm_object_new
   bit [7:0] intercept_ops[$] = {READ_STATUS_1, READ_STATUS_2, READ_STATUS_3,
-                                READ_JEDEC};
+                                READ_JEDEC,
+                                READ_SFDP};
 
   virtual task pre_start();
     allow_intercept = 1;

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -62,7 +62,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     add_cmd_info(info, 3);
     info = spi_flash_cmd_info::type_id::create("info");
     `DV_CHECK_RANDOMIZE_WITH_FATAL(info,
-      info.addr_bytes == 0 &&
+      info.addr_bytes == 3 &&
       info.opcode == READ_SFDP;
       info.num_lanes == 1 &&
       info.write_command == 0;)
@@ -172,6 +172,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
       // TODO, only support status intercept
       `DV_CHECK_RANDOMIZE_FATAL(ral.intercept_en.status)
       `DV_CHECK_RANDOMIZE_FATAL(ral.intercept_en.jedec)
+      ral.intercept_en.sfdp.set(1);
       csr_update(ral.intercept_en);
     end
 
@@ -228,6 +229,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     // Prepare Buffer
     for (int i = 0; i < 1024; i++) begin // Fill buffer with random data
       mem_wr(.ptr(ral.buffer), .offset(i), .data(buffer_data[i]));
+      `uvm_info(`gfn, $sformatf("write mem addr 0x%0x: 0x%0x", i << 2, buffer_data[i]), UVM_MEDIUM)
     end
   endtask : randomize_mem
 
@@ -282,6 +284,8 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
 
     if (allow_addr_swap) begin
       swap = $urandom_range(0, 99) < addr_payload_swap_pct;
+      if (swap) `uvm_info(`gfn, $sformatf("addr_swap is set for opcode 0x%0x", info.opcode),
+                          UVM_MEDIUM)
     end else begin
       swap = 0;
     end
@@ -290,6 +294,8 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     // only write and single mode allows payload swap
     if (allow_payload_swap && info.write_command && info.num_lanes == 1) begin
       swap = $urandom_range(0, 99) < addr_payload_swap_pct;
+      if (swap) `uvm_info(`gfn, $sformatf("payload_swap is set for opcode 0x%0x", info.opcode),
+                          UVM_MEDIUM)
     end else begin
       swap = 0;
     end

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -81,6 +81,22 @@ package spi_device_env_pkg;
   parameter uint SRAM_PTR_PHASE_BIT              = SRAM_MSB + 1;
   parameter uint SRAM_WORD_SIZE                  = 4;
   parameter uint ASYNC_FIFO_SIZE                 = 8;
+  parameter uint READ_CMD_START_ADDR             = SRAM_OFFSET;
+  parameter uint READ_CMD_BUFFER_SIZE            = 2048;
+  // MAILBOX_START_ADDR is 0x800
+  parameter uint MAILBOX_START_ADDR              = READ_CMD_START_ADDR + READ_CMD_BUFFER_SIZE;
+  parameter uint MAILBOX_BUFFER_SIZE             = 1024;
+  // SFDP_START_ADDR is 0xc00
+  parameter uint SFDP_START_ADDR                 = MAILBOX_START_ADDR + MAILBOX_BUFFER_SIZE;
+  parameter uint SFDP_SIZE                       = 256;
+  parameter uint PAYLOAD_FIFO_START_ADDR         = SFDP_START_ADDR + SFDP_SIZE; // 0xd00
+  parameter uint PAYLOAD_FIFO_SIZE               = 256;
+  // CMD_FIFO_START_ADDR is 0xe00
+  parameter uint CMD_FIFO_START_ADDR             = PAYLOAD_FIFO_START_ADDR + PAYLOAD_FIFO_SIZE;
+  parameter uint CMD_FIFO_SIZE                   = 32;
+  parameter uint ADDR_FIFO_START_ADDR            = CMD_FIFO_START_ADDR + CMD_FIFO_SIZE; // 0xe20
+  parameter uint ADDR_FIFO_SIZE                  = 32;
+
   parameter bit[7:0] TPM_WRITE_CMD               = 8'hC0;
   parameter bit[7:0] TPM_READ_CMD                = 8'hC1;
   parameter byte TPM_START                       = 8'h01;


### PR DESCRIPTION
Similar to the JEDEC command, enable testing it in intercept_vseq and
pass_all_vseq.

Signed-off-by: Weicai Yang <weicai@google.com>