### PR TITLE
[rtl] Fix lint warnings in `top_earlgrey` and OTBN

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -185,7 +185,7 @@ module otbn
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_rma_req_i),
-    .lc_en_o(lc_rma_req)
+    .lc_en_o({lc_rma_req})
   );
 
   // Internally, OTBN uses MUBI types.

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1560,8 +1560,8 @@
       }
       param_decl:
       {
-        ChipGen: 16'h 00000
-        ChipRev: 16'h 00000
+        ChipGen: 16'h 0000
+        ChipRev: 16'h 0000
         IdcodeValue: jtag_id_pkg::JTAG_IDCODE
       }
       clock_connections:
@@ -1620,7 +1620,7 @@
           name: ChipGen
           desc: Chip generation number.
           type: logic [15:0]
-          default: 16'h 00000
+          default: 16'h 0000
           expose: "true"
           name_top: LcCtrlChipGen
         }
@@ -1628,7 +1628,7 @@
           name: ChipRev
           desc: Chip revision number.
           type: logic [15:0]
-          default: 16'h 00000
+          default: 16'h 0000
           expose: "true"
           name_top: LcCtrlChipRev
         }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -308,8 +308,8 @@
       reset_connections: {rst_ni: "lc_io_div4", rst_kmac_ni: "sys"},
       base_addr: "0x40140000",
       param_decl: {
-        ChipGen: "16'h 00000",
-        ChipRev: "16'h 00000",
+        ChipGen: "16'h 0000",
+        ChipRev: "16'h 0000",
         IdcodeValue: "jtag_id_pkg::JTAG_IDCODE",
       },
     },

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -28,8 +28,8 @@ module top_earlgrey #(
   // parameters for otp_ctrl
   parameter OtpCtrlMemInitFile = "",
   // parameters for lc_ctrl
-  parameter logic [15:0] LcCtrlChipGen = 16'h 00000,
-  parameter logic [15:0] LcCtrlChipRev = 16'h 00000,
+  parameter logic [15:0] LcCtrlChipGen = 16'h 0000,
+  parameter logic [15:0] LcCtrlChipRev = 16'h 0000,
   parameter logic [31:0] LcCtrlIdcodeValue = jtag_id_pkg::JTAG_IDCODE,
   // parameters for alert_handler
   // parameters for spi_host0


### PR DESCRIPTION
Fixes #13926.