### PR TITLE
[rv_dm dv] Fix test failures

### DIFF
--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_block.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_block.sv
@@ -949,6 +949,23 @@ class jtag_dmi_reg_haltsum3 extends dv_base_reg;
   endfunction : build
 endclass : jtag_dmi_reg_haltsum3
 
+class jtag_dmi_reg_field_sbcs_sberror extends dv_base_reg_field;
+  `uvm_object_utils(jtag_dmi_reg_field_sbcs_sberror)
+
+  function new(string name = "jtag_dmi_reg_field_sbcs_sberror");
+    super.new(name);
+  endfunction: new
+
+  // Field is cleared when written to 1 exactly.
+  virtual function uvm_reg_data_t XpredictX(uvm_reg_data_t cur_val,
+                                            uvm_reg_data_t wr_val,
+                                            uvm_reg_map map);
+    if (get_access(map) == "W1C" && wr_val == 1) return 0;
+    else return super.XpredictX(cur_val, wr_val, map);
+  endfunction
+
+endclass
+
 class jtag_dmi_reg_sbcs extends dv_base_reg;
   // fields
   rand dv_base_reg_field sbaccess8;
@@ -957,7 +974,7 @@ class jtag_dmi_reg_sbcs extends dv_base_reg;
   rand dv_base_reg_field sbaccess64;
   rand dv_base_reg_field sbaccess128;
   rand dv_base_reg_field sbasize;
-  rand dv_base_reg_field sberror;
+  rand jtag_dmi_reg_field_sbcs_sberror sberror;
   rand dv_base_reg_field sbreadondata;
   rand dv_base_reg_field sbautoincrement;
   rand dv_base_reg_field sbaccess;
@@ -1067,7 +1084,7 @@ class jtag_dmi_reg_sbcs extends dv_base_reg;
 
     sbasize.set_original_access("RO");
 
-    sberror = (dv_base_reg_field::
+    sberror = (jtag_dmi_reg_field_sbcs_sberror::
                type_id::create("sberror"));
     sberror.configure(
       .parent(this),

--- a/hw/dv/sv/jtag_dmi_agent/sba_access_item.sv
+++ b/hw/dv/sv/jtag_dmi_agent/sba_access_item.sv
@@ -7,50 +7,43 @@ class sba_access_item extends uvm_sequence_item;
   rand bus_op_e           bus_op;
   rand sba_access_size_e  size;
   rand logic [BUS_AW-1:0] addr;
-  rand logic [BUS_DW-1:0] wdata;
+  rand logic [BUS_DW-1:0] wdata[$];
 
   // Special stimulus configuration knobs.
   rand logic readonaddr;
   rand logic readondata;
-  rand logic autoincrement;
+
+  // Have the design autoincrement the address.
+  //
+  // If set to 0, the autoincrement feature is disabled and a single access is made. If set to N (N
+  // > 0), N + 1 accesses are made by the sba_access_utils_pkg::sba_acess() task. This is only used
+  // during the generation of stimulus. It is not used by the sba_access_monitor.
+  uint autoincrement;
 
   // Response side signals.
-  rand logic [BUS_DW-1:0] rdata;
-  rand  sba_access_err_e  is_err;
-  rand logic              is_busy_err;
-  rand logic              timed_out;
+  logic [BUS_DW-1:0] rdata[$];
+  sba_access_err_e   is_err;
+  logic              is_busy_err;
+  logic              timed_out;
+
+  constraint wdata_size_c {
+    wdata.size() == (autoincrement + 1);
+  }
 
   `uvm_object_utils_begin(sba_access_item)
     `uvm_field_enum(bus_op_e, bus_op,         UVM_DEFAULT)
     `uvm_field_enum(sba_access_size_e, size,  UVM_DEFAULT)
     `uvm_field_int (addr,                     UVM_DEFAULT)
-    `uvm_field_int (wdata,                    UVM_DEFAULT)
+    `uvm_field_queue_int(wdata,               UVM_DEFAULT)
     `uvm_field_int (readonaddr,               UVM_DEFAULT)
     `uvm_field_int (readondata,               UVM_DEFAULT)
     `uvm_field_int (autoincrement,            UVM_DEFAULT)
-    `uvm_field_int (rdata,                    UVM_DEFAULT)
+    `uvm_field_queue_int(rdata,               UVM_DEFAULT)
     `uvm_field_int (is_busy_err,              UVM_DEFAULT)
     `uvm_field_enum(sba_access_err_e, is_err, UVM_DEFAULT)
     `uvm_field_int (timed_out,                UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
-
-  virtual function void disable_req_randomization();
-    bus_op.rand_mode(0);
-    addr.rand_mode(0);
-    size.rand_mode(0);
-    wdata.rand_mode(0);
-    readonaddr.rand_mode(0);
-    readondata.rand_mode(0);
-    autoincrement.rand_mode(0);
-  endfunction
-
-  virtual function void disable_rsp_randomization();
-    rdata.rand_mode(0);
-    is_err.rand_mode(0);
-    is_busy_err.rand_mode(0);
-    timed_out.rand_mode(0);
-  endfunction
 
 endclass

--- a/hw/dv/sv/jtag_dmi_agent/sba_access_utils_pkg.sv
+++ b/hw/dv/sv/jtag_dmi_agent/sba_access_utils_pkg.sv
@@ -50,7 +50,6 @@ package sba_access_utils_pkg;
                             input bit sba_access_err_clear = 1'b1);
 
     uvm_reg_data_t rdata, wdata;
-    logic is_busy;
 
     // Update sbcs for the new transaction.
     wdata = jtag_dmi_ral.sbcs.get_mirrored_value();
@@ -64,45 +63,94 @@ package sba_access_utils_pkg;
       wdata = get_csr_val_with_updated_field(jtag_dmi_ral.sbcs.sbreadondata, wdata, 0);
     end
     wdata = get_csr_val_with_updated_field(jtag_dmi_ral.sbcs.sbautoincrement, wdata,
-                                           req.autoincrement);
+                                           (req.autoincrement > 0));
     if (wdata != jtag_dmi_ral.sbcs.sbaccess.get_mirrored_value()) begin
       csr_wr(.ptr(jtag_dmi_ral.sbcs), .value(wdata), .predict(1));
     end
 
+    // Update the sbaddress0.
     csr_wr(.ptr(jtag_dmi_ral.sbaddress0), .value(req.addr), .predict(1));
+
+    // These steps are run in several branches in the following code. Macroize them.
+`define BUSYWAIT_AND_EXIT_ON_ERR                                                          \
+  sba_access_busy_wait_and_clear_error(.jtag_dmi_ral(jtag_dmi_ral), .cfg(cfg), .req(req), \
+      .sba_access_err_clear(sba_access_err_clear));                                       \
+                                                                                          \
+  // We don't know what to do if any of the following is true - return to the caller:     \
+  //                                                                                      \
+  // - The request timed out or returned is_busy_err                                      \
+  // - The access reported non-0 sberror and sba_access_err_clear is set to 0             \
+  // - Request was malformed (An SBA access is not made in the case)                      \
+  // - The access returned SbaErrOther error response (The DUT may need special handling) \
+  if (req.timed_out ||                                                                    \
+      req.is_busy_err ||                                                                  \
+      (req.is_err != SbaErrNone && !sba_access_err_clear) ||                              \
+      req.is_err inside {SbaErrBadAlignment, SbaErrBadSize, SbaErrOther}) begin           \
+    return;                                                                               \
+  end                                                                                     \
+
+    // Write / read sbdata, wait for transaction to complete.
     if (req.bus_op == BusOpRead) begin
-      // Writing to addr with readonaddr would have already trigger an SBA read.
-      if (req.readondata && !req.readonaddr) begin
-        csr_rd(.ptr(jtag_dmi_ral.sbdata0), .value(rdata));
-      end
-      if (!req.readonaddr && !req.readondata) begin
-        `uvm_info(MsgId, {"readonaddr and readondata are not set. ",
-                          "Read request will not be triggered. Returning."}, UVM_MEDIUM)
-        return;
-      end
+      case ({req.readondata, req.readonaddr})
+        2'b00: begin
+          `uvm_info(MsgId, {"readonaddr and readondata are not set. ",
+                            "Read request will not be triggered. Returning."}, UVM_MEDIUM)
+        end
+        2'b01: begin
+          // SBA read already triggered on write to sbaddress0. Read sbdata0 to fetch the response
+          // data. If autoincrement is set, then return to the caller - it is not a valid usecase.
+          `BUSYWAIT_AND_EXIT_ON_ERR
+          if (!cfg.in_reset) begin
+            csr_rd(.ptr(jtag_dmi_ral.sbdata0), .value(rdata));
+            req.rdata[0] = rdata;
+          end
+        end
+        2'b10, 2'b11: begin
+          if (!req.readonaddr) begin
+            // The first read to sbdata returns stale data. Discard it.
+            if (!cfg.in_reset) begin
+              csr_rd(.ptr(jtag_dmi_ral.sbdata0), .value(rdata));
+            end
+          end
+          // The previous step triggered an SBA read. Wait for it to complete.
+          `BUSYWAIT_AND_EXIT_ON_ERR
+
+          // Read sbdata req.autoincrement+1 number of times.
+          //
+          // Randomly also inject reads to sbaddress0 to verify address is correctly incremented
+          // (done externally by the scoreboard).
+          for (int i = 0; i < req.autoincrement + 1; i++) begin
+            if (!cfg.in_reset) begin
+              csr_rd(.ptr(jtag_dmi_ral.sbdata0), .value(rdata));
+              req.rdata[i] = rdata;
+            end
+            `BUSYWAIT_AND_EXIT_ON_ERR
+            if (i > 0 && !cfg.in_reset && !$urandom_range(0, 3)) begin  //25%
+              csr_rd(.ptr(jtag_dmi_ral.sbaddress0), .value(rdata));
+            end
+          end
+        end
+        default: begin
+          `uvm_fatal(MsgId, "Unreachable!")
+        end
+      endcase
     end else begin
-      csr_wr(.ptr(jtag_dmi_ral.sbdata0), .value(req.wdata), .predict(1));
-    end
-
-    // Wait for the access to complete.
-    sba_access_busy_wait(jtag_dmi_ral, cfg, req, is_busy);
-
-    // If the access returns with an error, then the request was not made - return back to the
-    // caller.
-    if (req.is_busy_err || req.is_err != SbaErrNone) begin
-      if (!cfg.in_reset && sba_access_err_clear) begin
-        sba_access_error_clear(jtag_dmi_ral, req);
+      // Write sbdata req.autoincrement+1 number of times.
+      //
+      // Randomly also inject reads to sbaddress0 to verify address is correctly incremented
+      // (done externally by the scoreboard).
+      for (int i = 0; i < req.autoincrement + 1; i++) begin
+        if (!cfg.in_reset) begin
+          csr_wr(.ptr(jtag_dmi_ral.sbdata0), .value(req.wdata[i]), .predict(1));
+        end
+        `BUSYWAIT_AND_EXIT_ON_ERR
+        if (i > 0 && !cfg.in_reset && !$urandom_range(0, 3)) begin  //25%
+          csr_rd(.ptr(jtag_dmi_ral.sbaddress0), .value(rdata));
+        end
       end
-      return;
     end
 
-    // Return the data on reads.
-    if (req.bus_op == BusOpRead && !cfg.in_reset && !is_busy) begin
-      csr_rd(.ptr(jtag_dmi_ral.sbdata0), .value(req.rdata));
-    end
-
-    // If readondata is set, the read above will trigger another SBA read, which needs to be handled
-    // by the caller.
+`undef BUSYWAIT_AND_EXIT_ON_ERR
   endtask
 
   // Read the SBA access status.
@@ -114,15 +162,17 @@ package sba_access_utils_pkg;
     is_busy = get_field_val(jtag_dmi_ral.sbcs.sbbusy, data);
     req.is_busy_err = get_field_val(jtag_dmi_ral.sbcs.sbbusyerror, data);
     req.is_err = sba_access_err_e'(get_field_val(jtag_dmi_ral.sbcs.sberror, data));
-    `uvm_info(MsgId, $sformatf("SBA req status: %0s", req.sprint(uvm_default_line_printer)),
-              UVM_HIGH)
+    if (!is_busy) begin
+      `uvm_info(MsgId, $sformatf("SBA req completed: %0s", req.sprint(uvm_default_line_printer)),
+                UVM_HIGH)
+    end
   endtask
 
   // Reads sbcs register to poll and wait for access to complete.
   task automatic sba_access_busy_wait(input jtag_dmi_reg_block jtag_dmi_ral,
                                       input jtag_agent_cfg cfg,
-                                      input sba_access_item req,
-                                      output logic is_busy);
+                                      input sba_access_item req);
+    logic is_busy;
     `DV_SPINWAIT_EXIT(
       do begin
         sba_access_status(jtag_dmi_ral, req, is_busy);
@@ -148,16 +198,30 @@ package sba_access_utils_pkg;
   // Clear SBA access busy error and access error sticky bits if they are set.
   //
   // Note that the req argument will continue to reflect the error bits.
-  task automatic sba_access_error_clear(jtag_dmi_reg_block jtag_dmi_ral, sba_access_item req);
+  task automatic sba_access_error_clear(jtag_dmi_reg_block jtag_dmi_ral, sba_access_item req,
+                                        bit clear_sbbusyerror = 1'b1, bit clear_sberror = 1'b1);
     uvm_reg_data_t data = jtag_dmi_ral.sbcs.get_mirrored_value();
-    if (req.is_busy_err) begin
+    if (clear_sbbusyerror && req.is_busy_err) begin
       data = get_csr_val_with_updated_field(jtag_dmi_ral.sbcs.sbbusyerror, data, 1);
     end
-    if (req.is_err != SbaErrNone) begin
+    if (clear_sberror && req.is_err != SbaErrNone) begin
       data = get_csr_val_with_updated_field(jtag_dmi_ral.sbcs.sberror, data, 1);
     end
     csr_wr(.ptr(jtag_dmi_ral.sbcs), .value(data), .predict(1));
   endtask
+
+  // Wrapper task for busy wait followed by clearing of sberror if an error was reported.
+  task automatic sba_access_busy_wait_and_clear_error(input jtag_dmi_reg_block jtag_dmi_ral,
+                                                      input jtag_agent_cfg cfg,
+                                                      input sba_access_item req,
+                                                      input bit sba_access_err_clear);
+    sba_access_busy_wait(jtag_dmi_ral, cfg, req);
+    // Only clear sberror - let the caller handle sbbusyerror.
+    if (!cfg.in_reset && sba_access_err_clear && req.is_err != SbaErrNone) begin
+      sba_access_error_clear(.jtag_dmi_ral(jtag_dmi_ral), .req(req), .clear_sbbusyerror(0));
+    end
+  endtask
+
 
   `include "sba_access_item.sv"
   `include "sba_access_monitor.sv"

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -223,8 +223,9 @@ module rv_dm
   );
 
   tlul_adapter_host #(
+    .MAX_REQS(1),
     .EnableDataIntgGen(1),
-    .MAX_REQS(1)
+    .EnableRspDataIntgCheck(1)
   ) tl_adapter_host_sba (
     .clk_i,
     .rst_ni,

--- a/hw/ip/tlul/rtl/tlul_adapter_host.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_host.sv
@@ -26,7 +26,8 @@ module tlul_adapter_host
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter int unsigned MAX_REQS = 2,
-  parameter bit EnableDataIntgGen = 0
+  parameter bit EnableDataIntgGen = 0,
+  parameter bit EnableRspDataIntgCheck = 0
 ) (
   input clk_i,
   input rst_ni,
@@ -118,7 +119,9 @@ module tlul_adapter_host
   assign rdata_intg_o = tl_i.d_user.data_intg;
 
   logic intg_err;
-  tlul_rsp_intg_chk u_rsp_chk (
+  tlul_rsp_intg_chk #(
+    .EnableRspDataIntgCheck(EnableRspDataIntgCheck)
+  ) u_rsp_chk (
     .tl_i,
     .err_o(intg_err)
   );

--- a/hw/ip/tlul/rtl/tlul_rsp_intg_chk.sv
+++ b/hw/ip/tlul/rtl/tlul_rsp_intg_chk.sv
@@ -8,7 +8,9 @@
  * Tile-Link UL response integrity check
  */
 
-module tlul_rsp_intg_chk import tlul_pkg::*; (
+module tlul_rsp_intg_chk import tlul_pkg::*; #(
+  parameter bit EnableRspDataIntgCheck = 0
+) (
   // TL-UL interface
   input  tl_d2h_t tl_i,
 
@@ -16,7 +18,7 @@ module tlul_rsp_intg_chk import tlul_pkg::*; (
   output logic err_o
 );
 
-  logic [1:0] err;
+  logic [1:0] rsp_err;
   tl_d2h_rsp_intg_t rsp;
   assign rsp = extract_d2h_rsp_intg(tl_i);
 
@@ -24,15 +26,25 @@ module tlul_rsp_intg_chk import tlul_pkg::*; (
     .data_i({tl_i.d_user.rsp_intg, D2HRspMaxWidth'(rsp)}),
     .data_o(),
     .syndrome_o(),
-    .err_o(err)
+    .err_o(rsp_err)
   );
+
+  logic rsp_data_err;
+  if (EnableRspDataIntgCheck) begin : gen_rsp_data_intg_check
+    tlul_data_integ_dec u_tlul_data_integ_dec (
+      .data_intg_i({tl_i.d_user.data_intg, DataMaxWidth'(tl_i.d_data)}),
+      .data_err_o(rsp_data_err)
+    );
+  end else begin : gen_no_rsp_data_intg_check
+    assign rsp_data_err = 1'b0;
+  end
 
   // error is not permanently latched as rsp_intg_chk is typically
   // used near the host.
   // if the error is permanent, it would imply the host could forever
   // receive bus errors and lose all ability to debug.
   // It should be up to the host to determine the permanence of this error.
-  assign err_o = tl_i.d_valid & |err;
+  assign err_o = tl_i.d_valid & (|rsp_err | rsp_data_err);
 
   logic unused_tl;
   assign unused_tl = |tl_i;


### PR DESCRIPTION
There are 3 commits in this series - first fixes the rv_dm IP to factor in d_data intg error. The second fixes the behavior of the sberror field in the hand-written DMI RAL model to properly handle the RW1C access policy. The third makes fixes to the SBA access util package and the dv_dm testbench to enable support for sberror=2,7 indication, a design update made recently. 