### PR TITLE
[silicon_creator] Ensure OTBN is idle before writes/commands.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -72,11 +72,13 @@ enum {
 rom_error_t otbn_execute(void);
 
 /**
- * Is OTBN busy executing an application?
+ * Blocks until OTBN is idle.
  *
- * @return OTBN is busy
+ * If OTBN is or becomes locked, an error will occur.
+ *
+ * @return Result of the operation.
  */
-bool otbn_is_busy(void);
+rom_error_t otbn_busy_wait_for_done(void);
 
 /**
  * OTBN Internal Errors

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -84,8 +84,13 @@ class IsBusyTest : public OtbnTest {};
 
 TEST_F(IsBusyTest, Success) {
   EXPECT_ABS_READ32(base_ + OTBN_STATUS_REG_OFFSET, kOtbnStatusBusyExecute);
+  EXPECT_ABS_READ32(base_ + OTBN_STATUS_REG_OFFSET, kOtbnStatusBusyExecute);
+  EXPECT_ABS_READ32(base_ + OTBN_STATUS_REG_OFFSET, kOtbnStatusBusyExecute);
+  EXPECT_ABS_READ32(base_ + OTBN_STATUS_REG_OFFSET, kOtbnStatusBusyExecute);
+  EXPECT_ABS_READ32(base_ + OTBN_STATUS_REG_OFFSET, kOtbnStatusIdle);
+  EXPECT_ABS_READ32(base_ + OTBN_STATUS_REG_OFFSET, kOtbnStatusIdle);
 
-  EXPECT_EQ(otbn_is_busy(), true);
+  EXPECT_EQ(otbn_busy_wait_for_done(), kErrorOk);
 }
 
 class GetErrBitsTest : public OtbnTest {};

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -99,6 +99,7 @@ enum module_ {
   X(kErrorOtbnSecWipeImemFailed,      ERROR_(4, kModuleOtbn, kInternal)), \
   X(kErrorOtbnSecWipeDmemFailed,      ERROR_(5, kModuleOtbn, kInternal)), \
   X(kErrorOtbnBadInsnCount,           ERROR_(6, kModuleOtbn, kInternal)), \
+  X(kErrorOtbnUnavailable,            ERROR_(7, kModuleOtbn, kInternal)), \
   \
   X(kErrorFlashCtrlDataRead,          ERROR_(1, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlInfoRead,          ERROR_(2, kModuleFlashCtrl, kInternal)), \

--- a/sw/device/silicon_creator/lib/otbn_util.c
+++ b/sw/device/silicon_creator/lib/otbn_util.c
@@ -21,19 +21,6 @@ void otbn_init(otbn_t *ctx) {
   };
 }
 
-rom_error_t otbn_busy_wait_for_done(otbn_t *ctx) {
-  while (otbn_is_busy()) {
-  }
-
-  otbn_err_bits_t err_bits;
-  otbn_err_bits_get(&err_bits);
-  if (err_bits != kOtbnErrBitsNoError) {
-    ctx->error_bits = err_bits;
-    return kErrorOtbnExecutionFailed;
-  }
-  return kErrorOk;
-}
-
 /**
  * Checks if the OTBN application's IMEM and DMEM address parameters are valid.
  *
@@ -61,6 +48,9 @@ rom_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
   if (!check_app_address_ranges(&app)) {
     return kErrorOtbnInvalidArgument;
   }
+
+  // If OTBN is busy, wait for it to be done.
+  HARDENED_RETURN_IF_ERROR(otbn_busy_wait_for_done());
 
   const size_t imem_num_words = app.imem_end - app.imem_start;
   const size_t data_num_words = app.dmem_data_end - app.dmem_data_start;


### PR DESCRIPTION
Adjust the silicon_creator OTBN driver to check that OTBN is idle before all writes/commands, and wait if not. Since OTBN now performs a secure wipe after coming out of reset, this check is needed to ensure mask ROM code waits for the secure wipe to finish before loading or running applications.

See https://github.com/lowRISC/opentitan/issues/13753 for some discussion.

CC @GregAC @johannheyszl @alphan 