### PR TITLE
[spi_device/dv] Add mailbox sequence

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -117,7 +117,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   endtask
 
   // TODO use  dv_utils_pkg::endian_swap_byte_arr() if possible
-  virtual function void swap_byte_order(ref bit [7:0] data[$]);
+  virtual function void swap_byte_order(ref logic [7:0] data[$]);
     bit [7:0] data_arr[];
     data_arr = data;
     `uvm_info(`gfn, $sformatf("\n  spi_agent_cfg, data_q_baseline: %p", data), UVM_DEBUG)

--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -69,7 +69,7 @@ class spi_device_driver extends spi_driver;
   virtual task send_flash_item(spi_item item);
     logic [3:0] sio_bits;
     bit         bits_q[$];
-    bit [7:0]   data[$] = {item.payload_q};
+    logic [7:0] data[$] = {item.payload_q};
 
     `uvm_info(`gfn, $sformatf("sending rx_item:\n%s", item.sprint()), UVM_MEDIUM)
 

--- a/hw/dv/sv/spi_agent/spi_flash_cmd_info.sv
+++ b/hw/dv/sv/spi_agent/spi_flash_cmd_info.sv
@@ -23,6 +23,8 @@ class spi_flash_cmd_info extends uvm_sequence_item;
   }
 
   constraint dummy_cycles_c {
+    // for dual/quad read, need at least 2 dummy cycles
+    num_lanes > 1 && !write_command -> dummy_cycles >= 2;
     dummy_cycles dist {
       0     :/ 1,
       [2:7] :/ 1,

--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -153,9 +153,9 @@ class spi_host_driver extends spi_driver;
 
     // align to DrivingEdge, if the item has more to send
     if (req.dummy_cycles > 0 || req.payload_q.size > 0 ) cfg.wait_sck_edge(DrivingEdge);
+    cfg.vif.sio <= 'dz;
 
     repeat (req.dummy_cycles) begin
-      //cfg.vif.sio <= 'dz;
       cfg.wait_sck_edge(DrivingEdge);
     end
     // drive data

--- a/hw/dv/sv/spi_agent/spi_item.sv
+++ b/hw/dv/sv/spi_agent/spi_item.sv
@@ -7,12 +7,12 @@ class spi_item extends uvm_sequence_item;
   // hold transaction type
   rand spi_trans_type_e item_type;
   // byte of data sent or received
-  rand bit [7:0] data[$];
+  rand logic [7:0] data[$];
   // start of transaction
   bit first_byte;
   // flash command constraints
   rand int read_size;
-  rand bit [7:0] payload_q[$];
+  rand logic [7:0] payload_q[$];
   rand bit write_command;
   rand bit [7:0] address_q[$];
   rand bit [7:0] opcode;

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_intercept_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_intercept_vseq.sv
@@ -7,10 +7,9 @@
 class spi_device_intercept_vseq extends spi_device_pass_cmd_filtering_vseq;
   `uvm_object_utils(spi_device_intercept_vseq)
   `uvm_object_new
-  // TODO, enable all opcode later
-  bit [7:0] intercept_ops[$] = {//READ_STATUS_1, READ_STATUS_2, READ_STATUS_3,
-                                //READ_JEDEC,
-                                //READ_SFDP,
+  bit [7:0] intercept_ops[$] = {READ_STATUS_1, READ_STATUS_2, READ_STATUS_3,
+                                READ_JEDEC,
+                                READ_SFDP,
                                 READ_CMD_LIST};
 
   rand bit use_intercept_op;
@@ -24,7 +23,7 @@ class spi_device_intercept_vseq extends spi_device_pass_cmd_filtering_vseq;
     }
   }
 
-  constraint simple_mailbox_addr_c {
+  constraint mailbox_addr_size_c {
     read_addr_size_type == ReadAddrWithinMailbox;
   }
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_mailbox_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_mailbox_vseq.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// 50% to send read cmd to test mailbox, especially test read cross mailbox
+// boundary. This seq tests both flash mode and passthrough mode
+class spi_device_mailbox_vseq extends spi_device_intercept_vseq;
+  `uvm_object_utils(spi_device_mailbox_vseq)
+  `uvm_object_new
+  rand bit use_read_cmd;
+
+  // high change to send read cmd
+  constraint opcode_addition_c {
+    solve use_read_cmd before opcode;
+    if (use_read_cmd) {
+      opcode inside {READ_CMD_LIST};
+    } else {
+      !(opcode inside {READ_CMD_LIST});
+    }
+  }
+
+  // override to enable boundary cross read
+  constraint mailbox_addr_size_c {
+    solve read_addr_size_type before payload_size;
+
+    read_addr_size_type dist {
+      ReadAddrWithinMailbox      :/ 1,
+      ReadAddrCrossIntoMailbox   :/ 2,
+      ReadAddrCrossOutOfMailbox  :/ 2,
+      ReadAddrCrossAllMailbox    :/ 2,
+      ReadAddrOutsideMailbox     :/ 1
+    };
+  }
+endclass : spi_device_mailbox_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -26,4 +26,5 @@
 `include "spi_device_pass_cmd_filtering_vseq.sv"
 `include "spi_device_pass_addr_payload_swap_vseq.sv"
 `include "spi_device_intercept_vseq.sv"
+`include "spi_device_mailbox_vseq.sv"
 `include "spi_device_pass_all_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -42,6 +42,7 @@ filesets:
       - seq_lib/spi_device_pass_cmd_filtering_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_pass_addr_payload_swap_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_intercept_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_mailbox_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_pass_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -65,7 +65,6 @@ package spi_device_env_pkg;
     PayloadOut
   } payload_dir_e;
 
-
   typedef enum int {
     ReadAddrWithinMailbox,
     ReadAddrCrossIntoMailbox,
@@ -125,6 +124,10 @@ package spi_device_env_pkg;
   parameter bit[7:0] READ_QUAD                   = 8'h6B;
   parameter bit[7:0] READ_DUALIO                 = 8'hBB;
   parameter bit[7:0] READ_QUADIO                 = 8'hEB;
+  parameter bit[7:0] WREN                        = 8'h06;
+  parameter bit[7:0] WRDI                        = 8'h04;
+  parameter bit[7:0] EN4B                        = 8'hB7;
+  parameter bit[7:0] EX4B                        = 8'hE9;
 
   parameter bit[7:0] READ_CMD_LIST[] = {READ_NORMAL, READ_FAST, READ_DUAL,
                                         READ_QUAD, READ_DUALIO, READ_QUADIO};

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -156,6 +156,11 @@
     }
 
     {
+      name: spi_device_mailbox
+      uvm_test_seq: spi_device_mailbox_vseq
+    }
+
+    {
       name: spi_device_pass_all
       uvm_test_seq: spi_device_pass_all_vseq
     }


### PR DESCRIPTION
spi_device agent update
1. use logic for data/payload as they can be high-z
2. check no X for all data, no high-z for opcode and address

spi device env/seq update
1. constrain dual/quad read with >= 2 dummy cycles
2. add mailbox sequence to test all mailbox read, including crossing boundary
3. update scb to check mailbox data
4. update scb to move item check to the place that processes upstream item, as
not all item appears at downstream port

Signed-off-by: Weicai Yang <weicai@google.com>