### PR TITLE
[base, dif] Make `dif_result_t` compatible with `status_t`

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -18,11 +18,6 @@ cc_library(
 )
 
 cc_library(
-    name = "absl_status",
-    hdrs = ["absl_status.h"],
-)
-
-cc_library(
     name = "stdasm",
     hdrs = ["stdasm.h"],
 )
@@ -100,6 +95,10 @@ opentitan_functest(
     srcs = ["memory_perftest.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:test_rom",
+        tags = [
+            "flaky",
+            "manual",
+        ],
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     targets = ["cw310"],
@@ -281,9 +280,10 @@ cc_library(
     srcs = ["status.c"],
     hdrs = ["status.h"],
     deps = [
-        ":absl_status",
         ":bitfield",
         ":macros",
+        "//sw/device/lib/base/internal:status",
+        "//sw/device/lib/dif:base",
     ],
 )
 

--- a/sw/device/lib/base/internal/BUILD
+++ b/sw/device/lib/base/internal/BUILD
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "absl_status",
+    hdrs = ["absl_status.h"],
+)
+
+cc_library(
+    name = "status",
+    hdrs = ["status.h"],
+    deps = [
+        ":absl_status",
+        "//sw/device/lib/base:bitfield",
+    ],
+)

--- a/sw/device/lib/base/internal/absl_status.h
+++ b/sw/device/lib/base/internal/absl_status.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_ABSL_STATUS_H_
-#define OPENTITAN_SW_DEVICE_LIB_BASE_ABSL_STATUS_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_ABSL_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_ABSL_STATUS_H_
 
 #ifndef USING_ABSL_STATUS
 #error \
@@ -231,4 +231,4 @@ typedef enum absl_status_code {
 }
 #endif
 
-#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_ABSL_STATUS_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_ABSL_STATUS_H_

--- a/sw/device/lib/base/internal/status.h
+++ b/sw/device/lib/base/internal/status.h
@@ -1,0 +1,83 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_STATUS_H_
+
+#ifndef USING_INTERNAL_STATUS
+#error "Do not include internal/status.h directly. Include status.h instead."
+#endif
+#include "sw/device/lib/base/bitfield.h"
+
+#define USING_ABSL_STATUS
+#include "sw/device/lib/base/internal/absl_status.h"
+#undef USING_ABSL_STATUS
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * We use the error category codes from absl_status.h.  We build a packed
+ * status value that identifies the source of the error (in the form of the
+ * module identifier and line number).
+ *
+ * By default, the module identifier is the first three letters of the
+ * source filename.  The identifier can be overridden (per-module) with the
+ * DECLARE_MODULE_ID macro.
+ *
+ * Our status codes are arranged as a packed bitfield, with the sign
+ * bit signifying whether the value represents a result or an error.
+ *
+ * All Ok (good) values:
+ *     31                                             0
+ *  +---+---------------------------------------------+
+ *  |   |                  31 bit                     |
+ *  | 0 |                  Result                     |
+ *  +---+---------------------------------------------+
+ *
+ * All Error values:
+ *     31      26      21      16             5       0
+ *  +---+-------+-------+-------+-------------+-------+
+ *  |   |   15 bit              | 11 bit      | 5 bit |
+ *  | 1 |   Module Identifier   | Line Number | code  |
+ *  +---+-------+-------+-------+-------------+-------+
+ *
+ * The module identifier value is interpreted as three 5-bit fields
+ * representing the characters [0x40..0x5F] (e.g. [@ABC ... _]).
+ */
+
+#define STATUS_FIELD_CODE ((bitfield_field32_t){.mask = 0x1f, .index = 0})
+#define STATUS_FIELD_ARG ((bitfield_field32_t){.mask = 0x7ff, .index = 5})
+#define STATUS_FIELD_MODULE_ID \
+  ((bitfield_field32_t){.mask = 0x7fff, .index = 16})
+#define STATUS_BIT_ERROR 31
+
+// clang-format off
+#define ASCII_5BIT(v) ( \
+    /*uppercase characters*/  (v) >= '@' && (v) <= '_' ? (v) - '@' \
+    /*lower cvt upper*/     : (v) >= '`' && (v) <= 'z' ? (v) - '`' \
+    /*else cvt underscore*/ : '_' - '@'                            \
+  )
+// clang-format on
+
+/*
+ * Creates a module ID from 3 ASCII characters.
+ *
+ * Note: the result is pre-shifted into the module identifier position within
+ * a `status_t`.
+ * - The kStatusModuleId can simply be ORed in when constucting a `status_t`.
+ * - The value of MAKE_MODULE_ID can be used in constructing constants for
+ *   types compatible with `status_t`.
+ */
+#define MAKE_MODULE_ID(a, b, c) \
+  (ASCII_5BIT(a) << 16) | (ASCII_5BIT(b) << 21) | (ASCII_5BIT(c) << 26)
+// A module that uses DECLARE_MODULE_ID shadows the global constant value with
+// its own local value.
+#define DECLARE_MODULE_ID(a, b, c) \
+  static const uint32_t kStatusModuleId = MAKE_MODULE_ID(a, b, c)
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_STATUS_H_

--- a/sw/device/lib/base/status.c
+++ b/sw/device/lib/base/status.c
@@ -9,7 +9,7 @@
 
 #include "sw/device/lib/base/bitfield.h"
 
-const uint32_t status_module_id = 0;
+const uint32_t kStatusModuleId = 0;
 
 static const char *basename(const char *file) {
   const char *f = file;

--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -11,6 +11,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:multibits",
+        "//sw/device/lib/base/internal:status",
     ],
 )
 

--- a/sw/device/lib/dif/dif_base.h
+++ b/sw/device/lib/dif/dif_base.h
@@ -15,6 +15,10 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits.h"
 
+#define USING_INTERNAL_STATUS
+#include "sw/device/lib/base/internal/status.h"
+#undef USING_INTERNAL_STATUS
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -43,44 +47,44 @@ typedef enum dif_result {
   /**
    * Indicates that the operation succeeded.
    */
-  kDifOk = 0,
+  kDifOk = kOk,
   /**
    * Indicates some unspecified failure.
    */
-  kDifError = 1,
+  kDifError = kInternal,
   /**
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
    * When this value is returned, no hardware operations occurred.
    */
-  kDifBadArg = 2,
+  kDifBadArg = kInvalidArgument,
   /**
    * The operation failed because writes to a required register are
    * disabled.
    */
-  kDifLocked = 3,
+  kDifLocked = kFailedPrecondition,
   /**
    * The operation failed because the IP is processing an operation, and will
    * finish in some amount of time. A function that returns this error may be
    * retried at any time, and is guaranteed to have not produced any side
    * effects.
    */
-  kDifUnavailable = 4,
+  kDifUnavailable = kUnavailable,
   /**
    * Indicates that the Ip's FIFO (if it has one or more of) is full.
    */
-  kDifIpFifoFull = 5,
+  kDifIpFifoFull = kResourceExhausted,
   /**
    * Indicates that the attempted operation would attempt a read/write to an
    * address that would go out of range.
    */
-  kDifOutOfRange = 6,
+  kDifOutOfRange = kOutOfRange,
   /**
    * Indicates that the attempted operation would attempt a read/write to an
    * address that is not aligned.
    */
-  kDifUnaligned = 7,
+  kDifUnaligned = kUnimplemented,
 } dif_result_t;
 
 /**

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -109,9 +109,9 @@ cc_library(
     name = "error",
     hdrs = ["error.h"],
     deps = [
-        "//sw/device/lib/base:absl_status",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base/internal:status",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -8,9 +8,9 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/hardened.h"
 
-#define USING_ABSL_STATUS
-#include "sw/device/lib/base/absl_status.h"
-#undef USING_ABSL_STATUS
+#define USING_INTERNAL_STATUS
+#include "sw/device/lib/base/internal/status.h"
+#undef USING_INTERNAL_STATUS
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
All of the current `dif_result_t` values have equivalents or
near-equivalents in `status_t`.  To unify error reporting
across the OpenTitan codebase, we should make these values
equivalent.

Longer term, I'd like to eliminate `dif_result_t` in favor of
`status_t`; This PR is a first step that gives some of the benefits
of `status_t`:
- Use of the `TRY` macro which permits early return in the event of
  an error condition (similar to `RETURN_IF_ERROR(...)`).
- Context information in the case of an error: the module_id and
  line number of the DIF call-site are recorded in the status_t.
- Convenient printing of errors: Our `printf`/`LOG_...` functions
  have a non-standard `%r` specifier which prints out a `status_t`.

Signed-off-by: Chris Frantz <cfrantz@google.com>