### PR TITLE
[docs] add DIF list to each IP's docs

### DIFF
--- a/hw/ip/adc_ctrl/doc/_index.md
+++ b/hw/ip/adc_ctrl/doc/_index.md
@@ -238,6 +238,10 @@ Note that for the debug controller (DTS in USB-C specification) as a power sourc
 If the debug controller is acting as a power sink then the orientation cannot be known unless the debug controller supports the optional behavior of converting one of its pulldowns to an Ra (rather than Rp) to indicate CC2 (the CC that is not used for communication).
 This would not be detected by the filters since it happens later than connection detection and debounce in the USB-C protocol state machine, but could be detected by monitoring the current ADC value.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_adc_ctrl.h" >}}
+
 ## Registers
 
 {{< incGenFromIpDesc "../data/adc_ctrl.hjson" "registers" >}}

--- a/hw/ip/aes/doc/_index.md
+++ b/hw/ip/aes/doc/_index.md
@@ -622,6 +622,9 @@ The code snippet below shows how to perform this task.
       (0x1 << AES_TRIGGER_DATA_OUT_CLEAR);
 ```
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_aes.h" >}}
 
 ## Register Table
 

--- a/hw/ip/aon_timer/doc/_index.md
+++ b/hw/ip/aon_timer/doc/_index.md
@@ -114,7 +114,7 @@ If {{<regref"WKUP_COUNT">}} remains above the threshold after clearing the inter
 
 ## Device Interface Functions (DIFs)
 
-TODO
+{{< dif_listing "sw/device/lib/dif/dif_aon_timer.h" >}}
 
 ## Register Table
 

--- a/hw/ip/clkmgr/doc/_index.md
+++ b/hw/ip/clkmgr/doc/_index.md
@@ -317,6 +317,10 @@ Note, a `0` does not indicate clock is actually disabled, software can thus chec
 ## Peripheral Clock Controls
 To control peripheral clocks, directly change the bits in {{< regref "CLK_ENABLES" >}}.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_clkmgr.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson" "registers" >}}

--- a/hw/ip/csrng/doc/_index.md
+++ b/hw/ip/csrng/doc/_index.md
@@ -550,6 +550,10 @@ void csrng_init(unsigned int enable) {
 }
 ```
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_csrng.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/csrng.hjson" "registers" >}}

--- a/hw/ip/edn/doc/_index.md
+++ b/hw/ip/edn/doc/_index.md
@@ -260,6 +260,10 @@ void edn_init(unsigned int enable) {
 
 Need to alert the system of a FIFO overflow condition.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_edn.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/edn.hjson" "registers" >}}

--- a/hw/ip/entropy_src/doc/_index.md
+++ b/hw/ip/entropy_src/doc/_index.md
@@ -451,6 +451,10 @@ After the handshakes with CSRNG are finished, the above bit should be set and th
 
 Need to alert the system of a FIFO overflow condition.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_entropy_src.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/entropy_src.hjson" "registers" >}}

--- a/hw/ip/flash_ctrl/doc/_index.md
+++ b/hw/ip/flash_ctrl/doc/_index.md
@@ -792,6 +792,9 @@ Correctable ECC errors are by nature not fatal errors and do not stop operation.
 Instead, if the error is correctable, the flash controller fixes the issue and registers the last address where a single bit error was seen.
 See {{< regref "ECC_SINGLE_ERR_CNT" >}} and {{< regref "ECC_SINGLE_ERR_ADDR" >}}
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_flash_ctrl.h" >}}
 
 ## Register Table
 

--- a/hw/ip/hmac/doc/_index.md
+++ b/hw/ip/hmac/doc/_index.md
@@ -307,6 +307,10 @@ more data into {{< regref "MSG_FIFO" >}} until the interrupt is cleared and the 
 writes until the FIFO has space which will cause back-pressure on the
 interconnect.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_hmac.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/hmac.hjson" "registers" >}}

--- a/hw/ip/keymgr/doc/_index.md
+++ b/hw/ip/keymgr/doc/_index.md
@@ -540,6 +540,10 @@ However, since these values are not hardened, they can be attacked.
 As such, software should be careful to not make critical system decisions based on these registers.
 They are meant generally for informational or debug purposes.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_keymgr.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/keymgr.hjson" "registers" >}}

--- a/hw/ip/kmac/doc/_index.md
+++ b/hw/ip/kmac/doc/_index.md
@@ -437,13 +437,13 @@ This version of KMAC/SHA3 HWIP _does not_ support the software context switching
 A context switching scheme would allow software to save the current hashing engine state and initiate a new high priority hashing operation.
 It could restore the previous hashing state later and continue the operation.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_kmac.h" >}}
+
 ## Registers
 
 {{< incGenFromIpDesc "../data/kmac.hjson" "registers" >}}
-
-
-
-
 
 [SHA3 specification, FIPS 202]: https://csrc.nist.gov/publications/detail/fips/202/final
 [NIST SP 800-185]: https://csrc.nist.gov/publications/detail/sp/800-185/final

--- a/hw/ip/lc_ctrl/doc/_index.md
+++ b/hw/ip/lc_ctrl/doc/_index.md
@@ -678,6 +678,10 @@ Hence, step 8. cannot be carried out in case device SW is used to implement the 
 This behavior is however not of concern, since access to the transition interface via the CSRs is considered a convenience feature for bringup in the lab.
 It is expected that the JTAG TAP interface is used to access the life cycle transition interface in production settings.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_lc_ctrl.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/lc_ctrl.hjson" "registers" >}}

--- a/hw/ip/otp_ctrl/doc/_index.md
+++ b/hw/ip/otp_ctrl/doc/_index.md
@@ -1004,10 +1004,13 @@ For the {{< regref "CREATOR_SW_CFG" >}} and {{< regref "OWNER_SW_CFG" >}} partit
 Note that any unrecoverable errors during the programming steps, or mismatches during the read-back and verification steps indicate that the device might be malfunctioning (possibly due to fabrication defects) and hence the device may have to be scrapped.
 This is however rare and should not happen after fabrication testing.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_otp_ctrl.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/otp_ctrl.hjson" "registers" >}}
-
 
 # Additional Notes
 

--- a/hw/ip/pattgen/doc/_index.md
+++ b/hw/ip/pattgen/doc/_index.md
@@ -136,6 +136,10 @@ For example, to repeat a pattern 30, a value of 29 should written to the field {
 1. Finally to start the pattern, set the {{< regref "CTRL.ENABLE_CH0" >}}.
 To start both channel patterns at the same time, configure both channels then simulataneously assert both the {{< regref "CTRL.ENABLE_CH0" >}} and {{< regref "CTRL.ENABLE_CH1" >}} bits in the same register access.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_pattgen.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/pattgen.hjson" "registers" >}}

--- a/hw/ip/pinmux/doc/_index.md
+++ b/hw/ip/pinmux/doc/_index.md
@@ -394,6 +394,10 @@ The tables below summarize the pinout and pinmux connectivity for certain top-le
 
 {{< snippet "../../../top_earlgrey/ip/pinmux/doc/autogen/targets.md" >}}
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_pinmux.h" >}}
+
 ## Register Table
 
 The register description below matches the instance in the [Earl Grey top level

--- a/hw/ip/pwm/doc/_index.md
+++ b/hw/ip/pwm/doc/_index.md
@@ -312,6 +312,10 @@ This step is necessary for changing the blink timing parameters
 4. Set {{< regref "BLINK_PARAM_0.Y_0" >}} to set the size of each step.
 5. In a single write, assert both {{< regref "PWM_PARAM_0.BLINK_EN_0" >}} and {{< regref "PWM_PARAM_0.HTBT_EN_0" >}}
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_pwm.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/pwm.hjson" "registers" >}}

--- a/hw/ip/pwrmgr/doc/_index.md
+++ b/hw/ip/pwrmgr/doc/_index.md
@@ -405,6 +405,10 @@ Since in these scenarios the system was not reset, software continues executing 
 
 For an in-depth discussion, please see [power management programmers model](https://docs.google.com/document/d/1w86rmvylJgZVmmQ6Q1YBcCp2VFctkQT3zJ408SJMLPE/edit?usp=sharing) for additional details.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_pwrmgr.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson" "registers" >}}

--- a/hw/ip/rom_ctrl/doc/_index.md
+++ b/hw/ip/rom_ctrl/doc/_index.md
@@ -236,6 +236,10 @@ Unlike the rest of the contents of ROM, this isn't scrambled.
 As such, software can't read it through the standard ROM interface (which would try to unscramble it again, resulting in rubbish data that woud cause a failed ECC check).
 In case software needs access to this value, it can be read at {{< regref "EXP_DIGEST_0" >}} through {{< regref "EXP_DIGEST_7" >}}.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_rom_ctrl.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/rom_ctrl.hjson" "registers" >}}

--- a/hw/ip/rstmgr/doc/_index.md
+++ b/hw/ip/rstmgr/doc/_index.md
@@ -340,6 +340,10 @@ Software then simply needs to write in {{< regref "CPU_INFO_CTRL.INDEX" >}} whic
 
 # Programmers Guide
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_rstmgr.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson" "registers" >}}

--- a/hw/ip/rv_core_ibex/doc/_index.md
+++ b/hw/ip/rv_core_ibex/doc/_index.md
@@ -178,6 +178,10 @@ The `PipeLine` parameter can be used to configure the bus adapter pipelining.
 * Setting `PipeLine` to `1` introduces a pipelining FIFO between the core instruction/data interfaces and the bus.
   This setting increases the memory access latency, but improves timing.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_rv_core_ibex.h" >}}
+
 ## Register Table
 
 A number of memory-mapped registers are available to control Ibex-related functionality that's specific to OpenTitan.

--- a/hw/ip/spi_host/doc/_index.md
+++ b/hw/ip/spi_host/doc/_index.md
@@ -1415,6 +1415,10 @@ In the event of an error the SPI_HOST IP can be reset under software control usi
    - Wait for both FIFOs to completely drain by polling {{< regref "STATUS.TXQD" >}} and {{< regref "STATUS.RXQD" >}} until they reach zero.
 3. Clear {{ < regref "CONTROL.SW_RST" >}}.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_spi_host.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/spi_host.hjson" "registers" >}}

--- a/hw/ip/sram_ctrl/doc/_index.md
+++ b/hw/ip/sram_ctrl/doc/_index.md
@@ -227,6 +227,10 @@ Note that before (re-)requesting an updated SRAM key it is imperative to make su
 
 It should also be noted that data and address scrambling is never entirely disabled - even when the default scrambling key is used.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_sram_ctrl.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/sram_ctrl.hjson" "registers" >}}

--- a/hw/ip/sysrst_ctrl/doc/_index.md
+++ b/hw/ip/sysrst_ctrl/doc/_index.md
@@ -16,14 +16,14 @@ The IP block implements the following features:
 - Always-on: uses the always-on power and clock domain
 - EC reset pulse duration control and stretching
 - Keyboard and button combination (combo) triggered action
-- AC_present can trigger interrupt 
+- AC_present can trigger interrupt
 - Configuration registers can be set and locked until the next chip reset
 - Pin output override
 
 ## Description
 
 The `sysrst_ctrl` logic is very simple.
-It looks up the configuration registers to decide how long the EC reset pulse duration and how long the keyboard debounce timer should be. 
+It looks up the configuration registers to decide how long the EC reset pulse duration and how long the keyboard debounce timer should be.
 Also what actions to take (e.g. Interrupt, EC reset, OpenTitan reset request, disconnect the battery from the power tree).
 
 ## Compatibility
@@ -39,8 +39,8 @@ The first is the configuration and status registers, the second is the keyboard 
 
 The `sysrst_ctrl` has four input pins (`pwrb_in_i`, `key[0,1,2]_in_i`) with corresponding output pins (`pwrb_out`, `key[0,1,2]_out`).
 During normal operation the `sysrst_ctrl` will pass the pin information directly from the input pins to the output pins with optional inversion.
-Combinations of the inputs being active for a specified time can be detected and used to trigger actions. 
-The override logic allows the output to be overridden (i.e. not follow the corresponding input) based either on trigger or software settings. 
+Combinations of the inputs being active for a specified time can be detected and used to trigger actions.
+The override logic allows the output to be overridden (i.e. not follow the corresponding input) based either on trigger or software settings.
 This allows the security chip to take over the inputs for its own use without disturbing the main user.
 
 The `sysrst_ctrl` also controls two active-low open-drain I/Os named `flash_wp_l_i` / `flash_wp_l_o` and `ec_rst_l_i` / `ec_rst_l_o`.
@@ -86,11 +86,11 @@ Software should therefore read and clear the {{< regref WKUP_STATUS >}} register
 
 The following four combo actions can be triggered:
 
-- Drive the `bat_disable` output high until the next reset. 
+- Drive the `bat_disable` output high until the next reset.
 - Issue an interrupt to the processor via `intr_sysrst_ctrl_o`.
 - Assert `ec_rst_l_o` for the amount of cycles configured in {{< regref EC_RST_CTL >}}.
 - Issue a reset request via `aon_ot_rst_req_o` to the reset manager of the OpenTitan system. Note that once a reset request is issued, it will remain asserted until the next reset.
- 
+
 These actions can be configured via the {{< regref COM_OUT_CTL_0 >}} register for each of the combo blocks as described in the previous section.
 
 ### Hardwired reset stretching functionality
@@ -127,7 +127,7 @@ Software should therefore read and clear the {{< regref WKUP_STATUS >}} register
 ## Ultra-low-power Wakeup Feature
 
 Software can program the `sysrst_ctrl` block to detect certain specific signal transitions on the (possibly inverted) `ac_present_i`, `pwrb_in_i` and `lid_open_i` inputs.
-As opposed to the combo detection and general key interrupt features above, this is a fixed function feature with limited configurability. 
+As opposed to the combo detection and general key interrupt features above, this is a fixed function feature with limited configurability.
 In particular, the transitions that can be detected are fixed to the following:
 
 - A high level on the `ac_present_i` signal
@@ -191,8 +191,10 @@ Hence, the value of `flash_wp_l_o` defaults to logic 0 when it is not explicitly
 
 Note that since the `sysrst_ctrl` does not have control over the pad open-drain settings, software should properly initialize the pad attributes of the corresponding pad in the [pinmux configuration]({{< relref "hw/ip/pinmux/doc/" >}}) before releasing `flash_wp_l_o`.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_sysrst_ctrl.h" >}}
+
 ## Registers
 
 {{< incGenFromIpDesc "../data/sysrst_ctrl.hjson" "registers" >}}
-
-

--- a/hw/ip/usbdev/doc/_index.md
+++ b/hw/ip/usbdev/doc/_index.md
@@ -351,11 +351,13 @@ The hardware will then send a STALL response to all IN/OUT transactions until th
 Receiving the **SETUP token clears the {{< regref "in_stall" >}} and {{< regref "out_stall" >}} registers** for that endpoint.
 If either a control endpoint's {{< regref "set_nak_out" >}} bit is set or software has cleared the {{< regref "rxenable_out" >}} bit before this transfer began, the hardware will send NAKs to any IN/OUT requests until the software has decided what action to take for the new SETUP request.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_usbdev.h" >}}
 
 ## Register Table
 
 {{< incGenFromIpDesc "../data/usbdev.hjson" "registers" >}}
-
 
 ## Application to FPGAs
 

--- a/hw/ip_templates/alert_handler/doc/_index.md
+++ b/hw/ip_templates/alert_handler/doc/_index.md
@@ -951,6 +951,10 @@ To handle an interrupt of a particular class, software should execute the follow
 Note that testing interrupts by writing to the interrupt test registers does also trigger the internal interrupt timeout (if enabled), since the interrupt state is used as enable signal for the timer.
 However, alert accumulation will not be triggered by this testing mechanism.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_alert_handler.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/alert_handler.hjson" "registers" >}}

--- a/hw/top_earlgrey/ip/sensor_ctrl/doc/_index.md
+++ b/hw/top_earlgrey/ip/sensor_ctrl/doc/_index.md
@@ -73,6 +73,9 @@ Each available alert has a corresponding fatality configuration.
 If an alert event is set to 1 in {{< regref "FATAL_ALERT_EN" >}}, `sensor_ctrl` treats it as a fatal event instead of a recoverable event.
 Fatal events are not acknowledged, and continuously send alert events in the system until some kind of escalation is seen.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_sensor_ctrl.h" >}}
 
 ## Register Table
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/doc/_index.md
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/doc/_index.md
@@ -951,6 +951,10 @@ To handle an interrupt of a particular class, software should execute the follow
 Note that testing interrupts by writing to the interrupt test registers does also trigger the internal interrupt timeout (if enabled), since the interrupt state is used as enable signal for the timer.
 However, alert accumulation will not be triggered by this testing mechanism.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_alert_handler.h" >}}
+
 ## Register Table
 
 {{< incGenFromIpDesc "../data/alert_handler.hjson" "registers" >}}


### PR DESCRIPTION
Our website documentation generation tools provide a mechanism to
autogenerate a list of available DIFs for each IP. However, some were
missing from the docs of multiple IPs. This adds the missing ones.

Signed-off-by: Timothy Trippel <ttrippel@google.com>