### PR TITLE
[entropy_src/rtl] Fewer alert cnt clear pulses in FW_OV mode

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -633,6 +633,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
           // The DUT should either set the alert, or crash the sim.
           // If we succeed, sample this alert_threshold as covered successfully.
           cov_vif.cg_alert_cnt_sample(alert_threshold);
+        end else if (!fw_ov_insert) begin
+          fmt = "Alerts suppressed:  Fail count (%01d) >= threshold (%01d)";
         end else begin
           fmt = "Alert already signalled:  Fail count (%01d) >= threshold (%01d)";
         end

--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -252,7 +252,13 @@ module entropy_src_main_sm #(
       end
       Sha3Process: begin
         cs_aes_halt_req_o = 1'b1;
-        rst_alert_cntr_o = 1'b1;
+        // The SHA control is asynchronous from the HT's in FW_OV mode
+        // breaking some of the timing assumptions associated with this
+        // alert clear pulse.  This makes predicting the alert count registers
+        // harder, and even though the alerts are surpressed in this mode
+        // the counters are still scoreboarded, so we supress this clear
+        // pulse in FW_OV insert mode.
+        rst_alert_cntr_o = ~fw_ov_ent_insert_i;
         sha3_process_o = 1'b1;
         state_d = Sha3Valid;
       end


### PR DESCRIPTION
In order to increase predictability this commit modifies the main SM to
not clear the alert counters when finishing a SHA3 digest in FW_OV mode.

Though FW_OV mode does not send alerts for HT failures, the HTs continue
to gather statistics, and the outcome of these statistics are still
scoreboarded.  However FW_OV mode does break many of the assumptions
about this mode such as relative timing of the health tests, vs.
the SHA3 controls.   This makes it very hard to predict the
timing of the CLR pulse that gets sent to the HT fail counters.

Suppressing these CLR pulses allows the alert counters to accumulate
regardless of when FW closes off a SHA3 digest, allowing the
test environment to correctly predict the HT diagnostic counters.

Also makes a minor clarification to the DV logs to help diagnose
this problem.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>