### PR TITLE
[flash_ctrl,dv] otf regression clean up

### DIFF
--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_monitor.sv
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_monitor.sv
@@ -23,11 +23,18 @@ class flash_phy_prim_monitor extends dv_base_monitor #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    foreach(eg_rtl_port[i]) begin
+    foreach (eg_rtl_port[i]) begin
       eg_rtl_port[i] = new($sformatf("eg_rtl_port[%0d]", i), this);
       rd_cmd_port[i] = new($sformatf("rd_cmd_port[%0d]", i), this);
     end
   endfunction
+
+  task reset_task;
+    forever begin
+      @(negedge cfg.vif.rst_n);
+      foreach (write_buffer[i]) write_buffer[i] = '{};
+    end
+  endtask // reset_task
 
   task run_phase(uvm_phase phase);
     if (cfg.scb_otf_en) begin
@@ -36,6 +43,7 @@ class flash_phy_prim_monitor extends dv_base_monitor #(
       fork
         super.run_phase(phase);
         monitor_core();
+        reset_task();
       join_none
     end
   endtask

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -22,6 +22,7 @@ filesets:
       - flash_mem_bkdr_util.sv: {is_include_file: true}
       - flash_mem_addr_attrs.sv: {is_include_file: true}
       - flash_otf_item.sv: {is_include_file: true}
+      - flash_otf_read_entry.sv: {is_include_file: true}
       - flash_ctrl_seq_cfg.sv: {is_include_file: true}
       - flash_ctrl_env_cfg.sv: {is_include_file: true}
       - flash_ctrl_env_cov.sv: {is_include_file: true}

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -706,7 +706,7 @@ class flash_ctrl_scoreboard #(
                         {item.a_addr[AddrWidth-1:3],3'b0},
                         item.a_addr, ecc_err,
                         channel.name, ral_name
-                        ), UVM_MEDIUM)
+                        ), UVM_HIGH)
 
     if ((ral_name == cfg.flash_ral_name) && (get_flash_instr_type_err(item, channel))) return (1);
     else if (ecc_err) begin

--- a/hw/ip/flash_ctrl/dv/env/flash_otf_read_entry.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_otf_read_entry.sv
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Miscellaneous class to maintain read address
+class flash_otf_read_entry extends uvm_object;
+  `uvm_object_utils(flash_otf_read_entry)
+  string name;
+  rd_cache_t prv_read[NumBanks][$];
+  bit hash[rd_cache_t];
+  `uvm_object_new
+
+  // Push to prv_read.
+  // When size > 4, pop the oldest entry
+  function void insert(rd_cache_t it, flash_op_t flash_op);
+    rd_cache_t ot;
+    int        size, is_odd, tail;
+    addr_t aligned_addr;
+    is_odd = flash_op.addr[2];
+    size = (flash_op.num_words + is_odd) / 2;
+    tail = (flash_op.num_words + is_odd) % 2;
+    aligned_addr = it.addr;
+    aligned_addr[2:0] = 'h0;
+
+    for (int i = 0; i < size; i++) begin
+      it.addr = aligned_addr;
+      if (!hash.exists(it)) begin
+        prv_read[it.bank].push_back(it);
+        hash[it] = 1;
+        if (prv_read[it.bank].size > 4) begin
+          ot = prv_read[it.bank].pop_front();
+          hash.delete(ot);
+        end
+      end
+      aligned_addr += 8;
+    end // for (int i = 0; i < size; i++)
+    if (tail) begin
+      it.addr = aligned_addr;
+      if (!hash.exists(it)) begin
+        prv_read[it.bank].push_back(it);
+        hash[it] = 1;
+        if (prv_read[it.bank].size > 4) begin
+          ot = prv_read[it.bank].pop_front();
+          hash.delete(ot);
+        end
+      end
+    end
+  endfunction
+
+  function void print(string str = "flash_otf_read_entry");
+    for(int i = 0; i < NumBanks; ++i) begin
+      foreach (prv_read[i][j]) begin
+        `uvm_info(str, $sformatf("ent[%0d][%0d]: %p", i, j, prv_read[i][j]), UVM_MEDIUM)
+      end
+    end
+  endfunction // print
+endclass // flash_otf_read_entry

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -86,7 +86,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       if (my_region.en != MuBi4True) my_region = default_region_cfg;
     end
     `uvm_info("get_region", $sformatf("page:%0d --> region:%0d",
-                                      page, cfg.p2r_map[page]), UVM_MEDIUM)
+                                      page, cfg.p2r_map[page]), UVM_HIGH)
     return my_region;
   endfunction // get_region
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_ro_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_ro_vseq.sv
@@ -33,6 +33,10 @@ class flash_ctrl_ro_vseq extends flash_ctrl_otf_base_vseq;
             num = $urandom_range(1, 32);
           end else begin
             num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
+            // Max transfer size of info is 512Byte.
+            if (num * fractions > 128) begin
+              num = 128 / fractions;
+            end
           end
           bank = rand_op.addr[OTFBankId];
           read_flash(ctrl, bank, num);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
@@ -38,6 +38,10 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
             num = $urandom_range(1, 32);
           end else begin
             num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
+            // Max transfer size of info is 512Byte.
+            if (num * fractions > 128) begin
+              num = 128 / fractions;
+            end
           end
           randcase
             1:prog_flash(ctrl, bank, num, fractions);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
@@ -22,6 +22,10 @@ class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
             num = $urandom_range(1, 32);
           end else begin
             num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
+            // Max transfer size of info is 512Byte.
+            if (num * fractions > 128) begin
+              num = 128 / fractions;
+            end
           end
           randcase
             1:prog_flash(ctrl, bank, num);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wo_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wo_vseq.sv
@@ -20,6 +20,10 @@ class flash_ctrl_wo_vseq extends flash_ctrl_otf_base_vseq;
         num = $urandom_range(1, 32);
       end else begin
         num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
+        // Max transfer size of info is 512Byte.
+        if (num * fractions > 128) begin
+          num = 128 / fractions;
+        end
       end
       bank = rand_op.addr[OTFBankId];
       prog_flash(ctrl, bank, num);


### PR DESCRIPTION
Fixed multiple regression test failure
- Add reset taks to phy_prim_monitor
- Add a new class 'flash_otf_read_entry' to mitigate read cache problem
  for error injection
- Expand error injection table to have address and part
- Fix to check error injection redundency and outstanding transaction
  per 8bytes.
- Remove misplaced ierr_created from add_bit_err function
- clean up analysis_fifo's and write_buffer for multiple runs
- Fix tb info page overflow issue
- Constraint single program access limit to 512B per page for info partition

Signed-off-by: Jaedon Kim <jdonjdon@google.com>