### PR TITLE
[dv,chip] Remove redundant pwrmgr_rstmgr_sva

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -27,7 +27,6 @@
   sim_tops: ["clkmgr_bind",
              "pwrmgr_bind",
              "rstmgr_bind",
-             "pwrmgr_rstmgr_bind",
              "top_earlgrey_bind",
              "xbar_main_bind",
              "xbar_peri_bind"]


### PR DESCRIPTION
The pwrmgr_rstmgr_sva_if interface bound to pwrmgr is incorrect for
full chip, as there is one bound to top_earlgrey that is more complete.

Signed-off-by: Guillermo Maturana <maturana@google.com>