### PR TITLE
[otbn,rtl] Fix DMEM read bus blanking for illegal access

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -652,7 +652,7 @@ module otbn
   // Blank bus read data interface during core operation to avoid leaking DMEM data through the bus
   // unintentionally. Also blank when OTBN is returning a dummy response (responding to an illegal
   // bus access) and when OTBN is locked.
-  assign dmem_rdata_bus_en_d = ~(busy_execute_d | start_d) & ~imem_dummy_response_d & ~locking;
+  assign dmem_rdata_bus_en_d = ~(busy_execute_d | start_d) & ~dmem_dummy_response_d & ~locking;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin


### PR DESCRIPTION
The DMEM read data bus currently is blanked upon illegal accesses to the IMEM but not the DMEM.  This seems to be a typo, which is fixed in this PR.