### PR TITLE
[dvsim] Use default dvsim wall clock time if tool is not supported

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
 import logging as log
 import pprint
 import random
@@ -294,6 +295,8 @@ class Deploy():
                 log_text, self.sim_cfg.tool)
         except NotImplementedError:
             log.debug("Using dvsim default runtime due to unsupported tool: " + self.sim_cfg.tool)
+            self.job_runtime.time = \
+                (datetime.datetime.now() - self.launcher.start_time).total_seconds()
         except SyntaxError:
             log.debug("Parsing job runtime has syntax error with " + self.sim_cfg.tool)
 


### PR DESCRIPTION
This PR adds logic to use default wall clock time if the tool is not
supported to parse the wall clock time.
Related to issue: https://github.com/lowRISC/opentitan/issues/13903

Signed-off-by: Cindy Chen <chencindy@opentitan.org>