### PR TITLE
[otp_ctrl] Remove prim CSR exclusion tags

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -18,7 +18,7 @@
   scan_en: "true",    // Enable `scan_en_i` port
   bus_interfaces: [
     { protocol: "tlul", direction: "device", name: "core" }
-    { protocol: "tlul", direction: "device", name: "prim" }
+    { protocol: "tlul", direction: "device", name: "prim", hier_path: "u_otp.gen_generic.u_impl_generic.u_reg_top" }
   ],
 
   available_output_list: [
@@ -1602,7 +1602,7 @@
         hwaccess: "hro",
         regwen:   "CHECK_REGWEN",
         tags: [ // Do not write to this automatically, as it may trigger fatal alert, and cause
-                // escalation. TODO: check with designer if the trigger escalation part is intended.
+                // escalation.
                 "excl:CsrAllTests:CsrExclWrite"],
         fields: [
           { bits: "31:0",
@@ -1914,10 +1914,6 @@
         hwaccess: "hro",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
           { bits: "0",
             name: "field0",
@@ -1952,10 +1948,6 @@
         hwaccess: "hro",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
           { bits: "6:0",
             name: "field0",
@@ -1990,10 +1982,6 @@
         hwaccess: "hro",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
           { bits: "0",
             name: "field0",
@@ -2008,10 +1996,6 @@
         hwaccess: "hrw",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
          { bits: "2:0",
             name: "field0",
@@ -2075,10 +2059,6 @@
         hwaccess: "hro",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
           { bits: "9:0",
             name: "field0",
@@ -2108,10 +2088,6 @@
         hwaccess: "hrw",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
          { bits: "5:0",
             name: "field0",
@@ -2163,10 +2139,6 @@
         hwaccess: "hro",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
           { bits: "9:0",
             name: "field0",
@@ -2198,10 +2170,6 @@
         hwaccess: "hrw",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
          { bits: "5:0",
            name: "field0",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -31,7 +31,7 @@
   scan_en: "true",    // Enable `scan_en_i` port
   bus_interfaces: [
     { protocol: "tlul", direction: "device", name: "core" }
-    { protocol: "tlul", direction: "device", name: "prim" }
+    { protocol: "tlul", direction: "device", name: "prim", hier_path: "u_otp.gen_generic.u_impl_generic.u_reg_top" }
   ],
 
   available_output_list: [
@@ -864,7 +864,7 @@
         hwaccess: "hro",
         regwen:   "CHECK_REGWEN",
         tags: [ // Do not write to this automatically, as it may trigger fatal alert, and cause
-                // escalation. TODO: check with designer if the trigger escalation part is intended.
+                // escalation.
                 "excl:CsrAllTests:CsrExclWrite"],
         fields: [
           { bits: "31:0",
@@ -1034,10 +1034,6 @@
         hwaccess: "hro",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
           { bits: "0",
             name: "field0",
@@ -1072,10 +1068,6 @@
         hwaccess: "hro",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
           { bits: "6:0",
             name: "field0",
@@ -1110,10 +1102,6 @@
         hwaccess: "hro",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
           { bits: "0",
             name: "field0",
@@ -1128,10 +1116,6 @@
         hwaccess: "hrw",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
          { bits: "2:0",
             name: "field0",
@@ -1195,10 +1179,6 @@
         hwaccess: "hro",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
           { bits: "9:0",
             name: "field0",
@@ -1228,10 +1208,6 @@
         hwaccess: "hrw",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
          { bits: "5:0",
             name: "field0",
@@ -1283,10 +1259,6 @@
         hwaccess: "hro",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
           { bits: "9:0",
             name: "field0",
@@ -1318,10 +1290,6 @@
         hwaccess: "hrw",
         hwext:    "false",
         hwqe:     "false",
-        // TODO: remove this tag once chip-level sims support alias registers.
-        tags: [
-          "excl:CsrAllTests:CsrExclAll"
-        ]
         fields: [
          { bits: "5:0",
            name: "field0",


### PR DESCRIPTION
The prim CSR mechanism is now supported in foundry chip-level sims also.

Signed-off-by: Michael Schaffner <msf@opentitan.org>