### PR TITLE
[spi_device] TPM FIFO Pointers to param

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -106,6 +106,18 @@
       default: "5"
       local:   "true"
     } // p: NumLocality
+    { name:    "TpmWrFifoPtrW"
+      desc:    "TPM WrFIFO Pointer Bit Width. clog2(Depth(4+1))"
+      type:    "int unsigned"
+      default: "3"
+      local:   "true"
+    } // p: TpmWrFifoPtrW
+    { name:    "TpmRdFifoPtrW"
+      desc:    "TPM RdFIFO Pointer Bit Width. clog2(Depth(4+1))"
+      type:    "int unsigned"
+      default: "3"
+      local:   "true"
+    } // p: TpmRdFifoPtrW
   ],
   inter_signal_list: [
     { struct:  "ram_2p_cfg",
@@ -1137,11 +1149,11 @@
           name: "rdfifo_notempty"
           desc: "If 1, the TPM_READ_FIFO still has pending data."
         } // f: rdfifo_notempty
-        { bits: "6:4"
+        { bits: "3+TpmRdFifoPtrW:4"
           name: "rdfifo_depth"
           desc: "This field represents the current read FIFO depth"
         } // f: rdfifo_depth
-        { bits: "10:8"
+        { bits: "7+TpmWrFifoPtrW:8"
           name: "wrfifo_depth"
           desc: "This field represents the current write FIFO depth."
         } // f: wrfifo_depth

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -326,8 +326,14 @@ module spi_device
   logic flash_sck_readbuf_watermark, flash_sck_readbuf_flip;
 
   // TPM ===============================================================
-  localparam int unsigned TpmFifoDepth    = 4; // 4B
-  localparam int unsigned TpmFifoPtrW     = $clog2(TpmFifoDepth+1);
+  localparam int unsigned TpmWrFifoDepth  = 4; // 4B
+  localparam int unsigned TpmRdFifoDepth  = 4; // 4B
+  localparam int unsigned TpmWrFifoPtrW     = $clog2(TpmWrFifoDepth+1);
+  localparam int unsigned TpmRdFifoPtrW     = $clog2(TpmRdFifoDepth+1);
+  `ASSERT_INIT(TpmWrPtrMatch_A,
+    TpmWrFifoPtrW == spi_device_reg_pkg::TpmWrFifoPtrW)
+  `ASSERT_INIT(TpmRdPtrMatch_A,
+    TpmRdFifoPtrW == spi_device_reg_pkg::TpmRdFifoPtrW)
 
   // pulse signal to set once from tpm_status_cmdaddr_notempty
   logic intr_tpm_cmdaddr_notempty;
@@ -362,8 +368,8 @@ module spi_device
 
   // TPM_STATUS
   logic tpm_status_cmdaddr_notempty, tpm_status_rdfifo_notempty;
-  logic [TpmFifoPtrW-1:0] tpm_status_rdfifo_depth;
-  logic [TpmFifoPtrW-1:0] tpm_status_wrfifo_depth;
+  logic [TpmRdFifoPtrW-1:0] tpm_status_rdfifo_depth;
+  logic [TpmWrFifoPtrW-1:0] tpm_status_wrfifo_depth;
 
   // TPM ---------------------------------------------------------------
 
@@ -1691,8 +1697,8 @@ module spi_device
   // Instance of spi_tpm
   spi_tpm #(
     // CmdAddrFifoDepth
-    .WrFifoDepth (TpmFifoDepth),
-    .RdFifoDepth (TpmFifoDepth),
+    .WrFifoDepth (TpmWrFifoDepth),
+    .RdFifoDepth (TpmRdFifoDepth),
     .EnLocality  (1)
   ) u_spi_tpm (
     .clk_in_i  (clk_spi_in_buf ),

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -10,6 +10,8 @@ package spi_device_reg_pkg;
   parameter int unsigned SramDepth = 1024;
   parameter int unsigned NumCmdInfo = 24;
   parameter int unsigned NumLocality = 5;
+  parameter int unsigned TpmWrFifoPtrW = 3;
+  parameter int unsigned TpmRdFifoPtrW = 3;
   parameter int NumAlerts = 1;
 
   // Address widths within the block


### PR DESCRIPTION
This commit splits TpmFifoPtrW into Read/Write parameters. And define
those parameters in `spi_device.hjson` to match with the design.

Related Issue #13816 

This is the first change to support 64B Transfer in TPM module easier for SW.