### PR TITLE
[spi_device] 4B wide TPM Read FIFO

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -118,6 +118,11 @@
       default: "3"
       local:   "true"
     } // p: TpmRdFifoPtrW
+    { name:    "TpmRdFifoWidth"
+      desc:    "TPM Read FIFO Data Width. (TpmRdFifoWidth/8) shall be power of two"
+      type:    "int unsigned"
+      default: "32"
+    } // p: TpmRdFifoWidth
   ],
   inter_signal_list: [
     { struct:  "ram_2p_cfg",
@@ -1292,7 +1297,7 @@
       hwqe: "true"
       hwext: "true"
       fields: [
-        { bits: "7:0"
+        { bits: "TpmRdFifoWidth-1:0"
           name: "value"
           desc: "write port of the read FIFO"
         }

--- a/hw/ip/spi_device/doc/_index.md
+++ b/hw/ip/spi_device/doc/_index.md
@@ -879,6 +879,13 @@ Due to the CDC issue, the SW is only permitted to update the registers when the 
 1. The SW reads a word from TPM_CMD_ADDR CSR (optional cmdaddr_notempty interrupt).
   1. If the address falls into the return-by-HW registers and TPM_CFG.hw_reg_dis is not set, the HW does not push the command and address bytes into the TPM_CMD_ADDR CSR.
 1. The SW prepares the register value and writes the value into the read FIFO.
+  1. It is assumed that the writes are atomic.
+     TPM IP sends the read data whenever the FIFO has entries inside.
+     As TPM protocol does not support BUSY wait after sending a byte,
+     all read data should send in a chunk.
+     SW should ensure the read data is fed into the HW continuously.
+     In this version of IP, TPM provides 16B (4B wide x 4 depth) read FIFO.
+     SW may return up to 64B payload by pushing more data into the FIFO whenever the FIFO has available entries.
 1. The TPM submodule sends `WAIT` until the read FIFO is available. When available, the TPM submodule sends `START` followed by the register value.
 
 ### TPM Write

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_vseq.sv
@@ -44,7 +44,17 @@ class spi_device_tpm_read_vseq extends spi_device_tpm_base_vseq;
           check_tpm_cmd_addr(tpm_cmd, tpm_addr);
           // Upon receiving read command, set read fifo contents
           `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(read_fifo_data, read_fifo_data.size() == 4;)
-          foreach (read_fifo_data[i]) csr_wr(.ptr(ral.tpm_read_fifo), .value(read_fifo_data[i]));
+          for (int i = 0 ; i < read_fifo_data.size() ; i += 4) begin
+            automatic logic [31:0] rdfifo_wdata;
+            for (int j = 0 ; j < 4 ; j++) begin
+              if (i+j < read_fifo_data.size()) begin
+                rdfifo_wdata[8*j+:8] = read_fifo_data[i+j];
+              end else begin
+                rdfifo_wdata[8*j+:8] = 8'h 0;
+              end
+            end
+            csr_wr(.ptr(ral.tpm_read_fifo), .value(rdfifo_wdata));
+          end
         end // Write Read Fifo Thread
         begin
           // poll START and collect data

--- a/hw/ip/spi_device/pre_dv/tb/spi_tpm_tb.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spi_tpm_tb.sv
@@ -51,6 +51,7 @@ module spi_tpm_tb;
   localparam int unsigned CmdAddrFifoDepth = 2;
   localparam int unsigned WrFifoDepth      = 64;
   localparam int unsigned RdFifoDepth      = 4;
+  localparam int unsigned RdFifoWidth      = 8;
 
   localparam bit EnLocality = 1;
 
@@ -107,6 +108,7 @@ module spi_tpm_tb;
     .CmdAddrFifoDepth (CmdAddrFifoDepth),
     .WrFifoDepth      (WrFifoDepth     ),
     .RdFifoDepth      (RdFifoDepth     ),
+    .RdDataFifoSize   (RdFifoWidth     ),
     .EnLocality       (EnLocality      )
   ) dut (
     .clk_in_i  (gated_sck),

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -12,6 +12,7 @@ package spi_device_reg_pkg;
   parameter int unsigned NumLocality = 5;
   parameter int unsigned TpmWrFifoPtrW = 7;
   parameter int unsigned TpmRdFifoPtrW = 3;
+  parameter int unsigned TpmRdFifoWidth = 32;
   parameter int NumAlerts = 1;
 
   // Address widths within the block
@@ -462,7 +463,7 @@ package spi_device_reg_pkg;
   } spi_device_reg2hw_tpm_cmd_addr_reg_t;
 
   typedef struct packed {
-    logic [7:0]  q;
+    logic [31:0] q;
     logic        qe;
   } spi_device_reg2hw_tpm_read_fifo_reg_t;
 
@@ -674,46 +675,46 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1647:1636]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1635:1624]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1623:1600]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1599:1598]
-    spi_device_reg2hw_control_reg_t control; // [1597:1592]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1591:1578]
-    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1577:1546]
-    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1545:1530]
-    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1529:1514]
-    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1513:1482]
-    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1481:1450]
-    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1449:1446]
-    spi_device_reg2hw_flash_status_reg_t flash_status; // [1445:1420]
-    spi_device_reg2hw_jedec_cc_reg_t jedec_cc; // [1419:1404]
-    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1403:1380]
-    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1379:1370]
-    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1369:1338]
-    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1337:1329]
-    spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1328:1296]
-    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1295:1040]
-    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [1039:1008]
-    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [1007:976]
-    spi_device_reg2hw_payload_swap_mask_reg_t payload_swap_mask; // [975:944]
-    spi_device_reg2hw_payload_swap_data_reg_t payload_swap_data; // [943:912]
-    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [911:312]
-    spi_device_reg2hw_cmd_info_en4b_reg_t cmd_info_en4b; // [311:303]
-    spi_device_reg2hw_cmd_info_ex4b_reg_t cmd_info_ex4b; // [302:294]
-    spi_device_reg2hw_cmd_info_wren_reg_t cmd_info_wren; // [293:285]
-    spi_device_reg2hw_cmd_info_wrdi_reg_t cmd_info_wrdi; // [284:276]
-    spi_device_reg2hw_tpm_cfg_reg_t tpm_cfg; // [275:271]
-    spi_device_reg2hw_tpm_access_mreg_t [4:0] tpm_access; // [270:231]
-    spi_device_reg2hw_tpm_sts_reg_t tpm_sts; // [230:199]
-    spi_device_reg2hw_tpm_intf_capability_reg_t tpm_intf_capability; // [198:167]
-    spi_device_reg2hw_tpm_int_enable_reg_t tpm_int_enable; // [166:135]
-    spi_device_reg2hw_tpm_int_vector_reg_t tpm_int_vector; // [134:127]
-    spi_device_reg2hw_tpm_int_status_reg_t tpm_int_status; // [126:95]
-    spi_device_reg2hw_tpm_did_vid_reg_t tpm_did_vid; // [94:63]
-    spi_device_reg2hw_tpm_rid_reg_t tpm_rid; // [62:55]
-    spi_device_reg2hw_tpm_cmd_addr_reg_t tpm_cmd_addr; // [54:19]
-    spi_device_reg2hw_tpm_read_fifo_reg_t tpm_read_fifo; // [18:10]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1671:1660]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1659:1648]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1647:1624]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1623:1622]
+    spi_device_reg2hw_control_reg_t control; // [1621:1616]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1615:1602]
+    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1601:1570]
+    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1569:1554]
+    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1553:1538]
+    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1537:1506]
+    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1505:1474]
+    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1473:1470]
+    spi_device_reg2hw_flash_status_reg_t flash_status; // [1469:1444]
+    spi_device_reg2hw_jedec_cc_reg_t jedec_cc; // [1443:1428]
+    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1427:1404]
+    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1403:1394]
+    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1393:1362]
+    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1361:1353]
+    spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1352:1320]
+    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1319:1064]
+    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [1063:1032]
+    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [1031:1000]
+    spi_device_reg2hw_payload_swap_mask_reg_t payload_swap_mask; // [999:968]
+    spi_device_reg2hw_payload_swap_data_reg_t payload_swap_data; // [967:936]
+    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [935:336]
+    spi_device_reg2hw_cmd_info_en4b_reg_t cmd_info_en4b; // [335:327]
+    spi_device_reg2hw_cmd_info_ex4b_reg_t cmd_info_ex4b; // [326:318]
+    spi_device_reg2hw_cmd_info_wren_reg_t cmd_info_wren; // [317:309]
+    spi_device_reg2hw_cmd_info_wrdi_reg_t cmd_info_wrdi; // [308:300]
+    spi_device_reg2hw_tpm_cfg_reg_t tpm_cfg; // [299:295]
+    spi_device_reg2hw_tpm_access_mreg_t [4:0] tpm_access; // [294:255]
+    spi_device_reg2hw_tpm_sts_reg_t tpm_sts; // [254:223]
+    spi_device_reg2hw_tpm_intf_capability_reg_t tpm_intf_capability; // [222:191]
+    spi_device_reg2hw_tpm_int_enable_reg_t tpm_int_enable; // [190:159]
+    spi_device_reg2hw_tpm_int_vector_reg_t tpm_int_vector; // [158:151]
+    spi_device_reg2hw_tpm_int_status_reg_t tpm_int_status; // [150:119]
+    spi_device_reg2hw_tpm_did_vid_reg_t tpm_did_vid; // [118:87]
+    spi_device_reg2hw_tpm_rid_reg_t tpm_rid; // [86:79]
+    spi_device_reg2hw_tpm_cmd_addr_reg_t tpm_cmd_addr; // [78:43]
+    spi_device_reg2hw_tpm_read_fifo_reg_t tpm_read_fifo; // [42:10]
     spi_device_reg2hw_tpm_write_fifo_reg_t tpm_write_fifo; // [9:0]
   } spi_device_reg2hw_t;
 
@@ -845,7 +846,7 @@ package spi_device_reg_pkg;
   parameter logic [7:0] SPI_DEVICE_UPLOAD_CMDFIFO_RESVAL = 8'h 0;
   parameter logic [31:0] SPI_DEVICE_UPLOAD_ADDRFIFO_RESVAL = 32'h 0;
   parameter logic [31:0] SPI_DEVICE_TPM_CMD_ADDR_RESVAL = 32'h 0;
-  parameter logic [7:0] SPI_DEVICE_TPM_READ_FIFO_RESVAL = 8'h 0;
+  parameter logic [31:0] SPI_DEVICE_TPM_READ_FIFO_RESVAL = 32'h 0;
   parameter logic [7:0] SPI_DEVICE_TPM_WRITE_FIFO_RESVAL = 8'h 0;
 
   // Window parameters
@@ -1014,7 +1015,7 @@ package spi_device_reg_pkg;
     4'b 1111, // index[74] SPI_DEVICE_TPM_DID_VID
     4'b 0001, // index[75] SPI_DEVICE_TPM_RID
     4'b 1111, // index[76] SPI_DEVICE_TPM_CMD_ADDR
-    4'b 0001, // index[77] SPI_DEVICE_TPM_READ_FIFO
+    4'b 1111, // index[77] SPI_DEVICE_TPM_READ_FIFO
     4'b 0001  // index[78] SPI_DEVICE_TPM_WRITE_FIFO
   };
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1551,7 +1551,7 @@ module spi_device_reg_top (
   logic [23:0] tpm_cmd_addr_addr_qs;
   logic [7:0] tpm_cmd_addr_cmd_qs;
   logic tpm_read_fifo_we;
-  logic [7:0] tpm_read_fifo_wd;
+  logic [31:0] tpm_read_fifo_wd;
   logic tpm_write_fifo_re;
   logic [7:0] tpm_write_fifo_qs;
 
@@ -18899,7 +18899,7 @@ module spi_device_reg_top (
   logic [0:0] tpm_read_fifo_flds_we;
   assign tpm_read_fifo_qe = &tpm_read_fifo_flds_we;
   prim_subreg_ext #(
-    .DW    (8)
+    .DW    (32)
   ) u_tpm_read_fifo (
     .re     (1'b0),
     .we     (tpm_read_fifo_we),
@@ -20468,7 +20468,7 @@ module spi_device_reg_top (
   assign tpm_cmd_addr_re = addr_hit[76] & reg_re & !reg_error;
   assign tpm_read_fifo_we = addr_hit[77] & reg_we & !reg_error;
 
-  assign tpm_read_fifo_wd = reg_wdata[7:0];
+  assign tpm_read_fifo_wd = reg_wdata[31:0];
   assign tpm_write_fifo_re = addr_hit[78] & reg_re & !reg_error;
 
   // Assign write-enables to checker logic vector.
@@ -21462,7 +21462,7 @@ module spi_device_reg_top (
       end
 
       addr_hit[77]: begin
-        reg_rdata_next[7:0] = '0;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[78]: begin

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -13,8 +13,9 @@ module spi_tpm
 
   // Max Write/Read buffer size to support is 64B in TPM spec.
   // But more than 4B is for future use. So, 4B is recommended.
-  parameter int unsigned WrFifoDepth   = 4,
-  parameter int unsigned RdFifoDepth   = 4,
+  parameter int unsigned WrFifoDepth    = 4,
+  parameter int unsigned RdFifoDepth    = 4,
+  parameter int unsigned RdDataFifoSize = 32,
 
   // Locality determines the number of TPM_ACCESS registers.
   // Other HW managed registers are shared across the locality.
@@ -45,7 +46,6 @@ module spi_tpm
   localparam int unsigned CmdAddrSize    = 32, // Cmd 8bit + Addr 24bit
   localparam int unsigned FifoRegSize    = 12, // lower 12bit excluding locality
   localparam int unsigned WrDataFifoSize = NumBits,
-  localparam int unsigned RdDataFifoSize = NumBits,
 
   // Read FIFO byte_offset calculation
   localparam int unsigned RdFifoNumBytes = RdDataFifoSize / NumBits,

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -41,9 +41,10 @@ module spi_tpm
 
   localparam int unsigned ActiveLocalityBitPos = 5, // Access[5]
 
-  localparam int unsigned CmdAddrSize  = 32, // Cmd 8bit + Addr 24bit
-  localparam int unsigned FifoRegSize  = 12, // lower 12bit excluding locality
-  localparam int unsigned DataFifoSize = $bits(spi_byte_t),
+  localparam int unsigned CmdAddrSize    = 32, // Cmd 8bit + Addr 24bit
+  localparam int unsigned FifoRegSize    = 12, // lower 12bit excluding locality
+  localparam int unsigned WrDataFifoSize = $bits(spi_byte_t),
+  localparam int unsigned RdDataFifoSize = $bits(spi_byte_t),
 
   // TPM_CAP related constants.
   //  - Revision: the number visible in TPM_CAP CSR. Need to update the
@@ -107,13 +108,13 @@ module spi_tpm
   output logic [CmdAddrSize-1:0] sys_cmdaddr_rdata_o,
   input                          sys_cmdaddr_rready_i,
 
-  output logic                    sys_wrfifo_rvalid_o,
-  output logic [DataFifoSize-1:0] sys_wrfifo_rdata_o,
-  input                           sys_wrfifo_rready_i,
+  output logic                      sys_wrfifo_rvalid_o,
+  output logic [WrDataFifoSize-1:0] sys_wrfifo_rdata_o,
+  input                             sys_wrfifo_rready_i,
 
-  input                     sys_rdfifo_wvalid_i,
-  input  [DataFifoSize-1:0] sys_rdfifo_wdata_i,
-  output logic              sys_rdfifo_wready_o,
+  input                       sys_rdfifo_wvalid_i,
+  input  [RdDataFifoSize-1:0] sys_rdfifo_wdata_i,
+  output logic                sys_rdfifo_wready_o,
 
   // TPM_STATUS
   output logic                  sys_cmdaddr_notempty_o,
@@ -359,16 +360,16 @@ module spi_tpm
   // (sys_cmdaddr_rdepth > 0)
   assign sys_cmdaddr_notempty_o = |sys_cmdaddr_rdepth;
 
-  logic                    sck_wrfifo_wvalid, sck_wrfifo_wready;
-  logic [DataFifoSize-1:0] sck_wrfifo_wdata;
-  logic [WrFifoPtrW-1:0]   sys_wrfifo_rdepth, sck_wrfifo_wdepth;
+  logic                      sck_wrfifo_wvalid, sck_wrfifo_wready;
+  logic [WrDataFifoSize-1:0] sck_wrfifo_wdata;
+  logic [WrFifoPtrW-1:0]     sys_wrfifo_rdepth, sck_wrfifo_wdepth;
 
   assign sys_wrfifo_depth_o = sys_wrfifo_rdepth;
 
   // Read FIFO uses inverted SCK (clk_out_i)
-  logic                    isck_rdfifo_rvalid, isck_rdfifo_rready;
-  logic [DataFifoSize-1:0] isck_rdfifo_rdata;
-  logic [RdFifoPtrW-1:0]   sys_rdfifo_wdepth, isck_rdfifo_rdepth;
+  logic                      isck_rdfifo_rvalid, isck_rdfifo_rready;
+  logic [RdDataFifoSize-1:0] isck_rdfifo_rdata;
+  logic [RdFifoPtrW-1:0]     sys_rdfifo_wdepth, isck_rdfifo_rdepth;
 
   assign sys_rdfifo_depth_o    = sys_rdfifo_wdepth;
   assign sys_rdfifo_notempty_o = |sys_rdfifo_wdepth;
@@ -1130,7 +1131,7 @@ module spi_tpm
   );
 
   prim_fifo_async #(
-    .Width (DataFifoSize),
+    .Width (WrDataFifoSize),
     .Depth (WrFifoDepth),
     .OutputZeroIfEmpty (1'b 1)
   ) u_wrfifo (
@@ -1154,7 +1155,7 @@ module spi_tpm
   // transaction is completed (CSb deasserted).  So, everytime CSb is
   // deasserted --> rst_n asserted. So, reset the read FIFO.
   prim_fifo_async #(
-    .Width (DataFifoSize),
+    .Width (RdDataFifoSize),
     .Depth (RdFifoDepth),
     .OutputZeroIfEmpty (1'b 1)
   ) u_rdfifo (


### PR DESCRIPTION
**This change breaks SW API**

This commit increases TPM Read FIFO width to 32 bits.
It helps SW to maintain the throughput when SW sends more than 4B read
payload to TPM host.

_This PR does not revise the DV/ SW codes yet_

_This PR contains #13997 and #14000. Please review last three commits_