### PR TITLE
[dv/kmac] Fix assertion failures in shadow reg

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
@@ -19,8 +19,11 @@ class kmac_common_vseq extends kmac_base_vseq;
       csr_excl_item csr_excl = ral.get_excl_item();
       // Shadow storage fatal error might cause req to drop without ack.
       $assertoff(0,
-      "tb.dut.gen_entropy.u_edn_req.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckHoldReq");
+      "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckHoldReq");
+      $assertoff(0,
+      "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
       $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
+      $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
     end
   endtask
 


### PR DESCRIPTION
This PR disable a few assertions when shadow_reg error fires.
Because the kmac will go to terminal state.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>