### PR TITLE
[dvsim] Change global options to only extend run options if not duplicate

### DIFF
--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -443,7 +443,9 @@ class Tests(RunModes):
                 processed_build_modes.append(test.build_mode.name)
             test.pre_run_cmds.extend(global_pre_run_cmds)
             test.post_run_cmds.extend(global_post_run_cmds)
-            test.run_opts.extend(global_run_opts)
+            for opt in global_run_opts:
+                if opt not in test.run_opts:
+                    test.run_opts.append(opt)
             test.sw_images.extend(global_sw_images)
             test.sw_build_opts.extend(global_sw_build_opts)
 

--- a/util/dvsim/Scheduler.py
+++ b/util/dvsim/Scheduler.py
@@ -12,7 +12,7 @@ from Timer import Timer
 from utils import VERBOSE
 
 
-# Sum of lenghts of all lists in the given dict.
+# Sum of lengths of all lists in the given dict.
 def sum_dict_lists(d):
     '''Given a dict whose key values are lists, return sum of lengths of
     thoese lists.'''


### PR DESCRIPTION
Prior to this PR, global options unconditionally extended the run
options for a test.  This could cause problems when run options already
contained an option already present in the global options, or when
global options contained the same option twice.  In such cases, the
duplicate options would be passed to the executing tool, which could
throw warnings or errors due to that.

This PR lets global options only extend run options if an option is
not already present in the run options.