### PR TITLE
[rv_plic] Typo on `alerts[0]`

### DIFF
--- a/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
@@ -214,7 +214,7 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -391,7 +391,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),


### PR DESCRIPTION
Typo `alerts[0]`. It should be `alerts[i]`.

