### PR TITLE
[dv,chip] Fix a few chip level failures

### DIFF
--- a/hw/ip/rstmgr/dv/rstmgr_sim.core
+++ b/hw/ip/rstmgr/dv/rstmgr_sim.core
@@ -13,6 +13,7 @@ filesets:
     depend:
       - lowrisc:dv:rstmgr_test
       - lowrisc:dv:rstmgr_sva
+      - lowrisc:dv:rstmgr_unit_only_sva
     files:
       - tb.sv
       - cov/rstmgr_cov_bind.sv

--- a/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -52,7 +52,7 @@
   ]
 
   // Add additional tops for simulation.
-  sim_tops: ["rstmgr_bind", "rstmgr_cov_bind",
+  sim_tops: ["rstmgr_bind", "rstmgr_unit_only_bind", "rstmgr_cov_bind",
              "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.

--- a/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
@@ -8,34 +8,6 @@ module rstmgr_bind;
     .EndpointType("Device")
   ) tlul_assert_device (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
 
-  // In top-level testbench, do not bind the csr_assert_fpv to reduce simulation time.
-  `ifndef TOP_LEVEL_DV
-  bind rstmgr rstmgr_csr_assert_fpv rstmgr_csr_assert (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
-  `endif
-
-  bind rstmgr pwrmgr_rstmgr_sva_if pwrmgr_rstmgr_sva_if (
-    .clk_i(clk_i),
-    .rst_ni(rst_ni),
-    .clk_slow_i(clk_aon_i),
-    .rst_slow_ni(&rst_por_aon_n),
-    // These inputs from pwrmgr are ignored since they check pwrmgr's rstreqs output.
-    .rstreqs_i('0),
-    .reset_en('0),
-    .sw_rst_req_i('0),
-    .main_rst_req_i('0),
-    .esc_rst_req_i('0),
-    .rstreqs('0),
-    // These are actually used for checks.
-    .rst_lc_req(pwr_i.rst_lc_req),
-    .rst_sys_req(pwr_i.rst_sys_req),
-    .main_pd_n('1),
-    .ndm_sys_req(ndmreset_req_i),
-    .reset_cause(pwr_i.reset_cause),
-    // The inputs from rstmgr.
-    .rst_lc_src_n(pwr_o.rst_lc_src_n),
-    .rst_sys_src_n(pwr_o.rst_sys_src_n)
-  );
-
   bind rstmgr rstmgr_cascading_sva_if rstmgr_cascading_sva_if (
     .clk_i,
     .clk_aon_i,

--- a/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -156,8 +156,8 @@ interface rstmgr_cascading_sva_if (
     // Controlled by rst_sys_src_n.
     // rst_sys_aon_n[Domain0Sel] is not used by anyone
     if (pd == rstmgr_pkg::DomainAonSel) begin : gen_sys_aon_chk
-    `CASCADED_ASSERTS(CascadeSysToSysAon, rst_sys_src_n[pd], resets_o.rst_sys_aon_n[pd], SysCycles,
-                      clk_aon_i)
+      `CASCADED_ASSERTS(CascadeSysToSysAon, rst_sys_src_n[pd], resets_o.rst_sys_aon_n[pd],
+                        SysCycles, clk_aon_i)
     end
     `CASCADED_ASSERTS(CascadeSysToSysIoDiv4, rst_sys_src_n[pd], resets_o.rst_sys_io_div4_n[pd],
                       SysCycles, clk_io_div4_i)

--- a/hw/ip/rstmgr/dv/sva/rstmgr_sva.core
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_sva.core
@@ -7,34 +7,18 @@ description: "RSTMGR assertion modules and bind file."
 filesets:
   files_dv:
     depend:
-      - lowrisc:tlul:headers
-      - lowrisc:fpv:csr_assert_gen
-      - lowrisc:dv:pwrmgr_rstmgr_sva_if
       - lowrisc:dv:rstmgr_sva_ifs
 
     files:
       - rstmgr_bind.sv
     file_type: systemVerilogSource
 
-  files_formal:
-    depend:
-      - lowrisc:systems:rstmgr
-
-generate:
-  csr_assert_gen:
-    generator: csr_assert_gen
-    parameters:
-      spec: ../../../../top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
-
 targets:
   default: &default_target
     filesets:
       - files_dv
-    generate:
-      - csr_assert_gen
   formal:
     <<: *default_target
     filesets:
-      - files_formal
       - files_dv
     toplevel: rstmgr

--- a/hw/ip/rstmgr/dv/sva/rstmgr_unit_only_bind.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_unit_only_bind.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This binds assertions that should not be bound at chip level.
+module rstmgr_unit_only_bind;
+
+  // In top-level testbench, do not bind the csr_assert_fpv to reduce simulation time.
+  bind rstmgr rstmgr_csr_assert_fpv rstmgr_csr_assert (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
+
+  // This doesn't connect all inputs, so it won't work at chip level. We bind it in the parent
+  // module instead, where all inputs are available.
+  bind rstmgr pwrmgr_rstmgr_sva_if pwrmgr_rstmgr_sva_if (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .clk_slow_i(clk_aon_i),
+    .rst_slow_ni(&rst_por_aon_n),
+    // These inputs from pwrmgr are ignored since they check pwrmgr's rstreqs output.
+    .rstreqs_i('0),
+    .reset_en('0),
+    .sw_rst_req_i('0),
+    .main_rst_req_i('0),
+    .esc_rst_req_i('0),
+    .rstreqs('0),
+    // These are actually used for checks.
+    .rst_lc_req(pwr_i.rst_lc_req),
+    .rst_sys_req(pwr_i.rst_sys_req),
+    .main_pd_n('1),
+    .ndm_sys_req(ndmreset_req_i),
+    .reset_cause(pwr_i.reset_cause),
+    // The inputs from rstmgr.
+    .rst_lc_src_n(pwr_o.rst_lc_src_n),
+    .rst_sys_src_n(pwr_o.rst_sys_src_n)
+  );
+
+endmodule : rstmgr_unit_only_bind

--- a/hw/ip/rstmgr/dv/sva/rstmgr_unit_only_sva.core
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_unit_only_sva.core
@@ -1,0 +1,39 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:rstmgr_unit_only_sva:0.1"
+description: "RSTMGR assertion modules not suitable for chip level and bind file."
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:tlul:headers
+      - lowrisc:fpv:csr_assert_gen
+      - lowrisc:dv:pwrmgr_rstmgr_sva_if
+
+    files:
+      - rstmgr_unit_only_bind.sv
+    file_type: systemVerilogSource
+
+  files_formal:
+    depend:
+      - lowrisc:systems:rstmgr
+
+generate:
+  csr_assert_gen:
+    generator: csr_assert_gen
+    parameters:
+      spec: ../../../../top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+
+targets:
+  default: &default_target
+    filesets:
+      - files_dv
+    generate:
+      - csr_assert_gen
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: rstmgr

--- a/hw/top_earlgrey/dv/env/ast_ext_clk_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_ext_clk_if.sv
@@ -2,24 +2,31 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This interface is used to detect when the external clock is activated and sub sequently
-// deactivated, as part of hardening chip level test(s) enabling the external clock.
+// This interface enables hardening tests that expect to use the external clock by sampling an ast
+// external clock enable signal.
 interface ast_ext_clk_if ();
+  import dv_utils_pkg::wait_timeout;
   import uvm_pkg::*;
 
-  string msg_id = "ast_ext_clk_if";
+  // A timeout in case something holds the expected change.
+  localparam int WaitForExctClkSelChangeInNs = 20_000;
 
-  task automatic detect_io_active_window();
-    fork
-      wait(u_ast.u_ast_clks_byp.u_io_clk_byp_en.out_o == 1'b1);
-      `uvm_info("ast_ext_clk_if", "External clk became active for io clk", UVM_MEDIUM)
-      wait(u_ast.u_ast_clks_byp.u_io_clk_osc_en.out_o == 1'b0);
-      `uvm_info("ast_ext_clk_if", "External clk back to inactive for io clk", UVM_MEDIUM)
-    join
+  // This task returns once the external clock has gone through an active cycle.
+  // Notice it will fail if the active cycle has already started.
+  task automatic span_external_clock_active_window();
+    `DV_SPINWAIT(wait(u_ast.u_ast_clks_byp.u_io_clk_byp_en.out_o == 1'b1);,
+                 "Took too long to enable external clock", WaitForExctClkSelChangeInNs,
+                 "ast_ext_clk_if")
+    `uvm_info("ast_ext_clk_if", "External clk became active for io clk", UVM_MEDIUM)
+    `DV_SPINWAIT(wait(u_ast.u_ast_clks_byp.u_io_clk_byp_en.out_o == 1'b0);,
+                 "Took too long to disable external clock", WaitForExctClkSelChangeInNs,
+                 "ast_ext_clk_if")
+    `uvm_info("ast_ext_clk_if", "External clk back to inactive for io clk", UVM_MEDIUM)
   endtask
 
-  function automatic void check_ext_clk_in_use();
-    `DV_CHECK_EQ(u_ast.u_ast_clks_byp.u_io_clk_osc_en.out_o, 0, , , msg_id)
+  // Returns 1 if the external clock is in use.
+  function automatic bit is_ext_clk_in_use();
+    return u_ast.u_ast_clks_byp.u_io_clk_byp_en.out_o;
   endfunction
 
 endinterface : ast_ext_clk_if

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -10,9 +10,7 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
   rand bit [7:0] lc_exit_token[TokenWidthByte];
   rand bit [7:0] lc_unlock_token[TokenWidthByte];
 
-  constraint num_trans_c {
-    num_trans inside {[1:2]};
-  }
+  constraint num_trans_c {num_trans inside {[1 : 2]};}
 
   // Reassign `select_jtag` variable to drive LC JTAG tap at start,
   // because LC_CTRL's TestLock state can only sample strap once at boot.
@@ -37,7 +35,6 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual task body();
-    bit io_ext_clk_done = 1'b0;
     super.body();
 
     for (int trans_i = 1; trans_i <= num_trans; trans_i++) begin
@@ -67,34 +64,38 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
       apply_reset();
 
       // Wait for SW to finish power on set up.
-      wait (cfg.sw_logger_vif.printed_log == "Start LC_CTRL transition test.");
+      wait(cfg.sw_logger_vif.printed_log == "Start LC_CTRL transition test.");
 
-      fork begin : isolation_fork
-        // Detect windows when the AST selects ext_clk to drive the io_clk, to verify the external
-        // clock, and not the io oscillator, is actually used for these lc_ctrl transitions.
-        fork begin
-          cfg.ast_ext_clk_vif.detect_io_active_window();
-          io_ext_clk_done = 1'b1;
-        end join_none
+      fork
+        begin : isolation_fork
+          bit external_clock_was_activated = 1'b0;
+          // Detect windows when the AST selects ext_clk to drive the io_clk, to verify the external
+          // clock, and not the io oscillator, is actually used for these lc_ctrl transitions.
+          fork
+            begin
+              cfg.ast_ext_clk_vif.span_external_clock_active_window();
+              external_clock_was_activated = 1'b1;
+            end
+          join_none
 
-        // Wait for LC_CTRL state trasition finish from TLUL interface.
-        wait_lc_status(LcTransitionSuccessful);
+          // Wait for LC_CTRL state transition finish from TLUL interface.
+          wait_lc_status(LcTransitionSuccessful);
 
-        // JTAG read out if LC_CTRL is configured to use external clock.
-        jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.transition_ctrl.get_offset(),
-                                            p_sequencer.jtag_sequencer_h,
-                                            ext_clock_en);
+          // JTAG read out if LC_CTRL is configured to use external clock.
+          jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.transition_ctrl.get_offset(),
+                                              p_sequencer.jtag_sequencer_h, ext_clock_en);
 
-        // LC_CTRL state transition requires a chip reset.
-        apply_reset();
-        `uvm_info(`gfn, "Second apply_reset done", UVM_MEDIUM)
+          // LC_CTRL state transition requires a chip reset.
+          apply_reset();
+          `uvm_info(`gfn, "Second apply_reset done", UVM_MEDIUM)
 
-        `DV_CHECK(io_ext_clk_done == ext_clock_en,
-                  $sformatf("External clock should be %0s", ext_clock_en ? "on" : "off"));
-        io_ext_clk_done = 1'b0;
+          `DV_CHECK(external_clock_was_activated == ext_clock_en, $sformatf(
+                    "External clock should be %0s", ext_clock_en ? "on" : "off"));
+          external_clock_was_activated = 1'b0;
 
-        disable fork;
-      end join
+          disable fork;
+        end
+      join
 
       // Wait for SW test finishes with a pass/fail status.
       wait (cfg.sw_test_status_vif.sw_test_status inside {SwTestStatusPassed,

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
@@ -13,11 +13,11 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
 
   localparam NCO_WIDTH = 16;
 
-  // Clkmgr external clock settings
+  // Clkmgr external clock settings.
   bit use_extclk = 0;
   bit extclk_low_speed_sel = 0;
 
-  int uart_clk_freq_khz; // use khz to avoid fractional value
+  int uart_clk_freq_khz;  // Use khz to avoid fractional value.
 
   rand baud_rate_e baud_rate;
 
@@ -39,10 +39,12 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
       // internal uart bus clock is 24Mhz
       uart_clk_freq_khz = 24_000;
     end
-    `uvm_info(`gfn,
-              $sformatf("External clock freq: %0dmhz, use_extclk: %0d, extclk_low_speed_sel: %0d",
-              cfg.clk_freq_mhz, use_extclk, extclk_low_speed_sel),
-              UVM_LOW)
+    `uvm_info(`gfn, $sformatf(
+              "External clock freq: %0dmhz, use_extclk: %0d, extclk_low_speed_sel: %0d",
+              cfg.clk_freq_mhz,
+              use_extclk,
+              extclk_low_speed_sel
+              ), UVM_LOW)
   endfunction
 
   virtual task dut_init(string reset_kind = "HARD");
@@ -52,17 +54,20 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
 
   virtual task cpu_init();
     // sw_symbol_backdoor_overwrite takes an array as the input
-    bit [7:0] uart_freq_arr[8] = {<< byte {cfg.uart_baud_rate}};
+    bit [7:0] uart_freq_arr[8] = {<<byte{cfg.uart_baud_rate}};
 
     super.cpu_init();
     sw_symbol_backdoor_overwrite("kUartBaudrate", uart_freq_arr);
-    `uvm_info(`gfn, $sformatf("Backdoor_overwrite: configure uart core clk %0d khz, baud_rate: %s",
-              uart_clk_freq_khz, baud_rate.name), UVM_LOW)
+    `uvm_info(`gfn, $sformatf(
+              "Backdoor_overwrite: configure uart core clk %0d khz, baud_rate: %s",
+              uart_clk_freq_khz,
+              baud_rate.name
+              ), UVM_LOW)
 
     if (use_extclk) begin
       bit [7:0] use_extclk_arr[] = {use_extclk};
       bit [7:0] low_speed_sel_arr[] = {extclk_low_speed_sel};
-      bit [7:0] uart_clk_freq_arr[8] = {<< byte {uart_clk_freq_khz * 1000}};
+      bit [7:0] uart_clk_freq_arr[8] = {<<byte{uart_clk_freq_khz * 1000}};
 
       sw_symbol_backdoor_overwrite("kUseExtClk", use_extclk_arr);
 
@@ -77,7 +82,8 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
   // When uart starts to send RX data, check if AST is using extclk if extclk is selected.
   virtual task send_uart_rx_data(int size = -1, bit random = 0);
     if (use_extclk) begin
-      cfg.ast_ext_clk_vif.check_ext_clk_in_use();
+      `DV_CHECK(cfg.ast_ext_clk_vif.is_ext_clk_in_use(),
+                "expected the external clock to be used for io");
     end
     super.send_uart_rx_data(size, random);
   endtask


### PR DESCRIPTION
Remove the pwrmgr_rstmgr_sva bound to the rstmgr instance: we already
bind it to the top_earlgrey instance, and the sva bound to rstmgr is only
suitable for unit level tests.
The fork in ast_ext_clk_if's detect_io_active_window task needs to be
removed. It clearly was a programming mistake.

Signed-off-by: Guillermo Maturana <maturana@google.com>