### PR TITLE
[dvsim] enable manufacturer tests to run in DV sim

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -278,6 +278,12 @@
       en_run_modes: ["sw_test_mode_common"]
     }
     {
+      name: chip_sw_example_manufacturer
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["@manufacturer_test_hooks//:example_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_sleep_pwm_pulses
       uvm_test_seq: chip_sw_pwm_pulses_vseq
       sw_images: ["//sw/device/tests:sleep_pwm_pulses_test:1"]

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -556,6 +556,7 @@ def opentitan_binary(
     ]
     deps = kwargs.pop("deps", [])
     targets = []
+    side_targets = []
 
     native_binary_name = "{}.elf".format(name)
     native.cc_binary(
@@ -568,28 +569,28 @@ def opentitan_binary(
     )
 
     preproc_name = "{}_{}".format(name, "preproc")
-    targets.append(preproc_name)
+    side_targets.append(preproc_name)
     rv_preprocess(
         name = preproc_name,
         target = native_binary_name,
     )
 
     asm_name = "{}_{}".format(name, "asm")
-    targets.append(asm_name)
+    side_targets.append(asm_name)
     rv_asm(
         name = asm_name,
         target = native_binary_name,
     )
 
     ll_name = "{}_{}".format(name, "ll")
-    targets.append(ll_name)
+    side_targets.append(ll_name)
     rv_llvm_ir(
         name = ll_name,
         target = native_binary_name,
     )
 
     map_name = "{}_{}".format(name, "map")
-    targets.append(map_name)
+    side_targets.append(map_name)
     rv_relink_with_linkmap(
         name = map_name,
         target = native_binary_name,
@@ -620,6 +621,12 @@ def opentitan_binary(
             srcs = [native_binary_name],
             platform = platform,
         )
+
+    # Create a filegroup with just the sides targets.
+    native.filegroup(
+        name = name + "_side_targets",
+        srcs = side_targets,
+    )
 
     return targets
 


### PR DESCRIPTION
This updates the interactions between dvsim and Bazel to enable running
manufacturer (closed-source) tests on the DV sim platform. Specifically,
a `bazel cquery ...` command is used to locate Bazel built SW images and
copy them into the simulation `run_dir`. This decouples the Bazel label
string for SW images from their (build) output directory.

Additionally, an example manufacturer test case is added to the
`chip_sim_cfg.hjson` file to demonstrate this capability.

This fixes #13430.

Signed-off-by: Timothy Trippel <ttrippel@google.com>