### PR TITLE
[e2e tests] Add a chip-specific startup test

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -100,3 +100,31 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "e2e_chip_specific_startup",
+    srcs = ["chip_specific_startup.c"],
+    args = [],
+    cw310 = cw310_params(
+        args = [
+            "--bitstream=\"$(location //hw/bitstream:rom)\"",
+            "--rom-kind=rom",
+            "--bootstrap=\"$(location {flash})\"",
+        ],
+        bitstream = "//hw/bitstream:rom",
+    ),
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    signed = True,
+    targets = ["cw310"],
+    test_harness = "//sw/host/tests/rom/e2e_chip_specific_startup",
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:sram_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/silicon_creator/rom/e2e/json:chip_specific_startup",
+        "//sw/device/silicon_creator/rom/e2e/json:command",
+    ],
+)

--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup.c
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup.c
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom/e2e/json/chip_specific_startup.h"
+
+#include <stdbool.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_sram_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/silicon_creator/rom/e2e/json/command.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+status_t test_chip_specific_startup(ujson_t *uj) {
+  dif_sram_ctrl_t sram_ctrl;
+
+  LOG_INFO("Initializing DIFs");
+  TRY(dif_sram_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR),
+      &sram_ctrl));
+
+  LOG_INFO("Querying hardware");
+  dif_sram_ctrl_status_bitfield_t sram;
+  TRY(dif_sram_ctrl_get_status(&sram_ctrl, &sram));
+
+  chip_startup_t cs = {
+      .ast_init_done = false,
+      .sram =
+          {
+              .scr_key_valid = (sram & kDifSramCtrlStatusScrKeyValid) != 0,
+              .scr_key_seed_valid =
+                  (sram & kDifSramCtrlStatusScrKeySeedValid) != 0,
+              .init_done = (sram & kDifSramCtrlStatusInitDone) != 0,
+          },
+  };
+
+  RESP_OK(ujson_serialize_chip_startup_t, uj, &cs);
+  return OK_STATUS();
+}
+
+status_t command_processor(ujson_t *uj) {
+  while (true) {
+    test_command_t command;
+    TRY(ujson_deserialize_test_command_t(uj, &command));
+    switch (command) {
+      case kTestCommandChipStartup:
+        RESP_ERR(uj, test_chip_specific_startup(uj));
+        break;
+      default:
+        LOG_ERROR("Unrecognized command: %d", command);
+        RESP_ERR(uj, INVALID_ARGUMENT());
+    }
+  }
+  return OK_STATUS(0);
+}
+
+bool test_main(void) {
+  ujson_t uj = ujson_ottf_console();
+  return status_ok(command_processor(&uj));
+}

--- a/sw/device/silicon_creator/rom/e2e/json/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/json/BUILD
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "command",
+    srcs = ["command.c"],
+    hdrs = ["command.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "chip_specific_startup",
+    srcs = ["chip_specific_startup.c"],
+    hdrs = ["chip_specific_startup.h"],
+    deps = ["//sw/device/lib/ujson"],
+)

--- a/sw/device/silicon_creator/rom/e2e/json/chip_specific_startup.c
+++ b/sw/device/silicon_creator/rom/e2e/json/chip_specific_startup.c
@@ -2,9 +2,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod bootstrap;
-pub mod e2e_command;
-pub mod init;
-pub mod load_bitstream;
-pub mod rpc;
-pub mod status;
+#define UJSON_SERDE_IMPL
+#include "sw/device/silicon_creator/rom/e2e/json/chip_specific_startup.h"

--- a/sw/device/silicon_creator/rom/e2e/json/chip_specific_startup.h
+++ b/sw/device/silicon_creator/rom/e2e/json/chip_specific_startup.h
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_E2E_JSON_CHIP_SPECIFIC_STARTUP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_E2E_JSON_CHIP_SPECIFIC_STARTUP_H_
+
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+// clang-format off
+
+#define STRUCT_SRAM_INIT(field, string) \
+    field(scr_key_valid, bool) \
+    field(scr_key_seed_valid, bool) \
+    field(init_done, bool)
+UJSON_SERDE_STRUCT(SramInit, sram_init_t, STRUCT_SRAM_INIT);
+
+#define STRUCT_CHIP_STARTUP(field, string) \
+    field(ast_init_done, bool) \
+    field(sram, sram_init_t)
+UJSON_SERDE_STRUCT(ChipStartup, chip_startup_t, STRUCT_CHIP_STARTUP);
+
+// clang-format on
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_E2E_JSON_CHIP_SPECIFIC_STARTUP_H_

--- a/sw/device/silicon_creator/rom/e2e/json/command.c
+++ b/sw/device/silicon_creator/rom/e2e/json/command.c
@@ -2,9 +2,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod bootstrap;
-pub mod e2e_command;
-pub mod init;
-pub mod load_bitstream;
-pub mod rpc;
-pub mod status;
+#define UJSON_SERDE_IMPL
+#include "sw/device/silicon_creator/rom/e2e/json/command.h"

--- a/sw/device/silicon_creator/rom/e2e/json/command.h
+++ b/sw/device/silicon_creator/rom/e2e/json/command.h
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_E2E_JSON_COMMAND_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_E2E_JSON_COMMAND_H_
+
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+// clang-format off
+
+#define ENUM_TEST_COMMAND(_, value) \
+    value(_, ChipStartup)
+UJSON_SERDE_ENUM(TestCommand, test_command_t, ENUM_TEST_COMMAND);
+
+// clang-format on
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_E2E_JSON_COMMAND_H_

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -3,8 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("//rules:ujson.bzl", "ujson_rust")
 
 package(default_visibility = ["//visibility:public"])
+
+ujson_rust(
+    name = "e2e_command",
+    srcs = ["//sw/device/silicon_creator/rom/e2e/json:command"],
+    defines = ["opentitanlib=crate"],
+)
 
 filegroup(
     name = "config",
@@ -59,6 +66,7 @@ rust_library(
         "src/spiflash/mod.rs",
         "src/spiflash/sfdp.rs",
         "src/test_utils/bootstrap.rs",
+        "src/test_utils/e2e_command.rs",
         "src/test_utils/init.rs",
         "src/test_utils/load_bitstream.rs",
         "src/test_utils/mod.rs",
@@ -114,10 +122,14 @@ rust_library(
     ],
     compile_data = [
         ":config",
+        ":e2e_command",
     ],
     proc_macro_deps = [
         "//sw/host/opentitanlib/opentitantool_derive",
     ],
+    rustc_env = {
+        "e2e_command": "$(location :e2e_command)",
+    },
     deps = [
         "//third_party/rust/crates:anyhow",
         "//third_party/rust/crates:bitflags",

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -62,6 +62,7 @@ rust_library(
         "src/test_utils/init.rs",
         "src/test_utils/load_bitstream.rs",
         "src/test_utils/mod.rs",
+        "src/test_utils/rpc.rs",
         "src/test_utils/status.rs",
         "src/transport/common/mod.rs",
         "src/transport/common/uart.rs",

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -171,6 +171,7 @@ rust_library(
 rust_test(
     name = "opentitanlib_test",
     compile_data = [
+        ":e2e_command",
         "src/bootstrap/simple.bin",
         "src/spiflash/SFDP_MX66L1G.bin",
     ],
@@ -186,4 +187,7 @@ rust_test(
         "src/otp/testdata/otp_ctrl_mmap.hjson",
         "src/otp/testdata/output.vmem",
     ],
+    rustc_env = {
+        "e2e_command": "$(location :e2e_command)",
+    },
 )

--- a/sw/host/opentitanlib/src/test_utils/e2e_command.rs
+++ b/sw/host/opentitanlib/src/test_utils/e2e_command.rs
@@ -2,9 +2,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod bootstrap;
-pub mod e2e_command;
-pub mod init;
-pub mod load_bitstream;
-pub mod rpc;
-pub mod status;
+// Bring in the auto-generated sources.
+include!(env!("e2e_command"));

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -5,4 +5,5 @@
 pub mod bootstrap;
 pub mod init;
 pub mod load_bitstream;
+pub mod rpc;
 pub mod status;

--- a/sw/host/opentitanlib/src/test_utils/rpc.rs
+++ b/sw/host/opentitanlib/src/test_utils/rpc.rs
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+use anyhow::{anyhow, Result};
+use regex::Regex;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::io::Write;
+use std::time::Duration;
+
+use crate::io::uart::{Uart, UartError};
+use crate::test_utils::status::Status;
+use crate::uart::console::{ExitStatus, UartConsole};
+
+pub trait UartSend {
+    fn send(&self, uart: &dyn Uart) -> Result<()>;
+}
+
+impl<T: Serialize> UartSend for T {
+    fn send(&self, uart: &dyn Uart) -> Result<()> {
+        let s = serde_json::to_string(self)?;
+        uart.write(s.as_bytes())?;
+        Ok(())
+    }
+}
+
+pub trait UartRecv {
+    fn recv(uart: &dyn Uart, timeout: Duration, quiet: bool) -> Result<Self>
+    where
+        Self: Sized;
+}
+
+impl<T: DeserializeOwned> UartRecv for T {
+    fn recv(uart: &dyn Uart, timeout: Duration, quiet: bool) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut console = UartConsole {
+            timeout: Some(timeout),
+            exit_success: Some(Regex::new(r"RESP_OK:(.*)\r")?),
+            exit_failure: Some(Regex::new(r"RESP_ERR:(.*)\r")?),
+            ..Default::default()
+        };
+        let mut stdout = std::io::stdout();
+        let out = if !quiet {
+            let w: &mut dyn Write = &mut stdout;
+            Some(w)
+        } else {
+            None
+        };
+        let result = console.interact(uart, None, out)?;
+        match result {
+            ExitStatus::ExitSuccess => {
+                let cap = console
+                    .captures(ExitStatus::ExitSuccess)
+                    .expect("RESP_OK capture");
+                let s = cap.get(1).expect("RESP_OK group").as_str();
+                Ok(serde_json::from_str::<Self>(s)?)
+            }
+            ExitStatus::ExitFailure => {
+                let cap = console
+                    .captures(ExitStatus::ExitFailure)
+                    .expect("RESP_ERR capture");
+                let s = cap.get(1).expect("RESP_ERR group").as_str();
+                let err = serde_json::from_str::<Status>(s)?;
+                Err(err.into())
+            }
+            ExitStatus::Timeout => Err(UartError::GenericError("Timed Out".into()).into()),
+            _ => Err(anyhow!("Impossible result: {:?}", result)),
+        }
+    }
+}

--- a/sw/host/tests/rom/e2e_chip_specific_startup/BUILD
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/BUILD
@@ -1,0 +1,33 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//rules:ujson.bzl", "ujson_rust")
+
+package(default_visibility = ["//visibility:public"])
+
+ujson_rust(
+    name = "chip_specific_startup",
+    srcs = ["//sw/device/silicon_creator/rom/e2e/json:chip_specific_startup"],
+)
+
+rust_binary(
+    name = "e2e_chip_specific_startup",
+    srcs = [
+        "src/chip_specific_startup.rs",
+        "src/main.rs",
+    ],
+    compile_data = [":chip_specific_startup"],
+    rustc_env = {
+        "chip_specific_startup": "$(location :chip_specific_startup)",
+    },
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:humantime",
+        "//third_party/rust/crates:serde",
+        "//third_party/rust/crates:serde_json",
+        "//third_party/rust/crates:structopt",
+    ],
+)

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/chip_specific_startup.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/chip_specific_startup.rs
@@ -2,9 +2,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod bootstrap;
-pub mod e2e_command;
-pub mod init;
-pub mod load_bitstream;
-pub mod rpc;
-pub mod status;
+// Bring in the auto-generated sources.
+include!(env!("chip_specific_startup"));

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::test_utils::e2e_command::TestCommand;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::uart::console::UartConsole;
+use std::time::Duration;
+use structopt::StructOpt;
+
+mod chip_specific_startup;
+use chip_specific_startup::ChipStartup;
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+
+    #[structopt(
+        long, parse(try_from_str=humantime::parse_duration),
+        default_value = "10s",
+        help = "Console receive timeout",
+    )]
+    timeout: Duration,
+}
+
+fn test_chip_specific_startup(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // TODO: Should really `opts.init.uart_params.create()` here, but we need to refactor
+    // BootstrapOptions first.
+    //let uart = opts.init.uart_params.create(&transport)?;
+    let uart = transport.uart("0")?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    TestCommand::ChipStartup.send(&*uart)?;
+    let response = ChipStartup::recv(&*uart, opts.timeout, false)?;
+
+    // FIXME(cfrantz): ast_init_done should really be true.
+    assert!(response.ast_init_done == false);
+    assert!(response.sram.scr_key_valid);
+    assert!(response.sram.scr_key_seed_valid);
+    assert!(response.sram.init_done);
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    test_chip_specific_startup(&opts, &transport)?;
+    Ok(())
+}


### PR DESCRIPTION
This test demonstrates how to write a rust test with a controlled
component running in the RV32 cpu.

1. Declare command structures to be shared between the rust test and C
   helper program.
2. Write a C helper program to read the hardware properties to be
   checked by the rust test into the command/status structures.
3. Write a rust test program to read out the data and check for
   expected values.

Signed-off-by: Chris Frantz <cfrantz@google.com>

Note: this builds on top of https://github.com/lowRISC/opentitan/pull/14043 and #14044.