### PR TITLE
[spi_device] Doc fix 

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -1318,8 +1318,8 @@
 
           In Generic mode, this buffer is used for RX/TX buffer.  In Flash &
           Passthrough mode, lower 2kB is for Read content emulating eFlash.
-          next 1kB is for Mailbox read/write buffer. The rest is 64B of
-          CmdFIFO, 64B of AddrFIFO, and 256B of payload FIFO.
+          next 1kB is for Mailbox read/write buffer. The rest is 256B SFDP
+          buffer, 32B of CmdFIFO, 32B of AddrFIFO, and 256B of payload FIFO.
           '''
       },
     },

--- a/hw/ip/spi_device/doc/_index.md
+++ b/hw/ip/spi_device/doc/_index.md
@@ -441,8 +441,8 @@ SW may configure {{<regref "JEDEC_CC">}} CSR for HW to return proper CC.
 The *cc* field in {{<regref "JEDEC_CC">}} defines the return value, which is `0x7F` by default.
 *num_cc* defines how many times the HW to send CC byte before sending the JEDEC ID.
 
-The actual JEDEC ID consists of one byte device ID and two bytes manufacturer ID.
-The HW sends the device ID first, then `[7:0]` of manufacturer ID then `[15:8]` byte.
+The actual JEDEC ID consists of one byte manufacturer ID and two bytes device ID.
+The HW sends the manufacturer ID first, then `[7:0]` of the device ID then `[15:8]` byte.
 
 ### Serial Flash Discoverable Parameters (SFDP) Control
 


### PR DESCRIPTION
Addressing #13783 

- "Device ID"/ "Manufacturer ID" were mis-used.
- Window desc described Cmd/Addr FIFOs' sizes incorrectly.
- Window desc missed SFDP buffer space.