### PR TITLE
[dv/kmac] Fix EDN timeout assertion failures

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
@@ -47,10 +47,7 @@ class kmac_edn_timeout_error_vseq extends kmac_app_vseq;
 
   virtual function void disable_asserts();
     $assertoff(0,
-      "tb.dut.gen_entropy.u_edn_req.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckHoldReq");
-    $assertoff(0,
-      // verilog_lint: waive line-length-exceeds-max
-      "tb.dut.gen_entropy.u_edn_req.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
+      "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
     $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
     $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
   endfunction

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -1104,7 +1104,7 @@ module kmac
       .rst_src_ni(rst_ni),
       .clk_dst_i (clk_edn_i),
       .rst_dst_ni(rst_edn_ni),
-      .req_chk_i (kmac_entropy_state_error == 1'b0),
+      .req_chk_i ((kmac_entropy_state_error == 1'b0) && (entropy_err.valid == 1'b0)),
       .src_req_i (entropy_req),
       .src_ack_o (entropy_ack),
       .dst_req_o (entropy_o.edn_req),

--- a/hw/ip/prim/rtl/prim_sync_reqack.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack.sv
@@ -171,7 +171,7 @@ module prim_sync_reqack (
   end
 
   // SRC domain can only de-assert REQ after receiving ACK.
-  `ASSERT(SyncReqAckHoldReq, $fell(src_req_i) |->
+  `ASSERT(SyncReqAckHoldReq, $fell(src_req_i) && req_chk_i |->
       $fell(src_ack_o), clk_src_i, !rst_src_ni || !req_chk_i)
 
   // DST domain cannot assert ACK without REQ.


### PR DESCRIPTION
This PR fixes edn_timeout test's assertion failures:
1). Req should be asserted until ack -> Fix this assertion error by
  extending the disable check statement to sequence level.
2). Fix a path within the disable assertion statement in DV.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>