### PR TITLE
[kmac] Remove outdated comment 

### DIFF
--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -275,8 +275,6 @@ package kmac_pkg;
     logic valid;
     logic [MsgWidth-1:0] data;
     logic [MsgStrbW-1:0] strb;
-    // last indicates the last beat of the data. strb can be partial only with
-    // last.
     logic last;
   } app_req_t;
 


### PR DESCRIPTION
As discussed in https://github.com/lowRISC/opentitan/issues/12429#issuecomment-1125258307 this comment is not actually true, hence it is removed in this commit.

Signed-off-by: Michael Schaffner <msf@google.com>