### PR TITLE
[silicon_creator/spi_device] Fix fault injection bug in spi_device_cmd_get()

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -647,6 +647,8 @@ rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd) {
   reg = abs_mmio_read32(kBase + SPI_DEVICE_UPLOAD_STATUS2_REG_OFFSET);
   cmd->payload_byte_count =
       bitfield_field32_read(reg, SPI_DEVICE_UPLOAD_STATUS2_PAYLOAD_DEPTH_FIELD);
+  // `payload_byte_count` can be at most `kSpiDevicePayloadAreaNumBytes`.
+  HARDENED_CHECK_LE(cmd->payload_byte_count, kSpiDevicePayloadAreaNumBytes);
   uint32_t src =
       kBase + SPI_DEVICE_BUFFER_REG_OFFSET + kSpiDevicePayloadAreaOffset;
   char *dest = (char *)&cmd->payload;

--- a/sw/device/silicon_creator/lib/drivers/spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.h
@@ -78,7 +78,8 @@ enum {
   /**
    * Size of the payload area in spi_device buffer in words.
    */
-  kSpiDevicePayloadAreaNumWords = 64,
+  kSpiDevicePayloadAreaNumWords =
+      kSpiDevicePayloadAreaNumBytes / sizeof(uint32_t),
   /**
    * Index of the WEL bit in flash status register.
    */


### PR DESCRIPTION
We discovered a fault injection bug in spi_device_cmd_get() in sw/device/silicon_creator/lib/drivers/spi_device.c, in which the code copies the number of bytes given in a 9-bit byte count from the PAYLOAD_DEPTH field of the SPI device's STATUS2 register into an output buffer of size 256.  While the hardware ensures always that PAYLOAD_DEPTH <= 256, a fault injection causing a flip of one of the PAYLOAD_DEPTH bits causes a stack buffer overflow.

We fixed this bug by (1) deriving the size of the spi_device_cmd_t::payload buffer from the size of the SPI device's payload buffer, and (2) performing a hardened bounds check on the PAYLOAD_DEPTH field read by the SPI device driver.

Signed-off-by: Nicholas Mosier <nmosier@google.com>