### PR TITLE
[sigverify] Add an automatic check for OTBN instruction count ranges.

### DIFF
--- a/hw/ip/otbn/util/BUILD
+++ b/hw/ip/otbn/util/BUILD
@@ -49,3 +49,12 @@ py_binary(
         requirement("pyelftools"),
     ],
 )
+
+py_binary(
+    name = "get_instruction_count_range",
+    srcs = ["get_instruction_count_range.py"],
+    deps = [
+        "//hw/ip/otbn/util/shared:decode",
+        "//hw/ip/otbn/util/shared:instruction_count_range",
+    ],
+)

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -10,6 +10,7 @@ load(
     "opentitan_functest",
     "verilator_params",
 )
+load("//rules:otbn.bzl", "otbn_insn_count_range")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -156,6 +157,30 @@ opentitan_functest(
         "//sw/device/silicon_creator/lib:test_main",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/sigverify/sigverify_tests:sigverify_testvectors_wycheproof",
+    ],
+)
+
+# This rule runs the instruction-counting script for OTBN and gets the expected
+# min/max instruction counts.
+otbn_insn_count_range(
+    name = "mod_exp_otbn_insn_count_range",
+    deps = [
+        "//sw/otbn/crypto:run_rsa_verify_3072_rr_modexp",
+    ],
+)
+
+# Check the OTBN instruction count in mod_exp_otbn.h
+sh_test(
+    name = "mod_exp_otbn_insn_count_check",
+    size = "small",
+    srcs = ["mod_exp_otbn_insn_count_check.sh"],
+    args = [
+        "$(location :mod_exp_otbn_insn_count_range)",
+        "$(location mod_exp_otbn.h)",
+    ],
+    data = [
+        "mod_exp_otbn.h",
+        ":mod_exp_otbn_insn_count_range",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.h
+++ b/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.h
@@ -16,14 +16,19 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * Manually-calculated instruction count range.
+ * Possible range of instruction counts for modexp.
  *
- * The OTBN modexp implementation is not constant-time (which is okay because
- * it has no secret inputs). However, all valid control-flow paths should fall
- * within this range, which is calculated by changing the code to either take
- * all branches or skip them all.
+ * This range should represent the theoretical minimum/maximum instruction
+ * counts for any input to the program; if the instruction count recorded by
+ * OTBN is different, we will suspect a fault injection attack.
  *
- * IMPORTANT: This may need to be modified if the modexp routine is changed!
+ * The OTBN modexp implementation is not constant-time, but that is okay
+ * because it has no secret inputs and therefore can't leak secret information.
+ *
+ * IMPORTANT: This may need to be modified if the modexp routine is changed! If
+ * updating this value, please both use the automatic script
+ * (get_instruction_count_range.py) and also double-check by manually
+ * modifying the code to skip/take all branches.
  */
 enum {
   kModExpOtbnInsnCountMin = 181147,

--- a/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn_insn_count_check.sh
+++ b/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn_insn_count_check.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Usage: mod_exp_otbn_insn_count_check.sh COUNTS_FILE HEADER_FILE
+#
+# COUNTS_FILE: file including min/max instruction counts
+# HEADER_FILE: header file that should contain matching counts
+
+set -e
+
+counts_file="$1"
+header_file="$2"
+
+# Get the minimum/maximum instruction counts from the `counts_file`.
+min=$(grep "Minimum instruction count: " "${counts_file}" | sed -e "s/Minimum instruction count: //")
+max=$(grep "Maximum instruction count: " "${counts_file}" | sed -e "s/Maximum instruction count: //")
+echo "Expected minimum count: ${min}"
+echo "Expected maximum count: ${max}"
+
+echo "If this test fails, double check that the instruction count range above matches the one in ${header_file}."
+
+# Check that these numbers match the ones in the header file.
+grep "kModExpOtbnInsnCountMin = ${min}," "${header_file}"
+grep "kModExpOtbnInsnCountMax = ${max}," "${header_file}"


### PR DESCRIPTION
This adds a custom Bazel test that can run in CI to check the min/max instruction count range in `mod_exp_otbn.h` against the values calculated by the new static analysis script. Adding a test in this way seems preferable to automatically generating the numbers, because we should in general be double-checking the script's answers with manual analysis to be extra certain.

This PR also adds some Bazel rules to some OTBN utilities that were missing them.

Resolves https://github.com/lowRISC/opentitan/issues/13185

Successful run:
```shell
$ bazel test --test_output=streamed --disk_cache=~/bazel_cache //sw/device/silicon_creator/lib/sigverify:mod_exp_otbn_insn_count_check
INFO: Invocation ID: 5ff62c20-d559-45cb-860b-bffdaf9ec30f
WARNING: Streamed test output requested. All tests will be run locally, without sharding, one at a time
INFO: Analyzed target //sw/device/silicon_creator/lib/sigverify:mod_exp_otbn_insn_count_check (4 packages loaded, 39 targets configured).
INFO: Found 1 test target...
Expected minimum count: 181147
Expected maximum count: 198397
If this test fails, double check that the instruction count range above matches the one in sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.h.
  kModExpOtbnInsnCountMin = 181147,
  kModExpOtbnInsnCountMax = 198397,
Target //sw/device/silicon_creator/lib/sigverify:mod_exp_otbn_insn_count_check up-to-date:
  bazel-bin/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn_insn_count_check
INFO: Elapsed time: 0.393s, Critical Path: 0.16s
INFO: 2 processes: 1 disk cache hit, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions
//sw/device/silicon_creator/lib/sigverify:mod_exp_otbn_insn_count_check  PASSED in 0.0s

INFO: Build completed successfully, 2 total actions
```

Failed run (after I manually modified the header's instruction counts to not match):
```shell
$ bazel test --test_output=streamed --disk_cache=~/bazel_cache //sw/device/silicon_creator/lib/sigverify:mod_exp_otbn_insn_count_check
INFO: Invocation ID: f9522e05-dfe9-46a4-93c9-bf3edb0caa2d
WARNING: Streamed test output requested. All tests will be run locally, without sharding, one at a time
INFO: Analyzed target //sw/device/silicon_creator/lib/sigverify:mod_exp_otbn_insn_count_check (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Expected minimum count: 181147
Expected maximum count: 198397
If this test fails, double check that the instruction count range above matches the one in sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.h.
FAIL: //sw/device/silicon_creator/lib/sigverify:mod_exp_otbn_insn_count_check (see /home/jadep/.cache/bazel/_bazel_jadep/87e97e71d7aca067127234428526e37b/execroot/lowrisc_opentitan/bazel-out/k8-fastbuild/testlogs/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn_insn_count_check/test.log)
Target //sw/device/silicon_creator/lib/sigverify:mod_exp_otbn_insn_count_check up-to-date:
  bazel-bin/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn_insn_count_check
INFO: Elapsed time: 0.417s, Critical Path: 0.16s
INFO: 2 processes: 2 linux-sandbox.
INFO: Build completed, 1 test FAILED, 2 total actions
//sw/device/silicon_creator/lib/sigverify:mod_exp_otbn_insn_count_check  FAILED in 0.0s
  /home/jadep/.cache/bazel/_bazel_jadep/87e97e71d7aca067127234428526e37b/execroot/lowrisc_opentitan/bazel-out/k8-fastbuild/testlogs/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn_insn_count_check/test.log

INFO: Build completed, 1 test FAILED, 2 total actions
```