### PR TITLE
[flash_ctrl] Track buffer / response queue dependency

### DIFF
--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -38,9 +38,10 @@ filesets:
       - rtl/flash_phy.sv
       - rtl/flash_phy_core.sv
       - rtl/flash_phy_rd.sv
+      - rtl/flash_phy_rd_buffers.sv
+      - rtl/flash_phy_rd_buf_dep.sv
       - rtl/flash_phy_prog.sv
       - rtl/flash_phy_erase.sv
-      - rtl/flash_phy_rd_buffers.sv
       - rtl/flash_phy_scramble.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -137,7 +137,14 @@ module flash_phy_rd
   for (genvar i = 0; i < NumBuf; i++) begin: gen_buf_states
     assign buf_valid[i]   = read_buf[i].attr == Valid;
     assign buf_wip[i]     = read_buf[i].attr == Wip;
-    assign buf_invalid[i] = read_buf[i].attr == Invalid;
+
+    // if a buffer is valid and contains an error, it should be considered
+    // invalid as long as there are no pending responses already waiting
+    // on that buffer.
+    assign buf_invalid[i] = (read_buf[i].attr == Invalid) |
+                            (read_buf[i].attr == Valid &
+                            read_buf[i].err &
+                            ~buf_dependency[i]);
   end
 
   assign buf_invalid_alloc[0] = buf_invalid[0];
@@ -290,76 +297,20 @@ module flash_phy_rd
   logic rsp_order_fifo_wr;
   assign rsp_order_fifo_wr = req_i && rdy_o;
 
-  // The following logic determines the dependency between entries in the read buffer
-  // with items currently queued up for response.
-  localparam int NumBufWidth = $clog2(NumBuf);
+  logic rsp_order_fifo_rd;
+  assign rsp_order_fifo_rd = rsp_fifo_vld & data_valid_o;
 
-   // also need to add an assertion to check for overflows
-  localparam int BufDepCntWidth = $clog2(RspOrderDepth + 1);
-  logic [NumBuf-1:0][BufDepCntWidth-1:0] buf_dependency_cnt;
-
-  // The logic below can be more simplified in an always_comb loop,
-  // but the `i` assignment causes some lint tools to be mildly unhappy.
-  // This separarate creation seems to be more tool friendly.
-  logic [NumBuf-1:0][NumBufWidth-1:0] buf_mux_cnt;
-  for(genvar i = 0; i < NumBuf; i++) begin : gen_cnt_assign
-     assign buf_mux_cnt[i] = i;
-  end
-
-  // the dep buf select needs to be different between increment and decrement
-  // When incrementing, we are looking at the wdata of the rsp_order_fifo
-  // When decrementing, we are looking at the rdata of the rsp_order_fifo
-  logic [NumBufWidth-1:0] incr_buf_sel;
-  logic [NumBufWidth-1:0] decr_buf_sel;
-  always_comb begin
-    incr_buf_sel = '0;
-    decr_buf_sel = '0;
-    for (int unsigned i = 0; i < NumBuf; i++) begin
-      if (rsp_fifo_wdata.buf_sel[i]) begin
-        incr_buf_sel = buf_mux_cnt[i];
-      end
-      if (rsp_fifo_rdata.buf_sel[i]) begin
-        decr_buf_sel = buf_mux_cnt[i];
-      end
-    end
-  end // always_comb
-
-  logic [BufDepCntWidth-1:0] curr_incr_cnt, curr_decr_cnt;
-  assign curr_incr_cnt = buf_en_q & buf_dependency_cnt[incr_buf_sel];
-  assign curr_decr_cnt = buf_en_q & buf_dependency_cnt[decr_buf_sel];
-
-  logic cnt_incr, cnt_decr;
-  assign cnt_incr = rsp_order_fifo_wr & (curr_incr_cnt < RspOrderDepth);
-  assign cnt_decr = (rsp_fifo_vld & data_valid_o) & (curr_decr_cnt > '0);
-
-  logic fin_cnt_incr, fin_cnt_decr;
-  assign fin_cnt_incr = (incr_buf_sel == decr_buf_sel) ? cnt_incr && !cnt_decr : cnt_incr;
-  assign fin_cnt_decr = (incr_buf_sel == decr_buf_sel) ? !cnt_incr && cnt_decr : cnt_decr;
-
-  // This tells us which buffer currently has a dependency to an item in the rsp_order_fifo
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      buf_dependency_cnt <= '0;
-    end else begin
-       if (fin_cnt_incr) begin
-          buf_dependency_cnt[incr_buf_sel] <= curr_incr_cnt + 1'b1;
-       end
-       if (fin_cnt_decr) begin
-          buf_dependency_cnt[decr_buf_sel] <= curr_decr_cnt - 1'b1;
-       end
-    end
-  end
-
-  // per buffer dependency determination
-  always_comb begin
-    buf_dependency = '0;
-    for (int i = 0; i < NumBuf; i++) begin
-      buf_dependency[i] = |buf_dependency_cnt[i];
-    end
-  end
-
-  // all buffer entries currently have a dependency
-  assign all_buf_dependency = &buf_dependency;
+  flash_phy_rd_buf_dep u_rd_buf_dep (
+    .clk_i,
+    .rst_ni,
+    .en_i(buf_en_q),
+    .fifo_wr_i(rsp_order_fifo_wr),
+    .fifo_rd_i(rsp_order_fifo_rd),
+    .wr_buf_i(rsp_fifo_wdata.buf_sel),
+    .rd_buf_i(rsp_fifo_rdata.buf_sel),
+    .dependency_o(buf_dependency),
+    .all_dependency_o(all_buf_dependency)
+  );
 
   // If width is the same, word_sel is unused
   if (WidthMultiple == 1) begin : gen_single_word_sel
@@ -393,7 +344,6 @@ module flash_phy_rd
     .rdata_o (rsp_fifo_rdata),
     .err_o   (rsp_order_fifo_err)
   );
-
 
   // Consider converting this to a FIFO for better matching
   // The rd_busy flag is effectively a "full" flag anyways of a single
@@ -670,7 +620,7 @@ module flash_phy_rd
     for (int i = 0; i < NumBuf; i++) begin
       if (buf_rsp_match[i]) begin
         buf_rsp_data = read_buf[i].data;
-        buf_rsp_err = read_buf[i].err;
+        buf_rsp_err = buf_rsp_err | read_buf[i].err;
       end
     end
   end
@@ -752,6 +702,9 @@ module flash_phy_rd
   // update should happen only to 1 buffer at time
   `ASSERT(OneHotUpdate_A, $onehot0(update))
 
+  // buffer response match should happen only to 1 buffer at time
+  `ASSERT(OneHotRspMatch_A, $onehot0(buf_rsp_match))
+
   // alloc and update should be mutually exclusive for a buffer
   `ASSERT(ExclusiveOps_A, (alloc & update) == 0 )
 
@@ -772,29 +725,6 @@ module flash_phy_rd
 
   // The read storage depth and mask depth should always be the same after popping
   `ASSERT(FifoSameDepth_A, rd_and_mask_fifo_pop |=> unused_rd_depth == unused_mask_depth)
-
-  // If there are more buffers than there are number of response fifo entries, we an never have
-  // a fully dependent condition
-  `ASSERT(BufferDepRsp_A, NumBuf > RspOrderDepth |-> ~all_buf_dependency)
-
-  // We should never attempt to increment when at max value
-  `ASSERT(BufferIncrOverFlow_A, rsp_order_fifo_wr |-> curr_incr_cnt < RspOrderDepth)
-
-  // We should never attempt to decrement when at min value
-  `ASSERT(BufferDecrUnderRun_A, rsp_fifo_vld & data_valid_o |-> (curr_decr_cnt > '0))
-
-  // The total number of dependent buffers cannot never exceed the size of response queue
-  `ifdef INC_ASSERT
-  logic [31:0] assert_cnt;
-  always_comb begin
-    assert_cnt = '0;
-    for (int unsigned i = 0; i < NumBuf; i++) begin
-      assert_cnt = assert_cnt + buf_dependency[i];
-    end
-  end
-
-  `ASSERT(DepBufferRspOrder_A, rsp_order_fifo_wr |=> assert_cnt <= RspOrderDepth)
-  `endif
 
   /////////////////////////////////
   // Functional coverage points to add

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd_buf_dep.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd_buf_dep.sv
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Flash Phy Read Buffers Dependency
+//
+// This module handles the dependency between response order FIFO
+// and the buffers.
+// Basically, it ensures that if an item queued up in the response
+// FIFO is waiting for a specific buffer, that buffer is not de-allocated
+// to serve a new request.
+//
+
+module flash_phy_rd_buf_dep import flash_phy_pkg::*;(
+  input clk_i,
+  input rst_ni,
+  input en_i,
+  input fifo_wr_i,
+  input fifo_rd_i,
+  input [NumBuf-1:0] wr_buf_i,
+  input [NumBuf-1:0] rd_buf_i,
+  output logic [NumBuf-1:0] dependency_o,
+  output logic all_dependency_o
+);
+
+  // The following logic determines the dependency between entries in the read buffer
+  // with items currently queued up for response.
+  localparam int NumBufWidth = $clog2(NumBuf);
+
+   // also need to add an assertion to check for overflows
+  localparam int BufDepCntWidth = $clog2(RspOrderDepth + 1);
+  logic [NumBuf-1:0][BufDepCntWidth-1:0] buf_dependency_cnt;
+
+  // The logic below can be more simplified in an always_comb loop,
+  // but the `i` assignment causes some lint tools to be mildly unhappy.
+  // This separarate creation seems to be more tool friendly.
+  logic [NumBuf-1:0][NumBufWidth-1:0] buf_mux_cnt;
+  for(genvar i = 0; i < NumBuf; i++) begin : gen_cnt_assign
+     assign buf_mux_cnt[i] = i;
+  end
+
+  // the dep buf select needs to be different between increment and decrement
+  // When incrementing, we are looking at the wdata of the rsp_order_fifo
+  // When decrementing, we are looking at the rdata of the rsp_order_fifo
+  logic [NumBufWidth-1:0] incr_buf_sel;
+  logic [NumBufWidth-1:0] decr_buf_sel;
+  always_comb begin
+    incr_buf_sel = '0;
+    decr_buf_sel = '0;
+    for (int unsigned i = 0; i < NumBuf; i++) begin
+      if (wr_buf_i[i]) begin
+        incr_buf_sel = buf_mux_cnt[i];
+      end
+      if (rd_buf_i[i]) begin
+        decr_buf_sel = buf_mux_cnt[i];
+      end
+    end
+  end // always_comb
+
+  logic [BufDepCntWidth-1:0] curr_incr_cnt, curr_decr_cnt;
+  assign curr_incr_cnt = buf_dependency_cnt[incr_buf_sel];
+  assign curr_decr_cnt = buf_dependency_cnt[decr_buf_sel];
+
+  logic cnt_incr, cnt_decr;
+  assign cnt_incr = en_i & fifo_wr_i & (curr_incr_cnt < RspOrderDepth);
+  assign cnt_decr = en_i & fifo_rd_i & (curr_decr_cnt > '0);
+
+  //assign cnt_decr = fifo_rd_i & (rsp_fifo_vld & data_valid_o) & (curr_decr_cnt > '0);
+
+  logic fin_cnt_incr, fin_cnt_decr;
+  assign fin_cnt_incr = (incr_buf_sel == decr_buf_sel) ? cnt_incr && !cnt_decr : cnt_incr;
+  assign fin_cnt_decr = (incr_buf_sel == decr_buf_sel) ? !cnt_incr && cnt_decr : cnt_decr;
+
+  // This tells us which buffer currently has a dependency to an item in the rsp_order_fifo
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      buf_dependency_cnt <= '0;
+    end else begin
+       if (fin_cnt_incr) begin
+          buf_dependency_cnt[incr_buf_sel] <= curr_incr_cnt + 1'b1;
+       end
+       if (fin_cnt_decr) begin
+          buf_dependency_cnt[decr_buf_sel] <= curr_decr_cnt - 1'b1;
+       end
+    end
+  end
+
+  // per buffer dependency determination
+  always_comb begin
+    dependency_o = '0;
+    for (int i = 0; i < NumBuf; i++) begin
+      dependency_o[i] = |buf_dependency_cnt[i];
+    end
+  end
+
+  // all buffer entries currently have a dependency
+  assign all_dependency_o = &dependency_o;
+
+
+  // If there are more buffers than there are number of response fifo entries, we an never have
+  // a fully dependent condition
+  `ASSERT(BufferDepRsp_A, NumBuf > RspOrderDepth |-> ~all_dependency_o)
+
+  // We should never attempt to increment when at max value
+  `ASSERT(BufferIncrOverFlow_A, en_i & fifo_wr_i |-> curr_incr_cnt < RspOrderDepth)
+
+  // We should never attempt to decrement when at min value
+  `ASSERT(BufferDecrUnderRun_A, en_i & fifo_rd_i |-> (curr_decr_cnt > '0))
+
+  // The total number of dependent buffers cannot never exceed the size of response queue
+  `ifdef INC_ASSERT
+  logic [31:0] assert_cnt;
+  always_comb begin
+    assert_cnt = '0;
+    for (int unsigned i = 0; i < NumBuf; i++) begin
+      assert_cnt = assert_cnt + dependency_o[i];
+    end
+  end
+
+  `ASSERT(DepBufferRspOrder_A, fifo_wr_i |=> assert_cnt <= RspOrderDepth)
+  `endif
+
+
+endmodule // flash_phy_rd_buf_dep


### PR DESCRIPTION
- fixes https://github.com/lowRISC/opentitan/issues/13808
- This fix allows each buffer to track how many items in the
  response queue is currently dependent on its current state. If the
  dependency is 0, then it is allowed to re-allocate for a new
  transaction.
- If all buffers have a dependency, then a new flash transaction cannot
  be accepted.
- This is not the ideal solution, https://github.com/lowRISC/opentitan/issues/13812 is a slightly better solution with less blocking, but that's a more significant change that what is proposed in this PR.