### PR TITLE
[spi_device] Intercept Assertion

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1198,9 +1198,10 @@ module spi_device
     if (!rst_spi_n) intercept_en <= 1'b 0;
     else            intercept_en <= |intercept;
   end
-  // intercept_en shall not be de-asserted except reset
+  // intercept_en shall not be de-asserted except mailbox
   `ASSUME(InterceptLevel_M,
-    $rose(intercept_en) |=> $stable(intercept_en) until !rst_spi_n,
+    $rose(|{intercept.status, intercept.jedec, intercept.sfdp}) |=>
+      $stable(intercept_en) until !rst_spi_n,
     clk_spi_out_buf, !rst_spi_n)
 
   ////////////////////////////


### PR DESCRIPTION
Mailbox intercept behavior was revised to support mailbox crossing event
(from passthrough -> mailbox or mailbox -> passthrough). In this case,
`intercept_en` signal will be dropped when the read address crosses
upper mailbox boundary.

This commit revises the assertion to check intercept_en stability only
for Read Status, Read JEDEC ID, Read SFDP case.

Issue #13934 