### PR TITLE
[fpv/keymgr] Fix keymgr prim_flop_sparse_fsm path

### DIFF
--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -434,8 +434,7 @@
                rel_path: "hw/ip/keymgr/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: ["{*u_state_regs.state_o}",
-                         "{*u_ctrl.u_data_state_regs.state_o}"]
+               stopats: ["{*u_state_regs.state_o}"]
              }
              {
                name: kmac_sec_cm


### PR DESCRIPTION
This PR removes a non-exist path for prim_flop_sparse_fsm in keymgr,
which causes compile error.

Signed-off-by: Cindy Chen <chencindy@google.com>