### PR TITLE
[conn] Add new connectivity checks

### DIFF
--- a/hw/top_earlgrey/data/chip_conn_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_conn_testplan.hjson
@@ -65,6 +65,33 @@
     }
 
     /////////////////////////
+    // ast_scanmode.csv    //
+    /////////////////////////
+    {
+      name: scanmode_connections
+      desc: '''Verify the connectivity of scanmode to the following IPs:
+            - clkmgr
+            - flash_ctrl
+            - lc_ctrl
+            - otp_ctrl
+            - padring
+            - pinmux
+            - rstmgr
+            - rv_core_ibex
+            - rv_dm
+            - spi_device
+            - xbar_main
+            - xbar_peri
+            '''
+      milestone: V2
+      tests: ["ast_scanmode_padring", "ast_scanmode_clkmgr", "ast_scanmode_flash_ctrl",
+              "ast_scanmode_lc_ctrl", "ast_scanmode_otp_ctrl", "ast_scanmode_pinmux",
+              "ast_scanmode_rstmgr", "ast_scanmode_rv_core_ibex", "ast_scanmode_rv_dm",
+              "ast_scanmode_spi_device", "ast_scanmode_xbar_main", "ast_scanmode_xbar_peri"]
+      tags: ["conn"]
+    }
+
+    /////////////////////////
     // clkmgr_ast.csv      //
     /////////////////////////
     {
@@ -452,26 +479,41 @@
     }
 
     /////////////////////////
-    // TODO: JTAG         //
+    // jtag.csv            //
     /////////////////////////
     {
       name: flash_jtag
       desc: "Verify jtag interface is connected to flash_phy_req interface."
       milestone: V2
-      tests: []
+      tests: ["pinmux_flash_ctrl_tck", "pinmux_flash_ctrl_tms", "pinmux_flash_ctrl_tdi",
+              "pinmux_flash_ctrl_tdo", "pinmux_flash_ctrl_tdo_en"]
       tags: ["conn"]
     }
     {
       name: lc_jtag_trst
       desc: "Verify jtag rst pin is connected to lc_ctrl interface."
       milestone: V2
-      tests: []
+      tests: ["pinmux_lc_ctrl_jtag_req", "pinmux_lc_ctrl_jtag_rsp"]
       tags: ["conn"]
     }
 
-    /////////////////////////
-    // lc_escalate_en.csv  //
-    /////////////////////////
+    //////////////////////////
+    // lc_ctrl_broadcast.sv //
+    //////////////////////////
+    {
+      name: lc_keymgr_en
+      desc: "Verify LC_CTRL's lc_ctrl_lc_keymgr_en is connects correctly to keymgr."
+      milestone: V2
+      tests: ["lc_keymgr_en_keymgr"]
+      tags: ["conn"]
+    }
+    {
+      name: lc_nvm_debug_en
+      desc: "Verify lc_ctrl's lc_nvm_debug_en is connected correctly to flash_ctrl."
+      milestone: V2
+      tests: ["lc_nvm_debug_en_flash_ctrl"]
+      tags: ["conn"]
+    }
     {
       name: lc_escalate_en
       desc: '''Verify lc_ctrl's `lc_escalate_en_o` is connected to the following blocks'
@@ -528,41 +570,6 @@
       tests: ["rstmgr_rst_sys_src_n"]
       tags: ["conn"]
     }
-    /////////////////////////
-    // TODO: EDN           //
-    /////////////////////////
-    {
-      name: edn_clk_rst
-      desc: "Verify EDN's clock and reset connects correctly to other IPs."
-      milestone: V2
-      tests: []
-      tags: ["conn"]
-    }
-
-    /////////////////////////
-    // TODO: LC_CTRL       //
-    /////////////////////////
-    {
-      name: lc_keymgr_en
-      desc: "Verify LC_CTRL's lc_ctrl_lc_keymgr_en is connects correctly to keymgr."
-      milestone: V2
-      tests: []
-      tags: ["conn"]
-    }
-    {
-      name: flash_lc_nvm_debug_en
-      desc: "Verify lc_ctrl's lc_nvm_debug_en is connected correctly to flash_ctrl."
-      milestone: V2
-      tests: []
-      tags: ["conn"]
-    }
-    {
-      name: lc_ctrl_scanmode
-      desc: "Verify the connectivity of scanmode to LC ctrl."
-      milestone: V2
-      tests: []
-      tags: ["conn"]
-    }
 
     /////////////////////////
     // TODO: OTP_CTRL       //
@@ -570,13 +577,6 @@
     {
       name: otp_ctrl_external_voltage
       desc: "Verify the connectivity of the external voltage signal to OTP ctrl."
-      milestone: V2
-      tests: []
-      tags: ["conn"]
-    }
-    {
-      name: otp_ctrl_scan
-      desc: "Verify the connectivity of the scan signals to OTP ctrl."
       milestone: V2
       tests: []
       tags: ["conn"]

--- a/hw/top_earlgrey/formal/chip_conn_cfg.hjson
+++ b/hw/top_earlgrey/formal/chip_conn_cfg.hjson
@@ -14,6 +14,7 @@
   conn_csvs: ["{conn_csvs_dir}/aon_timer_rst.csv",
               "{conn_csvs_dir}/ast_entropy_src_cfg.csv",
               "{conn_csvs_dir}/ast_mem_cfg.csv",
+              "{conn_csvs_dir}/ast_scanmode.csv",
               "{conn_csvs_dir}/clkmgr_ast.csv",
               "{conn_csvs_dir}/clkmgr_idle.csv",
               "{conn_csvs_dir}/clkmgr_infra.csv",
@@ -23,7 +24,8 @@
               "{conn_csvs_dir}/clkmgr_timers.csv",
               "{conn_csvs_dir}/clkmgr_trans.csv",
               "{conn_csvs_dir}/flash_ast.csv",
-              "{conn_csvs_dir}/lc_escalate_en.csv",
+              "{conn_csvs_dir}/jtag.csv",
+              "{conn_csvs_dir}/lc_ctrl_broadcast.csv",
               "{conn_csvs_dir}/pwrmgr_rstmgr.csv"]
 
   // TODO: reduce run time and turn on coverage

--- a/hw/top_earlgrey/formal/conn_csvs/ast_scanmode.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_scanmode.csv
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run these checks with:
+#  ./util/dvsim/dvsim.py hw/top_earlgrey/formal/chip_conn_cfg.hjson
+
+,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
+
+# Verify the scanmode connectivities.
+CONNECTION, AST_SCANMODE_PADRING,      u_ast, dft_scan_md_o, u_padring,                   scanmode_i
+CONNECTION, AST_SCANMODE_CLKMGR,       u_ast, dft_scan_md_o, top_earlgrey.u_clkmgr_aon,   scanmode_i
+CONNECTION, AST_SCANMODE_FLASH_CTRL,   u_ast, dft_scan_md_o, top_earlgrey.u_flash_ctrl,   scanmode_i
+CONNECTION, AST_SCANMODE_LC_CTRL,      u_ast, dft_scan_md_o, top_earlgrey.u_lc_ctrl,      scanmode_i
+CONNECTION, AST_SCANMODE_OTP_CTRL,     u_ast, dft_scan_md_o, top_earlgrey.u_otp_ctrl,     scanmode_i
+CONNECTION, AST_SCANMODE_PINMUX,       u_ast, dft_scan_md_o, top_earlgrey.u_pinmux_aon,   scanmode_i
+CONNECTION, AST_SCANMODE_RSTMGR,       u_ast, dft_scan_md_o, top_earlgrey.u_rstmgr_aon,   scanmode_i
+CONNECTION, AST_SCANMODE_RV_CORE_IBEX, u_ast, dft_scan_md_o, top_earlgrey.u_rv_core_ibex, scanmode_i
+CONNECTION, AST_SCANMODE_RV_DM,        u_ast, dft_scan_md_o, top_earlgrey.u_rv_dm,        scanmode_i
+CONNECTION, AST_SCANMODE_SPI_DEVICE,   u_ast, dft_scan_md_o, top_earlgrey.u_spi_device,   scanmode_i
+CONNECTION, AST_SCANMODE_XBAR_MAIN,    u_ast, dft_scan_md_o, top_earlgrey.u_xbar_main,    scanmode_i
+CONNECTION, AST_SCANMODE_XBAR_PERI,    u_ast, dft_scan_md_o, top_earlgrey.u_xbar_peri,    scanmode_i

--- a/hw/top_earlgrey/formal/conn_csvs/jtag.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/jtag.csv
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run these checks with:
+#  ./util/dvsim/dvsim.py hw/top_earlgrey/formal/chip_conn_cfg.hjson
+
+,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
+
+# Pinmux and lc_ctrl jtag connection.
+CONNECTION, PINMUX_LC_CTRL_JTAG_REQ, top_earlgrey.u_pinmux_aon, lc_jtag_o, top_earlgrey.u_lc_ctrl, jtag_i
+CONNECTION, PINMUX_LC_CTRL_JTAG_RSP, top_earlgrey.u_pinmux_aon, lc_jtag_i, top_earlgrey.u_lc_ctrl, jtag_o
+
+# Pinmux and flash_ctrl jtag connection.
+# TODO: currently hardcode the seletect values, check if we can use top_earlgrey_pkg::MioInFlashCtrlTck.
+CONNECTION, PINMUX_FLASH_CTRL_TCK, top_earlgrey.u_pinmux_aon, mio_to_periph_o[47], top_earlgrey.u_flash_ctrl, cio_tck_i
+CONNECTION, PINMUX_FLASH_CTRL_TMS, top_earlgrey.u_pinmux_aon, mio_to_periph_o[48], top_earlgrey.u_flash_ctrl, cio_tms_i
+CONNECTION, PINMUX_FLASH_CTRL_TDI, top_earlgrey.u_pinmux_aon, mio_to_periph_o[49], top_earlgrey.u_flash_ctrl, cio_tdi_i
+
+CONNECTION, PINMUX_FLASH_CTRL_TDO,    top_earlgrey.u_flash_ctrl, cio_tdo_o,    top_earlgrey.u_pinmux_aon, periph_to_mio_i[52]
+CONNECTION, PINMUX_FLASH_CTRL_TDO_EN, top_earlgrey.u_flash_ctrl, cio_tdo_en_o, top_earlgrey.u_pinmux_aon, periph_to_mio_oe_i[52]

--- a/hw/top_earlgrey/formal/conn_csvs/lc_ctrl_broadcast.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/lc_ctrl_broadcast.csv
@@ -16,3 +16,9 @@ CONNECTION, LC_ESCALATE_EN_FLASH,     top_earlgrey.u_lc_ctrl, lc_escalate_en_o, 
 CONNECTION, LC_ESCALATE_EN_AES,       top_earlgrey.u_lc_ctrl, lc_escalate_en_o, top_earlgrey.u_aes,               lc_escalate_en_i
 CONNECTION, LC_ESCALATE_EN_KMAC,      top_earlgrey.u_lc_ctrl, lc_escalate_en_o, top_earlgrey.u_kmac,              lc_escalate_en_i
 CONNECTION, LC_ESCALATE_EN_OTBN,      top_earlgrey.u_lc_ctrl, lc_escalate_en_o, top_earlgrey.u_otbn,              lc_escalate_en_i
+
+# Verify that lc_ctrl's lc_keymgr_en_o signal is correctly connected to keymgr.
+CONNECTION, LC_KEYMGR_EN_KEYMGR, top_earlgrey.u_lc_ctrl, lc_keymgr_en_o, top_earlgrey.u_keymgr, lc_keymgr_en_i
+
+# Verify that lc_ctrl's lc_nvm_debug_en_o signal is correctly connected to flash_ctrl.
+CONNECTION, LC_NVM_DEBUG_EN_FLASH_CTRL, top_earlgrey.u_lc_ctrl, lc_nvm_debug_en_o, top_earlgrey.u_flash_ctrl, lc_nvm_debug_en_i


### PR DESCRIPTION
This PR adds some more connecitivity checks by the recent testplan
update.
It also changes the order of the existing testplan and group a few tests
together.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>