### PR TITLE
[spi_device] Increase TPM Write FIFO to 64B

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -109,7 +109,7 @@
     { name:    "TpmWrFifoPtrW"
       desc:    "TPM WrFIFO Pointer Bit Width. clog2(Depth(4+1))"
       type:    "int unsigned"
-      default: "3"
+      default: "7"
       local:   "true"
     } // p: TpmWrFifoPtrW
     { name:    "TpmRdFifoPtrW"
@@ -1149,11 +1149,11 @@
           name: "rdfifo_notempty"
           desc: "If 1, the TPM_READ_FIFO still has pending data."
         } // f: rdfifo_notempty
-        { bits: "3+TpmRdFifoPtrW:4"
+        { bits: "7+TpmRdFifoPtrW:8"
           name: "rdfifo_depth"
           desc: "This field represents the current read FIFO depth"
         } // f: rdfifo_depth
-        { bits: "7+TpmWrFifoPtrW:8"
+        { bits: "15+TpmWrFifoPtrW:16"
           name: "wrfifo_depth"
           desc: "This field represents the current write FIFO depth."
         } // f: wrfifo_depth

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -326,10 +326,10 @@ module spi_device
   logic flash_sck_readbuf_watermark, flash_sck_readbuf_flip;
 
   // TPM ===============================================================
-  localparam int unsigned TpmWrFifoDepth  = 4; // 4B
-  localparam int unsigned TpmRdFifoDepth  = 4; // 4B
-  localparam int unsigned TpmWrFifoPtrW     = $clog2(TpmWrFifoDepth+1);
-  localparam int unsigned TpmRdFifoPtrW     = $clog2(TpmRdFifoDepth+1);
+  localparam int unsigned TpmWrFifoDepth  = 64; // 64B
+  localparam int unsigned TpmRdFifoDepth  = 4;  // 4B
+  localparam int unsigned TpmWrFifoPtrW   = $clog2(TpmWrFifoDepth+1);
+  localparam int unsigned TpmRdFifoPtrW   = $clog2(TpmRdFifoDepth+1);
   `ASSERT_INIT(TpmWrPtrMatch_A,
     TpmWrFifoPtrW == spi_device_reg_pkg::TpmWrFifoPtrW)
   `ASSERT_INIT(TpmRdPtrMatch_A,

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -10,7 +10,7 @@ package spi_device_reg_pkg;
   parameter int unsigned SramDepth = 1024;
   parameter int unsigned NumCmdInfo = 24;
   parameter int unsigned NumLocality = 5;
-  parameter int unsigned TpmWrFifoPtrW = 3;
+  parameter int unsigned TpmWrFifoPtrW = 7;
   parameter int unsigned TpmRdFifoPtrW = 3;
   parameter int NumAlerts = 1;
 
@@ -654,7 +654,7 @@ package spi_device_reg_pkg;
       logic        de;
     } rdfifo_depth;
     struct packed {
-      logic [2:0]  d;
+      logic [6:0]  d;
       logic        de;
     } wrfifo_depth;
   } spi_device_hw2reg_tpm_status_reg_t;
@@ -719,20 +719,20 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [279:256]
-    spi_device_hw2reg_cfg_reg_t cfg; // [255:254]
-    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [253:238]
-    spi_device_hw2reg_status_reg_t status; // [237:232]
-    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [231:215]
-    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [214:198]
-    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [197:166]
-    spi_device_hw2reg_flash_status_reg_t flash_status; // [165:142]
-    spi_device_hw2reg_upload_status_reg_t upload_status; // [141:126]
-    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [125:107]
-    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [106:99]
-    spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [98:67]
-    spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [66:52]
-    spi_device_hw2reg_tpm_status_reg_t tpm_status; // [51:40]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [283:260]
+    spi_device_hw2reg_cfg_reg_t cfg; // [259:258]
+    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [257:242]
+    spi_device_hw2reg_status_reg_t status; // [241:236]
+    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [235:219]
+    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [218:202]
+    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [201:170]
+    spi_device_hw2reg_flash_status_reg_t flash_status; // [169:146]
+    spi_device_hw2reg_upload_status_reg_t upload_status; // [145:130]
+    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [129:111]
+    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [110:103]
+    spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [102:71]
+    spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [70:56]
+    spi_device_hw2reg_tpm_status_reg_t tpm_status; // [55:40]
     spi_device_hw2reg_tpm_cmd_addr_reg_t tpm_cmd_addr; // [39:8]
     spi_device_hw2reg_tpm_write_fifo_reg_t tpm_write_fifo; // [7:0]
   } spi_device_hw2reg_t;
@@ -1003,7 +1003,7 @@ package spi_device_reg_pkg;
     4'b 1111, // index[63] SPI_DEVICE_CMD_INFO_WRDI
     4'b 0111, // index[64] SPI_DEVICE_TPM_CAP
     4'b 0001, // index[65] SPI_DEVICE_TPM_CFG
-    4'b 0011, // index[66] SPI_DEVICE_TPM_STATUS
+    4'b 0111, // index[66] SPI_DEVICE_TPM_STATUS
     4'b 1111, // index[67] SPI_DEVICE_TPM_ACCESS_0
     4'b 0001, // index[68] SPI_DEVICE_TPM_ACCESS_1
     4'b 1111, // index[69] SPI_DEVICE_TPM_STS

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1511,7 +1511,7 @@ module spi_device_reg_top (
   logic tpm_status_cmdaddr_notempty_qs;
   logic tpm_status_rdfifo_notempty_qs;
   logic [2:0] tpm_status_rdfifo_depth_qs;
-  logic [2:0] tpm_status_wrfifo_depth_qs;
+  logic [6:0] tpm_status_wrfifo_depth_qs;
   logic tpm_access_0_we;
   logic [7:0] tpm_access_0_access_0_qs;
   logic [7:0] tpm_access_0_access_0_wd;
@@ -18453,7 +18453,7 @@ module spi_device_reg_top (
     .qs     (tpm_status_rdfifo_notempty_qs)
   );
 
-  //   F[rdfifo_depth]: 6:4
+  //   F[rdfifo_depth]: 10:8
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -18479,11 +18479,11 @@ module spi_device_reg_top (
     .qs     (tpm_status_rdfifo_depth_qs)
   );
 
-  //   F[wrfifo_depth]: 10:8
+  //   F[wrfifo_depth]: 22:16
   prim_subreg #(
-    .DW      (3),
+    .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (3'h0)
+    .RESVAL  (7'h0)
   ) u_tpm_status_wrfifo_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21412,8 +21412,8 @@ module spi_device_reg_top (
       addr_hit[66]: begin
         reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
         reg_rdata_next[1] = tpm_status_rdfifo_notempty_qs;
-        reg_rdata_next[6:4] = tpm_status_rdfifo_depth_qs;
-        reg_rdata_next[10:8] = tpm_status_wrfifo_depth_qs;
+        reg_rdata_next[10:8] = tpm_status_rdfifo_depth_qs;
+        reg_rdata_next[22:16] = tpm_status_wrfifo_depth_qs;
       end
 
       addr_hit[67]: begin


### PR DESCRIPTION
TPM Write FIFO is increased to 64B to cover the maximum TPM transfer
size. The previous design had 4B Write FIFO size. With 4B Write FIFO, SW
still process 64B transfer by fetching data from the FIFO during TPM
transaction.

However, it requires SW to check the FIFO status frequently and
immediate fetch from the FIFO to not make FIFO full.

With this change, SW may process the TPM Write command after the
transaction has been fully received.

This PR includes #13997 Please review last two commits.