### PR TITLE
[dvsim] Include error message cotext

### DIFF
--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -345,7 +345,7 @@ class Launcher:
                 status = "F"
                 err_msg = ErrorMessage(line_number=None,
                                        message=f"{e}",
-                                       context=[])
+                                       context=[f"{e}"])
 
         self.status = status
         if self.status != "P":

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -95,7 +95,7 @@ class LocalLauncher(Launcher):
                     'K',
                     ErrorMessage(line_number=None,
                                  message=timeout_message,
-                                 context=[]))
+                                 context=[timeout_message]))
                 return 'K'
 
             return 'D'

--- a/util/dvsim/LsfLauncher.py
+++ b/util/dvsim/LsfLauncher.py
@@ -266,7 +266,7 @@ class LsfLauncher(Launcher):
                         line_number=None,
                         message="ERROR: Failed to open {}\n{}.".format(
                             self.bsub_out, e),
-                        context=[]))
+                        context=[e]))
                 return "F"
 
         # Now that the job has completed, we need to determine its status.
@@ -303,7 +303,7 @@ class LsfLauncher(Launcher):
             if self.bsub_out_err_msg:
                 err_msg = ErrorMessage(line_number=None,
                                        message=self.bsub_out_err_msg,
-                                       context=[])
+                                       context=[self.bsub_out_err_msg])
             self._post_finish(status, err_msg)
             return status
 
@@ -402,4 +402,4 @@ class LsfLauncher(Launcher):
             job._post_finish(
                 'F', ErrorMessage(line_number=None,
                                   message=err_msg,
-                                  context=[]))
+                                  context=[err_msg]))


### PR DESCRIPTION
The result bucketizer replaces numeric values in error
messages when jobs fail or get killed. If the job was
killed due to timeout exceeded, the error message
has the timeout value. If this error message is not
replicated in the `context` field of the ErrorMessage
class, then it is not immediately clear what the timeout
setting was.

This commit replicates thre error messages in various
scenarios into `context` to ensure valuable information
is not lost due to bucketization.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>