### PR TITLE
[otbn] Add SVA to ensure were not using X from uninitialized registers

### DIFF
--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -220,4 +220,9 @@ module otbn_rf_base
   assign rf_err_o = (|rd_data_a_err & rd_en_a_i & ~pop_stack_a_err) |
                     (|rd_data_b_err & rd_en_b_i & ~pop_stack_b_err) |
                     spurious_we_err;
+
+  // Make sure we're not outputting X. This indicates that something went wrong during the initial
+  // secure wipe.
+  `ASSERT(OtbnRfBaseRdAKnown, rd_en_a_i && !pop_stack_a |-> !$isunknown(rd_data_a_raw_intg))
+  `ASSERT(OtbnRfBaseRdBKnown, rd_en_b_i && !pop_stack_b |-> !$isunknown(rd_data_b_raw_intg))
 endmodule

--- a/hw/ip/otbn/rtl/otbn_rf_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum.sv
@@ -162,4 +162,9 @@ module otbn_rf_bignum
   assign rf_err_o = ((|rd_data_a_err) & rd_en_a_i) |
                     ((|rd_data_b_err) & rd_en_b_i) |
                     spurious_we_err;
+
+  // Make sure we're not outputting X. This indicates that something went wrong during the initial
+  // secure wipe.
+  `ASSERT(OtbnRfBignumRdAKnown, rd_en_a_i && !rd_en_a_mismatch |-> !$isunknown(rd_data_a_intg_o))
+  `ASSERT(OtbnRfBignumRdBKnown, rd_en_b_i && !rd_en_b_mismatch |-> !$isunknown(rd_data_b_intg_o))
 endmodule


### PR DESCRIPTION
Using X from uninitialized GPRs and WDRs indicates that something during the initial secure wipe went wrong. This PR adds some SystemVerilog assertions to detect this.

As discussed in https://github.com/lowRISC/opentitan/pull/13724#pullrequestreview-1049497184 