### PR TITLE
refactor(rv_timer)!: Rearrange INTERRUPT regs

### DIFF
--- a/hw/ip/rv_timer/data/rv_timer.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.hjson
@@ -37,7 +37,7 @@
   ],
   no_auto_intr_regs: "true",
   countermeasures: [
-    { name: "BUS.INTEGRITY",
+    { name: "BUS.INTEGRITY"
       desc: "End-to-end bus integrity scheme."
     }
   ]
@@ -59,6 +59,48 @@
       }
     },
     { skipto: "0x100" },
+    { multireg: {
+        name: "INTR_ENABLE0",
+        desc: "Interrupt Enable",
+        count: "N_TIMERS",
+        cname: "TIMER",
+        swaccess: "rw",
+        hwaccess: "hro",
+        fields: [
+          { bits: "0", name: "IE", desc: "Interrupt Enable for timer" }
+        ]
+      }
+    }, // R: INTR_ENABLE0
+    { multireg: {
+        name: "INTR_STATE0",
+        desc: "Interrupt Status",
+        count: "N_TIMERS",
+        cname: "TIMER",
+        swaccess: "rw1c",
+        hwaccess: "hrw",
+        fields: [
+          { bits: "0", name: "IS", desc: "Interrupt status for timer",
+            tags: [// intr_state csr is affected by writes to other csrs - skip write-check
+                   "excl:CsrNonInitTests:CsrExclWriteCheck"] }
+        ],
+      }
+    }, // R: INTR_STATE0
+    { multireg: {
+        name: "INTR_TEST0",
+        desc: "Interrupt test register",
+        count: "N_TIMERS",
+        cname: "TIMER",
+        swaccess: "wo",
+        hwaccess: "hro",
+        hwext: "true",
+        hwqe: "true",
+        fields: [
+          { bits: "0", name: "T", desc: "Interrupt test for timer",
+            tags: [// intr_test csr is WO which - it reads back 0s
+                   "excl:CsrNonInitTests:CsrExclWrite"] }
+        ]
+      }
+    }, // R: INTR_TEST0
     { name: "CFG0",
       desc: "Configuration for Hart 0",
       swaccess: "rw",
@@ -102,48 +144,5 @@
         { bits: "31:0", name: "v", resval: "0xffffffff", desc: "Timer compare value [63:32]" },
       ],
     },
-    { multireg: {
-        name: "INTR_ENABLE0",
-        desc: "Interrupt Enable",
-        count: "N_TIMERS",
-        cname: "TIMER",
-        swaccess: "rw",
-        hwaccess: "hro",
-        fields: [
-          { bits: "0", name: "IE", desc: "Interrupt Enable for timer" }
-        ]
-      }
-    },
-    { multireg: {
-        name: "INTR_STATE0",
-        desc: "Interrupt Status",
-        count: "N_TIMERS",
-        cname: "TIMER",
-        swaccess: "rw1c",
-        hwaccess: "hrw",
-        fields: [
-          { bits: "0", name: "IS", desc: "Interrupt status for timer",
-            tags: [// intr_state csr is affected by writes to other csrs - skip write-check
-                   "excl:CsrNonInitTests:CsrExclWriteCheck"] }
-        ],
-      }
-    },
-    { multireg: {
-        name: "INTR_TEST0",
-        desc: "Interrupt test register",
-        count: "N_TIMERS",
-        cname: "TIMER",
-        swaccess: "wo",
-        hwaccess: "hro",
-        hwext: "true",
-        hwqe: "true",
-        fields: [
-          { bits: "0", name: "T", desc: "Interrupt test for timer",
-            tags: [// intr_test csr is WO which - it reads back 0s
-                   "excl:CsrNonInitTests:CsrExclWrite"] }
-        ]
-      }
-    },
   ],
 }
-

--- a/hw/ip/rv_timer/data/rv_timer.hjson.tpl
+++ b/hw/ip/rv_timer/data/rv_timer.hjson.tpl
@@ -43,6 +43,11 @@
     }
   ],
   no_auto_intr_regs: "true",
+  countermeasures: [
+    { name: "BUS.INTEGRITY"
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: [
     { multireg: {
@@ -62,6 +67,48 @@
     },
 % for i in range(harts):
     { skipto: "${"0x%x" % (256*(i+1))}" },
+    { multireg: {
+        name: "INTR_ENABLE${i}",
+        desc: "Interrupt Enable",
+        count: "N_TIMERS",
+        cname: "TIMER",
+        swaccess: "rw",
+        hwaccess: "hro",
+        fields: [
+          { bits: "0", name: "IE", desc: "Interrupt Enable for timer" }
+        ]
+      }
+    }, // R: INTR_ENABLE${i}
+    { multireg: {
+        name: "INTR_STATE${i}",
+        desc: "Interrupt Status",
+        count: "N_TIMERS",
+        cname: "TIMER",
+        swaccess: "rw1c",
+        hwaccess: "hrw",
+        fields: [
+          { bits: "0", name: "IS", desc: "Interrupt status for timer",
+            tags: [// intr_state csr is affected by writes to other csrs - skip write-check
+                   "excl:CsrNonInitTests:CsrExclWriteCheck"] }
+        ],
+      }
+    }, // R: INTR_STATE${i}
+    { multireg: {
+        name: "INTR_TEST${i}",
+        desc: "Interrupt test register",
+        count: "N_TIMERS",
+        cname: "TIMER",
+        swaccess: "wo",
+        hwaccess: "hro",
+        hwext: "true",
+        hwqe: "true",
+        fields: [
+          { bits: "0", name: "T", desc: "Interrupt test for timer",
+            tags: [// intr_test csr is WO which - it reads back 0s
+                   "excl:CsrNonInitTests:CsrExclWrite"] }
+        ]
+      }
+    }, // R: INTR_TEST${i}
     { name: "CFG${i}",
       desc: "Configuration for Hart ${i}",
       swaccess: "rw",
@@ -107,48 +154,6 @@
       ],
     },
 % endfor
-    { multireg: {
-        name: "INTR_ENABLE${i}",
-        desc: "Interrupt Enable",
-        count: "N_TIMERS",
-        cname: "TIMER",
-        swaccess: "rw",
-        hwaccess: "hro",
-        fields: [
-          { bits: "0", name: "IE", desc: "Interrupt Enable for timer" }
-        ]
-      }
-    },
-    { multireg: {
-        name: "INTR_STATE${i}",
-        desc: "Interrupt Status",
-        count: "N_TIMERS",
-        cname: "TIMER",
-        swaccess: "rw1c",
-        hwaccess: "hrw",
-        fields: [
-          { bits: "0", name: "IS", desc: "Interrupt status for timer",
-            tags: [// intr_state csr is affected by writes to other csrs - skip write-check
-                   "excl:CsrNonInitTests:CsrExclWriteCheck"] }
-        ],
-      }
-    },
-    { multireg: {
-        name: "INTR_TEST${i}",
-        desc: "Interrupt test register",
-        count: "N_TIMERS",
-        cname: "TIMER",
-        swaccess: "wo",
-        hwaccess: "hro",
-        hwext: "true",
-        hwqe: "true",
-        fields: [
-          { bits: "0", name: "T", desc: "Interrupt test for timer",
-            tags: [// intr_test csr is WO which - it reads back 0s
-                   "excl:CsrNonInitTests:CsrExclWrite"] }
-        ]
-      }
-    },
 % endfor
   ],
 }

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
@@ -28,6 +28,19 @@ package rv_timer_reg_pkg;
   } rv_timer_reg2hw_ctrl_mreg_t;
 
   typedef struct packed {
+    logic        q;
+  } rv_timer_reg2hw_intr_enable0_mreg_t;
+
+  typedef struct packed {
+    logic        q;
+  } rv_timer_reg2hw_intr_state0_mreg_t;
+
+  typedef struct packed {
+    logic        q;
+    logic        qe;
+  } rv_timer_reg2hw_intr_test0_mreg_t;
+
+  typedef struct packed {
     struct packed {
       logic [11:0] q;
     } prescale;
@@ -55,17 +68,9 @@ package rv_timer_reg_pkg;
   } rv_timer_reg2hw_compare_upper0_0_reg_t;
 
   typedef struct packed {
-    logic        q;
-  } rv_timer_reg2hw_intr_enable0_mreg_t;
-
-  typedef struct packed {
-    logic        q;
-  } rv_timer_reg2hw_intr_state0_mreg_t;
-
-  typedef struct packed {
-    logic        q;
-    logic        qe;
-  } rv_timer_reg2hw_intr_test0_mreg_t;
+    logic        d;
+    logic        de;
+  } rv_timer_hw2reg_intr_state0_mreg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -77,43 +82,38 @@ package rv_timer_reg_pkg;
     logic        de;
   } rv_timer_hw2reg_timer_v_upper0_reg_t;
 
-  typedef struct packed {
-    logic        d;
-    logic        de;
-  } rv_timer_hw2reg_intr_state0_mreg_t;
-
   // Register -> HW type
   typedef struct packed {
     rv_timer_reg2hw_alert_test_reg_t alert_test; // [156:155]
     rv_timer_reg2hw_ctrl_mreg_t [0:0] ctrl; // [154:154]
-    rv_timer_reg2hw_cfg0_reg_t cfg0; // [153:134]
-    rv_timer_reg2hw_timer_v_lower0_reg_t timer_v_lower0; // [133:102]
-    rv_timer_reg2hw_timer_v_upper0_reg_t timer_v_upper0; // [101:70]
-    rv_timer_reg2hw_compare_lower0_0_reg_t compare_lower0_0; // [69:37]
-    rv_timer_reg2hw_compare_upper0_0_reg_t compare_upper0_0; // [36:4]
-    rv_timer_reg2hw_intr_enable0_mreg_t [0:0] intr_enable0; // [3:3]
-    rv_timer_reg2hw_intr_state0_mreg_t [0:0] intr_state0; // [2:2]
-    rv_timer_reg2hw_intr_test0_mreg_t [0:0] intr_test0; // [1:0]
+    rv_timer_reg2hw_intr_enable0_mreg_t [0:0] intr_enable0; // [153:153]
+    rv_timer_reg2hw_intr_state0_mreg_t [0:0] intr_state0; // [152:152]
+    rv_timer_reg2hw_intr_test0_mreg_t [0:0] intr_test0; // [151:150]
+    rv_timer_reg2hw_cfg0_reg_t cfg0; // [149:130]
+    rv_timer_reg2hw_timer_v_lower0_reg_t timer_v_lower0; // [129:98]
+    rv_timer_reg2hw_timer_v_upper0_reg_t timer_v_upper0; // [97:66]
+    rv_timer_reg2hw_compare_lower0_0_reg_t compare_lower0_0; // [65:33]
+    rv_timer_reg2hw_compare_upper0_0_reg_t compare_upper0_0; // [32:0]
   } rv_timer_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    rv_timer_hw2reg_timer_v_lower0_reg_t timer_v_lower0; // [67:35]
-    rv_timer_hw2reg_timer_v_upper0_reg_t timer_v_upper0; // [34:2]
-    rv_timer_hw2reg_intr_state0_mreg_t [0:0] intr_state0; // [1:0]
+    rv_timer_hw2reg_intr_state0_mreg_t [0:0] intr_state0; // [67:66]
+    rv_timer_hw2reg_timer_v_lower0_reg_t timer_v_lower0; // [65:33]
+    rv_timer_hw2reg_timer_v_upper0_reg_t timer_v_upper0; // [32:0]
   } rv_timer_hw2reg_t;
 
   // Register offsets
   parameter logic [BlockAw-1:0] RV_TIMER_ALERT_TEST_OFFSET = 9'h 0;
   parameter logic [BlockAw-1:0] RV_TIMER_CTRL_OFFSET = 9'h 4;
-  parameter logic [BlockAw-1:0] RV_TIMER_CFG0_OFFSET = 9'h 100;
-  parameter logic [BlockAw-1:0] RV_TIMER_TIMER_V_LOWER0_OFFSET = 9'h 104;
-  parameter logic [BlockAw-1:0] RV_TIMER_TIMER_V_UPPER0_OFFSET = 9'h 108;
-  parameter logic [BlockAw-1:0] RV_TIMER_COMPARE_LOWER0_0_OFFSET = 9'h 10c;
-  parameter logic [BlockAw-1:0] RV_TIMER_COMPARE_UPPER0_0_OFFSET = 9'h 110;
-  parameter logic [BlockAw-1:0] RV_TIMER_INTR_ENABLE0_OFFSET = 9'h 114;
-  parameter logic [BlockAw-1:0] RV_TIMER_INTR_STATE0_OFFSET = 9'h 118;
-  parameter logic [BlockAw-1:0] RV_TIMER_INTR_TEST0_OFFSET = 9'h 11c;
+  parameter logic [BlockAw-1:0] RV_TIMER_INTR_ENABLE0_OFFSET = 9'h 100;
+  parameter logic [BlockAw-1:0] RV_TIMER_INTR_STATE0_OFFSET = 9'h 104;
+  parameter logic [BlockAw-1:0] RV_TIMER_INTR_TEST0_OFFSET = 9'h 108;
+  parameter logic [BlockAw-1:0] RV_TIMER_CFG0_OFFSET = 9'h 10c;
+  parameter logic [BlockAw-1:0] RV_TIMER_TIMER_V_LOWER0_OFFSET = 9'h 110;
+  parameter logic [BlockAw-1:0] RV_TIMER_TIMER_V_UPPER0_OFFSET = 9'h 114;
+  parameter logic [BlockAw-1:0] RV_TIMER_COMPARE_LOWER0_0_OFFSET = 9'h 118;
+  parameter logic [BlockAw-1:0] RV_TIMER_COMPARE_UPPER0_0_OFFSET = 9'h 11c;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] RV_TIMER_ALERT_TEST_RESVAL = 1'h 0;
@@ -124,28 +124,28 @@ package rv_timer_reg_pkg;
   typedef enum int {
     RV_TIMER_ALERT_TEST,
     RV_TIMER_CTRL,
+    RV_TIMER_INTR_ENABLE0,
+    RV_TIMER_INTR_STATE0,
+    RV_TIMER_INTR_TEST0,
     RV_TIMER_CFG0,
     RV_TIMER_TIMER_V_LOWER0,
     RV_TIMER_TIMER_V_UPPER0,
     RV_TIMER_COMPARE_LOWER0_0,
-    RV_TIMER_COMPARE_UPPER0_0,
-    RV_TIMER_INTR_ENABLE0,
-    RV_TIMER_INTR_STATE0,
-    RV_TIMER_INTR_TEST0
+    RV_TIMER_COMPARE_UPPER0_0
   } rv_timer_id_e;
 
   // Register width information to check illegal writes
   parameter logic [3:0] RV_TIMER_PERMIT [10] = '{
     4'b 0001, // index[0] RV_TIMER_ALERT_TEST
     4'b 0001, // index[1] RV_TIMER_CTRL
-    4'b 0111, // index[2] RV_TIMER_CFG0
-    4'b 1111, // index[3] RV_TIMER_TIMER_V_LOWER0
-    4'b 1111, // index[4] RV_TIMER_TIMER_V_UPPER0
-    4'b 1111, // index[5] RV_TIMER_COMPARE_LOWER0_0
-    4'b 1111, // index[6] RV_TIMER_COMPARE_UPPER0_0
-    4'b 0001, // index[7] RV_TIMER_INTR_ENABLE0
-    4'b 0001, // index[8] RV_TIMER_INTR_STATE0
-    4'b 0001  // index[9] RV_TIMER_INTR_TEST0
+    4'b 0001, // index[2] RV_TIMER_INTR_ENABLE0
+    4'b 0001, // index[3] RV_TIMER_INTR_STATE0
+    4'b 0001, // index[4] RV_TIMER_INTR_TEST0
+    4'b 0111, // index[5] RV_TIMER_CFG0
+    4'b 1111, // index[6] RV_TIMER_TIMER_V_LOWER0
+    4'b 1111, // index[7] RV_TIMER_TIMER_V_UPPER0
+    4'b 1111, // index[8] RV_TIMER_COMPARE_LOWER0_0
+    4'b 1111  // index[9] RV_TIMER_COMPARE_UPPER0_0
   };
 
 endpackage

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -126,6 +126,14 @@ module rv_timer_reg_top (
   logic ctrl_we;
   logic ctrl_qs;
   logic ctrl_wd;
+  logic intr_enable0_we;
+  logic intr_enable0_qs;
+  logic intr_enable0_wd;
+  logic intr_state0_we;
+  logic intr_state0_qs;
+  logic intr_state0_wd;
+  logic intr_test0_we;
+  logic intr_test0_wd;
   logic cfg0_we;
   logic [11:0] cfg0_prescale_qs;
   logic [11:0] cfg0_prescale_wd;
@@ -143,14 +151,6 @@ module rv_timer_reg_top (
   logic compare_upper0_0_we;
   logic [31:0] compare_upper0_0_qs;
   logic [31:0] compare_upper0_0_wd;
-  logic intr_enable0_we;
-  logic intr_enable0_qs;
-  logic intr_enable0_wd;
-  logic intr_state0_we;
-  logic intr_state0_qs;
-  logic intr_state0_wd;
-  logic intr_test0_we;
-  logic intr_test0_wd;
 
   // Register instances
   // R[alert_test]: V(True)
@@ -199,6 +199,83 @@ module rv_timer_reg_top (
     // to register interface (read)
     .qs     (ctrl_qs)
   );
+
+
+  // Subregister 0 of Multireg intr_enable0
+  // R[intr_enable0]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_intr_enable0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (intr_enable0_we),
+    .wd     (intr_enable0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable0[0].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (intr_enable0_qs)
+  );
+
+
+  // Subregister 0 of Multireg intr_state0
+  // R[intr_state0]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_intr_state0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (intr_state0_we),
+    .wd     (intr_state0_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state0[0].de),
+    .d      (hw2reg.intr_state0[0].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state0[0].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (intr_state0_qs)
+  );
+
+
+  // Subregister 0 of Multireg intr_test0
+  // R[intr_test0]: V(True)
+  logic intr_test0_qe;
+  logic [0:0] intr_test0_flds_we;
+  assign intr_test0_qe = &intr_test0_flds_we;
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test0 (
+    .re     (1'b0),
+    .we     (intr_test0_we),
+    .wd     (intr_test0_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (intr_test0_flds_we[0]),
+    .q      (reg2hw.intr_test0[0].q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.intr_test0[0].qe = intr_test0_qe;
 
 
   // R[cfg0]: V(False)
@@ -387,97 +464,20 @@ module rv_timer_reg_top (
   assign reg2hw.compare_upper0_0.qe = compare_upper0_0_qe;
 
 
-  // Subregister 0 of Multireg intr_enable0
-  // R[intr_enable0]: V(False)
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_intr_enable0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (intr_enable0_we),
-    .wd     (intr_enable0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_enable0[0].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (intr_enable0_qs)
-  );
-
-
-  // Subregister 0 of Multireg intr_state0
-  // R[intr_state0]: V(False)
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_intr_state0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (intr_state0_we),
-    .wd     (intr_state0_wd),
-
-    // from internal hardware
-    .de     (hw2reg.intr_state0[0].de),
-    .d      (hw2reg.intr_state0[0].d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_state0[0].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (intr_state0_qs)
-  );
-
-
-  // Subregister 0 of Multireg intr_test0
-  // R[intr_test0]: V(True)
-  logic intr_test0_qe;
-  logic [0:0] intr_test0_flds_we;
-  assign intr_test0_qe = &intr_test0_flds_we;
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_intr_test0 (
-    .re     (1'b0),
-    .we     (intr_test0_we),
-    .wd     (intr_test0_wd),
-    .d      ('0),
-    .qre    (),
-    .qe     (intr_test0_flds_we[0]),
-    .q      (reg2hw.intr_test0[0].q),
-    .ds     (),
-    .qs     ()
-  );
-  assign reg2hw.intr_test0[0].qe = intr_test0_qe;
-
-
 
   logic [9:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[0] = (reg_addr == RV_TIMER_ALERT_TEST_OFFSET);
     addr_hit[1] = (reg_addr == RV_TIMER_CTRL_OFFSET);
-    addr_hit[2] = (reg_addr == RV_TIMER_CFG0_OFFSET);
-    addr_hit[3] = (reg_addr == RV_TIMER_TIMER_V_LOWER0_OFFSET);
-    addr_hit[4] = (reg_addr == RV_TIMER_TIMER_V_UPPER0_OFFSET);
-    addr_hit[5] = (reg_addr == RV_TIMER_COMPARE_LOWER0_0_OFFSET);
-    addr_hit[6] = (reg_addr == RV_TIMER_COMPARE_UPPER0_0_OFFSET);
-    addr_hit[7] = (reg_addr == RV_TIMER_INTR_ENABLE0_OFFSET);
-    addr_hit[8] = (reg_addr == RV_TIMER_INTR_STATE0_OFFSET);
-    addr_hit[9] = (reg_addr == RV_TIMER_INTR_TEST0_OFFSET);
+    addr_hit[2] = (reg_addr == RV_TIMER_INTR_ENABLE0_OFFSET);
+    addr_hit[3] = (reg_addr == RV_TIMER_INTR_STATE0_OFFSET);
+    addr_hit[4] = (reg_addr == RV_TIMER_INTR_TEST0_OFFSET);
+    addr_hit[5] = (reg_addr == RV_TIMER_CFG0_OFFSET);
+    addr_hit[6] = (reg_addr == RV_TIMER_TIMER_V_LOWER0_OFFSET);
+    addr_hit[7] = (reg_addr == RV_TIMER_TIMER_V_UPPER0_OFFSET);
+    addr_hit[8] = (reg_addr == RV_TIMER_COMPARE_LOWER0_0_OFFSET);
+    addr_hit[9] = (reg_addr == RV_TIMER_COMPARE_UPPER0_0_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -504,46 +504,46 @@ module rv_timer_reg_top (
   assign ctrl_we = addr_hit[1] & reg_we & !reg_error;
 
   assign ctrl_wd = reg_wdata[0];
-  assign cfg0_we = addr_hit[2] & reg_we & !reg_error;
+  assign intr_enable0_we = addr_hit[2] & reg_we & !reg_error;
+
+  assign intr_enable0_wd = reg_wdata[0];
+  assign intr_state0_we = addr_hit[3] & reg_we & !reg_error;
+
+  assign intr_state0_wd = reg_wdata[0];
+  assign intr_test0_we = addr_hit[4] & reg_we & !reg_error;
+
+  assign intr_test0_wd = reg_wdata[0];
+  assign cfg0_we = addr_hit[5] & reg_we & !reg_error;
 
   assign cfg0_prescale_wd = reg_wdata[11:0];
 
   assign cfg0_step_wd = reg_wdata[23:16];
-  assign timer_v_lower0_we = addr_hit[3] & reg_we & !reg_error;
+  assign timer_v_lower0_we = addr_hit[6] & reg_we & !reg_error;
 
   assign timer_v_lower0_wd = reg_wdata[31:0];
-  assign timer_v_upper0_we = addr_hit[4] & reg_we & !reg_error;
+  assign timer_v_upper0_we = addr_hit[7] & reg_we & !reg_error;
 
   assign timer_v_upper0_wd = reg_wdata[31:0];
-  assign compare_lower0_0_we = addr_hit[5] & reg_we & !reg_error;
+  assign compare_lower0_0_we = addr_hit[8] & reg_we & !reg_error;
 
   assign compare_lower0_0_wd = reg_wdata[31:0];
-  assign compare_upper0_0_we = addr_hit[6] & reg_we & !reg_error;
+  assign compare_upper0_0_we = addr_hit[9] & reg_we & !reg_error;
 
   assign compare_upper0_0_wd = reg_wdata[31:0];
-  assign intr_enable0_we = addr_hit[7] & reg_we & !reg_error;
-
-  assign intr_enable0_wd = reg_wdata[0];
-  assign intr_state0_we = addr_hit[8] & reg_we & !reg_error;
-
-  assign intr_state0_wd = reg_wdata[0];
-  assign intr_test0_we = addr_hit[9] & reg_we & !reg_error;
-
-  assign intr_test0_wd = reg_wdata[0];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
     reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = ctrl_we;
-    reg_we_check[2] = cfg0_we;
-    reg_we_check[3] = timer_v_lower0_we;
-    reg_we_check[4] = timer_v_upper0_we;
-    reg_we_check[5] = compare_lower0_0_we;
-    reg_we_check[6] = compare_upper0_0_we;
-    reg_we_check[7] = intr_enable0_we;
-    reg_we_check[8] = intr_state0_we;
-    reg_we_check[9] = intr_test0_we;
+    reg_we_check[2] = intr_enable0_we;
+    reg_we_check[3] = intr_state0_we;
+    reg_we_check[4] = intr_test0_we;
+    reg_we_check[5] = cfg0_we;
+    reg_we_check[6] = timer_v_lower0_we;
+    reg_we_check[7] = timer_v_upper0_we;
+    reg_we_check[8] = compare_lower0_0_we;
+    reg_we_check[9] = compare_upper0_0_we;
   end
 
   // Read data return
@@ -559,36 +559,36 @@ module rv_timer_reg_top (
       end
 
       addr_hit[2]: begin
+        reg_rdata_next[0] = intr_enable0_qs;
+      end
+
+      addr_hit[3]: begin
+        reg_rdata_next[0] = intr_state0_qs;
+      end
+
+      addr_hit[4]: begin
+        reg_rdata_next[0] = '0;
+      end
+
+      addr_hit[5]: begin
         reg_rdata_next[11:0] = cfg0_prescale_qs;
         reg_rdata_next[23:16] = cfg0_step_qs;
       end
 
-      addr_hit[3]: begin
+      addr_hit[6]: begin
         reg_rdata_next[31:0] = timer_v_lower0_qs;
       end
 
-      addr_hit[4]: begin
+      addr_hit[7]: begin
         reg_rdata_next[31:0] = timer_v_upper0_qs;
       end
 
-      addr_hit[5]: begin
+      addr_hit[8]: begin
         reg_rdata_next[31:0] = compare_lower0_0_qs;
       end
 
-      addr_hit[6]: begin
-        reg_rdata_next[31:0] = compare_upper0_0_qs;
-      end
-
-      addr_hit[7]: begin
-        reg_rdata_next[0] = intr_enable0_qs;
-      end
-
-      addr_hit[8]: begin
-        reg_rdata_next[0] = intr_state0_qs;
-      end
-
       addr_hit[9]: begin
-        reg_rdata_next[0] = '0;
+        reg_rdata_next[31:0] = compare_upper0_0_qs;
       end
 
       default: begin

--- a/hw/ip/rv_timer/util/reg_timer.py
+++ b/hw/ip/rv_timer/util/reg_timer.py
@@ -36,7 +36,7 @@ def main():
     out = StringIO()
 
     reg_tpl = Template(args.input.read())
-    out.write(reg_tpl.render(harts=args.harts, timers=args.timers))
+    out.write(reg_tpl.render(harts=args.harts, timers=args.timers).rstrip())
 
     print(out.getvalue())
 

--- a/sw/device/lib/dif/dif_rv_timer_unittest.cc
+++ b/sw/device/lib/dif/dif_rv_timer_unittest.cc
@@ -99,14 +99,6 @@ ptrdiff_t RegForHart(uint32_t hart, ptrdiff_t reg_offset) {
   return 0x100 * hart + reg_offset;
 }
 
-// Copy of `irq_reg_for_hart()` in the C translation unit under test.
-ptrdiff_t IrqRegForHart(uint32_t hart, uint32_t comparators,
-                        ptrdiff_t reg_offset) {
-  auto base = RegForHart(hart, reg_offset);
-  auto extra_comparator_offset = sizeof(uint64_t) * (comparators - 1);
-  return base + extra_comparator_offset;
-}
-
 constexpr uint32_t kAllOnes = std::numeric_limits<uint32_t>::max();
 
 class ResetTest : public TimerTest {};
@@ -115,9 +107,8 @@ TEST_F(ResetTest, Success) {
   EXPECT_WRITE32(RV_TIMER_CTRL_REG_OFFSET, 0x0);
 
   for (uint32_t hart_id = 0; hart_id < RV_TIMER_PARAM_N_HARTS; ++hart_id) {
-    EXPECT_WRITE32(IrqRegForHart(0, 1, RV_TIMER_INTR_ENABLE0_REG_OFFSET), 0x0);
-    EXPECT_WRITE32(IrqRegForHart(0, 1, RV_TIMER_INTR_STATE0_REG_OFFSET),
-                   kAllOnes);
+    EXPECT_WRITE32(RegForHart(0, RV_TIMER_INTR_ENABLE0_REG_OFFSET), 0x0);
+    EXPECT_WRITE32(RegForHart(0, RV_TIMER_INTR_STATE0_REG_OFFSET), kAllOnes);
 
     for (uint32_t comp_id = 0; comp_id < RV_TIMER_PARAM_N_TIMERS; ++comp_id) {
       EXPECT_WRITE32(RegForHart(0, RV_TIMER_COMPARE_UPPER0_0_REG_OFFSET),


### PR DESCRIPTION
**This commit breaks the SW API**

Put INTR related CSRs prior to the comparator registers for SW to
compute the INTR easily.

