### PR TITLE
[dv/kmac] Enhance app mode constraints

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -350,10 +350,13 @@ class kmac_scoreboard extends cip_base_scoreboard #(
             // we need to choose the correct application interface
             if (`KMAC_APP_VALID_TRANS(AppKeymgr)) begin
               app_mode = AppKeymgr;
+              strength = sha3_pkg::L256;
             end else if (`KMAC_APP_VALID_TRANS(AppLc)) begin
               app_mode = AppLc;
+              strength = sha3_pkg::L128;
             end else if (`KMAC_APP_VALID_TRANS(AppRom)) begin
               app_mode = AppRom;
+              strength = sha3_pkg::L256;
             end
 
             // sample sideload-related coverage

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
@@ -24,13 +24,6 @@ class kmac_app_vseq extends kmac_sideload_vseq;
       // application interface outputs 384-bit digest (48 bytes)
       output_len == kmac_pkg::AppDigestW / 8;
 
-      // LC_CTRL uses 128-bit strength, KeyMgr and OTP_CTRL use 256-bit strength
-      if (app_mode == AppLc) {
-        strength == sha3_pkg::L128;
-      } else {
-        strength == sha3_pkg::L256;
-      }
-
       // KMAC_APP will never use XOF mode
       xof_en == 0;
     }

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -277,7 +277,6 @@ class kmac_smoke_vseq extends kmac_base_vseq;
 
         // issue Process cmd
         issue_cmd(CmdProcess);
-        read_regwen_and_rand_write_locked_regs();
 
         wait_for_kmac_done();
         kmac_done = 1;


### PR DESCRIPTION
This PR removes the constraint to always input the correct strength when
using kmac app interface.
Instead, it will randomly choose a valid strength mode.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>