### PR TITLE
[docs] Expand menus without immedate siblings

### DIFF
--- a/site/docs/layouts/partials/menu.html
+++ b/site/docs/layouts/partials/menu.html
@@ -25,7 +25,7 @@
                     {{- replaceRE "/" "-" $noparent }}{{- .File.TranslationBaseName }}
                 {{- end }}
             </a>
-            {{- if and (ne $numberOfPages 0) (or (.IsDescendant $displayedNode) (.IsAncestor $displayedNode) (.InSection $displayedNode)) }}
+            {{- if (or (.IsDescendant $displayedNode) (.IsAncestor $displayedNode) (.InSection $displayedNode)) }}
                 <ul class="{{- if .IsAncestor $displayedNode}} ancestor{{- end }}
                     {{- if ne $numberOfPages 0 }} parent{{- end }}">
                     {{- $subElements := dict }}


### PR DESCRIPTION
This change fixes an issue with the hardware IP menu not rendering the
IP specification pages. With this change, the menus traversal is
continued as long as there are more nodes to parse, instead of truncating
the traversal if there are no **immediate** sections or pages detected,

<img width="1286" alt="Screen Shot 2022-07-29 at 20 40 44" src="https://user-images.githubusercontent.com/4177786/181871113-0855342b-254b-44c4-a516-fff43fa6d08c.png">

