### PR TITLE
[rv_dm dv] Fix DTM RAL CSR failures

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_dtm_reg_block.sv
+++ b/hw/dv/sv/jtag_agent/jtag_dtm_reg_block.sv
@@ -253,6 +253,8 @@ class jtag_dtm_reg_dtmcs extends jtag_dtm_base_reg;
       .individually_accessible(0));
 
     dmihardreset.set_original_access("W1C");
+    // Writing 1 to this field will clear the dmi register, causing read-check mismatches.
+    csr_excl.add_excl(dmihardreset.get_full_name(), CsrExclWrite, CsrNonInitTests);
 
     zero1 = (dv_base_reg_field::type_id::create("zero1"));
     zero1.configure(

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_csr_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_csr_vseq.sv
@@ -8,6 +8,9 @@ class rv_dm_jtag_dtm_csr_vseq extends rv_dm_common_vseq;
   `uvm_object_new
 
   virtual task body();
+    // Clear the jtag_dtm_ral.dmi.op field before starting the CSR suite of tests to ensure its
+    // mirrored value reflects 0 (nop) instead of the value from previous accesses.
+    csr_wr(.ptr(jtag_dtm_ral.dmi.op), .value(0), .blocking(1), .predict(1));
     run_csr_vseq_wrapper(.num_times(num_trans), .models({jtag_dtm_ral}));
   endtask : body
 


### PR DESCRIPTION
There are 2 fixes - write exclusion on `dtmcs.dmihardreset` field
and write of 0 to `dmi.op` field before CSR suite tests commence.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>