### PR TITLE
[ottf] Add ujson IO functions

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -18,11 +18,6 @@ cc_library(
 )
 
 cc_library(
-    name = "absl_status",
-    hdrs = ["absl_status.h"],
-)
-
-cc_library(
     name = "stdasm",
     hdrs = ["stdasm.h"],
 )
@@ -100,6 +95,10 @@ opentitan_functest(
     srcs = ["memory_perftest.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:test_rom",
+        tags = [
+            "flaky",
+            "manual",
+        ],
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     targets = ["cw310"],
@@ -281,9 +280,10 @@ cc_library(
     srcs = ["status.c"],
     hdrs = ["status.h"],
     deps = [
-        ":absl_status",
         ":bitfield",
         ":macros",
+        "//sw/device/lib/base/internal:status",
+        "//sw/device/lib/dif:base",
     ],
 )
 

--- a/sw/device/lib/base/internal/BUILD
+++ b/sw/device/lib/base/internal/BUILD
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "absl_status",
+    hdrs = ["absl_status.h"],
+)
+
+cc_library(
+    name = "status",
+    hdrs = ["status.h"],
+    deps = [
+        ":absl_status",
+        "//sw/device/lib/base:bitfield",
+    ],
+)

--- a/sw/device/lib/base/internal/absl_status.h
+++ b/sw/device/lib/base/internal/absl_status.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_ABSL_STATUS_H_
-#define OPENTITAN_SW_DEVICE_LIB_BASE_ABSL_STATUS_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_ABSL_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_ABSL_STATUS_H_
 
 #ifndef USING_ABSL_STATUS
 #error \
@@ -231,4 +231,4 @@ typedef enum absl_status_code {
 }
 #endif
 
-#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_ABSL_STATUS_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_ABSL_STATUS_H_

--- a/sw/device/lib/base/internal/status.h
+++ b/sw/device/lib/base/internal/status.h
@@ -1,0 +1,83 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_STATUS_H_
+
+#ifndef USING_INTERNAL_STATUS
+#error "Do not include internal/status.h directly. Include status.h instead."
+#endif
+#include "sw/device/lib/base/bitfield.h"
+
+#define USING_ABSL_STATUS
+#include "sw/device/lib/base/internal/absl_status.h"
+#undef USING_ABSL_STATUS
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * We use the error category codes from absl_status.h.  We build a packed
+ * status value that identifies the source of the error (in the form of the
+ * module identifier and line number).
+ *
+ * By default, the module identifier is the first three letters of the
+ * source filename.  The identifier can be overridden (per-module) with the
+ * DECLARE_MODULE_ID macro.
+ *
+ * Our status codes are arranged as a packed bitfield, with the sign
+ * bit signifying whether the value represents a result or an error.
+ *
+ * All Ok (good) values:
+ *     31                                             0
+ *  +---+---------------------------------------------+
+ *  |   |                  31 bit                     |
+ *  | 0 |                  Result                     |
+ *  +---+---------------------------------------------+
+ *
+ * All Error values:
+ *     31      26      21      16             5       0
+ *  +---+-------+-------+-------+-------------+-------+
+ *  |   |   15 bit              | 11 bit      | 5 bit |
+ *  | 1 |   Module Identifier   | Line Number | code  |
+ *  +---+-------+-------+-------+-------------+-------+
+ *
+ * The module identifier value is interpreted as three 5-bit fields
+ * representing the characters [0x40..0x5F] (e.g. [@ABC ... _]).
+ */
+
+#define STATUS_FIELD_CODE ((bitfield_field32_t){.mask = 0x1f, .index = 0})
+#define STATUS_FIELD_ARG ((bitfield_field32_t){.mask = 0x7ff, .index = 5})
+#define STATUS_FIELD_MODULE_ID \
+  ((bitfield_field32_t){.mask = 0x7fff, .index = 16})
+#define STATUS_BIT_ERROR 31
+
+// clang-format off
+#define ASCII_5BIT(v) ( \
+    /*uppercase characters*/  (v) >= '@' && (v) <= '_' ? (v) - '@' \
+    /*lower cvt upper*/     : (v) >= '`' && (v) <= 'z' ? (v) - '`' \
+    /*else cvt underscore*/ : '_' - '@'                            \
+  )
+// clang-format on
+
+/*
+ * Creates a module ID from 3 ASCII characters.
+ *
+ * Note: the result is pre-shifted into the module identifier position within
+ * a `status_t`.
+ * - The kStatusModuleId can simply be ORed in when constucting a `status_t`.
+ * - The value of MAKE_MODULE_ID can be used in constructing constants for
+ *   types compatible with `status_t`.
+ */
+#define MAKE_MODULE_ID(a, b, c) \
+  (ASCII_5BIT(a) << 16) | (ASCII_5BIT(b) << 21) | (ASCII_5BIT(c) << 26)
+// A module that uses DECLARE_MODULE_ID shadows the global constant value with
+// its own local value.
+#define DECLARE_MODULE_ID(a, b, c) \
+  static const uint32_t kStatusModuleId = MAKE_MODULE_ID(a, b, c)
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_INTERNAL_STATUS_H_

--- a/sw/device/lib/base/status.c
+++ b/sw/device/lib/base/status.c
@@ -9,7 +9,7 @@
 
 #include "sw/device/lib/base/bitfield.h"
 
-const uint32_t status_module_id = 0;
+const uint32_t kStatusModuleId = 0;
 
 static const char *basename(const char *file) {
   const char *f = file;

--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -11,6 +11,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:multibits",
+        "//sw/device/lib/base/internal:status",
     ],
 )
 

--- a/sw/device/lib/dif/dif_base.h
+++ b/sw/device/lib/dif/dif_base.h
@@ -15,6 +15,10 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits.h"
 
+#define USING_INTERNAL_STATUS
+#include "sw/device/lib/base/internal/status.h"
+#undef USING_INTERNAL_STATUS
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -43,44 +47,44 @@ typedef enum dif_result {
   /**
    * Indicates that the operation succeeded.
    */
-  kDifOk = 0,
+  kDifOk = kOk,
   /**
    * Indicates some unspecified failure.
    */
-  kDifError = 1,
+  kDifError = kInternal,
   /**
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
    * When this value is returned, no hardware operations occurred.
    */
-  kDifBadArg = 2,
+  kDifBadArg = kInvalidArgument,
   /**
    * The operation failed because writes to a required register are
    * disabled.
    */
-  kDifLocked = 3,
+  kDifLocked = kFailedPrecondition,
   /**
    * The operation failed because the IP is processing an operation, and will
    * finish in some amount of time. A function that returns this error may be
    * retried at any time, and is guaranteed to have not produced any side
    * effects.
    */
-  kDifUnavailable = 4,
+  kDifUnavailable = kUnavailable,
   /**
    * Indicates that the Ip's FIFO (if it has one or more of) is full.
    */
-  kDifIpFifoFull = 5,
+  kDifIpFifoFull = kResourceExhausted,
   /**
    * Indicates that the attempted operation would attempt a read/write to an
    * address that would go out of range.
    */
-  kDifOutOfRange = 6,
+  kDifOutOfRange = kOutOfRange,
   /**
    * Indicates that the attempted operation would attempt a read/write to an
    * address that is not aligned.
    */
-  kDifUnaligned = 7,
+  kDifUnaligned = kUnimplemented,
 } dif_result_t;
 
 /**

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -207,6 +207,18 @@ cc_library(
 )
 
 cc_library(
+    name = "ujson_ottf",
+    srcs = ["ujson_ottf.c"],
+    hdrs = ["ujson_ottf.h"],
+    deps = [
+        ":ottf_main",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/ujson",
+    ],
+)
+
+cc_library(
     name = "freertos_config",
     hdrs = ["FreeRTOSConfig.h"],
     # FreeRTOS sources don't follow our project's include-path standard,

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -71,6 +71,8 @@ static void test_wrapper(void *task_parameters) {
   report_test_status(result);
 }
 
+dif_uart_t *ottf_console(void) { return &uart0; }
+
 void _ottf_main(void) {
   test_status_set(kTestStatusInTest);
 

--- a/sw/device/lib/testing/test_framework/ottf_main.h
+++ b/sw/device/lib/testing/test_framework/ottf_main.h
@@ -9,6 +9,7 @@
 
 // This private header is included here so that OTTF users can include a single
 // header in their test application (the `ottf_main.h` header).
+#include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 
@@ -28,6 +29,11 @@
  * @return success or failure of the test as boolean.
  */
 extern bool test_main(void);
+
+/**
+ * Returns the UART that is the console device.
+ */
+dif_uart_t *ottf_console(void);
 
 /**
  * TODO: add description

--- a/sw/device/lib/testing/test_framework/ujson_ottf.c
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.c
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+static status_t ottf_putbuf(void *io, const char *buf, size_t len) {
+  const dif_uart_t *uart = (const dif_uart_t *)io;
+  for (size_t i = 0; i < len; ++i) {
+    TRY(dif_uart_byte_send_polled(uart, buf[i]));
+  }
+  return OK_STATUS(len);
+}
+
+static status_t ottf_getc(void *io) {
+  const dif_uart_t *uart = (const dif_uart_t *)io;
+  uint8_t byte;
+  TRY(dif_uart_byte_receive_polled(uart, &byte));
+  return OK_STATUS(byte);
+}
+
+ujson_t ujson_ottf_console(void) {
+  return ujson_init(ottf_console(), ottf_getc, ottf_putbuf);
+}

--- a/sw/device/lib/testing/test_framework/ujson_ottf.h
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.h
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_UJSON_OTTF_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_UJSON_OTTF_H_
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initializes and returns a ujson context linked to the ottf console.
+ *
+ * @return An initialized ujson_t context.
+ */
+ujson_t ujson_ottf_console(void);
+
+/**
+ * Respond with an OK result and JSON encoded data.
+ *
+ * @param responder_ A ujson serializer function for `data_`.
+ * @param uj_ctx_ A `ujson_t` representing the IO context.
+ * @param data_ A pointer to the data to send.
+ */
+#define RESP_OK(responder_, uj_ctx_, data_)    \
+  do {                                         \
+    TRY(ujson_putbuf(uj_ctx_, "RESP_OK:", 8)); \
+    TRY(responder_(uj_ctx_, data_));           \
+    TRY(ujson_putbuf(uj_ctx_, "\r\n", 2));     \
+  } while (0)
+
+/**
+ * Respond with an ERR result and JSON encoded `status_t`.
+ *
+ * @param uj_ctx_ A `ujson_t` representing the IO context.
+ * @param expr_ An expression of type `status_t`.
+ */
+#define RESP_ERR(uj_ctx_, expr_)                    \
+  do {                                              \
+    status_t sts = expr_;                           \
+    if (!status_ok(sts)) {                          \
+      TRY(ujson_putbuf(uj_ctx_, "RESP_ERR:", 9));   \
+      TRY(ujson_serialize_status_t(uj_ctx_, &sts)); \
+      TRY(ujson_putbuf(uj_ctx_, "\r\n", 2));        \
+    }                                               \
+  } while (0)
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_UJSON_OTTF_H_

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -109,9 +109,9 @@ cc_library(
     name = "error",
     hdrs = ["error.h"],
     deps = [
-        "//sw/device/lib/base:absl_status",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base/internal:status",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -8,9 +8,9 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/hardened.h"
 
-#define USING_ABSL_STATUS
-#include "sw/device/lib/base/absl_status.h"
-#undef USING_ABSL_STATUS
+#define USING_INTERNAL_STATUS
+#include "sw/device/lib/base/internal/status.h"
+#undef USING_INTERNAL_STATUS
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
1. Create a function to allow test programs to get access to the ottf
   console.
2. Create ujson IO functions for the ottf console.
3. Add helper macros for exchanging command & status messages with a
   rust program

Signed-off-by: Chris Frantz <cfrantz@google.com>

Note: this builds on top of #14043.