### PR TITLE
[rom_ctrl] KMAC interface optimization

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
@@ -59,11 +59,6 @@ interface kmac_app_intf (input clk, input rst_n);
   `ASSERT(StrbNotZero_A, kmac_data_req.valid |-> kmac_data_req.strb > 0,
           clk, !rst_n || if_mode == dv_utils_pkg::Host)
 
-  // strb should be all 1s unless it's last cycle
-  `ASSERT(StrbAllSetIfNotLast_A, kmac_data_req.valid && !kmac_data_req.last |->
-                                 kmac_data_req.strb == '1,
-                                 clk, !rst_n || if_mode == dv_utils_pkg::Host)
-
   // Check strb is aligned to LSB, for example: if strb[1]==0, strb[$:2] should be 0 too
   for (genvar k = 1; k < KmacDataIfWidth / 8 - 1; k++) begin : gen_strb_check
     `ASSERT(StrbAlignLSB_A, kmac_data_req.valid && kmac_data_req.strb[k] === 0 |->

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
@@ -34,8 +34,10 @@ package rom_ctrl_env_pkg;
   // KMAC's max digest size is larger than what is required, so declare the size here.
   parameter uint DIGEST_SIZE    = 256;
   parameter uint MAX_CHECK_ADDR = rom_ctrl_reg_pkg::ROM_CTRL_ROM_SIZE - (DIGEST_SIZE / 8);
-  // The data for each line in rom up to the digest is padded out to the kmac message width
-  parameter uint KMAC_DATA_SIZE = MAX_CHECK_ADDR / (TL_DW / 8) * (kmac_pkg::MsgWidth / 8);
+  // The data for each line in rom up to the digest padded to the next byte boundary
+  parameter uint KMAC_DATA_WORD_SIZE = (39 + 7) / 8;
+  parameter uint KMAC_DATA_NUM_WORDS = MAX_CHECK_ADDR / (TL_DW / 8);
+  parameter uint KMAC_DATA_SIZE = KMAC_DATA_NUM_WORDS * KMAC_DATA_WORD_SIZE;
   // The rom width in bits
   parameter uint ROM_MEM_W = 39;
 

--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -478,7 +478,10 @@ class Scrambler:
         for log_addr in range(self.rom_size_words - num_digest_words):
             phy_addr = self.addr_sp_enc(log_addr)
             scr_word = scr_chunk.words[phy_addr]
-            to_hash += scr_word.to_bytes(64 // 8, byteorder='little')
+            # Note that a scrambled word with ECC amounts to 39bit. The
+            # expression (39 + 7) // 8 calculates the amount of bytes that are
+            # required to store these bits.
+            to_hash += scr_word.to_bytes((39 + 7) // 8, byteorder='little')
 
         # Hash it
         hash_obj = cSHAKE256.new(data=to_hash,


### PR DESCRIPTION
As discussed in #12429, the KMAC interface actually supports byte strobes. Since the ROM controller only reads out 39bit per cycle, it therefore makes sense to only transmit 5 bytes worth of data to KMAC per cycle instead of a zero padding to the maximum interface with and transferring 8 bytes per cycle.

This change should improve the ROM hash time by almost 50%.

Signed-off-by: Michael Schaffner <msf@google.com>