### PR TITLE
[entropy_src/dv] Track FW_OV FIFO exceptions

### DIFF
--- a/hw/dv/sv/common_ifs/entropy_subsys_fifo_exception_if.core
+++ b/hw/dv/sv/common_ifs/entropy_subsys_fifo_exception_if.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:entropy_subsys_fifo_exception_if"
+description: "DV interface for detecting FIFO exceptions, particularly in entropy subsystem IPs"
+
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_lib
+    files:
+      - entropy_subsys_fifo_exception_pkg.sv
+      - entropy_subsys_fifo_exception_if.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/common_ifs/entropy_subsys_fifo_exception_if.sv
+++ b/hw/dv/sv/common_ifs/entropy_subsys_fifo_exception_if.sv
@@ -1,0 +1,59 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Interface for capturing overflow/underflow/status events in
+// entropy complex (entropy_src, CSRNG, EDN) fifos
+
+
+interface entropy_subsys_fifo_exception_if#(
+  parameter bit IsPackerFifo = 0
+)
+(
+   input logic clk_i,
+   input logic rst_ni,
+
+   input logic wready_o,
+   input logic wvalid_i,
+   input logic rready_i,
+   input logic rvalid_o,
+   input logic full_o
+);
+
+   import entropy_subsys_fifo_exception_pkg::*;
+
+   logic read_err_d, write_err_d, state_err_d;
+   logic read_err_q, write_err_q, state_err_q;
+   logic read_err_pulse, write_err_pulse, state_err_pulse;
+   logic write_forbidden;
+
+   logic [N_FIFO_ERR_TYPES-1:0] error_pulses;
+   assign error_pulses[FIFO_READ_ERR]  = read_err_pulse;
+   assign error_pulses[FIFO_WRITE_ERR] = write_err_pulse;
+   assign error_pulses[FIFO_STATE_ERR] = state_err_pulse;
+
+   // Error conidtions map to the types of events that cause errors in the
+   // entropy subsystem IPs
+   assign write_forbidden = IsPackerFifo ? !wready_o : full_o;
+
+   assign write_err_d  = wvalid_i && write_forbidden;
+   assign read_err_d   = IsPackerFifo ?  1'b0 : (!rvalid_o && rready_i);
+   assign state_err_d  = IsPackerFifo ?  1'b0 : (!rvalid_o && full_o);
+
+   always @(posedge clk_i) begin
+     state_err_q <= state_err_d;
+     read_err_q  <= read_err_d;
+     write_err_q <= write_err_d;
+   end
+
+   clocking mon_cb @(posedge clk_i);
+     input write_forbidden;
+     input error_pulses;
+   endclocking
+
+
+   assign write_err_pulse = write_err_d && !write_err_q;
+   assign state_err_pulse = state_err_d && !state_err_q;
+   assign read_err_pulse = read_err_d && !read_err_q;
+
+endinterface : entropy_subsys_fifo_exception_if

--- a/hw/dv/sv/common_ifs/entropy_subsys_fifo_exception_pkg.sv
+++ b/hw/dv/sv/common_ifs/entropy_subsys_fifo_exception_pkg.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Datatypes for describing FIFO exceptions in the Entropy Subsystem
+//
+
+package entropy_subsys_fifo_exception_pkg;
+
+  typedef enum int {
+    FIFO_READ_ERR  = 0,
+    FIFO_WRITE_ERR,
+    FIFO_STATE_ERR,
+    N_FIFO_ERR_TYPES
+  } fifo_exception_e;
+
+endpackage

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.core
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:cip_lib
       - lowrisc:dv:push_pull_agent
+      - lowrisc:dv:entropy_subsys_fifo_exception_if
     files:
       - entropy_src_env_pkg.sv
       - entropy_src_path_if.sv

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -45,6 +45,9 @@ class entropy_src_env extends cip_base_env #(
     cfg.m_csrng_agent_cfg.if_mode    = dv_utils_pkg::Host;
     cfg.m_csrng_agent_cfg.en_cov     = cfg.en_cov;
 
+    uvm_config_db#(virtual entropy_subsys_fifo_exception_if#(1))::get(this, "", "precon_fifo_vif",
+        cfg.precon_fifo_vif);
+
     if (!uvm_config_db#(virtual pins_if#(8))::get(this, "", "otp_en_es_fw_read_vif",
         cfg.otp_en_es_fw_read_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get otp_en_es_fw_read_vif from uvm_config_db")

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -18,6 +18,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   virtual pins_if#(8)   otp_en_es_fw_read_vif;
   virtual pins_if#(8)   otp_en_es_fw_over_vif;
 
+
   // Configuration for DUT CSRs (held in a separate object for easy re-randomization)
   entropy_src_dut_cfg dut_cfg;
 
@@ -28,6 +29,9 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
 
   // handle to the interrupt interface
   intr_vif interrupt_vif;
+  // Pointer to the preconditioning fifo exception interface.
+  // (For tracking errors during FW_OV mode)
+  virtual entropy_subsys_fifo_exception_if#(1) precon_fifo_vif;
 
   //
   // Variables for controlling test duration.  Depending on the test there are two options:
@@ -139,10 +143,10 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
     dut_cfg = entropy_src_dut_cfg::type_id::create("dut_cfg");
 
     // create agent config objs
-    m_rng_agent_cfg   = push_pull_agent_cfg#(.HostDataWidth(RNG_BUS_WIDTH))::
-                        type_id::create("m_rng_agent_cfg");
-    m_csrng_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))::
-                        type_id::create("m_csrng_agent_cfg");
+    m_rng_agent_cfg       = push_pull_agent_cfg#(.HostDataWidth(RNG_BUS_WIDTH))::
+                            type_id::create("m_rng_agent_cfg");
+    m_csrng_agent_cfg     = push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))::
+                            type_id::create("m_csrng_agent_cfg");
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -15,6 +15,7 @@ package entropy_src_env_pkg;
   import push_pull_agent_pkg::*;
   import entropy_src_pkg::*;
   import prim_mubi_pkg::*;
+  import entropy_subsys_fifo_exception_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -83,6 +83,9 @@ module tb;
   assign interrupts[ObserveFifoReady] = intr_observe_fifo_ready;
   assign interrupts[FatalErr]         = intr_fatal_err;
 
+  bind prim_packer_fifo : dut.u_entropy_src_core.u_prim_packer_fifo_precon
+    entropy_subsys_fifo_exception_if#(1) u_fifo_exc_if (.*);
+
   initial begin
     // Drive clk and rst_n from clk_if
     // Set interfaces in config_db
@@ -99,6 +102,8 @@ module tb;
     uvm_config_db#(virtual pins_if#(8))::set(null, "*.env", "otp_en_es_fw_over_vif",
         otp_en_es_fw_over_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+    uvm_config_db#(virtual entropy_subsys_fifo_exception_if#(1))::set(null, "*.env",
+        "precon_fifo_vif", dut.u_entropy_src_core.u_prim_packer_fifo_precon.u_fifo_exc_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH)))::set
         (null, "*.env.m_rng_agent*", "vif", rng_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)))::


### PR DESCRIPTION
This commit aims to support verification of the the new
recoverable ES_FW_OV_WR_ALERT by tracking FIFO overflow conditions
inside the DUT

To a achieve this a new entropy_subsys_fifo_exception_monitor class is
added.  This uses interface that can be bound to either a packer FIFO or
a synchronous FIFO.  (Though these two primitives have some port
differences, the interface is parametrizeable to attach to either,
leaving unbound/non-existent ports unused).

This new FIFO exception monitor is identified as specific to the entropy
subsystem, as only the IPs in this subsystem have exceptions for these
FIFO events.

A new exception monitor is then bound to the Pre-conditioning packer
FIFO, and the scoreboard is updated to properly predict future
DUT outputs should one of these events occur.

Further more the FW_OV test, now runs on average at a higher rate,
in order to both test the new testbench functionality, but also
to generate more seeds for better coverage in each test.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>