### PR TITLE
[bazel] generate unsigned and signed flash images simultaneously

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -726,7 +726,7 @@ def opentitan_flash_binary(
         signing_keys = {
             "test_key_0": "@//sw/device/silicon_creator/mask_rom/keys:test_private_key_0",
         },
-        output_signed = False,
+        signed = False,
         manifest = None,
         **kwargs):
     """A helper macro for generating OpenTitan binary artifacts for flash.
@@ -740,7 +740,7 @@ def opentitan_flash_binary(
       @param name: The name of this rule.
       @param platform: The target platform for the artifacts.
       @param signing_keys: The signing keys for to sign each BIN file with.
-      @param output_signed: Whether or not to emit signed binary/VMEM files.
+      @param signed: Whether or not to emit signed binary/VMEM files.
       @param **kwargs: Arguments to forward to `opentitan_binary`.
     Emits rules:
       For each device in per_device_deps entry:
@@ -782,7 +782,7 @@ def opentitan_flash_binary(
         bin_name = "{}_{}".format(devname, "bin")
 
         # Sign BIN (if required) and generate scrambled VMEM images.
-        if output_signed:
+        if signed:
             for (key_name, key) in signing_keys.items():
                 # Sign the Binary.
                 signed_bin_name = "{}_bin_signed_{}".format(devname, key_name)
@@ -819,25 +819,25 @@ def opentitan_flash_binary(
                     vmem = signed_vmem_name,
                     platform = platform,
                 )
-        else:
-            # Generate a VMEM64 from the binary.
-            vmem_name = "{}_vmem64".format(devname)
-            dev_targets.append(":" + vmem_name)
-            bin_to_vmem(
-                name = vmem_name,
-                bin = bin_name,
-                platform = platform,
-                word_size = 64,  # Backdoor-load VMEM image uses 64-bit words
-            )
 
-            # Scramble VMEM64.
-            scr_vmem_name = "{}_scr_vmem64".format(devname)
-            dev_targets.append(":" + scr_vmem_name)
-            scramble_flash_vmem(
-                name = scr_vmem_name,
-                vmem = vmem_name,
-                platform = platform,
-            )
+        # Generate a VMEM64 from the binary.
+        vmem_name = "{}_vmem64".format(devname)
+        dev_targets.append(":" + vmem_name)
+        bin_to_vmem(
+            name = vmem_name,
+            bin = bin_name,
+            platform = platform,
+            word_size = 64,  # Backdoor-load VMEM image uses 64-bit words
+        )
+
+        # Scramble VMEM64.
+        scr_vmem_name = "{}_scr_vmem64".format(devname)
+        dev_targets.append(":" + scr_vmem_name)
+        scramble_flash_vmem(
+            name = scr_vmem_name,
+            vmem = vmem_name,
+            platform = platform,
+        )
 
         # Create a filegroup with just the current device's targets.
         native.filegroup(

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -278,7 +278,7 @@ def opentitan_functest(
         ot_flash_binary = name + "_prog"
         opentitan_flash_binary(
             name = ot_flash_binary,
-            output_signed = signed,
+            signed = signed,
             deps = deps,
             **kwargs
         )

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -153,7 +153,7 @@ opentitan_flash_binary(
     name = "slot_a",
     srcs = ["rom_ext_start.S"],
     manifest = ":manifest_standard",
-    output_signed = True,
+    signed = True,
     deps = [
         ":ld_slot_a",
         ":rom_ext",
@@ -166,7 +166,7 @@ opentitan_flash_binary(
     name = "slot_b",
     srcs = ["rom_ext_start.S"],
     manifest = ":manifest_standard",
-    output_signed = True,
+    signed = True,
     deps = [
         ":ld_slot_b",
         ":rom_ext",
@@ -179,7 +179,7 @@ opentitan_flash_binary(
     name = "virtual_addr",
     srcs = ["rom_ext_start.S"],
     manifest = ":manifest_virtual",
-    output_signed = True,
+    signed = True,
     deps = [
         ":ld_virtual_addr",
         ":rom_ext",

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -69,7 +69,7 @@ opentitan_flash_binary(
     name = "bare_metal_example_slot_a",
     srcs = ["bare_metal_start.S"],
     manifest = ":manifest_standard",
-    output_signed = True,
+    signed = True,
     deps = [
         ":bare_metal_example",
         ":ld_slot_a",
@@ -82,7 +82,7 @@ opentitan_flash_binary(
     name = "bare_metal_example_slot_b",
     srcs = ["bare_metal_start.S"],
     manifest = ":manifest_standard",
-    output_signed = True,
+    signed = True,
     deps = [
         ":bare_metal_example",
         ":ld_slot_b",
@@ -95,7 +95,7 @@ opentitan_flash_binary(
     name = "bare_metal_example_virtual_addr",
     srcs = ["bare_metal_start.S"],
     manifest = ":manifest_virtual",
-    output_signed = True,
+    signed = True,
     deps = [
         ":bare_metal_example",
         ":ld_virtual_addr",


### PR DESCRIPTION
There is a parameter on the `opentitan_flash_binary` macro that enables the generation of signed images. When a `opentitan_functest` macro passes this parameter through to the `opentitan_flash_binary`, and this parameter was set to `true`, then only signed images would be generated. This was an issue for chip-level tests like the UART smoke test that run with both test ROM and mask ROM in DV sim nightly regressions as the unsigned image would never get generated, and the testbench would look for the unsigned image. This fixes this by generating both signed and unsigned images when the `signed` flag is true, and only unsigned images when the signed flag is false. This enables the same bazel label to be passed to both dvsim.py invocations to run two different tests.

**_Note: this depends on #13979 and #14003; only review the last commit._**