### PR TITLE
[ralgen] Minor correction in alias-file passing mechanism

### DIFF
--- a/hw/dv/tools/ralgen/ralgen.py
+++ b/hw/dv/tools/ralgen/ralgen.py
@@ -62,8 +62,9 @@ def main():
         if hjson_path:
             args += ["--hjson-path", root_dir / hjson_path]
         if alias_hjson:
+            args += ["--alias-files"]
             for alias in alias_hjson:
-                args += ["--alias-files", root_dir / alias]
+                args += [root_dir / alias]
     if dv_base_names:
         args += ["--dv-base-names"] + dv_base_names
 


### PR DESCRIPTION
This fixes a bug that occurs when multiple alias files are passed from `ralgen` into `topgen`. 

Rather than specfying the `--alias-files` switch for each alias file, the switch should be specified only once with a variable number of arguments.

(This issue currently preventing us from activating the alias registers on `flash_ctrl`.)

Signed-off-by: Michael Schaffner <msf@google.com>