### PR TITLE
[hmac] Remove Unreachable Error

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -481,10 +481,9 @@ module hmac
   /////////////////////////
   // HMAC Error Handling //
   /////////////////////////
-  logic msg_push_sha_disabled, hash_start_sha_disabled, update_seckey_inprocess;
+  logic hash_start_sha_disabled, update_seckey_inprocess;
   logic hash_start_active;  // `reg_hash_start` set when hash already in active
   logic msg_push_not_allowed; // Message is received when `hash_start` isn't set
-  assign msg_push_sha_disabled = msg_write & ~sha_en;
   assign hash_start_sha_disabled = reg_hash_start & ~sha_en;
   assign hash_start_active = reg_hash_start & cfg_block;
   assign msg_push_not_allowed = msg_fifo_req & ~msg_allowed;
@@ -507,16 +506,12 @@ module hmac
   // It is recommended that the software reads ERR_CODE register when interrupt
   // is pending to avoid any race conditions.
   assign err_valid = ~reg2hw.intr_state.hmac_err.q &
-                   ( msg_push_sha_disabled | hash_start_sha_disabled
-                   | update_seckey_inprocess | hash_start_active
-                   | msg_push_not_allowed );
+                   ( hash_start_sha_disabled | update_seckey_inprocess
+                   | hash_start_active | msg_push_not_allowed );
 
   always_comb begin
     err_code = NoError;
     unique case (1'b1)
-      msg_push_sha_disabled: begin
-        err_code = SwPushMsgWhenShaDisabled;
-      end
       hash_start_sha_disabled: begin
         err_code = SwHashStartWhenShaDisabled;
       end

--- a/hw/ip/hmac/rtl/hmac_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_pkg.sv
@@ -88,6 +88,12 @@ package hmac_pkg;
 
   typedef enum logic [31:0] {
     NoError                    = 32'h 0000_0000,
+    // SwPushMsgWhenShaDisabled is not used in this version. The error code is
+    // guarded by the HW. HW drops the message write request if `sha_en` is
+    // off. eunchan@ left the error code to not corrupt the code sequence.
+    // Need to rename to DeprecatedSwPush...
+    //
+    // Issue #3022
     SwPushMsgWhenShaDisabled   = 32'h 0000_0001,
     SwHashStartWhenShaDisabled = 32'h 0000_0002,
     SwUpdateSecretKeyInProcess = 32'h 0000_0003,


### PR DESCRIPTION
Issue https://github.com/lowRISC/opentitan/issues/3022

`SwPushMsgWhenDisable` is unreachable as `msg_allowed` signal already
protects the error scenario `msg_valid && !sha_en`.

This commit removes the error signal but leaves the Error code in
`hmac_pkg` to be compatible to the previous code. Soon, in the next
release, the code may be renamed to `DeprecatedSwPushMsgWhenDisable`.