### PR TITLE
[kmac] FI protected `absorbed` signal

### DIFF
--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -16,6 +16,7 @@ filesets:
       - lowrisc:prim:sparse_fsm
       - lowrisc:prim:max_tree
       - lowrisc:prim:sum_tree
+      - lowrisc:prim:mubi
       - lowrisc:ip:tlul
       - lowrisc:ip:sha3
       - lowrisc:ip:otp_ctrl_pkg

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -390,7 +390,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     sha3_process;
   logic                     sha3_block_processed;
   logic                     sha3_done;
-  logic                     sha3_absorbed;
+  prim_mubi_pkg::mubi4_t    sha3_absorbed;
   logic                     sha3_squeezing;
   logic [2:0]               sha3_fsm;
   logic [32:0]              sha3_err;
@@ -824,7 +824,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign hw2reg.debug_status.sha3_fsm.d = sha3_fsm;
   assign hw2reg.debug_status.sha3_block_pr.d = sha3_block_processed;
   assign hw2reg.debug_status.sha3_squeezing.d = sha3_squeezing;
-  assign hw2reg.debug_status.sha3_absorbed.d = sha3_absorbed;
+  assign hw2reg.debug_status.sha3_absorbed.d =
+    prim_mubi_pkg::mubi4_test_true_strict(sha3_absorbed) ? 1'b 1 : 1'b 0;
   assign hw2reg.debug_status.sha3_err.d = sha3_err_q;
 
   assign sha3_err_d =

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -200,6 +200,9 @@
     { name: "LOGIC.INTEGRITY"
       desc: "The reset net for the internal state register and critical nets around the output register are buried."
     }
+    { name: "ABSORBED.CTRL.MUBI"
+      desc: "`absorbed` signal is mubi4_t type to protect against FI attacks."
+    }
   ]
   regwidth: "32"
   registers: [

--- a/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
@@ -89,5 +89,11 @@
       milestone: V2S
       tests: []
     }
+    {
+      name: sec_cm_absorbed_ctrl_mubi
+      desc: "Verify the countermeasure(s) ABSORBED.CTRL.INTEGRITY"
+      milestone: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:count
       - lowrisc:prim:sparse_fsm
+      - lowrisc:prim:mubi
       - lowrisc:ip:tlul
       - lowrisc:ip:keymgr_pkg
       - lowrisc:ip:sha3

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -257,7 +257,6 @@ module kmac_app
   app_mux_sel_e mux_sel;
   app_mux_sel_e mux_sel_buf_output;
   app_mux_sel_e mux_sel_buf_err_check;
-  app_mux_sel_e mux_sel_buf_key;
   app_mux_sel_e mux_sel_buf_kmac;
 
   // Error checking logic
@@ -632,17 +631,6 @@ module kmac_app
   ) u_prim_buf_state_kmac_sel (
     .in_i(mux_sel),
     .out_o(mux_sel_buf_kmac_logic)
-  );
-
-  logic [AppMuxWidth-1:0] mux_sel_buf_key_logic;
-  assign mux_sel_buf_key = app_mux_sel_e'(mux_sel_buf_key_logic);
-
-  // SEC_CM: LOGIC.INTEGRITY
-  prim_sec_anchor_buf #(
-   .Width(AppMuxWidth)
-  ) u_prim_buf_state_key_sel (
-    .in_i(mux_sel),
-    .out_o(mux_sel_buf_key_logic)
   );
 
   // SEC_CM: LOGIC.INTEGRITY

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -81,13 +81,13 @@ module kmac_app
   input kmac_cmd_e sw_cmd_i,
 
   // from SHA3
-  input absorbed_i,
+  input prim_mubi_pkg::mubi4_t absorbed_i,
 
   // to KMAC
   output kmac_cmd_e cmd_o,
 
   // to SW
-  output logic absorbed_o,
+  output prim_mubi_pkg::mubi4_t absorbed_o,
 
   // To status
   output logic app_active_o,
@@ -372,7 +372,7 @@ module kmac_app
     cmd_o = CmdNone;
 
     // Software output
-    absorbed_o = 1'b 0;
+    absorbed_o = prim_mubi_pkg::MuBi4False;
 
     // Error
     fsm_err = '{valid: 1'b 0, code: ErrNone, info: '0};
@@ -444,7 +444,7 @@ module kmac_app
       end
 
       StAppWait: begin
-        if (absorbed_i) begin
+        if (prim_mubi_pkg::mubi4_test_true_strict(absorbed_i)) begin
           // Send digest to KeyMgr and complete the op
           st_d = StIdle;
           cmd_o = CmdDone;
@@ -658,7 +658,7 @@ module kmac_app
   always_comb begin
     app_digest_done = 1'b 0;
     app_digest = '{default:'0};
-    if (st == StAppWait && absorbed_i &&
+    if (st == StAppWait && prim_mubi_pkg::mubi4_test_true_strict(absorbed_i) &&
         lc_escalate_en_i == lc_ctrl_pkg::Off) begin
       // SHA3 engine has calculated the hash. Return the data to KeyMgr
       app_digest_done = 1'b 1;

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -70,7 +70,7 @@ module kmac_errchk
   input app_active_i,
 
   // Status from SHA3 core
-  input sha3_absorbed_i,
+  input prim_mubi_pkg::mubi4_t sha3_absorbed_i,
   input keccak_done_i,
 
   // Life cycle
@@ -343,7 +343,7 @@ module kmac_errchk
       end
 
       StProcessing: begin
-        if (sha3_absorbed_i) begin
+        if (prim_mubi_pkg::mubi4_test_true_strict(sha3_absorbed_i)) begin
           st_d = StAbsorbed;
         end
       end

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -286,6 +286,7 @@ module sha3pad
 
 
   // Next logic and output logic ==============================================
+  // SEC_CM: ABSORBED.CTRL.MUBI
   prim_mubi_pkg::mubi4_t absorbed_d;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) absorbed_o <= prim_mubi_pkg::MuBi4False;

--- a/hw/ip/kmac/sha3.core
+++ b/hw/ip/kmac/sha3.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:prim_dom_and_2share
       - lowrisc:prim:assert
+      - lowrisc:prim:mubi
       - lowrisc:ip:tlul
     files:
       - rtl/sha3_pkg.sv


### PR DESCRIPTION
This commit protects `sha3pad::absorbed_d` signal against FI attacks.
The signal is converted into `mubi4_t` and uses `mubi4_*` functions to
check the True and False values.

Reporting to SW side still remains logic to create an interrupt.

Related issue: https://github.com/lowRISC/opentitan/issues/13855