### PR TITLE
[otbn, dv] Enabled prim count tests to verify stack REDUN cms

### DIFF
--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -157,7 +157,7 @@
       name: sec_cm_stack_wr_ptr_ctr_redun
       desc: "Verify the countermeasure(s) STACK_WR_PTR.CTR.REDUN."
       milestone: V2S
-      tests: []
+      tests: ["otbn_sec_cm"]
     }
     {
       name: sec_cm_rf_bignum_data_reg_sw_integrity
@@ -175,7 +175,7 @@
       name: sec_cm_loop_stack_ctr_redun
       desc: "Verify the countermeasure(s) LOOP_STACK.CTR.REDUN."
       milestone: V2S
-      tests: []
+      tests: ["otbn_sec_cm"]
     }
     {
       name: sec_cm_loop_stack_addr_integrity

--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -11,6 +11,7 @@
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
                      "otbn_sec_cm_testplan.hjson"]
   testpoints: [
     {

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -476,11 +476,13 @@ int OtbnModel::check() const {
     return -1;
   }
 
-  try {
-    good &= check_call_stack(*iss);
-  } catch (const std::exception &err) {
-    std::cerr << "Failed to check call stack: " << err.what() << "\n";
-    return -1;
+  if (stack_check_enabled_) {
+    try {
+      good &= check_call_stack(*iss);
+    } catch (const std::exception &err) {
+      std::cerr << "Failed to check call stack: " << err.what() << "\n";
+      return -1;
+    }
   }
 
   return good ? 1 : 0;
@@ -556,6 +558,11 @@ int OtbnModel::set_software_errs_fatal(unsigned char new_val) {
 
 int OtbnModel::set_no_sec_wipe_chk() {
   OtbnTraceChecker::get().set_no_sec_wipe_chk();
+  return 0;
+}
+
+int OtbnModel::disable_stack_check() {
+  stack_check_enabled_ = false;
   return 0;
 }
 
@@ -1004,6 +1011,11 @@ int otbn_model_set_software_errs_fatal(OtbnModel *model,
 int otbn_set_no_sec_wipe_chk(OtbnModel *model) {
   assert(model);
   return model->set_no_sec_wipe_chk();
+}
+
+int otbn_disable_stack_check(OtbnModel *model) {
+  assert(model);
+  return model->disable_stack_check();
 }
 
 int otbn_model_step_crc(OtbnModel *model, svBitVecVal *item /* bit [47:0] */,

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -122,6 +122,9 @@ class OtbnModel {
   // Trigger initial secure wipe.
   int initial_secure_wipe();
 
+  // Disable stack integrity checks
+  int disable_stack_check();
+
  private:
   // Constructs an ISS wrapper if necessary. If something goes wrong, this
   // function prints a message and then returns null. If ensure is true, it
@@ -158,6 +161,8 @@ class OtbnModel {
 
   OtbnMemUtil mem_util_;
   std::string design_scope_;
+
+  bool stack_check_enabled_ = true;
 };
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_MODEL_H_

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -116,6 +116,9 @@ int otbn_model_set_software_errs_fatal(OtbnModel *model, unsigned char new_val);
 // random data to all registers before wiping them with zeroes.
 int otbn_set_no_sec_wipe_chk(OtbnModel *model);
 
+// Disable stack integrity checks
+int otbn_disable_stack_check(OtbnModel *model);
+
 // Step the CRC calculation for item
 //
 // state is an inout parameter and should be updated in-place. This is

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.svh
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.svh
@@ -70,4 +70,6 @@ import "DPI-C" function int otbn_model_send_err_escalation(chandle model, bit [3
 
 import "DPI-C" function int otbn_model_initial_secure_wipe(chandle model);
 
+import "DPI-C" function int otbn_disable_stack_check(chandle model);
+
 `endif // SYNTHESIS

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -131,6 +131,13 @@ class otbn_common_vseq extends otbn_base_vseq;
       $assertoff(0, "tb.MatchingStatus_A");
       $assertoff(0, "tb.dut.u_otbn_core.u_otbn_start_stop_control.StartStopStateValid_A");
     end
+    if (if_proxy.sec_cm_type == SecCmPrimCount) begin
+      cfg.model_agent_cfg.vif.otbn_disable_stack_check();
+      $assertoff(0, "tb.dut.u_otbn_core.u_otbn_controller.u_otbn_loop_controller.loop_info_stack\
+               .next_stack_top_idx_correct");
+      $assertoff(0, "tb.dut.u_otbn_core.u_otbn_rf_base.u_call_stack.next_stack_top_idx_correct");
+    end
+
   endfunction: sec_cm_fi_ctrl_svas
 
   virtual task sec_cm_inject_fault(sec_cm_base_if_proxy if_proxy);

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -104,12 +104,17 @@ interface otbn_model_if
                     "Failed to set software_errs_fatal", "otbn_model_if")
   endfunction
 
-   function automatic void otbn_set_no_sec_wipe_chk();
+  function automatic void otbn_set_no_sec_wipe_chk();
     `uvm_info("otbn_model_if", "writing to no_sec_wipe_data_chk", UVM_HIGH);
     `DV_CHECK_FATAL(u_model.otbn_set_no_sec_wipe_chk(handle) == 0,
                     "Failed to set no_sec_wipe_data_chk", "otbn_model_if")
   endfunction
 
+  function automatic void otbn_disable_stack_check();
+    `uvm_info("otbn_model_if", "Disabling stack integrity checks", UVM_HIGH);
+    `DV_CHECK_FATAL(u_model.otbn_disable_stack_check(handle) == 0,
+                    "Failed to disable stack integrity checks", "otbn_model_if")
+  endfunction
 
   // The err signal is asserted by the model if it fails to find the DUT or if it finds a mismatch
   // in results. It should never go high.

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -54,7 +54,8 @@ name:
                    "{tool}_memutil_dpi_scrambled_build_opts"]
 
   // Add additional tops for simulation.
-  sim_tops: ["otbn_bind", "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind"]
+  sim_tops: ["otbn_bind", "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind",
+             "sec_cm_prim_count_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
This commit enables prim count tests to verify
OTBN.STACK_WR_PTR.CTR.REDUN and OTBN.LOOP_STACK.CTR.REDUN
countermeasures.
It also adds a function to disable stack intgegrity checks when errors
are  injected on otbn_loop_controller and call_stack.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>