### PR TITLE
[reggen/doc] Treat Register/Field Description as markdown

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy-mistletoe]
+ignore_missing_imports = True

--- a/util/reggen/BUILD
+++ b/util/reggen/BUILD
@@ -227,6 +227,7 @@ py_library(
         ":reg_block",
         ":register",
         ":window",
+        requirement("mistletoe"),
     ],
 )
 

--- a/util/reggen/Makefile
+++ b/util/reggen/Makefile
@@ -7,7 +7,7 @@ all: lint
 
 # We need a directory to build stuff and use the "util/reggen" namespace
 # in the top-level build-bin directory.
-repo-top := ../../../..
+repo-top := ../..
 build-dir := $(repo-top)/build-bin/util/reggen
 
 $(build-dir):
@@ -19,7 +19,7 @@ mypy-excls := gen_json.py gen_selfdoc.py
 py-files := $(filter-out $(mypy-excls),$(wildcard *.py))
 
 $(build-dir)/mypy.stamp: $(py-files) | $(build-dir)
-	mypy --strict $^
+	mypy --strict --config $(repo-top)/mypy.ini $^
 	touch $@
 
 .PHONY: lint

--- a/util/reggen/field.py
+++ b/util/reggen/field.py
@@ -18,7 +18,11 @@ REQUIRED_FIELDS = {
 
 OPTIONAL_FIELDS = {
     'name': ['s', "name of the field"],
-    'desc': ['t', "description of field (required if the field has a name)"],
+    'desc': [
+        't',
+        "description of field (required if the field has a name). "
+        "This field supports the markdown syntax."
+    ],
     'alias_target': [
         's',
         "name of the field to apply the alias definition to."

--- a/util/reggen/gen_html.py
+++ b/util/reggen/gen_html.py
@@ -7,6 +7,8 @@ Generate HTML documentation from IpBlock
 
 from typing import Optional, Set, TextIO
 
+import mistletoe as mk
+
 from .ip_block import IpBlock
 from .html_helpers import expand_paras, render_td
 from .multi_register import MultiRegister
@@ -161,7 +163,7 @@ def gen_html_register(outfile: TextIO,
     if desc_body:
         genout(outfile,
                '<tr><td colspan=5>{}</td></tr>'
-               .format(''.join(desc_body)))
+               .format(mk.markdown(desc_body)))
 
     genout(outfile, "<tr><td colspan=5>")
     gen_html_reg_pic(outfile, reg, width)
@@ -200,7 +202,7 @@ def gen_html_register(outfile: TextIO,
         desc_parts = []
 
         if field.desc is not None:
-            desc_parts += expand_paras(field.desc, rnames)
+            desc_parts += expand_paras(mk.markdown(field.desc), rnames)
 
         if field.enum is not None:
             desc_parts.append('<table>')

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -16,7 +16,11 @@ import re
 
 REQUIRED_FIELDS = {
     'name': ['s', "name of the register"],
-    'desc': ['t', "description of the register"],
+    'desc': [
+        't',
+        "description of the register. "
+        "This field supports the markdown syntax."
+    ],
     'fields': ['l', "list of register field description groups"]
 }
 


### PR DESCRIPTION
This commit revises reggen to parse the descriptions as markdown doc.
This allows writers to use markdown syntax (list, emphasis, etc) inside
the register description and field description.

