### PR TITLE
[dvsim] Minor cleanup of job_runtime updates

### DIFF
--- a/util/dvsim/JobTime.py
+++ b/util/dvsim/JobTime.py
@@ -1,0 +1,84 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r"""An abstraction for maintaining job runtime and its units.
+"""
+
+from typing import Tuple
+
+
+class JobTime:
+    # Possible units.
+    units = ["h", "m", "s", "ms", "us", "ns", "ps", "fs"]
+    dividers = [60.0, ] * 3 + [1000.0, ] * 5
+
+    def __init__(self, time: float = 0.0, unit: str = "s"):
+        self.set(time, unit)
+
+    def set(self, time: float, unit: str):
+        """Public API to set the instance variables time, unit."""
+        self.__time = time
+        self.__unit = unit
+        assert self.__unit in self.units
+        self._normalize()
+
+    def get(self) -> Tuple[float, str]:
+        """Returns the time and unit as a tuple."""
+        return self.__time, self.__unit
+
+    def _normalize(self):
+        """Brings the time and its units to a more meaningful magnitude.
+
+        If the time is very large with a lower magnitude, this method divides
+        the time to get it to the next higher magnitude recursively, stopping
+        if the next division causes the time to go < 1. Examples:
+          123123232ps -> 123.12us
+          23434s -> 6.509h
+
+        The supported magnitudes and their associated divider values are
+        provided by JobTime.units and JobTime.dividers.
+        """
+        if self.__time == 0:
+            return
+
+        index = self.units.index(self.__unit)
+        normalized_time = self.__time
+        while index > 0 and normalized_time >= self.dividers[index]:
+            normalized_time = normalized_time / self.dividers[index]
+            index = index - 1
+        self.__time = normalized_time
+        self.__unit = self.units[index]
+
+    def __str__(self):
+        """Indicates <time><unit> as string.
+
+        The time value is truncated to 3 decimal places.
+        Returns an empty string if the __time is set to 0.
+        """
+        if self.__time == 0:
+            return ""
+        else:
+            return f"{self.__time:.3f}{self.__unit}"
+
+    def __eq__(self, other) -> bool:
+        assert isinstance(other, JobTime)
+        other_time, other_unit = other.get()
+        return self.__unit == other_unit and self.__time == other_time
+
+    def __gt__(self, other) -> bool:
+        if self.__time == 0:
+            return False
+
+        assert isinstance(other, JobTime)
+        other_time, other_unit = other.get()
+        if other_time == 0:
+            return True
+
+        sidx = JobTime.units.index(self.__unit)
+        oidx = JobTime.units.index(other_unit)
+        if sidx < oidx:
+            return True
+        elif sidx > oidx:
+            return False
+        else:
+            return self.__time > other_time

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -54,8 +54,7 @@ class LocalLauncher(Launcher):
             f.flush()
             timeout_mins = self.deploy.get_timeout_mins()
             if timeout_mins:
-                self.timeout_secs = datetime.timedelta(
-                    seconds=timeout_mins * 60)
+                self.timeout_secs = timeout_mins * 60
             else:
                 self.timeout_secs = None
             self.process = subprocess.Popen(shlex.split(self.deploy.cmd),
@@ -84,9 +83,11 @@ class LocalLauncher(Launcher):
         '''
 
         assert self.process is not None
+        elapsed_time = datetime.datetime.now() - self.start_time
+        self.job_runtime_secs = elapsed_time.total_seconds()
         if self.process.poll() is None:
-            if self.timeout_secs and (self.start_time + self.timeout_secs <
-                                      datetime.datetime.now()):
+            if self.timeout_secs and (self.job_runtime_secs >
+                                      self.timeout_secs):
                 self._kill()
                 timeout_message = 'Job timed out after {} minutes'.format(
                     self.deploy.get_timeout_mins())


### PR DESCRIPTION
This commit makes the following minor cleanups on the
job_runtime / simulated_time enhancements:
- Move JobTime class to its own file from Testplan
  - This is fine - Testplan does not actually need to know
    the type of job_runtime and simulated_time in the Results
    class. It can be of any numerical type and it will still
    work fine.
  - Associated changes in other sources.
- JobTime class enhancements
  - Make time and unit class members private - add set() and
    get() methods to set / retrieve them
  - Add _normalize() method to normalize the time, unit
    immediately after they are set.
  - Add `__gt__` method to enable obj1 > obj2 comparison
    (done in SimResults.py)
- Cleanup lint errors (run yapf, isort, flake8, mypy)
- Use more robust patterns when matching and extracting
  job_runtime and simulated time in sim_utils.py
  - VCS does not invoke $finish on NOA errors - fix this usecase.
  - Remove SyntaxError exception since it is not needed.
- Rename `Deploy::extract_runtimes()` to a more generic sounding
  `Deploy::extract_info_from_log()`
- Move (Passing, Total, Pass Rate) columns to the end.
- Use dvsim computed job runtime if the extraction of tool provided
  runtime fails.
- Bucketize killed jobs as well.
  - Add Launcher::fail_msg class attribute for jobs that are killed
    when their dependent jobs fail.
- Other general coding style / formatting / comment / docstring
  improvements.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>