### PR TITLE
[entropy_src/dv] Refactor entropy_src_rng_vseq

### DIFF
--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_indefinite_host_seq.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_indefinite_host_seq.sv
@@ -17,6 +17,8 @@ class push_pull_indefinite_host_seq #(parameter int HostDataWidth = 32,
 
   `uvm_object_new
 
+  int items_processed;
+
   typedef enum int {
     Continue = 0,
     Stop     = 1,
@@ -25,7 +27,12 @@ class push_pull_indefinite_host_seq #(parameter int HostDataWidth = 32,
 
   stop_status_e stop_status;
 
+  task wait_for_items_processed(int n);
+    wait(items_processed >= n);
+  endtask;
+
   virtual task body();
+    items_processed = 0;
     fork : isolation_fork
       begin
         fork
@@ -39,6 +46,7 @@ class push_pull_indefinite_host_seq #(parameter int HostDataWidth = 32,
             randomize_item(req);
             finish_item(req);
             get_response(rsp);
+            items_processed++;
           end : send_req
         join_any;
         disable fork;

--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -102,12 +102,12 @@
 
   component_a: "uvm_test_top.env.scoreboard"
   id_a : _ALL_
-  verbosity_a: UVM_MEDIUM
+  verbosity_a: UVM_FULL
   phase_a: run
 
   component_b: "uvm_test_top.env.virtual_sequencer"
   id_b : _ALL_
-  verbosity_b: UVM_MEDIUM
+  verbosity_b: UVM_FULL
   phase_b: run
 
   run_modes: [

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -10,8 +10,6 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   `uvm_object_utils(entropy_src_rng_vseq)
 
   push_pull_indefinite_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH) m_csrng_pull_seq;
-  // For use in non-FIPS mode
-  push_pull_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)            m_csrng_pull_seq_single;
   entropy_src_base_rng_seq                                              m_rng_push_seq;
 
   rand uint dly_to_access_intr;
@@ -22,7 +20,8 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   rand bit  do_check_ht_diag;
   rand bit  do_clear_ht_alert;
 
-  int do_background_procs;
+  // flags for coordinating between threads
+  bit do_background_procs, continue_sim, reset_needed;
 
   // Scheduled time for next unexpected reconfig event;
   // This time is exponentially distributed to yield an average period between
@@ -85,31 +84,18 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
   `uvm_object_new
 
-  task software_read_seed();
-    int seeds_found;
-    `uvm_info(`gfn, "CSR Thread: Reading seed via SW", UVM_FULL)
-    ral.entropy_control.es_route.set(prim_mubi_pkg::MuBi4True);
-    csr_update(.csr(ral.entropy_control));
-    // Wait for data to arrive for TL consumption via the ENTROPY_DATA register
-    poll();
-    ral.entropy_control.es_route.set(prim_mubi_pkg::MuBi4False);
-    csr_update(.csr(ral.entropy_control));
-
-    // read all available seeds
-    do begin
-      do_entropy_data_read(.bundles_found(seeds_found));
-    end while (seeds_found > 0);
-    `uvm_info(`gfn, "CSR Thread: Seed read Successfully", UVM_HIGH)
-  endtask
-
   task enable_dut();
     `uvm_info(`gfn, "CSR Thread: Enabling DUT", UVM_MEDIUM)
-    ral.module_enable.set(prim_mubi_pkg::MuBi4True);
-    csr_update(.csr(ral.module_enable));
+    csr_wr(.ptr(ral.module_enable.module_enable), .value(prim_mubi_pkg::MuBi4True));
   endtask
 
-  virtual task entropy_src_init(entropy_src_dut_cfg newcfg=cfg.dut_cfg);
+  virtual task entropy_src_init(entropy_src_dut_cfg newcfg=cfg.dut_cfg, bit do_disable=1'b0);
     int hi_thresh, lo_thresh;
+
+    if (do_disable) begin
+      ral.module_enable.set(MuBi4False);
+      csr_update(.csr(ral.module_enable));
+    end
 
     // TODO: RepCnt and RepCntS thresholds
     // TODO: Separate sigmas for bypass and FIPS operation
@@ -152,18 +138,10 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
     // configure the rest of the variables afterwards so that sw_regupd & module_enable
     // get written last
-    super.entropy_src_init(newcfg);
+    // Note there is no need to disable the dut again for the remaining registers
+    // it has already been done above.
+    super.entropy_src_init(.newcfg(newcfg), .do_disable(1'b0));
 
-  endtask
-
-  //
-  // The csr_access seq task executes all csr accesses for enabling/disabling the DUT as needed,
-  // clearing assertions
-  //
-  task csr_access_seq();
-    // Explicitly enable the DUT
-    enable_dut();
-    #(cfg.sim_duration);
   endtask
 
   task pre_start();
@@ -178,18 +156,8 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     // Create rng host sequence
     m_rng_push_seq = entropy_src_base_rng_seq::type_id::create("m_rng_push_seq");
 
-    // Create csrng host sequence
-    m_csrng_pull_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)::
-        type_id::create("m_csrng_pull_seq");
-
-    m_csrng_pull_seq_single = push_pull_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)::
-        type_id::create("m_csrng_pull_seq_single");
-    m_csrng_pull_seq_single.num_trans = 1;
-
     m_rng_push_seq.hard_mtbf = cfg.hard_mtbf;
     m_rng_push_seq.soft_mtbf = cfg.soft_mtbf;
-
-    do_background_procs = 1'b1;
 
     super.pre_start();
   endtask
@@ -200,7 +168,11 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   // TODO (documentation): Make sure this get an issue to be sure it goes into SW
   task reinit_dut(bit switch_to_fips_mode = 0);
 
-    csr_wr(.ptr(ral.module_enable.module_enable), .value(prim_mubi_pkg::MuBi4False));
+    // Flag to force SW update to fire.
+    // We'll only use this if we have gaps in coverage.
+    bit check_sw_update_explicit = 1'b0;
+
+    csr_wr(.ptr(ral.module_enable.module_enable), .value(MuBi4False));
     // Disabling the module will clear the error state,
     // as well as the observe and entropy_data FIFOs
     // Clear all three related interupts here
@@ -208,10 +180,12 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
     // Optionally switch the device into FIPS mode for the remainder of the test
     if (switch_to_fips_mode) begin
+      `uvm_info(`gfn, "SWITCHING to FIPS mode", UVM_MEDIUM)
       csr_wr(.ptr(ral.conf.fips_enable), .value(MuBi4True));
     end
 
-    csr_wr(.ptr(ral.recov_alert_sts.es_main_sm_alert), .value(1'b1));
+    // Clear all recoverable alerts
+    csr_wr(.ptr(ral.recov_alert_sts), .value(32'hffff_ffff));
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_check_ht_diag)
     if (do_check_ht_diag) begin
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_access_alert_sts)
@@ -222,11 +196,15 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
       `uvm_info(`gfn, "HT value check complete", UVM_HIGH)
     end
 
-    if ((cfg.dut_cfg.sw_regupd == 0) && (ral.sw_regupd.sw_regupd.get() == 0)) begin
-      // Take this opportunity to test the sw_regupd register
-      // Even though the module is disabled, the reconfig should not work
-      random_reconfig();
+    if (check_sw_update_explicit &&
+        (cfg.dut_cfg.sw_regupd == 0) && (ral.sw_regupd.sw_regupd.get() == 0)) begin
+      entropy_src_dut_cfg altcfg;
+      altcfg=cfg.dut_cfg;
+      `DV_CHECK_RANDOMIZE_FATAL(altcfg)
+      entropy_src_init(altcfg);
       check_reconfig();
+      // Don't bother updating cfg.dut_cfg for this rare case.  Updating the dut_cfg is
+      // useful for logging, but it may not be worth the complexity here.
     end
 
     enable_dut();
@@ -296,16 +274,14 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     end
 
     if (intr_status[FatalErr]) begin
+      bit [TL_DW - 1:0] err_code_val;
       `uvm_info(`gfn, "starting shutdown", UVM_MEDIUM)
       // Gracefully stop the indefinite push and pull sequences, which
       // tend to raise endless objections after a hard reset.
-      shutdown_indefinite_seqs();
-      `uvm_info(`gfn, "SEQs SHUTDOWN applying hard reset", UVM_MEDIUM)
-      apply_reset(.kind("HARD"));
-      // Relaunch the push and pull sequences
-      start_indefinite_seqs();
-      // Restart the DUT with a new configuration
-      random_reconfig();
+      do_background_procs = 0;
+      // check the err_codes
+      csr_rd(.ptr(ral.err_code), .value(err_code_val));
+      reset_needed = 1;
     end
 
     `uvm_info(`gfn, "Interrupt handler complete", UVM_FULL)
@@ -316,14 +292,21 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     // Once the CSR access is done, we can shut down everything else
     // Note: the CSRNG agent needs to be completely shut down before
     // shutting down the the AST/RNG.  Otherwise the CSRNG pull agent
-    // will stall waiting for entropy.
+    // will stall waiting for entropy
+    `uvm_info(`gfn, "Confirming that CSRNG indefinite seq has started", UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("STATE: %s", m_csrng_pull_seq.get_sequence_state().name), UVM_HIGH)
+    m_csrng_pull_seq.wait_for_sequence_state(UVM_BODY);
+
     `uvm_info(`gfn, "Stopping CSRNG seq", UVM_LOW)
     m_csrng_pull_seq.stop(.hard(1));
+    //p_sequencer.csrng_sequencer_h.stop_sequences();
+    `uvm_info(`gfn, "Stopping CSRNG sequencer", UVM_LOW)
     m_csrng_pull_seq.wait_for_sequence_state(UVM_FINISHED);
     `uvm_info(`gfn, "Stopping RNG seq", UVM_LOW)
     m_rng_push_seq.stop(.hard(0));
     m_rng_push_seq.wait_for_sequence_state(UVM_FINISHED);
-    `uvm_info(`gfn, "Exiting test body.", UVM_LOW)
+    `uvm_info(`gfn, "SEQs SHUTDOWN applying CSRNG reset", UVM_MEDIUM)
+    apply_reset(.kind("CSRNG_ONLY"));
   endtask
 
   function void randomize_unexpected_config_time();
@@ -349,24 +332,6 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     end
   endfunction
 
-  // A task to test the regupd and auto-lock regwen features.
-  // Copies the existing env_cfg (with existing knobs)
-  // and randomizes it to yield a new random configuration,
-  // which it then applies to the DUT.
-  //
-  // If the Reg-locking features are working properly this
-  // should have no effect
-  task random_reconfig();
-     entropy_src_dut_cfg altcfg;
-    `uvm_info(`gfn, "Randomly reconfiguring DUT", UVM_HIGH)
-    altcfg = new cfg.dut_cfg;
-
-    `DV_CHECK_RANDOMIZE_FATAL(altcfg);
-    altcfg.default_ht_thresholds = 1;
-    `uvm_info(`gfn, altcfg.convert2string(), UVM_HIGH)
-    entropy_src_init(altcfg);
-  endtask
-
   task check_reconfig();
     string lockable_conf_regs [] = '{
         "conf", "entropy_control", "health_test_windows", "repcnt_thresholds", "repcnts_thresholds",
@@ -376,109 +341,297 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     foreach (lockable_conf_regs[i]) begin
       bit [TL_DW - 1:0] val;
       uvm_reg csr = ral.get_reg_by_name(lockable_conf_regs[i]);
-      val = csr.get();
+      csr_rd(.ptr(csr), .value(val));
     end
   endtask
 
+  task post_start();
+    expect_fatal_alerts = 1;
+    super.post_start();
+  endtask
+
   task start_indefinite_seqs();
+
+    // Create a new csrng host sequence
+    //
+    // (Since we are frequently interrupting the CSRNG sequence mid-item, it
+    // seems to often not like to be restarted, and the old one will often just
+    // stay in the UVM_FINISHED state, so we create a new sequence item each time)
+    m_csrng_pull_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)::
+        type_id::create("m_csrng_pull_seq");
+
     fork
       // Thread 1 of 2: run the RNG push sequencer
-      m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
-      // Thread 2 or 2: run the CSRNG pull sequencer
-      // If the DUT is supposed to start in BOOT mode,
-      // send a signal to reenable the DUT in continuous mode
-      // after receiving one CSRNG seed.
       begin
-        if (cfg.dut_cfg.route_software == MuBi4False &&
-            cfg.dut_cfg.fips_enable == MuBi4False) begin
-          // Notify the CSR access thread after the single boot mode seed has been received
-          m_csrng_pull_seq_single.start(p_sequencer.csrng_sequencer_h);
-          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_reenable_dut);
-          cfg.clk_rst_vif.wait_clks(dly_to_reenable_dut);
-          // restart the DUT in continuous mode
-          do_reenable = 1;
-        end
-        // Collect all post boot mode seeds in indefinite mode
+        m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
+      end
+
+      // Thread 2 or 2: run the CSRNG pull sequencer
+      begin
         m_csrng_pull_seq.start(p_sequencer.csrng_sequencer_h);
       end
     join_none
   endtask
 
-  task body();
+  // A thread-task to continuously inject entropy
+  //
+  // To be started if:
+  // A. the DUT config requires it, or
+  // B. the env config wants to inject it spuriously (to test that it has
+  //    to side effects)
+  //
+  // This task is fairly simple it only does two things:
+  // 1. It writes to fw_ov_wr_data
+  // 2. As needed, it turns the SHA3 conditioning on and off.
+  //    TODO: check that the behavior of this thread matches what is expected
+  //    For boot mode.
+  //
+  // Runs until the timer thread halts background operations
+  task entropy_inject_thread();
+    bit do_inject, injection_mandatory;
     bit [TL_DW - 1:0] fw_ov_value;
-    super.body();
-    randomize_unexpected_config_time();
-    randomize_csr_alert_time();
-    // Start sequences in the background
-    start_indefinite_seqs();
-    fork
-      begin
-        `uvm_info(`gfn, "Starting interrupt loop", UVM_HIGH)
-        while (do_background_procs) begin
-          process_interrupts();
-          // If a NON-FIPS-to-FIPS re-enable is needed, coordinate the
-          // re-enable process with the interrupt handler to avoid
-          // I/O conflicts (e.g. reading I/O queues while the DUT is being
-          // disabled.) Such activities lead to alerts which are very hard
-          // to predict generally, and should be validated in the alert
-          // tests.
-          if (do_reenable) begin
-            do_reenable = 0;
-            reinit_dut(1);
-          end
-          // Check if it is time to attempt another random reconfig event
-          if (sched_reconfig_time > 0 && $realtime() > sched_reconfig_time) begin
-            random_reconfig();
-            randomize_unexpected_config_time();
-            check_reconfig();
-          end
-          // Check if it is time for a randomized csr-driven alert
-          // (generated via the ERR_CODE_TEST register)
-          // Note: these alerts are only checked when enabled.
-          if (sched_csr_alert_time > 0 && $realtime() > sched_csr_alert_time &&
-              ral.module_enable.module_enable.get_mirrored_value() == MuBi4True) begin
-            string msg;
-            `DV_CHECK_MEMBER_RANDOMIZE_FATAL(csr_alert_value);
-            msg = $sformatf("Generating alert via ERR_CODE_TEST with err_code %d", csr_alert_value);
-            `uvm_info(`gfn, msg, UVM_LOW)
-            csr_wr(.ptr(ral.err_code_test.err_code_test), .value(csr_alert_value));
-            randomize_csr_alert_time();
-          end
-        end
-        `uvm_info(`gfn, "Exiting interrupt loop", UVM_HIGH)
-      end
-      // Inject entropy if
-      // 1. the DUT config requires it, or
-      // 2. the env config wants to inject it spuriously
-      if (cfg.spurious_inject_entropy ||
-          ((cfg.dut_cfg.fw_over_enable == MuBi4True)
-            && (cfg.dut_cfg.fw_read_enable == MuBi4True)) ) begin
-        while (do_background_procs) begin
-          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fw_ov_insert_per_seed);
-          ral.fw_ov_sha3_start.fw_ov_insert_start.set(MuBi4True);
-          csr_update(.csr(ral.fw_ov_sha3_start));
-          for(int i = 0; i < fw_ov_insert_per_seed; i++) begin
-            `DV_CHECK_STD_RANDOMIZE_FATAL(fw_ov_value);
-            `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_insert_entropy);
-            cfg.clk_rst_vif.wait_clks(dly_to_insert_entropy);
-            `uvm_info(`gfn, $sformatf("injecting entropy: %08x", fw_ov_value), UVM_FULL)
-            ral.fw_ov_wr_data.set(fw_ov_value);
-            csr_update(.csr(ral.fw_ov_wr_data));
-          end
-          ral.fw_ov_sha3_start.fw_ov_insert_start.set(MuBi4False);
-          csr_update(.csr(ral.fw_ov_sha3_start));
+
+    injection_mandatory = ((cfg.dut_cfg.fw_over_enable == MuBi4True) &&
+                           (cfg.dut_cfg.fw_read_enable == MuBi4True));
+    do_inject           = injection_mandatory || cfg.spurious_inject_entropy;
+
+    if (do_inject) begin
+      while (do_background_procs) begin
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fw_ov_insert_per_seed);
+        ral.fw_ov_sha3_start.fw_ov_insert_start.set(MuBi4True);
+        csr_update(.csr(ral.fw_ov_sha3_start));
+        for(int i = 0; i < fw_ov_insert_per_seed; i++) begin
+          `DV_CHECK_STD_RANDOMIZE_FATAL(fw_ov_value);
           `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_insert_entropy);
           cfg.clk_rst_vif.wait_clks(dly_to_insert_entropy);
+          `uvm_info(`gfn, $sformatf("injecting entropy: %08x", fw_ov_value), UVM_FULL)
+          ral.fw_ov_wr_data.set(fw_ov_value);
+          csr_update(.csr(ral.fw_ov_wr_data));
         end
+        ral.fw_ov_sha3_start.fw_ov_insert_start.set(MuBi4False);
+        csr_update(.csr(ral.fw_ov_sha3_start));
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_insert_entropy);
+        cfg.clk_rst_vif.wait_clks(dly_to_insert_entropy);
       end
-      begin
-        csr_access_seq();
+    end
+  endtask
+
+  // A thread task to continously handle interrupts
+  // runs until the timer thread
+  task interrupt_handler_thread();
+    `uvm_info(`gfn, "Starting interrupt loop", UVM_HIGH)
+    while (do_background_procs) begin
+      process_interrupts();
+      // If a NONFIPS-to-FIPS re-enable is needed, coordinate the
+      // re-enable process with the interrupt handler to avoid
+      // I/O conflicts (e.g. reading I/O queues while the DUT is being
+      // disabled.) Such activities lead to alerts which are very hard
+      // to predict generally, and should be validated in the alert
+      // tests.
+      if (do_reenable) begin
+        do_reenable = 0;
+        `uvm_info(`gfn, "Reinitializing DUT in continuous mode", UVM_MEDIUM)
+        reinit_dut(1);
+        `uvm_info(`gfn, "Reinit complete", UVM_HIGH)
+       end
+    end
+    `uvm_info(`gfn, "Exiting interrupt loop", UVM_HIGH)
+  endtask
+
+  // A thread to prompt the simulation to end at the correct time.
+  // 1. Sets continue_sim to 0 when simulation is due to end
+  // 2. Stops background processes
+  task master_timer_thread();
+    realtime delta = cfg.sim_duration - $realtime();
+    // Assumes that continue_sim has already
+    // been set to 1
+    if (delta > 0) begin
+      #(delta);
+      do_background_procs = 0;
+      continue_sim = 0;
+    end
+  endtask
+
+  // Keep an eye on the number of SEEDS received on the
+  // CSRNG interface, and trigger a re-start if the
+  // DUT has probably hung because when in Boot Mode
+  // it can only generate one seed.
+  task reinit_monitor_thread();
+    bit boot_mode_csrng;
+    mubi4_t fips_enable, es_route;
+
+    wait(cfg.under_reset == 0);
+    csr_rd(.ptr(ral.conf.fips_enable), .value(fips_enable));
+    csr_rd(.ptr(ral.entropy_control.es_route), .value(es_route));
+
+    boot_mode_csrng = fips_enable != MuBi4True &&
+                      es_route != MuBi4True;
+
+    if (boot_mode_csrng && do_background_procs) begin
+      fork : isolation_fork
+        fork
+          begin
+            m_csrng_pull_seq.wait_for_items_processed(1);
+            // Notify the interrtupt/CSR access thread after the single boot mode seed has been
+            // received
+            `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_reenable_dut)
+            cfg.clk_rst_vif.wait_clks(dly_to_reenable_dut);
+            // restart the DUT in continuous mode
+            `uvm_info(`gfn, "Triggering reinit from BOOT to Continuous Mode", UVM_MEDIUM)
+            do_reenable = 1;
+          end
+          // Give up if we get a call to stop
+          wait(!do_background_procs);
+        join_any
+        disable fork;
+      join
+    end
+  endtask
+
+  task forced_alert_thread();
+    realtime delta;
+    string msg;
+    while (do_background_procs) begin
+      randomize_csr_alert_time();
+      if (sched_csr_alert_time > 0) begin
+        delta = sched_csr_alert_time - $realtime();
+        fork : isolation_fork
+          fork
+            #(delta);
+            wait(!do_background_procs);
+          join_any
+          disable fork;
+        join
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(csr_alert_value);
+        msg = $sformatf("Generating alert via ERR_CODE_TEST with err_code %d", csr_alert_value);
+        `uvm_info(`gfn, msg, UVM_MEDIUM)
+        csr_wr(.ptr(ral.err_code_test.err_code_test), .value(csr_alert_value));
+        // This may generate an alert.  Most codes, except code 22 (mismatched counter primitives)
+        // only generate alerts when enabled.  Code 22 always generates an alert.
+      end
+    end
+  endtask
+
+  task reconfig_timer_thread();
+    realtime delta;
+    randomize_unexpected_config_time();
+    if (sched_reconfig_time > 0) begin
+      delta = (sched_reconfig_time - $realtime());
+      fork : isolation_fork
+        fork
+          #(delta);
+          wait(!do_background_procs);
+        join_any
+        disable fork;
+      join
+      // Stop other background procs (if they haven't been already)
+      // This will prompt a reconfig.
+      do_background_procs = 0;
+    end
+  endtask
+
+  task body();
+
+    do_background_procs = 1;
+    continue_sim = 1;
+    reset_needed = 0;
+
+    // Start sequences in the background
+    start_indefinite_seqs();
+
+    // Do the first DUT initialization as usual
+    super.body();
+
+    fork
+      master_timer_thread();
+
+      while (continue_sim) begin
+        bit regwen;
+        // For use when doing random reconfigs
+        entropy_src_dut_cfg altcfg;
+
+        // Explicitly enable the DUT
+        enable_dut();
+
+        // In addition to the CSRNG and RNG sequences
+        // the following four threads will run until
+        // do_background_procs == 0
+        fork
+          entropy_inject_thread();
+          interrupt_handler_thread();
+          forced_alert_thread();
+          reconfig_timer_thread();
+          reinit_monitor_thread();
+        join
+
+        if(!continue_sim) break;
+
+        // Resuming single thread operation
+
+        //
+        // Resetting and/or reconfiguring before the next loop.
+        //
+        // The CSRNG agent is often an important part of DUT reinitialization it tells us when
+        // it is safe to reconfigure the entropy source from BOOT mode into CONTINUOUS mode.
+        // That said, regardless of whether we resetting we should turn off the CSRNG/RNG
+        // sequences.
+        //
+        // Meanwhile, this shutdown of the CSRNG agent is even more important, as
+        // the CSRNG monitor can cause things to hang or give spurious fatal errors
+        // if the monitor is reset without stopping the sequence first.
+        // (TODO: Examine this more closely & file an issue)
+        //
+
         `uvm_info(`gfn, "Shutting down push_pull seqs", UVM_LOW)
         shutdown_indefinite_seqs();
-        `uvm_info(`gfn, "Stopping background procs", UVM_LOW)
-        do_background_procs = 1'b0;
+
+        if (reset_needed) begin
+          `uvm_info(`gfn, "SEQs SHUTDOWN applying hard reset", UVM_MEDIUM)
+          apply_reset(.kind("HARD"));
+          post_apply_reset(.reset_kind("HARD"));
+          wait(cfg.under_reset == 0);
+        end
+
+        // Make a new random dut configuration according
+        // to our current DUT constraints
+        altcfg=cfg.dut_cfg;
+        `DV_CHECK_RANDOMIZE_FATAL(altcfg)
+        entropy_src_init(altcfg);
+        // Capture the current DUT settings in cfg.dut_cfg
+        // This presents the results of the update
+        // to the scoreboard for review.
+        check_reconfig();
+        csr_rd(.ptr(ral.regwen.regwen), .value(regwen));
+        if (regwen || reset_needed) begin
+          cfg.dut_cfg = altcfg;
+          `uvm_info(`gfn, "DUT Reconfigured", UVM_LOW)
+          `uvm_info(`gfn, cfg.dut_cfg.convert2string(), UVM_LOW)
+        end
+
+        // Now we can clear the reset flag.
+        reset_needed = 0;
+        // Also, don't schedule a reinit yet (for BOOT-to-Continuous mode switching)
+        do_reenable = 0;
+
+        // We start the CSRNG sequence _here_ (and not earlier as) it needs
+        // to know the current configuration for whether or not the DUT is
+        // in boot mode.
+        //
+        // Ideally, however, we would like to start it before reconfiguring
+        // the DUT for checking issues with order of bring-up etc.
+        // Running the restart after the DUT has been configured is not the
+        // most stressful test.
+        `uvm_info(`gfn, "RESTARTING RNG/CSRNG SEQS", UVM_MEDIUM)
+        start_indefinite_seqs();
       end
     join
+
+    // Simulation complete
+    //
+    // Stop the CSRNG/RNG sequences, and then exit to
+    // the base class vseq for cleanup.
+
+    shutdown_indefinite_seqs();
     `uvm_info(`gfn, "Body complete", UVM_LOW)
   endtask : body
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -18,10 +18,10 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.dut_cfg.boot_mode_retry_limit       = 10;
     cfg.sim_duration                = 20ms;
     cfg.hard_mtbf                   = 100s;
-    cfg.mean_rand_reconfig_time     = -1;
-    cfg.mean_rand_csr_alert_time    = -1;
-
+    cfg.mean_rand_reconfig_time     = 1ms;
+    cfg.mean_rand_csr_alert_time    = 10ms;
     cfg.soft_mtbf                   = 7500us;
+
     // Apply standards ranging from strict to relaxed
     cfg.dut_cfg.adaptp_sigma_min            = 1.0;
     cfg.dut_cfg.adaptp_sigma_max            = 6.0;


### PR DESCRIPTION
Rewrites the entropy_src_rng_vseq to be more stable and reliable. The
fundamental changes are:
- Moves all event loops to their own explicit thread function
- All major DUT reconfigurations, resets or sequence re-initializations
  are done in a single main thread.
- Communication between the main thread and the child threads is managed
  by event signals.  When a reconfiguration is necessary the child
  threads all exit to let the main thread operate without confusion
  about the exact state of the DUT.
- A master timing thread tracks the elapsed time of the simulation
  and signals all the other threads to shut down once the simulation
  has run for the desired ammount of time.

Also includes a number of small scoreboarding changes to more accurately
predict the DUT's behavior.

Fixes #13741 

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>