### PR TITLE
[dv, otbn] Fix otbn scramble test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2142,12 +2142,10 @@
 
             - Initialize the entropy_src subsystem to enable OTP_CTRL fetch random data (already
               done by the test_rom startup code).
-            - Have OTBN fetch a new key and nonce from the OTP_CTRL.
+            - Have OTBN fetch a new key and nonce from the OTP_CTRL by issuing a DMEM and IMEM wipe command.
             - Write and read-check OTBN and IMEM for consistency.
-            - Fetch a new key from the OTP_CTRL and ensure that previous contents in the IMEM and
-              DMEM cannot be read anymore.
-            - Verify the validity of EDN's output to OTP_CTRL via assertions
-              (unique, non-zero data).
+            - Fetch a new key from the OTP_CTRL by issuing a DMEM and IMEM wipe command.
+            - Verify that IMEM and DMEM can not be read by waiting for a internal interruption.
             '''
       milestone: V2
       tests: ["chip_sw_otbn_mem_scramble"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -689,7 +689,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_mem_scramble_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15_000_000"]
+      run_opts: ["+sw_test_timeout_ns=15_000_000", "+en_scb_tl_err_chk=0", "+bypass_alert_ready_to_end_check=1"]
     }
     {
       name: chip_sw_rv_core_ibex_rnd

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -7,7 +7,7 @@
 
 /**
  * @file
- * @brief <a href="/hw/ip/otbn/doc/">OTBN</a> Device Interface Functions
+ * @brief <a href="/hw/ip/otbn/doc/">OTBN</a> Device Interface Functions.
  */
 
 #include <stddef.h>
@@ -23,7 +23,7 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * OTBN commands
+ * OTBN commands.
  */
 typedef enum dif_otbn_cmd {
   kDifOtbnCmdExecute = 0xd8,
@@ -32,7 +32,7 @@ typedef enum dif_otbn_cmd {
 } dif_otbn_cmd_t;
 
 /**
- * OTBN status
+ * OTBN status.
  */
 typedef enum dif_otbn_status {
   kDifOtbnStatusIdle = 0x00,
@@ -44,7 +44,7 @@ typedef enum dif_otbn_status {
 } dif_otbn_status_t;
 
 /**
- * OTBN Errors
+ * OTBN Errors.
  *
  * OTBN uses a bitfield to indicate which errors have been seen. Multiple errors
  * can be seen at the same time. This enum gives the individual bits that may be
@@ -86,7 +86,7 @@ typedef enum dif_otbn_err_bits {
  * Resets the given OTBN device by setting its configuration registers to
  * reset values. Disables interrupts, output, and input filter.
  *
- * @param otbn OTBN instance
+ * @param otbn OTBN instance.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -105,8 +105,8 @@ dif_result_t dif_otbn_write_cmd(const dif_otbn_t *otbn, dif_otbn_cmd_t cmd);
 /**
  * Gets the current status of OTBN.
  *
- * @param otbn OTBN instance
- * @param[out] status OTBN status
+ * @param otbn OTBN instance.
+ * @param[out] status OTBN status.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -116,7 +116,7 @@ dif_result_t dif_otbn_get_status(const dif_otbn_t *otbn,
 /**
  * Get the error bits set by the device if the operation failed.
  *
- * @param otbn OTBN instance
+ * @param otbn OTBN instance.
  * @param[out] err_bits The error bits returned by the hardware.
  * @return The result of the operation.
  */
@@ -131,7 +131,7 @@ dif_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
  * there is one. Otherwise, gets the number executed in total in the previous
  * OTBN run.
  *
- * @param otbn OTBN instance
+ * @param otbn OTBN instance.
  * @param[out] insn_cnt The number of instructions executed by OTBN.
  * @return The result of the operation.
  */
@@ -139,12 +139,12 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_get_insn_cnt(const dif_otbn_t *otbn, uint32_t *insn_cnt);
 
 /**
- * Write an OTBN application into its instruction memory (IMEM)
+ * Write an OTBN application into its instruction memory (IMEM).
  *
  * Only 32b-aligned 32b word accesses are allowed.
  *
- * @param otbn OTBN instance
- * @param offset_bytes the byte offset in IMEM the first word is written to
+ * @param otbn OTBN instance.
+ * @param offset_bytes the byte offset in IMEM the first word is written to.
  * @param src the main memory location to start reading from.
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
@@ -154,13 +154,13 @@ dif_result_t dif_otbn_imem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                  const void *src, size_t len_bytes);
 
 /**
- * Read from OTBN's instruction memory (IMEM)
+ * Read from OTBN's instruction memory (IMEM).
  *
  * Only 32b-aligned 32b word accesses are allowed.
  *
  * @param otbn OTBN instance
- * @param offset_bytes the byte offset in IMEM the first word is read from
- * @param[out] dest the main memory location to copy the data to (preallocated)
+ * @param offset_bytes the byte offset in IMEM the first word is read from.
+ * @param[out] dest the main memory location to copy the data to (preallocated).
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
  */
@@ -169,12 +169,12 @@ dif_result_t dif_otbn_imem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                 void *dest, size_t len_bytes);
 
 /**
- * Write to OTBN's data memory (DMEM)
+ * Write to OTBN's data memory (DMEM).
  *
  * Only 32b-aligned 32b word accesses are allowed.
  *
- * @param otbn OTBN instance
- * @param offset_bytes the byte offset in DMEM the first word is written to
+ * @param otbn OTBN instance.
+ * @param offset_bytes the byte offset in DMEM the first word is written to.
  * @param src the main memory location to start reading from.
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
@@ -184,13 +184,13 @@ dif_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                  const void *src, size_t len_bytes);
 
 /**
- * Read from OTBN's data memory (DMEM)
+ * Read from OTBN's data memory (DMEM).
  *
  * Only 32b-aligned 32b word accesses are allowed.
  *
  * @param otbn OTBN instance
- * @param offset_bytes the byte offset in DMEM the first word is read from
- * @param[out] dest the main memory location to copy the data to (preallocated)
+ * @param offset_bytes the byte offset in DMEM the first word is read from.
+ * @param[out] dest the main memory location to copy the data to (preallocated).
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
  */
@@ -204,7 +204,7 @@ dif_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
  * When set any software error becomes a fatal error. The bit can only be
  * changed when the OTBN status is IDLE.
  *
- * @param otbn OTBN instance
+ * @param otbn OTBN instance.
  * @param enable Enable or disable whether software errors are fatal.
  * @return The result of the operation, `kDifUnavailable` is returned when the
  * requested change cannot be made.
@@ -216,16 +216,16 @@ dif_result_t dif_otbn_set_ctrl_software_errs_fatal(const dif_otbn_t *otbn,
 /**
  * Get the size of OTBN's data memory in bytes.
  *
- * @param otbn OTBN instance
- * @return data memory size in bytes
+ * @param otbn OTBN instance.
+ * @return data memory size in bytes.
  */
 size_t dif_otbn_get_dmem_size_bytes(const dif_otbn_t *otbn);
 
 /**
  * Get the size of OTBN's instruction memory in bytes.
  *
- * @param otbn OTBN instance
- * @return instruction memory size in bytes
+ * @param otbn OTBN instance.
+ * @return instruction memory size in bytes.
  */
 size_t dif_otbn_get_imem_size_bytes(const dif_otbn_t *otbn);
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -931,13 +931,15 @@ opentitan_functest(
         tags = ["broken"],
     ),
     deps = [
+        "//hw/ip/aes:model",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:otbn",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:otbn",
+        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/otbn/code-snippets:randomness",
+        "//sw/otbn/code-snippets:dmemset",
     ],
 )
 

--- a/sw/otbn/code-snippets/BUILD
+++ b/sw/otbn/code-snippets/BUILD
@@ -61,3 +61,10 @@ otbn_binary(
         "randomness.s",
     ],
 )
+
+otbn_binary(
+    name = "dmemset",
+    srcs = [
+        "dmemset.s",
+    ],
+)

--- a/sw/otbn/code-snippets/dmemset.s
+++ b/sw/otbn/code-snippets/dmemset.s
@@ -1,0 +1,25 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+/* Test entry point, no arguments need to be passed in nor results returned. */
+.globl main
+main:
+  jal x0, dmemset
+
+.text
+dmemset:
+  la x2, set_value
+  bn.lid x0, 0(x2)
+  li x2, 0
+  loopi 128, 1
+    bn.sid x0, 0(x2++)
+  ecall
+
+.data
+/* imput data to dmemset function. */
+.globl set_value
+.balign 32
+set_value:
+  .zero 32


### PR DESCRIPTION
## Issues 

1. The behavior for ECC errors has changed from firing an exception to firing an internal interruption. 
2. The test wasn't initializing the whole memory (dmem and imem), so after scrambling it was reading `x` values with vcs.
3. Reading the scrambled memory was triggering an integrity error in the DV infrastructure.
4. The test was not handling the alert triggered by the ECC error, so the test was timing out with vcs.
5. The internal irq is not firing with FPGA.

## Solutions
1. Change the handler from exception to internal interruption.
2. Initialized the whole imem from ibex and load a otbn app to initialize the dmem, since part of it is only accessible by otbn.
3. Disable the verification in the test entry `"+en_scb_tl_err_chk=0"`
4. Disable the verification in the tests entry `"+bypass_alert_ready_to_end_check=1"`.
5. Pending solution

Fixes #14196
Fixes #13974 