### PR TITLE
[dv,chip,reset_info] Fix tests that read reset_info via difs

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -241,6 +241,7 @@ opentitan_functest(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aon_timer_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
+++ b/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
@@ -13,6 +13,7 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/aon_timer_testutils.h"
 #include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -45,9 +46,8 @@ bool test_main(void) {
                                               kDifToggleEnabled));
 
   // Check if there was a HW reset caused by the wdog bite.
-  dif_rstmgr_reset_info_bitfield_t rst_info;
-  CHECK_DIF_OK(dif_rstmgr_reset_info_get(&rstmgr, &rst_info));
-  CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+  dif_rstmgr_reset_info_bitfield_t rst_info = rstmgr_testutils_reason_get();
+  rstmgr_testutils_reason_clear();
 
   uint32_t wkup_cnt;
   uint32_t wdog_cnt;

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -721,6 +721,7 @@ opentitan_functest(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:alert_handler_testutils",
         "//sw/device/lib/testing:lc_ctrl_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/sim_dv/lc_ctrl_program_error.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_program_error.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/alert_handler_testutils.h"
 #include "sw/device/lib/testing/lc_ctrl_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -59,9 +60,8 @@ bool test_main(void) {
       &alert_handler));
 
   // Check if there was a HW reset caused by the escalation.
-  dif_rstmgr_reset_info_bitfield_t rst_info;
-  CHECK_DIF_OK(dif_rstmgr_reset_info_get(&rstmgr, &rst_info));
-  CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+  dif_rstmgr_reset_info_bitfield_t rst_info = rstmgr_testutils_reason_get();
+  rstmgr_testutils_reason_clear();
 
   if (rst_info & kDifRstmgrResetInfoPor) {
     // set the alert we care about to class A


### PR DESCRIPTION
Signed-off-by: Guillermo Maturana <maturana@google.com>