### PR TITLE
[entropy_src/dv] Leave CSRNG & RNG Seq's running during RST.

### DIFF
--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -36,9 +36,9 @@ module tb;
   pins_if#(8) otp_en_es_fw_over_if(otp_en_es_fw_over);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   push_pull_if#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))
-      rng_if(.clk(clk), .rst_n(rst_n));
+      rng_if(.clk(clk), .rst_n(csrng_rst_n));
   push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
-      csrng_if(.clk(clk), .rst_n(rst_n & csrng_rst_n));
+      csrng_if(.clk(clk), .rst_n(csrng_rst_n));
   entropy_src_path_if entropy_src_path_if (.entropy_src_hw_if_i(entropy_src_hw_if_i));
   entropy_src_assert_if entropy_src_assert_if (.entropy_src_hw_if_i(entropy_src_hw_if_i));
 


### PR DESCRIPTION
This commit makes a clean break between the csrng_rst_ni (used by the
CSRNG and RNG pull-push monitors) and the rst_ni used by the DUT.

The purpose is to allow the DUT to be reset in the middle of the
simulation without stopping the other I/O sequences running around it.

This change prevents assertion failures that may occur if there
are CSRNG/RNG sequences are shutdown before the DUT.  It also
gives a stronger test of how the DUT behaves if there is activity
on the pins during reset.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>