### PR TITLE
[chip/dv] replace wait with DV_WAIT

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -380,6 +380,12 @@
   `DV_SPINWAIT_EXIT(WAIT_, wait_timeout(TIMEOUT_NS_, ID_, MSG_);, "", ID_)
 `endif
 
+// a shorthand of `DV_SPINWAIT(wait(...))
+`ifndef DV_WAIT
+`define DV_WAIT(WAIT_CON_, MSG_ = "wait timeout occurred!", TIMEOUT_NS_ = default_spinwait_timeout_ns, ID_ =`gfn) \
+  `DV_SPINWAIT(wait(WAIT_CON_), MSG_, TIMEOUT_NS_, ID_)
+`endif
+
 // Control assertions in the DUT.
 //
 // This macro is invoked in top level testbench that instantiates the DUT. It spawns off an initial

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -382,8 +382,8 @@
 
 // a shorthand of `DV_SPINWAIT(wait(...))
 `ifndef DV_WAIT
-`define DV_WAIT(WAIT_CON_, MSG_ = "wait timeout occurred!", TIMEOUT_NS_ = default_spinwait_timeout_ns, ID_ =`gfn) \
-  `DV_SPINWAIT(wait(WAIT_CON_), MSG_, TIMEOUT_NS_, ID_)
+`define DV_WAIT(WAIT_COND_, MSG_ = "wait timeout occurred!", TIMEOUT_NS_ = default_spinwait_timeout_ns, ID_ =`gfn) \
+  `DV_SPINWAIT(wait (WAIT_COND_);, MSG_, TIMEOUT_NS_, ID_)
 `endif
 
 // Control assertions in the DUT.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_ndm_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_ndm_reset_vseq.sv
@@ -9,10 +9,8 @@ class chip_rv_dm_ndm_reset_vseq extends chip_jtag_base_vseq;
 
   virtual task body();
     super.body();
-
-    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "wait for ndm reset");,
-                 "Timedout waiting for ndm reset.")
-
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "wait for ndm reset",
+             "Timedout waiting for ndm reset.")
     cfg.clk_rst_vif.wait_clks(10);
     debug_mode_en();
     cfg.clk_rst_vif.wait_clks(10);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -42,8 +42,8 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
   virtual task apply_reset(string kind = "HARD");
     super.apply_reset(kind);
     // internal reset does not immediately go to 0 when external reset is applied
-    wait (cfg.rst_n_mon_vif.pins[0] === 0);
-    wait (cfg.rst_n_mon_vif.pins[0] === 1);
+    `DV_WAIT(cfg.rst_n_mon_vif.pins[0] === 0)
+    `DV_WAIT(cfg.rst_n_mon_vif.pins[0] === 1)
 
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv
@@ -178,8 +178,8 @@ class chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq extends chip_sw_base_vseq;
 
     // Wait for test to enter WFI before generating ADC data which will
     // cause a wakeup event.
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
 
     // Fork tasks for detecting edges.
     powerdown_count = 0;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_power_glitch_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_power_glitch_vseq.sv
@@ -18,12 +18,12 @@ class chip_sw_deep_power_glitch_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
     // Wait until we reach the SW test state.
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
     cfg.ast_supply_vif.glitch_vcmain_pok_on_next_low_power_trigger();
 
     // the above glitch should cause the system to reboot, now wait for reset
     // before re-enabling assertion
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
     cfg.ast_supply_vif.reenable_vcmain_assertion();
   endtask
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_sleep_all_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_sleep_all_reset_vseq.sv
@@ -61,16 +61,17 @@ class chip_sw_deep_sleep_all_reset_vseq extends chip_sw_base_vseq;
     // mimic external pull up in key in0
     cfg.ast_supply_vif.force_key0_i(1'b1);
     // Wait until we reach the SW test state.
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
     `uvm_info(`gfn, "SW test ready", UVM_MEDIUM)
 
     repeat (loop_num) begin
-      wait (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" |
+      `DV_WAIT(
+            cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" |
             cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by hw por" |
             cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" |
             cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by sysrst" |
             cfg.sw_logger_vif.printed_log == "Last Booting" |
-            cfg.sw_logger_vif.printed_log == "Test finish");
+            cfg.sw_logger_vif.printed_log == "Test finish")
 
        if (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" |
                 cfg.sw_logger_vif.printed_log ==
@@ -98,7 +99,7 @@ class chip_sw_deep_sleep_all_reset_vseq extends chip_sw_base_vseq;
 
   task execute_reset();
     `uvm_info(`gfn, "wait for low power entry", UVM_MEDIUM)
-    wait(cfg.pwrmgr_low_power_vif.low_power == 1);
+    `DV_WAIT(cfg.pwrmgr_low_power_vif.low_power == 1)
     `uvm_info(`gfn, "reset after low power entry", UVM_MEDIUM)
     assert_por_reset_deep_sleep (reset_delay);
   endtask // execute_reset

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv
@@ -49,16 +49,16 @@ class chip_sw_flash_ctrl_lc_rw_en_vseq extends chip_sw_base_vseq;
     cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStDev);
     apply_reset();
 
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest, 50_000_000)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
 
     // LC state changed to Prod.
 
     cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStProd);
     apply_reset();
 
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
 
     // LC state changed to Scrap. CPU not enabled so do the checks directly.
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
@@ -273,8 +273,8 @@ class chip_sw_flash_init_vseq extends chip_sw_base_vseq;
           do_keymgr_check = 0;
         end
         // Wait for the test to start and enter the WFI state,
-        wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-        wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+        `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+        `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
         // Randomize the data and keys for the next test phase.
         randomize_data();
         randomize_keys();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_full_aon_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_full_aon_reset_vseq.sv
@@ -37,7 +37,7 @@ class chip_sw_full_aon_reset_vseq extends chip_sw_base_vseq;
     super.body();
 
     // Wait until we reach the SW test state.
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
 
     repeat (NumberOfResets) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
@@ -45,7 +45,7 @@ class chip_sw_full_aon_reset_vseq extends chip_sw_base_vseq;
       repeat (cycles_before_trigger) @(posedge cfg.ast_supply_vif.clk);
     end
     // Now let the processor finish booting and send another one.
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
     `uvm_info(`gfn, "Triggering an AON power glitch reset once boot is done", UVM_LOW)
     reset_cause = ResetCauseGlitch;
     trigger_por_reset();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
@@ -40,7 +40,7 @@ class chip_sw_gpio_smoke_vseq extends chip_sw_base_vseq;
     super.body();
 
     // Wait until we reach the SW test state.
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
 
     // Disable the default pulldown on GPIOs.
     cfg.gpio_vif.set_pulldown_en({chip_env_pkg::NUM_GPIOS{1'b0}});

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_vseq.sv
@@ -14,7 +14,7 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
     super.body();
 
     // Wait until we reach the SW test state.
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
 
     // Disable pullups and pulldowns on GPIOs.
     cfg.gpio_vif.set_pulldown_en({chip_env_pkg::NUM_GPIOS{1'b0}});

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
@@ -113,7 +113,7 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
     super.body();
 
     // wait and check Keymgr entered CreatorRootKey State
-    wait (cfg.sw_logger_vif.printed_log == "Keymgr entered CreatorRootKey State");
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Keymgr entered CreatorRootKey State")
     cur_unmasked_key = get_unmasked_key(get_otp_root_key());
     `DV_CHECK_FATAL(uvm_hdl_check_path(path_internal_key))
     `DV_CHECK_FATAL(uvm_hdl_read(path_internal_key, new_key))
@@ -122,34 +122,34 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
     get_creator_data(creator_data);
     check_internal_key(cur_unmasked_key, creator_data, new_unmasked_key);
 
-    wait (cfg.sw_logger_vif.printed_log == "Keymgr generated identity at CreatorRootKey State");
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Keymgr generated identity at CreatorRootKey State")
     check_gen_id(new_unmasked_key, top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrCreatorIdentitySeed);
 
     // wait and check Keymgr entered OwnerIntKey State
-    wait (cfg.sw_logger_vif.printed_log == "Keymgr entered OwnerIntKey State");
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Keymgr entered OwnerIntKey State");
     cur_unmasked_key = new_unmasked_key;
     `DV_CHECK_FATAL(uvm_hdl_read(path_internal_key, new_key))
     new_unmasked_key = get_unmasked_key(new_key);
 
     check_internal_key(cur_unmasked_key, get_owner_int_data(), new_unmasked_key);
 
-    wait (cfg.sw_logger_vif.printed_log == "Keymgr generated identity at OwnerIntKey State");
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Keymgr generated identity at OwnerIntKey State")
     check_gen_id(new_unmasked_key, top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrOwnerIntIdentitySeed);
 
-    wait (cfg.sw_logger_vif.printed_log == "Keymgr generated SW output at OwnerIntKey State");
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Keymgr generated SW output at OwnerIntKey State")
     get_sw_shares(exp_digest);
     check_gen_out(new_unmasked_key, GenSWOutData, exp_digest);
 
     // check 3 sideload interfaces
-    wait (cfg.sw_logger_vif.printed_log ==
-          "Keymgr generated HW output for Kmac at OwnerIntKey State");
+    `DV_WAIT(cfg.sw_logger_vif.printed_log ==
+          "Keymgr generated HW output for Kmac at OwnerIntKey State")
     `DV_CHECK_FATAL(uvm_hdl_check_path(path_kmac_key))
     `DV_CHECK_FATAL(uvm_hdl_read(path_kmac_key, hw_key))
     `DV_CHECK_EQ(hw_key.valid, 1)
     check_gen_out(new_unmasked_key, GenKmacOutData, get_unmasked_key(hw_key.key));
 
-    wait (cfg.sw_logger_vif.printed_log ==
-          "Keymgr generated HW output for Aes at OwnerIntKey State");
+    `DV_WAIT(cfg.sw_logger_vif.printed_log ==
+          "Keymgr generated HW output for Aes at OwnerIntKey State")
     `DV_CHECK_FATAL(uvm_hdl_check_path(path_aes_key))
     `DV_CHECK_FATAL(uvm_hdl_read(path_aes_key, hw_key))
     `DV_CHECK_EQ(hw_key.valid, 1)
@@ -159,8 +159,8 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
     begin
       bit [7:0] data_arr[];
       bit [kmac_pkg::AppDigestW-1:0] unmask_act_key, unmask_exp_key;
-      wait (cfg.sw_logger_vif.printed_log ==
-            "Keymgr generated HW output for Otbn at OwnerIntKey State");
+      `DV_WAIT(cfg.sw_logger_vif.printed_log ==
+            "Keymgr generated HW output for Otbn at OwnerIntKey State")
       `DV_CHECK_FATAL(uvm_hdl_check_path(path_otbn_key))
       `DV_CHECK_FATAL(uvm_hdl_read(path_otbn_key, otbn_key))
       `DV_CHECK_EQ(otbn_key.valid, 1)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -64,7 +64,7 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
       apply_reset();
 
       // Wait for SW to finish power on set up.
-      wait(cfg.sw_logger_vif.printed_log == "Start LC_CTRL transition test.");
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == "Start LC_CTRL transition test.")
 
       fork
         begin : isolation_fork
@@ -98,8 +98,8 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
       join
 
       // Wait for SW test finishes with a pass/fail status.
-      wait (cfg.sw_test_status_vif.sw_test_status inside {SwTestStatusPassed,
-                                                          SwTestStatusFailed});
+      `DV_WAIT(cfg.sw_test_status_vif.sw_test_status inside {SwTestStatusPassed,
+                                                          SwTestStatusFailed})
       `uvm_info(`gfn, $sformatf("Sequence %0d/%0d finished!", trans_i, num_trans), UVM_LOW)
     end
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
@@ -48,8 +48,8 @@ class chip_sw_lc_walkthrough_testunlocks_vseq extends chip_sw_base_vseq;
     apply_reset();
 
     repeat (NumIterations) begin
-      wait (string'(cfg.sw_logger_vif.printed_log) ==
-            $sformatf("Waiting for LC transtition %0d done and reboot.", curr_state));
+      `DV_WAIT(string'(cfg.sw_logger_vif.printed_log) ==
+            $sformatf("Waiting for LC transtition %0d done and reboot.", curr_state))
       wait_lc_status(LcTransitionSuccessful);
       apply_reset();
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
@@ -61,7 +61,7 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
     jtag_lc_state_transition(DecLcStRaw, DecLcStTestUnlocked0);
     apply_reset();
 
-    wait (cfg.sw_logger_vif.printed_log == "Waiting for LC transition done and reboot.");
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Waiting for LC transition done and reboot.")
     // Wait for a large number of cycles to transit to RMA state.
     wait_lc_status(LcTransitionSuccessful, 50_000);
     apply_reset();
@@ -70,7 +70,7 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
 
     // The following states will transfer twice to make sure LC_EXIT and RMA tokens are used.
     if (dest_dec_state inside {DecLcStProd, DecLcStDev}) begin
-      wait (cfg.sw_logger_vif.printed_log == "Waiting for LC RMA transition done and reboot.");
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == "Waiting for LC RMA transition done and reboot.")
       // Wait for a large number of cycles to transit to RMA state.
       wait_lc_status(LcTransitionSuccessful, 50_000);
       apply_reset();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_main_power_glitch_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_main_power_glitch_vseq.sv
@@ -22,12 +22,12 @@ class chip_sw_main_power_glitch_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
     // Wait until we reach the SW test state.
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
     cfg.ast_supply_vif.glitch_vcmain_pok_on_next_core_sleeping_trigger(cycles_after_trigger);
 
     // the above glitch should cause the system to reboot, now wait for reset
     // before re-enabling assertion
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
     cfg.ast_supply_vif.reenable_vcmain_assertion();
   endtask
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwm_pulses_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwm_pulses_vseq.sv
@@ -37,7 +37,7 @@ class chip_sw_pwm_pulses_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
     `uvm_info(`gfn, $sformatf("PWMSEQ : duty_cycle = %p",duty_cycle), UVM_MEDIUM)
-    wait(cfg.sw_logger_vif.printed_log == "pinmux_init end");
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "pinmux_init end")
     `uvm_info(`gfn, $sformatf("set mon active 1"), UVM_MEDIUM)
     foreach (cfg.m_pwm_monitor_cfg[i]) begin
       cfg.m_pwm_monitor_cfg[i].active = 1;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_sleep_all_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_sleep_all_reset_vseq.sv
@@ -61,18 +61,21 @@ class chip_sw_random_sleep_all_reset_vseq extends chip_sw_base_vseq;
     // mimic external pull up in key in0
     cfg.ast_supply_vif.force_key0_i(1'b1);
     // Wait until we reach the SW test state.
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
     `uvm_info(`gfn, "SW test ready", UVM_MEDIUM)
 
     repeat (loop_num) begin
-      wait (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" ||
+      `DV_WAIT(
+            cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" ||
             cfg.sw_logger_vif.printed_log ==
                 "Booting and setting normal sleep followed by hw por" ||
             cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" ||
             cfg.sw_logger_vif.printed_log ==
                 "Booting and setting normal sleep followed by sysrst" ||
             cfg.sw_logger_vif.printed_log == "Last Booting" ||
-            cfg.sw_logger_vif.printed_log == "Test finish");
+            cfg.sw_logger_vif.printed_log == "Test finish",
+            // 20ms
+            20_000_000)
 
        if (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" ||
            cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by sysrst")
@@ -104,7 +107,7 @@ class chip_sw_random_sleep_all_reset_vseq extends chip_sw_base_vseq;
 
   task execute_reset();
     `uvm_info(`gfn, "wait for low power entry", UVM_MEDIUM)
-    wait(cfg.pwrmgr_low_power_vif.low_power == 1);
+    `DV_WAIT(cfg.pwrmgr_low_power_vif.low_power == 1)
     `uvm_info(`gfn, "reset after low power entry", UVM_MEDIUM)
     assert_por_reset_deep_sleep (reset_delay);
   endtask // execute_reset

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_repeat_reset_wkup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_repeat_reset_wkup_vseq.sv
@@ -37,7 +37,7 @@ class chip_sw_repeat_reset_wkup_vseq extends chip_sw_base_vseq;
       `DV_CHECK_RANDOMIZE_FATAL(this)
 
       // Wait until we reach the SW test state.
-      wait(cfg.sw_logger_vif.printed_log == "ready for power down");
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == "ready for power down")
 
       `uvm_info(`gfn, $sformatf("round %0d input_type: %s add_cycle: %d  reset_dealy: %d ",
                                 i, input_type.name(), add_cycle, reset_delay), UVM_MEDIUM)
@@ -59,8 +59,8 @@ class chip_sw_repeat_reset_wkup_vseq extends chip_sw_base_vseq;
 
       // after reset / wakep, waitfor reboot
       // before test goes to the next round
-      wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
-      wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+      `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
+      `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
 
     end
   endtask // body
@@ -77,7 +77,7 @@ class chip_sw_repeat_reset_wkup_vseq extends chip_sw_base_vseq;
   task execute_reset();
     if (add_cycle == 1) begin
       `uvm_info(`gfn, "reset after low power entry", UVM_MEDIUM)
-      wait(cfg.pwrmgr_low_power_vif.low_power == 1);
+      `DV_WAIT(cfg.pwrmgr_low_power_vif.low_power == 1)
 
     end
     assert_por_reset(reset_delay);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
@@ -32,8 +32,8 @@ class chip_sw_rom_ctrl_integrity_check_vseq extends chip_sw_base_vseq;
 
   virtual task test_state_monitor();
     // wait for the test to boot and issue the WFI status
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
 
     // update the lc state to a production state and do a reset
     cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(lc_ctrl_state_pkg::LcStProd);
@@ -44,7 +44,7 @@ class chip_sw_rom_ctrl_integrity_check_vseq extends chip_sw_base_vseq;
     // process should be locked up.
     fork
       begin
-        wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+        `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
         `uvm_error(`gfn, "Unexpected successful boot in PROD LC_STATE.")
       end
       begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sensor_ctrl_status_intr_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sensor_ctrl_status_intr_vseq.sv
@@ -39,11 +39,13 @@ class chip_sw_sensor_ctrl_status_intr_vseq extends chip_sw_base_vseq;
 
    virtual task wait_for_sleeping();
      bit sleeping = 0;
-     while (sleeping == 0) begin
-      `DV_CHECK_FATAL(uvm_hdl_read(SLEEPING_PATH, sleeping));
-      cfg.clk_rst_vif.wait_clks(10);
-      `uvm_info(`gfn, $sformatf("Cpu sleeping status: 0x%h", sleeping), UVM_HIGH)
-     end
+     `DV_SPINWAIT(
+      while (sleeping == 0) begin
+        `DV_CHECK_FATAL(uvm_hdl_read(SLEEPING_PATH, sleeping));
+        cfg.clk_rst_vif.wait_clks(10);
+        `uvm_info(`gfn, $sformatf("Cpu sleeping status: 0x%h", sleeping), UVM_HIGH)
+      end
+     )
    endtask
 
 
@@ -59,11 +61,11 @@ class chip_sw_sensor_ctrl_status_intr_vseq extends chip_sw_base_vseq;
     check_hdl_paths();
     for (int i = 0; i < iterations; i++) begin
       `uvm_info(`gfn, $sformatf("Iteration %d start", i), UVM_MEDIUM)
-      wait (cfg.sw_logger_vif.printed_log == "Waiting for IO change");
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == "Waiting for IO change")
       wait_for_sleeping();
       change_io_val();
       `uvm_info(`gfn, $sformatf("Iteration %d end", i), UVM_MEDIUM)
-      wait (cfg.sw_logger_vif.printed_log == "IO change complete");
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == "IO change complete")
     end
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv
@@ -31,8 +31,8 @@ class chip_sw_sram_ctrl_execution_main_vseq extends chip_sw_base_vseq;
         .en_entropy_src_fw_read(EN_ENTROPY_SRC_FW_READ),
         .en_entropy_src_fw_over(EN_ENTROPY_SRC_FW_OVER));
 
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
   endtask
 
   virtual task body();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_inputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_inputs_vseq.sv
@@ -60,8 +60,8 @@ class chip_sw_sysrst_ctrl_inputs_vseq extends chip_sw_base_vseq;
       #1us;
       write_test_phase_and_expected(current_phase, pads_to_set);
 
-      wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-      wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+      `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+      `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
     end
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv
@@ -59,8 +59,8 @@ class chip_sw_sysrst_ctrl_outputs_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual task sync_with_sw();
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
   endtask
 
   virtual task check_loopback_pattern();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_reset_vseq.sv
@@ -142,8 +142,8 @@ class chip_sw_sysrst_ctrl_reset_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
 
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
     check_flash_wp_value(1);
     wait_for_ec_rst_high();
     set_combo0_pads_low();
@@ -152,17 +152,17 @@ class chip_sw_sysrst_ctrl_reset_vseq extends chip_sw_base_vseq;
     check_flash_wp_value(0);
 
     write_test_phase(DEEP_SLEEP_WAKEUP_PHASE);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
     set_ulp_pads_deassert();
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
     set_ulp_pads_assert();
 
     write_test_phase(DEEP_SLEEP_RESET_PHASE);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
     set_all_pads_high();
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
     check_flash_wp_value(1);
     set_combo1_pads_low();
     check_ec_rst_when_rstreq_low();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_vseq.sv
@@ -53,14 +53,14 @@ class chip_sw_sysrst_ctrl_vseq extends chip_sw_base_vseq;
     // mimic external pull up in key in0
     cfg.ast_supply_vif.force_key0_i(1'b1);
     // Wait until we reach the SW test state.
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
     `uvm_info(`gfn, "SW test ready", UVM_MEDIUM)
 
     repeat (loop_num) begin
-      wait (cfg.sw_logger_vif.printed_log == "Reset Request SourceOne is set" |
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == "Reset Request SourceOne is set" |
             cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" |
             cfg.sw_logger_vif.printed_log == "Last Booting" |
-            cfg.sw_logger_vif.printed_log == "Test finish");
+            cfg.sw_logger_vif.printed_log == "Test finish")
 
        if (cfg.sw_logger_vif.printed_log == "Reset Request SourceOne is set") begin
          `uvm_info(`gfn, "SW message delivered to TB", UVM_MEDIUM)
@@ -83,7 +83,7 @@ class chip_sw_sysrst_ctrl_vseq extends chip_sw_base_vseq;
 
   task execute_reset();
     `uvm_info(`gfn, "wait for low power entry", UVM_MEDIUM)
-    wait(cfg.pwrmgr_low_power_vif.low_power == 1);
+    `DV_WAIT(cfg.pwrmgr_low_power_vif.low_power == 1)
     `uvm_info(`gfn, "reset after low power entry", UVM_MEDIUM)
     assert_por_reset(reset_delay);
   endtask // execute_reset

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
@@ -51,13 +51,13 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
     fork get_uart_tx_items(uart_idx); join_none
 
     // Wait until we receive at least 1 byte from the DUT (SW test).
-    wait(uart_tx_data_q.size() > 0);
+    `DV_WAIT(uart_tx_data_q.size() > 0)
 
     // Start sending uart_rx_data over RX.
     send_uart_rx_data();
 
     // Wait until we receive all bytes over TX.
-    wait(uart_tx_data_q.size() == exp_uart_tx_data.size());
+    `DV_WAIT(uart_tx_data_q.size() == exp_uart_tx_data.size())
 
     // Check if we received the right data set over the TX port.
     `uvm_info(`gfn, "Checking the received UART TX data for consistency.", UVM_LOW)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
@@ -85,7 +85,7 @@ class chip_tap_straps_vseq extends chip_sw_base_vseq;
     // load rom/flash and wait for rom_check to complete
     cpu_init();
     wait_rom_check_done();
-    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
 
     check_dft_straps();
 


### PR DESCRIPTION
2 commits:
[dv] Add DV_WAIT macro
a shorthand of `DV_SPINWAIT(wait(...))

[chip/dv] replace wait with DV_WAIT/DV_SPINWAIT
Addressed https://github.com/lowRISC/opentitan/issues/13402
Replace wait or non-forever while loop with DV_WAIT/DV_SPINWAIT

Signed-off-by: Weicai Yang <weicai@google.com>
