### PR TITLE
[dv/clkmgr] Exclude hint_status reads and fix max_outstanding

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -440,6 +440,9 @@
         }
 % endfor
       ]
+      // the CLK_HINT_STATUS register is read-only and cannot be checked.
+      // This register's value depends on the IDLE inputs, so cannot be predicted.
+      tags: ["excl:CsrNonInitTests:CsrExclCheck:CsrExclCheck"]
     },
 
     { name: "MEASURE_CTRL_REGWEN",

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_cfg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_cfg.sv
@@ -30,6 +30,7 @@ class clkmgr_env_cfg extends cip_base_env_cfg #(
 
     // This is for the integrity error test.
     tl_intg_alert_fields[ral.fatal_err_code.reg_intg] = 1;
+    m_tl_agent_cfg.max_outstanding_req = 1;
 
     // shadow registers
     shadow_update_err_status_fields[ral.recov_err_code.shadow_update_err] = 1;

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -513,6 +513,9 @@
           '''
         }
       ]
+      // the CLK_HINT_STATUS register is read-only and cannot be checked.
+      // This register's value depends on the IDLE inputs, so cannot be predicted.
+      tags: ["excl:CsrNonInitTests:CsrExclCheck:CsrExclCheck"]
     },
 
     { name: "MEASURE_CTRL_REGWEN",


### PR DESCRIPTION
Disable generated checks of hint_status register since it depends on
idle inputs.
Set the tl_agent max_outstanding_req to 1.

Signed-off-by: Guillermo Maturana <maturana@google.com>