### PR TITLE
[test] Disable wycheproof tests.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -78,6 +78,8 @@ opentitan_functest(
     cw310 = cw310_params(
         timeout = "long",
     ),
+    # Temporarily disable this test because it takes too long.
+    tags = ["broken"],
     targets = ["cw310"],  # Test set is too large to run in simulation
     deps = [
         ":mod_exp_ibex",
@@ -144,6 +146,8 @@ opentitan_functest(
 opentitan_functest(
     name = "mod_exp_otbn_functest_wycheproof",
     srcs = ["mod_exp_otbn_functest.c"],
+    # Temporarily disable this test because it takes too long.
+    tags = ["broken"],
     verilator = verilator_params(
         timeout = "long",
         tags = [
@@ -254,6 +258,8 @@ opentitan_functest(
     cw310 = cw310_params(
         timeout = "long",
     ),
+    # Temporarily disable this test because it takes too long.
+    tags = ["broken"],
     targets = ["cw310"],  # Test set is too large to run in simulation
     deps = [
         ":sigverify",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -65,6 +65,8 @@ autogen_cryptotest_header(
 opentitan_functest(
     name = "rsa_3072_verify_functest_wycheproof",
     srcs = ["rsa_3072_verify_functest.c"],
+    # Temporarily disable this test because it takes too long.
+    tags = ["broken"],
     verilator = verilator_params(
         timeout = "long",
     ),


### PR DESCRIPTION
Recently added wycheproof tests are adding too much time to CI. For now, disable them to ease pressure while we consider what to do.

CC @alphan 