### PR TITLE
[flash_ctrl,dv] tl integrity error from rd_fifo rsp

### DIFF
--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -25,10 +25,12 @@ package csr_utils_pkg;
 
   function automatic void increment_outstanding_access();
     outstanding_accesses++;
+    `JDBG(("OSTD inc ost : %0d",outstanding_accesses))
   endfunction
 
   function automatic void decrement_outstanding_access();
     outstanding_accesses--;
+    `JDBG(("OSTD dec ost : %0d",outstanding_accesses))
   endfunction
 
   task automatic wait_no_outstanding_access();

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -549,3 +549,8 @@
 `ifndef DV_MAX2
   `define DV_MAX2(a, b) ((a) > (b) ? (a) : (b))
 `endif
+`ifndef JDBG
+  `define JDBG(x) \
+  $write($sformatf("%t:JDBG:",$time));\
+  $display($sformatf x);
+`endif

--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -276,18 +276,40 @@
       tests: ["flash_ctrl_mid_op_rst"]
     }
     {
-      name: ecc
+      name: double_bit_err
       desc: '''
-            Randomly enable ECC for a randomly selected set of pages. Randomly corrupt a single bit
-            in the memory that is about to be read and ensure that the ECC works - the corrupted
-            bit should be fixed. Corrupt randomly either the data or the ECC bits. Randomly corrupt
-            2 bits in the same word and ensure that the read results in error. Ensure that pages
-            with ECC not enabled reads back corrupted data without any errors. Verify both types,
-            pre-scramble ECC(integrity ECC, 4-bits) and post-scramble ECC(reliability ECC, 8-bits).
-	    Test status and control ECC bits.
+            Run read only or read write test with randomly injected double bit error.
+            For ctrl read, expected double bit error transaction is checked by reading
+            op_status.err and err_code.rd_err.
+            For direct read, expected double bit error transaction is checked by
+            tl_agent.
             '''
       milestone: V2
-      tests: []
+      tests: ["flash_ctrl_read_word_sweep_derr", "flash_ctrl_read_rand_word_derr",
+              "flash_ctrl_ro_derr", "flash_ctrl_rw_derr", "flash_ctrl_rw_rand_word_derr"]
+    }
+    {
+      name: double_bit_err_detect
+      desc: '''
+            Run read write test and inject double bit erorr only once in random time.
+            Check wheter the fatal alert is asserted.
+            For ctrl read, op_status.err and err_code.rd_err shoudl be set.
+            For direct read, read response should have d_error set.
+            Do this for a multiple rounds.
+            '''
+      milestone: V2
+      tests: ["flash_ctrl_derr_detect"]
+    }
+    {
+      name: integrity_ecc_test
+      desc: '''
+            Run read write test with corrupted integrity value in random time.
+            Check wheter the fatal alert is asserted.
+            For ctrl read, op_status.err and err_code.rd_err shoudl be set.
+            For direct read, read response should have d_error set.
+            '''
+      milestone: V2
+      tests: ["flash_ctrl_integrity"]
     }
     {
       name: single_bit_err

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -65,6 +65,8 @@ filesets:
       - seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_serr_counter_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_serr_address_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_derr_detect_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_integrity_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -61,6 +61,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // 2 : 1 bit error test mode
   //     Based on serr_pct, single bit error is injected in 'flash_mem_otf_read'
   // 3 : 2 bit error test mode
+  // 4 : integrity error test mode
   int ecc_mode = 0;
 
   // single bit error rate scale of 0~10. 10: 100%.
@@ -76,6 +77,25 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // Create serr only once. Used in directed test case.
   bit serr_once = 0;
   bit serr_created = 0;
+
+  // Double bit error test
+  int derr_pct = 0;
+  int derr_idx[76];
+  bit derr_addr_tbl[addr_t];
+  bit derr_once = 0;
+  bit derr_created[2] = '{default : 0};
+
+  // Mark out standing transactions.
+  // With heavy concurrency, derr can be injected where read transaction
+  // is issued and outstanding.
+  // This can change error expectation of the first transaction.
+  // To handle this conrnercase, don't assert derr on outstanding read location.
+  int derr_otd[addr_t];
+
+  // Integrity ecc err
+  int ierr_pct = 0;
+  bit ierr_addr_tbl[addr_t];
+  bit ierr_created[2] = '{default : 0};
   // Transaction counters for otf
   int otf_ctrl_wr_sent = 0;
   int otf_ctrl_wr_rcvd = 0;
@@ -154,6 +174,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     alert_max_delay = 20000;
     `uvm_info(`gfn, $sformatf("ral_model_names: %0p", ral_model_names), UVM_LOW)
     foreach (tgt_pre[i]) tgt_pre[i] = i;
+    foreach (derr_idx[i]) derr_idx[i] = i;
   endfunction : initialize
 
   // For a given partition returns its size in bytes in each of the banks.
@@ -662,7 +683,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     end
   endfunction : set_scb_mem
 
-  function int get_err_idx();
+  function int get_serr_idx();
     int rnd_odds;
     int idx = -1;
     if (serr_once == 1 && serr_created == 1) return -1;
@@ -677,6 +698,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     return idx;
   endfunction // get_err_idx
 
+  // Increase single bit error count.
   function void inc_serr_cnt(int bank, bit dis = 0);
     if (serr_cnt[bank] < 255) serr_cnt[bank]++;
     if (dis) begin
@@ -684,13 +706,39 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     end
   endfunction
 
-  function void add_serr(flash_op_t flash_op);
+  // Flip a bit at given address.
+  function void flash_bit_flip(mem_bkdr_util _h, addr_t addr, int idx);
+    bit [75:0] rdata;
+    rdata = _h.read(addr);
+    rdata[idx] = ~rdata[idx];
+    _h.write(addr, rdata);
+  endfunction
+
+  // Corrupt integrity check value only
+  function void flash_icv_flip(mem_bkdr_util _h, addr_t addr,
+                               flash_otf_item exp_item);
+    flash_otf_item item;
+
+    `uvm_create_obj(flash_otf_item, item)
+    item.dq.push_back($urandom());
+    item.dq.push_back($urandom());
+    item.region = exp_item.region;
+    item.scramble(exp_item.addr_key, exp_item.data_key, addr, 0, 1);
+    _h.write(addr, item.fq[0]);
+    item.clear_qs();
+  endfunction
+
+  // Create bit error follwing flash_op and  ecc_mode.
+  // @caller : 0 controller,  1: host
+  function void add_bit_err(flash_op_t flash_op, bit caller = 0,
+                            flash_otf_item item = null);
     flash_dv_part_e partition;
     int bank;
     bit [75:0] rdata;
     int        size, is_odd, tail;
     int        err_idx;
     addr_t aligned_addr, addr_cp;
+    string     name = $sformatf("add_bit_err_%0d", caller);
 
     err_idx = -1;
     aligned_addr = flash_op.addr;
@@ -706,39 +754,142 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     tail = (flash_op.num_words + is_odd) % 2;
 
     addr_cp = aligned_addr;
+    if (ecc_mode == 3 && derr_otd.exists(addr_cp)) return;
     // Use per bank address.
     aligned_addr[31:OTFBankId] = 'h0;
     for (int i = 0; i < size; i++) begin
-      err_idx = get_err_idx();
-      if (err_idx >= 0) begin
+      if (ecc_mode == 2) begin
+        err_idx = get_serr_idx();
         if (!serr_addr_tbl.exists(addr_cp)) begin
           serr_addr_tbl[addr_cp] = 1;
-          rdata = mem_bkdr_util_h[partition][bank].read(aligned_addr);
-          `uvm_info("add_serr",
+          `uvm_info(name,
                     $sformatf("single bit error is inserted at line:%0d the databit[%0d]",
-                    i, err_idx), UVM_MEDIUM)
-          rdata[err_idx] = ~rdata[err_idx];
-
-          mem_bkdr_util_h[partition][bank].write(aligned_addr, rdata);
+                              i, err_idx), UVM_MEDIUM)
+          flash_bit_flip(mem_bkdr_util_h[partition][bank], aligned_addr, err_idx);
         end
-      end
+      end else if (ecc_mode == 4) begin
+        randcase
+          ierr_pct:begin
+            if (!ierr_addr_tbl.exists(addr_cp)) begin
+              ierr_addr_tbl[addr_cp] = 1;
+              `uvm_info(name,
+                        $sformatf("icv error is inserted at line:%0d", i), UVM_MEDIUM)
+              flash_icv_flip(mem_bkdr_util_h[partition][bank], aligned_addr, item);
+            end
+            ierr_created[caller] = 1;
+          end
+          10-ierr_pct:begin
+          end
+        endcase // randcase
+      end else begin // if (ecc_mode == 2)
+        derr_idx.shuffle();
+        err_idx = 0;
+        if (derr_once == 0 || (derr_created[0] | derr_created[1]) == 0 ) begin
+          repeat(2) begin
+            randcase
+              derr_pct:begin
+                `uvm_info(name,
+                          $sformatf({"addr:0x%x %x bit error is inserted at line:%0d",
+                                     " the databit[%0d] err_idx:%0d"},
+                                    aligned_addr, addr_cp, i, derr_idx[err_idx], err_idx),
+                          UVM_MEDIUM)
+
+                // If address already had a single bit error, just skip this line.
+                // We could add another bit error then we have to model read cache behavior.
+                if (err_idx != 0 || serr_addr_tbl.exists(addr_cp) == 0) begin
+                  flash_bit_flip(mem_bkdr_util_h[partition][bank], aligned_addr, derr_idx[err_idx++]);
+                  serr_addr_tbl[addr_cp] = 1;
+                end
+                if (err_idx == 2) begin
+                  `uvm_info(name, $sformatf(" addr:0x%x is added to derr_addr_tbl", addr_cp),
+                            UVM_MEDIUM)
+                  derr_addr_tbl[addr_cp] = 1;
+                  derr_created[caller] = 1;
+                end
+              end
+              10-derr_pct:begin
+              end
+            endcase // randcase
+          end
+        end // if (derr_once == 0 || (|derr_created) == 0)
+      end // else: !if(ecc_mode == 2)
       aligned_addr += 8;
       addr_cp[OTFBankId-1:0] = aligned_addr[OTFBankId-1:0];
     end
     if (tail) begin
-      err_idx = get_err_idx();
-      if (err_idx >= 0) begin
+      if (ecc_mode == 2) begin
+        err_idx = get_serr_idx();
         if (!serr_addr_tbl.exists(addr_cp)) begin
           serr_addr_tbl[addr_cp] = 1;
-          rdata = mem_bkdr_util_h[partition][bank].read(aligned_addr);
-          `uvm_info("add_serr",
+          `uvm_info(name,
                     $sformatf("single bit error is inserted at line:%0d the databit[%0d]",
-                    size, err_idx), UVM_MEDIUM)
-          rdata[err_idx] = ~rdata[err_idx];
-          mem_bkdr_util_h[partition][bank].write(aligned_addr, rdata);
+                              size, err_idx), UVM_MEDIUM)
+          flash_bit_flip(mem_bkdr_util_h[partition][bank], aligned_addr, err_idx);
         end
+        ierr_created[caller] = 1;
+      end else if (ecc_mode == 4) begin
+        randcase
+          ierr_pct:begin
+            if (!ierr_addr_tbl.exists(addr_cp)) begin
+              ierr_addr_tbl[addr_cp] = 1;
+              `uvm_info(name,
+                        $sformatf("last:icv error is inserted at line:%0d", size), UVM_MEDIUM)
+              flash_icv_flip(mem_bkdr_util_h[partition][bank], aligned_addr, item);
+            end
+            ierr_created[caller] = 1;
+          end
+          10-ierr_pct:begin
+          end
+        endcase // randcase
+      end else begin // if (ecc_mode == 2)
+        derr_idx.shuffle();
+        err_idx = 0;
+        if (derr_once == 0 || (derr_created[0] | derr_created[1]) == 0) begin
+          repeat(2) begin
+            randcase
+              derr_pct:begin
+                `uvm_info(name,
+                          $sformatf({"last:addr:0x%x %x bit error is inserted at line:%0d",
+                                     " the databit[%0d] err_idx:%0d"},
+                                    aligned_addr, addr_cp, size, derr_idx[err_idx], err_idx),
+                          UVM_MEDIUM)
+                if (err_idx != 0 || serr_addr_tbl.exists(addr_cp) == 0) begin
+                  flash_bit_flip(mem_bkdr_util_h[partition][bank], aligned_addr,
+                                 derr_idx[err_idx++]);
+                  serr_addr_tbl[addr_cp] = 1;
+                end
+                if (err_idx == 2) begin
+                  derr_addr_tbl[addr_cp] = 1;
+                  derr_created[caller] = 1;
+                end
+              end
+              10-derr_pct:begin
+              end
+            endcase // randcase
+          end
+        end // if (derr_once == 0 || (|derr_created) == 0)
       end
     end
+  endfunction // add_bit_err
 
-  endfunction // add_serr
+  // Increase outstanding table entry.
+  function void inc_otd_tbl(addr_t addr);
+    addr[2:0] = 3'h0;
+    if (!derr_otd.exists(addr)) begin
+      derr_otd[addr] = 1;
+    end else begin
+      derr_otd[addr]++;
+    end
+  endfunction // inc_otd_tbl
+  // Descrease outstanding table entry.
+  function void dec_otd_tbl(addr_t addr);
+    addr[2:0] = 3'h0;
+    if (!derr_otd.exists(addr)) begin
+      `uvm_error("dec_otd_tbl", $sformatf("addr %x doesn't exits", addr))
+    end else begin
+      derr_otd[addr]--;
+      if (derr_otd[addr] == 0) derr_otd.delete(addr);
+    end
+  endfunction // dec_otd_tbl
+
 endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -82,6 +82,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     flash_otf_item obs;
     data_4s_t rcvd_data;
     fdata_q_t fq;
+    addr_t err_addr;
     string str = $sformatf("host_read_comp_bank%0d", bank);
 
     `uvm_info("EXPGET_HOST", $sformatf(" addr %x  data:%x   cnt:%0d  rtlff:%0d  ctrlff:%0d",
@@ -98,9 +99,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     obs.cmd.addr = exp.start_addr; // tl_addr
     // for debug print
     obs.start_addr = exp.start_addr;
-    // descramble needs 2 buswords
-    obs.cmd.num_words = 2;
-
+    obs.cmd.num_words = 1;
     obs.mem_addr = exp.start_addr >> 3;
 
     obs.print("RAW");
@@ -108,22 +107,36 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
 
     obs.print("rtl_host: before");
     obs.region = exp.region;
+    if (cfg.ecc_mode > 2) obs.skip_err_chk = 1;
+    // descramble needs 2 buswords
+    obs.cmd.num_words = 2;
     obs.descramble(exp.addr_key, exp.data_key);
     obs.print("rtl_host: after");
     `uvm_info("process_eg_host", $sformatf(" rcvd:%0d",cfg.otf_host_rd_sent), UVM_MEDIUM)
 
-    if (exp.start_addr[2]) begin
-       rcvd_data = obs.dq[1];
+    if (cfg.ecc_mode > 2 && obs.derr == 1) begin
+      err_addr = {obs.cmd.addr[31:3],3'h0};
+      // check expected derr
+      if (cfg.derr_addr_tbl.exists(err_addr)) begin
+        `uvm_info("process_eg_host", $sformatf("expected double bit error 0x%x", err_addr), UVM_MEDIUM)
+      end else if (cfg.ierr_addr_tbl.exists(err_addr)) begin
+        `uvm_info("process_eg_host", $sformatf("expected icv error 0x%x", err_addr), UVM_MEDIUM)
+      end else begin
+        `uvm_error("process_eg_host", $sformatf("unexpected double bit error 0x%x", err_addr))
+      end
     end else begin
-       rcvd_data = obs.dq[0];
-    end
+      if (exp.start_addr[2]) begin
+        rcvd_data = obs.dq[1];
+      end else begin
+        rcvd_data = obs.dq[0];
+      end
 
-    if (rcvd_data == exp.dq[0]) begin
-      `dv_info("data match!!", UVM_MEDIUM, str)
-    end else begin
-      `dv_error($sformatf(" : obs:exp    %8x:%8x mismatch!!", rcvd_data, exp.dq[0]), str)
+      if (rcvd_data == exp.dq[0]) begin
+        `dv_info("data match!!", UVM_MEDIUM, str)
+      end else begin
+        `dv_error($sformatf(" : obs:exp    %8x:%8x mismatch!!", rcvd_data, exp.dq[0]), str)
+      end
     end
-
     cfg.otf_host_rd_sent++;
   endtask // process_eg_host
 
@@ -152,6 +165,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
   //   - Compare read data.
   task process_read(flash_otf_item exp, int bank);
     flash_otf_item send;
+    addr_t err_addr;
     int col_sz = exp.fq.size;
     `uvm_info("process_read", $sformatf("bank:%0d colsz:%0d ffsz:%0d",
                                         bank, col_sz, eg_rtl_fifo[bank].used()), UVM_MEDIUM)
@@ -175,13 +189,27 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     end
     send.mem_addr = exp.start_addr >> 3;
     send.region = exp.region;
+    if (cfg.ecc_mode > 2) send.skip_err_chk = 1;
     send.descramble(exp.addr_key, exp.data_key);
     send.print("exp_read: raw_data");
     `dv_info($sformatf("RDATA size: %d x 8B bank:%0d sent_cnt:%0d",
                        send.raw_fq.size(), bank, cfg.otf_ctrl_rd_sent++),
              UVM_MEDIUM, "process_read")
 
-    compare_data(send.raw_fq, exp.fq, bank, "rdata");
+    if (cfg.ecc_mode > 2 && send.derr == 1) begin
+      send.err_addr[OTFBankId] = bank;
+
+      // check expected derr
+      if (cfg.derr_addr_tbl.exists(send.err_addr)) begin
+        `uvm_info("process_read", $sformatf("expected double bit error 0x%x", send.err_addr), UVM_MEDIUM)
+      end else if (cfg.ierr_addr_tbl.exists(send.err_addr)) begin
+        `uvm_info("process_read", $sformatf("expected icv error 0x%x", send.err_addr), UVM_MEDIUM)
+      end else begin
+        `uvm_error("process_read", $sformatf("unexpected double bit error 0x%x", send.err_addr))
+      end
+    end else begin
+      compare_data(send.raw_fq, exp.fq, bank, "rdata");
+    end
   endtask
 
   // Scoreboard process write in following order.

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -275,7 +275,7 @@ class flash_ctrl_scoreboard #(
             "intr_test": begin
             end
 
-            "op_status", "status", "erase_suspend",
+            "op_status", "status", "erase_suspend", "err_code",
             "ecc_single_err_cnt", "ecc_single_err_addr_0",
             "ecc_single_err_addr_1": begin
               // TODO: FIXME
@@ -700,6 +700,13 @@ class flash_ctrl_scoreboard #(
     bit   ecc_err;
     // For flash, address has to be 8byte aligned.
     ecc_err = ecc_error_addr.exists({item.a_addr[AddrWidth-1:3],3'b0});
+
+    `uvm_info("predic_tl_err_dbg", $sformatf("addr:0x%x(%x) ecc_err:%0d channel:%s ral_name:%s item:%p",
+                                             {item.a_addr[AddrWidth-1:3],3'b0},
+                                             item.a_addr, ecc_err,
+                                             channel.name, ral_name,
+                                             item
+                                             ), UVM_MEDIUM)
 
     if ((ral_name == cfg.flash_ral_name) && (get_flash_instr_type_err(item, channel))) return (1);
     else if (ecc_err) begin

--- a/hw/ip/flash_ctrl/dv/env/flash_otf_item.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_otf_item.sv
@@ -14,11 +14,15 @@ class flash_otf_item extends uvm_object;
   bit                                    scr_en, ecc_en;
   int                                    page;
   flash_mp_region_cfg_t region;
-
+  bit                                    derr;
+  bit                                    skip_err_chk;
+  addr_t                                 err_addr;
   function new(string name = "flash_otf_item");
     super.new(name);
     head_pad = 0;
     tail_pad = 0;
+    derr = 0;
+    skip_err_chk = 0;
   endfunction // new
 
   virtual function void print(string name = "flash_otf_item");
@@ -101,7 +105,8 @@ class flash_otf_item extends uvm_object;
   function void scramble(bit [flash_phy_pkg::KeySize-1:0] addr_key,
                          bit [flash_phy_pkg::KeySize-1:0] data_key,
                          bit [flash_ctrl_pkg::BusAddrByteW-2:0] addr,
-                         bit dis = 1);
+                         bit dis = 1,
+                         bit add_icv_err = 0);
     bit [FlashDataWidth-1:0] data;
     bit [71:0]               data_with_icv;
     bit [75:0]               ecc_76;
@@ -126,6 +131,11 @@ class flash_otf_item extends uvm_object;
       data = raw_fq[i][FlashDataWidth-1:0];
       if (ecc_en) begin
         data_with_icv = prim_secded_pkg::prim_secded_hamming_72_64_enc(raw_fq[i][63:0]);
+        if (add_icv_err) begin
+          `JDBG(("icvdbg:addr:%x before %x", addr, data_with_icv[67:64]))
+          data_with_icv[67:64] = ~data_with_icv[67:64];
+          `JDBG(("icvdbg:after %x", data_with_icv[67:64]))
+        end
       end else begin
         // We only need bit 67:64 when ecc_en == true.
         // So set all vector to zero when ecc_en is off.
@@ -155,6 +165,7 @@ class flash_otf_item extends uvm_object;
     bit [71:0]               data_with_icv;
     bit[flash_ctrl_pkg::BusAddrByteW-2:0] addr = mem_addr;
     data_q_t   tmp_dq;
+
     ecc_err = 'h0;
     if (region == null) begin
       `uvm_fatal("scramble", "region should be assigned before calling this function")
@@ -162,7 +173,6 @@ class flash_otf_item extends uvm_object;
       scr_en = (region.scramble_en == MuBi4True);
       ecc_en = (region.ecc_en == MuBi4True);
     end
-
     `uvm_info("rd_scr", $sformatf("size:%0d addr:%x scr_en:%0d ecc_en:%0d",
                                   fq.size(), addr, scr_en, ecc_en), UVM_MEDIUM)
     foreach (fq[i]) begin
@@ -186,6 +196,7 @@ class flash_otf_item extends uvm_object;
         icv_err = (data_with_icv[67:64] != data[67:64]);
         ecc_err |= (dec68.err[1] | icv_err);
         if (dec68.err[1] | icv_err) begin
+          err_addr = addr << 3;
           `uvm_info("DCR_DBG", $sformatf("%4d:err76:%2b synd:%x icv_err:%2b",
                                          i, dec68.err, dec68.syndrome, icv_err),
                     UVM_MEDIUM)
@@ -198,7 +209,7 @@ class flash_otf_item extends uvm_object;
 
       raw_fq.push_back(data);
 
-      if (ecc_en == 1 && ecc_err != 0) begin
+      if (skip_err_chk == 0 && ecc_err != 0) begin
         `uvm_error("rd_scr", "ecc error is detected")
       end
       addr++;
@@ -213,6 +224,7 @@ class flash_otf_item extends uvm_object;
     if (head_pad) dq = dq[1:$];
     if (tail_pad) dq = dq[0:$-1];
     raw_fq = dq2fq(dq);
+    derr = ecc_err;
   endfunction // descramble
 
   function void clear_qs();

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -364,8 +364,6 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
                       .compare_mask(mask), .check_exp_data(check_rdata), .blocking(blocking),
                       .instr_type(instr_type),
                       .tl_sequencer_h(p_sequencer.tl_sequencer_hs[cfg.flash_ral_name]));
-//confider override
-//                      .use_rsp_ff(use_rsp_ff));
   endtask : do_direct_read
 
   // Task to Read/Erase/Program the Two Secret Seed Partitions (Creator and Owner)

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Directed test to check flash_ctrl.single_err_addr
+// Each round test insert one single bit error and capture the address from tb.
+// At the end of each round, compare the captured value with
+// csr read (flash_ctrl.single_err_addr) value.
+class flash_ctrl_derr_detect_vseq extends flash_ctrl_otf_base_vseq;
+  `uvm_object_utils(flash_ctrl_derr_detect_vseq)
+  `uvm_object_new
+
+  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN := 7, [2:31] :/ 1, CTRL_TRANS_MAX := 2}; }
+  constraint fractions_c {
+       solve ctrl_num before fractions;
+       if (ctrl_num == 1)
+          fractions dist { [1:4] := 4, [5:16] := 1};
+       else
+          fractions == 16;
+  }
+
+  constraint odd_addr_c {
+                         solve fractions before is_addr_odd;
+                         (fractions == 16) -> is_addr_odd == 0;
+                         }
+
+  virtual task body();
+    flash_op_t ctrl;
+    int bank;
+    int fatal_cnt = 0;
+    uvm_reg_data_t addr0, addr1;
+    cfg.derr_once = 1;
+    cfg.scb_h.do_alert_check = 1;
+    cfg.m_tl_agent_cfg.check_tl_errs = 0;
+    cfg.m_tl_agent_cfgs["flash_ctrl_eflash_reg_block"].check_tl_errs = 0;
+
+    ctrl.partition = FlashPartData;
+    otf_tb_clean_up();
+    cfg.clk_rst_vif.wait_clks(5);
+
+    fork
+      begin
+        repeat(20) begin
+          `DV_CHECK_RANDOMIZE_FATAL(this)
+          bank = $urandom_range(0, 1);
+          ctrl.partition  = FlashPartData;
+          ctrl.otf_addr += (is_addr_odd * 4);
+          randcase
+            1:prog_flash(ctrl, bank, ctrl_num, fractions);
+            1:read_flash(ctrl, bank, ctrl_num, fractions);
+          endcase
+        end
+      end
+      begin
+        for (int i = 0; i < 3; ++i) begin
+          fork
+            send_rand_host_rd();
+          join_none
+          #0;
+        end
+        csr_utils_pkg::wait_no_outstanding_access();
+      end
+      begin
+        while (cfg.scb_h.alert_count["fatal_err"] == 0) begin
+          cfg.clk_rst_vif.wait_clks(1);
+        end
+        dut_init();
+      end
+    join_any
+    disable fork;
+    if (cfg.derr_created[0] + cfg.derr_created[1] > 0) begin
+      fatal_cnt = cfg.scb_h.alert_count["fatal_err"];
+      `DV_CHECK_NE(fatal_cnt, 0, "fatal alert is not detected",
+                   error, "SEQ")
+    end
+    `uvm_info("SEQ", $sformatf("seqend derr_created: %p", cfg.derr_created), UVM_LOW)
+  endtask // body
+endclass // flash_ctrl_serr_address_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Directed test to check flash_ctrl.single_err_addr
+// Each round test insert one single bit error and capture the address from tb.
+// At the end of each round, compare the captured value with
+// csr read (flash_ctrl.single_err_addr) value.
+class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
+  `uvm_object_utils(flash_ctrl_integrity_vseq)
+  `uvm_object_new
+
+  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN := 7, [2:31] :/ 1, CTRL_TRANS_MAX := 2}; }
+  constraint fractions_c {
+       solve ctrl_num before fractions;
+       if (ctrl_num == 1)
+          fractions dist { [1:4] := 4, [5:16] := 1};
+       else
+          fractions == 16;
+  }
+
+  constraint odd_addr_c {
+                         solve fractions before is_addr_odd;
+                         (fractions == 16) -> is_addr_odd == 0;
+                         }
+
+  virtual task body();
+    flash_op_t ctrl;
+    int bank;
+
+    ctrl.partition = FlashPartData;
+    cfg.clk_rst_vif.wait_clks(5);
+
+    fork
+      begin
+        repeat(100) begin
+          `DV_CHECK_RANDOMIZE_FATAL(this)
+          bank = $urandom_range(0, 1);
+          ctrl.partition  = FlashPartData;
+          ctrl.otf_addr = is_addr_odd * 4;
+          randcase
+            1:prog_flash(ctrl, bank, ctrl_num, fractions);
+            1:read_flash(ctrl, bank, ctrl_num, fractions);
+          endcase
+        end
+      end
+      begin
+        for (int i = 0; i < 10; ++i) begin
+          fork
+            send_rand_host_rd();
+          join_none
+          #0;
+        end
+        csr_utils_pkg::wait_no_outstanding_access();
+      end
+    join
+  endtask // body
+endclass // flash_ctrl_integrity_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_ro_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_ro_vseq.sv
@@ -17,18 +17,19 @@ class flash_ctrl_ro_vseq extends flash_ctrl_otf_base_vseq;
 
     fork
       begin
-        for (int i = 0; i < 1000; ++i) begin
+        for (int i = 0; i < 10; ++i) begin
           fork
-            send_rand_host_rd();
+            send_rand_host_rd(, i);
           join_none
           #0;
         end
+        `JDBG(("TEST: outstanding_access:%0d", csr_utils_pkg::outstanding_accesses))
         csr_utils_pkg::wait_no_outstanding_access();
       end
       begin
         repeat(100) begin
-          num = $urandom_range(CTRL_TRANS_MIN, CTRL_TRANS_MAX);
-          bank = $urandom_range(0, 1);
+          num = 1;//$urandom_range(CTRL_TRANS_MIN, CTRL_TRANS_MAX);
+          bank = 0;//$urandom_range(0, 1);
           read_flash(ctrl, bank, num);
         end
       end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -37,3 +37,5 @@
 `include "flash_ctrl_rw_rnd_wd_vseq.sv"
 `include "flash_ctrl_serr_counter_vseq.sv"
 `include "flash_ctrl_serr_address_vseq.sv"
+`include "flash_ctrl_derr_detect_vseq.sv"
+`include "flash_ctrl_integrity_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -301,6 +301,55 @@
       run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+serr_pct=1"]
       reseed: 5
     }
+
+    {
+      name: flash_ctrl_read_word_sweep_derr
+      uvm_test_seq: flash_ctrl_read_word_sweep_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=3", "+derr_pct=3",
+                 "+bypass_alert_ready_to_end_check=1"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_read_rand_word_derr
+      uvm_test_seq: flash_ctrl_read_rnd_wd_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=3", "+derr_pct=3",
+                 "+bypass_alert_ready_to_end_check=1"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_ro_derr
+      uvm_test_seq: flash_ctrl_ro_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=3", "+derr_pct=3",
+                 "+bypass_alert_ready_to_end_check=1"]
+      reseed: 10
+    }
+    {
+      name: flash_ctrl_rw_derr
+      uvm_test_seq: flash_ctrl_rw_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=3", "+derr_pct=3",
+                 "+bypass_alert_ready_to_end_check=1"]
+      reseed: 10
+    }
+    {
+      name: flash_ctrl_rw_rand_word_derr
+      uvm_test_seq: flash_ctrl_rw_rnd_wd_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=3", "+derr_pct=3",
+                 "+bypass_alert_ready_to_end_check=1"]
+      reseed: 10
+    }
+    {
+      name: flash_ctrl_derr_detect
+      uvm_test_seq: flash_ctrl_derr_detect_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=3", "+derr_pct=1", "+rerun=5"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_integrity
+      uvm_test_seq: flash_ctrl_integrity_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=4", "+ierr_pct=3",
+                 "+bypass_alert_ready_to_end_check=1"]
+      reseed: 5
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
+++ b/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
@@ -41,7 +41,7 @@ class flash_ctrl_base_test #(
   endfunction : get_type_name
 
   `uvm_component_new
-
+  int run_cnt = 1;
   // the base class dv_base_test creates the following instances:
   // flash_ctrl_env_cfg: cfg
   // flash_ctrl_env:     env
@@ -56,5 +56,23 @@ class flash_ctrl_base_test #(
     void'($value$plusargs("multi_alert=%0b", cfg.multi_alert_en));
     void'($value$plusargs("ecc_mode=%0d", cfg.ecc_mode));
     void'($value$plusargs("serr_pct=%0d", cfg.serr_pct));
+    void'($value$plusargs("derr_pct=%0d", cfg.derr_pct));
+    void'($value$plusargs("ierr_pct=%0d", cfg.ierr_pct));
   endfunction
+
+  task run_phase(uvm_phase phase);
+    if ($value$plusargs("rerun=%0d", run_cnt)) begin
+      `uvm_info("TEST", $sformatf("run_cnt is set to %0d", run_cnt), UVM_LOW)
+    end
+    phase.raise_objection(this);
+    run_test_seq = 0;
+    super.run_phase(phase);
+
+    repeat(run_cnt) begin
+      run_seq(test_seq_s, phase);
+      env.virtual_sequencer.stop_sequences();
+    end
+    phase.drop_objection(this);
+
+  endtask // run_phase
 endclass : flash_ctrl_base_test


### PR DESCRIPTION
cmd:
./util/dvsim/dvsim.py ./hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson -i flash_ctrl_ro_derr -r 1 -v m -s 1 --waves
This is double bit error test. From the wave,
@35977.4 TB sends rd_fifo read but return data has integrity error (tb.dut.core_tl_o.d_user)
obs: 0x7F  exp: 2a (looks like 1 cycle off )