### PR TITLE
[dv, chip] Fixes to enable simulations with Xcelium

### DIFF
--- a/hw/dv/sv/tl_agent/tl_device_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_device_driver.sv
@@ -23,6 +23,8 @@ class tl_device_driver extends tl_base_driver;
 
   // reset signals every time reset occurs.
   virtual task reset_signals();
+    invalidate_d_channel();
+    cfg.vif.d2h_int.a_ready <= 1'b0;
     forever begin
       @(negedge cfg.vif.rst_n);
       invalidate_d_channel();

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -50,6 +50,8 @@ class tl_host_driver extends tl_base_driver;
 
   // reset signals every time reset occurs.
   virtual task reset_signals();
+    invalidate_a_channel();
+    cfg.vif.h2d_int.d_ready <= 1'b0;
     forever begin
       @(negedge cfg.vif.rst_n);
       reset_asserted = 1'b1;

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -8,6 +8,7 @@
   build_db_dir: "{build_dir}/xcelium.d"
 
   build_opts: ["-elaborate -64bit -sv",
+               // Wait to acquire a license.
                "-licqueue",
                // TODO: duplicate primitives between OT and Ibex #1231
                "-ALLOWREDEFINITION",
@@ -15,6 +16,7 @@
                "-timescale {timescale}",
                "-f {sv_flist}",
                "-uvmhome CDNS-1.2",
+               // Specify the library name for the run step to use.
                "-xmlibdirname {build_db_dir}",
                // List multiple tops for the simulation. Prepend each top level with `-top`.
                "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
@@ -29,6 +31,8 @@
                // Use this to conditionally compile for Xcelium (example: LRM interpretations differ
                // across tools).
                "+define+XCELIUM",
+               // Suppress printing of the copyright banner.
+               "-nocopyright",
                // Ignore "timescale is not specified for the package" warning
                "-nowarn TSNSPK",
                // Ignore "IEEE 1800-2009 SystemVerilog simulation semantics" warning
@@ -53,6 +57,9 @@
   uvm_testseq_plusarg: "{eval_cmd} echo {uvm_test_seq} | sed -E 's/(.+)/+UVM_TEST_SEQ=\\1/'"
 
   run_opts:   ["-input {run_script}",
+               // Suppress printing of the copyright banner.
+               "-nocopyright",
+               // Wait to acquire a license.
                "-licqueue",
                "-64bit -xmlibdirname {build_db_dir}",
                // Use the same snapshot name set during the build step.
@@ -228,8 +235,8 @@
     {
       name: xcelium_profile
       is_sim_mode: 1
-      build_opts: []
-      run_opts:   []
+      build_opts: ["-perfstat"]
+      run_opts:   ["-perfstat", "-perflog perfstat.log"]
     }
     {
       name: xcelium_xprop

--- a/hw/dv/tools/sim.tcl
+++ b/hw/dv/tools/sim.tcl
@@ -37,5 +37,11 @@ global tb_top
 global gui
 if {$gui == 0} {
   run
-  quit
+  if {$simulator eq "xcelium"} {
+    # Xcelium provides a `finish` tcl command instead of `quit`. The argument '2' enables the
+    # logging of additional resource usage information.
+    finish 2
+  } else {
+    quit
+  }
 }

--- a/hw/dv/tools/sim.tcl
+++ b/hw/dv/tools/sim.tcl
@@ -33,6 +33,11 @@ global tb_top
 # wavedumpScope $waves $simulator tb.dut.foo.bar 12
 # wavedumpScope $waves $simulator tb.dut.baz 0
 
+if {$simulator eq "xcelium"} {
+  puts "INFO: The following assertions are permamently disabled:"
+  assertion -list -depth all -multiline -permoff $tb_top
+}
+
 # In GUI mode, let the user take control of running the simulation.
 global gui
 if {$gui == 0} {

--- a/hw/ip/rv_core_ibex/rtl/rv_core_addr_trans.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_addr_trans.sv
@@ -12,10 +12,10 @@ module rv_core_addr_trans import rv_core_ibex_pkg::*; #(
   parameter int AddrWidth = 32,
   parameter int NumRegions = 2
 ) (
-  input clk_i,
-  input rst_ni,
+  input logic clk_i,
+  input logic rst_ni,
   input region_cfg_t [NumRegions-1:0] region_cfg_i,
-  input [AddrWidth-1:0] addr_i,
+  input logic [AddrWidth-1:0] addr_i,
   output logic [AddrWidth-1:0] addr_o
 );
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -147,14 +147,10 @@ class chip_base_vseq #(
 
   // shorten alert ping timer enable wait time
   virtual task check_lc_ctrl_broadcast(bit [LcBroadcastLast-1:0] bool_vector);
-    string path;
-    lc_ctrl_pkg::lc_tx_t curr_val;
-
     foreach (lc_broadcast_paths[i]) begin
-      path = {`DV_STRINGIFY(`LC_CTRL_HIER),
-      ".", lc_broadcast_paths[i]};
-      uvm_hdl_read(path, curr_val);
-
+      uvm_hdl_data_t curr_val;
+      string path = {`DV_STRINGIFY(`LC_CTRL_HIER), ".", lc_broadcast_paths[i]};
+      `DV_CHECK_FATAL(uvm_hdl_read(path, curr_val))
       // if bool vector bit is 1, the probed value should be ON
       // if bool vector bit is 0, the probed value should be OFF
       if (bool_vector[i] ~^ (curr_val == lc_ctrl_pkg::On)) begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -14,10 +14,10 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
     super.post_apply_reset(reset_kind);
 
     for (int ram_idx = 0; ram_idx < cfg.num_ram_ret_tiles; ram_idx++) begin
-      cfg.mem_bkdr_util_h[int'(RamRet0) + ram_idx].randomize_mem();
+      cfg.mem_bkdr_util_h[chip_mem_e'(RamRet0 + ram_idx)].randomize_mem();
     end
     for (int ram_idx = 0; ram_idx < cfg.num_ram_main_tiles; ram_idx++) begin
-      cfg.mem_bkdr_util_h[int'(RamMain0) + ram_idx].randomize_mem();
+      cfg.mem_bkdr_util_h[chip_mem_e'(RamMain0 + ram_idx)].randomize_mem();
     end
     wait_rom_check_done();
   endtask
@@ -52,4 +52,5 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
     $asserton(0, "tb.dut.u_ast.u_jitter_en_sync.PrimMubi4SyncCheckTransients0_A");
     $asserton(0, "tb.dut.u_ast.u_jitter_en_sync.PrimMubi4SyncCheckTransients1_A");
   endtask
+
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_escalation_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_escalation_vseq.sv
@@ -68,7 +68,7 @@ class chip_sw_alert_handler_escalation_vseq extends chip_sw_base_vseq;
       cfg.sw_test_timeout_ns);
 
     prev_key = curr_key;
-    uvm_hdl_read(keymgr_path, curr_key);
+    `DV_CHECK_FATAL(uvm_hdl_read(keymgr_path, curr_key))
     if (curr_key == prev_key) begin
       `uvm_fatal(`gfn, $sformatf("something is very wrong"))
     end

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -71,7 +71,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     // as early portions of mask ROM will initialize it to the correct value.
     // The randomization here is just to ensure we do not have x's in the memory.
     for (int ram_idx = 0; ram_idx < cfg.num_ram_ret_tiles; ram_idx++) begin
-      cfg.mem_bkdr_util_h[int'(RamRet0) + ram_idx].randomize_mem();
+      cfg.mem_bkdr_util_h[chip_mem_e'(RamRet0 + ram_idx)].randomize_mem();
     end
 
     `uvm_info(`gfn, "Initializing ROM", UVM_MEDIUM)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_sleep_all_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_sleep_all_reset_vseq.sv
@@ -23,7 +23,7 @@ class chip_sw_deep_sleep_all_reset_vseq extends chip_sw_base_vseq;
 
   rand int cycles_after_trigger;
   rand int cycles_till_reset;
-  rand bit reset_delay;
+  rand int reset_delay;
   int loop_num;
 
   constraint cycles_after_trigger_c {cycles_after_trigger inside {[0 : 9]};}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_sleep_all_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_sleep_all_reset_vseq.sv
@@ -23,7 +23,7 @@ class chip_sw_random_sleep_all_reset_vseq extends chip_sw_base_vseq;
 
   rand int cycles_after_trigger;
   rand int cycles_till_reset;
-  rand bit reset_delay;
+  rand int reset_delay;
   int loop_num;
 
   constraint cycles_after_trigger_c {cycles_after_trigger inside {[0 : 9]};}

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -568,6 +568,28 @@ module tb;
     end
   end
 
+
+  // Kill "strong" assertion properties in these scopes at the end of simulation.
+  //
+  // At the end of the simulation, these assertions start (i.e. the antecedent is true) but before
+  // the consequent property is satisfied (which happens a few clocks later), the simulation ends
+  // via $finish, causing the simulation to report a failure. It is safe to kill these assertions
+  // because they have already succeeded several times during the course of the simulation.
+  // TODO: Find a more robust way to turn off these assertions at the end of simulation.
+  //
+  // This does not apply to VCS. Here'e the relevant note from VCS documentation that explains
+  // why:
+  // In VCS, strong and weak properties are not distinguished in terms of their reporting at the end
+  // of simulation. In all cases, if a property evaluation attempt did not complete evaluation, it
+  // is reported as unfinished evaluation attempt, and allows you to decide whether it is a failure
+  // or a success.
+`ifndef VCS
+  final begin
+    $assertkill(0, prim_reg_cdc);
+    $assertkill(0, sha3pad);
+  end
+`endif
+
   // Control assertions in the DUT with UVM resource string "dut_assert_en".
   `DV_ASSERT_CTRL("dut_assert_en", tb.dut)
 

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -75,6 +75,7 @@ class chip_base_test extends cip_base_test #(
     // Set the test timeout value to be sufficiently large.
     test_timeout_ns = 50_000_000;
     test_timeout_ns = `DV_MAX2(test_timeout_ns, 5 * cfg.sw_test_timeout_ns);
+    `uvm_info(`gfn, $sformatf("test_timeout_ns = %0d", test_timeout_ns), UVM_LOW)
   endfunction : build_phase
 
 endclass : chip_base_test


### PR DESCRIPTION
Assorted fixes in the testbench and infra code to get all chip level smoke tests to pass with Xcelium. 
All build warnings are cleaned up. There still are some very benign runtime warnings which will be cleaned in subsequent PRs. 
Once this PR is merged, a new chip level target (dvsim cfg hjson) will be added to run chip level sims with Xcelium. 
This will enable chip level sims to be run with Xcelium in CI. 