### PR TITLE
[flash_ctrl] Protect ADDR from modification during transaction

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -730,6 +730,7 @@
         desc: "Address for flash operation",
         swaccess: "rw",
         hwaccess: "hro",
+        regwen: "CTRL_REGWEN",
         resval: "0",
         fields: [
           { bits: "19:0",
@@ -757,6 +758,7 @@
       // Program type
       { name: "PROG_TYPE_EN",
         desc: "Enable different program types",
+        regwen: "CTRL_REGWEN",
         swaccess: "rw0c",
         hwaccess: "hro",
         fields: [

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -731,6 +731,7 @@
         desc: "Address for flash operation",
         swaccess: "rw",
         hwaccess: "hro",
+        regwen: "CTRL_REGWEN",
         resval: "0",
         fields: [
           { bits: "${total_byte_width-1}:0",
@@ -758,6 +759,7 @@
       // Program type
       { name: "PROG_TYPE_EN",
         desc: "Enable different program types",
+        regwen: "CTRL_REGWEN",
         swaccess: "rw0c",
         hwaccess: "hro",
         fields: [

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -1772,6 +1772,9 @@ module flash_ctrl_core_reg_top (
 
 
   // R[addr]: V(False)
+  // Create REGWEN-gated WE signal
+  logic addr_gated_we;
+  assign addr_gated_we = addr_we & ctrl_regwen_qs;
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1781,7 +1784,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (addr_we),
+    .we     (addr_gated_we),
     .wd     (addr_wd),
 
     // from internal hardware
@@ -1799,6 +1802,9 @@ module flash_ctrl_core_reg_top (
 
 
   // R[prog_type_en]: V(False)
+  // Create REGWEN-gated WE signal
+  logic prog_type_en_gated_we;
+  assign prog_type_en_gated_we = prog_type_en_we & ctrl_regwen_qs;
   //   F[normal]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1809,7 +1815,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (prog_type_en_we),
+    .we     (prog_type_en_gated_we),
     .wd     (prog_type_en_normal_wd),
 
     // from internal hardware
@@ -1835,7 +1841,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (prog_type_en_we),
+    .we     (prog_type_en_gated_we),
     .wd     (prog_type_en_repair_wd),
 
     // from internal hardware
@@ -12362,8 +12368,8 @@ module flash_ctrl_core_reg_top (
     reg_we_check[6] = init_we;
     reg_we_check[7] = 1'b0;
     reg_we_check[8] = control_gated_we;
-    reg_we_check[9] = addr_we;
-    reg_we_check[10] = prog_type_en_we;
+    reg_we_check[9] = addr_gated_we;
+    reg_we_check[10] = prog_type_en_gated_we;
     reg_we_check[11] = erase_suspend_we;
     reg_we_check[12] = region_cfg_regwen_0_we;
     reg_we_check[13] = region_cfg_regwen_1_we;

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -736,6 +736,7 @@
         desc: "Address for flash operation",
         swaccess: "rw",
         hwaccess: "hro",
+        regwen: "CTRL_REGWEN",
         resval: "0",
         fields: [
           { bits: "19:0",
@@ -763,6 +764,7 @@
       // Program type
       { name: "PROG_TYPE_EN",
         desc: "Enable different program types",
+        regwen: "CTRL_REGWEN",
         swaccess: "rw0c",
         hwaccess: "hro",
         fields: [

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -1772,6 +1772,9 @@ module flash_ctrl_core_reg_top (
 
 
   // R[addr]: V(False)
+  // Create REGWEN-gated WE signal
+  logic addr_gated_we;
+  assign addr_gated_we = addr_we & ctrl_regwen_qs;
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1781,7 +1784,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (addr_we),
+    .we     (addr_gated_we),
     .wd     (addr_wd),
 
     // from internal hardware
@@ -1799,6 +1802,9 @@ module flash_ctrl_core_reg_top (
 
 
   // R[prog_type_en]: V(False)
+  // Create REGWEN-gated WE signal
+  logic prog_type_en_gated_we;
+  assign prog_type_en_gated_we = prog_type_en_we & ctrl_regwen_qs;
   //   F[normal]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1809,7 +1815,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (prog_type_en_we),
+    .we     (prog_type_en_gated_we),
     .wd     (prog_type_en_normal_wd),
 
     // from internal hardware
@@ -1835,7 +1841,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (prog_type_en_we),
+    .we     (prog_type_en_gated_we),
     .wd     (prog_type_en_repair_wd),
 
     // from internal hardware
@@ -12362,8 +12368,8 @@ module flash_ctrl_core_reg_top (
     reg_we_check[6] = init_we;
     reg_we_check[7] = 1'b0;
     reg_we_check[8] = control_gated_we;
-    reg_we_check[9] = addr_we;
-    reg_we_check[10] = prog_type_en_we;
+    reg_we_check[9] = addr_gated_we;
+    reg_we_check[10] = prog_type_en_gated_we;
     reg_we_check[11] = erase_suspend_we;
     reg_we_check[12] = region_cfg_regwen_0_we;
     reg_we_check[13] = region_cfg_regwen_1_we;

--- a/sw/device/lib/dif/dif_flash_ctrl.c
+++ b/sw/device/lib/dif/dif_flash_ctrl.c
@@ -273,6 +273,7 @@ dif_result_t dif_flash_ctrl_get_allowed_prog_types(
   if (handle == NULL || allowed_types_out == NULL) {
     return kDifBadArg;
   }
+
   uint32_t reg = mmio_region_read32(handle->dev.base_addr,
                                     FLASH_CTRL_PROG_TYPE_EN_REG_OFFSET);
   dif_flash_ctrl_prog_capabilities_t allowed_types = {
@@ -292,6 +293,13 @@ dif_result_t dif_flash_ctrl_disallow_prog_types(
   if (handle == NULL) {
     return kDifBadArg;
   }
+
+  uint32_t ctrl_regwen = mmio_region_read32(handle->dev.base_addr,
+                                            FLASH_CTRL_CTRL_REGWEN_REG_OFFSET);
+  if (!bitfield_bit32_read(ctrl_regwen, FLASH_CTRL_CTRL_REGWEN_EN_BIT)) {
+    return kDifUnavailable;
+  }
+
   uint32_t reg = 0;
   reg = bitfield_bit32_write(reg, FLASH_CTRL_PROG_TYPE_EN_NORMAL_BIT,
                              !types_to_disallow.normal_prog_type);

--- a/sw/device/lib/dif/dif_flash_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_flash_ctrl_unittest.cc
@@ -253,6 +253,10 @@ TEST_F(FlashCtrlTest, SetProgPermissions) {
       .normal_prog_type = 0,
       .repair_prog_type = 1,
   };
+
+  EXPECT_READ32(FLASH_CTRL_CTRL_REGWEN_REG_OFFSET,
+                {{FLASH_CTRL_CTRL_REGWEN_EN_BIT, 1}});
+
   EXPECT_WRITE32(FLASH_CTRL_PROG_TYPE_EN_REG_OFFSET,
                  {
                      {FLASH_CTRL_PROG_TYPE_EN_NORMAL_BIT, 1},
@@ -272,6 +276,10 @@ TEST_F(FlashCtrlTest, SetProgPermissions) {
 
   prog_caps.normal_prog_type = 1;
   prog_caps.repair_prog_type = 0;
+
+  EXPECT_READ32(FLASH_CTRL_CTRL_REGWEN_REG_OFFSET,
+                {{FLASH_CTRL_CTRL_REGWEN_EN_BIT, 1}});
+
   EXPECT_WRITE32(FLASH_CTRL_PROG_TYPE_EN_REG_OFFSET,
                  {
                      {FLASH_CTRL_PROG_TYPE_EN_NORMAL_BIT, 0},


### PR DESCRIPTION
- Other transaction attributes were already protected, but ADDR was
  missing. This led to issues in #13933

Signed-off-by: Timothy Chen <timothytim@google.com>