### PR TITLE
[dvsim] Address duplication of values in hjson

### DIFF
--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -320,14 +320,14 @@ name:
         # V2
         "otbn_reset", "otbn_multi", "otbn_stress_all",
         "otbn_zero_state_err_urnd", "otbn_sw_errs_fatal_chk", "otbn_alert_test",
-        "otbn_intr_test", "otbn_tl_errors", "otbn_csr_hw_reset",
+        "otbn_intr_test", "otbn_tl_errors",
         "otbn_same_csr_outstanding"
         # V2 but known broken
         # "otbn_multi_err", "otbn_escalate",
         # V2S
         "otbn_imem_err", "otbn_dmem_err", "otbn_illegal_mem_acc",
         "otbn_tl_intg_err", "otbn_sec_cm", "otbn_pc_ctrl_flow_redun",
-        "otbn_rnd_sec_cm", "otbn_pc_ctrl_flow_redun", "otbn_alu_bignum_mod_err",
+        "otbn_rnd_sec_cm", "otbn_alu_bignum_mod_err",
         "otbn_controller_ispr_rdata_err", "otbn_mac_bignum_acc_err",
         # V2S but known broken
         # "otbn_passthru_mem_tl_intg_err",

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -14,6 +14,7 @@ class Modes():
     Abstraction for specifying collection of options called as 'modes'. This is
     the base class which is extended for run_modes, build_modes, tests and regressions.
     """
+
     def self_str(self):
         '''
         This is used to construct the string representation of the entire class object.
@@ -52,7 +53,8 @@ class Modes():
 
         for key in keys:
             if key not in attrs:
-                log.error("Key %s in %s is invalid", key, mdict)
+                log.error(f"Key {key} in {mdict} is invalid. Supported "
+                          f"attributes in {self.mname} are {attrs}")
                 sys.exit(1)
             setattr(self, key, mdict[key])
 
@@ -151,6 +153,7 @@ class Modes():
         Process dependencies.
         Return a list of modes objects.
         '''
+
         def merge_sub_modes(mode, parent, objs):
             # Check if there are modes available to merge
             sub_modes = mode.get_sub_modes()
@@ -348,6 +351,7 @@ class Tests(RunModes):
         Process enabled run modes and the set build mode.
         Return a list of test objects.
         '''
+
         def get_pruned_en_run_modes(test_en_run_modes, global_en_run_modes):
             pruned_en_run_modes = []
             for test_en_run_mode in test_en_run_modes:
@@ -434,13 +438,13 @@ class Tests(RunModes):
                           global_build_opts, global_pre_run_cmds,
                           global_post_run_cmds, global_run_opts,
                           global_sw_images, global_sw_build_opts):
-        processed_build_modes = []
+        processed_build_modes = set()
         for test in tests:
             if test.build_mode.name not in processed_build_modes:
                 test.build_mode.pre_build_cmds.extend(global_pre_build_cmds)
                 test.build_mode.post_build_cmds.extend(global_post_build_cmds)
                 test.build_mode.build_opts.extend(global_build_opts)
-                processed_build_modes.append(test.build_mode.name)
+                processed_build_modes.add(test.build_mode.name)
             test.pre_run_cmds.extend(global_pre_run_cmds)
             test.post_run_cmds.extend(global_post_run_cmds)
             test.run_opts.extend(global_run_opts)
@@ -597,7 +601,7 @@ class Regressions(Modes):
                 regression_obj.test_names = Tests.item_names
 
             else:
-                tests_objs = []
+                tests_objs = set()
                 regression_obj.test_names = regression_obj.tests
                 for test in regression_obj.tests:
                     test_obj = Modes.find_mode(test, sim_cfg.tests)
@@ -606,8 +610,8 @@ class Regressions(Modes):
                             "Test \"%s\" added to regression \"%s\" not found!",
                             test, regression_obj.name)
                         continue
-                    tests_objs.append(test_obj)
-                regression_obj.tests = tests_objs
+                    tests_objs.add(test_obj)
+                regression_obj.tests = list(tests_objs)
 
         # Return the list of tests
         return regressions_objs


### PR DESCRIPTION
The duplication of tests in regressions is not reported as
an issue. The issue instead manifests after the test is run
and it fails. The test duplicated in regressions gets merged into
itself, duplicating the entire list of run_opts. This commit
uniquifies the list of tests in regressions.

The second commit removes duplicate tests in the ci regression
target of otbn. 