### PR TITLE
[dv] AON timer regression failure fixes

### DIFF
--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -62,6 +62,9 @@ class aon_timer_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, "Disabling AON Timer. Writing 0 to WKUP_CTRL and WDOG_CTRL", UVM_HIGH)
     csr_utils_pkg::csr_wr(ral.wkup_ctrl.enable, 1'b0);
     csr_utils_pkg::csr_wr(ral.wdog_ctrl.enable, 1'b0);
+
+    // Wait to settle registers on AON timer domain
+    cfg.aon_clk_rst_vif.wait_clks(5);
   endtask
 
   // setup basic aon_timer features

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_jump_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_jump_vseq.sv
@@ -69,6 +69,8 @@ class aon_timer_jump_vseq extends aon_timer_base_vseq;
               $sformatf("\n\t Writing random COUNT value of %d to WDOG", wdog_count),
               UVM_HIGH)
 
+    cfg.aon_clk_rst_vif.wait_clks(1);
+
     `uvm_info(`gfn, "Enabling AON Timer. Writing 1 to WKUP_CTRL and WDOG_CTRL", UVM_HIGH)
     csr_utils_pkg::csr_wr(ral.wdog_ctrl.enable, 1'b1);
     csr_utils_pkg::csr_wr(ral.wkup_ctrl.enable, 1'b1);

--- a/hw/ip/prim/rtl/prim_reg_cdc.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc.sv
@@ -169,21 +169,4 @@ module prim_reg_cdc #(
   // If busy goes high, we must eventually see an ack
   `ASSERT(HungHandShake_A, $rose(src_req) |-> strong(##[0:$] src_ack), clk_src_i, !rst_src_ni)
 
-  `ifdef INC_ASSERT
-    logic async_flag;
-    always_ff @(posedge clk_dst_i or negedge rst_dst_ni or posedge src_update) begin
-      if (!rst_src_ni) begin
-        async_flag <= '0;
-      end else if (src_update) begin
-        async_flag <= '0;
-      end else if (dst_update_i) begin
-        async_flag <= 1'b1;
-      end
-    end
-
-   // once hardware makes an update request, we must eventually see an update pulse
-   `ASSERT(ReqTimeout_A, $rose(async_flag) |-> strong(##[0:$] src_update), clk_src_i, !rst_src_ni)
-  `endif
-
-
 endmodule // prim_subreg_cdc

--- a/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
@@ -224,6 +224,12 @@ module prim_reg_cdc_arb #(
     assign src_ack_o = src_req & (id_q == SelSwReq);
     assign src_update_o = src_req & (id_q == SelHwReq);
 
+    `ifdef INC_ASSERT
+     // once hardware makes an update request, we must eventually see an update pulse
+     `ASSERT(ReqTimeout_A, $rose(id_q == SelHwReq) |-> strong(##[0:$] src_update_o),
+             clk_src_i, !rst_src_ni)
+    `endif
+
   end else begin : gen_passthru
     // when there is no possibility of conflicting HW transactions,
     // we can assume that dst_qs_i will only ever take on the value


### PR DESCRIPTION
First commit is mostly about giving the test more time to settle software side registers. More interesting change is in the second commit.

@tjaychen : I did a change in the assertion around receiving an update pulse for the source(software) side in the case of a hardware request. Because we already catch the hardware request and process it in the arbitration module I moved the assertion there. This change possibly made this assertion weaker but I couldn't find any other way to make it consistent with the module behaviour. Could you have a look when you are available?