### PR TITLE
[spi_device/dv] TPM mode fixes

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -209,19 +209,6 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     end
   endtask : randomize_all_cmd_filters
 
-  // Task for keeping opcode integrity regardless of rx_order config
-  virtual task order_cmd_bits(bit [7:0] pass_cmd, bit[23:0] pass_addr, ref bit [31:0] addr_cmd);
-    bit rx_order;
-    csr_rd(.ptr(ral.cfg.rx_order), .value(rx_order));
-    if (rx_order == 0) begin
-      pass_cmd = {<<1{pass_cmd}};
-      pass_addr = {<<1{pass_addr}};
-      addr_cmd = {pass_addr, pass_cmd};
-    end else begin
-      addr_cmd = {pass_addr, pass_cmd};
-    end
-  endtask : order_cmd_bits
-
   // Task for preparing memory buffer for read commands
   virtual task randomize_mem();
     bit [31:0] buffer_data [1024];

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_vseq.sv
@@ -35,14 +35,13 @@ class spi_device_tpm_read_vseq extends spi_device_tpm_base_vseq;
       `DV_CHECK_STD_RANDOMIZE_FATAL(tpm_addr)
       // Data size will be 5, first byte dummy for polling, remaining 4 for payload
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(data_bytes, data_bytes.size() == 5;)
-      tpm_addr = {<<1{tpm_addr}};
       address_command = {tpm_addr, tpm_cmd};
       `uvm_info(`gfn, $sformatf("Address Command = 0x%0h", address_command), UVM_LOW)
       cfg.spi_host_agent_cfg.csb_consecutive = 1;
       spi_host_xfer_word(address_command, device_word_rsp);
       fork
         begin
-          csr_rd(.ptr(ral.tpm_cmd_addr), .value(tpm_addr_read));
+          check_tpm_cmd_addr(tpm_cmd, tpm_addr);
           // Upon receiving read command, set read fifo contents
           `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(read_fifo_data, read_fifo_data.size() == 4;)
           foreach (read_fifo_data[i]) csr_wr(.ptr(ral.tpm_read_fifo), .value(read_fifo_data[i]));

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -14,6 +14,7 @@ package spi_device_env_pkg;
   import cip_base_pkg::*;
   import mem_model_pkg::*;
   import spi_device_ral_pkg::*;
+  import dv_base_reg_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -97,8 +98,8 @@ package spi_device_env_pkg;
   parameter uint ADDR_FIFO_START_ADDR            = CMD_FIFO_START_ADDR + CMD_FIFO_SIZE; // 0xe20
   parameter uint ADDR_FIFO_SIZE                  = 32;
 
-  parameter bit[7:0] TPM_WRITE_CMD               = 8'hC0;
-  parameter bit[7:0] TPM_READ_CMD                = 8'hC1;
+  parameter bit[7:0] TPM_WRITE_CMD               = 8'h03;
+  parameter bit[7:0] TPM_READ_CMD                = 8'h83;
   parameter byte TPM_START                       = 8'h01;
   parameter byte TPM_WAIT                        = 8'h00;
   parameter bit[11:0] TPM_HW_STS_OFFSET          = 12'h018;


### PR DESCRIPTION
1. Fix bit order, it supports order 0 rather than 1
2. Fix CMD code
3. Add DV_SPINWAIT for while-loop
4. add checking cmd and addr for TPM read

Signed-off-by: Weicai Yang <weicai@google.com>