### PR TITLE
[sw,dif,testutils] Tighten up return values

### DIFF
--- a/sw/device/lib/dif/dif_adc_ctrl.h
+++ b/sw/device/lib/dif/dif_adc_ctrl.h
@@ -405,6 +405,7 @@ dif_result_t dif_adc_ctrl_irq_clear_causes(const dif_adc_ctrl_t *adc_ctrl,
  * @param enabled The enablement state to set.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_adc_ctrl_filter_match_wakeup_set_enabled(
     const dif_adc_ctrl_t *adc_ctrl, dif_adc_ctrl_filter_t filter,
     dif_toggle_t enabled);
@@ -417,6 +418,7 @@ dif_result_t dif_adc_ctrl_filter_match_wakeup_set_enabled(
  * @param[out] is_enabled The enablement state retrieved.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_adc_ctrl_filter_match_wakeup_get_enabled(
     const dif_adc_ctrl_t *adc_ctrl, dif_adc_ctrl_filter_t filter,
     dif_toggle_t *is_enabled);
@@ -433,6 +435,7 @@ dif_result_t dif_adc_ctrl_filter_match_wakeup_get_enabled(
  * @param enabled The enablement state to set.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_adc_ctrl_irq_cause_set_enabled(const dif_adc_ctrl_t *adc_ctrl,
                                                 uint32_t causes,
                                                 dif_toggle_t enabled);
@@ -446,6 +449,7 @@ dif_result_t dif_adc_ctrl_irq_cause_set_enabled(const dif_adc_ctrl_t *adc_ctrl,
  *                            `debug_cable` IRQ.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_adc_ctrl_irq_cause_get_enabled(const dif_adc_ctrl_t *adc_ctrl,
                                                 uint32_t *enabled_causes);
 

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -377,6 +377,7 @@ dif_result_t dif_aes_read_output(const dif_aes_t *aes, dif_aes_data_t *data);
  * @param block_amount The amount of blocks to be encrypted.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_aes_process_data(const dif_aes_t *aes,
                                   const dif_aes_data_t *plain_text,
                                   dif_aes_data_t *cipher_text,

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -310,6 +310,7 @@ dif_result_t dif_clkmgr_disable_measure_counts(
  * @param[out] state The state of control enable.
  * @returns The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_clkmgr_measure_counts_get_enable(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_measure_clock_t clock,
     dif_toggle_t *state);
@@ -323,6 +324,7 @@ dif_result_t dif_clkmgr_measure_counts_get_enable(
  * @param[out] max_threshold The maximum threshold.
  * @returns The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_clkmgr_measure_counts_get_thresholds(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_measure_clock_t clock,
     uint32_t *min_threshold, uint32_t *max_threshold);

--- a/sw/device/lib/dif/dif_edn.h
+++ b/sw/device/lib/dif/dif_edn.h
@@ -248,6 +248,7 @@ dif_result_t dif_edn_set_auto_mode(const dif_edn_t *edn,
  * @param set Flag state (set/unset).
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_edn_get_status(const dif_edn_t *edn, dif_edn_status_t flag,
                                 bool *set);
 
@@ -261,6 +262,7 @@ dif_result_t dif_edn_get_status(const dif_edn_t *edn, dif_edn_status_t flag,
  * `dif_edn_error_t`.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_edn_get_errors(const dif_edn_t *edn, uint32_t *unhealthy_fifos,
                                 uint32_t *errors);
 

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -560,7 +560,7 @@ TEST_F(ObserveFifoBlockingReadTest, SuccessDataSave) {
 class ObserveFifoWriteTest : public EntropySrcTest {};
 
 TEST_F(ObserveFifoWriteTest, NullArgs) {
-  uint32_t buf[8];
+  uint32_t buf[8] = {0};
   EXPECT_DIF_BADARG(dif_entropy_src_observe_fifo_write(nullptr, buf, 8));
   EXPECT_DIF_BADARG(
       dif_entropy_src_observe_fifo_write(&entropy_src_, nullptr, 8));
@@ -773,7 +773,7 @@ TEST_F(GetRecoverableAlertsTest, Success) {
 class ClearRecoverableAlertsTest : public EntropySrcTest {};
 
 TEST_F(ClearRecoverableAlertsTest, NullHandle) {
-  uint32_t alerts;
+  uint32_t alerts = 0;
   EXPECT_DIF_BADARG(dif_entropy_src_clear_recoverable_alerts(nullptr, alerts));
 }
 

--- a/sw/device/lib/dif/dif_flash_ctrl.h
+++ b/sw/device/lib/dif/dif_flash_ctrl.h
@@ -48,6 +48,7 @@ typedef struct dif_flash_ctrl_state {
  * @param base_addr The base address for the flash controller.
  * @return `kDifBadArg` if `handle` is null. `kDifOk` otherwise.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_flash_ctrl_init_state(dif_flash_ctrl_state_t *handle,
                                        mmio_region_t base_addr);
 
@@ -88,6 +89,7 @@ dif_flash_ctrl_device_info_t dif_flash_ctrl_get_device_info(void);
  * @param enable Enable/disable flash functionality.
  * @return `kDifBadArg` if `handle` is null. `kDifOk` otherwise.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_flash_ctrl_set_flash_enablement(dif_flash_ctrl_state_t *handle,
                                                  dif_toggle_t enable);
 
@@ -99,6 +101,7 @@ dif_result_t dif_flash_ctrl_set_flash_enablement(dif_flash_ctrl_state_t *handle,
  * @return `kDifBadArg` if `handle` or `enabled_out` are null and `kDifOk`
  * otherwise.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_flash_ctrl_get_flash_enablement(
     const dif_flash_ctrl_state_t *handle, dif_toggle_t *enabled_out);
 
@@ -110,6 +113,7 @@ dif_result_t dif_flash_ctrl_get_flash_enablement(
  * @return `kDifBadArg` if `handle` or `enabled_out` are null and `kDifOk`
  * otherwise.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_flash_ctrl_set_exec_enablement(dif_flash_ctrl_state_t *handle,
                                                 dif_toggle_t enable);
 
@@ -122,6 +126,7 @@ dif_result_t dif_flash_ctrl_set_exec_enablement(dif_flash_ctrl_state_t *handle,
  * @return `kDifBadArg` if `handle` or `enabled_out` are null and `kDifOk`
  * otherwise.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_flash_ctrl_get_exec_enablement(
     const dif_flash_ctrl_state_t *handle, dif_toggle_t *enabled_out);
 
@@ -135,6 +140,7 @@ dif_result_t dif_flash_ctrl_get_exec_enablement(
  * @return `kDifBadArg` if `handle` is null, `kDifError` if initialization has
  * already been started, and `kDifOk` otherwise.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_flash_ctrl_start_controller_init(
     dif_flash_ctrl_state_t *handle);
 
@@ -205,6 +211,7 @@ typedef struct dif_flash_ctrl_prog_capabilities {
  * @return `kDifBadArg` if `handle` or `allowed_types_out` are null. `kDifOk`
  * otherwise.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_flash_ctrl_get_allowed_prog_types(
     const dif_flash_ctrl_state_t *handle,
     dif_flash_ctrl_prog_capabilities_t *allowed_types_out);
@@ -220,6 +227,7 @@ dif_result_t dif_flash_ctrl_get_allowed_prog_types(
  * given type should be *disabled*.
  * @return `kDifBadArg` if handle is null. `kDifOk` otherwise.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_flash_ctrl_disallow_prog_types(
     dif_flash_ctrl_state_t *handle,
     dif_flash_ctrl_prog_capabilities_t types_to_disable);

--- a/sw/device/lib/dif/dif_hmac.h
+++ b/sw/device/lib/dif/dif_hmac.h
@@ -76,6 +76,7 @@ typedef struct dif_hmac_digest {
  * @param config The per-transaction configuration.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_hmac_mode_hmac_start(const dif_hmac_t *hmac,
                                       const uint8_t *key,
                                       const dif_hmac_transaction_t config);
@@ -92,6 +93,7 @@ dif_result_t dif_hmac_mode_hmac_start(const dif_hmac_t *hmac,
  * @param config The per-transaction configuration.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_hmac_mode_sha256_start(const dif_hmac_t *hmac,
                                         const dif_hmac_transaction_t config);
 
@@ -116,6 +118,7 @@ dif_result_t dif_hmac_mode_sha256_start(const dif_hmac_t *hmac,
  * @param[out] bytes_sent The number of bytes sent to the FIFO (optional).
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_hmac_fifo_push(const dif_hmac_t *hmac, const void *data,
                                 size_t len, size_t *bytes_sent);
 
@@ -128,6 +131,7 @@ dif_result_t dif_hmac_fifo_push(const dif_hmac_t *hmac, const void *data,
  * @param[out] num_entries The number of entries in the FIFO.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_hmac_fifo_count_entries(const dif_hmac_t *hmac,
                                          uint32_t *num_entries);
 
@@ -141,6 +145,7 @@ dif_result_t dif_hmac_fifo_count_entries(const dif_hmac_t *hmac,
  * @param[out] msg_len The number of bits in the HMAC message.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_hmac_get_message_length(const dif_hmac_t *hmac,
                                          uint64_t *msg_len);
 
@@ -154,6 +159,7 @@ dif_result_t dif_hmac_get_message_length(const dif_hmac_t *hmac,
  * @param hmac The HMAC device to initiate the run on.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_hmac_process(const dif_hmac_t *hmac);
 
 /**
@@ -177,6 +183,7 @@ dif_result_t dif_hmac_process(const dif_hmac_t *hmac);
  * digest.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_hmac_finish(const dif_hmac_t *hmac, dif_hmac_digest_t *digest);
 
 /**
@@ -189,6 +196,7 @@ dif_result_t dif_hmac_finish(const dif_hmac_t *hmac, dif_hmac_digest_t *digest);
  * @param entropy A source of randomness to write to the HMAC internal state.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_hmac_wipe_secret(const dif_hmac_t *hmac, uint32_t entropy);
 
 #ifdef __cplusplus

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -89,6 +89,7 @@ typedef enum dif_otbn_err_bits {
  * @param otbn OTBN instance
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_reset(const dif_otbn_t *otbn);
 
 /**
@@ -98,6 +99,7 @@ dif_result_t dif_otbn_reset(const dif_otbn_t *otbn);
  * @param cmd The command.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_write_cmd(const dif_otbn_t *otbn, dif_otbn_cmd_t cmd);
 
 /**
@@ -107,6 +109,7 @@ dif_result_t dif_otbn_write_cmd(const dif_otbn_t *otbn, dif_otbn_cmd_t cmd);
  * @param[out] status OTBN status
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_get_status(const dif_otbn_t *otbn,
                                  dif_otbn_status_t *status);
 
@@ -117,6 +120,7 @@ dif_result_t dif_otbn_get_status(const dif_otbn_t *otbn,
  * @param[out] err_bits The error bits returned by the hardware.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
                                    dif_otbn_err_bits_t *err_bits);
 
@@ -131,6 +135,7 @@ dif_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
  * @param[out] insn_cnt The number of instructions executed by OTBN.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_get_insn_cnt(const dif_otbn_t *otbn, uint32_t *insn_cnt);
 
 /**
@@ -144,6 +149,7 @@ dif_result_t dif_otbn_get_insn_cnt(const dif_otbn_t *otbn, uint32_t *insn_cnt);
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_imem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                  const void *src, size_t len_bytes);
 
@@ -158,6 +164,7 @@ dif_result_t dif_otbn_imem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_imem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                 void *dest, size_t len_bytes);
 
@@ -172,6 +179,7 @@ dif_result_t dif_otbn_imem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                  const void *src, size_t len_bytes);
 
@@ -186,6 +194,7 @@ dif_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                 void *dest, size_t len_bytes);
 
@@ -200,6 +209,7 @@ dif_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
  * @return The result of the operation, `kDifUnavailable` is returned when the
  * requested change cannot be made.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_set_ctrl_software_errs_fatal(const dif_otbn_t *otbn,
                                                    bool enable);
 

--- a/sw/device/lib/dif/dif_pinmux.h
+++ b/sw/device/lib/dif/dif_pinmux.h
@@ -359,6 +359,7 @@ dif_result_t dif_pinmux_output_select(const dif_pinmux_t *pinmux,
  *                       hardware.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_pinmux_pad_write_attrs(const dif_pinmux_t *pinmux,
                                         dif_pinmux_index_t pad,
                                         dif_pinmux_pad_kind_t type,
@@ -374,6 +375,7 @@ dif_result_t dif_pinmux_pad_write_attrs(const dif_pinmux_t *pinmux,
  * @param attrs[out] Obtained attributes.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_pinmux_pad_get_attrs(const dif_pinmux_t *pinmux,
                                       dif_pinmux_index_t pad,
                                       dif_pinmux_pad_kind_t type,

--- a/sw/device/lib/dif/dif_rv_timer.h
+++ b/sw/device/lib/dif/dif_rv_timer.h
@@ -80,6 +80,7 @@ typedef struct dif_rv_timer_tick_params {
  *         counter frequency.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_timer_approximate_tick_params(
     uint64_t clock_freq, uint64_t counter_freq,
     dif_rv_timer_tick_params_t *out);
@@ -91,6 +92,7 @@ dif_result_t dif_rv_timer_approximate_tick_params(
  * @param timer A timer device.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_timer_reset(const dif_rv_timer_t *timer);
 
 /**
@@ -106,6 +108,7 @@ dif_result_t dif_rv_timer_reset(const dif_rv_timer_t *timer);
  * @param params The timing parameters.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_timer_set_tick_params(const dif_rv_timer_t *timer,
                                           uint32_t hart_id,
                                           dif_rv_timer_tick_params_t params);
@@ -121,6 +124,7 @@ dif_result_t dif_rv_timer_set_tick_params(const dif_rv_timer_t *timer,
  * @param state The new enablement state.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_timer_counter_set_enabled(const dif_rv_timer_t *timer,
                                               uint32_t hart_id,
                                               dif_toggle_t state);
@@ -133,6 +137,7 @@ dif_result_t dif_rv_timer_counter_set_enabled(const dif_rv_timer_t *timer,
  * @param[out] out The counter value.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_timer_counter_read(const dif_rv_timer_t *timer,
                                        uint32_t hart_id, uint64_t *out);
 
@@ -144,6 +149,7 @@ dif_result_t dif_rv_timer_counter_read(const dif_rv_timer_t *timer,
  * @param count The counter value to write.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_timer_counter_write(const dif_rv_timer_t *timer,
                                         uint32_t hart_id, uint64_t count);
 
@@ -175,6 +181,7 @@ dif_result_t dif_rv_timer_counter_write(const dif_rv_timer_t *timer,
  * @param threshold The value to go off at.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_timer_arm(const dif_rv_timer_t *timer, uint32_t hart_id,
                               uint32_t comp_id, uint64_t threshold);
 

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -271,6 +271,7 @@ dif_result_t dif_uart_tx_bytes_available(const dif_uart_t *uart,
  * @param reset FIFO to reset (RX, TX or both).
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_uart_fifo_reset(const dif_uart_t *uart,
                                  dif_uart_fifo_reset_t reset);
 
@@ -294,6 +295,7 @@ dif_result_t dif_uart_fifo_reset(const dif_uart_t *uart,
  * @param enable Enable/disable control flag.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_uart_loopback_set(const dif_uart_t *uart,
                                    dif_uart_loopback_t loopback,
                                    dif_toggle_t enable);

--- a/sw/device/lib/runtime/otbn.c
+++ b/sw/device/lib/runtime/otbn.c
@@ -179,7 +179,9 @@ otbn_result_t otbn_dump_dmem(const otbn_t *ctx, uint32_t max_addr) {
 
   for (int i = 0; i < max_addr; i += kOtbnWlenBytes) {
     uint32_t data[kOtbnWlenBytes / sizeof(uint32_t)];
-    dif_otbn_dmem_read(&ctx->dif, i, data, kOtbnWlenBytes);
+    if (dif_otbn_dmem_read(&ctx->dif, i, data, kOtbnWlenBytes) != kDifOk) {
+      return kOtbnError;
+    }
 
     LOG_INFO("DMEM @%04d: 0x%08x%08x%08x%08x%08x%08x%08x%08x",
              i / kOtbnWlenBytes, data[7], data[6], data[5], data[4], data[3],

--- a/sw/device/lib/testing/_index.md
+++ b/sw/device/lib/testing/_index.md
@@ -24,6 +24,8 @@ code will live in: `sw/device/lib/testing/test\_framework`.
   This corresponds to the format: `<filename>_<function name>()`.
 - There is no strict return typing required, though ideally most `testutils` functions should return **void** or **bool**.
   This is because test errors should be checked in `testutils` functions themselves using the `CHECK()` macros defined in `sw/device/lib/testing/check.h`.
+  - Functions that return **bool** to represent an error should be marked with **OT_WARN_UNUSED_RESULT** to avoid mistakenly ignoring errors.
+    Return **false** to represent an error.
 - Try to keep `testutils` libraries toplevel agnostic (e.g., don’t include `hw/top_earlgrey/sw/autogen/top_earlgrey.h` if you can avoid it).
   This means `dif_<ip>_init()` DIFs should be invoked in chip-level tests, *not* `testutils`, and the DIF handles should be passed in as parameters to `testutils` functions.
 - Pass-through `sw/device/lib/dif_base.h` types where appropriate.

--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -53,7 +53,7 @@ bool flash_ctrl_testutils_wait_transaction_end(
   }
   CHECK_DIF_OK(
       dif_flash_ctrl_clear_error_codes(flash_state, output.error_code.codes));
-  return output.operation_error;
+  return output.operation_error == 0;
 }
 
 uint32_t flash_ctrl_testutils_data_region_setup_properties(
@@ -186,7 +186,7 @@ bool flash_ctrl_testutils_write(dif_flash_ctrl_state_t *flash_state,
   const uint32_t prog_window_size =
       (uint32_t)FLASH_CTRL_PARAM_REG_BUS_PGM_RES_BYTES / sizeof(uint32_t);
   const uint32_t prog_window_mask = ~(prog_window_size - 1);
-  bool retval = false;
+  bool retval = true;
   while (words_written < word_count) {
     // Writes must not cross programming resolution window boundaries, which
     // occur at every prog_window_size words.
@@ -200,7 +200,7 @@ bool flash_ctrl_testutils_write(dif_flash_ctrl_state_t *flash_state,
     CHECK_DIF_OK(dif_flash_ctrl_start(flash_state, transaction));
     CHECK_DIF_OK(dif_flash_ctrl_prog_fifo_push(flash_state, words_to_write,
                                                data + words_written));
-    retval |= flash_ctrl_testutils_wait_transaction_end(flash_state);
+    retval &= flash_ctrl_testutils_wait_transaction_end(flash_state);
     word_address += words_to_write;
     words_written += words_to_write;
   }
@@ -214,7 +214,7 @@ bool flash_ctrl_testutils_erase_and_write_page(
     dif_flash_ctrl_partition_type_t partition_type, uint32_t word_count) {
   bool retval = flash_ctrl_testutils_erase_page(flash_state, byte_address,
                                                 partition_id, partition_type);
-  retval |= flash_ctrl_testutils_write(flash_state, byte_address, partition_id,
+  retval &= flash_ctrl_testutils_write(flash_state, byte_address, partition_id,
                                        data, partition_type, word_count);
   return retval;
 }

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -24,8 +24,9 @@ void flash_ctrl_testutils_wait_for_init(dif_flash_ctrl_state_t *flash_state);
  * Clears any error codes and returns the value of operation_error.
  *
  * @param flash_state A flash_ctrl state handle.
- * @return True if the operation produced an error.
+ * @return False if the operation produced an error.
  */
+OT_WARN_UNUSED_RESULT
 bool flash_ctrl_testutils_wait_transaction_end(
     dif_flash_ctrl_state_t *flash_state);
 
@@ -119,8 +120,9 @@ uint32_t flash_ctrl_testutils_info_region_scrambled_setup(
  * @param byte_address The byte address of the page to erase.
  * @param partition_id The partition index.
  * @param partition_type The partition type, data or info.
- * @return The operation error flag.
+ * @return False if the operation failed.
  */
+OT_WARN_UNUSED_RESULT
 bool flash_ctrl_testutils_erase_page(
     dif_flash_ctrl_state_t *flash_state, uint32_t byte_address,
     uint32_t partition_id, dif_flash_ctrl_partition_type_t partition_type);
@@ -138,8 +140,9 @@ bool flash_ctrl_testutils_erase_page(
  * @param data The data to program.
  * @param partition_type The partition type, data or info.
  * @param word_count The number of words to program.
- * @return True if the operation produced an error.
+ * @return False if the operation produced an error.
  */
+OT_WARN_UNUSED_RESULT
 bool flash_ctrl_testutils_write(dif_flash_ctrl_state_t *flash_state,
                                 uint32_t byte_address, uint32_t partition_id,
                                 const uint32_t *data,
@@ -157,8 +160,9 @@ bool flash_ctrl_testutils_write(dif_flash_ctrl_state_t *flash_state,
  * @param data The data to program.
  * @param partition_type The partition type, data or info.
  * @param word_count The number of words to program.
- * @return The combined operation error flags from erase and program.
+ * @return False if the operation fails.
  */
+OT_WARN_UNUSED_RESULT
 bool flash_ctrl_testutils_erase_and_write_page(
     dif_flash_ctrl_state_t *flash_state, uint32_t byte_address,
     uint32_t partition_id, const uint32_t *data,
@@ -176,6 +180,7 @@ bool flash_ctrl_testutils_erase_and_write_page(
  * @param word_count The number of words to read.
  * @return The operation error flag.
  */
+OT_WARN_UNUSED_RESULT
 bool flash_ctrl_testutils_read(dif_flash_ctrl_state_t *flash_state,
                                uint32_t byte_address, uint32_t partition_id,
                                uint32_t *data_out,
@@ -205,8 +210,9 @@ void flash_ctrl_testutils_default_region_access(
  * @param bank The bank ID.
  * @param data_only True to only erase the data partitions. False to erase
  *                  everything.
- * @return if the operation failed.
+ * @return False if the operation failed.
  */
+OT_WARN_UNUSED_RESULT
 bool flash_ctrl_testutils_bank_erase(dif_flash_ctrl_state_t *flash_state,
                                      uint32_t bank, bool data_only);
 

--- a/sw/device/lib/testing/sram_ctrl_testutils.h
+++ b/sw/device/lib/testing/sram_ctrl_testutils.h
@@ -35,6 +35,7 @@ void sram_ctrl_testutils_write(uintptr_t address,
  *
  * The data is checked for equality.
  */
+OT_WARN_UNUSED_RESULT
 bool sram_ctrl_testutils_read_check_eq(
     uintptr_t address, const sram_ctrl_testutils_data_t *expected);
 
@@ -43,6 +44,7 @@ bool sram_ctrl_testutils_read_check_eq(
  *
  * The data is checked for inequality.
  */
+OT_WARN_UNUSED_RESULT
 bool sram_ctrl_testutils_read_check_neq(
     uintptr_t address, const sram_ctrl_testutils_data_t *expected);
 

--- a/sw/device/tests/flash_ctrl_test.c
+++ b/sw/device/tests/flash_ctrl_test.c
@@ -67,17 +67,17 @@ static void test_basic_io(void) {
 
   // Test erasing flash data partition; this should turn the whole bank to all
   // ones.
-  CHECK_EQZ(flash_ctrl_testutils_erase_page(&flash, flash_bank_1_addr,
-                                            /*partition_id=*/0,
-                                            kDifFlashCtrlPartitionTypeData));
+  CHECK(flash_ctrl_testutils_erase_page(&flash, flash_bank_1_addr,
+                                        /*partition_id=*/0,
+                                        kDifFlashCtrlPartitionTypeData));
   for (int i = 0; i < FLASH_WORDS_PER_PAGE; ++i) {
     CHECK_EQZ(~mmio_region_read32(flash_bank_1, i * sizeof(uint32_t)));
   }
 
   // Erasing flash info partition 0; this should turn one page to all ones.
-  CHECK_EQZ(flash_ctrl_testutils_erase_page(&flash, flash_bank_1_addr,
-                                            /*partition_id=*/0,
-                                            kDifFlashCtrlPartitionTypeInfo));
+  CHECK(flash_ctrl_testutils_erase_page(&flash, flash_bank_1_addr,
+                                        /*partition_id=*/0,
+                                        kDifFlashCtrlPartitionTypeInfo));
 
   // Prepare an entire page of non-trivial data to program
   // into flash.
@@ -90,12 +90,12 @@ static void test_basic_io(void) {
 
   // Attempt to live-program an entire page, where the overall
   // payload is much larger than the internal flash FIFO.
-  CHECK_EQZ(flash_ctrl_testutils_erase_and_write_page(
+  CHECK(flash_ctrl_testutils_erase_and_write_page(
       &flash, flash_bank_1_addr, /*partition_id=*/0, input_page,
       kDifFlashCtrlPartitionTypeData, FLASH_WORDS_PER_PAGE));
-  CHECK_EQZ(flash_ctrl_testutils_read(
-      &flash, flash_bank_1_addr, /*partition_id=*/0, output_page,
-      kDifFlashCtrlPartitionTypeData, FLASH_WORDS_PER_PAGE, /*delay=*/0));
+  CHECK(flash_ctrl_testutils_read(&flash, flash_bank_1_addr, /*partition_id=*/0,
+                                  output_page, kDifFlashCtrlPartitionTypeData,
+                                  FLASH_WORDS_PER_PAGE, /*delay=*/0));
   CHECK_ARRAYS_EQ(output_page, input_page, FLASH_WORDS_PER_PAGE);
 
   // Check from host side also.
@@ -105,12 +105,12 @@ static void test_basic_io(void) {
   CHECK_ARRAYS_EQ(output_page, input_page, FLASH_WORDS_PER_PAGE);
 
   // Similar check for info page.
-  CHECK_EQZ(flash_ctrl_testutils_erase_and_write_page(
+  CHECK(flash_ctrl_testutils_erase_and_write_page(
       &flash, flash_bank_1_addr, /*partition_id=*/0, input_page,
       kDifFlashCtrlPartitionTypeInfo, FLASH_WORDS_PER_PAGE));
-  CHECK_EQZ(flash_ctrl_testutils_read(
-      &flash, flash_bank_1_addr, /*partition_id=*/0, output_page,
-      kDifFlashCtrlPartitionTypeInfo, FLASH_WORDS_PER_PAGE, /*delay=*/0));
+  CHECK(flash_ctrl_testutils_read(&flash, flash_bank_1_addr, /*partition_id=*/0,
+                                  output_page, kDifFlashCtrlPartitionTypeInfo,
+                                  FLASH_WORDS_PER_PAGE, /*delay=*/0));
   CHECK_ARRAYS_EQ(output_page, input_page, FLASH_WORDS_PER_PAGE);
 
   // Set up default access for data partitions.
@@ -122,18 +122,18 @@ static void test_basic_io(void) {
   ptrdiff_t flash_bank_0_last_page_addr = flash_bank_1_addr - FLASH_PAGE_SZ;
   mmio_region_t flash_bank_0_last_page = mmio_region_from_addr(
       TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR + flash_bank_0_last_page_addr);
-  CHECK_EQZ(flash_ctrl_testutils_erase_page(&flash, flash_bank_0_last_page_addr,
-                                            /*partition_id=*/0,
-                                            kDifFlashCtrlPartitionTypeData));
+  CHECK(flash_ctrl_testutils_erase_page(&flash, flash_bank_0_last_page_addr,
+                                        /*partition_id=*/0,
+                                        kDifFlashCtrlPartitionTypeData));
   for (int i = 0; i < FLASH_WORDS_PER_PAGE; ++i) {
     CHECK_EQZ(
         ~mmio_region_read32(flash_bank_0_last_page, i * sizeof(uint32_t)));
   }
 
-  CHECK_EQZ(flash_ctrl_testutils_write(
+  CHECK(flash_ctrl_testutils_write(
       &flash, flash_bank_0_last_page_addr, /*partition_id=*/0, input_page,
       kDifFlashCtrlPartitionTypeData, FLASH_WORDS_PER_PAGE));
-  CHECK_EQZ(flash_ctrl_testutils_read(
+  CHECK(flash_ctrl_testutils_read(
       &flash, flash_bank_0_last_page_addr, /*partition_id=*/0, output_page,
       kDifFlashCtrlPartitionTypeData, FLASH_WORDS_PER_PAGE, /*delay=*/0));
 
@@ -173,12 +173,12 @@ static void test_memory_protection(void) {
   uintptr_t bad_region_start = ok_region_end;
 
   // Erase good and bad regions.
-  CHECK_EQZ(flash_ctrl_testutils_erase_page(&flash, ok_region_start,
-                                            /*partition_id=*/0,
-                                            kDifFlashCtrlPartitionTypeData));
-  CHECK_EQZ(flash_ctrl_testutils_erase_page(&flash, bad_region_start,
-                                            /*partition_id=*/0,
-                                            kDifFlashCtrlPartitionTypeData));
+  CHECK(flash_ctrl_testutils_erase_page(&flash, ok_region_start,
+                                        /*partition_id=*/0,
+                                        kDifFlashCtrlPartitionTypeData));
+  CHECK(flash_ctrl_testutils_erase_page(&flash, bad_region_start,
+                                        /*partition_id=*/0,
+                                        kDifFlashCtrlPartitionTypeData));
 
   // Turn off flash access by default.
   flash_ctrl_testutils_default_region_access(
@@ -201,7 +201,7 @@ static void test_memory_protection(void) {
   }
 
   // Perform a partial write.
-  CHECK_NEZ(flash_ctrl_testutils_write(
+  CHECK(!flash_ctrl_testutils_write(
       &flash, region_boundary_start, /*partition_id=*/0, words,
       kDifFlashCtrlPartitionTypeData, ARRAYSIZE(words)));
   // Words in the good region should still match, while words in the bad
@@ -216,14 +216,14 @@ static void test_memory_protection(void) {
   }
 
   // Attempt to erase bad page, which should fail.
-  CHECK_NEZ(flash_ctrl_testutils_erase_page(&flash, bad_region_start,
-                                            /*partition_id=*/0,
-                                            kDifFlashCtrlPartitionTypeData));
+  CHECK(!flash_ctrl_testutils_erase_page(&flash, bad_region_start,
+                                         /*partition_id=*/0,
+                                         kDifFlashCtrlPartitionTypeData));
 
   // Attempt to erase the good page, which should succeed.
-  CHECK_EQZ(flash_ctrl_testutils_erase_page(&flash, ok_region_start,
-                                            /*partition_id=*/0,
-                                            kDifFlashCtrlPartitionTypeData));
+  CHECK(flash_ctrl_testutils_erase_page(&flash, ok_region_start,
+                                        /*partition_id=*/0,
+                                        kDifFlashCtrlPartitionTypeData));
   for (int i = 0; i < FLASH_WORDS_PER_PAGE; i++) {
     CHECK_EQZ(~mmio_region_read32(ok_region, i * sizeof(uint32_t)));
   }


### PR DESCRIPTION
Fix a number of dif functions missing OT_WARN_UNUSED_RESULT.
Add OT_WARN_UNUSED_RESULT to testutils functions that return errors.
Change the polarity of testutils returning bool for errors so true
means okay.
Add some recommendations regarding this to the testutils doc.

Signed-off-by: Guillermo Maturana <maturana@google.com>