### PR TITLE
[bazel] Generate a release archive

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -272,7 +272,7 @@ jobs:
   - bash: |
       . util/build_consts.sh
       mkdir -p "$BIN_DIR/hw/top_earlgrey/"
-      cp $(ci/scripts/target-location.sh //hw:verilator)/sim-verilator/Vchip_sim_tb \
+      cp $(ci/scripts/target-location.sh //hw:verilator) \
         "$BIN_DIR/hw/top_earlgrey/Vchip_earlgrey_verilator"
     displayName: Copy //hw:verilator to $BIN_DIR
   - template: ci/upload-artifacts-template.yml

--- a/hw/BUILD
+++ b/hw/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//rules:fusesoc.bzl", "fusesoc_build")
 
 # This configuration exposes fusesoc's "verilator_options" option to the
@@ -30,10 +31,19 @@ fusesoc_build(
     ],
     data = ["//hw/ip/otbn:all_files"],
     flags = ["--verilator_options=--threads 1"],
+    output_groups = {
+        "binary": ["sim-verilator/Vchip_sim_tb"],
+    },
     systems = ["lowrisc:dv:chip_verilator_sim"],
     tags = ["verilator"],
     target = "sim",
     verilator_options = ":verilator_options",
+)
+
+filegroup(
+    name = "verilator_bin",
+    srcs = [":verilator_real"],
+    output_group = "binary",
 )
 
 # This is used in CI steps that do not want to run Verilator tests, and thus
@@ -49,23 +59,22 @@ config_setting(
 
 genrule(
     name = "verilator_stub",
-    outs = ["verilator-stub"],
+    outs = ["Vfake_sim_tb"],
     cmd = """
-        mkdir -p $@/sim-verilator
-        script=$@/sim-verilator/Vchip_sim_tb
+        script=$@
         echo '#!/bin/bash' > $$script
         echo 'echo "ERROR: sim_verilator tests cannot be run when --define DISABLE_VERILATOR_BUILD=true is set!"' >> $$script
         echo 'echo "This indicates an error in your Bazel invokation"' >> $$script
         echo 'exit 1' >> $$script
-        chmod +x $@/sim-verilator/Vchip_sim_tb
+        chmod +x $@
     """,
 )
 
 alias(
     name = "verilator",
     actual = select({
-        ":disable_verilator_build": ":verilator-stub",
-        "//conditions:default": ":verilator_real",
+        ":disable_verilator_build": ":verilator_stub",
+        "//conditions:default": ":verilator_bin",
     }),
     tags = ["verilator"],
     visibility = ["//visibility:public"],
@@ -89,5 +98,12 @@ filegroup(
         "//hw/ip:all_files",
         "//hw/top_earlgrey:all_files",
     ],
+    visibility = ["//visibility:public"],
+)
+
+pkg_files(
+    name = "package",
+    srcs = ["verilator_bin"],
+    prefix = "earlgrey/verilator",
     visibility = ["//visibility:public"],
 )

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load("//rules:fusesoc.bzl", "fusesoc_build")
 load("//rules:splice.bzl", "bitstream_splice")
 
@@ -110,4 +111,59 @@ fusesoc_build(
     systems = ["lowrisc:systems:chip_earlgrey_cw310_hyperdebug"],
     tags = ["manual"],
     target = "synth",
+)
+
+filegroup(
+    name = "fpga_cw310_test_rom_hyp",
+    srcs = [":fpga_cw310_hyperdebug"],
+    output_group = "bitstream",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "rom_mmi_hyp",
+    srcs = [":fpga_cw310_hyperdebug"],
+    output_group = "rom_mmi",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "otp_mmi_hyp",
+    srcs = [":fpga_cw310_hyperdebug"],
+    output_group = "otp_mmi",
+    tags = ["manual"],
+)
+
+# Packaging rules for bitstreams
+pkg_files(
+    name = "standard",
+    srcs = [
+        ":fpga_cw310_mask_rom",
+        ":fpga_cw310_mask_rom_otp_dev",
+        ":fpga_cw310_test_rom",
+        ":otp_mmi",
+        ":rom_mmi",
+    ],
+    prefix = "earlgrey/fpga_cw310/standard",
+    tags = ["manual"],
+)
+
+pkg_files(
+    name = "hyperdebug",
+    srcs = [
+        ":fpga_cw310_test_rom_hyp",
+        ":otp_mmi_hyp",
+        ":rom_mmi_hyp",
+    ],
+    prefix = "earlgrey/fpga_cw310/hyperdebug",
+    tags = ["manual"],
+)
+
+pkg_filegroup(
+    name = "package",
+    srcs = [
+        ":hyperdebug",
+        ":standard",
+    ],
+    tags = ["manual"],
 )

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:autogen.bzl", "autogen_hjson_header", "otp_image")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,4 +27,13 @@ otp_image(
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
+)
+
+pkg_files(
+    name = "package",
+    srcs = [
+        ":img_dev",
+        ":img_rma",
+    ],
+    prefix = "earlgrey/otp",
 )

--- a/release/BUILD
+++ b/release/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+package(default_visibility = ["//visibility:public"])
+
+pkg_tar(
+    name = "opentitan",
+    srcs = [
+        "//hw:package",
+        "//hw/bitstream/vivado:package",
+        "//hw/ip/otp_ctrl/data:package",
+        "//sw/device/examples/hello_world:package",
+        "//sw/device/lib/testing/test_rom:package",
+        "//sw/device/silicon_creator/mask_rom:package",
+        "//sw/host/opentitantool:package",
+    ],
+    extension = "tar.xz",
+    tags = ["manual"],
+)

--- a/rules/exclude_files.bzl
+++ b/rules/exclude_files.bzl
@@ -1,0 +1,29 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+def _exclude_files_impl(ctx):
+    out = []
+    for src in ctx.files.srcs:
+        include = True
+        for suffix in ctx.attr.exclude_suffix:
+            if src.path.endswith(suffix):
+                include = False
+                break
+        if include:
+            out.append(src)
+    return [DefaultInfo(files = depset(out))]
+
+exclude_files = rule(
+    implementation = _exclude_files_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+            mandatory = True,
+            doc = "Targets producing file outputs",
+        ),
+        "exclude_suffix": attr.string_list(
+            doc = "File suffixes to exlucude from the result",
+        ),
+    },
+)

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -113,7 +113,7 @@ def verilator_params(
         "--rcfile=",
         "--logging=info",
         "--interface=verilator",
-        "--verilator-bin=$(location @//hw:verilator)/sim-verilator/Vchip_sim_tb",
+        "--verilator-bin=$(location @//hw:verilator)",
         "--verilator-rom=$(location {rom})",
         "--verilator-flash=$(location {flash})",
         "--verilator-otp=$(location {otp})",

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_flash_binary")
+load("//rules:exclude_files.bzl", "exclude_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 opentitan_flash_binary(
     name = "hello_world",
@@ -42,4 +44,20 @@ cc_library(
         "//sw/device/lib/testing/test_framework:ottf_start",
         "//sw/device/lib/testing/test_framework:ottf_test_config",
     ],
+)
+
+exclude_files(
+    name = "pre_package",
+    srcs = [":hello_world"],
+    exclude_suffix = [
+        ".ll",
+        ".i",
+        ".s",
+    ],
+)
+
+pkg_files(
+    name = "package",
+    srcs = [":pre_package"],
+    prefix = "earlgrey/examples",
 )

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -4,8 +4,10 @@
 
 load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_rom_binary")
 load("//rules:opentitan_test.bzl", "opentitan_functest")
+load("//rules:exclude_files.bzl", "exclude_files")
 load("//rules:autogen.bzl", "autogen_chip_info")
 load("//rules:linker.bzl", "ld_library")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -152,4 +154,20 @@ opentitan_functest(
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
+)
+
+exclude_files(
+    name = "pre_package",
+    srcs = [":test_rom"],
+    exclude_suffix = [
+        ".ll",
+        ".i",
+        ".s",
+    ],
+)
+
+pkg_files(
+    name = "package",
+    srcs = [":pre_package"],
+    prefix = "earlgrey/test_rom",
 )

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_rom_binary")
+load("//rules:exclude_files.bzl", "exclude_files")
 load("//rules:linker.bzl", "ld_library")
 load(
     "//rules:opentitan_test.bzl",
@@ -11,6 +12,7 @@ load(
     "verilator_params",
 )
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -393,4 +395,20 @@ opentitan_functest(
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
+)
+
+exclude_files(
+    name = "pre_package",
+    srcs = [":mask_rom"],
+    exclude_suffix = [
+        ".ll",
+        ".i",
+        ".s",
+    ],
+)
+
+pkg_files(
+    name = "package",
+    srcs = [":pre_package"],
+    prefix = "earlgrey/mask_rom",
 )

--- a/sw/device/tock/BUILD
+++ b/sw/device/tock/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -53,4 +54,17 @@ filegroup(
     srcs = [
         ":opentitantool",
     ],
+)
+
+pkg_files(
+    name = "binary",
+    srcs = [":opentitantool"],
+)
+
+pkg_filegroup(
+    name = "package",
+    srcs = [
+        ":binary",
+    ],
+    prefix = "opentitantool",
 )


### PR DESCRIPTION
1. Create a file-exclusion rule to filter all of the compiler "side
   products" from various build results (e.g. preprocessed files,
   llvm-ir, assembly).
2. Use packaging rules to declare packaging targets for each component
   of the release.
3. Group all release artifacts together into `//release:opentitan`.

The structure of the release is:
```
earlgrey/fpga_cw310/standard/...
earlgrey/fpga_cw310/hyperdebug/...
earlgrey/mask_rom/...
earlgrey/otp/...
earlgrey/test_rom/...
earlgrey/verilator/Vchip_sim_tb
opentitantool/opentitantool
```

Signed-off-by: Chris Frantz <cfrantz@google.com>