### PR TITLE
[entropy_src.dv] Expect SHA3_disable alert

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1158,7 +1158,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
               // Disabling the fw_ov_sha3_start field triggers the conditioner, but only
               // if the DUT is configured properly.
               if (dut_pipeline_enabled && is_fips_mode && fw_ov_insert && do_disable_sha) begin
-                `uvm_info(`gfn, "SHA3 disabled for FW_OV", UVM_HIGH)
+                `uvm_info(`gfn, "SHA3 disabled for FW_OV", UVM_FULL)
                 // SW _shouldn't_ turn off the SHA3 processing until the last data word
                 // has been processed.  However if it _does_, we should note an alert.
                 // We can also make an accurate prediction of the output (to pass our sims).
@@ -1169,6 +1169,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
                   sha_temp = process_fifo_q.pop_back();
                   package_and_release_entropy();
                   process_fifo_q.push_back(sha_temp);
+                  `uvm_info(`gfn, "SHA3 disabled while data pending, expecting alert", UVM_MEDIUM)
+                  set_exp_alert(.alert_name("recov_alert"), .is_fatal(0));
                 end else begin
                   package_and_release_entropy();
                 end

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -60,6 +60,7 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
   constraint dly_to_insert_entropy_c {
     dly_to_insert_entropy dist {
+      0                   :/ 1,
       [1      :10]        :/ 3,
       [11     :100]       :/ 2,
       [101    :1000]      :/ 1


### PR DESCRIPTION
This commit fixes the scoreboard to expect the ES_FW_OV_DISABLE_ALERT
recoverable alert.

It also increases the stress level produced by the fw_ov test,
in order to better detect this alert condition.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>