### PR TITLE
[kmac] Use `mode_q` to request EDN

### DIFF
--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -553,7 +553,7 @@ module kmac_entropy
           end else begin
             st_d = StRandReady;
           end
-        end else if ((mode_i == EntropyModeEdn) &&
+        end else if ((mode_q == EntropyModeEdn) &&
             (entropy_refresh_req_i || threshold_hit_q)) begin
           st_d = StRandEdn;
 
@@ -642,7 +642,7 @@ module kmac_entropy
 
         err_o = '{ valid: 1'b 1,
                    code: ErrIncorrectEntropyMode,
-                   info: 24'(mode_i)
+                   info: 24'(mode_q)
                  };
       end
 


### PR DESCRIPTION
Issue https://github.com/lowRISC/opentitan/issues/13872

Problem
-------

KMAC Entropy module reports Unknown Assertion error if SW changes the
entropy mode from SW to Edn while operating.

Analysis
--------

The entropy module latches the entropy mode when SW configures the
`entropy_ready` bit. The mode is to select the LFSRs' seed input data
between EDN data and SW seed CSR.

Somehow, the module reseeds LFSRs from EDN if SW changes the mode while
active. The state machine moves to `StRandEdn` state. The FSM sees
`mode_i` in `StRandReady` rather than the latched version `mode_q`.

Resolution
----------

Changed the logic to look at `mode_q`.
