### PR TITLE
[sw/silicon_creator] Fix KMAC entropy config for keymgr functest

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -352,34 +352,53 @@
           name: entropy_mode
           desc: '''Entropy Mode
 
-          Software selects the entropy source with this field. In EdnMode,
-          the entropy generator sends requests to EDN to get the entropy. The
-          received entropy is fed into internal LFSR.
-
-          In SwMode, the software should update the internal LFSR seed
-          through !!ENTROPY_SEED_0 etc.
-
-          Out of the reset, the entropy module inside KMAC IP generates LFSR to
-          support the ROM_CTRL operation. The logic does not go back to the
-          reset state to prevent KMAC from using LFSR with seeds. SW must
-          configure correct entropy_mode prior to setting the entropy_ready.
+          Using this field, software can configure mode of operation of the internal pseudo-random number generator (PRNG).
+          For the hardware to actually switch to an entropy mode other than the default idle_mode, software further needs to set the !!CFG_SHADOWED.entropy_ready bit.
+          After that point, the hardware cannot be made to return to idle_mode unless the module is reset.
           '''
 
           enum: [
             { value: "0"
               name: "idle_mode"
-              desc: '''At reset state, the entropy mode is Idle mode. It does
-              not operate in this mode.
+              desc: '''Default mode after reset.
+
+              The sole purpose of this mode is to enable ROM_CTRL operation right after coming out of reset.
+
+              The internal PRNG is not reseeded with fresh entropy, nor updated while the core operates.
+              It should therefore not be used after this very initial stage.
+              Software should setup a different mode and set !!CFG_SHADOWED.entropy_ready as early as possible.
+
+              The module cannot be made to return to idle_mode once any of the other modes have been used.
               '''
             }
             { value: "1"
               name: "edn_mode"
-              desc: "Entropy generator module fetches entropy from EDN"
+              desc: '''Receive fresh entropy from EDN for reseeding the internal PRNG.
+
+              This entropy mode is to be used for regular operation.
+
+              Once the !!CFG_SHADOWED.entropy_ready bit is set after reset, the module requests fresh entropy from EDN for reseeding the internal PRNG.
+              Only after that, the module can start processing commands.
+              Depending on !!CFG_SHADOWED, the internal PRNG is then used for (re-)masking inputs (prefix, key, message) and intermediate results of the Keccak core.
+
+              Depending on !!ENTROPY_PERIOD, the module will periodically reseed the internal PRNG with fresh entropy from EDN.
+              Using !!CMD.entropy_req software can manually initiate the reseeding.
+
+              '''
             }
             { value: "2"
               name: "sw_mode"
-              desc: '''Software update the internal entropy via register
-              interface'''
+              desc: '''Receive initial entropy from software for reseeding the internal PRNG.
+
+              This entropy mode is a fall-back option to be used if the entropy complex is not available.
+
+              Once the !!CFG_SHADOWED.entropy_ready bit is set after reset, the module will wait for software to write each of the !!ENTROPY_SEED_0 - !!ENTROPY_SEED_4 registers exactly once and in ascending order.
+              Only after that, the module can start processing commands.
+              Depending on !!CFG_SHADOWED, the internal PRNG is then used for (re-)masking inputs (prefix, key, message) and intermediate results of the Keccak core.
+
+              After this point, the PRNG can no longer be reseeded by software - also after switching back into this mode from edn_mode.
+              However, it is possible to switch to edn_mode.
+              '''
             }
           ]
           tags: ["shadowed_reg_path:u_cfg_reg_shadowed.u_cfg_reg_shadowed_entropy_mode"]

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -148,7 +148,12 @@ static void init_kmac_for_keymgr(void) {
 
   // Configure KMAC hardware using software entropy.
   dif_kmac_config_t config = (dif_kmac_config_t){
+      .entropy_mode = kDifKmacEntropyModeSoftware,
+      .entropy_fast_process = false,
+      .entropy_seed = {0xaa25b4bf, 0x48ce8fff, 0x5a78282a, 0x48465647,
+                       0x70410fef},
       .sideload = true,
+      .msg_mask = true,
   };
   CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
   for (size_t i = 0; i < kKmacPrefixSize; ++i) {


### PR DESCRIPTION
Despite a comment saying KMAC was configured to use software entropy, it was actually using idle_mode (reset configuration). However, the sole purpose of this mode is to enable ROM ctrl right after coming out of reset. No reseeding is happening and the PRNG is not advanced in this mode. It thus shouldn't be used after ROM ctrl has finished.

This commit changes the configuration to indeed reseed the PRNG with entropy provided by software. In addition, message masking is switched on to reduce potential SCA leakage.