### PR TITLE
[dv, waves] Improve wave dumping

### DIFF
--- a/hw/dv/tools/sim.tcl
+++ b/hw/dv/tools/sim.tcl
@@ -14,8 +14,24 @@ if {[info exists ::env(dv_root)]} {
   quit
 }
 
+# Dumping waves in specific hierarchies.
+#
+# By default, if wave dumping is enabled, all hierarchies of the top level testbench are dumped.
+# For large designs, this may slow down the simulation considerably. To bypass this and only enable
+# waves in specific hierarchies, set the dump_tb_top flag to 0 (i.e. uncomment the line below), and
+# specify the paths to dump on line 32.
+# set dump_tb_top 0
+
 source "${dv_root}/tools/common.tcl"
 source "${dv_root}/tools/waves.tcl"
+
+global waves
+global simulator
+global tb_top
+
+# Dumping waves in specific hierarchies (example):
+# wavedumpScope $waves $simulator tb.dut.foo.bar 12
+# wavedumpScope $waves $simulator tb.dut.baz 0
 
 # In GUI mode, let the user take control of running the simulation.
 global gui

--- a/hw/dv/tools/waves.tcl
+++ b/hw/dv/tools/waves.tcl
@@ -12,91 +12,31 @@ if {[info proc setDefault] ne "setDefault"} {
   quit
 }
 
-global simulator
-global waves
-global tb_top
-
-set wavedump_db "waves.$waves"
-
-# TODO: convert this to a proc?
-set fid ""
-switch $waves {
-  "none" {
-    puts "INFO: Dumping waves is not enabled."
-  }
-
-  "fsdb" {
-    if {$simulator eq "xcelium"} {
-      call fsdbDumpfile $wavedump_db
-    } else {
-      fsdbDumpfile $wavedump_db
-    }
-  }
-
-  "shm" {
-    checkEq simulator "xcelium"
-    database -open $wavedump_db -default -shm
-  }
-
-  "vpd" {
-    checkEq simulator "vcs"
-    set fid [dump -file $wavedump_db -type VPD]
-  }
-
-  "vcd" {
-    if {$simulator eq "xcelium"} {
-      database -open $wavedump_db -default -vcd
-    } else {
-      puts "ERROR: Simulator $simulator does not support dumping waves in VCD."
-      quit
-    }
-  }
-
-  "evcd" {
-    if {$simulator eq "xcelium"} {
-      database -open $wavedump_db -default -evcd
-    } else {
-      puts "ERROR: Simulator $simulator does not support dumping waves in EVCD."
-      quit
-    }
-  }
-
-  default {
-    puts "ERROR: Unknown wave format: ${waves}."
-    quit
-  }
-}
-
-if {$waves ne "none"} {
-  puts "INFO: Dumping waves in [string toupper $waves] format to $wavedump_db."
-}
-
-# Provides wave-format-agnostic way to set a scope (design heirarchy).
+# A procedure that provides a wave-format-agnostic way to enable a scope (design heirarchy).
 #
 # In large designs, dumping waves on the entire hierarchy can significantly slow down the
 # simulation. It is useful in that case to only dump the relevant scopes of interest during debug.
 #
+# waves       : The wave-format (fsdb, shm, vpd, vcd, evcd, etc).
+# simulator   : The simulator used for running the simulation (vcs, xcelium, etc).
 # scope       : Design / testbench hierarchy to dump waves. Defaults to $tb_top.
-# fid         : File ID returned by the dump command in the first step above.
 # depth       : Levels in the hierarchy to dump waves. Defaults to 0 (dump all levels).
-# fsdb_flags  : Additional string flags passed to fsdbDumpVars. Defaults to "+all".
+# fsdb_flags  : Additional string flags passed to fsdbDumpVars. Defaults to "+all", which enables
+#               dumping of memories, MDAs, structs, unions, power, packed structs, and SVAs.
 # probe_flags : Additional string flags passed to probe command (Xcelium). Defaults to "-all".
-# dump_flags  : Additional string flags passed to dump command (VCS). Defaults to "-aggregates".
+# dump_flags  : Additional string flags passed to dump command (VCS). Defaults to "-aggregates",
+#               which enables dumping of structs and arrays.
 #
-# Depending on the need, more such technlogy specific flags can be added in future.
-proc wavedumpScope {scope fid {depth 0} {fsdb_flags "+all"} {probe_flags  "-all"}
+# Depending on the need, more such technology specific flags can be added in future.
+proc wavedumpScope {waves simulator scope {depth 0} {fsdb_flags "+all"} {probe_flags "-all"}
                     {dump_flags "-aggregates"}} {
-  global simulator
-  global waves
-  global wavedump_db
 
   switch $waves {
     "none" {
+      return
     }
 
     "fsdb" {
-      # The fsdbDumpvars +all command dumps everything: memories, MDAs,
-      # structs, unions, power, packed structs. In addition, also dump SVAs.
       if {$simulator eq "xcelium"} {
         call fsdbDumpvars $depth $scope $fsdb_flags
         call fsdbDumpSVA $depth $scope
@@ -114,9 +54,8 @@ proc wavedumpScope {scope fid {depth 0} {fsdb_flags "+all"} {probe_flags  "-all"
     }
 
     "vpd" {
-      # The dump command switch -aggregates enables dumping of structs &
-      # arrays.
-      dump -add "$scope" -fid $fid -depth $depth $dump_flags
+      global vpd_fid
+      dump -add "$scope" -fid $vpd_fid -depth $depth $dump_flags
     }
 
     "vcd" {
@@ -142,19 +81,83 @@ proc wavedumpScope {scope fid {depth 0} {fsdb_flags "+all"} {probe_flags  "-all"
       quit
     }
   }
+
   puts "INFO: Dumping waves in scope \"$scope:$depth\"."
 }
 
-# Decide whether to dump the entire testbench hierarchy by default.
+# A global variable representing the file id (fid) of the waves dumped in VPD format.
+setDefault vpd_fid 0
+
+# The entry point to enable dumping waves.
 #
-# If this variable is not set externally, it is set to 1 by default here. When set to 1, it adds the
-# entire top-level testbench instance for dumping waves. For larger designs, this may slow down the
-# simulation. The user can if needed, set it to 0 in the external tcl script that sources this
-# script and manually add the hierarchies of interest in there, using the wavedumpScope proc.
-setDefault dump_tb_top 1
+# If waves are not enabled (i.e. $waves == "none"), we do nothing. If enabled, then first, we run
+# the tcl command to establish the dump file. Then, we run `wavedumpScope args...` to enable dumping
+# the required hierarchies.
+global waves
+global simulator
+if {$waves ne "none"} {
+  set wavedump_db "waves.$waves"
+  puts "INFO: Dumping waves in [string toupper $waves] format to $wavedump_db."
 
+  # If waves are enabled, then issue the necessary tcl commands to enable the generation of waves.
+  # To explicitly list the hierarchies to dump, use the wavedumpScope proc instead.
+  switch $waves {
+    "fsdb" {
+      if {$simulator eq "xcelium"} {
+        call fsdbDumpfile $wavedump_db
+      } else {
+        fsdbDumpfile $wavedump_db
+      }
+    }
 
-# By default, add the full test bench scope for wavedump.
-if {$dump_tb_top == 1} {
-  wavedumpScope $tb_top $fid
+    "shm" {
+      checkEq simulator "xcelium"
+      database -open $wavedump_db -default -shm
+    }
+
+    "vpd" {
+      checkEq simulator "vcs"
+      global vpd_fid
+      set vpd_fid [dump -file $wavedump_db -type VPD]
+    }
+
+    "vcd" {
+      if {$simulator eq "xcelium"} {
+        database -open $wavedump_db -default -vcd
+      } else {
+        puts "ERROR: Simulator $simulator does not support dumping waves in VCD."
+        quit
+      }
+    }
+
+    "evcd" {
+      if {$simulator eq "xcelium"} {
+        database -open $wavedump_db -default -evcd
+      } else {
+        puts "ERROR: Simulator $simulator does not support dumping waves in EVCD."
+        quit
+      }
+    }
+
+    default {
+      puts "ERROR: Unknown wave format: ${waves}."
+      quit
+    }
+  }
+
+  # Decide whether to dump the entire testbench hierarchy by default.
+  #
+  # If this variable is not set externally, it is set to 1 by default here. When set to 1, it adds
+  # the entire top-level testbench instance for dumping waves. For larger designs, this may slow
+  # down the simulation. The user can if needed, set it to 0 in the external tcl script that sources
+  # this script and manually add the hierarchies of interest in there, using the wavedumpScope proc.
+  # See the adjoining sim.tcl for an example.
+  setDefault dump_tb_top 1
+
+  if {$dump_tb_top == 1} {
+    global tb_top
+    wavedumpScope $waves $simulator $tb_top 0
+  } else {
+    puts "INFO: the hierarchies to be dumped are expected to be indicated externally."
+  }
 }


### PR DESCRIPTION
A minor non-functional change to waves.tcl improves the way
wavedumpScope method is used to dump specific hierarchies
rather than dump the tb top by default.

The code is rearranged a little, and several comments are added
to make the usage clearer. the `fid` argument of `wavedumpScope
proc is removed in favor of using the value internally by
referencing a global variable instead of passing it as an arg.

Wavedumping has been tested with vcs:fsdb,vpd,vcd and
xcelium:shm,fsdb and everything seeems to be working ok.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>