### PR TITLE
[dv] Update TL max_outstanding_req for aes, edn, entropy_src, csrng

### DIFF
--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -281,5 +281,8 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
         `uvm_fatal(`gfn, $sformatf("FAILED TO GET HANDLE TO ROUND COUNTER INJECT INTERFACE %d",nn))
       end
     end
+
+    // only support 1 outstanding TL item
+    m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 endclass

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -138,6 +138,9 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
         get(null, "*.env" , "csrng_assert_vif", csrng_assert_vif)) begin
       `uvm_fatal(`gfn, $sformatf("FAILED TO GET HANDLE TO ASSERT IF"))
     end
+
+    // only support 1 outstanding TL item
+    m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 
   // Check internal state w/ optional compare

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -104,6 +104,9 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
         get(null, "*.env" , "edn_assert_vif", edn_assert_vif)) begin
       `uvm_fatal(`gfn, $sformatf("FAILED TO GET HANDLE TO ASSERT IF"))
     end
+
+    // only support 1 outstanding TL item
+    m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 
   virtual function string convert2string();

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -153,6 +153,9 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
         get(null, "*.env" , "entropy_src_assert_vif", entropy_src_assert_vif)) begin
       `uvm_fatal(`gfn, $sformatf("FAILED TO GET HANDLE TO ASSERT IF"))
     end
+
+    // only support 1 outstanding TL item
+    m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 
   virtual function string convert2string();


### PR DESCRIPTION
These blocks only support 1 TL outstanding_req item.
This change will make `m_max_outstanding_cg` reach 100%

Signed-off-by: Weicai Yang <weicai@google.com>