### PR TITLE
[dv/kmac] Fix unmapped testplan

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -209,6 +209,15 @@
       tests: ["{variant}_lc_escalation"]
     }
     {
+      name: stress_all
+      desc: '''
+            - Combine above sequences in one test to run sequentially, except csr sequence and
+              some error tests that disabled scoreboard.
+            - Randomly add reset between each sequence'''
+      milestone: V2
+      tests: ["kmac_stress_all"]
+    }
+    {
       name: entropy_timers
       desc: ''' Test entropy interface for KMAC.
 


### PR DESCRIPTION
This PR fixes unmapped stress_all tests because they have not been
declared in the testplan.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>