### PR TITLE
[kmac] FI protected sw_cmd signal

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -203,6 +203,9 @@
     { name: "ABSORBED.CTRL.MUBI"
       desc: "`absorbed` signal is mubi4_t type to protect against FI attacks."
     }
+    { name: "SW_CMD.CTRL.SPARSE"
+      desc: "`sw_cmd` and related signals are sparse encoded to protect against FI attacks."
+    }
   ]
   regwidth: "32"
   registers: [

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -474,8 +474,8 @@
           enum: [
             { value: "29"
               name: "start"
-              desc: '''If writes 1 into this field when KMAC/SHA3 is in idle,
-                    KMAC/SHA3 begins its operation.
+              desc: '''Writing 6'b011101 or dec 29 into this field when KMAC/SHA3
+                    is in idle, KMAC/SHA3 begins its operation.
 
                     If the mode is cSHAKE, before receiving the message, the
                     hashing logic processes Function name string N and
@@ -485,9 +485,9 @@
             } // e: start
             { value: "46"
               name: "process"
-              desc: '''If writes 1 into this field when KMAC/SHA3 began its
-                    operation and received the entire message, it computes the
-                    digest or signing.
+              desc: '''Writing 6'b101110 or dec 46 into this field when KMAC/SHA3
+                    began its operation and received the entire message, it
+                    computes the digest or signing.
                     '''
             } // e: process
             { value: "49"
@@ -502,8 +502,8 @@
             } // e: run
             { value: "22"
               name: "done"
-              desc: '''If writes 1 into this field when KMAC/SHA3 squeezing is
-                    completed. KMAC/SHA3 hashing engine clears internal
+              desc: '''Writing 6'b010110 or dec 22 into this field when KMAC/SHA3
+                    squeezing is completed, KMAC/SHA3 hashing engine clears internal
                     variables and goes back to Idle state for next command.
                     '''
             } // e: done

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -465,13 +465,14 @@
              // design assertion : process can be set only after start is set
              "excl:CsrAllTests:CsrExclWrite"]
       fields: [
-        { bits: "3:0"
+        { bits: "5:0"
           name: "cmd"
-          desc: '''Issue a command to the KMAC/SHA3 IP. To prevent sw from
-                writing multiple bits at once, the field is defined as enum.
+          desc: '''Issue a command to the KMAC/SHA3 IP. The command is sparse
+                encoded. To prevent sw from writing multiple commands at once,
+                the field is defined as enum.
                 '''
           enum: [
-            { value: "1"
+            { value: "29"
               name: "start"
               desc: '''If writes 1 into this field when KMAC/SHA3 is in idle,
                     KMAC/SHA3 begins its operation.
@@ -482,14 +483,14 @@
                     additionally it processes secret key block.
                     '''
             } // e: start
-            { value: "2"
+            { value: "46"
               name: "process"
               desc: '''If writes 1 into this field when KMAC/SHA3 began its
                     operation and received the entire message, it computes the
                     digest or signing.
                     '''
             } // e: process
-            { value: "4"
+            { value: "49"
               name: "run"
               desc: '''The `run` field is used in the sponge squeezing stage.
                     It triggers the keccak round logic to run full 24 rounds.
@@ -499,7 +500,7 @@
                     It only affects when the kmac/sha3 operation is completed.
                     '''
             } // e: run
-            { value: "8"
+            { value: "22"
               name: "done"
               desc: '''If writes 1 into this field when KMAC/SHA3 squeezing is
                     completed. KMAC/SHA3 hashing engine clears internal

--- a/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
@@ -95,5 +95,11 @@
       milestone: V2S
       tests: []
     }
+    {
+      name: sec_cm_sw_cmd_ctrl_sparse
+      desc: "Verify the countermeasure(s) SW_CMD.CTRL.INTEGRITY"
+      milestone: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -266,8 +266,8 @@ module kmac
   // If SW initiates the KMAC/SHA3, kmac_cmd represents SW command,
   // if KeyMgr drives the data, kmac_cmd is controled in the state machine
   // in KeyMgr interface logic.
-  kmac_cmd_s_e sw_cmd, checked_sw_cmd, kmac_cmd, cmd_q;
-  logic        cmd_update;
+  kmac_cmd_e sw_cmd, checked_sw_cmd, kmac_cmd, cmd_q;
+  logic      cmd_update;
 
   // Entropy configurations
   logic [9:0]  wait_timer_prescaler;
@@ -330,9 +330,9 @@ module kmac
     logic [WidthCounter-1:0] count_d, count_q;
     logic                    counting_d, counting_q;
     logic                    cmd_buf_empty;
-    kmac_cmd_s_e             cmd_buf_q;
+    kmac_cmd_e               cmd_buf_q;
 
-    assign cmd_buf_empty = (cmd_buf_q == CmdNoneS);
+    assign cmd_buf_empty = (cmd_buf_q == CmdNone);
 
     // When seeing a write to the cmd register, we start counting. We stop counting once the
     // counter has expired and the command buffer is empty.
@@ -347,7 +347,7 @@ module kmac
     // The manual run command cannot be delayed. Software expects this to be triggered immediately
     // and will poll the status register to wait for the SHA3 engine to return back to the squeeze
     // state.
-    assign cmd_update = (cmd_q == CmdManualRunS)                   ? 1'b1 :
+    assign cmd_update = (cmd_q == CmdManualRun)                    ? 1'b1 :
                         (count_q == SecCmdDelay[WidthCounter-1:0]) ? 1'b1 : 1'b0;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -365,26 +365,26 @@ module kmac
     // sleep.
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
-        cmd_q     <= CmdNoneS;
-        cmd_buf_q <= CmdNoneS;
+        cmd_q     <= CmdNone;
+        cmd_buf_q <= CmdNone;
       end else begin
         if (reg2hw.cmd.cmd.qe && cmd_update) begin
           // New write & counter expired.
           cmd_q     <= cmd_buf_q;
-          cmd_buf_q <= kmac_cmd_logic2sparse(kmac_cmd_e'(reg2hw.cmd.cmd.q));
+          cmd_buf_q <= kmac_cmd_e'(reg2hw.cmd.cmd.q);
 
         end else if (reg2hw.cmd.cmd.qe) begin
           // New write.
           if (counting_q == 1'b0) begin
-            cmd_q     <= kmac_cmd_logic2sparse(kmac_cmd_e'(reg2hw.cmd.cmd.q));
+            cmd_q     <= kmac_cmd_e'(reg2hw.cmd.cmd.q);
           end else begin
-            cmd_buf_q <= kmac_cmd_logic2sparse(kmac_cmd_e'(reg2hw.cmd.cmd.q));
+            cmd_buf_q <= kmac_cmd_e'(reg2hw.cmd.cmd.q);
           end
 
         end else if (cmd_update) begin
           // Counter expired.
           cmd_q     <= cmd_buf_q;
-          cmd_buf_q <= CmdNoneS;
+          cmd_buf_q <= CmdNone;
         end
       end
     end
@@ -392,11 +392,11 @@ module kmac
   end else begin : gen_no_cmd_delay_buf
     // Directly forward signals from register IF.
     assign cmd_update = reg2hw.cmd.cmd.qe;
-    assign cmd_q      = kmac_cmd_logic2sparse(kmac_cmd_e'(reg2hw.cmd.cmd.q));
+    assign cmd_q      = kmac_cmd_e'(reg2hw.cmd.cmd.q);
   end
 
   // Command signals
-  assign sw_cmd = (cmd_update) ? cmd_q : CmdNoneS;
+  assign sw_cmd = (cmd_update) ? cmd_q : CmdNone;
   `ASSERT_KNOWN(KmacCmd_A, sw_cmd)
   always_comb begin
     sha3_start = 1'b 0;
@@ -405,23 +405,23 @@ module kmac
     reg2msgfifo_process = 1'b 0;
 
     unique case (kmac_cmd)
-      CmdStartS: begin
+      CmdStart: begin
         sha3_start = 1'b 1;
       end
 
-      CmdProcessS: begin
+      CmdProcess: begin
         reg2msgfifo_process = 1'b 1;
       end
 
-      CmdManualRunS: begin
+      CmdManualRun: begin
         sha3_run = 1'b 1;
       end
 
-      CmdDoneS: begin
+      CmdDone: begin
         sha3_done = 1'b 1;
       end
 
-      CmdNoneS: begin
+      CmdNone: begin
         // inactive state
       end
 
@@ -680,7 +680,7 @@ module kmac
 
     unique case (kmac_st)
       KmacIdle: begin
-        if (kmac_cmd == CmdStartS) begin
+        if (kmac_cmd == CmdStart) begin
           // If cSHAKE turned on
           if (sha3_pkg::CShake == app_sha3_mode) begin
             kmac_st_d = KmacPrefix;
@@ -1387,8 +1387,9 @@ module kmac
   // Parameter as desired
   `ASSERT_INIT(SecretKeyDivideBy32_A, (kmac_pkg::MaxKeyLen % 32) == 0)
 
-  // Command input should be onehot0
-  `ASSUME(CmdOneHot0_M, reg2hw.cmd.cmd.qe |-> $onehot0(reg2hw.cmd.cmd.q))
+  // Command input should be sparse
+  `ASSUME(CmdSparse_M, reg2hw.cmd.cmd.qe |-> reg2hw.cmd.cmd.q inside {CmdStart, CmdProcess,
+                                                                CmdManualRun,CmdDone, CmdNone})
 
   // redundant counter error
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(SentMsgCountCheck_A, u_sha3.u_pad.u_sentmsg_count,

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -78,13 +78,13 @@ module kmac_app
 
   // Commands
   // Command from software
-  input kmac_cmd_e sw_cmd_i,
+  input kmac_cmd_s_e sw_cmd_i,
 
   // from SHA3
   input prim_mubi_pkg::mubi4_t absorbed_i,
 
   // to KMAC
-  output kmac_cmd_e cmd_o,
+  output kmac_cmd_s_e cmd_o,
 
   // to SW
   output prim_mubi_pkg::mubi4_t absorbed_o,
@@ -369,7 +369,7 @@ module kmac_app
     clr_appid = 1'b 0;
 
     // Commands
-    cmd_o = CmdNone;
+    cmd_o = CmdNoneS;
 
     // Software output
     absorbed_o = prim_mubi_pkg::MuBi4False;
@@ -389,10 +389,10 @@ module kmac_app
 
           // choose app_id
           set_appid = 1'b 1;
-        end else if (sw_cmd_i == CmdStart) begin
+        end else if (sw_cmd_i == CmdStartS) begin
           st_d = StSw;
           // Software initiates the sequence
-          cmd_o = CmdStart;
+          cmd_o = CmdStartS;
         end else begin
           st_d = StIdle;
         end
@@ -411,7 +411,7 @@ module kmac_app
           st_d = StAppMsg;
 
           // App initiates the data
-          cmd_o = CmdStart;
+          cmd_o = CmdStartS;
         end
       end
 
@@ -439,7 +439,7 @@ module kmac_app
       end
 
       StAppProcess: begin
-        cmd_o = CmdProcess;
+        cmd_o = CmdProcessS;
         st_d = StAppWait;
       end
 
@@ -447,7 +447,7 @@ module kmac_app
         if (prim_mubi_pkg::mubi4_test_true_strict(absorbed_i)) begin
           // Send digest to KeyMgr and complete the op
           st_d = StIdle;
-          cmd_o = CmdDone;
+          cmd_o = CmdDoneS;
 
           clr_appid = 1'b 1;
         end else begin
@@ -461,7 +461,7 @@ module kmac_app
         cmd_o = sw_cmd_i;
         absorbed_o = absorbed_i;
 
-        if (sw_cmd_i == CmdDone) begin
+        if (sw_cmd_i == CmdDoneS) begin
           st_d = StIdle;
         end else begin
           st_d = StSw;
@@ -590,7 +590,7 @@ module kmac_app
         code: ErrSwPushedMsgFifo,
         info: 24'({8'h 00, 8'(st), 8'(mux_sel_buf_err_check)})
       };
-    end else if (app_active_o && sw_cmd_i != CmdNone) begin
+    end else if (app_active_o && sw_cmd_i != CmdNoneS) begin
       // If SW issues command except start
       mux_err = '{
         valid: 1'b 1,

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -78,13 +78,13 @@ module kmac_app
 
   // Commands
   // Command from software
-  input kmac_cmd_s_e sw_cmd_i,
+  input kmac_cmd_e sw_cmd_i,
 
   // from SHA3
   input prim_mubi_pkg::mubi4_t absorbed_i,
 
   // to KMAC
-  output kmac_cmd_s_e cmd_o,
+  output kmac_cmd_e cmd_o,
 
   // to SW
   output prim_mubi_pkg::mubi4_t absorbed_o,
@@ -369,7 +369,7 @@ module kmac_app
     clr_appid = 1'b 0;
 
     // Commands
-    cmd_o = CmdNoneS;
+    cmd_o = CmdNone;
 
     // Software output
     absorbed_o = prim_mubi_pkg::MuBi4False;
@@ -389,10 +389,10 @@ module kmac_app
 
           // choose app_id
           set_appid = 1'b 1;
-        end else if (sw_cmd_i == CmdStartS) begin
+        end else if (sw_cmd_i == CmdStart) begin
           st_d = StSw;
           // Software initiates the sequence
-          cmd_o = CmdStartS;
+          cmd_o = CmdStart;
         end else begin
           st_d = StIdle;
         end
@@ -411,7 +411,7 @@ module kmac_app
           st_d = StAppMsg;
 
           // App initiates the data
-          cmd_o = CmdStartS;
+          cmd_o = CmdStart;
         end
       end
 
@@ -439,7 +439,7 @@ module kmac_app
       end
 
       StAppProcess: begin
-        cmd_o = CmdProcessS;
+        cmd_o = CmdProcess;
         st_d = StAppWait;
       end
 
@@ -447,7 +447,7 @@ module kmac_app
         if (prim_mubi_pkg::mubi4_test_true_strict(absorbed_i)) begin
           // Send digest to KeyMgr and complete the op
           st_d = StIdle;
-          cmd_o = CmdDoneS;
+          cmd_o = CmdDone;
 
           clr_appid = 1'b 1;
         end else begin
@@ -461,7 +461,7 @@ module kmac_app
         cmd_o = sw_cmd_i;
         absorbed_o = absorbed_i;
 
-        if (sw_cmd_i == CmdDoneS) begin
+        if (sw_cmd_i == CmdDone) begin
           st_d = StIdle;
         end else begin
           st_d = StSw;
@@ -590,7 +590,7 @@ module kmac_app
         code: ErrSwPushedMsgFifo,
         info: 24'({8'h 00, 8'(st), 8'(mux_sel_buf_err_check)})
       };
-    end else if (app_active_o && sw_cmd_i != CmdNoneS) begin
+    end else if (app_active_o && sw_cmd_i != CmdNone) begin
       // If SW issues command except start
       mux_err = '{
         valid: 1'b 1,

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -63,8 +63,8 @@ module kmac_errchk
   input        cfg_en_unsupported_modestrength_i,
 
   // SW commands: Only valid command is sent out to the rest of the modules
-  input  kmac_cmd_s_e sw_cmd_i,
-  output kmac_cmd_s_e sw_cmd_o,
+  input  kmac_cmd_e sw_cmd_i,
+  output kmac_cmd_e sw_cmd_o,
 
   // Status from KMAC_APP
   input app_active_i,
@@ -172,33 +172,33 @@ module kmac_errchk
     unique case (st)
       StIdle: begin
         // Allow Start command only
-        if (!(sw_cmd_i inside {CmdNoneS, CmdStartS})) begin
+        if (!(sw_cmd_i inside {CmdNone, CmdStart})) begin
           err_swsequence = 1'b 1;
         end
       end
 
       StMsgFeed: begin
         // Allow Process only
-        if (!(sw_cmd_i inside {CmdNoneS, CmdProcessS})) begin
+        if (!(sw_cmd_i inside {CmdNone, CmdProcess})) begin
           err_swsequence = 1'b 1;
         end
       end
 
       StProcessing: begin
-        if (sw_cmd_i != CmdNoneS) begin
+        if (sw_cmd_i != CmdNone) begin
           err_swsequence = 1'b 1;
         end
       end
 
       StAbsorbed: begin
         // Allow ManualRun and Done
-        if (!(sw_cmd_i inside {CmdNoneS, CmdManualRunS, CmdDoneS})) begin
+        if (!(sw_cmd_i inside {CmdNone, CmdManualRun, CmdDone})) begin
           err_swsequence = 1'b 1;
         end
       end
 
       StSqueezing: begin
-        if (sw_cmd_i != CmdNoneS) begin
+        if (sw_cmd_i != CmdNone) begin
           err_swsequence = 1'b 1;
         end
       end
@@ -222,7 +222,7 @@ module kmac_errchk
   // sw_cmd_o latch
   // To reduce the command path delay, sw_cmd is latched here
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)           sw_cmd_o <= CmdNoneS;
+    if (!rst_ni)           sw_cmd_o <= CmdNone;
     else if (!block_swcmd) sw_cmd_o <= sw_cmd_i;
   end
 
@@ -275,8 +275,8 @@ module kmac_errchk
                  code: ErrSwCmdSequence,
                  info: {5'h0,
                         {err_swsequence, err_modestrength, err_prefix},
-                        8'h 0,
-                        {1'b0, stL, kmac_cmd_sparse2logic(sw_cmd_i)}
+                        {5'h 0, stL},
+                        {2'b0, sw_cmd_i}
                        }
                };
       end
@@ -312,8 +312,7 @@ module kmac_errchk
   assign error_o = err;
 
   // If below failed, revise err_swsequence error response info field.
-  `ASSERT_INIT(ExpectedStSwCmdBits_A, $bits(st) == StateWidth &&
-               $bits(kmac_cmd_sparse2logic(sw_cmd_i)) == 4)
+  `ASSERT_INIT(ExpectedStSwCmdBits_A, $bits(st) == StateWidth && $bits(sw_cmd_i) == 6)
 
   // If failed, revise err_modestrength error info field.
   `ASSERT_INIT(ExpectedModeStrengthBits_A,
@@ -330,7 +329,7 @@ module kmac_errchk
 
     unique case (st)
       StIdle: begin
-        if (!app_active_i && sw_cmd_i == CmdStartS) begin
+        if (!app_active_i && sw_cmd_i == CmdStart) begin
           // Proceed to the next state only when the SW issues the Start command
           // in a valid period.
           st_d = StMsgFeed;
@@ -338,7 +337,7 @@ module kmac_errchk
       end
 
       StMsgFeed: begin
-        if (sw_cmd_i == CmdProcessS) begin
+        if (sw_cmd_i == CmdProcess) begin
           st_d = StProcessing;
         end
       end
@@ -350,9 +349,9 @@ module kmac_errchk
       end
 
       StAbsorbed: begin
-        if (sw_cmd_i == CmdManualRunS) begin
+        if (sw_cmd_i == CmdManualRun) begin
           st_d = StSqueezing;
-        end else if (sw_cmd_i == CmdDoneS) begin
+        end else if (sw_cmd_i == CmdDone) begin
           st_d = StIdle;
         end
       end

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -93,7 +93,10 @@ package kmac_pkg;
   // Maximum Hamming weight: 4
   //
   typedef enum logic [5:0] {
-    CmdNone      = 6'b001011, // dec 10
+    //CmdNone      = 6'b001011, // dec 10
+    // CmdNone is manually set to all zero by design!
+    // The minimum Hamming distance is still 3
+    CmdNone      = 6'b000000, // dec  0
     CmdStart     = 6'b011101, // dec 29
     CmdProcess   = 6'b101110, // dec 46
     CmdManualRun = 6'b110001, // dec 49

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -79,6 +79,55 @@ package kmac_pkg;
     CmdDone      = 4'b 1000
   } kmac_cmd_e;
 
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 5 -n 6 \
+  //      -s 1891656028 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: |||||||||||||||||||| (50.00%)
+  //  4: |||||||||||||||| (40.00%)
+  //  5: |||| (10.00%)
+  //  6: --
+  //
+  // Minimum Hamming distance: 3
+  // Maximum Hamming distance: 5
+  // Minimum Hamming weight: 3
+  // Maximum Hamming weight: 4
+  //
+  typedef enum logic [5:0] {
+    CmdNoneS      = 6'b001011,
+    CmdStartS     = 6'b011101,
+    CmdProcessS   = 6'b101110,
+    CmdManualRunS = 6'b110001,
+    CmdDoneS      = 6'b010110
+  } kmac_cmd_s_e;
+
+  function automatic kmac_cmd_e kmac_cmd_sparse2logic(kmac_cmd_s_e cmd_s);
+    unique case (cmd_s)
+      CmdNoneS      : return CmdNone;
+      CmdStartS     : return CmdStart;
+      CmdProcessS   : return CmdProcess;
+      CmdManualRunS : return CmdManualRun;
+      CmdDoneS      : return CmdDone;
+      default       : return CmdNone;
+    endcase
+  endfunction : kmac_cmd_sparse2logic
+
+  function automatic kmac_cmd_s_e kmac_cmd_logic2sparse(kmac_cmd_e cmd);
+    unique case (cmd)
+      CmdNone      : return CmdNoneS;
+      CmdStart     : return CmdStartS;
+      CmdProcess   : return CmdProcessS;
+      CmdManualRun : return CmdManualRunS;
+      CmdDone      : return CmdDoneS;
+      default      : return CmdNoneS;
+    endcase
+  endfunction : kmac_cmd_logic2sparse
+
   // Timer
   parameter int unsigned TimerPrescalerW = 10;
   parameter int unsigned EdnWaitTimerW   = 16;

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -70,15 +70,9 @@ package kmac_pkg;
 
   // kmac_cmd_e defines the possible command sets that software issues via
   // !!CMD register. This is mainly to limit the error scenario that SW writes
-  // multiple commands at once.
-  typedef enum logic [3:0] {
-    CmdNone      = 4'b 0000,
-    CmdStart     = 4'b 0001,
-    CmdProcess   = 4'b 0010,
-    CmdManualRun = 4'b 0100,
-    CmdDone      = 4'b 1000
-  } kmac_cmd_e;
-
+  // multiple commands at once. Additionally they are sparse encoded to harden
+  // against FI attacks
+  //
   // Encoding generated with:
   // $ ./util/design/sparse-fsm-encode.py -d 3 -m 5 -n 6 \
   //      -s 1891656028 --language=sv
@@ -99,34 +93,12 @@ package kmac_pkg;
   // Maximum Hamming weight: 4
   //
   typedef enum logic [5:0] {
-    CmdNoneS      = 6'b001011,
-    CmdStartS     = 6'b011101,
-    CmdProcessS   = 6'b101110,
-    CmdManualRunS = 6'b110001,
-    CmdDoneS      = 6'b010110
-  } kmac_cmd_s_e;
-
-  function automatic kmac_cmd_e kmac_cmd_sparse2logic(kmac_cmd_s_e cmd_s);
-    unique case (cmd_s)
-      CmdNoneS      : return CmdNone;
-      CmdStartS     : return CmdStart;
-      CmdProcessS   : return CmdProcess;
-      CmdManualRunS : return CmdManualRun;
-      CmdDoneS      : return CmdDone;
-      default       : return CmdNone;
-    endcase
-  endfunction : kmac_cmd_sparse2logic
-
-  function automatic kmac_cmd_s_e kmac_cmd_logic2sparse(kmac_cmd_e cmd);
-    unique case (cmd)
-      CmdNone      : return CmdNoneS;
-      CmdStart     : return CmdStartS;
-      CmdProcess   : return CmdProcessS;
-      CmdManualRun : return CmdManualRunS;
-      CmdDone      : return CmdDoneS;
-      default      : return CmdNoneS;
-    endcase
-  endfunction : kmac_cmd_logic2sparse
+    CmdNone      = 6'b001011, // dec 10
+    CmdStart     = 6'b011101, // dec 29
+    CmdProcess   = 6'b101110, // dec 46
+    CmdManualRun = 6'b110001, // dec 49
+    CmdDone      = 6'b010110  // dec 22
+  } kmac_cmd_e;
 
   // Timer
   parameter int unsigned TimerPrescalerW = 10;

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -123,7 +123,7 @@ package kmac_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [3:0]  q;
+      logic [5:0]  q;
       logic        qe;
     } cmd;
     struct packed {
@@ -230,12 +230,12 @@ package kmac_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    kmac_reg2hw_intr_state_reg_t intr_state; // [1664:1662]
-    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1661:1659]
-    kmac_reg2hw_intr_test_reg_t intr_test; // [1658:1653]
-    kmac_reg2hw_alert_test_reg_t alert_test; // [1652:1649]
-    kmac_reg2hw_cfg_shadowed_reg_t cfg_shadowed; // [1648:1621]
-    kmac_reg2hw_cmd_reg_t cmd; // [1620:1612]
+    kmac_reg2hw_intr_state_reg_t intr_state; // [1666:1664]
+    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1663:1661]
+    kmac_reg2hw_intr_test_reg_t intr_test; // [1660:1655]
+    kmac_reg2hw_alert_test_reg_t alert_test; // [1654:1651]
+    kmac_reg2hw_cfg_shadowed_reg_t cfg_shadowed; // [1650:1623]
+    kmac_reg2hw_cmd_reg_t cmd; // [1622:1612]
     kmac_reg2hw_entropy_period_reg_t entropy_period; // [1611:1586]
     kmac_reg2hw_entropy_refresh_threshold_shadowed_reg_t
         entropy_refresh_threshold_shadowed; // [1585:1576]

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -258,7 +258,7 @@ module kmac_reg_top (
   logic cfg_shadowed_en_unsupported_modestrength_storage_err;
   logic cfg_shadowed_en_unsupported_modestrength_update_err;
   logic cmd_we;
-  logic [3:0] cmd_cmd_wd;
+  logic [5:0] cmd_cmd_wd;
   logic cmd_entropy_req_wd;
   logic cmd_hash_cnt_clr_wd;
   logic status_re;
@@ -1112,9 +1112,9 @@ module kmac_reg_top (
   logic cmd_qe;
   logic [2:0] cmd_flds_we;
   assign cmd_qe = &cmd_flds_we;
-  //   F[cmd]: 3:0
+  //   F[cmd]: 5:0
   prim_subreg_ext #(
-    .DW    (4)
+    .DW    (6)
   ) u_cmd_cmd (
     .re     (1'b0),
     .we     (cmd_we),
@@ -2884,7 +2884,7 @@ module kmac_reg_top (
   assign cfg_shadowed_en_unsupported_modestrength_wd = reg_wdata[26];
   assign cmd_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign cmd_cmd_wd = reg_wdata[3:0];
+  assign cmd_cmd_wd = reg_wdata[5:0];
 
   assign cmd_entropy_req_wd = reg_wdata[8];
 
@@ -3160,7 +3160,7 @@ module kmac_reg_top (
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[3:0] = '0;
+        reg_rdata_next[5:0] = '0;
         reg_rdata_next[8] = '0;
         reg_rdata_next[9] = '0;
       end


### PR DESCRIPTION
This commits protects sw_cmd and related signals against FI attacks
The signals are using sparse encodings internally.

Reporting to and from SW sill remains logic

Related issue: #13855

Signed-off-by: Michael Tempelmeier <michael.tempelmeier@gi-de.com>