### PR TITLE
[sw] Reduce the number of runs in memory_perftest and remove OT_NEVER_INLINE

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -45,8 +45,6 @@
  * A directive to force the compiler to inline a function.
  */
 #define OT_ALWAYS_INLINE __attribute__((always_inline)) inline
-// TODO Delete and use OT_NOINLINE if #13383 is merged before #13871.
-#define OT_NEVER_INLINE __attribute__((noinline))
 
 /**
  * The `restrict` keyword is C specific, so we provide a C++-portable wrapper
@@ -291,7 +289,7 @@
  *
  * See https://clang.llvm.org/docs/AttributeReference.html#noinline.
  */
-#define OT_NOINLINE() __attribute__((noinline))
+#define OT_NOINLINE __attribute__((noinline))
 
 /**
  * Returns the address of the current function stack frame.

--- a/sw/device/lib/base/memory_perftest.c
+++ b/sw/device/lib/base/memory_perftest.c
@@ -91,29 +91,29 @@ static inline void fill_buf_one_then_zeroes(uint8_t *buf, size_t len) {
   buf[0] = 1;
 }
 
-OT_NEVER_INLINE void test_memcpy(uint8_t *buf1, uint8_t *buf2, size_t len) {
+OT_NOINLINE void test_memcpy(uint8_t *buf1, uint8_t *buf2, size_t len) {
   memcpy(buf1, buf2, len);
 }
 
-OT_NEVER_INLINE void test_memset(uint8_t *buf1, uint8_t *buf2, size_t len) {
+OT_NOINLINE void test_memset(uint8_t *buf1, uint8_t *buf2, size_t len) {
   const int value = buf2[0];
   memset(buf1, value, len);
 }
 
-OT_NEVER_INLINE void test_memcmp(uint8_t *buf1, uint8_t *buf2, size_t len) {
+OT_NOINLINE void test_memcmp(uint8_t *buf1, uint8_t *buf2, size_t len) {
   memcmp(buf1, buf2, len);
 }
 
-OT_NEVER_INLINE void test_memrcmp(uint8_t *buf1, uint8_t *buf2, size_t len) {
+OT_NOINLINE void test_memrcmp(uint8_t *buf1, uint8_t *buf2, size_t len) {
   memrcmp(buf1, buf2, len);
 }
 
-OT_NEVER_INLINE void test_memchr(uint8_t *buf1, uint8_t *buf2, size_t len) {
+OT_NOINLINE void test_memchr(uint8_t *buf1, uint8_t *buf2, size_t len) {
   const uint8_t value = buf1[len - 1];
   memchr(buf1, value, len);
 }
 
-OT_NEVER_INLINE void test_memrchr(uint8_t *buf1, uint8_t *buf2, size_t len) {
+OT_NOINLINE void test_memrchr(uint8_t *buf1, uint8_t *buf2, size_t len) {
   const uint8_t value = buf1[0];
   memrchr(buf1, value, len);
 }

--- a/sw/device/tests/sram_ctrl_execution_test.c
+++ b/sw/device/tests/sram_ctrl_execution_test.c
@@ -29,7 +29,7 @@ enum {
 };
 
 OT_SECTION(".data.sram_function_test")
-OT_NOINLINE()
+OT_NOINLINE
 static void sram_function_test(void) {
   uint32_t pc = 0;
   asm("auipc %[pc], 0;" : [pc] "=r"(pc));


### PR DESCRIPTION
This PR 
* Removes `OT_NEVER_INLINE` and replaces its usages with `OT_NOINLINE`
* Reduces the number of runs in memory_perftest (reducing the time this test takes from 20+ secs to ~2 secs)