### PR TITLE
[spi_device] Remove `bitcnt`

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -251,7 +251,6 @@ module spi_device
   io_mode_e           sub_iomode[IoModeEnd];
   logic               s2p_data_valid;
   spi_byte_t          s2p_data;
-  logic [BitCntW-1:0] s2p_bitcnt;
 
   logic        p2s_valid;
   spi_byte_t   p2s_data;
@@ -1216,7 +1215,6 @@ module spi_device
 
     .data_valid_o (s2p_data_valid),
     .data_o       (s2p_data      ),
-    .bitcnt_o     (s2p_bitcnt    ),
 
     // Config (changed dynamically)
     .order_i      (rxorder),
@@ -1361,7 +1359,6 @@ module spi_device
     // S2P
     .s2p_valid_i   (s2p_data_valid),
     .s2p_byte_i    (s2p_data),
-    .s2p_bitcnt_i  (s2p_bitcnt),
 
     // P2S
     .p2s_valid_o   (sub_p2s_valid [IoModeReadCmd]),
@@ -1527,7 +1524,6 @@ module spi_device
     // Interface: SPI to Parallel
     .s2p_valid_i  (s2p_data_valid),
     .s2p_byte_i   (s2p_data),
-    .s2p_bitcnt_i (s2p_bitcnt),
 
     // Interface: Parallel to SPI
     .p2s_valid_o (sub_p2s_valid[IoModeUpload]),

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -126,7 +126,6 @@ module spi_readcmd
   // Interface: SPI to Parallel
   input               s2p_valid_i,
   input spi_byte_t    s2p_byte_i,
-  input [BitCntW-1:0] s2p_bitcnt_i,
 
   // Interface: Parallel to SPI
   // Should be latched to clk_out_i
@@ -200,9 +199,6 @@ module spi_readcmd
           main_st == MainAddress |-> (cmd_info_i.addr_mode != AddrDisabled)
           && cmd_info_i.payload_dir == PayloadOut
           && cmd_info_i.valid)
-
-  logic unused_s2p_bitcnt;
-  assign unused_s2p_bitcnt = ^s2p_bitcnt_i;
 
   /////////////////
   // Definitions //

--- a/hw/ip/spi_device/rtl/spi_s2p.sv
+++ b/hw/ip/spi_device/rtl/spi_s2p.sv
@@ -16,7 +16,6 @@ module spi_s2p
   // to following logic
   output logic               data_valid_o,
   output spi_byte_t          data_o,
-  output logic [BitCntW-1:0] bitcnt_o, // up to 256B payload
 
   // Configuration
   input                             order_i,
@@ -37,7 +36,6 @@ module spi_s2p
   typedef logic [BitCntW-1:0] bitcount_t;
 
   count_t cnt;
-  bitcount_t bitcnt;
 
   spi_byte_t data_d, data_q;
 
@@ -72,21 +70,6 @@ module spi_s2p
   // send un-latched data
   assign data_o = data_d;
 
-  // total bit count
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      bitcnt <= '0;
-    end else begin
-      unique case (io_mode_i)
-        SingleIO: bitcnt <= bitcnt + bitcount_t'('h1);
-        DualIO:   bitcnt <= bitcnt + bitcount_t'('h2);
-        QuadIO:   bitcnt <= bitcnt + bitcount_t'('h4);
-        default:  bitcnt <= bitcnt;
-      endcase
-    end
-  end
-  assign bitcnt_o = bitcnt;
-
   // Bitcount in a byte
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -120,9 +103,5 @@ module spi_s2p
   // Right after reset (CSb assert), the io_mode_i shall be Single IO
   // to decode SPI Opcode.
   `ASSERT(IoModeDefault_A, $rose(rst_ni) |-> io_mode_i == SingleIO, clk_i, 0)
-
-  // Bitcnd shall not exceed 2**12
-  `ASSERT(BitcountOverflow_A, bitcnt != '1)
-
 
 endmodule

--- a/hw/ip/spi_device/rtl/spid_upload.sv
+++ b/hw/ip/spi_device/rtl/spid_upload.sv
@@ -87,7 +87,6 @@ module spid_upload
   // Interface: SPI to Parallel
   input               s2p_valid_i,
   input spi_byte_t    s2p_byte_i,
-  input [BitCntW-1:0] s2p_bitcnt_i,
 
   // Interface: Parallel to SPI
   // Not used in spid_upload
@@ -227,9 +226,6 @@ module spid_upload
 
 
   // unused
-  logic unused_s2p_bitcnt;
-  assign unused_s2p_bitcnt = ^s2p_bitcnt_i;
-
   logic unused_cmdinfo_idx;
   assign unused_cmdinfo_idx = ^cmd_info_idx_i;
 


### PR DESCRIPTION
`bitcnt` is 12 bit data counting how many bits `spi_s2p` has received.
The signal is then sent to the following modules along with the valid
signal and a byte data.

The signal assumes the max data transfer in a SPI transaction to 256B.
256B is common for SPI Flash page size.

However, the host can read more than a page size. And the signal is
never used in the following modules (spi_readcmd, spid_upload)

The issue has been reported by @weicaiyang in #13934 