### PR TITLE
[flash_ctrl] Calculate correct integrity on read error

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -1787,14 +1787,6 @@
             '''
           },
           { bits: "6",
-            name: "flash_macro_err",
-            desc: '''
-              The flash access encountered a native flash macro error.
-              Please check the vendor specs for details of the error.
-              This is a synchronous error.
-            '''
-          },
-          { bits: "7",
             name: "update_err",
             desc: '''
               A shadow register encountered an update error.

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -1262,14 +1262,6 @@
             '''
           },
           { bits: "6",
-            name: "flash_macro_err",
-            desc: '''
-              The flash access encountered a native flash macro error.
-              Please check the vendor specs for details of the error.
-              This is a synchronous error.
-            '''
-          },
-          { bits: "7",
             name: "update_err",
             desc: '''
               A shadow register encountered an update error.

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -583,7 +583,6 @@ module flash_ctrl
     .flash_type_o   (flash_prog_type),
     .flash_done_i   (flash_prog_done),
     .flash_prog_intg_err_i (flash_phy_rsp.prog_intg_err),
-    .flash_macro_err_i(flash_phy_rsp.macro_err),
     .flash_mp_err_i (flash_mp_err)
   );
 
@@ -684,8 +683,7 @@ module flash_ctrl
     .flash_data_i   (flash_rd_data),
     .flash_done_i   (flash_rd_done),
     .flash_mp_err_i (flash_mp_err),
-    .flash_rd_err_i (flash_rd_err),
-    .flash_macro_err_i(flash_phy_rsp.macro_err)
+    .flash_rd_err_i (flash_rd_err)
   );
 
   // Erase handler does not consume fifo
@@ -705,8 +703,7 @@ module flash_ctrl
     .flash_addr_o   (erase_flash_addr),
     .flash_op_o     (erase_flash_type),
     .flash_done_i   (flash_erase_done),
-    .flash_mp_err_i (flash_mp_err),
-    .flash_macro_err_i(flash_phy_rsp.macro_err)
+    .flash_mp_err_i (flash_mp_err)
   );
 
   // Final muxing to flash macro module
@@ -1003,7 +1000,6 @@ module flash_ctrl
   assign hw2reg.err_code.prog_err.d         = 1'b1;
   assign hw2reg.err_code.prog_win_err.d     = 1'b1;
   assign hw2reg.err_code.prog_type_err.d    = 1'b1;
-  assign hw2reg.err_code.flash_macro_err.d  = 1'b1;
   assign hw2reg.err_code.update_err.d       = 1'b1;
   assign hw2reg.err_code.op_err.de          = sw_ctrl_err.invalid_op_err;
   assign hw2reg.err_code.mp_err.de          = sw_ctrl_err.mp_err;
@@ -1011,13 +1007,12 @@ module flash_ctrl
   assign hw2reg.err_code.prog_err.de        = sw_ctrl_err.prog_err;
   assign hw2reg.err_code.prog_win_err.de    = sw_ctrl_err.prog_win_err;
   assign hw2reg.err_code.prog_type_err.de   = sw_ctrl_err.prog_type_err;
-  assign hw2reg.err_code.flash_macro_err.de = sw_ctrl_err.macro_err;
   assign hw2reg.err_code.update_err.de      = update_err;
   assign hw2reg.err_addr.d                  = {ctrl_err_addr, {BusByteWidth{1'h0}}};
   assign hw2reg.err_addr.de                 = sw_ctrl_err.mp_err |
                                               sw_ctrl_err.rd_err |
-                                              sw_ctrl_err.prog_err |
-                                              sw_ctrl_err.macro_err;
+                                              sw_ctrl_err.prog_err;
+
 
   // all hardware interface errors are considered faults
   // There are two types of faults
@@ -1042,7 +1037,7 @@ module flash_ctrl
   assign hw2reg.fault_status.prog_err.de        = hw_err.prog_err;
   assign hw2reg.fault_status.prog_win_err.de    = hw_err.prog_win_err;
   assign hw2reg.fault_status.prog_type_err.de   = hw_err.prog_type_err;
-  assign hw2reg.fault_status.flash_macro_err.de = hw_err.macro_err;
+  assign hw2reg.fault_status.flash_macro_err.de = flash_phy_rsp.macro_err;
   assign hw2reg.fault_status.seed_err.de        = seed_err;
   assign hw2reg.fault_status.phy_relbl_err.de   = flash_phy_rsp.storage_relbl_err;
   assign hw2reg.fault_status.phy_storage_err.de = flash_phy_rsp.storage_intg_err;

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -544,7 +544,6 @@ package flash_ctrl_pkg;
     logic prog_err;
     logic prog_win_err;
     logic prog_type_err;
-    logic macro_err;
   } flash_ctrl_err_t;
 
   // interrupt bit positioning

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -584,7 +584,6 @@ module flash_ctrl
     .flash_type_o   (flash_prog_type),
     .flash_done_i   (flash_prog_done),
     .flash_prog_intg_err_i (flash_phy_rsp.prog_intg_err),
-    .flash_macro_err_i(flash_phy_rsp.macro_err),
     .flash_mp_err_i (flash_mp_err)
   );
 
@@ -685,8 +684,7 @@ module flash_ctrl
     .flash_data_i   (flash_rd_data),
     .flash_done_i   (flash_rd_done),
     .flash_mp_err_i (flash_mp_err),
-    .flash_rd_err_i (flash_rd_err),
-    .flash_macro_err_i(flash_phy_rsp.macro_err)
+    .flash_rd_err_i (flash_rd_err)
   );
 
   // Erase handler does not consume fifo
@@ -706,8 +704,7 @@ module flash_ctrl
     .flash_addr_o   (erase_flash_addr),
     .flash_op_o     (erase_flash_type),
     .flash_done_i   (flash_erase_done),
-    .flash_mp_err_i (flash_mp_err),
-    .flash_macro_err_i(flash_phy_rsp.macro_err)
+    .flash_mp_err_i (flash_mp_err)
   );
 
   // Final muxing to flash macro module
@@ -1004,7 +1001,6 @@ module flash_ctrl
   assign hw2reg.err_code.prog_err.d         = 1'b1;
   assign hw2reg.err_code.prog_win_err.d     = 1'b1;
   assign hw2reg.err_code.prog_type_err.d    = 1'b1;
-  assign hw2reg.err_code.flash_macro_err.d  = 1'b1;
   assign hw2reg.err_code.update_err.d       = 1'b1;
   assign hw2reg.err_code.op_err.de          = sw_ctrl_err.invalid_op_err;
   assign hw2reg.err_code.mp_err.de          = sw_ctrl_err.mp_err;
@@ -1012,13 +1008,12 @@ module flash_ctrl
   assign hw2reg.err_code.prog_err.de        = sw_ctrl_err.prog_err;
   assign hw2reg.err_code.prog_win_err.de    = sw_ctrl_err.prog_win_err;
   assign hw2reg.err_code.prog_type_err.de   = sw_ctrl_err.prog_type_err;
-  assign hw2reg.err_code.flash_macro_err.de = sw_ctrl_err.macro_err;
   assign hw2reg.err_code.update_err.de      = update_err;
   assign hw2reg.err_addr.d                  = {ctrl_err_addr, {BusByteWidth{1'h0}}};
   assign hw2reg.err_addr.de                 = sw_ctrl_err.mp_err |
                                               sw_ctrl_err.rd_err |
-                                              sw_ctrl_err.prog_err |
-                                              sw_ctrl_err.macro_err;
+                                              sw_ctrl_err.prog_err;
+
 
   // all hardware interface errors are considered faults
   // There are two types of faults
@@ -1043,7 +1038,7 @@ module flash_ctrl
   assign hw2reg.fault_status.prog_err.de        = hw_err.prog_err;
   assign hw2reg.fault_status.prog_win_err.de    = hw_err.prog_win_err;
   assign hw2reg.fault_status.prog_type_err.de   = hw_err.prog_type_err;
-  assign hw2reg.fault_status.flash_macro_err.de = hw_err.macro_err;
+  assign hw2reg.fault_status.flash_macro_err.de = flash_phy_rsp.macro_err;
   assign hw2reg.fault_status.seed_err.de        = seed_err;
   assign hw2reg.fault_status.phy_relbl_err.de   = flash_phy_rsp.storage_relbl_err;
   assign hw2reg.fault_status.phy_storage_err.de = flash_phy_rsp.storage_intg_err;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -961,8 +961,6 @@ module flash_ctrl_core_reg_top (
   logic err_code_prog_win_err_wd;
   logic err_code_prog_type_err_qs;
   logic err_code_prog_type_err_wd;
-  logic err_code_flash_macro_err_qs;
-  logic err_code_flash_macro_err_wd;
   logic err_code_update_err_qs;
   logic err_code_update_err_wd;
   logic std_fault_status_reg_intg_err_qs;
@@ -10309,33 +10307,7 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_prog_type_err_qs)
   );
 
-  //   F[flash_macro_err]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_err_code_flash_macro_err (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (err_code_we),
-    .wd     (err_code_flash_macro_err_wd),
-
-    // from internal hardware
-    .de     (hw2reg.err_code.flash_macro_err.de),
-    .d      (hw2reg.err_code.flash_macro_err.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (err_code_flash_macro_err_qs)
-  );
-
-  //   F[update_err]: 7:7
+  //   F[update_err]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -12354,9 +12326,7 @@ module flash_ctrl_core_reg_top (
 
   assign err_code_prog_type_err_wd = reg_wdata[5];
 
-  assign err_code_flash_macro_err_wd = reg_wdata[6];
-
-  assign err_code_update_err_wd = reg_wdata[7];
+  assign err_code_update_err_wd = reg_wdata[6];
   assign ecc_single_err_cnt_we = addr_hit[98] & reg_we & !reg_error;
 
   assign ecc_single_err_cnt_ecc_single_err_cnt_0_wd = reg_wdata[7:0];
@@ -13126,8 +13096,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[3] = err_code_prog_err_qs;
         reg_rdata_next[4] = err_code_prog_win_err_qs;
         reg_rdata_next[5] = err_code_prog_type_err_qs;
-        reg_rdata_next[6] = err_code_flash_macro_err_qs;
-        reg_rdata_next[7] = err_code_update_err_qs;
+        reg_rdata_next[6] = err_code_update_err_qs;
       end
 
       addr_hit[95]: begin

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_erase.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_erase.sv
@@ -20,8 +20,7 @@ module flash_ctrl_erase import flash_ctrl_pkg::*; (
   output logic [BusAddrW-1:0] flash_addr_o,
   output flash_erase_e        flash_op_o,
   input                       flash_done_i,
-  input                       flash_mp_err_i,
-  input                       flash_macro_err_i
+  input                       flash_mp_err_i
 );
 
   localparam int WordsBitWidth = $clog2(BusWordsPerPage);
@@ -48,7 +47,6 @@ module flash_ctrl_erase import flash_ctrl_pkg::*; (
     op_err_o = '0;
     op_err_o.oob_err = op_done_o & oob_err;
     op_err_o.mp_err = op_done_o & flash_mp_err_i;
-    op_err_o.macro_err = op_done_o & flash_macro_err_i;
   end
 
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -544,7 +544,6 @@ package flash_ctrl_pkg;
     logic prog_err;
     logic prog_win_err;
     logic prog_type_err;
-    logic macro_err;
   } flash_ctrl_err_t;
 
   // interrupt bit positioning

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_prog.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_prog.sv
@@ -34,7 +34,6 @@ module flash_ctrl_prog import flash_ctrl_pkg::*; (
   output logic             flash_last_o, // last beat of prog data
   output flash_prog_e      flash_type_o,
   input                    flash_done_i,
-  input                    flash_macro_err_i,
   input                    flash_mp_err_i,
   input                    flash_prog_intg_err_i
 );
@@ -151,7 +150,6 @@ module flash_ctrl_prog import flash_ctrl_pkg::*; (
 
           if (txn_done) begin
             op_err_d.mp_err = flash_mp_err_i;
-            op_err_d.macro_err = flash_macro_err_i;
             op_err_d.prog_err = flash_prog_intg_err_i;
             data_rd_o = 1'b1;
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -585,10 +585,6 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } flash_macro_err;
-    struct packed {
-      logic        d;
-      logic        de;
     } update_err;
   } flash_ctrl_hw2reg_err_code_reg_t;
 
@@ -759,14 +755,14 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [198:187]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [186:186]
-    flash_ctrl_hw2reg_control_reg_t control; // [185:184]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [183:182]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [181:178]
-    flash_ctrl_hw2reg_status_reg_t status; // [177:168]
-    flash_ctrl_hw2reg_debug_state_reg_t debug_state; // [167:157]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [156:141]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [196:185]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [184:184]
+    flash_ctrl_hw2reg_control_reg_t control; // [183:182]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [181:180]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [179:176]
+    flash_ctrl_hw2reg_status_reg_t status; // [175:166]
+    flash_ctrl_hw2reg_debug_state_reg_t debug_state; // [165:155]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [154:141]
     flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [140:123]
     flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [122:97]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [96:76]

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -1793,14 +1793,6 @@
             '''
           },
           { bits: "6",
-            name: "flash_macro_err",
-            desc: '''
-              The flash access encountered a native flash macro error.
-              Please check the vendor specs for details of the error.
-              This is a synchronous error.
-            '''
-          },
-          { bits: "7",
             name: "update_err",
             desc: '''
               A shadow register encountered an update error.

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -590,7 +590,6 @@ module flash_ctrl
     .flash_type_o   (flash_prog_type),
     .flash_done_i   (flash_prog_done),
     .flash_prog_intg_err_i (flash_phy_rsp.prog_intg_err),
-    .flash_macro_err_i(flash_phy_rsp.macro_err),
     .flash_mp_err_i (flash_mp_err)
   );
 
@@ -691,8 +690,7 @@ module flash_ctrl
     .flash_data_i   (flash_rd_data),
     .flash_done_i   (flash_rd_done),
     .flash_mp_err_i (flash_mp_err),
-    .flash_rd_err_i (flash_rd_err),
-    .flash_macro_err_i(flash_phy_rsp.macro_err)
+    .flash_rd_err_i (flash_rd_err)
   );
 
   // Erase handler does not consume fifo
@@ -712,8 +710,7 @@ module flash_ctrl
     .flash_addr_o   (erase_flash_addr),
     .flash_op_o     (erase_flash_type),
     .flash_done_i   (flash_erase_done),
-    .flash_mp_err_i (flash_mp_err),
-    .flash_macro_err_i(flash_phy_rsp.macro_err)
+    .flash_mp_err_i (flash_mp_err)
   );
 
   // Final muxing to flash macro module
@@ -1010,7 +1007,6 @@ module flash_ctrl
   assign hw2reg.err_code.prog_err.d         = 1'b1;
   assign hw2reg.err_code.prog_win_err.d     = 1'b1;
   assign hw2reg.err_code.prog_type_err.d    = 1'b1;
-  assign hw2reg.err_code.flash_macro_err.d  = 1'b1;
   assign hw2reg.err_code.update_err.d       = 1'b1;
   assign hw2reg.err_code.op_err.de          = sw_ctrl_err.invalid_op_err;
   assign hw2reg.err_code.mp_err.de          = sw_ctrl_err.mp_err;
@@ -1018,13 +1014,12 @@ module flash_ctrl
   assign hw2reg.err_code.prog_err.de        = sw_ctrl_err.prog_err;
   assign hw2reg.err_code.prog_win_err.de    = sw_ctrl_err.prog_win_err;
   assign hw2reg.err_code.prog_type_err.de   = sw_ctrl_err.prog_type_err;
-  assign hw2reg.err_code.flash_macro_err.de = sw_ctrl_err.macro_err;
   assign hw2reg.err_code.update_err.de      = update_err;
   assign hw2reg.err_addr.d                  = {ctrl_err_addr, {BusByteWidth{1'h0}}};
   assign hw2reg.err_addr.de                 = sw_ctrl_err.mp_err |
                                               sw_ctrl_err.rd_err |
-                                              sw_ctrl_err.prog_err |
-                                              sw_ctrl_err.macro_err;
+                                              sw_ctrl_err.prog_err;
+
 
   // all hardware interface errors are considered faults
   // There are two types of faults
@@ -1049,7 +1044,7 @@ module flash_ctrl
   assign hw2reg.fault_status.prog_err.de        = hw_err.prog_err;
   assign hw2reg.fault_status.prog_win_err.de    = hw_err.prog_win_err;
   assign hw2reg.fault_status.prog_type_err.de   = hw_err.prog_type_err;
-  assign hw2reg.fault_status.flash_macro_err.de = hw_err.macro_err;
+  assign hw2reg.fault_status.flash_macro_err.de = flash_phy_rsp.macro_err;
   assign hw2reg.fault_status.seed_err.de        = seed_err;
   assign hw2reg.fault_status.phy_relbl_err.de   = flash_phy_rsp.storage_relbl_err;
   assign hw2reg.fault_status.phy_storage_err.de = flash_phy_rsp.storage_intg_err;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -961,8 +961,6 @@ module flash_ctrl_core_reg_top (
   logic err_code_prog_win_err_wd;
   logic err_code_prog_type_err_qs;
   logic err_code_prog_type_err_wd;
-  logic err_code_flash_macro_err_qs;
-  logic err_code_flash_macro_err_wd;
   logic err_code_update_err_qs;
   logic err_code_update_err_wd;
   logic std_fault_status_reg_intg_err_qs;
@@ -10309,33 +10307,7 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_prog_type_err_qs)
   );
 
-  //   F[flash_macro_err]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_err_code_flash_macro_err (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (err_code_we),
-    .wd     (err_code_flash_macro_err_wd),
-
-    // from internal hardware
-    .de     (hw2reg.err_code.flash_macro_err.de),
-    .d      (hw2reg.err_code.flash_macro_err.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (err_code_flash_macro_err_qs)
-  );
-
-  //   F[update_err]: 7:7
+  //   F[update_err]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -12354,9 +12326,7 @@ module flash_ctrl_core_reg_top (
 
   assign err_code_prog_type_err_wd = reg_wdata[5];
 
-  assign err_code_flash_macro_err_wd = reg_wdata[6];
-
-  assign err_code_update_err_wd = reg_wdata[7];
+  assign err_code_update_err_wd = reg_wdata[6];
   assign ecc_single_err_cnt_we = addr_hit[98] & reg_we & !reg_error;
 
   assign ecc_single_err_cnt_ecc_single_err_cnt_0_wd = reg_wdata[7:0];
@@ -13126,8 +13096,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[3] = err_code_prog_err_qs;
         reg_rdata_next[4] = err_code_prog_win_err_qs;
         reg_rdata_next[5] = err_code_prog_type_err_qs;
-        reg_rdata_next[6] = err_code_flash_macro_err_qs;
-        reg_rdata_next[7] = err_code_update_err_qs;
+        reg_rdata_next[6] = err_code_update_err_qs;
       end
 
       addr_hit[95]: begin

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -550,7 +550,6 @@ package flash_ctrl_pkg;
     logic prog_err;
     logic prog_win_err;
     logic prog_type_err;
-    logic macro_err;
   } flash_ctrl_err_t;
 
   // interrupt bit positioning

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -585,10 +585,6 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } flash_macro_err;
-    struct packed {
-      logic        d;
-      logic        de;
     } update_err;
   } flash_ctrl_hw2reg_err_code_reg_t;
 
@@ -759,14 +755,14 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [198:187]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [186:186]
-    flash_ctrl_hw2reg_control_reg_t control; // [185:184]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [183:182]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [181:178]
-    flash_ctrl_hw2reg_status_reg_t status; // [177:168]
-    flash_ctrl_hw2reg_debug_state_reg_t debug_state; // [167:157]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [156:141]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [196:185]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [184:184]
+    flash_ctrl_hw2reg_control_reg_t control; // [183:182]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [181:180]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [179:176]
+    flash_ctrl_hw2reg_status_reg_t status; // [175:166]
+    flash_ctrl_hw2reg_debug_state_reg_t debug_state; // [165:155]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [154:141]
     flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [140:123]
     flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [122:97]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [96:76]

--- a/sw/device/lib/dif/dif_flash_ctrl.c
+++ b/sw/device/lib/dif/dif_flash_ctrl.c
@@ -548,8 +548,6 @@ dif_result_t dif_flash_ctrl_get_error_codes(
           bitfield_bit32_read(code_reg, FLASH_CTRL_ERR_CODE_PROG_WIN_ERR_BIT),
       .prog_type_error =
           bitfield_bit32_read(code_reg, FLASH_CTRL_ERR_CODE_PROG_TYPE_ERR_BIT),
-      .flash_phy_error = bitfield_bit32_read(
-          code_reg, FLASH_CTRL_ERR_CODE_FLASH_MACRO_ERR_BIT),
       .shadow_register_error =
           bitfield_bit32_read(code_reg, FLASH_CTRL_ERR_CODE_UPDATE_ERR_BIT),
   };
@@ -579,8 +577,6 @@ dif_result_t dif_flash_ctrl_clear_error_codes(
       code_reg, FLASH_CTRL_ERR_CODE_PROG_WIN_ERR_BIT, codes.prog_window_error);
   code_reg = bitfield_bit32_write(
       code_reg, FLASH_CTRL_ERR_CODE_PROG_TYPE_ERR_BIT, codes.prog_type_error);
-  code_reg = bitfield_bit32_write(
-      code_reg, FLASH_CTRL_ERR_CODE_FLASH_MACRO_ERR_BIT, codes.flash_phy_error);
   code_reg = bitfield_bit32_write(code_reg, FLASH_CTRL_ERR_CODE_UPDATE_ERR_BIT,
                                   codes.shadow_register_error);
   mmio_region_write32(handle->dev.base_addr, FLASH_CTRL_ERR_CODE_REG_OFFSET,
@@ -1185,9 +1181,6 @@ dif_result_t dif_flash_ctrl_get_faults(const dif_flash_ctrl_state_t *handle,
       bitfield_bit32_read(reg, FLASH_CTRL_FAULT_STATUS_PROG_WIN_ERR_BIT);
   faults.prog_type_error =
       bitfield_bit32_read(reg, FLASH_CTRL_FAULT_STATUS_PROG_TYPE_ERR_BIT);
-  faults.flash_phy_error =
-      bitfield_bit32_read(reg, FLASH_CTRL_FAULT_STATUS_FLASH_MACRO_ERR_BIT);
-
   reg = mmio_region_read32(handle->dev.base_addr,
                            FLASH_CTRL_STD_FAULT_STATUS_REG_OFFSET);
   faults.register_integrity_error =

--- a/sw/device/lib/dif/dif_flash_ctrl.h
+++ b/sw/device/lib/dif/dif_flash_ctrl.h
@@ -490,10 +490,6 @@ typedef struct dif_flash_ctrl_error_codes {
    */
   bool prog_type_error : 1;
   /**
-   * A flash access encountered a native flash PHY error.
-   */
-  bool flash_phy_error : 1;
-  /**
    * A shadow register encountered an update error.
    */
   bool shadow_register_error : 1;

--- a/sw/device/lib/dif/dif_flash_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_flash_ctrl_unittest.cc
@@ -389,7 +389,6 @@ TEST_F(FlashCtrlTest, ReadTransaction) {
                     {FLASH_CTRL_ERR_CODE_RD_ERR_BIT, 0},
                     {FLASH_CTRL_ERR_CODE_PROG_WIN_ERR_BIT, 1},
                     {FLASH_CTRL_ERR_CODE_PROG_TYPE_ERR_BIT, 0},
-                    {FLASH_CTRL_ERR_CODE_FLASH_MACRO_ERR_BIT, 1},
                     {FLASH_CTRL_ERR_CODE_UPDATE_ERR_BIT, 0},
                 });
   EXPECT_READ32(FLASH_CTRL_ERR_ADDR_REG_OFFSET, 0x12345678u);
@@ -402,7 +401,6 @@ TEST_F(FlashCtrlTest, ReadTransaction) {
   EXPECT_EQ(output.error_code.codes.read_error, 0);
   EXPECT_EQ(output.error_code.codes.prog_window_error, 1);
   EXPECT_EQ(output.error_code.codes.prog_type_error, 0);
-  EXPECT_EQ(output.error_code.codes.flash_phy_error, 1);
   EXPECT_EQ(output.error_code.codes.shadow_register_error, 0);
 }
 
@@ -503,7 +501,6 @@ TEST_F(FlashCtrlTest, ProgramTransaction) {
                     {FLASH_CTRL_ERR_CODE_RD_ERR_BIT, 0},
                     {FLASH_CTRL_ERR_CODE_PROG_WIN_ERR_BIT, 1},
                     {FLASH_CTRL_ERR_CODE_PROG_TYPE_ERR_BIT, 1},
-                    {FLASH_CTRL_ERR_CODE_FLASH_MACRO_ERR_BIT, 0},
                     {FLASH_CTRL_ERR_CODE_UPDATE_ERR_BIT, 1},
                 });
   EXPECT_READ32(FLASH_CTRL_ERR_ADDR_REG_OFFSET, 0x87654321u);
@@ -516,7 +513,6 @@ TEST_F(FlashCtrlTest, ProgramTransaction) {
   EXPECT_EQ(output.error_code.codes.read_error, 0);
   EXPECT_EQ(output.error_code.codes.prog_window_error, 1);
   EXPECT_EQ(output.error_code.codes.prog_type_error, 1);
-  EXPECT_EQ(output.error_code.codes.flash_phy_error, 0);
   EXPECT_EQ(output.error_code.codes.shadow_register_error, 1);
 }
 
@@ -722,7 +718,6 @@ TEST_F(FlashCtrlTest, SimpleQueries) {
                     {FLASH_CTRL_ERR_CODE_RD_ERR_BIT, 0},
                     {FLASH_CTRL_ERR_CODE_PROG_WIN_ERR_BIT, 0},
                     {FLASH_CTRL_ERR_CODE_PROG_TYPE_ERR_BIT, 1},
-                    {FLASH_CTRL_ERR_CODE_FLASH_MACRO_ERR_BIT, 1},
                     {FLASH_CTRL_ERR_CODE_UPDATE_ERR_BIT, 1},
                 });
   EXPECT_READ32(FLASH_CTRL_ERR_ADDR_REG_OFFSET, 0x1effe0u);
@@ -731,7 +726,6 @@ TEST_F(FlashCtrlTest, SimpleQueries) {
   EXPECT_EQ(error_value.codes.read_error, 0);
   EXPECT_EQ(error_value.codes.prog_window_error, 0);
   EXPECT_EQ(error_value.codes.prog_type_error, 1);
-  EXPECT_EQ(error_value.codes.flash_phy_error, 1);
   EXPECT_EQ(error_value.codes.shadow_register_error, 1);
   EXPECT_EQ(error_value.address, 0x1effe0u);
 
@@ -840,7 +834,6 @@ TEST_F(FlashCtrlTest, SimpleQueries) {
                     {FLASH_CTRL_FAULT_STATUS_RD_ERR_BIT, 0},
                     {FLASH_CTRL_FAULT_STATUS_PROG_WIN_ERR_BIT, 1},
                     {FLASH_CTRL_FAULT_STATUS_PROG_TYPE_ERR_BIT, 0},
-                    {FLASH_CTRL_FAULT_STATUS_FLASH_MACRO_ERR_BIT, 1},
                 });
   EXPECT_READ32(FLASH_CTRL_STD_FAULT_STATUS_REG_OFFSET,
                 {
@@ -854,7 +847,6 @@ TEST_F(FlashCtrlTest, SimpleQueries) {
   EXPECT_EQ(faults.read_error, 0);
   EXPECT_EQ(faults.prog_window_error, 1);
   EXPECT_EQ(faults.prog_type_error, 0);
-  EXPECT_EQ(faults.flash_phy_error, 1);
   EXPECT_EQ(faults.register_integrity_error, 0);
   EXPECT_EQ(faults.phy_integrity_error, 1);
   EXPECT_EQ(faults.lifecycle_manager_error, 0);

--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -47,9 +47,6 @@ bool flash_ctrl_testutils_wait_transaction_end(
         bitfield_bit32_write(error_reg, FLASH_CTRL_ERR_CODE_PROG_TYPE_ERR_BIT,
                              codes.prog_type_error);
     error_reg =
-        bitfield_bit32_write(error_reg, FLASH_CTRL_ERR_CODE_FLASH_MACRO_ERR_BIT,
-                             codes.flash_phy_error);
-    error_reg =
         bitfield_bit32_write(error_reg, FLASH_CTRL_ERR_CODE_UPDATE_ERR_BIT,
                              codes.shadow_register_error);
     LOG_INFO("Transaction end error_codes = %08x", error_reg);

--- a/sw/device/tests/sim_dv/flash_init_test.c
+++ b/sw/device/tests/sim_dv/flash_init_test.c
@@ -195,7 +195,6 @@ static bool transaction_end_check_read_error(void) {
                        output.error_code.codes.read_error &
                        !output.error_code.codes.prog_window_error &
                        !output.error_code.codes.prog_type_error &
-                       !output.error_code.codes.flash_phy_error &
                        !output.error_code.codes.shadow_register_error;
   CHECK_DIF_OK(
       dif_flash_ctrl_clear_error_codes(&flash_state, output.error_code.codes));


### PR DESCRIPTION
- Addresses issue discovered in #13817
- When the flash controller encounters an error durign read,
  it simply returns all 1's to the read FIFO.
- This causes an issue because the transmission integrity do
  not match becaues the window'd access passthrough integrity
  directly.

- In this commit, the macro error previously seen by the
  read / program / erase modules is also removed. The macro
  error is not guaranteed to nicly synchronous, and is more
  appropriate as a directly hardware error.

Signed-off-by: Timothy Chen <timothytim@google.com>