### PR TITLE
[sigverify] Check that OTBN status is idle after command completes.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -118,8 +118,15 @@ static rom_error_t otbn_cmd_run(otbn_cmd_t cmd, rom_error_t error) {
   otbn_err_bits_get(&err_bits);
   res ^= err_bits;
 
-  if (launder32(res) == kErrorOk) {
+  // Status should be kOtbnStatusIdle; OTBN can also issue a done interrupt
+  // when transitioning to the "locked" state, so it is important to check
+  // the status here.
+  uint32_t status = abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET);
+
+  if (launder32(res) == kErrorOk && launder32(status) == kOtbnStatusIdle) {
     HARDENED_CHECK_EQ(res, kErrorOk);
+    HARDENED_CHECK_EQ(abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET),
+                      kOtbnStatusIdle);
     return res;
   }
   return error;

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -46,6 +46,11 @@ class OtbnTest : public mask_rom_test::MaskRomTest {
                        });
 
     EXPECT_ABS_READ32(base_ + OTBN_ERR_BITS_REG_OFFSET, err_bits);
+    EXPECT_ABS_READ32(base_ + OTBN_STATUS_REG_OFFSET, kOtbnStatusIdle);
+
+    if (err_bits == kOtbnErrBitsNoError) {
+      EXPECT_ABS_READ32(base_ + OTBN_STATUS_REG_OFFSET, kOtbnStatusIdle);
+    }
   }
 
   uint32_t base_ = TOP_EARLGREY_OTBN_BASE_ADDR;


### PR DESCRIPTION
OTBN can issue a "done" interrupt when transitioning to a locked state as well as to an idle state. This adds a check to catch any non-idle status after a command and return an error in that case, rather than returning `kErrorOk`.