### PR TITLE
[crypto] Add constant-time test rule for OTBN programs.

### DIFF
--- a/hw/ip/otbn/util/BUILD
+++ b/hw/ip/otbn/util/BUILD
@@ -37,3 +37,15 @@ py_binary(
         "//hw/ip/otbn/util/shared:toolchain",
     ],
 )
+
+py_binary(
+    name = "check_const_time",
+    srcs = ["check_const_time.py"],
+    deps = [
+        "//hw/ip/otbn/util/shared:check",
+        "//hw/ip/otbn/util/shared:control_flow",
+        "//hw/ip/otbn/util/shared:decode",
+        "//hw/ip/otbn/util/shared:information_flow_analysis",
+        requirement("pyelftools"),
+    ],
+)

--- a/hw/ip/otbn/util/check_const_time.py
+++ b/hw/ip/otbn/util/check_const_time.py
@@ -5,7 +5,6 @@
 
 import argparse
 import sys
-from typing import Dict, List, Optional, Set, Tuple
 
 from shared.check import CheckResult
 from shared.control_flow import program_control_graph, subroutine_control_graph
@@ -76,6 +75,9 @@ def main() -> int:
 
     if args.verbose or out.has_errors() or out.has_warnings():
         print(out.report())
+
+    if out.has_errors() or out.has_warnings():
+        return 1
 
     return 0
 

--- a/hw/ip/otbn/util/shared/BUILD
+++ b/hw/ip/otbn/util/shared/BUILD
@@ -17,6 +17,52 @@ py_library(
 )
 
 py_library(
+    name = "cache",
+    srcs = ["cache.py"],
+)
+
+py_library(
+    name = "check",
+    srcs = ["check.py"],
+)
+
+py_library(
+    name = "constants",
+    srcs = ["constants.py"],
+    deps = [
+        ":insn_yaml",
+        ":operand",
+    ],
+)
+
+py_library(
+    name = "control_flow",
+    srcs = ["control_flow.py"],
+    deps = [
+        ":decode",
+        ":insn_yaml",
+        ":section",
+    ],
+)
+
+py_library(
+    name = "decode",
+    srcs = ["decode.py"],
+    deps = [
+        ":elf",
+        ":insn_yaml",
+    ],
+)
+
+py_library(
+    name = "elf",
+    srcs = ["elf.py"],
+    deps = [
+        ":mem_layout",
+    ],
+)
+
+py_library(
     name = "encoding",
     srcs = ["encoding.py"],
     deps = [
@@ -46,6 +92,20 @@ py_library(
 )
 
 py_library(
+    name = "information_flow_analysis",
+    srcs = ["information_flow_analysis.py"],
+    deps = [
+        ":cache",
+        ":constants",
+        ":control_flow",
+        ":decode",
+        ":information_flow",
+        ":insn_yaml",
+        "//util/serialize:parse_helpers",
+    ],
+)
+
+py_library(
     name = "insn_yaml",
     srcs = ["insn_yaml.py"],
     deps = [
@@ -56,6 +116,15 @@ py_library(
         ":operand",
         ":syntax",
         "//util/serialize:parse_helpers",
+    ],
+)
+
+py_library(
+    name = "instruction_count_range",
+    srcs = ["instruction_count_range.py"],
+    deps = [
+        ":control_flow",
+        ":decode",
     ],
 )
 
@@ -93,6 +162,15 @@ py_library(
     deps = [
         "//util/reggen:ip_block",
         "//util/reggen:reg_block",
+    ],
+)
+
+py_library(
+    name = "section",
+    srcs = ["section.py"],
+    deps = [
+        ":decode",
+        ":insn_yaml",
     ],
 )
 

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:otbn.bzl", "otbn_binary", "otbn_library", "otbn_sim_test")
+load("//rules:otbn.bzl", "otbn_binary", "otbn_consttime_test", "otbn_library", "otbn_sim_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,6 +21,14 @@ otbn_sim_test(
     deps = [
         ":ed25519",
         ":field25519",
+    ],
+)
+
+otbn_consttime_test(
+    name = "ed25519_ext_add_consttime",
+    subroutine = "ext_add",
+    deps = [
+        ":ed25519_ext_add_test",
     ],
 )
 
@@ -58,6 +66,30 @@ otbn_sim_test(
     ],
 )
 
+otbn_consttime_test(
+    name = "field25519_fe_inv_consttime",
+    subroutine = "fe_inv",
+    deps = [
+        ":field25519_test",
+    ],
+)
+
+otbn_consttime_test(
+    name = "field25519_fe_mul_consttime",
+    subroutine = "fe_mul",
+    deps = [
+        ":field25519_test",
+    ],
+)
+
+otbn_consttime_test(
+    name = "field25519_fe_square_consttime",
+    subroutine = "fe_square",
+    deps = [
+        ":field25519_test",
+    ],
+)
+
 otbn_library(
     name = "modexp",
     srcs = [
@@ -91,6 +123,52 @@ otbn_binary(
         ":p256",
     ],
 )
+
+otbn_consttime_test(
+    name = "p256_base_mult_consttime",
+    subroutine = "p256_base_mult",
+    deps = [
+        ":p256_ecdsa",
+    ],
+)
+
+otbn_consttime_test(
+    name = "p256_isoncurve_consttime",
+    subroutine = "p256_isoncurve",
+    deps = [
+        ":p256_ecdsa",
+    ],
+)
+
+otbn_consttime_test(
+    name = "p256_proj_add_consttime",
+    subroutine = "proj_add",
+    deps = [
+        ":p256_ecdsa",
+    ],
+)
+
+otbn_consttime_test(
+    name = "p256_scalar_mult_consttime",
+    subroutine = "p256_scalar_mult",
+    deps = [
+        ":p256_ecdsa",
+    ],
+)
+
+# TODO: Add more fine-grained DMEM tracing to the constant-time checker. This
+# test fails because p256_sign branches based on some non-secret values from
+# DMEM. However, since there are also secret values in DMEM, it's not safe to
+# mark DMEM non-secret, and the constant-time checker doesn't currently have
+# the ability to track different DMEM regions separately.
+#
+# otbn_consttime_test(
+#   name = "p256_sign_consttime",
+#   deps = [
+#       ":p256_ecdsa"
+#   ],
+#   subroutine = "p256_sign",
+# )
 
 otbn_binary(
     name = "p256_ecdsa_sign_test",
@@ -225,6 +303,66 @@ otbn_binary(
     deps = [
         ":p384_base",
         ":p384_sign",
+    ],
+)
+
+otbn_consttime_test(
+    name = "p384_base_mult_consttime",
+    subroutine = "p384_base_mult",
+    deps = [
+        ":p384_ecdsa_sign_test",
+    ],
+)
+
+otbn_consttime_test(
+    name = "p384_mulmod_p_consttime",
+    subroutine = "p384_mulmod_p",
+    deps = [
+        ":p384_ecdsa_sign_test",
+    ],
+)
+
+otbn_consttime_test(
+    name = "p384_mulmod_n_consttime",
+    subroutine = "p384_mulmod_n",
+    deps = [
+        ":p384_ecdsa_sign_test",
+    ],
+)
+
+# TODO: Add more fine-grained DMEM tracing to the constant-time checker. This
+# test fails because p384_sign branches based on some non-secret values from
+# DMEM. However, since there are also secret values in DMEM, it's not safe to
+# mark DMEM non-secret, and the constant-time checker doesn't currently have
+# the ability to track different DMEM regions separately.
+#
+# otbn_consttime_test(
+#   name = "p384_sign_consttime",
+#   deps = [
+#       ":p384_ecdsa_sign_test"
+#   ],
+#   subroutine = "p384_sign",
+# )
+
+# TODO: Add an argument to the constant-time checker script that accepts
+# "required constant registers". This test fails because the subroutine
+# requires some registers (indirect references) to be constant at the start,
+# and without this information the constant-time checker cannot construct the
+# information-flow graph.
+#
+# otbn_consttime_test(
+#   name = "p384_proj_add_consttime",
+#   deps = [
+#       ":p384_ecdsa_sign_test"
+#   ],
+#   subroutine = "proj_add_p384",
+# )
+
+otbn_consttime_test(
+    name = "scalar_mult_p384_consttime",
+    subroutine = "scalar_mult_p384",
+    deps = [
+        ":p384_ecdsa_sign_test",
     ],
 )
 
@@ -387,5 +525,13 @@ otbn_sim_test(
     deps = [
         ":field25519",
         ":x25519",
+    ],
+)
+
+otbn_consttime_test(
+    name = "x25519_consttime",
+    subroutine = "X25519",
+    deps = [
+        ":x25519_test",
     ],
 )

--- a/sw/otbn/crypto/p384_base.s
+++ b/sw/otbn/crypto/p384_base.s
@@ -23,7 +23,7 @@
  * @param[in] w31: all-zero.
  * @param[out] [w20:w18]: c, result, max. length 768 bit.
  *
- * Clobbered registers: TODO
+ * Clobbered registers: w18 to w20
  * Clobbered flag groups: FG0
  */
 mul384:


### PR DESCRIPTION
This rule allows us to create Bazel tests that run the OTBN constant-time checker on specific programs or subroutines, causing CI failures when an expected constant-time subroutine is not provably constant-time.

Resolves #13909