### PR TITLE
[bazel] Use cached MMI when splicing bitstreams

### DIFF
--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -7,30 +7,38 @@ set -x
 set -e
 
 . util/build_consts.sh
-readonly SHA=$(git rev-parse HEAD)
-readonly BIT_CACHE_DIR="${HOME}/.cache/opentitan-bitstreams/cache/${SHA}"
-readonly BIT_SRC_PREFIX="${BIN_DIR}/hw/top_earlgrey/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
-readonly BIT_DST_PREFIX="${BIT_CACHE_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
 
-mkdir -p ${BIT_CACHE_DIR}
-for suffix in orig splice; do
-  cp "${BIT_SRC_PREFIX}.${suffix}" "${BIT_DST_PREFIX}.${suffix}"
-done
-echo -n ${SHA} > ${BIT_CACHE_DIR}/../../latest.txt
+SHA=$(git rev-parse HEAD)
+readonly SHA
+
+# Copy bitstreams and related files into the cache directory so Bazel will have
+# the corresponding targets in the @bitstreams workspace.
+#
+# TODO(#13807) Update this when we change the naming scheme.
+readonly BIT_CACHE_DIR="${HOME}/.cache/opentitan-bitstreams/cache/${SHA}"
+readonly BIT_SRC_DIR="${BIN_DIR}/hw/top_earlgrey"
+readonly BIT_NAME_PREFIX="lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+mkdir -p "${BIT_CACHE_DIR}"
+cp "${BIT_SRC_DIR}/${BIT_NAME_PREFIX}.orig" \
+    "${BIT_SRC_DIR}/${BIT_NAME_PREFIX}.splice" \
+    "${BIT_SRC_DIR}/otp.mmi"  \
+    "${BIT_SRC_DIR}/rom.mmi" \
+    "${BIT_CACHE_DIR}"
+
+echo -n "$SHA" > "${BIT_CACHE_DIR}/../../latest.txt"
 export BITSTREAM="--offline --list ${SHA}"
 
 # We will lose serial access when we reboot, but if tests fail we should reboot
 # in case we've crashed the UART handler on the CW310's SAM3U
 trap 'python3 ./util/fpga/cw310_reboot.py' EXIT
 
-ci/bazelisk.sh test \
-    --define DISABLE_VERILATOR_BUILD=true \
-    --nokeep_going \
-    --test_tag_filters=cw310,-broken \
-    --test_timeout_filters=short,moderate \
-    --test_output=all \
-    --build_tests_only \
-    --define cw310=lowrisc \
-    --flaky_test_attempts=2 \
-    $(./bazelisk.sh query 'rdeps(//...,@bitstreams//:bitstream_test_rom)') \
-    $(./bazelisk.sh query 'rdeps(//...,@bitstreams//:bitstream_mask_rom)')
+./bazelisk.sh query 'rdeps(//..., @bitstreams//...)' |
+    xargs ci/bazelisk.sh test \
+        --define DISABLE_VERILATOR_BUILD=true \
+        --nokeep_going \
+        --test_tag_filters=cw310,-broken,-manual \
+        --test_timeout_filters=short,moderate \
+        --test_output=all \
+        --build_tests_only \
+        --define cw310=lowrisc \
+        --flaky_test_attempts=2

--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -2,27 +2,35 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:splice.bzl", "bitstream_splice")
+
 package(default_visibility = ["//visibility:public"])
 
-# Use a bitstream from the GCP bucket (this is also the default condition).
-# You can control the GCP bitstream selection via the BITSTREAM environment
-# variable.  See //rules/bitstreams.bzl for more information.
+# By default, targets in this file will use cached artifacts from the GCP bucket
+# instead of building them from scratch.
 #
-# Example:
-#   bazel test //sw/device/silicon_creator/lib/drivers:hmac_functest_fpga_cw310 --define bitstream=gcp
-config_setting(
-    name = "bitstream_gcp",
-    define_values = {
-        "bitstream": "gcp",
-    },
-)
+# You can control GCP bitstream selection with the BITSTREAM environment
+# variable. See //rules:bitstreams.bzl for more information.
+#
+# Alternatively, you can disable or alter this caching behavior with the
+# "bitstream" config setting.
+#
+# * `--define bitstream=skip` skips loading a bitstream into the FPGA. This is
+#   useful if you already have a bitstream loaded into the FPGA and you don't
+#   want the GCP cache manager to do anything unexpected.
+#
+# * `--define bitstream=vivado` causes these targets to build from scratch with
+#   Vivado. You'll need to have Xilinx Vivado installed and have properly
+#   configured access to a license or license server.
+#
+# * `--define bitstream=gcp_splice` causes these targets to use a cached
+#   bitstream, but splice in a locally-built ROM image or OTP.
+#
+# Downstream targets will see the effects of this caching logic. For example,
+# specifying `--define bitstream=vivado` when testing
+# //sw/device/silicon_creator/lib/drivers:hmac_functest_fpga_cw310 will turn
+# `:test_rom` into a full Vivado bitstream build.
 
-# Skip loading a bitstream in to the FPGA.  This is useful if you already
-# have a bitstream loaded into the FPGA and you don't want the GCP cache
-# manager to do anything unexpected.
-#
-# Example:
-#   bazel test //sw/device/silicon_creator/lib/drivers:hmac_functest_fpga_cw310 --define bitstream=skip
 config_setting(
     name = "bitstream_skip",
     define_values = {
@@ -30,16 +38,17 @@ config_setting(
     },
 )
 
-# Use a bitstream built by Vivado.  You'll need to have Xilinx Vivado
-# installed and have properly configured access to a license or license
-# server.
-#
-# Example:
-#   bazel test //sw/device/silicon_creator/lib/drivers:hmac_functest_fpga_cw310 --define bitstream=vivado
 config_setting(
     name = "bitstream_vivado",
     define_values = {
         "bitstream": "vivado",
+    },
+)
+
+config_setting(
+    name = "bitstream_gcp_splice",
+    define_values = {
+        "bitstream": "gcp_splice",
     },
 )
 
@@ -48,7 +57,7 @@ filegroup(
     srcs = select({
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_test_rom"],
-        "bitstream_gcp": ["@bitstreams//:bitstream_test_rom"],
+        "bitstream_gcp_splice": [":gcp_spliced_test_rom"],
         "//conditions:default": ["@bitstreams//:bitstream_test_rom"],
     }),
 )
@@ -58,16 +67,67 @@ filegroup(
     srcs = select({
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_mask_rom"],
-        "bitstream_gcp": ["@bitstreams//:bitstream_mask_rom"],
+        "bitstream_gcp_splice": [":gcp_spliced_mask_rom"],
         "//conditions:default": ["@bitstreams//:bitstream_mask_rom"],
     }),
 )
 
-# TODO(lowRISC/opentitan#13603): Use `select` once we're uploading these
-# artifacts to GCP.
 filegroup(
     name = "mask_rom_otp_dev",
-    srcs = [
-        "//hw/bitstream/vivado:fpga_cw310_mask_rom_otp_dev",
-    ],
+    srcs = select({
+        "bitstream_skip": ["skip.bit"],
+        "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_mask_rom_otp_dev"],
+        "bitstream_gcp_splice": [":gcp_spliced_mask_rom_otp_dev"],
+        # FIXME(#13603) By default, this will actually do a local splice instead
+        # of retrieving the pre-spliced bitstream from the cache.
+        "//conditions:default": [":gcp_spliced_mask_rom_otp_dev"],
+    }),
+)
+
+filegroup(
+    name = "rom_mmi",
+    srcs = select({
+        "bitstream_skip": ["skip.bit"],
+        "bitstream_vivado": ["//hw/bitstream/vivado:rom_mmi"],
+        "//conditions:default": ["@bitstreams//:rom_mmi"],
+    }),
+)
+
+filegroup(
+    name = "otp_mmi",
+    srcs = select({
+        "bitstream_skip": ["skip.bit"],
+        "bitstream_vivado": ["//hw/bitstream/vivado:otp_mmi"],
+        "//conditions:default": ["@bitstreams//:otp_mmi"],
+    }),
+)
+
+# Build the Test ROM and splice it into a cached bitstream.
+bitstream_splice(
+    name = "gcp_spliced_test_rom",
+    src = "@bitstreams//:bitstream_test_rom",
+    data = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem",
+    meminfo = ":rom_mmi",
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
+)
+
+# Build the Mask ROM and splice it into a cached bitstream.
+bitstream_splice(
+    name = "gcp_spliced_mask_rom",
+    src = "@bitstreams//:bitstream_test_rom",
+    data = "//sw/device/silicon_creator/mask_rom:mask_rom_fpga_cw310_scr_vmem",
+    meminfo = ":rom_mmi",
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
+)
+
+# Splice the OTP Dev image into `:gcp_spliced_mask_rom`.
+bitstream_splice(
+    name = "gcp_spliced_mask_rom_otp_dev",
+    src = ":gcp_spliced_mask_rom",
+    data = "//hw/ip/otp_ctrl/data:img_dev",
+    meminfo = ":otp_mmi",
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
 )


### PR DESCRIPTION
Using cached MMI files, we can quickly splice the Mask ROM and OTP
images without incurring a multi-hour bitstream build. Note that the
splicing is performed locally, and thus requires Vivado's `updatemem`
command to be installed.

This commit adds //hw/bitstream:rom_mmi and :otp_mmi, which work the
same as their sibling targets; depending on the "bitstream" config, they
either pull in a cached file or build it from scratch.

Fixes #13603
See also #10867

Signed-off-by: Dan McArdle <dmcardle@google.com>