### PR TITLE
[flash_ctrl] Add generic registers for alias mechanism

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -4,14 +4,14 @@
 
 
 
-{ name: "FLASH_CTRL",
+{ name: "flash_ctrl",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
     {clock: "clk_otp_i", reset: "rst_otp_ni"}
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device", name: "core" }
-    { protocol: "tlul", direction: "device", name: "prim" }
+    { protocol: "tlul", direction: "device", name: "prim" , hier_path: "u_eflash.u_flash.gen_generic.u_impl_generic.u_reg_top"}
     { protocol: "tlul", direction: "device", name: "mem" }
   ],
   available_input_list: [
@@ -2156,7 +2156,867 @@
       },
     ],
 
-    prim: []
+    prim: [
+      {
+        name: "CSR0_REGWEN",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw0c",
+            hwaccess: "none",
+            resval: "1",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False"
+      },
+      {
+        name: "CSR1",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "12:8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR2",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "1",
+            name: "field1",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "2",
+            name: "field2",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "3",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "4",
+            name: "field4",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "5",
+            name: "field5",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "6",
+            name: "field6",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "7",
+            name: "field7",
+            swaccess: "rw",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False"
+      },
+      {
+        name: "CSR3",
+        desc: "",
+        fields: [
+          {
+            bits: "3:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "7:4",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "10:8",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "13:11",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "16:14",
+            name: "field4",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "19:17",
+            name: "field5",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "20",
+            name: "field6",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "23:21",
+            name: "field7",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "25:24",
+            name: "field8",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "27:26",
+            name: "field9",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR4",
+        desc: "",
+        fields: [
+          {
+            bits: "2:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "5:3",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8:6",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "11:9",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR5",
+        desc: "",
+        fields: [
+          {
+            bits: "2:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "4:3",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "13:5",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "18:14",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "22:19",
+            name: "field4",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR6",
+        desc: "",
+        fields: [
+          {
+            bits: "2:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "5:3",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "13:6",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "16:14",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "18:17",
+            name: "field4",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "20:19",
+            name: "field5",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "22:21",
+            name: "field6",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "23",
+            name: "field7",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "24",
+            name: "field8",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR7",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "16:8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR8",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR9",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR10",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR11",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR12",
+        desc: "",
+        fields: [
+          {
+            bits: "9:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR13",
+        desc: "",
+        fields: [
+          {
+            bits: "19:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "20",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR14",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR15",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR16",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR17",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR18",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR19",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR20",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "1",
+            name: "field1",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "2",
+            name: "field2",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False"
+      }
+    ],
     mem: []
   }
 }

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -15,14 +15,14 @@
   max_fifo_width = max_fifo_depth.bit_length()
 %>
 
-{ name: "FLASH_CTRL",
+{ name: "flash_ctrl",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
     {clock: "clk_otp_i", reset: "rst_otp_ni"}
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device", name: "core" }
-    { protocol: "tlul", direction: "device", name: "prim" }
+    { protocol: "tlul", direction: "device", name: "prim" , hier_path: "u_eflash.u_flash.gen_generic.u_impl_generic.u_reg_top"}
     { protocol: "tlul", direction: "device", name: "mem" }
   ],
   available_input_list: [
@@ -1631,7 +1631,867 @@
       },
     ],
 
-    prim: []
+    prim: [
+      {
+        name: "CSR0_REGWEN",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw0c",
+            hwaccess: "none",
+            resval: "1",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False"
+      },
+      {
+        name: "CSR1",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "12:8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR2",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "1",
+            name: "field1",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "2",
+            name: "field2",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "3",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "4",
+            name: "field4",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "5",
+            name: "field5",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "6",
+            name: "field6",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "7",
+            name: "field7",
+            swaccess: "rw",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False"
+      },
+      {
+        name: "CSR3",
+        desc: "",
+        fields: [
+          {
+            bits: "3:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "7:4",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "10:8",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "13:11",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "16:14",
+            name: "field4",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "19:17",
+            name: "field5",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "20",
+            name: "field6",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "23:21",
+            name: "field7",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "25:24",
+            name: "field8",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "27:26",
+            name: "field9",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR4",
+        desc: "",
+        fields: [
+          {
+            bits: "2:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "5:3",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8:6",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "11:9",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR5",
+        desc: "",
+        fields: [
+          {
+            bits: "2:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "4:3",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "13:5",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "18:14",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "22:19",
+            name: "field4",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR6",
+        desc: "",
+        fields: [
+          {
+            bits: "2:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "5:3",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "13:6",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "16:14",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "18:17",
+            name: "field4",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "20:19",
+            name: "field5",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "22:21",
+            name: "field6",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "23",
+            name: "field7",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "24",
+            name: "field8",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR7",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "16:8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR8",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR9",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR10",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR11",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR12",
+        desc: "",
+        fields: [
+          {
+            bits: "9:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR13",
+        desc: "",
+        fields: [
+          {
+            bits: "19:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "20",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR14",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR15",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR16",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR17",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR18",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR19",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR20",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "1",
+            name: "field1",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "2",
+            name: "field2",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False"
+      }
+    ],
     mem: []
   }
 }

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -1429,4 +1429,13 @@ module flash_ctrl
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg_core, alert_tx_o[1])
+
+  `ifndef PRIM_DEFAULT_IMPL
+    `define PRIM_DEFAULT_IMPL prim_pkg::ImplGeneric
+  `endif
+  if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_reg_we_assert_generic
+    `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(PrimRegWeOnehotCheck_A,
+        u_eflash.u_flash.gen_generic.u_impl_generic.u_reg_top, alert_tx_o[1])
+  end
+
 endmodule

--- a/hw/ip/flash_ctrl/flash_ctrl_prim_reg_top.core
+++ b/hw/ip/flash_ctrl/flash_ctrl_prim_reg_top.core
@@ -1,0 +1,26 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:flash_ctrl_prim_reg_top:1.0"
+description: "Generic register top for the FLASH wrapper"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:flash_ctrl_pkg
+    files:
+      - rtl/flash_ctrl_prim_reg_top.sv
+    file_type: systemVerilogSource
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl
+    toplevel: lc_ctrl

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -1430,4 +1430,13 @@ module flash_ctrl
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg_core, alert_tx_o[1])
+
+  `ifndef PRIM_DEFAULT_IMPL
+    `define PRIM_DEFAULT_IMPL prim_pkg::ImplGeneric
+  `endif
+  if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_reg_we_assert_generic
+    `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(PrimRegWeOnehotCheck_A,
+        u_eflash.u_flash.gen_generic.u_impl_generic.u_reg_top, alert_tx_o[1])
+  end
+
 endmodule

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
@@ -12,6 +12,8 @@ module flash_ctrl_prim_reg_top (
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
   // To HW
+  output flash_ctrl_reg_pkg::flash_ctrl_prim_reg2hw_t reg2hw, // Write
+  input  flash_ctrl_reg_pkg::flash_ctrl_prim_hw2reg_t hw2reg, // Read
 
   // Integrity check errors
   output logic intg_err_o,
@@ -22,11 +24,60 @@ module flash_ctrl_prim_reg_top (
 
   import flash_ctrl_reg_pkg::* ;
 
+  localparam int AW = 7;
+  localparam int DW = 32;
+  localparam int DBW = DW/8;                    // Byte Width
+
+  // register signals
+  logic           reg_we;
+  logic           reg_re;
+  logic [AW-1:0]  reg_addr;
+  logic [DW-1:0]  reg_wdata;
+  logic [DBW-1:0] reg_be;
+  logic [DW-1:0]  reg_rdata;
+  logic           reg_error;
+
+  logic          addrmiss, wr_err;
+
+  logic [DW-1:0] reg_rdata_next;
+  logic reg_busy;
+
+  tlul_pkg::tl_h2d_t tl_reg_h2d;
+  tlul_pkg::tl_d2h_t tl_reg_d2h;
 
 
-  // Since there are no registers in this block, commands are routed through to windows which
-  // can report their own integrity errors.
-  assign intg_err_o = 1'b0;
+  // incoming payload check
+  logic intg_err;
+  tlul_cmd_intg_chk u_chk (
+    .tl_i(tl_i),
+    .err_o(intg_err)
+  );
+
+  // also check for spurious write enables
+  logic reg_we_err;
+  logic [20:0] reg_we_check;
+  prim_reg_we_check #(
+    .OneHotWidth(21)
+  ) u_prim_reg_we_check (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .oh_i  (reg_we_check),
+    .en_i  (reg_we && !addrmiss),
+    .err_o (reg_we_err)
+  );
+
+  logic err_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      err_q <= '0;
+    end else if (intg_err || reg_we_err) begin
+      err_q <= 1'b1;
+    end
+  end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = err_q | intg_err | reg_we_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
@@ -41,8 +92,2240 @@ module flash_ctrl_prim_reg_top (
   assign tl_reg_h2d = tl_i;
   assign tl_o_pre   = tl_reg_d2h;
 
+  tlul_adapter_reg #(
+    .RegAw(AW),
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
+  ) u_reg_if (
+    .clk_i  (clk_i),
+    .rst_ni (rst_ni),
+
+    .tl_i (tl_reg_h2d),
+    .tl_o (tl_reg_d2h),
+
+    .we_o    (reg_we),
+    .re_o    (reg_re),
+    .addr_o  (reg_addr),
+    .wdata_o (reg_wdata),
+    .be_o    (reg_be),
+    .busy_i  (reg_busy),
+    .rdata_i (reg_rdata),
+    .error_i (reg_error)
+  );
+
+  // cdc oversampling signals
+
+  assign reg_rdata = reg_rdata_next ;
+  assign reg_error = (devmode_i & addrmiss) | wr_err | intg_err;
+
+  // Define SW related signals
+  // Format: <reg>_<field>_{wd|we|qs}
+  //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic csr0_regwen_we;
+  logic csr0_regwen_qs;
+  logic csr0_regwen_wd;
+  logic csr1_we;
+  logic [7:0] csr1_field0_qs;
+  logic [7:0] csr1_field0_wd;
+  logic [4:0] csr1_field1_qs;
+  logic [4:0] csr1_field1_wd;
+  logic csr2_we;
+  logic csr2_field0_qs;
+  logic csr2_field0_wd;
+  logic csr2_field1_qs;
+  logic csr2_field1_wd;
+  logic csr2_field2_qs;
+  logic csr2_field2_wd;
+  logic csr2_field3_qs;
+  logic csr2_field3_wd;
+  logic csr2_field4_qs;
+  logic csr2_field4_wd;
+  logic csr2_field5_qs;
+  logic csr2_field5_wd;
+  logic csr2_field6_qs;
+  logic csr2_field6_wd;
+  logic csr2_field7_qs;
+  logic csr2_field7_wd;
+  logic csr3_we;
+  logic [3:0] csr3_field0_qs;
+  logic [3:0] csr3_field0_wd;
+  logic [3:0] csr3_field1_qs;
+  logic [3:0] csr3_field1_wd;
+  logic [2:0] csr3_field2_qs;
+  logic [2:0] csr3_field2_wd;
+  logic [2:0] csr3_field3_qs;
+  logic [2:0] csr3_field3_wd;
+  logic [2:0] csr3_field4_qs;
+  logic [2:0] csr3_field4_wd;
+  logic [2:0] csr3_field5_qs;
+  logic [2:0] csr3_field5_wd;
+  logic csr3_field6_qs;
+  logic csr3_field6_wd;
+  logic [2:0] csr3_field7_qs;
+  logic [2:0] csr3_field7_wd;
+  logic [1:0] csr3_field8_qs;
+  logic [1:0] csr3_field8_wd;
+  logic [1:0] csr3_field9_qs;
+  logic [1:0] csr3_field9_wd;
+  logic csr4_we;
+  logic [2:0] csr4_field0_qs;
+  logic [2:0] csr4_field0_wd;
+  logic [2:0] csr4_field1_qs;
+  logic [2:0] csr4_field1_wd;
+  logic [2:0] csr4_field2_qs;
+  logic [2:0] csr4_field2_wd;
+  logic [2:0] csr4_field3_qs;
+  logic [2:0] csr4_field3_wd;
+  logic csr5_we;
+  logic [2:0] csr5_field0_qs;
+  logic [2:0] csr5_field0_wd;
+  logic [1:0] csr5_field1_qs;
+  logic [1:0] csr5_field1_wd;
+  logic [8:0] csr5_field2_qs;
+  logic [8:0] csr5_field2_wd;
+  logic [4:0] csr5_field3_qs;
+  logic [4:0] csr5_field3_wd;
+  logic [3:0] csr5_field4_qs;
+  logic [3:0] csr5_field4_wd;
+  logic csr6_we;
+  logic [2:0] csr6_field0_qs;
+  logic [2:0] csr6_field0_wd;
+  logic [2:0] csr6_field1_qs;
+  logic [2:0] csr6_field1_wd;
+  logic [7:0] csr6_field2_qs;
+  logic [7:0] csr6_field2_wd;
+  logic [2:0] csr6_field3_qs;
+  logic [2:0] csr6_field3_wd;
+  logic [1:0] csr6_field4_qs;
+  logic [1:0] csr6_field4_wd;
+  logic [1:0] csr6_field5_qs;
+  logic [1:0] csr6_field5_wd;
+  logic [1:0] csr6_field6_qs;
+  logic [1:0] csr6_field6_wd;
+  logic csr6_field7_qs;
+  logic csr6_field7_wd;
+  logic csr6_field8_qs;
+  logic csr6_field8_wd;
+  logic csr7_we;
+  logic [7:0] csr7_field0_qs;
+  logic [7:0] csr7_field0_wd;
+  logic [8:0] csr7_field1_qs;
+  logic [8:0] csr7_field1_wd;
+  logic csr8_we;
+  logic [31:0] csr8_qs;
+  logic [31:0] csr8_wd;
+  logic csr9_we;
+  logic [31:0] csr9_qs;
+  logic [31:0] csr9_wd;
+  logic csr10_we;
+  logic [31:0] csr10_qs;
+  logic [31:0] csr10_wd;
+  logic csr11_we;
+  logic [31:0] csr11_qs;
+  logic [31:0] csr11_wd;
+  logic csr12_we;
+  logic [9:0] csr12_qs;
+  logic [9:0] csr12_wd;
+  logic csr13_we;
+  logic [19:0] csr13_field0_qs;
+  logic [19:0] csr13_field0_wd;
+  logic csr13_field1_qs;
+  logic csr13_field1_wd;
+  logic csr14_we;
+  logic [7:0] csr14_field0_qs;
+  logic [7:0] csr14_field0_wd;
+  logic csr14_field1_qs;
+  logic csr14_field1_wd;
+  logic csr15_we;
+  logic [7:0] csr15_field0_qs;
+  logic [7:0] csr15_field0_wd;
+  logic csr15_field1_qs;
+  logic csr15_field1_wd;
+  logic csr16_we;
+  logic [7:0] csr16_field0_qs;
+  logic [7:0] csr16_field0_wd;
+  logic csr16_field1_qs;
+  logic csr16_field1_wd;
+  logic csr17_we;
+  logic [7:0] csr17_field0_qs;
+  logic [7:0] csr17_field0_wd;
+  logic csr17_field1_qs;
+  logic csr17_field1_wd;
+  logic csr18_we;
+  logic csr18_qs;
+  logic csr18_wd;
+  logic csr19_we;
+  logic csr19_qs;
+  logic csr19_wd;
+  logic csr20_we;
+  logic csr20_field0_qs;
+  logic csr20_field0_wd;
+  logic csr20_field1_qs;
+  logic csr20_field1_wd;
+  logic csr20_field2_qs;
+  logic csr20_field2_wd;
+
+  // Register instances
+  // R[csr0_regwen]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1)
+  ) u_csr0_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr0_regwen_we),
+    .wd     (csr0_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr0_regwen_qs)
+  );
+
+
+  // R[csr1]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr1_gated_we;
+  assign csr1_gated_we = csr1_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr1_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr1_gated_we),
+    .wd     (csr1_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr1.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr1_field0_qs)
+  );
+
+  //   F[field1]: 12:8
+  prim_subreg #(
+    .DW      (5),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (5'h0)
+  ) u_csr1_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr1_gated_we),
+    .wd     (csr1_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr1.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr1_field1_qs)
+  );
+
+
+  // R[csr2]: V(False)
+  //   F[field0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field0_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field0.de),
+    .d      (hw2reg.csr2.field0.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field0_qs)
+  );
+
+  //   F[field1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field1_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field1.de),
+    .d      (hw2reg.csr2.field1.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field1_qs)
+  );
+
+  //   F[field2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field2_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field2.de),
+    .d      (hw2reg.csr2.field2.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field2_qs)
+  );
+
+  //   F[field3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr2_field3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field3_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field3.de),
+    .d      (hw2reg.csr2.field3.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field3.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field3_qs)
+  );
+
+  //   F[field4]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field4_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field4.de),
+    .d      (hw2reg.csr2.field4.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field4.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field4_qs)
+  );
+
+  //   F[field5]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field5_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field5.de),
+    .d      (hw2reg.csr2.field5.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field5.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field5_qs)
+  );
+
+  //   F[field6]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field6_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field6.de),
+    .d      (hw2reg.csr2.field6.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field6.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field6_qs)
+  );
+
+  //   F[field7]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr2_field7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field7_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field7.de),
+    .d      (hw2reg.csr2.field7.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field7.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field7_qs)
+  );
+
+
+  // R[csr3]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr3_gated_we;
+  assign csr3_gated_we = csr3_we & csr0_regwen_qs;
+  //   F[field0]: 3:0
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (4'h0)
+  ) u_csr3_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field0_qs)
+  );
+
+  //   F[field1]: 7:4
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (4'h0)
+  ) u_csr3_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field1_qs)
+  );
+
+  //   F[field2]: 10:8
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr3_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field2_qs)
+  );
+
+  //   F[field3]: 13:11
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr3_field3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field3.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field3_qs)
+  );
+
+  //   F[field4]: 16:14
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr3_field4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field4.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field4_qs)
+  );
+
+  //   F[field5]: 19:17
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr3_field5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field5.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field5_qs)
+  );
+
+  //   F[field6]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr3_field6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field6.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field6_qs)
+  );
+
+  //   F[field7]: 23:21
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr3_field7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field7.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field7_qs)
+  );
+
+  //   F[field8]: 25:24
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr3_field8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field8.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field8_qs)
+  );
+
+  //   F[field9]: 27:26
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr3_field9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field9.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field9_qs)
+  );
+
+
+  // R[csr4]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr4_gated_we;
+  assign csr4_gated_we = csr4_we & csr0_regwen_qs;
+  //   F[field0]: 2:0
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr4_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr4_gated_we),
+    .wd     (csr4_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr4.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr4_field0_qs)
+  );
+
+  //   F[field1]: 5:3
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr4_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr4_gated_we),
+    .wd     (csr4_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr4.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr4_field1_qs)
+  );
+
+  //   F[field2]: 8:6
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr4_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr4_gated_we),
+    .wd     (csr4_field2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr4.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr4_field2_qs)
+  );
+
+  //   F[field3]: 11:9
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr4_field3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr4_gated_we),
+    .wd     (csr4_field3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr4.field3.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr4_field3_qs)
+  );
+
+
+  // R[csr5]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr5_gated_we;
+  assign csr5_gated_we = csr5_we & csr0_regwen_qs;
+  //   F[field0]: 2:0
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr5_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr5_gated_we),
+    .wd     (csr5_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr5.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr5_field0_qs)
+  );
+
+  //   F[field1]: 4:3
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr5_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr5_gated_we),
+    .wd     (csr5_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr5.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr5_field1_qs)
+  );
+
+  //   F[field2]: 13:5
+  prim_subreg #(
+    .DW      (9),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (9'h0)
+  ) u_csr5_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr5_gated_we),
+    .wd     (csr5_field2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr5.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr5_field2_qs)
+  );
+
+  //   F[field3]: 18:14
+  prim_subreg #(
+    .DW      (5),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (5'h0)
+  ) u_csr5_field3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr5_gated_we),
+    .wd     (csr5_field3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr5.field3.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr5_field3_qs)
+  );
+
+  //   F[field4]: 22:19
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (4'h0)
+  ) u_csr5_field4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr5_gated_we),
+    .wd     (csr5_field4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr5.field4.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr5_field4_qs)
+  );
+
+
+  // R[csr6]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr6_gated_we;
+  assign csr6_gated_we = csr6_we & csr0_regwen_qs;
+  //   F[field0]: 2:0
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr6_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field0_qs)
+  );
+
+  //   F[field1]: 5:3
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr6_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field1_qs)
+  );
+
+  //   F[field2]: 13:6
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr6_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field2_qs)
+  );
+
+  //   F[field3]: 16:14
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr6_field3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field3.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field3_qs)
+  );
+
+  //   F[field4]: 18:17
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr6_field4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field4.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field4_qs)
+  );
+
+  //   F[field5]: 20:19
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr6_field5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field5.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field5_qs)
+  );
+
+  //   F[field6]: 22:21
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr6_field6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field6.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field6_qs)
+  );
+
+  //   F[field7]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr6_field7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field7.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field7_qs)
+  );
+
+  //   F[field8]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr6_field8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field8.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field8_qs)
+  );
+
+
+  // R[csr7]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr7_gated_we;
+  assign csr7_gated_we = csr7_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr7_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr7_gated_we),
+    .wd     (csr7_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr7.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr7_field0_qs)
+  );
+
+  //   F[field1]: 16:8
+  prim_subreg #(
+    .DW      (9),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (9'h0)
+  ) u_csr7_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr7_gated_we),
+    .wd     (csr7_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr7.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr7_field1_qs)
+  );
+
+
+  // R[csr8]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr8_gated_we;
+  assign csr8_gated_we = csr8_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_csr8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr8_gated_we),
+    .wd     (csr8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr8.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr8_qs)
+  );
+
+
+  // R[csr9]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr9_gated_we;
+  assign csr9_gated_we = csr9_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_csr9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr9_gated_we),
+    .wd     (csr9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr9.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr9_qs)
+  );
+
+
+  // R[csr10]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr10_gated_we;
+  assign csr10_gated_we = csr10_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_csr10 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr10_gated_we),
+    .wd     (csr10_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr10.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr10_qs)
+  );
+
+
+  // R[csr11]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr11_gated_we;
+  assign csr11_gated_we = csr11_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_csr11 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr11_gated_we),
+    .wd     (csr11_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr11.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr11_qs)
+  );
+
+
+  // R[csr12]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr12_gated_we;
+  assign csr12_gated_we = csr12_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (10),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (10'h0)
+  ) u_csr12 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr12_gated_we),
+    .wd     (csr12_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr12.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr12_qs)
+  );
+
+
+  // R[csr13]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr13_gated_we;
+  assign csr13_gated_we = csr13_we & csr0_regwen_qs;
+  //   F[field0]: 19:0
+  prim_subreg #(
+    .DW      (20),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (20'h0)
+  ) u_csr13_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr13_gated_we),
+    .wd     (csr13_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr13.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr13_field0_qs)
+  );
+
+  //   F[field1]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr13_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr13_gated_we),
+    .wd     (csr13_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr13.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr13_field1_qs)
+  );
+
+
+  // R[csr14]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr14_gated_we;
+  assign csr14_gated_we = csr14_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr14_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr14_gated_we),
+    .wd     (csr14_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr14.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr14_field0_qs)
+  );
+
+  //   F[field1]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr14_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr14_gated_we),
+    .wd     (csr14_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr14.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr14_field1_qs)
+  );
+
+
+  // R[csr15]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr15_gated_we;
+  assign csr15_gated_we = csr15_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr15_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr15_gated_we),
+    .wd     (csr15_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr15.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr15_field0_qs)
+  );
+
+  //   F[field1]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr15_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr15_gated_we),
+    .wd     (csr15_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr15.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr15_field1_qs)
+  );
+
+
+  // R[csr16]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr16_gated_we;
+  assign csr16_gated_we = csr16_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr16_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr16_gated_we),
+    .wd     (csr16_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr16.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr16_field0_qs)
+  );
+
+  //   F[field1]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr16_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr16_gated_we),
+    .wd     (csr16_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr16.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr16_field1_qs)
+  );
+
+
+  // R[csr17]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr17_gated_we;
+  assign csr17_gated_we = csr17_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr17_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr17_gated_we),
+    .wd     (csr17_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr17.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr17_field0_qs)
+  );
+
+  //   F[field1]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr17_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr17_gated_we),
+    .wd     (csr17_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr17.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr17_field1_qs)
+  );
+
+
+  // R[csr18]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr18_gated_we;
+  assign csr18_gated_we = csr18_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr18 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr18_gated_we),
+    .wd     (csr18_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr18.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr18_qs)
+  );
+
+
+  // R[csr19]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr19_gated_we;
+  assign csr19_gated_we = csr19_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr19 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr19_gated_we),
+    .wd     (csr19_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr19.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr19_qs)
+  );
+
+
+  // R[csr20]: V(False)
+  //   F[field0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr20_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr20_we),
+    .wd     (csr20_field0_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr20.field0.de),
+    .d      (hw2reg.csr20.field0.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr20.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr20_field0_qs)
+  );
+
+  //   F[field1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr20_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr20_we),
+    .wd     (csr20_field1_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr20.field1.de),
+    .d      (hw2reg.csr20.field1.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr20.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr20_field1_qs)
+  );
+
+  //   F[field2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr20_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr20_we),
+    .wd     (csr20_field2_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr20.field2.de),
+    .d      (hw2reg.csr20.field2.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr20.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr20_field2_qs)
+  );
+
+
+
+  logic [20:0] addr_hit;
+  always_comb begin
+    addr_hit = '0;
+    addr_hit[ 0] = (reg_addr == FLASH_CTRL_CSR0_REGWEN_OFFSET);
+    addr_hit[ 1] = (reg_addr == FLASH_CTRL_CSR1_OFFSET);
+    addr_hit[ 2] = (reg_addr == FLASH_CTRL_CSR2_OFFSET);
+    addr_hit[ 3] = (reg_addr == FLASH_CTRL_CSR3_OFFSET);
+    addr_hit[ 4] = (reg_addr == FLASH_CTRL_CSR4_OFFSET);
+    addr_hit[ 5] = (reg_addr == FLASH_CTRL_CSR5_OFFSET);
+    addr_hit[ 6] = (reg_addr == FLASH_CTRL_CSR6_OFFSET);
+    addr_hit[ 7] = (reg_addr == FLASH_CTRL_CSR7_OFFSET);
+    addr_hit[ 8] = (reg_addr == FLASH_CTRL_CSR8_OFFSET);
+    addr_hit[ 9] = (reg_addr == FLASH_CTRL_CSR9_OFFSET);
+    addr_hit[10] = (reg_addr == FLASH_CTRL_CSR10_OFFSET);
+    addr_hit[11] = (reg_addr == FLASH_CTRL_CSR11_OFFSET);
+    addr_hit[12] = (reg_addr == FLASH_CTRL_CSR12_OFFSET);
+    addr_hit[13] = (reg_addr == FLASH_CTRL_CSR13_OFFSET);
+    addr_hit[14] = (reg_addr == FLASH_CTRL_CSR14_OFFSET);
+    addr_hit[15] = (reg_addr == FLASH_CTRL_CSR15_OFFSET);
+    addr_hit[16] = (reg_addr == FLASH_CTRL_CSR16_OFFSET);
+    addr_hit[17] = (reg_addr == FLASH_CTRL_CSR17_OFFSET);
+    addr_hit[18] = (reg_addr == FLASH_CTRL_CSR18_OFFSET);
+    addr_hit[19] = (reg_addr == FLASH_CTRL_CSR19_OFFSET);
+    addr_hit[20] = (reg_addr == FLASH_CTRL_CSR20_OFFSET);
+  end
+
+  assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
+
+  // Check sub-word write is permitted
+  always_comb begin
+    wr_err = (reg_we &
+              ((addr_hit[ 0] & (|(FLASH_CTRL_PRIM_PERMIT[ 0] & ~reg_be))) |
+               (addr_hit[ 1] & (|(FLASH_CTRL_PRIM_PERMIT[ 1] & ~reg_be))) |
+               (addr_hit[ 2] & (|(FLASH_CTRL_PRIM_PERMIT[ 2] & ~reg_be))) |
+               (addr_hit[ 3] & (|(FLASH_CTRL_PRIM_PERMIT[ 3] & ~reg_be))) |
+               (addr_hit[ 4] & (|(FLASH_CTRL_PRIM_PERMIT[ 4] & ~reg_be))) |
+               (addr_hit[ 5] & (|(FLASH_CTRL_PRIM_PERMIT[ 5] & ~reg_be))) |
+               (addr_hit[ 6] & (|(FLASH_CTRL_PRIM_PERMIT[ 6] & ~reg_be))) |
+               (addr_hit[ 7] & (|(FLASH_CTRL_PRIM_PERMIT[ 7] & ~reg_be))) |
+               (addr_hit[ 8] & (|(FLASH_CTRL_PRIM_PERMIT[ 8] & ~reg_be))) |
+               (addr_hit[ 9] & (|(FLASH_CTRL_PRIM_PERMIT[ 9] & ~reg_be))) |
+               (addr_hit[10] & (|(FLASH_CTRL_PRIM_PERMIT[10] & ~reg_be))) |
+               (addr_hit[11] & (|(FLASH_CTRL_PRIM_PERMIT[11] & ~reg_be))) |
+               (addr_hit[12] & (|(FLASH_CTRL_PRIM_PERMIT[12] & ~reg_be))) |
+               (addr_hit[13] & (|(FLASH_CTRL_PRIM_PERMIT[13] & ~reg_be))) |
+               (addr_hit[14] & (|(FLASH_CTRL_PRIM_PERMIT[14] & ~reg_be))) |
+               (addr_hit[15] & (|(FLASH_CTRL_PRIM_PERMIT[15] & ~reg_be))) |
+               (addr_hit[16] & (|(FLASH_CTRL_PRIM_PERMIT[16] & ~reg_be))) |
+               (addr_hit[17] & (|(FLASH_CTRL_PRIM_PERMIT[17] & ~reg_be))) |
+               (addr_hit[18] & (|(FLASH_CTRL_PRIM_PERMIT[18] & ~reg_be))) |
+               (addr_hit[19] & (|(FLASH_CTRL_PRIM_PERMIT[19] & ~reg_be))) |
+               (addr_hit[20] & (|(FLASH_CTRL_PRIM_PERMIT[20] & ~reg_be)))));
+  end
+
+  // Generate write-enables
+  assign csr0_regwen_we = addr_hit[0] & reg_we & !reg_error;
+
+  assign csr0_regwen_wd = reg_wdata[0];
+  assign csr1_we = addr_hit[1] & reg_we & !reg_error;
+
+  assign csr1_field0_wd = reg_wdata[7:0];
+
+  assign csr1_field1_wd = reg_wdata[12:8];
+  assign csr2_we = addr_hit[2] & reg_we & !reg_error;
+
+  assign csr2_field0_wd = reg_wdata[0];
+
+  assign csr2_field1_wd = reg_wdata[1];
+
+  assign csr2_field2_wd = reg_wdata[2];
+
+  assign csr2_field3_wd = reg_wdata[3];
+
+  assign csr2_field4_wd = reg_wdata[4];
+
+  assign csr2_field5_wd = reg_wdata[5];
+
+  assign csr2_field6_wd = reg_wdata[6];
+
+  assign csr2_field7_wd = reg_wdata[7];
+  assign csr3_we = addr_hit[3] & reg_we & !reg_error;
+
+  assign csr3_field0_wd = reg_wdata[3:0];
+
+  assign csr3_field1_wd = reg_wdata[7:4];
+
+  assign csr3_field2_wd = reg_wdata[10:8];
+
+  assign csr3_field3_wd = reg_wdata[13:11];
+
+  assign csr3_field4_wd = reg_wdata[16:14];
+
+  assign csr3_field5_wd = reg_wdata[19:17];
+
+  assign csr3_field6_wd = reg_wdata[20];
+
+  assign csr3_field7_wd = reg_wdata[23:21];
+
+  assign csr3_field8_wd = reg_wdata[25:24];
+
+  assign csr3_field9_wd = reg_wdata[27:26];
+  assign csr4_we = addr_hit[4] & reg_we & !reg_error;
+
+  assign csr4_field0_wd = reg_wdata[2:0];
+
+  assign csr4_field1_wd = reg_wdata[5:3];
+
+  assign csr4_field2_wd = reg_wdata[8:6];
+
+  assign csr4_field3_wd = reg_wdata[11:9];
+  assign csr5_we = addr_hit[5] & reg_we & !reg_error;
+
+  assign csr5_field0_wd = reg_wdata[2:0];
+
+  assign csr5_field1_wd = reg_wdata[4:3];
+
+  assign csr5_field2_wd = reg_wdata[13:5];
+
+  assign csr5_field3_wd = reg_wdata[18:14];
+
+  assign csr5_field4_wd = reg_wdata[22:19];
+  assign csr6_we = addr_hit[6] & reg_we & !reg_error;
+
+  assign csr6_field0_wd = reg_wdata[2:0];
+
+  assign csr6_field1_wd = reg_wdata[5:3];
+
+  assign csr6_field2_wd = reg_wdata[13:6];
+
+  assign csr6_field3_wd = reg_wdata[16:14];
+
+  assign csr6_field4_wd = reg_wdata[18:17];
+
+  assign csr6_field5_wd = reg_wdata[20:19];
+
+  assign csr6_field6_wd = reg_wdata[22:21];
+
+  assign csr6_field7_wd = reg_wdata[23];
+
+  assign csr6_field8_wd = reg_wdata[24];
+  assign csr7_we = addr_hit[7] & reg_we & !reg_error;
+
+  assign csr7_field0_wd = reg_wdata[7:0];
+
+  assign csr7_field1_wd = reg_wdata[16:8];
+  assign csr8_we = addr_hit[8] & reg_we & !reg_error;
+
+  assign csr8_wd = reg_wdata[31:0];
+  assign csr9_we = addr_hit[9] & reg_we & !reg_error;
+
+  assign csr9_wd = reg_wdata[31:0];
+  assign csr10_we = addr_hit[10] & reg_we & !reg_error;
+
+  assign csr10_wd = reg_wdata[31:0];
+  assign csr11_we = addr_hit[11] & reg_we & !reg_error;
+
+  assign csr11_wd = reg_wdata[31:0];
+  assign csr12_we = addr_hit[12] & reg_we & !reg_error;
+
+  assign csr12_wd = reg_wdata[9:0];
+  assign csr13_we = addr_hit[13] & reg_we & !reg_error;
+
+  assign csr13_field0_wd = reg_wdata[19:0];
+
+  assign csr13_field1_wd = reg_wdata[20];
+  assign csr14_we = addr_hit[14] & reg_we & !reg_error;
+
+  assign csr14_field0_wd = reg_wdata[7:0];
+
+  assign csr14_field1_wd = reg_wdata[8];
+  assign csr15_we = addr_hit[15] & reg_we & !reg_error;
+
+  assign csr15_field0_wd = reg_wdata[7:0];
+
+  assign csr15_field1_wd = reg_wdata[8];
+  assign csr16_we = addr_hit[16] & reg_we & !reg_error;
+
+  assign csr16_field0_wd = reg_wdata[7:0];
+
+  assign csr16_field1_wd = reg_wdata[8];
+  assign csr17_we = addr_hit[17] & reg_we & !reg_error;
+
+  assign csr17_field0_wd = reg_wdata[7:0];
+
+  assign csr17_field1_wd = reg_wdata[8];
+  assign csr18_we = addr_hit[18] & reg_we & !reg_error;
+
+  assign csr18_wd = reg_wdata[0];
+  assign csr19_we = addr_hit[19] & reg_we & !reg_error;
+
+  assign csr19_wd = reg_wdata[0];
+  assign csr20_we = addr_hit[20] & reg_we & !reg_error;
+
+  assign csr20_field0_wd = reg_wdata[0];
+
+  assign csr20_field1_wd = reg_wdata[1];
+
+  assign csr20_field2_wd = reg_wdata[2];
+
+  // Assign write-enables to checker logic vector.
+  always_comb begin
+    reg_we_check = '0;
+    reg_we_check[0] = csr0_regwen_we;
+    reg_we_check[1] = csr1_gated_we;
+    reg_we_check[2] = csr2_we;
+    reg_we_check[3] = csr3_gated_we;
+    reg_we_check[4] = csr4_gated_we;
+    reg_we_check[5] = csr5_gated_we;
+    reg_we_check[6] = csr6_gated_we;
+    reg_we_check[7] = csr7_gated_we;
+    reg_we_check[8] = csr8_gated_we;
+    reg_we_check[9] = csr9_gated_we;
+    reg_we_check[10] = csr10_gated_we;
+    reg_we_check[11] = csr11_gated_we;
+    reg_we_check[12] = csr12_gated_we;
+    reg_we_check[13] = csr13_gated_we;
+    reg_we_check[14] = csr14_gated_we;
+    reg_we_check[15] = csr15_gated_we;
+    reg_we_check[16] = csr16_gated_we;
+    reg_we_check[17] = csr17_gated_we;
+    reg_we_check[18] = csr18_gated_we;
+    reg_we_check[19] = csr19_gated_we;
+    reg_we_check[20] = csr20_we;
+  end
+
+  // Read data return
+  always_comb begin
+    reg_rdata_next = '0;
+    unique case (1'b1)
+      addr_hit[0]: begin
+        reg_rdata_next[0] = csr0_regwen_qs;
+      end
+
+      addr_hit[1]: begin
+        reg_rdata_next[7:0] = csr1_field0_qs;
+        reg_rdata_next[12:8] = csr1_field1_qs;
+      end
+
+      addr_hit[2]: begin
+        reg_rdata_next[0] = csr2_field0_qs;
+        reg_rdata_next[1] = csr2_field1_qs;
+        reg_rdata_next[2] = csr2_field2_qs;
+        reg_rdata_next[3] = csr2_field3_qs;
+        reg_rdata_next[4] = csr2_field4_qs;
+        reg_rdata_next[5] = csr2_field5_qs;
+        reg_rdata_next[6] = csr2_field6_qs;
+        reg_rdata_next[7] = csr2_field7_qs;
+      end
+
+      addr_hit[3]: begin
+        reg_rdata_next[3:0] = csr3_field0_qs;
+        reg_rdata_next[7:4] = csr3_field1_qs;
+        reg_rdata_next[10:8] = csr3_field2_qs;
+        reg_rdata_next[13:11] = csr3_field3_qs;
+        reg_rdata_next[16:14] = csr3_field4_qs;
+        reg_rdata_next[19:17] = csr3_field5_qs;
+        reg_rdata_next[20] = csr3_field6_qs;
+        reg_rdata_next[23:21] = csr3_field7_qs;
+        reg_rdata_next[25:24] = csr3_field8_qs;
+        reg_rdata_next[27:26] = csr3_field9_qs;
+      end
+
+      addr_hit[4]: begin
+        reg_rdata_next[2:0] = csr4_field0_qs;
+        reg_rdata_next[5:3] = csr4_field1_qs;
+        reg_rdata_next[8:6] = csr4_field2_qs;
+        reg_rdata_next[11:9] = csr4_field3_qs;
+      end
+
+      addr_hit[5]: begin
+        reg_rdata_next[2:0] = csr5_field0_qs;
+        reg_rdata_next[4:3] = csr5_field1_qs;
+        reg_rdata_next[13:5] = csr5_field2_qs;
+        reg_rdata_next[18:14] = csr5_field3_qs;
+        reg_rdata_next[22:19] = csr5_field4_qs;
+      end
+
+      addr_hit[6]: begin
+        reg_rdata_next[2:0] = csr6_field0_qs;
+        reg_rdata_next[5:3] = csr6_field1_qs;
+        reg_rdata_next[13:6] = csr6_field2_qs;
+        reg_rdata_next[16:14] = csr6_field3_qs;
+        reg_rdata_next[18:17] = csr6_field4_qs;
+        reg_rdata_next[20:19] = csr6_field5_qs;
+        reg_rdata_next[22:21] = csr6_field6_qs;
+        reg_rdata_next[23] = csr6_field7_qs;
+        reg_rdata_next[24] = csr6_field8_qs;
+      end
+
+      addr_hit[7]: begin
+        reg_rdata_next[7:0] = csr7_field0_qs;
+        reg_rdata_next[16:8] = csr7_field1_qs;
+      end
+
+      addr_hit[8]: begin
+        reg_rdata_next[31:0] = csr8_qs;
+      end
+
+      addr_hit[9]: begin
+        reg_rdata_next[31:0] = csr9_qs;
+      end
+
+      addr_hit[10]: begin
+        reg_rdata_next[31:0] = csr10_qs;
+      end
+
+      addr_hit[11]: begin
+        reg_rdata_next[31:0] = csr11_qs;
+      end
+
+      addr_hit[12]: begin
+        reg_rdata_next[9:0] = csr12_qs;
+      end
+
+      addr_hit[13]: begin
+        reg_rdata_next[19:0] = csr13_field0_qs;
+        reg_rdata_next[20] = csr13_field1_qs;
+      end
+
+      addr_hit[14]: begin
+        reg_rdata_next[7:0] = csr14_field0_qs;
+        reg_rdata_next[8] = csr14_field1_qs;
+      end
+
+      addr_hit[15]: begin
+        reg_rdata_next[7:0] = csr15_field0_qs;
+        reg_rdata_next[8] = csr15_field1_qs;
+      end
+
+      addr_hit[16]: begin
+        reg_rdata_next[7:0] = csr16_field0_qs;
+        reg_rdata_next[8] = csr16_field1_qs;
+      end
+
+      addr_hit[17]: begin
+        reg_rdata_next[7:0] = csr17_field0_qs;
+        reg_rdata_next[8] = csr17_field1_qs;
+      end
+
+      addr_hit[18]: begin
+        reg_rdata_next[0] = csr18_qs;
+      end
+
+      addr_hit[19]: begin
+        reg_rdata_next[0] = csr19_qs;
+      end
+
+      addr_hit[20]: begin
+        reg_rdata_next[0] = csr20_field0_qs;
+        reg_rdata_next[1] = csr20_field1_qs;
+        reg_rdata_next[2] = csr20_field2_qs;
+      end
+
+      default: begin
+        reg_rdata_next = '1;
+      end
+    endcase
+  end
+
+  // shadow busy
+  logic shadow_busy;
+  assign shadow_busy = 1'b0;
+
+  // register busy
+  assign reg_busy = shadow_busy;
+
   // Unused signal tieoff
-  // devmode_i is not used if there are no registers
-  logic unused_devmode;
-  assign unused_devmode = ^devmode_i;
+
+  // wdata / byte enable are not always fully used
+  // add a blanket unused statement to handle lint waivers
+  logic unused_wdata;
+  logic unused_be;
+  assign unused_wdata = ^reg_wdata;
+  assign unused_be = ^reg_be;
+
+  // Assertions for Register Interface
+  `ASSERT_PULSE(wePulse, reg_we, clk_i, !rst_ni)
+  `ASSERT_PULSE(rePulse, reg_re, clk_i, !rst_ni)
+
+  `ASSERT(reAfterRv, $rose(reg_re || reg_we) |=> tl_o_pre.d_valid, clk_i, !rst_ni)
+
+  `ASSERT(en2addrHit, (reg_we || reg_re) |-> $onehot0(addr_hit), clk_i, !rst_ni)
+
+  // this is formulated as an assumption such that the FPV testbenches do disprove this
+  // property by mistake
+  //`ASSUME(reqParity, tl_reg_h2d.a_valid |-> tl_reg_h2d.a_user.chk_en == tlul_pkg::CheckDis)
+
 endmodule

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -28,7 +28,7 @@ package flash_ctrl_reg_pkg;
 
   // Address widths within the block
   parameter int CoreAw = 9;
-  parameter int PrimAw = 1;
+  parameter int PrimAw = 7;
   parameter int MemAw = 1;
 
   ///////////////////////////////////////////////
@@ -1126,6 +1126,389 @@ package flash_ctrl_reg_pkg;
     4'b 0011, // index[104] FLASH_CTRL_FIFO_LVL
     4'b 0001, // index[105] FLASH_CTRL_FIFO_RST
     4'b 0011  // index[106] FLASH_CTRL_CURR_FIFO_LVL
+  };
+
+  ///////////////////////////////////////////////
+  // Typedefs for registers for prim interface //
+  ///////////////////////////////////////////////
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic [4:0]  q;
+    } field1;
+  } flash_ctrl_reg2hw_csr1_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+    struct packed {
+      logic        q;
+    } field2;
+    struct packed {
+      logic        q;
+    } field3;
+    struct packed {
+      logic        q;
+    } field4;
+    struct packed {
+      logic        q;
+    } field5;
+    struct packed {
+      logic        q;
+    } field6;
+    struct packed {
+      logic        q;
+    } field7;
+  } flash_ctrl_reg2hw_csr2_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [3:0]  q;
+    } field0;
+    struct packed {
+      logic [3:0]  q;
+    } field1;
+    struct packed {
+      logic [2:0]  q;
+    } field2;
+    struct packed {
+      logic [2:0]  q;
+    } field3;
+    struct packed {
+      logic [2:0]  q;
+    } field4;
+    struct packed {
+      logic [2:0]  q;
+    } field5;
+    struct packed {
+      logic        q;
+    } field6;
+    struct packed {
+      logic [2:0]  q;
+    } field7;
+    struct packed {
+      logic [1:0]  q;
+    } field8;
+    struct packed {
+      logic [1:0]  q;
+    } field9;
+  } flash_ctrl_reg2hw_csr3_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [2:0]  q;
+    } field0;
+    struct packed {
+      logic [2:0]  q;
+    } field1;
+    struct packed {
+      logic [2:0]  q;
+    } field2;
+    struct packed {
+      logic [2:0]  q;
+    } field3;
+  } flash_ctrl_reg2hw_csr4_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [2:0]  q;
+    } field0;
+    struct packed {
+      logic [1:0]  q;
+    } field1;
+    struct packed {
+      logic [8:0]  q;
+    } field2;
+    struct packed {
+      logic [4:0]  q;
+    } field3;
+    struct packed {
+      logic [3:0]  q;
+    } field4;
+  } flash_ctrl_reg2hw_csr5_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [2:0]  q;
+    } field0;
+    struct packed {
+      logic [2:0]  q;
+    } field1;
+    struct packed {
+      logic [7:0]  q;
+    } field2;
+    struct packed {
+      logic [2:0]  q;
+    } field3;
+    struct packed {
+      logic [1:0]  q;
+    } field4;
+    struct packed {
+      logic [1:0]  q;
+    } field5;
+    struct packed {
+      logic [1:0]  q;
+    } field6;
+    struct packed {
+      logic        q;
+    } field7;
+    struct packed {
+      logic        q;
+    } field8;
+  } flash_ctrl_reg2hw_csr6_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic [8:0]  q;
+    } field1;
+  } flash_ctrl_reg2hw_csr7_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } flash_ctrl_reg2hw_csr8_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } flash_ctrl_reg2hw_csr9_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } flash_ctrl_reg2hw_csr10_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } flash_ctrl_reg2hw_csr11_reg_t;
+
+  typedef struct packed {
+    logic [9:0] q;
+  } flash_ctrl_reg2hw_csr12_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [19:0] q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+  } flash_ctrl_reg2hw_csr13_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+  } flash_ctrl_reg2hw_csr14_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+  } flash_ctrl_reg2hw_csr15_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+  } flash_ctrl_reg2hw_csr16_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+  } flash_ctrl_reg2hw_csr17_reg_t;
+
+  typedef struct packed {
+    logic        q;
+  } flash_ctrl_reg2hw_csr18_reg_t;
+
+  typedef struct packed {
+    logic        q;
+  } flash_ctrl_reg2hw_csr19_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+    struct packed {
+      logic        q;
+    } field2;
+  } flash_ctrl_reg2hw_csr20_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } field0;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field1;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field2;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field3;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field4;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field5;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field6;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field7;
+  } flash_ctrl_hw2reg_csr2_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } field0;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field1;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field2;
+  } flash_ctrl_hw2reg_csr20_reg_t;
+
+  // Register -> HW type for prim interface
+  typedef struct packed {
+    flash_ctrl_reg2hw_csr1_reg_t csr1; // [325:313]
+    flash_ctrl_reg2hw_csr2_reg_t csr2; // [312:305]
+    flash_ctrl_reg2hw_csr3_reg_t csr3; // [304:277]
+    flash_ctrl_reg2hw_csr4_reg_t csr4; // [276:265]
+    flash_ctrl_reg2hw_csr5_reg_t csr5; // [264:242]
+    flash_ctrl_reg2hw_csr6_reg_t csr6; // [241:217]
+    flash_ctrl_reg2hw_csr7_reg_t csr7; // [216:200]
+    flash_ctrl_reg2hw_csr8_reg_t csr8; // [199:168]
+    flash_ctrl_reg2hw_csr9_reg_t csr9; // [167:136]
+    flash_ctrl_reg2hw_csr10_reg_t csr10; // [135:104]
+    flash_ctrl_reg2hw_csr11_reg_t csr11; // [103:72]
+    flash_ctrl_reg2hw_csr12_reg_t csr12; // [71:62]
+    flash_ctrl_reg2hw_csr13_reg_t csr13; // [61:41]
+    flash_ctrl_reg2hw_csr14_reg_t csr14; // [40:32]
+    flash_ctrl_reg2hw_csr15_reg_t csr15; // [31:23]
+    flash_ctrl_reg2hw_csr16_reg_t csr16; // [22:14]
+    flash_ctrl_reg2hw_csr17_reg_t csr17; // [13:5]
+    flash_ctrl_reg2hw_csr18_reg_t csr18; // [4:4]
+    flash_ctrl_reg2hw_csr19_reg_t csr19; // [3:3]
+    flash_ctrl_reg2hw_csr20_reg_t csr20; // [2:0]
+  } flash_ctrl_prim_reg2hw_t;
+
+  // HW -> register type for prim interface
+  typedef struct packed {
+    flash_ctrl_hw2reg_csr2_reg_t csr2; // [21:6]
+    flash_ctrl_hw2reg_csr20_reg_t csr20; // [5:0]
+  } flash_ctrl_prim_hw2reg_t;
+
+  // Register offsets for prim interface
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR0_REGWEN_OFFSET = 7'h 0;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR1_OFFSET = 7'h 4;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR2_OFFSET = 7'h 8;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR3_OFFSET = 7'h c;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR4_OFFSET = 7'h 10;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR5_OFFSET = 7'h 14;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR6_OFFSET = 7'h 18;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR7_OFFSET = 7'h 1c;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR8_OFFSET = 7'h 20;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR9_OFFSET = 7'h 24;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR10_OFFSET = 7'h 28;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR11_OFFSET = 7'h 2c;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR12_OFFSET = 7'h 30;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR13_OFFSET = 7'h 34;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR14_OFFSET = 7'h 38;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR15_OFFSET = 7'h 3c;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR16_OFFSET = 7'h 40;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR17_OFFSET = 7'h 44;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR18_OFFSET = 7'h 48;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR19_OFFSET = 7'h 4c;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR20_OFFSET = 7'h 50;
+
+  // Register index for prim interface
+  typedef enum int {
+    FLASH_CTRL_CSR0_REGWEN,
+    FLASH_CTRL_CSR1,
+    FLASH_CTRL_CSR2,
+    FLASH_CTRL_CSR3,
+    FLASH_CTRL_CSR4,
+    FLASH_CTRL_CSR5,
+    FLASH_CTRL_CSR6,
+    FLASH_CTRL_CSR7,
+    FLASH_CTRL_CSR8,
+    FLASH_CTRL_CSR9,
+    FLASH_CTRL_CSR10,
+    FLASH_CTRL_CSR11,
+    FLASH_CTRL_CSR12,
+    FLASH_CTRL_CSR13,
+    FLASH_CTRL_CSR14,
+    FLASH_CTRL_CSR15,
+    FLASH_CTRL_CSR16,
+    FLASH_CTRL_CSR17,
+    FLASH_CTRL_CSR18,
+    FLASH_CTRL_CSR19,
+    FLASH_CTRL_CSR20
+  } flash_ctrl_prim_id_e;
+
+  // Register width information to check illegal writes for prim interface
+  parameter logic [3:0] FLASH_CTRL_PRIM_PERMIT [21] = '{
+    4'b 0001, // index[ 0] FLASH_CTRL_CSR0_REGWEN
+    4'b 0011, // index[ 1] FLASH_CTRL_CSR1
+    4'b 0001, // index[ 2] FLASH_CTRL_CSR2
+    4'b 1111, // index[ 3] FLASH_CTRL_CSR3
+    4'b 0011, // index[ 4] FLASH_CTRL_CSR4
+    4'b 0111, // index[ 5] FLASH_CTRL_CSR5
+    4'b 1111, // index[ 6] FLASH_CTRL_CSR6
+    4'b 0111, // index[ 7] FLASH_CTRL_CSR7
+    4'b 1111, // index[ 8] FLASH_CTRL_CSR8
+    4'b 1111, // index[ 9] FLASH_CTRL_CSR9
+    4'b 1111, // index[10] FLASH_CTRL_CSR10
+    4'b 1111, // index[11] FLASH_CTRL_CSR11
+    4'b 0011, // index[12] FLASH_CTRL_CSR12
+    4'b 0111, // index[13] FLASH_CTRL_CSR13
+    4'b 0011, // index[14] FLASH_CTRL_CSR14
+    4'b 0011, // index[15] FLASH_CTRL_CSR15
+    4'b 0011, // index[16] FLASH_CTRL_CSR16
+    4'b 0011, // index[17] FLASH_CTRL_CSR17
+    4'b 0001, // index[18] FLASH_CTRL_CSR18
+    4'b 0001, // index[19] FLASH_CTRL_CSR19
+    4'b 0001  // index[20] FLASH_CTRL_CSR20
   };
 
 endpackage

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -13,6 +13,7 @@ filesets:
       - "fileset_partner  ? (partner:systems:ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
       - lowrisc:ip:flash_ctrl_pkg
+      - lowrisc:ip:flash_ctrl_prim_reg_top
     files:
       - rtl/prim_generic_flash_bank.sv
       - rtl/prim_generic_flash.sv

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -119,61 +119,26 @@ module prim_generic_flash #(
   assign unused_tms = tms_i;
   assign tdo_o = '0;
 
-  // fake memory used to emulate configuration
-  logic cfg_req;
-  logic cfg_we;
-  logic [CfgAddrWidth-1:0] cfg_addr;
-  logic [31:0] cfg_wdata;
-  logic cfg_rvalid;
-  logic [31:0] cfg_rdata;
+  ////////////////////////////////////
+  // TL-UL Test Interface Emulation //
+  ////////////////////////////////////
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      cfg_rvalid <= 1'b0;
-    end else begin
-      cfg_rvalid <= cfg_req & !cfg_we;
-    end
-  end
-
-  tlul_adapter_sram #(
-    .SramAw(CfgAddrWidth),
-    .SramDw(32),
-    .Outstanding(2),
-    .ErrOnWrite(0),
-    .EnableRspIntgGen(1),
-    .EnableDataIntgGen(1)
-  ) u_cfg (
+  flash_ctrl_reg_pkg::flash_ctrl_prim_reg2hw_t reg2hw;
+  flash_ctrl_reg_pkg::flash_ctrl_prim_hw2reg_t hw2reg;
+  flash_ctrl_prim_reg_top u_reg_top (
     .clk_i,
     .rst_ni,
-    .tl_i,
-    .tl_o,
-    .en_ifetch_i(prim_mubi_pkg::MuBi4False),
-    .req_o(cfg_req),
-    .req_type_o(),
-    .gnt_i(1'b1),
-    .we_o(cfg_we),
-    .addr_o(cfg_addr),
-    .wdata_o(cfg_wdata),
-    .wmask_o(),
-    .intg_error_o(),
-    .rdata_i(cfg_rdata),
-    .rvalid_i(cfg_rvalid),
-    .rerror_i('0)
+    .tl_i      (tl_i),
+    .tl_o      (tl_o),
+    .reg2hw    (reg2hw),
+    .hw2reg    (hw2reg),
+    .intg_err_o(), // TODO: do we need to wire this up?
+    .devmode_i (1'b1)
   );
 
-  prim_ram_1p #(
-    .Width(32),
-    .Depth(CfgRegs)
-  ) u_cfg_ram (
-    .clk_i,
-    .req_i(cfg_req),
-    .write_i(cfg_we),
-    .addr_i(cfg_addr),
-    .wdata_i(cfg_wdata),
-    .wmask_i({32{1'b1}}),
-    .rdata_o(cfg_rdata),
-    .cfg_i('0)
-  );
+  logic unused_reg_sig;
+  assign unused_reg_sig = ^reg2hw;
+  assign hw2reg = '0;
 
   logic unused_bist_enable;
   assign unused_bist_enable = ^bist_enable_i;

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -10,14 +10,14 @@
 
 
 
-{ name: "FLASH_CTRL",
+{ name: "flash_ctrl",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
     {clock: "clk_otp_i", reset: "rst_otp_ni"}
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device", name: "core" }
-    { protocol: "tlul", direction: "device", name: "prim" }
+    { protocol: "tlul", direction: "device", name: "prim" , hier_path: "u_eflash.u_flash.gen_generic.u_impl_generic.u_reg_top"}
     { protocol: "tlul", direction: "device", name: "mem" }
   ],
   available_input_list: [
@@ -2162,7 +2162,867 @@
       },
     ],
 
-    prim: []
+    prim: [
+      {
+        name: "CSR0_REGWEN",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw0c",
+            hwaccess: "none",
+            resval: "1",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False"
+      },
+      {
+        name: "CSR1",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "12:8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR2",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "1",
+            name: "field1",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "2",
+            name: "field2",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "3",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "4",
+            name: "field4",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "5",
+            name: "field5",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "6",
+            name: "field6",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "7",
+            name: "field7",
+            swaccess: "rw",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False"
+      },
+      {
+        name: "CSR3",
+        desc: "",
+        fields: [
+          {
+            bits: "3:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "7:4",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "10:8",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "13:11",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "16:14",
+            name: "field4",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "19:17",
+            name: "field5",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "20",
+            name: "field6",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "23:21",
+            name: "field7",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "25:24",
+            name: "field8",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "27:26",
+            name: "field9",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR4",
+        desc: "",
+        fields: [
+          {
+            bits: "2:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "5:3",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8:6",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "11:9",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR5",
+        desc: "",
+        fields: [
+          {
+            bits: "2:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "4:3",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "13:5",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "18:14",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "22:19",
+            name: "field4",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR6",
+        desc: "",
+        fields: [
+          {
+            bits: "2:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "5:3",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "13:6",
+            name: "field2",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "16:14",
+            name: "field3",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "18:17",
+            name: "field4",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "20:19",
+            name: "field5",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "22:21",
+            name: "field6",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "23",
+            name: "field7",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "24",
+            name: "field8",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR7",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "16:8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR8",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR9",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR10",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR11",
+        desc: "",
+        fields: [
+          {
+            bits: "31:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR12",
+        desc: "",
+        fields: [
+          {
+            bits: "9:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR13",
+        desc: "",
+        fields: [
+          {
+            bits: "19:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "20",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR14",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR15",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR16",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR17",
+        desc: "",
+        fields: [
+          {
+            bits: "7:0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "8",
+            name: "field1",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR18",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR19",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw",
+            hwaccess: "hro",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False",
+        regwen: "CSR0_REGWEN"
+      },
+      {
+        name: "CSR20",
+        desc: "",
+        fields: [
+          {
+            bits: "0",
+            name: "field0",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "1",
+            name: "field1",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          },
+          {
+            bits: "2",
+            name: "field2",
+            swaccess: "rw1c",
+            hwaccess: "hrw",
+            resval: "0",
+            tags: [],
+            desc: "",
+            enum: []
+          }
+        ],
+        hwext: "False",
+        hwqe: "False",
+        hwre: "False",
+        tags: [],
+        shadowed: "False"
+      }
+    ],
     mem: []
   }
 }

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -1436,4 +1436,13 @@ module flash_ctrl
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg_core, alert_tx_o[1])
+
+  `ifndef PRIM_DEFAULT_IMPL
+    `define PRIM_DEFAULT_IMPL prim_pkg::ImplGeneric
+  `endif
+  if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_reg_we_assert_generic
+    `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(PrimRegWeOnehotCheck_A,
+        u_eflash.u_flash.gen_generic.u_impl_generic.u_reg_top, alert_tx_o[1])
+  end
+
 endmodule

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_prim_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_prim_reg_top.sv
@@ -12,6 +12,8 @@ module flash_ctrl_prim_reg_top (
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
   // To HW
+  output flash_ctrl_reg_pkg::flash_ctrl_prim_reg2hw_t reg2hw, // Write
+  input  flash_ctrl_reg_pkg::flash_ctrl_prim_hw2reg_t hw2reg, // Read
 
   // Integrity check errors
   output logic intg_err_o,
@@ -22,11 +24,60 @@ module flash_ctrl_prim_reg_top (
 
   import flash_ctrl_reg_pkg::* ;
 
+  localparam int AW = 7;
+  localparam int DW = 32;
+  localparam int DBW = DW/8;                    // Byte Width
+
+  // register signals
+  logic           reg_we;
+  logic           reg_re;
+  logic [AW-1:0]  reg_addr;
+  logic [DW-1:0]  reg_wdata;
+  logic [DBW-1:0] reg_be;
+  logic [DW-1:0]  reg_rdata;
+  logic           reg_error;
+
+  logic          addrmiss, wr_err;
+
+  logic [DW-1:0] reg_rdata_next;
+  logic reg_busy;
+
+  tlul_pkg::tl_h2d_t tl_reg_h2d;
+  tlul_pkg::tl_d2h_t tl_reg_d2h;
 
 
-  // Since there are no registers in this block, commands are routed through to windows which
-  // can report their own integrity errors.
-  assign intg_err_o = 1'b0;
+  // incoming payload check
+  logic intg_err;
+  tlul_cmd_intg_chk u_chk (
+    .tl_i(tl_i),
+    .err_o(intg_err)
+  );
+
+  // also check for spurious write enables
+  logic reg_we_err;
+  logic [20:0] reg_we_check;
+  prim_reg_we_check #(
+    .OneHotWidth(21)
+  ) u_prim_reg_we_check (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .oh_i  (reg_we_check),
+    .en_i  (reg_we && !addrmiss),
+    .err_o (reg_we_err)
+  );
+
+  logic err_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      err_q <= '0;
+    end else if (intg_err || reg_we_err) begin
+      err_q <= 1'b1;
+    end
+  end
+
+  // integrity error output is permanent and should be used for alert generation
+  // register errors are transactional
+  assign intg_err_o = err_q | intg_err | reg_we_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
@@ -41,8 +92,2240 @@ module flash_ctrl_prim_reg_top (
   assign tl_reg_h2d = tl_i;
   assign tl_o_pre   = tl_reg_d2h;
 
+  tlul_adapter_reg #(
+    .RegAw(AW),
+    .RegDw(DW),
+    .EnableDataIntgGen(0)
+  ) u_reg_if (
+    .clk_i  (clk_i),
+    .rst_ni (rst_ni),
+
+    .tl_i (tl_reg_h2d),
+    .tl_o (tl_reg_d2h),
+
+    .we_o    (reg_we),
+    .re_o    (reg_re),
+    .addr_o  (reg_addr),
+    .wdata_o (reg_wdata),
+    .be_o    (reg_be),
+    .busy_i  (reg_busy),
+    .rdata_i (reg_rdata),
+    .error_i (reg_error)
+  );
+
+  // cdc oversampling signals
+
+  assign reg_rdata = reg_rdata_next ;
+  assign reg_error = (devmode_i & addrmiss) | wr_err | intg_err;
+
+  // Define SW related signals
+  // Format: <reg>_<field>_{wd|we|qs}
+  //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic csr0_regwen_we;
+  logic csr0_regwen_qs;
+  logic csr0_regwen_wd;
+  logic csr1_we;
+  logic [7:0] csr1_field0_qs;
+  logic [7:0] csr1_field0_wd;
+  logic [4:0] csr1_field1_qs;
+  logic [4:0] csr1_field1_wd;
+  logic csr2_we;
+  logic csr2_field0_qs;
+  logic csr2_field0_wd;
+  logic csr2_field1_qs;
+  logic csr2_field1_wd;
+  logic csr2_field2_qs;
+  logic csr2_field2_wd;
+  logic csr2_field3_qs;
+  logic csr2_field3_wd;
+  logic csr2_field4_qs;
+  logic csr2_field4_wd;
+  logic csr2_field5_qs;
+  logic csr2_field5_wd;
+  logic csr2_field6_qs;
+  logic csr2_field6_wd;
+  logic csr2_field7_qs;
+  logic csr2_field7_wd;
+  logic csr3_we;
+  logic [3:0] csr3_field0_qs;
+  logic [3:0] csr3_field0_wd;
+  logic [3:0] csr3_field1_qs;
+  logic [3:0] csr3_field1_wd;
+  logic [2:0] csr3_field2_qs;
+  logic [2:0] csr3_field2_wd;
+  logic [2:0] csr3_field3_qs;
+  logic [2:0] csr3_field3_wd;
+  logic [2:0] csr3_field4_qs;
+  logic [2:0] csr3_field4_wd;
+  logic [2:0] csr3_field5_qs;
+  logic [2:0] csr3_field5_wd;
+  logic csr3_field6_qs;
+  logic csr3_field6_wd;
+  logic [2:0] csr3_field7_qs;
+  logic [2:0] csr3_field7_wd;
+  logic [1:0] csr3_field8_qs;
+  logic [1:0] csr3_field8_wd;
+  logic [1:0] csr3_field9_qs;
+  logic [1:0] csr3_field9_wd;
+  logic csr4_we;
+  logic [2:0] csr4_field0_qs;
+  logic [2:0] csr4_field0_wd;
+  logic [2:0] csr4_field1_qs;
+  logic [2:0] csr4_field1_wd;
+  logic [2:0] csr4_field2_qs;
+  logic [2:0] csr4_field2_wd;
+  logic [2:0] csr4_field3_qs;
+  logic [2:0] csr4_field3_wd;
+  logic csr5_we;
+  logic [2:0] csr5_field0_qs;
+  logic [2:0] csr5_field0_wd;
+  logic [1:0] csr5_field1_qs;
+  logic [1:0] csr5_field1_wd;
+  logic [8:0] csr5_field2_qs;
+  logic [8:0] csr5_field2_wd;
+  logic [4:0] csr5_field3_qs;
+  logic [4:0] csr5_field3_wd;
+  logic [3:0] csr5_field4_qs;
+  logic [3:0] csr5_field4_wd;
+  logic csr6_we;
+  logic [2:0] csr6_field0_qs;
+  logic [2:0] csr6_field0_wd;
+  logic [2:0] csr6_field1_qs;
+  logic [2:0] csr6_field1_wd;
+  logic [7:0] csr6_field2_qs;
+  logic [7:0] csr6_field2_wd;
+  logic [2:0] csr6_field3_qs;
+  logic [2:0] csr6_field3_wd;
+  logic [1:0] csr6_field4_qs;
+  logic [1:0] csr6_field4_wd;
+  logic [1:0] csr6_field5_qs;
+  logic [1:0] csr6_field5_wd;
+  logic [1:0] csr6_field6_qs;
+  logic [1:0] csr6_field6_wd;
+  logic csr6_field7_qs;
+  logic csr6_field7_wd;
+  logic csr6_field8_qs;
+  logic csr6_field8_wd;
+  logic csr7_we;
+  logic [7:0] csr7_field0_qs;
+  logic [7:0] csr7_field0_wd;
+  logic [8:0] csr7_field1_qs;
+  logic [8:0] csr7_field1_wd;
+  logic csr8_we;
+  logic [31:0] csr8_qs;
+  logic [31:0] csr8_wd;
+  logic csr9_we;
+  logic [31:0] csr9_qs;
+  logic [31:0] csr9_wd;
+  logic csr10_we;
+  logic [31:0] csr10_qs;
+  logic [31:0] csr10_wd;
+  logic csr11_we;
+  logic [31:0] csr11_qs;
+  logic [31:0] csr11_wd;
+  logic csr12_we;
+  logic [9:0] csr12_qs;
+  logic [9:0] csr12_wd;
+  logic csr13_we;
+  logic [19:0] csr13_field0_qs;
+  logic [19:0] csr13_field0_wd;
+  logic csr13_field1_qs;
+  logic csr13_field1_wd;
+  logic csr14_we;
+  logic [7:0] csr14_field0_qs;
+  logic [7:0] csr14_field0_wd;
+  logic csr14_field1_qs;
+  logic csr14_field1_wd;
+  logic csr15_we;
+  logic [7:0] csr15_field0_qs;
+  logic [7:0] csr15_field0_wd;
+  logic csr15_field1_qs;
+  logic csr15_field1_wd;
+  logic csr16_we;
+  logic [7:0] csr16_field0_qs;
+  logic [7:0] csr16_field0_wd;
+  logic csr16_field1_qs;
+  logic csr16_field1_wd;
+  logic csr17_we;
+  logic [7:0] csr17_field0_qs;
+  logic [7:0] csr17_field0_wd;
+  logic csr17_field1_qs;
+  logic csr17_field1_wd;
+  logic csr18_we;
+  logic csr18_qs;
+  logic csr18_wd;
+  logic csr19_we;
+  logic csr19_qs;
+  logic csr19_wd;
+  logic csr20_we;
+  logic csr20_field0_qs;
+  logic csr20_field0_wd;
+  logic csr20_field1_qs;
+  logic csr20_field1_wd;
+  logic csr20_field2_qs;
+  logic csr20_field2_wd;
+
+  // Register instances
+  // R[csr0_regwen]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1)
+  ) u_csr0_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr0_regwen_we),
+    .wd     (csr0_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr0_regwen_qs)
+  );
+
+
+  // R[csr1]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr1_gated_we;
+  assign csr1_gated_we = csr1_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr1_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr1_gated_we),
+    .wd     (csr1_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr1.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr1_field0_qs)
+  );
+
+  //   F[field1]: 12:8
+  prim_subreg #(
+    .DW      (5),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (5'h0)
+  ) u_csr1_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr1_gated_we),
+    .wd     (csr1_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr1.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr1_field1_qs)
+  );
+
+
+  // R[csr2]: V(False)
+  //   F[field0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field0_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field0.de),
+    .d      (hw2reg.csr2.field0.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field0_qs)
+  );
+
+  //   F[field1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field1_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field1.de),
+    .d      (hw2reg.csr2.field1.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field1_qs)
+  );
+
+  //   F[field2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field2_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field2.de),
+    .d      (hw2reg.csr2.field2.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field2_qs)
+  );
+
+  //   F[field3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr2_field3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field3_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field3.de),
+    .d      (hw2reg.csr2.field3.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field3.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field3_qs)
+  );
+
+  //   F[field4]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field4_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field4.de),
+    .d      (hw2reg.csr2.field4.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field4.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field4_qs)
+  );
+
+  //   F[field5]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field5_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field5.de),
+    .d      (hw2reg.csr2.field5.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field5.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field5_qs)
+  );
+
+  //   F[field6]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr2_field6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field6_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field6.de),
+    .d      (hw2reg.csr2.field6.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field6.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field6_qs)
+  );
+
+  //   F[field7]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr2_field7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr2_we),
+    .wd     (csr2_field7_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr2.field7.de),
+    .d      (hw2reg.csr2.field7.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr2.field7.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr2_field7_qs)
+  );
+
+
+  // R[csr3]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr3_gated_we;
+  assign csr3_gated_we = csr3_we & csr0_regwen_qs;
+  //   F[field0]: 3:0
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (4'h0)
+  ) u_csr3_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field0_qs)
+  );
+
+  //   F[field1]: 7:4
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (4'h0)
+  ) u_csr3_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field1_qs)
+  );
+
+  //   F[field2]: 10:8
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr3_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field2_qs)
+  );
+
+  //   F[field3]: 13:11
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr3_field3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field3.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field3_qs)
+  );
+
+  //   F[field4]: 16:14
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr3_field4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field4.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field4_qs)
+  );
+
+  //   F[field5]: 19:17
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr3_field5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field5.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field5_qs)
+  );
+
+  //   F[field6]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr3_field6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field6.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field6_qs)
+  );
+
+  //   F[field7]: 23:21
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr3_field7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field7.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field7_qs)
+  );
+
+  //   F[field8]: 25:24
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr3_field8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field8.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field8_qs)
+  );
+
+  //   F[field9]: 27:26
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr3_field9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr3_gated_we),
+    .wd     (csr3_field9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr3.field9.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr3_field9_qs)
+  );
+
+
+  // R[csr4]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr4_gated_we;
+  assign csr4_gated_we = csr4_we & csr0_regwen_qs;
+  //   F[field0]: 2:0
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr4_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr4_gated_we),
+    .wd     (csr4_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr4.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr4_field0_qs)
+  );
+
+  //   F[field1]: 5:3
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr4_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr4_gated_we),
+    .wd     (csr4_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr4.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr4_field1_qs)
+  );
+
+  //   F[field2]: 8:6
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr4_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr4_gated_we),
+    .wd     (csr4_field2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr4.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr4_field2_qs)
+  );
+
+  //   F[field3]: 11:9
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr4_field3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr4_gated_we),
+    .wd     (csr4_field3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr4.field3.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr4_field3_qs)
+  );
+
+
+  // R[csr5]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr5_gated_we;
+  assign csr5_gated_we = csr5_we & csr0_regwen_qs;
+  //   F[field0]: 2:0
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr5_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr5_gated_we),
+    .wd     (csr5_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr5.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr5_field0_qs)
+  );
+
+  //   F[field1]: 4:3
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr5_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr5_gated_we),
+    .wd     (csr5_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr5.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr5_field1_qs)
+  );
+
+  //   F[field2]: 13:5
+  prim_subreg #(
+    .DW      (9),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (9'h0)
+  ) u_csr5_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr5_gated_we),
+    .wd     (csr5_field2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr5.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr5_field2_qs)
+  );
+
+  //   F[field3]: 18:14
+  prim_subreg #(
+    .DW      (5),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (5'h0)
+  ) u_csr5_field3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr5_gated_we),
+    .wd     (csr5_field3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr5.field3.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr5_field3_qs)
+  );
+
+  //   F[field4]: 22:19
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (4'h0)
+  ) u_csr5_field4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr5_gated_we),
+    .wd     (csr5_field4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr5.field4.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr5_field4_qs)
+  );
+
+
+  // R[csr6]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr6_gated_we;
+  assign csr6_gated_we = csr6_we & csr0_regwen_qs;
+  //   F[field0]: 2:0
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr6_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field0_qs)
+  );
+
+  //   F[field1]: 5:3
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr6_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field1_qs)
+  );
+
+  //   F[field2]: 13:6
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr6_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field2_qs)
+  );
+
+  //   F[field3]: 16:14
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (3'h0)
+  ) u_csr6_field3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field3.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field3_qs)
+  );
+
+  //   F[field4]: 18:17
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr6_field4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field4.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field4_qs)
+  );
+
+  //   F[field5]: 20:19
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr6_field5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field5.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field5_qs)
+  );
+
+  //   F[field6]: 22:21
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0)
+  ) u_csr6_field6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field6.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field6_qs)
+  );
+
+  //   F[field7]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr6_field7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field7.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field7_qs)
+  );
+
+  //   F[field8]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr6_field8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr6_gated_we),
+    .wd     (csr6_field8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr6.field8.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr6_field8_qs)
+  );
+
+
+  // R[csr7]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr7_gated_we;
+  assign csr7_gated_we = csr7_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr7_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr7_gated_we),
+    .wd     (csr7_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr7.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr7_field0_qs)
+  );
+
+  //   F[field1]: 16:8
+  prim_subreg #(
+    .DW      (9),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (9'h0)
+  ) u_csr7_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr7_gated_we),
+    .wd     (csr7_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr7.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr7_field1_qs)
+  );
+
+
+  // R[csr8]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr8_gated_we;
+  assign csr8_gated_we = csr8_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_csr8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr8_gated_we),
+    .wd     (csr8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr8.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr8_qs)
+  );
+
+
+  // R[csr9]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr9_gated_we;
+  assign csr9_gated_we = csr9_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_csr9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr9_gated_we),
+    .wd     (csr9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr9.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr9_qs)
+  );
+
+
+  // R[csr10]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr10_gated_we;
+  assign csr10_gated_we = csr10_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_csr10 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr10_gated_we),
+    .wd     (csr10_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr10.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr10_qs)
+  );
+
+
+  // R[csr11]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr11_gated_we;
+  assign csr11_gated_we = csr11_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_csr11 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr11_gated_we),
+    .wd     (csr11_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr11.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr11_qs)
+  );
+
+
+  // R[csr12]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr12_gated_we;
+  assign csr12_gated_we = csr12_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (10),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (10'h0)
+  ) u_csr12 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr12_gated_we),
+    .wd     (csr12_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr12.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr12_qs)
+  );
+
+
+  // R[csr13]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr13_gated_we;
+  assign csr13_gated_we = csr13_we & csr0_regwen_qs;
+  //   F[field0]: 19:0
+  prim_subreg #(
+    .DW      (20),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (20'h0)
+  ) u_csr13_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr13_gated_we),
+    .wd     (csr13_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr13.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr13_field0_qs)
+  );
+
+  //   F[field1]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr13_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr13_gated_we),
+    .wd     (csr13_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr13.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr13_field1_qs)
+  );
+
+
+  // R[csr14]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr14_gated_we;
+  assign csr14_gated_we = csr14_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr14_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr14_gated_we),
+    .wd     (csr14_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr14.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr14_field0_qs)
+  );
+
+  //   F[field1]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr14_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr14_gated_we),
+    .wd     (csr14_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr14.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr14_field1_qs)
+  );
+
+
+  // R[csr15]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr15_gated_we;
+  assign csr15_gated_we = csr15_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr15_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr15_gated_we),
+    .wd     (csr15_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr15.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr15_field0_qs)
+  );
+
+  //   F[field1]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr15_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr15_gated_we),
+    .wd     (csr15_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr15.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr15_field1_qs)
+  );
+
+
+  // R[csr16]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr16_gated_we;
+  assign csr16_gated_we = csr16_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr16_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr16_gated_we),
+    .wd     (csr16_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr16.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr16_field0_qs)
+  );
+
+  //   F[field1]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr16_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr16_gated_we),
+    .wd     (csr16_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr16.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr16_field1_qs)
+  );
+
+
+  // R[csr17]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr17_gated_we;
+  assign csr17_gated_we = csr17_we & csr0_regwen_qs;
+  //   F[field0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_csr17_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr17_gated_we),
+    .wd     (csr17_field0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr17.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr17_field0_qs)
+  );
+
+  //   F[field1]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr17_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr17_gated_we),
+    .wd     (csr17_field1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr17.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr17_field1_qs)
+  );
+
+
+  // R[csr18]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr18_gated_we;
+  assign csr18_gated_we = csr18_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr18 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr18_gated_we),
+    .wd     (csr18_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr18.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr18_qs)
+  );
+
+
+  // R[csr19]: V(False)
+  // Create REGWEN-gated WE signal
+  logic csr19_gated_we;
+  assign csr19_gated_we = csr19_we & csr0_regwen_qs;
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_csr19 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr19_gated_we),
+    .wd     (csr19_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr19.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr19_qs)
+  );
+
+
+  // R[csr20]: V(False)
+  //   F[field0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr20_field0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr20_we),
+    .wd     (csr20_field0_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr20.field0.de),
+    .d      (hw2reg.csr20.field0.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr20.field0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr20_field0_qs)
+  );
+
+  //   F[field1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr20_field1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr20_we),
+    .wd     (csr20_field1_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr20.field1.de),
+    .d      (hw2reg.csr20.field1.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr20.field1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr20_field1_qs)
+  );
+
+  //   F[field2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_csr20_field2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (csr20_we),
+    .wd     (csr20_field2_wd),
+
+    // from internal hardware
+    .de     (hw2reg.csr20.field2.de),
+    .d      (hw2reg.csr20.field2.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.csr20.field2.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (csr20_field2_qs)
+  );
+
+
+
+  logic [20:0] addr_hit;
+  always_comb begin
+    addr_hit = '0;
+    addr_hit[ 0] = (reg_addr == FLASH_CTRL_CSR0_REGWEN_OFFSET);
+    addr_hit[ 1] = (reg_addr == FLASH_CTRL_CSR1_OFFSET);
+    addr_hit[ 2] = (reg_addr == FLASH_CTRL_CSR2_OFFSET);
+    addr_hit[ 3] = (reg_addr == FLASH_CTRL_CSR3_OFFSET);
+    addr_hit[ 4] = (reg_addr == FLASH_CTRL_CSR4_OFFSET);
+    addr_hit[ 5] = (reg_addr == FLASH_CTRL_CSR5_OFFSET);
+    addr_hit[ 6] = (reg_addr == FLASH_CTRL_CSR6_OFFSET);
+    addr_hit[ 7] = (reg_addr == FLASH_CTRL_CSR7_OFFSET);
+    addr_hit[ 8] = (reg_addr == FLASH_CTRL_CSR8_OFFSET);
+    addr_hit[ 9] = (reg_addr == FLASH_CTRL_CSR9_OFFSET);
+    addr_hit[10] = (reg_addr == FLASH_CTRL_CSR10_OFFSET);
+    addr_hit[11] = (reg_addr == FLASH_CTRL_CSR11_OFFSET);
+    addr_hit[12] = (reg_addr == FLASH_CTRL_CSR12_OFFSET);
+    addr_hit[13] = (reg_addr == FLASH_CTRL_CSR13_OFFSET);
+    addr_hit[14] = (reg_addr == FLASH_CTRL_CSR14_OFFSET);
+    addr_hit[15] = (reg_addr == FLASH_CTRL_CSR15_OFFSET);
+    addr_hit[16] = (reg_addr == FLASH_CTRL_CSR16_OFFSET);
+    addr_hit[17] = (reg_addr == FLASH_CTRL_CSR17_OFFSET);
+    addr_hit[18] = (reg_addr == FLASH_CTRL_CSR18_OFFSET);
+    addr_hit[19] = (reg_addr == FLASH_CTRL_CSR19_OFFSET);
+    addr_hit[20] = (reg_addr == FLASH_CTRL_CSR20_OFFSET);
+  end
+
+  assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
+
+  // Check sub-word write is permitted
+  always_comb begin
+    wr_err = (reg_we &
+              ((addr_hit[ 0] & (|(FLASH_CTRL_PRIM_PERMIT[ 0] & ~reg_be))) |
+               (addr_hit[ 1] & (|(FLASH_CTRL_PRIM_PERMIT[ 1] & ~reg_be))) |
+               (addr_hit[ 2] & (|(FLASH_CTRL_PRIM_PERMIT[ 2] & ~reg_be))) |
+               (addr_hit[ 3] & (|(FLASH_CTRL_PRIM_PERMIT[ 3] & ~reg_be))) |
+               (addr_hit[ 4] & (|(FLASH_CTRL_PRIM_PERMIT[ 4] & ~reg_be))) |
+               (addr_hit[ 5] & (|(FLASH_CTRL_PRIM_PERMIT[ 5] & ~reg_be))) |
+               (addr_hit[ 6] & (|(FLASH_CTRL_PRIM_PERMIT[ 6] & ~reg_be))) |
+               (addr_hit[ 7] & (|(FLASH_CTRL_PRIM_PERMIT[ 7] & ~reg_be))) |
+               (addr_hit[ 8] & (|(FLASH_CTRL_PRIM_PERMIT[ 8] & ~reg_be))) |
+               (addr_hit[ 9] & (|(FLASH_CTRL_PRIM_PERMIT[ 9] & ~reg_be))) |
+               (addr_hit[10] & (|(FLASH_CTRL_PRIM_PERMIT[10] & ~reg_be))) |
+               (addr_hit[11] & (|(FLASH_CTRL_PRIM_PERMIT[11] & ~reg_be))) |
+               (addr_hit[12] & (|(FLASH_CTRL_PRIM_PERMIT[12] & ~reg_be))) |
+               (addr_hit[13] & (|(FLASH_CTRL_PRIM_PERMIT[13] & ~reg_be))) |
+               (addr_hit[14] & (|(FLASH_CTRL_PRIM_PERMIT[14] & ~reg_be))) |
+               (addr_hit[15] & (|(FLASH_CTRL_PRIM_PERMIT[15] & ~reg_be))) |
+               (addr_hit[16] & (|(FLASH_CTRL_PRIM_PERMIT[16] & ~reg_be))) |
+               (addr_hit[17] & (|(FLASH_CTRL_PRIM_PERMIT[17] & ~reg_be))) |
+               (addr_hit[18] & (|(FLASH_CTRL_PRIM_PERMIT[18] & ~reg_be))) |
+               (addr_hit[19] & (|(FLASH_CTRL_PRIM_PERMIT[19] & ~reg_be))) |
+               (addr_hit[20] & (|(FLASH_CTRL_PRIM_PERMIT[20] & ~reg_be)))));
+  end
+
+  // Generate write-enables
+  assign csr0_regwen_we = addr_hit[0] & reg_we & !reg_error;
+
+  assign csr0_regwen_wd = reg_wdata[0];
+  assign csr1_we = addr_hit[1] & reg_we & !reg_error;
+
+  assign csr1_field0_wd = reg_wdata[7:0];
+
+  assign csr1_field1_wd = reg_wdata[12:8];
+  assign csr2_we = addr_hit[2] & reg_we & !reg_error;
+
+  assign csr2_field0_wd = reg_wdata[0];
+
+  assign csr2_field1_wd = reg_wdata[1];
+
+  assign csr2_field2_wd = reg_wdata[2];
+
+  assign csr2_field3_wd = reg_wdata[3];
+
+  assign csr2_field4_wd = reg_wdata[4];
+
+  assign csr2_field5_wd = reg_wdata[5];
+
+  assign csr2_field6_wd = reg_wdata[6];
+
+  assign csr2_field7_wd = reg_wdata[7];
+  assign csr3_we = addr_hit[3] & reg_we & !reg_error;
+
+  assign csr3_field0_wd = reg_wdata[3:0];
+
+  assign csr3_field1_wd = reg_wdata[7:4];
+
+  assign csr3_field2_wd = reg_wdata[10:8];
+
+  assign csr3_field3_wd = reg_wdata[13:11];
+
+  assign csr3_field4_wd = reg_wdata[16:14];
+
+  assign csr3_field5_wd = reg_wdata[19:17];
+
+  assign csr3_field6_wd = reg_wdata[20];
+
+  assign csr3_field7_wd = reg_wdata[23:21];
+
+  assign csr3_field8_wd = reg_wdata[25:24];
+
+  assign csr3_field9_wd = reg_wdata[27:26];
+  assign csr4_we = addr_hit[4] & reg_we & !reg_error;
+
+  assign csr4_field0_wd = reg_wdata[2:0];
+
+  assign csr4_field1_wd = reg_wdata[5:3];
+
+  assign csr4_field2_wd = reg_wdata[8:6];
+
+  assign csr4_field3_wd = reg_wdata[11:9];
+  assign csr5_we = addr_hit[5] & reg_we & !reg_error;
+
+  assign csr5_field0_wd = reg_wdata[2:0];
+
+  assign csr5_field1_wd = reg_wdata[4:3];
+
+  assign csr5_field2_wd = reg_wdata[13:5];
+
+  assign csr5_field3_wd = reg_wdata[18:14];
+
+  assign csr5_field4_wd = reg_wdata[22:19];
+  assign csr6_we = addr_hit[6] & reg_we & !reg_error;
+
+  assign csr6_field0_wd = reg_wdata[2:0];
+
+  assign csr6_field1_wd = reg_wdata[5:3];
+
+  assign csr6_field2_wd = reg_wdata[13:6];
+
+  assign csr6_field3_wd = reg_wdata[16:14];
+
+  assign csr6_field4_wd = reg_wdata[18:17];
+
+  assign csr6_field5_wd = reg_wdata[20:19];
+
+  assign csr6_field6_wd = reg_wdata[22:21];
+
+  assign csr6_field7_wd = reg_wdata[23];
+
+  assign csr6_field8_wd = reg_wdata[24];
+  assign csr7_we = addr_hit[7] & reg_we & !reg_error;
+
+  assign csr7_field0_wd = reg_wdata[7:0];
+
+  assign csr7_field1_wd = reg_wdata[16:8];
+  assign csr8_we = addr_hit[8] & reg_we & !reg_error;
+
+  assign csr8_wd = reg_wdata[31:0];
+  assign csr9_we = addr_hit[9] & reg_we & !reg_error;
+
+  assign csr9_wd = reg_wdata[31:0];
+  assign csr10_we = addr_hit[10] & reg_we & !reg_error;
+
+  assign csr10_wd = reg_wdata[31:0];
+  assign csr11_we = addr_hit[11] & reg_we & !reg_error;
+
+  assign csr11_wd = reg_wdata[31:0];
+  assign csr12_we = addr_hit[12] & reg_we & !reg_error;
+
+  assign csr12_wd = reg_wdata[9:0];
+  assign csr13_we = addr_hit[13] & reg_we & !reg_error;
+
+  assign csr13_field0_wd = reg_wdata[19:0];
+
+  assign csr13_field1_wd = reg_wdata[20];
+  assign csr14_we = addr_hit[14] & reg_we & !reg_error;
+
+  assign csr14_field0_wd = reg_wdata[7:0];
+
+  assign csr14_field1_wd = reg_wdata[8];
+  assign csr15_we = addr_hit[15] & reg_we & !reg_error;
+
+  assign csr15_field0_wd = reg_wdata[7:0];
+
+  assign csr15_field1_wd = reg_wdata[8];
+  assign csr16_we = addr_hit[16] & reg_we & !reg_error;
+
+  assign csr16_field0_wd = reg_wdata[7:0];
+
+  assign csr16_field1_wd = reg_wdata[8];
+  assign csr17_we = addr_hit[17] & reg_we & !reg_error;
+
+  assign csr17_field0_wd = reg_wdata[7:0];
+
+  assign csr17_field1_wd = reg_wdata[8];
+  assign csr18_we = addr_hit[18] & reg_we & !reg_error;
+
+  assign csr18_wd = reg_wdata[0];
+  assign csr19_we = addr_hit[19] & reg_we & !reg_error;
+
+  assign csr19_wd = reg_wdata[0];
+  assign csr20_we = addr_hit[20] & reg_we & !reg_error;
+
+  assign csr20_field0_wd = reg_wdata[0];
+
+  assign csr20_field1_wd = reg_wdata[1];
+
+  assign csr20_field2_wd = reg_wdata[2];
+
+  // Assign write-enables to checker logic vector.
+  always_comb begin
+    reg_we_check = '0;
+    reg_we_check[0] = csr0_regwen_we;
+    reg_we_check[1] = csr1_gated_we;
+    reg_we_check[2] = csr2_we;
+    reg_we_check[3] = csr3_gated_we;
+    reg_we_check[4] = csr4_gated_we;
+    reg_we_check[5] = csr5_gated_we;
+    reg_we_check[6] = csr6_gated_we;
+    reg_we_check[7] = csr7_gated_we;
+    reg_we_check[8] = csr8_gated_we;
+    reg_we_check[9] = csr9_gated_we;
+    reg_we_check[10] = csr10_gated_we;
+    reg_we_check[11] = csr11_gated_we;
+    reg_we_check[12] = csr12_gated_we;
+    reg_we_check[13] = csr13_gated_we;
+    reg_we_check[14] = csr14_gated_we;
+    reg_we_check[15] = csr15_gated_we;
+    reg_we_check[16] = csr16_gated_we;
+    reg_we_check[17] = csr17_gated_we;
+    reg_we_check[18] = csr18_gated_we;
+    reg_we_check[19] = csr19_gated_we;
+    reg_we_check[20] = csr20_we;
+  end
+
+  // Read data return
+  always_comb begin
+    reg_rdata_next = '0;
+    unique case (1'b1)
+      addr_hit[0]: begin
+        reg_rdata_next[0] = csr0_regwen_qs;
+      end
+
+      addr_hit[1]: begin
+        reg_rdata_next[7:0] = csr1_field0_qs;
+        reg_rdata_next[12:8] = csr1_field1_qs;
+      end
+
+      addr_hit[2]: begin
+        reg_rdata_next[0] = csr2_field0_qs;
+        reg_rdata_next[1] = csr2_field1_qs;
+        reg_rdata_next[2] = csr2_field2_qs;
+        reg_rdata_next[3] = csr2_field3_qs;
+        reg_rdata_next[4] = csr2_field4_qs;
+        reg_rdata_next[5] = csr2_field5_qs;
+        reg_rdata_next[6] = csr2_field6_qs;
+        reg_rdata_next[7] = csr2_field7_qs;
+      end
+
+      addr_hit[3]: begin
+        reg_rdata_next[3:0] = csr3_field0_qs;
+        reg_rdata_next[7:4] = csr3_field1_qs;
+        reg_rdata_next[10:8] = csr3_field2_qs;
+        reg_rdata_next[13:11] = csr3_field3_qs;
+        reg_rdata_next[16:14] = csr3_field4_qs;
+        reg_rdata_next[19:17] = csr3_field5_qs;
+        reg_rdata_next[20] = csr3_field6_qs;
+        reg_rdata_next[23:21] = csr3_field7_qs;
+        reg_rdata_next[25:24] = csr3_field8_qs;
+        reg_rdata_next[27:26] = csr3_field9_qs;
+      end
+
+      addr_hit[4]: begin
+        reg_rdata_next[2:0] = csr4_field0_qs;
+        reg_rdata_next[5:3] = csr4_field1_qs;
+        reg_rdata_next[8:6] = csr4_field2_qs;
+        reg_rdata_next[11:9] = csr4_field3_qs;
+      end
+
+      addr_hit[5]: begin
+        reg_rdata_next[2:0] = csr5_field0_qs;
+        reg_rdata_next[4:3] = csr5_field1_qs;
+        reg_rdata_next[13:5] = csr5_field2_qs;
+        reg_rdata_next[18:14] = csr5_field3_qs;
+        reg_rdata_next[22:19] = csr5_field4_qs;
+      end
+
+      addr_hit[6]: begin
+        reg_rdata_next[2:0] = csr6_field0_qs;
+        reg_rdata_next[5:3] = csr6_field1_qs;
+        reg_rdata_next[13:6] = csr6_field2_qs;
+        reg_rdata_next[16:14] = csr6_field3_qs;
+        reg_rdata_next[18:17] = csr6_field4_qs;
+        reg_rdata_next[20:19] = csr6_field5_qs;
+        reg_rdata_next[22:21] = csr6_field6_qs;
+        reg_rdata_next[23] = csr6_field7_qs;
+        reg_rdata_next[24] = csr6_field8_qs;
+      end
+
+      addr_hit[7]: begin
+        reg_rdata_next[7:0] = csr7_field0_qs;
+        reg_rdata_next[16:8] = csr7_field1_qs;
+      end
+
+      addr_hit[8]: begin
+        reg_rdata_next[31:0] = csr8_qs;
+      end
+
+      addr_hit[9]: begin
+        reg_rdata_next[31:0] = csr9_qs;
+      end
+
+      addr_hit[10]: begin
+        reg_rdata_next[31:0] = csr10_qs;
+      end
+
+      addr_hit[11]: begin
+        reg_rdata_next[31:0] = csr11_qs;
+      end
+
+      addr_hit[12]: begin
+        reg_rdata_next[9:0] = csr12_qs;
+      end
+
+      addr_hit[13]: begin
+        reg_rdata_next[19:0] = csr13_field0_qs;
+        reg_rdata_next[20] = csr13_field1_qs;
+      end
+
+      addr_hit[14]: begin
+        reg_rdata_next[7:0] = csr14_field0_qs;
+        reg_rdata_next[8] = csr14_field1_qs;
+      end
+
+      addr_hit[15]: begin
+        reg_rdata_next[7:0] = csr15_field0_qs;
+        reg_rdata_next[8] = csr15_field1_qs;
+      end
+
+      addr_hit[16]: begin
+        reg_rdata_next[7:0] = csr16_field0_qs;
+        reg_rdata_next[8] = csr16_field1_qs;
+      end
+
+      addr_hit[17]: begin
+        reg_rdata_next[7:0] = csr17_field0_qs;
+        reg_rdata_next[8] = csr17_field1_qs;
+      end
+
+      addr_hit[18]: begin
+        reg_rdata_next[0] = csr18_qs;
+      end
+
+      addr_hit[19]: begin
+        reg_rdata_next[0] = csr19_qs;
+      end
+
+      addr_hit[20]: begin
+        reg_rdata_next[0] = csr20_field0_qs;
+        reg_rdata_next[1] = csr20_field1_qs;
+        reg_rdata_next[2] = csr20_field2_qs;
+      end
+
+      default: begin
+        reg_rdata_next = '1;
+      end
+    endcase
+  end
+
+  // shadow busy
+  logic shadow_busy;
+  assign shadow_busy = 1'b0;
+
+  // register busy
+  assign reg_busy = shadow_busy;
+
   // Unused signal tieoff
-  // devmode_i is not used if there are no registers
-  logic unused_devmode;
-  assign unused_devmode = ^devmode_i;
+
+  // wdata / byte enable are not always fully used
+  // add a blanket unused statement to handle lint waivers
+  logic unused_wdata;
+  logic unused_be;
+  assign unused_wdata = ^reg_wdata;
+  assign unused_be = ^reg_be;
+
+  // Assertions for Register Interface
+  `ASSERT_PULSE(wePulse, reg_we, clk_i, !rst_ni)
+  `ASSERT_PULSE(rePulse, reg_re, clk_i, !rst_ni)
+
+  `ASSERT(reAfterRv, $rose(reg_re || reg_we) |=> tl_o_pre.d_valid, clk_i, !rst_ni)
+
+  `ASSERT(en2addrHit, (reg_we || reg_re) |-> $onehot0(addr_hit), clk_i, !rst_ni)
+
+  // this is formulated as an assumption such that the FPV testbenches do disprove this
+  // property by mistake
+  //`ASSUME(reqParity, tl_reg_h2d.a_valid |-> tl_reg_h2d.a_user.chk_en == tlul_pkg::CheckDis)
+
 endmodule

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -28,7 +28,7 @@ package flash_ctrl_reg_pkg;
 
   // Address widths within the block
   parameter int CoreAw = 9;
-  parameter int PrimAw = 1;
+  parameter int PrimAw = 7;
   parameter int MemAw = 1;
 
   ///////////////////////////////////////////////
@@ -1126,6 +1126,389 @@ package flash_ctrl_reg_pkg;
     4'b 0011, // index[104] FLASH_CTRL_FIFO_LVL
     4'b 0001, // index[105] FLASH_CTRL_FIFO_RST
     4'b 0011  // index[106] FLASH_CTRL_CURR_FIFO_LVL
+  };
+
+  ///////////////////////////////////////////////
+  // Typedefs for registers for prim interface //
+  ///////////////////////////////////////////////
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic [4:0]  q;
+    } field1;
+  } flash_ctrl_reg2hw_csr1_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+    struct packed {
+      logic        q;
+    } field2;
+    struct packed {
+      logic        q;
+    } field3;
+    struct packed {
+      logic        q;
+    } field4;
+    struct packed {
+      logic        q;
+    } field5;
+    struct packed {
+      logic        q;
+    } field6;
+    struct packed {
+      logic        q;
+    } field7;
+  } flash_ctrl_reg2hw_csr2_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [3:0]  q;
+    } field0;
+    struct packed {
+      logic [3:0]  q;
+    } field1;
+    struct packed {
+      logic [2:0]  q;
+    } field2;
+    struct packed {
+      logic [2:0]  q;
+    } field3;
+    struct packed {
+      logic [2:0]  q;
+    } field4;
+    struct packed {
+      logic [2:0]  q;
+    } field5;
+    struct packed {
+      logic        q;
+    } field6;
+    struct packed {
+      logic [2:0]  q;
+    } field7;
+    struct packed {
+      logic [1:0]  q;
+    } field8;
+    struct packed {
+      logic [1:0]  q;
+    } field9;
+  } flash_ctrl_reg2hw_csr3_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [2:0]  q;
+    } field0;
+    struct packed {
+      logic [2:0]  q;
+    } field1;
+    struct packed {
+      logic [2:0]  q;
+    } field2;
+    struct packed {
+      logic [2:0]  q;
+    } field3;
+  } flash_ctrl_reg2hw_csr4_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [2:0]  q;
+    } field0;
+    struct packed {
+      logic [1:0]  q;
+    } field1;
+    struct packed {
+      logic [8:0]  q;
+    } field2;
+    struct packed {
+      logic [4:0]  q;
+    } field3;
+    struct packed {
+      logic [3:0]  q;
+    } field4;
+  } flash_ctrl_reg2hw_csr5_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [2:0]  q;
+    } field0;
+    struct packed {
+      logic [2:0]  q;
+    } field1;
+    struct packed {
+      logic [7:0]  q;
+    } field2;
+    struct packed {
+      logic [2:0]  q;
+    } field3;
+    struct packed {
+      logic [1:0]  q;
+    } field4;
+    struct packed {
+      logic [1:0]  q;
+    } field5;
+    struct packed {
+      logic [1:0]  q;
+    } field6;
+    struct packed {
+      logic        q;
+    } field7;
+    struct packed {
+      logic        q;
+    } field8;
+  } flash_ctrl_reg2hw_csr6_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic [8:0]  q;
+    } field1;
+  } flash_ctrl_reg2hw_csr7_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } flash_ctrl_reg2hw_csr8_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } flash_ctrl_reg2hw_csr9_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } flash_ctrl_reg2hw_csr10_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } flash_ctrl_reg2hw_csr11_reg_t;
+
+  typedef struct packed {
+    logic [9:0] q;
+  } flash_ctrl_reg2hw_csr12_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [19:0] q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+  } flash_ctrl_reg2hw_csr13_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+  } flash_ctrl_reg2hw_csr14_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+  } flash_ctrl_reg2hw_csr15_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+  } flash_ctrl_reg2hw_csr16_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+  } flash_ctrl_reg2hw_csr17_reg_t;
+
+  typedef struct packed {
+    logic        q;
+  } flash_ctrl_reg2hw_csr18_reg_t;
+
+  typedef struct packed {
+    logic        q;
+  } flash_ctrl_reg2hw_csr19_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } field0;
+    struct packed {
+      logic        q;
+    } field1;
+    struct packed {
+      logic        q;
+    } field2;
+  } flash_ctrl_reg2hw_csr20_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } field0;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field1;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field2;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field3;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field4;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field5;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field6;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field7;
+  } flash_ctrl_hw2reg_csr2_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } field0;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field1;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field2;
+  } flash_ctrl_hw2reg_csr20_reg_t;
+
+  // Register -> HW type for prim interface
+  typedef struct packed {
+    flash_ctrl_reg2hw_csr1_reg_t csr1; // [325:313]
+    flash_ctrl_reg2hw_csr2_reg_t csr2; // [312:305]
+    flash_ctrl_reg2hw_csr3_reg_t csr3; // [304:277]
+    flash_ctrl_reg2hw_csr4_reg_t csr4; // [276:265]
+    flash_ctrl_reg2hw_csr5_reg_t csr5; // [264:242]
+    flash_ctrl_reg2hw_csr6_reg_t csr6; // [241:217]
+    flash_ctrl_reg2hw_csr7_reg_t csr7; // [216:200]
+    flash_ctrl_reg2hw_csr8_reg_t csr8; // [199:168]
+    flash_ctrl_reg2hw_csr9_reg_t csr9; // [167:136]
+    flash_ctrl_reg2hw_csr10_reg_t csr10; // [135:104]
+    flash_ctrl_reg2hw_csr11_reg_t csr11; // [103:72]
+    flash_ctrl_reg2hw_csr12_reg_t csr12; // [71:62]
+    flash_ctrl_reg2hw_csr13_reg_t csr13; // [61:41]
+    flash_ctrl_reg2hw_csr14_reg_t csr14; // [40:32]
+    flash_ctrl_reg2hw_csr15_reg_t csr15; // [31:23]
+    flash_ctrl_reg2hw_csr16_reg_t csr16; // [22:14]
+    flash_ctrl_reg2hw_csr17_reg_t csr17; // [13:5]
+    flash_ctrl_reg2hw_csr18_reg_t csr18; // [4:4]
+    flash_ctrl_reg2hw_csr19_reg_t csr19; // [3:3]
+    flash_ctrl_reg2hw_csr20_reg_t csr20; // [2:0]
+  } flash_ctrl_prim_reg2hw_t;
+
+  // HW -> register type for prim interface
+  typedef struct packed {
+    flash_ctrl_hw2reg_csr2_reg_t csr2; // [21:6]
+    flash_ctrl_hw2reg_csr20_reg_t csr20; // [5:0]
+  } flash_ctrl_prim_hw2reg_t;
+
+  // Register offsets for prim interface
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR0_REGWEN_OFFSET = 7'h 0;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR1_OFFSET = 7'h 4;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR2_OFFSET = 7'h 8;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR3_OFFSET = 7'h c;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR4_OFFSET = 7'h 10;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR5_OFFSET = 7'h 14;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR6_OFFSET = 7'h 18;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR7_OFFSET = 7'h 1c;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR8_OFFSET = 7'h 20;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR9_OFFSET = 7'h 24;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR10_OFFSET = 7'h 28;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR11_OFFSET = 7'h 2c;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR12_OFFSET = 7'h 30;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR13_OFFSET = 7'h 34;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR14_OFFSET = 7'h 38;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR15_OFFSET = 7'h 3c;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR16_OFFSET = 7'h 40;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR17_OFFSET = 7'h 44;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR18_OFFSET = 7'h 48;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR19_OFFSET = 7'h 4c;
+  parameter logic [PrimAw-1:0] FLASH_CTRL_CSR20_OFFSET = 7'h 50;
+
+  // Register index for prim interface
+  typedef enum int {
+    FLASH_CTRL_CSR0_REGWEN,
+    FLASH_CTRL_CSR1,
+    FLASH_CTRL_CSR2,
+    FLASH_CTRL_CSR3,
+    FLASH_CTRL_CSR4,
+    FLASH_CTRL_CSR5,
+    FLASH_CTRL_CSR6,
+    FLASH_CTRL_CSR7,
+    FLASH_CTRL_CSR8,
+    FLASH_CTRL_CSR9,
+    FLASH_CTRL_CSR10,
+    FLASH_CTRL_CSR11,
+    FLASH_CTRL_CSR12,
+    FLASH_CTRL_CSR13,
+    FLASH_CTRL_CSR14,
+    FLASH_CTRL_CSR15,
+    FLASH_CTRL_CSR16,
+    FLASH_CTRL_CSR17,
+    FLASH_CTRL_CSR18,
+    FLASH_CTRL_CSR19,
+    FLASH_CTRL_CSR20
+  } flash_ctrl_prim_id_e;
+
+  // Register width information to check illegal writes for prim interface
+  parameter logic [3:0] FLASH_CTRL_PRIM_PERMIT [21] = '{
+    4'b 0001, // index[ 0] FLASH_CTRL_CSR0_REGWEN
+    4'b 0011, // index[ 1] FLASH_CTRL_CSR1
+    4'b 0001, // index[ 2] FLASH_CTRL_CSR2
+    4'b 1111, // index[ 3] FLASH_CTRL_CSR3
+    4'b 0011, // index[ 4] FLASH_CTRL_CSR4
+    4'b 0111, // index[ 5] FLASH_CTRL_CSR5
+    4'b 1111, // index[ 6] FLASH_CTRL_CSR6
+    4'b 0111, // index[ 7] FLASH_CTRL_CSR7
+    4'b 1111, // index[ 8] FLASH_CTRL_CSR8
+    4'b 1111, // index[ 9] FLASH_CTRL_CSR9
+    4'b 1111, // index[10] FLASH_CTRL_CSR10
+    4'b 1111, // index[11] FLASH_CTRL_CSR11
+    4'b 0011, // index[12] FLASH_CTRL_CSR12
+    4'b 0111, // index[13] FLASH_CTRL_CSR13
+    4'b 0011, // index[14] FLASH_CTRL_CSR14
+    4'b 0011, // index[15] FLASH_CTRL_CSR15
+    4'b 0011, // index[16] FLASH_CTRL_CSR16
+    4'b 0011, // index[17] FLASH_CTRL_CSR17
+    4'b 0001, // index[18] FLASH_CTRL_CSR18
+    4'b 0001, // index[19] FLASH_CTRL_CSR19
+    4'b 0001  // index[20] FLASH_CTRL_CSR20
   };
 
 endpackage


### PR DESCRIPTION
The first commit is part of #13949 and will be rebased away.
The second commit adds generic registers for the flash controller.