### PR TITLE
[dif/edn] Allow `seed_material` to be NULL for `dif_edn_instantiate()`

### DIFF
--- a/sw/device/lib/dif/dif_csrng_shared.c
+++ b/sw/device/lib/dif/dif_csrng_shared.c
@@ -24,6 +24,13 @@ dif_result_t csrng_send_app_cmd(mmio_region_t base_addr, ptrdiff_t offset,
     return kDifBadArg;
   }
 
+  // Ensure the `seed_material` array is word-aligned, so it can be loaded to a
+  // CPU register with natively aligned loads.
+  if (cmd.seed_material != NULL &&
+      misalignment32_of((uintptr_t)cmd.seed_material->seed_material) != 0) {
+    return kDifBadArg;
+  }
+
   // Build and write application command header.
   uint32_t reg = bitfield_field32_write(0, kAppCmdFieldCmdId, cmd.id);
   reg = bitfield_field32_write(reg, kAppCmdFieldCmdLen, cmd_len);

--- a/sw/device/lib/dif/dif_edn.c
+++ b/sw/device/lib/dif/dif_edn.c
@@ -222,24 +222,13 @@ dif_result_t dif_edn_instantiate(
   if (edn == NULL) {
     return kDifBadArg;
   }
-  dif_csrng_seed_material_t *seed_material_ptr;
-  dif_csrng_seed_material_t seed_material2;
-  if (seed_material == NULL) {
-    // Caller provided no seed material; simply pass the NULL pointer on.
-    seed_material_ptr = NULL;
-  } else {
-    // Caller provided seed material; copy it to the stack and pass a pointer
-    // to that.
-    memcpy(&seed_material2, seed_material, sizeof(seed_material2));
-    seed_material_ptr = &seed_material2;
-  }
   return csrng_send_app_cmd(
       edn->base_addr, EDN_SW_CMD_REQ_REG_OFFSET,
       (csrng_app_cmd_t){
           .id = kCsrngAppCmdInstantiate,
           .entropy_src_enable =
               (dif_csrng_entropy_src_toggle_t)entropy_src_enable,
-          .seed_material = seed_material_ptr,
+          .seed_material = (const dif_csrng_seed_material_t *)seed_material,
       });
 }
 

--- a/sw/device/lib/dif/dif_edn.c
+++ b/sw/device/lib/dif/dif_edn.c
@@ -219,18 +219,27 @@ dif_result_t dif_edn_get_main_state_machine(const dif_edn_t *edn,
 dif_result_t dif_edn_instantiate(
     const dif_edn_t *edn, dif_edn_entropy_src_toggle_t entropy_src_enable,
     const dif_edn_seed_material_t *seed_material) {
-  if (edn == NULL || seed_material == NULL) {
+  if (edn == NULL) {
     return kDifBadArg;
   }
+  dif_csrng_seed_material_t *seed_material_ptr;
   dif_csrng_seed_material_t seed_material2;
-  memcpy(&seed_material2, seed_material, sizeof(seed_material2));
+  if (seed_material == NULL) {
+    // Caller provided no seed material; simply pass the NULL pointer on.
+    seed_material_ptr = NULL;
+  } else {
+    // Caller provided seed material; copy it to the stack and pass a pointer
+    // to that.
+    memcpy(&seed_material2, seed_material, sizeof(seed_material2));
+    seed_material_ptr = &seed_material2;
+  }
   return csrng_send_app_cmd(
       edn->base_addr, EDN_SW_CMD_REQ_REG_OFFSET,
       (csrng_app_cmd_t){
           .id = kCsrngAppCmdInstantiate,
           .entropy_src_enable =
               (dif_csrng_entropy_src_toggle_t)entropy_src_enable,
-          .seed_material = &seed_material2,
+          .seed_material = seed_material_ptr,
       });
 }
 

--- a/sw/device/lib/dif/dif_edn_unittest.cc
+++ b/sw/device/lib/dif/dif_edn_unittest.cc
@@ -268,6 +268,13 @@ TEST_F(CommandTest, InstantiateBadArgs) {
   EXPECT_DIF_BADARG(dif_edn_instantiate(nullptr, kDifEdnEntropySrcToggleDisable,
                                         &seed_material_));
 
+  // Unaligned `seed_material` pointer.
+  dif_edn_seed_material_t *corrupt_seed_material_ptr =
+      reinterpret_cast<dif_edn_seed_material_t *>(
+          reinterpret_cast<uintptr_t>(&seed_material_) + 3);
+  EXPECT_DIF_BADARG(dif_edn_instantiate(&edn_, kDifEdnEntropySrcToggleDisable,
+                                        corrupt_seed_material_ptr));
+
   // Failed overflow check.
   seed_material_.len = 16;
   EXPECT_DIF_BADARG(dif_edn_instantiate(&edn_, kDifEdnEntropySrcToggleDisable,


### PR DESCRIPTION
The documentation of `dif_edn_instantiate()` specifies that the
`seed_material` argument can be `NULL`, in which case CSRNG will use a
zero vector instead.  Prior to this commit, `dif_edn_instantiate()`
would return `kDifBadArg` in this case, however.

This commit fixes that by passing the `NULL` pointer for `seed_material`
on to `csrng_send_app_cmd()`, which in this case will correctly program
the CSRNG with a seed of length zero.