### PR TITLE
[dv] Support extra test type for test_in_rom

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -418,14 +418,14 @@
     {
       name: chip_sw_flash_init
       uvm_test_seq: chip_sw_flash_init_vseq
-      sw_images: ["//sw/device/tests/sim_dv:flash_init_test:0"]
+      sw_images: ["//sw/device/tests/sim_dv:flash_init_test:0:test_in_rom"]
       en_run_modes: ["sw_test_mode_common"]
       run_opts: ["+sw_test_timeout_ns=25000000"]
     }
     {
       name: chip_sw_flash_rma_unlocked
       uvm_test_seq: chip_sw_flash_rma_unlocked_vseq
-      sw_images: ["//sw/device/tests/sim_dv:flash_rma_unlocked_test:0"]
+      sw_images: ["//sw/device/tests/sim_dv:flash_rma_unlocked_test:0:test_in_rom"]
       en_run_modes: ["sw_test_mode_common"]
       run_opts: ["+sw_test_timeout_ns=200_000_000"]
     }

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -325,7 +325,8 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // The index (optional) is mapped to the type of SW image (enumerated in sw_type_e). If index is
   // not specified, then `SwTypeTest` is assumed. Flags (optional) are arbitrary strings attached to
   // the SW image. They can be used to treat the SW image in a specific way. The flag "signed" for
-  // example, is used to set the SW image extension correctly.
+  // example, is used to set the SW image extension correctly. The flag "test_in_rom" is used to
+  // indicate a test runs directly out of ROM instead of flash.
   virtual function void parse_sw_images_string(string sw_images_string);
     string sw_images_split[$];
 
@@ -366,7 +367,13 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
         // `rules/opentitan.bzl` for options.
         sw_images[i] = $sformatf("%0s_prog_%0s.test_key_0.signed", sw_images[i], sw_build_device);
       end else begin
-        if (i == SwTypeTest) begin
+        // If Rom type but not test_in_rom, no need to tweak name further
+        // If Rom type AND test_in_rom, append suffix to the image name
+        if (i == SwTypeRom && ("test_in_rom" inside {sw_image_flags[i]})) begin
+            string test_image_suffix = "rom_prog_";
+            sw_images[i] = $sformatf("%0s_%0s%0s", sw_images[i], test_image_suffix,
+              sw_build_device);
+        end else if (i == SwTypeTest) begin
           sw_images[i] = $sformatf("%0s_prog_%0s", sw_images[i],
             sw_build_device);
         end else begin


### PR DESCRIPTION
Currently, tests that meant to be executed in ROM get an extra
"_rom_prog" suffix when compared to the normal ROM.

This causes a memory load error in chip_sw_base_vseq since the name
no longer matches.

This commit introduces a new flag that would be recognized by
the load routine to ensure the correct version is loaded.

Signed-off-by: Timothy Chen <timothytim@google.com>