### PR TITLE
[dv] Add return when reset occurs

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -164,6 +164,7 @@ virtual task tl_instr_type_err(string ral_name);
     bit [BUS_DW-1:0] data;
     mubi4_t          instr_type;
 
+    if (cfg.under_reset) return;
     `DV_CHECK_STD_RANDOMIZE_FATAL(addr);
     `DV_CHECK_STD_RANDOMIZE_FATAL(data);
 


### PR DESCRIPTION
Add return when reset occurs, in order to avoid printing many logs
during reset.

Signed-off-by: Weicai Yang <weicai@google.com>