### PR TITLE
[ci,bazel] only run short and moderate FPGA tests in CI

### DIFF
--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -27,6 +27,7 @@ ci/bazelisk.sh test \
     --define DISABLE_VERILATOR_BUILD=true \
     --nokeep_going \
     --test_tag_filters=cw310,-broken \
+    --test_timeout_filters=short,moderate \
     --test_output=all \
     --build_tests_only \
     --define cw310=lowrisc \


### PR DESCRIPTION
Currently, we run all FPGA tests in CI regardless of the test timeout
duration. Recently, some long tests were added that have increased CI
times to the point where the CW310 FPGA test running CI stage is almost
timing out. This updates CI to only run short (<1 min) and moderate
(<5 min) tests.

Signed-off-by: Timothy Trippel <ttrippel@google.com>