### PR TITLE
Replace libncurses5 with libncursesw5 in apt-requirements.txt

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -30,7 +30,7 @@ libelf-dev
 libftdi1-2
 libftdi1-dev
 # A requirement of the prebuilt clang toolchain.
-libncurses5
+libncursesw5
 libssl-dev
 libudev-dev
 libusb-1.0-0


### PR DESCRIPTION
Note that libncurses**w** != libncurses. I ran into the missing lib when trying to run `riscv32-unknown-elf-gdb`.

It appears we only need libncursesw for the riscv toolchain.

```console
% ldd  /tools/riscv/bin/* | grep ncurses
        not a dynamic executable
        not a dynamic executable
        libncursesw.so.5 => /lib/x86_64-linux-gnu/libncursesw.so.5 (0x00007f9cd53a5000)
        not a dynamic executable
        not a dynamic executable
        not a dynamic executable
        not a dynamic executable
```


Signed-off-by: Dan McArdle <dmcardle@google.com>