### PR TITLE
[chip/dv] Map chip_sw_flash_keymgr_seeds with keymgr_key_derivation

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2550,7 +2550,7 @@
             X-ref'ed with keymgr test.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_keymgr_key_derivation"]
     }
     {
       name: chip_sw_flash_lc_creator_seed_sw_rw_en


### PR DESCRIPTION
Both creator and owner seeds are used and checked in chip_sw_keymgr_key_derivation

Signed-off-by: Weicai Yang <weicai@google.com>