### PR TITLE
[rdc] ENV file and Reset Scenario

### DIFF
--- a/hw/rdc/tools/dvsim/meridianrdc.hjson
+++ b/hw/rdc/tools/dvsim/meridianrdc.hjson
@@ -8,6 +8,7 @@
     { FOUNDRY_CONSTRAINT: "{foundry_sdc_file}" },
     { RDC_WAIVER_FILE:    "{rdc_waiver_file}" }
     { ENV_FILE:           "{env_file}" }
+    { RESET_SCENARIO_FILE: "{reset_scenario_file}"}
   ]
 
   // Tool invocation

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Meridian RDC ENV
+#
+# This .env file defines additional constraints on top of
+# chip_earlgrey_asic.sdc. This file adds constraints below:
+#
+#   1. Reset groups
+#   2. Set Constant

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_rdc_cfg.hjson
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_rdc_cfg.hjson
@@ -24,8 +24,12 @@
   // Timing constraints for this module
   sdc_file: "{proj_root}/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc"
 
-  // Verix environment file with additional definitions (may have to populate later)
-  env_file: ""
+  // Meridian environment file with additional definitions (may have to
+  // populate later)
+  env_file: "{proj_root}/hw/top_earlgrey/rdc/chip_earlgrey_asic.env"
+
+  // Reset Scenario file
+  reset_scenario_file: "{proj_root}/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl"
 
   // Main RDC waiver file. It includes waivers per module
   rdc_waiver_file: "{proj_root}/hw/top_earlgrey/rdc/rdc_waivers.tcl"

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Meridian RDC Reset Scenario
+
+###################
+# Reset Scenarios #
+###################
+
+# TODO: SPI_CSB asserted(release from reset) only when SYS_RST_N is not asserted


### PR DESCRIPTION
This commit tweaks the script to read ENV file for additional
constraints based on the recommended method from Real Intent.

In addition to above, this commit adds a reset scenario template.