### PR TITLE
[doc] add reference to autogenerated ISR testutils for rv_plic

### DIFF
--- a/hw/ip_templates/rv_plic/doc/_index.md
+++ b/hw/ip_templates/rv_plic/doc/_index.md
@@ -221,6 +221,9 @@ void interrupt_service() {
 }
 ~~~~
 
+As a reference, default interrupt service routines are auto-generated for each
+IP, and are documented [here](/sw/apis/isr__testutils_8h.html).
+
 ## Device Interface Functions (DIFs)
 
 {{< dif_listing "sw/device/lib/dif/dif_rv_plic.h" >}}

--- a/hw/top_earlgrey/ip_autogen/rv_plic/doc/_index.md
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/doc/_index.md
@@ -221,6 +221,9 @@ void interrupt_service() {
 }
 ~~~~
 
+As a reference, default interrupt service routines are auto-generated for each
+IP, and are documented [here](/sw/apis/isr__testutils_8h.html).
+
 ## Device Interface Functions (DIFs)
 
 {{< dif_listing "sw/device/lib/dif/dif_rv_plic.h" >}}

--- a/sw/device/lib/testing/autogen/isr_testutils.h
+++ b/sw/device/lib/testing/autogen/isr_testutils.h
@@ -8,6 +8,11 @@
 // THIS FILE HAS BEEN GENERATED, DO NOT EDIT MANUALLY. COMMAND:
 // util/autogen_testutils.py
 
+/**
+ * @file
+ * @brief Default ISRs for each IP
+ */
+
 #include "sw/device/lib/dif/dif_adc_ctrl.h"
 #include "sw/device/lib/dif/dif_alert_handler.h"
 #include "sw/device/lib/dif/dif_aon_timer.h"

--- a/util/autogen_testutils/templates/isr_testutils.h.tpl
+++ b/util/autogen_testutils/templates/isr_testutils.h.tpl
@@ -7,6 +7,11 @@
 
 ${autogen_banner}
 
+/**
+ * @file
+ * @brief Default ISRs for each IP
+ */
+
 #include "sw/device/lib/dif/dif_rv_plic.h"
 % for ip in ips_with_difs:
   % if ip.irqs:


### PR DESCRIPTION
This updates the rv_plic website documentation to reference the
autogenerated ISR testutils.

This partially addresses #13828.

Signed-off-by: Timothy Trippel <ttrippel@google.com>