### PR TITLE
[doc] Terminology cleanup

### DIFF
--- a/doc/project/checklist.md
+++ b/doc/project/checklist.md
@@ -370,7 +370,7 @@ A functional coverage shell object has been created - this may not contain cover
 ### PRE_VERIFIED_SUB_MODULES_V1
 
 Sub-modules that are pre-verified with their own testbenches have already reached V1 or a higher stage.
-The coverage level of the pre-verified sub-modules that are not tracked (i.e., not taken through the verification milestones), meets or exceeds the V1 milestone requirement.
+The coverage level of the pre-verified sub-modules that are not tracked (i.e., not taken through the verification stages), meets or exceeds the V1 stage requirement.
 They are clearly cited in the DV document and the coverage of these sub-modules can be excluded in the IP-level testbench.
 
 ### DESIGN_SPEC_REVIEWED
@@ -480,7 +480,7 @@ COI coverage for FPV testbenches has reached 75%.
 ### PRE_VERIFIED_SUB_MODULES_V2
 
 Sub-modules that are pre-verified with their own testbenches have already reached V2 or a higher stage.
-The coverage level of the pre-verified sub-modules that are not tracked (i.e., not taken through the verification milestones), meets or exceeds the V2 milestone requirement.
+The coverage level of the pre-verified sub-modules that are not tracked (i.e., not taken through the verification stages), meets or exceeds the V2 stage requirement.
 
 ### SEC_CM_PLANNED
 
@@ -613,7 +613,7 @@ Any lint waiver files have been reviewed and signed off by the technical steerin
 ### PRE_VERIFIED_SUB_MODULES_V3
 
 Sub-modules that are pre-verified with their own testbenches have already reached the V3 stage.
-The coverage level of the pre-verified sub-modules that are not tracked (i.e., not taken through the verification milestones), meets the V3 milestone requirement.
+The coverage level of the pre-verified sub-modules that are not tracked (i.e., not taken through the verification stages), meets the V3 stage requirement.
 
 ### NO_ISSUES_PENDING
 

--- a/doc/project/development_stages.md
+++ b/doc/project/development_stages.md
@@ -34,7 +34,7 @@ Once the specification has been shared with the OpenTitan audience and sufficien
 The next life stage is **Development**.
 The hardware IP is being developed in GitHub, the specification is converted to Markdown, and design and verification planning is underway.
 This is a long phase expected to last until a more formal review is requested for full completion sign-off.
-When in Development phase, the stage tracking of the design and verification milestones are valid.
+When in Development phase, the stage tracking of the design and verification stages are valid.
 See those sections that follow for details there.
 To exit this stage, a sign-off review must occur.
 See the section on sign-off for details.
@@ -62,8 +62,8 @@ We may later evaluate adding a **Silicon Proven** stage, after deciding criteria
 
 ## Hardware Design Stages (D)
 
-The following development milestones are for hardware peripheral designs, i.e. SystemVerilog RTL development.
-They are similar to typical chip design milestones, but less rigid in the movement from one stage to the next.
+The following development stages are for hardware peripheral designs, i.e. SystemVerilog RTL development.
+They are similar to typical chip design stages, but less rigid in the movement from one stage to the next.
 The metric here is the quality bar and feature completeness of the design.
 
 The first design stage is **Initial Work**.
@@ -93,8 +93,8 @@ Once all bugs have been fixed, lint and CDC violations cleaned up, the design mo
 
 ## Hardware Verification Stages (V)
 
-The following development milestones are for hardware peripheral verification work.
-They are similar to typical chip verification milestones, but less rigid in the movement from one stage to the next.
+The following development stages are for hardware peripheral verification work.
+They are similar to typical chip verification stages, but less rigid in the movement from one stage to the next.
 The metric here is the progress towards testing completion and proof of testing coverage.
 The verification stages can be applied to simulation-based DV and formal property verification (FPV) approaches.
 
@@ -138,7 +138,7 @@ Once all coverage metrics have been met, waivers checked, the verification moves
 ## Device Interface Function Stages (S)
 
 The following development stages are for [Device Interface Function (DIF)]({{< relref "doc/rm/device_interface_functions.md" >}}) work.
-These milestones have a slightly different emphasis to the hardware design and verification milestones, because software is much easier to change if bugs are found.
+These stages have a slightly different emphasis to the hardware design and verification stages, because software is much easier to change if bugs are found.
 The metric they are trying to capture is the stability and completeness of a low-level software interface to hardware design.
 We are aiming to keep this process fairly lightweight in the early stages, and not significantly burdeonsome to the associated HW designer through all stages.
 

--- a/doc/ug/design.md
+++ b/doc/ug/design.md
@@ -113,7 +113,7 @@ These waivers have to be reviewed as part of the pull request review process.
 Note that our continuous integration infrastructure does not currently run AscentLint on each pull request as it does with Verilator lint.
 However, all designs with enabled AscentLint targets on the master branch will be run through the tool in eight-hour intervals and the results are published as part of the tool dashboards on the [hardware IP overview page](https://docs.opentitan.org/hw), enabling designers to close the lint errors and warnings even if they cannot run the sign-off tool locally.
 
-Goals for sign-off linting closure per design milestone are given in the [OpenTitan Development Stages]({{< relref "doc/project/development_stages" >}}) document.
+Goals for sign-off linting closure per design development stage are given in the [OpenTitan Development Stages]({{< relref "doc/project/development_stages" >}}) document.
 
 Note that cases may occur where the open-source and the sign-off lint tools both output a warning/error that is difficult to fix in RTL in a way that satisfies both tools at the same time.
 In those cases, priority shall be given to the RTL fix that satisfies the sign-off lint tool, and the open-source tool message shall be waived.

--- a/hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson
@@ -20,9 +20,8 @@
               all sets back to 0.
             - Repeat the above steps a bunch of times.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}{intf}_alert_test"]
     }
   ]
 }
-

--- a/hw/dv/tools/dvsim/testplans/csr_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/csr_testplan.hjson
@@ -16,7 +16,7 @@
               CSRs are accessible from.
             - Shuffle the list of CSRs first to remove the effect of ordering.
             '''
-      milestone: V1
+      stage: V1
       tests: ["{name}{intf}_csr_hw_reset"]
     }
     {
@@ -30,7 +30,7 @@
               CSRs are accessible from.
             - Shuffle the list of CSRs first to remove the effect of ordering.
             '''
-      milestone: V1
+      stage: V1
       tests: ["{name}{intf}_csr_rw"]
     }
     {
@@ -46,7 +46,7 @@
               CSRs are accessible from.
             - Shuffle the list of CSRs first to remove the effect of ordering.
             '''
-      milestone: V1
+      stage: V1
       tests: ["{name}{intf}_csr_bit_bash"]
     }
     {
@@ -63,7 +63,7 @@
               CSRs are accessible from.
             - Shuffle the list of CSRs first to remove the effect of ordering.
             '''
-      milestone: V1
+      stage: V1
       tests: ["{name}{intf}_csr_aliasing"]
     }
     {
@@ -77,7 +77,7 @@
             - It is mandatory to run this test for all available interfaces the
               CSRs are accessible from.
             '''
-      milestone: V1
+      stage: V1
       tests: ["{name}{intf}_csr_mem_rw_with_rand_reset"]
     }
     {
@@ -95,7 +95,7 @@
 
             This is only applicable if the block contains regwen and locakable CSRs.
             '''
-      milestone: V1
+      stage: V1
       tests: ["{name}{intf}_csr_rw", "{name}{intf}_csr_aliasing"]
     }
   ]
@@ -114,4 +114,3 @@
     }
   ]
 }
-

--- a/hw/dv/tools/dvsim/testplans/fpv_csr_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/fpv_csr_testplan.hjson
@@ -10,9 +10,8 @@
             assertion to ensure the read value from the TileLink is expected, and a write assertion
             to ensure the write value is updated correctly to DUT according to the register's access.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}{intf}_fpv_csr_rw"]
     }
   ]
 }
-

--- a/hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson
@@ -19,9 +19,8 @@
               CSR(s).
             - Repeat the above steps a bunch of times.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}{intf}_intr_test"]
     }
   ]
 }
-

--- a/hw/dv/tools/dvsim/testplans/mem_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/mem_testplan.hjson
@@ -11,7 +11,7 @@
             - It is mandatory to run this test from all available interfaces the
               memories are accessible from.
             '''
-      milestone: V1
+      stage: V1
       tests: ["{name}{intf}_mem_walk"]
     }
     {
@@ -22,10 +22,9 @@
               correctness.
             - Also test outstanding access on memories
             '''
-      milestone: V1
+      stage: V1
       tests: ["{name}{intf}_mem_partial_access"]
     }
     // TODO: add mem access with reset
   ]
 }
-

--- a/hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson
@@ -16,9 +16,8 @@
                - Above sequences will be run with `csr_rw_vseq` to ensure it won't affect CSR
                  accesses.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_passthru_mem_tl_intg_err"]
     }
   ]
 }
-

--- a/hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson
@@ -21,9 +21,8 @@
             - Check that err_code/fault_status is updated correctly and preserved until reset.
             - Verify any operations that follow fail (as applicable).
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_sec_cm"]
     }
   ]
 }
-

--- a/hw/dv/tools/dvsim/testplans/sec_cm_double_lfsr_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/sec_cm_double_lfsr_testplan.hjson
@@ -21,9 +21,8 @@
             - Check that err_code/fault_status is updated correctly and preserved until reset.
             - Verify any operations that follow fail (as applicable).
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_sec_cm"]
     }
   ]
 }
-

--- a/hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson
@@ -20,9 +20,8 @@
             - Check that err_code/fault_status is updated correctly and preserved until reset.
             - Verify any operations that follow fail (as applicable).
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_sec_cm"]
     }
   ]
 }
-

--- a/hw/dv/tools/dvsim/testplans/sec_cm_one_hot_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/sec_cm_one_hot_testplan.hjson
@@ -21,9 +21,8 @@
             - Check that err_code/fault_status is updated correctly and preserved until reset.
             - Verify any operations that follow fail (as applicable).
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_sec_cm"]
     }
   ]
 }
-

--- a/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson
@@ -15,7 +15,7 @@
             - Verify the update_error status register field is set to 1.
             - Repeat the above steps a bunch of times.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_shadow_reg_errors"]
     }
 
@@ -31,7 +31,7 @@
             - Verify the update_error status register field remains the same value.
             - Repeat the above steps a bunch of times.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_shadow_reg_errors"]
     }
 
@@ -48,7 +48,7 @@
             - Read all CSRs to ensure the DUT is properly reset.
             - Repeat the above steps a bunch of times.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_shadow_reg_errors"]
     }
 
@@ -65,7 +65,7 @@
             - Read all CSRs to ensure the DUT is properly reset.
             - Repeat the above steps a bunch of times.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_shadow_reg_errors"]
     }
 
@@ -79,7 +79,7 @@
               shadowed registers' write/read to be executed without aborting.
             - Repeat the above steps a bunch of times.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_shadow_reg_errors_with_csr_rw"]
     }
   ]

--- a/hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson
@@ -8,7 +8,7 @@
       desc: '''This test runs 3 parallel threads - stress_all, tl_errors and random reset.
             After reset is asserted, the test will read and check all valid CSR registers.
             '''
-      milestone: V3
+      stage: V3
       tests: ["{name}_stress_all_with_rand_reset"]
     }
   ]

--- a/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson
@@ -6,7 +6,7 @@
     {
       name: tl_d_oob_addr_access
       desc: "Access out of bounds address and verify correctness of response / behavior"
-      milestone: V2
+      stage: V2
       tests: ["{name}_tl_errors"]
     }
     {
@@ -30,7 +30,7 @@
               - read a WO (write-only) memory
               - write a RO (read-only) memory
               - write with `instr_type = True`'''
-      milestone: V2
+      stage: V2
       tests: ["{name}_tl_errors"]
     }
     {
@@ -38,7 +38,7 @@
       desc: '''Drive back-to-back requests without waiting for response to ensure there is one
             transaction outstanding within the TL device. Also, verify one outstanding when back-
             to-back accesses are made to the same address.'''
-      milestone: V2
+      stage: V2
       tests: ["{name}_csr_hw_reset",
               "{name}_csr_rw",
               "{name}_csr_aliasing",
@@ -49,7 +49,7 @@
       desc: '''Access CSR with one or more bytes of data.
             For read, expect to return all word value of the CSR.
             For write, enabling bytes should cover all CSR valid fields.'''
-      milestone: V2
+      stage: V2
       tests: ["{name}_csr_hw_reset",
               "{name}_csr_rw",
               "{name}_csr_aliasing",
@@ -63,7 +63,7 @@
               Verify that triggers the correct fatal alert.
             - Inject a fault at the onehot check in `u_reg.u_prim_reg_we_check` and verify the
               corresponding fatal alert occurs'''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_tl_intg_err", "{name}_sec_cm"]
     }
   ]

--- a/hw/ip/adc_ctrl/data/adc_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["adc_ctrl_tl_intg_err"]
     }
   ]

--- a/hw/ip/adc_ctrl/data/adc_ctrl_testplan.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl_testplan.hjson
@@ -29,7 +29,7 @@
             - Compare sample registers against expected.
             - Check oneshot bit of interrupt status register works as expected.
             '''
-      milestone: V1
+      stage: V1
       tests: ["adc_ctrl_smoke"]
     }
     {
@@ -50,7 +50,7 @@
           - Confirm this by reading the filter status register.
           - Ensure that only one ADC channel is selected at a time.
           '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_filters_polled"]
     }
     {
@@ -58,7 +58,7 @@
       desc: '''
           As filters_polled but with filter parameters fixed during the test.
           '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_filters_polled_fixed"]
     }
     {
@@ -80,7 +80,7 @@
           - Confirm correct interrupt sample value has been captured in ADC sample registers(s)
           - Check interrupt signal operates as expected.
           '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_filters_interrupt"]
     }
     {
@@ -88,7 +88,7 @@
       desc: '''
           As filters_interrupt but with filter parameters fixed during the test.
           '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_filters_interrupt_fixed"]
     }
     {
@@ -108,7 +108,7 @@
           - Confirm this by reading the filter status register.
           - Check wakeup signal operates as expected.
           '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_filters_wakeup"]
     }
     {
@@ -116,7 +116,7 @@
       desc: '''
           As filters_wakeup but with filter parameters fixed during the test.
           '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_filters_wakeup_fixed"]
     }
     {
@@ -138,7 +138,7 @@
           - Check wakeup signal operates as expected.
           - Check interrupt signal operates as expected.
           '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_filters_both"]
     }
     {
@@ -163,7 +163,7 @@
           - Check wakeup signal operates as expected.
           - Check interrupt signal operates as expected.
           '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_clock_gating"]
     }
     {
@@ -182,7 +182,7 @@
 
           - Confirm timing of power down and channel select signals to ADC.
           '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_poweron_counter"]
     }
     {
@@ -201,7 +201,7 @@
 
           - Confirm return to fast sampling happens as expected.
         '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_lowpower_counter"]
     }
     {
@@ -221,7 +221,7 @@
 
           - Ensure ADC controller FSM and counters are reset.
         '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_fsm_reset"]
     }
 
@@ -236,7 +236,7 @@
             Checking:
               - All sequences should be finished and checked by the scoreboard
       '''
-      milestone: V2
+      stage: V2
       tests: ["adc_ctrl_stress_all"]
     }
 

--- a/hw/ip/aes/data/aes_sec_cm_testplan.hjson
+++ b/hw/ip/aes/data/aes_sec_cm_testplan.hjson
@@ -26,163 +26,163 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_lc_escalate_en_intersig_mubi
       desc: "Verify the countermeasure(s) LC_ESCALATE_EN.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_config_shadow
       desc: "Verify the countermeasure(s) MAIN.CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_config_sparse
       desc: "Verify the countermeasure(s) MAIN.CONFIG.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_aux_config_shadow
       desc: "Verify the countermeasure(s) AUX.CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_aux_config_regwen
       desc: "Verify the countermeasure(s) AUX.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_key_sideload
       desc: "Verify the countermeasure(s) KEY.SIDELOAD."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_key_sw_unreadable
       desc: "Verify the countermeasure(s) KEY.SW_UNREADABLE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_reg_sw_unreadable
       desc: "Verify the countermeasure(s) DATA_REG.SW_UNREADABLE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_key_sec_wipe
       desc: "Verify the countermeasure(s) KEY.SEC_WIPE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_iv_config_sec_wipe
       desc: "Verify the countermeasure(s) IV.CONFIG.SEC_WIPE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_reg_sec_wipe
       desc: "Verify the countermeasure(s) DATA_REG.SEC_WIPE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_reg_key_sca
       desc: "Verify the countermeasure(s) DATA_REG.KEY.SCA."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_key_masking
       desc: "Verify the countermeasure(s) KEY.MASKING."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_fsm_sparse
       desc: "Verify the countermeasure(s) MAIN.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_fsm_redun
       desc: "Verify the countermeasure(s) MAIN.FSM.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_cipher_fsm_sparse
       desc: "Verify the countermeasure(s) CIPHER.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_cipher_fsm_redun
       desc: "Verify the countermeasure(s) CIPHER.FSM.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_cipher_ctr_redun
       desc: "Verify the countermeasure(s) CIPHER.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctr_fsm_sparse
       desc: "Verify the countermeasure(s) CTR.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctr_fsm_redun
       desc: "Verify the countermeasure(s) CTR.FSM.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_sparse
       desc: "Verify the countermeasure(s) CTRL.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_fsm_global_esc
       desc: "Verify the countermeasure(s) MAIN.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_fsm_local_esc
       desc: "Verify the countermeasure(s) MAIN.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_cipher_fsm_local_esc
       desc: "Verify the countermeasure(s) CIPHER.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctr_fsm_local_esc
       desc: "Verify the countermeasure(s) CTR.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_reg_local_esc
       desc: "Verify the countermeasure(s) DATA_REG.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -13,35 +13,35 @@
    //   name: default_setting
    //   desc: '''
    //        '''
-   //   milestone: V1
+   //   stage: V1
    //   tests: []
    // }
     {
       name: wake_up
       desc: '''
            Basic hello world,  encrypt a plain text read it back - decrypt and compare to input.'''
-      milestone: V1
+      stage: V1
       tests: ["aes_wake_up"]
     }
     {
       name: smoke
       desc: '''
            Encrypt a plain text read it back - decrypt and compare to input but use reference model to compare after both encryption and decryption.'''
-      milestone: V1
+      stage: V1
       tests: ["aes_smoke"]
     }
     {
       name: algorithm
       desc: '''
            Compare cypher text from DUT with the output of a C model using same key and data.'''
-           milestone: V2
+           stage: V2
       tests: ["aes_smoke", "aes_stress", "aes_config_error"]
     }
     {
       name: key_length
       desc: '''
            Randomly select key length to verify all supported key lengths are working.'''
-           milestone: V2
+           stage: V2
       tests: ["aes_stress", "aes_smoke", "aes_config_error"]
     }
     {
@@ -49,14 +49,14 @@
       desc: '''
            Back to back Messages are not possible as the DUT need to be idle before writing a new configuration.
            But Back2back verifies that DUT can handle back to back data blocks and other spacings.'''
-      milestone: V2
+      stage: V2
       tests: ["aes_b2b", "aes_stress"]
     }
     {
       name: backpressure
       desc: '''
         Try to write data to registers without offloading the DUT output to verify Stall functionality.'''
-        milestone: V2
+        stage: V2
       tests: ["aes_stress"]
     }
     {
@@ -64,7 +64,7 @@
       desc: '''
         Run multiple messages in a random mix of encryption / decryption.
         Each message should select its mode randomly.'''
-      milestone: V2
+      stage: V2
       tests: ["aes_stress", "aes_smoke", "aes_config_error", "aes_alert_reset"]
     }
     {
@@ -77,7 +77,7 @@
               Then enter the 128bit of the key and use for decryption.
               Will result match plain text and vice.
             - Write unsupported configurations (Key length and mode are 1 hot, what happens if more than one bit is set.)'''
-      milestone: V2
+      stage: V2
       tests: ["aes_config_error", "aes_alert_reset", "aes_man_cfg_err"]
     }
     {
@@ -85,28 +85,28 @@
       desc: '''
             Exercise trigger and clear registers at random times to make sure we handle the different cornercases correctly.
             Example of a cornercases clearing data input or data output before the data is consumed or the DUT finishes an operation.'''
-      milestone: V2
+      stage: V2
       tests: ["aes_clear"]
     }
     {
       name: nist_test_vectors
       desc: '''
             Verify that the DUT handles the NIST test vectors correctly.'''
-      milestone: V2
+      stage: V2
       tests: ["aes_nist_vectors"]
     }
     {
       name: reset_recovery
       desc: '''
             Pull reset at random times, make sure DUT recover/resets correctly and there is no residual data left in the registers.'''
-      milestone: V2
+      stage: V2
       tests: ["aes_alert_reset"]
     }
     {
       name: stress
       desc: '''
             This will combine the other individual testpoints to ensure we stress test everything across the board.'''
-      milestone: V2
+      stage: V2
       tests: ["aes_stress"]
     }
     {
@@ -114,14 +114,14 @@
       desc: '''
             Verify that DUT uses sideload correctly when sideload is enabled.
             and that it ignores any valid on the bus when disabled.'''
-      milestone: V2
+      stage: V2
       tests: ["aes_stress", "aes_sideload"]
     }
     {
       name: deinitialization
       desc: '''
             Make sure that there is no residual data from latest operation. '''
-      milestone: V2
+      stage: V2
       tests: ["aes_deinit"]
     }
     {
@@ -130,14 +130,14 @@
             excercise the different reseeding configuations
             for reseeding every 8k blocks the DUT internal block counter will be manually changed to something close to 8k.
             to provoke the reseeding within reasonable simulation time '''
-      milestone: V2S
+      stage: V2S
       tests: ["aes_deinit"]
     }
     {
       name:fault_inject
       desc: '''
             Verify that injecting bit errors in one of the statemachines or the round counter triggers an error '''
-      milestone: V2S
+      stage: V2S
       tests: ["aes_fi"]
     }
   ]

--- a/hw/ip/aon_timer/data/aon_timer_sec_cm_testplan.hjson
+++ b/hw/ip/aon_timer/data/aon_timer_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/aon_timer/data/aon_timer_testplan.hjson
+++ b/hw/ip/aon_timer/data/aon_timer_testplan.hjson
@@ -28,7 +28,7 @@
             - If we are changing WKUP_THOLD to be lower than the current WKUP_COUNT
             wakeup timer should raise the interrupt `wkup_timer_expired`.
             '''
-      milestone: V1
+      stage: V1
       tests: ["aon_timer_smoke"]
     }
     {
@@ -44,7 +44,7 @@
             - WKUP_COUNT should reflect expected -and changed- passing of real time
             regardless of its changing prescaler value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["aon_timer_prescaler"]
     }
     {
@@ -66,7 +66,7 @@
             - WKUP_COUNT should reflect expected passing of real time regardless of
             prescaler value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["aon_timer_jump"]
     }
     {
@@ -80,7 +80,7 @@
             - aon_timer_prescaler
             - aon_timer_smoke
             '''
-      milestone: V2
+      stage: V2
       tests: ["aon_timer_stress_all"]
     }
   ]

--- a/hw/ip/clkmgr/data/clkmgr_sec_cm_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_sec_cm_testplan.hjson
@@ -26,73 +26,73 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_timeout_clk_bkgn_chk
       desc: "Verify the countermeasure(s) TIMEOUT.CLK.BKGN_CHK."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_meas_clk_bkgn_chk
       desc: "Verify the countermeasure(s) MEAS.CLK.BKGN_CHK."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_idle_intersig_mubi
       desc: "Verify the countermeasure(s) IDLE.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_lc_ctrl_intersig_mubi
       desc: "Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_lc_ctrl_clk_handshake_intersig_mubi
       desc: "Verify the countermeasure(s) LC_CTRL_CLK_HANDSHAKE.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_clk_handshake_intersig_mubi
       desc: "Verify the countermeasure(s) CLK_HANDSHAKE.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_div_intersig_mubi
       desc: "Verify the countermeasure(s) DIV.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_jitter_config_mubi
       desc: "Verify the countermeasure(s) JITTER.CONFIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_idle_ctr_redun
       desc: "Verify the countermeasure(s) IDLE.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_sec_cm"]
     }
     {
       name: sec_cm_meas_config_regwen
       desc: "Verify the countermeasure(s) MEAS.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_clk_ctrl_config_regwen
       desc: "Verify the countermeasure(s) CLK_CTRL.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -45,7 +45,7 @@
             - Check in scoreboard the `jitter_en_o` output tracks updates of the
               `jitter_enable` CSR.
             '''
-      milestone: V1
+      stage: V1
       tests: ["clkmgr_smoke"]
     }
     {
@@ -64,7 +64,7 @@
             - The scoreboard checks the gated clock activities against its
               model of the expected behavior.
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_peri"]
     }
     {
@@ -89,7 +89,7 @@
             - SVA assertions for transactional unit clocks described in
               clkmgr_smoke.
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_trans"]
     }
     {
@@ -141,7 +141,7 @@
                `lc_clk_byp_req_i`, the `lc_clk_byp_ack_o` output is set to
                `lc_ctrl_pkg::On`.
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_extclk"]
     }
     {
@@ -159,7 +159,7 @@
             **Check**:
             - The checks are done in SVA at `clkmbf_pwrmgr_sva_if.sv`.
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_clk_status"]
     }
     {
@@ -178,7 +178,7 @@
             - The `jitter_en_o` output pin reflects the `jitter_enable` CSR.
               Test is implemented in the scoreboard, and runs always.
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_smoke"]
     }
     {
@@ -199,7 +199,7 @@
             - Slow and fast intervals should cause a recoverable alert.
             - Coverage collected per clock.
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_frequency"]
     }
     {
@@ -218,7 +218,7 @@
             - Timeout should cause a recoverable alert.
             - Coverage collected per clock.
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_frequency_timeout"]
     }
     {
@@ -236,7 +236,7 @@
             - The internal cnt_ovfl flop is set.
             - The fast_o output should be set.
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_frequency"]
     }
     {
@@ -251,7 +251,7 @@
             - clkmgr_smoke_vseq,
             - clkmgr_trans_vseq
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_stress_all"]
     }
   ]

--- a/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
@@ -26,127 +26,127 @@
     {
       name: sec_cm_config_regwen
       desc: "Verify the countermeasure(s) CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_config_mubi
       desc: "Verify the countermeasure(s) CONFIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_intersig_mubi
       desc: "Verify the countermeasure(s) INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_sm_fsm_sparse
       desc: "Verify the countermeasure(s) MAIN_SM.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_update_fsm_sparse
       desc: "Verify the countermeasure(s) UPDATE.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_blk_enc_fsm_sparse
       desc: "Verify the countermeasure(s) BLK_ENC.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_outblk_fsm_sparse
       desc: "Verify the countermeasure(s) OUTBLK.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_gen_cmd_ctr_redun
       desc: "Verify the countermeasure(s) GEN_CMD.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_drbg_upd_ctr_redun
       desc: "Verify the countermeasure(s) DRBG_UPD.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_drbg_gen_ctr_redun
       desc: "Verify the countermeasure(s) DRBG_GEN.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_mubi
       desc: "Verify the countermeasure(s) CTRL.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_sm_ctr_local_esc
       desc: "Verify the countermeasure(s) MAIN_SM.CTR.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_constants_lc_gated
       desc: "Verify the countermeasure(s) CONSTANTS.LC_GATED."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_sw_genbits_bus_consistency
       desc: "Verify the countermeasure(s) SW_GENBITS.BUS.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_tile_link_bus_integrity
       desc: "Verify the countermeasure(s) TILE_LINK.BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_aes_cipher_fsm_sparse
       desc: "Verify the countermeasure(s) AES_CIPHER.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_aes_cipher_fsm_redun
       desc: "Verify the countermeasure(s) AES_CIPHER.FSM.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_aes_cipher_ctrl_sparse
       desc: "Verify the countermeasure(s) AES_CIPHER.CTRL.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_aes_cipher_fsm_local_esc
       desc: "Verify the countermeasure(s) AES_CIPHER.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_aes_cipher_ctr_redun
       desc: "Verify the countermeasure(s) AES_CIPHER.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_aes_cipher_data_reg_local_esc
       desc: "Verify the countermeasure(s) AES_CIPHER.DATA_REG.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/csrng/data/csrng_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_testplan.hjson
@@ -16,7 +16,7 @@
             Verify sending instantiate/generate cmds via SW path.
             Verify reading genbits via SW path.
             '''
-      milestone: V1
+      stage: V1
       tests: ["csrng_smoke"]
     }
     {
@@ -28,7 +28,7 @@
             Verify cs_fifo_err interrupt asserts/clears as predicted.
             Verify fifo error status bits are set as predicted.
             '''
-      milestone: V2
+      stage: V2
       tests: ["csrng_intr"]
     }
     {
@@ -38,7 +38,7 @@
             Verify all recov_alert_sts bits assert/clear as predicted.
             Verify fatal_alert asserts as predicted.
             '''
-      milestone: V2
+      stage: V2
       tests: ["csrng_alert"]
     }
     {
@@ -46,7 +46,7 @@
       desc: '''
             Verify err_code register bits assert/clear as predicted.
             '''
-      milestone: V2
+      stage: V2
       tests: ["csrng_err"]
     }
     {
@@ -64,7 +64,7 @@
             Verify AES_HALT.
             Verify commands with continuous/non-continuous valid.
             '''
-      milestone: V2
+      stage: V2
       tests: ["csrng_cmds"]
     }
     {
@@ -72,7 +72,7 @@
       desc: '''
             Verify lifecycle hardware debug mode.
             '''
-      milestone: V2
+      stage: V2
       tests: ["csrng_cmds"]
     }
     {
@@ -81,7 +81,7 @@
             Combine the other individual testpoints while injecting TL errors and running CSR tests
             in parallel.
             '''
-      milestone: V2
+      stage: V2
       tests: ["csrng_stress_all"]
     }
   ]

--- a/hw/ip/edn/data/edn_sec_cm_testplan.hjson
+++ b/hw/ip/edn/data/edn_sec_cm_testplan.hjson
@@ -26,49 +26,49 @@
     {
       name: sec_cm_config_regwen
       desc: "Verify the countermeasure(s) CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_config_mubi
       desc: "Verify the countermeasure(s) CONFIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_sm_fsm_sparse
       desc: "Verify the countermeasure(s) MAIN_SM.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ack_sm_fsm_sparse
       desc: "Verify the countermeasure(s) ACK_SM.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctr_redun
       desc: "Verify the countermeasure(s) CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_sm_ctr_local_esc
       desc: "Verify the countermeasure(s) MAIN_SM.CTR.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_cs_rdata_bus_consistency
       desc: "Verify the countermeasure(s) CS_RDATA.BUS.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_tile_link_bus_integrity
       desc: "Verify the countermeasure(s) TILE_LINK.BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/edn/data/edn_testplan.hjson
+++ b/hw/ip/edn/data/edn_testplan.hjson
@@ -17,7 +17,7 @@
             Verify single endpoint requests
             Verify endpoint data = genbits data
             '''
-      milestone: V1
+      stage: V1
       tests: ["edn_smoke"]
     }
     {
@@ -28,7 +28,7 @@
             Verify INSTANTIATE/GENERATE software cmds.
             Verify cmd_fifo_reset bit causes fifos to reset.
             '''
-      milestone: V2
+      stage: V2
       tests: ["edn_genbits"]
     }
     {
@@ -43,7 +43,7 @@
             Verify all csrng commands (clen = 0-12, sw_mode, boot/auto_req_mode).
             Verify with ready randomly asserting/deasserting
             '''
-      milestone: V2
+      stage: V2
       tests: ["edn_genbits"]
     }
     {
@@ -52,7 +52,7 @@
             Verify genbits input is transferred to endpoint(s) as predicted.
             Verify fips bit(s) are properly transferred to endpoint.
             '''
-      milestone: V2
+      stage: V2
       tests: ["edn_genbits"]
     }
     {
@@ -61,7 +61,7 @@
             Verify intr_edn_cmd_req_done interrupt asserts/clears as predicted.
             Verify intr_edn_fatal_err interrupt asserts/clears as predicted.
             '''
-      milestone: V2
+      stage: V2
       tests: ["edn_intr"]
     }
     {
@@ -69,7 +69,7 @@
       desc: '''
             Verify recov_alert_sts asserts/clears as predicted.
             '''
-      milestone: V2
+      stage: V2
       tests: ["edn_alert"]
     }
     {
@@ -78,7 +78,7 @@
             Verify ERR_CODE asserts as predicted.
             Verify ERR_CODE all reg bits via ERR_CODE_TEST.
             '''
-      milestone: V2
+      stage: V2
       tests: ["edn_err"]
     }
     {
@@ -87,7 +87,7 @@
             Combine the other individual testpoints while injecting TL errors and running CSR tests
             in parallel.
             '''
-      milestone: V2
+      stage: V2
       tests: ["edn_stress_all"]
     }
   ]

--- a/hw/ip/entropy_src/data/entropy_src_sec_cm_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_sec_cm_testplan.hjson
@@ -26,67 +26,67 @@
     {
       name: sec_cm_config_regwen
       desc: "Verify the countermeasure(s) CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_config_mubi
       desc: "Verify the countermeasure(s) CONFIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_config_redun
       desc: "Verify the countermeasure(s) CONFIG.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_intersig_mubi
       desc: "Verify the countermeasure(s) INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_main_sm_fsm_sparse
       desc: "Verify the countermeasure(s) MAIN_SM.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ack_sm_fsm_sparse
       desc: "Verify the countermeasure(s) ACK_SM.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_rng_bkgn_chk
       desc: "Verify the countermeasure(s) RNG.BKGN_CHK."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctr_redun
       desc: "Verify the countermeasure(s) CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctr_local_esc
       desc: "Verify the countermeasure(s) CTR.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_esfinal_rdata_bus_consistency
       desc: "Verify the countermeasure(s) ESFINAL_RDATA.BUS.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_tile_link_bus_integrity
       desc: "Verify the countermeasure(s) TILE_LINK.BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -15,7 +15,7 @@
       desc: '''
             Enable entropy_src, wait for interrupt, verify entropy.
             '''
-      milestone: V1
+      stage: V1
       tests: ["entropy_src_smoke"]
     }
     {
@@ -26,7 +26,7 @@
             Verify control registers are read-only while DUT is enabled
             Verify registers at End-Of-Test
             '''
-      milestone: V2
+      stage: V2
       tests: ["entropy_src_smoke", "entropy_src_fw_ov", "entropy_src_rng"]
     }
     {
@@ -37,7 +37,7 @@
             Verify read FIFO
             - Random FIFO depths
             '''
-      milestone: V2
+      stage: V2
       tests: ["entropy_src_fw_ov"]
     }
     {
@@ -49,7 +49,7 @@
             - Verify single_bit_mode for all bit_selector values
             Verify FIPS bits match predicted
             '''
-      milestone: V2
+      stage: V2
       tests: ["entropy_src_rng"]
     }
     {
@@ -67,7 +67,7 @@
             - Pulse inputs and verify captured
             - Verify health testing stops when no demand for entropy
             '''
-      milestone: V2
+      stage: V2
       tests: ["entropy_src_rng"]
     }
     {
@@ -76,7 +76,7 @@
             Verify genbits seeds in bypass mode as predicted.
             Verify genbits seeds after shah3 conditioning as predicted.
             '''
-      milestone: V2
+      stage: V2
       tests: ["entropy_src_rng"]
     }
     {
@@ -86,7 +86,7 @@
             Verify es_health_test_failed interrupt asserts as predicted.
             Verify es_fifo_err interrupt asserts as predicted.
             '''
-      milestone: V2
+      stage: V2
       tests: ["entropy_src_intr"]
     }
     {
@@ -94,7 +94,7 @@
       desc: '''
             Verify es_alert_count_met asserts as expected.
             '''
-      milestone: V2
+      stage: V2
       tests: ["entropy_src_alert"]
     }
     {
@@ -103,7 +103,7 @@
             Combine the individual test points while injecting TL errors and
             running CSR tests in parallel.
             '''
-      milestone: V2
+      stage: V2
       tests: ["entropy_src_stress_all"]
     }
     {
@@ -111,7 +111,7 @@
       desc: '''
             Verify they never occur with asserts
             '''
-      milestone: V2
+      stage: V2
       tests: ["entropy_src_err"]
     }
   ]

--- a/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
@@ -26,163 +26,163 @@
     {
       name: sec_cm_reg_bus_integrity
       desc: "Verify the countermeasure(s) REG.BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_host_bus_integrity
       desc: "Verify the countermeasure(s) HOST.BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_bus_integrity
       desc: "Verify the countermeasure(s) MEM.BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_scramble_key_sideload
       desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_lc_ctrl_intersig_mubi
       desc: "Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_config_regwen
       desc: "Verify the countermeasure(s) CTRL.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_regions_config_regwen
       desc: "Verify the countermeasure(s) DATA_REGIONS.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_regions_config_shadow
       desc: "Verify the countermeasure(s) DATA_REGIONS.CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_info_regions_config_regwen
       desc: "Verify the countermeasure(s) INFO_REGIONS.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_info_regions_config_shadow
       desc: "Verify the countermeasure(s) INFO_REGIONS.CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_bank_config_regwen
       desc: "Verify the countermeasure(s) BANK.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_bank_config_shadow
       desc: "Verify the countermeasure(s) BANK.CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_ctrl_global_esc
       desc: "Verify the countermeasure(s) MEM.CTRL.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_ctrl_local_esc
       desc: "Verify the countermeasure(s) MEM.CTRL.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_disable_config_mubi
       desc: "Verify the countermeasure(s) MEM_DISABLE.CONFIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_exec_config_redun
       desc: "Verify the countermeasure(s) EXEC.CONFIG.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_scramble
       desc: "Verify the countermeasure(s) MEM.SCRAMBLE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_integrity
       desc: "Verify the countermeasure(s) MEM.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_rma_entry_mem_sec_wipe
       desc: "Verify the countermeasure(s) RMA_ENTRY.MEM.SEC_WIPE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_fsm_sparse
       desc: "Verify the countermeasure(s) CTRL.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_phy_fsm_sparse
       desc: "Verify the countermeasure(s) PHY.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_phy_prog_fsm_sparse
       desc: "Verify the countermeasure(s) PHY_PROG.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctr_redun
       desc: "Verify the countermeasure(s) CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_phy_arbiter_ctrl_redun
       desc: "Verify the countermeasure(s) PHY_ARBITER.CTRL.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_phy_host_grant_ctrl_consistency
       desc: "Verify the countermeasure(s) PHY_HOST_GRANT.CTRL.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_phy_ack_ctrl_consistency
       desc: "Verify the countermeasure(s) PHY_ACK.CTRL.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_fifo_ctr_redun
       desc: "Verify the countermeasure(s) FIFO.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -24,7 +24,7 @@
             for writes. Interrupts are not enabled, Completion is ascertained through polling. The
             success of each operation is verified via backdoor.
             '''
-      milestone: V1
+      stage: V1
       tests: ["flash_ctrl_smoke"]
     }
     {
@@ -34,7 +34,7 @@
             initialized with random values and then it is being read directly by Host interface.
             Finally, backdoor read is used for checking read data.
             '''
-      milestone: V1
+      stage: V1
       tests: ["flash_ctrl_smoke_hw"]
     }
     {
@@ -44,7 +44,7 @@
             bank within Data partition. Finally perform read on same location in order to test
             if previous operation was done successfully.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_sw_op"]
     }
     {
@@ -54,7 +54,7 @@
             interface. In addition, perform stalls to test pipeline structure. Enable scramble to
             test pipeline structure.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_host_dir_rd"]
     }
     {
@@ -63,7 +63,7 @@
             Perform RMA entry requests and check afterwards that the  software has no access to
             the Flash.  After RMA entry, verify that the content of the flash is wiped out.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_hw_rma", "flash_ctrl_hw_rma_reset"]
     }
     {
@@ -75,7 +75,7 @@
             before the RMA starts. When the RMA completes the RMA FSM remains in its final state
             until Reset and software access is blocked.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_host_ctrl_arb"]
     }
     {
@@ -86,7 +86,7 @@
             Check if request is cleared in case when suspend is handled.
             Read affected bank in order to verify erase suspension feature.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_erase_suspend"]
     }
     {
@@ -96,7 +96,7 @@
             partitions can be directly read by Software(Flash controller) and hardware hosts,
             while Info partitions can be read only by the Flash controller.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_full_mem_access"]
     }
     {
@@ -107,7 +107,7 @@
             and Host interface. All combinations should be tested. Covergroup for this hazardous
             behavior is rd_buff_evict_cg.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_rd_buff_evict"]
     }
     {
@@ -119,7 +119,7 @@
             progress. Perform parallel operations at addresses of different banks and also on same
             bank. Expect that operations are successfully executed.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_phy_arb"]
     }
     {
@@ -131,7 +131,7 @@
             and on the same address. Expect that operations are successfully
             executed.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_phy_arb"]
     }
     {
@@ -142,7 +142,7 @@
             enable bits. Test boundary values of regions. Test overlap of regions in which lower
             region wins arbitration.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_mp_regions"]
     }
     {
@@ -152,7 +152,7 @@
             Reads for instructions via the Hardware Interface are allowed if a specific value
             is written to the EXEC csr.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_fetch_code"]
     }
     {
@@ -161,7 +161,7 @@
             Sanity + both, legal data and info partitions are accessed. In future, support for
             multiple info partitions may be added - those will be covered as well.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_rand_ops"]
     }
     {
@@ -170,7 +170,7 @@
             Perform accesses in order to provoke memory permission errors. Test the Software
             interface (Erase, Program, Read). Related covergroup is error_cg.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_error_mp"]
     }
     {
@@ -179,7 +179,7 @@
             Perform accesses in order to provoke read data error. Test both, Software interface and
             Hardware interface. Related covergroup is error_cg.
             '''
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
@@ -188,7 +188,7 @@
             Perform accesses in order to provoke the 'program resolution' error.
             Test via the Software interface. Related covergroup is error_cg.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_error_prog_win"]
     }
     {
@@ -197,7 +197,7 @@
             Perform accesses in order to provoke the 'program type' error.
             Test via the Software interface. Related covergroup is error_cg.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_error_prog_type"]
     }
     {
@@ -206,7 +206,7 @@
             - combine above sequences in one test to run sequentially, except csr sequence
             - randomly add reset between each sequence
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_stress_all"]
     }
     {
@@ -215,7 +215,7 @@
             Perform accesses in order to provoke native flash error. Test both, Software interface
             and Hardware interface. Related covergroup is error_cg.
             '''
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
@@ -224,7 +224,7 @@
             Perform accesses in order to provoke life cycle management interface error. Related
             covergroup is error_cg.
             '''
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
@@ -235,7 +235,7 @@
             that scramble Keys are Read from the OTP and sent into the Flash Ctlr.  Also erify that programmed
             Secret Partitions retain their values through a Reset Cycle.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_hw_sec_otp", "flash_ctrl_otp_reset"]
     }
     {
@@ -245,7 +245,7 @@
             Cycle Controller.  Verify Partition can be erase, written and programmed, with
             HW control, and wipes after an RMA.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_hw_rma"]
     }
     {
@@ -254,7 +254,7 @@
             Perform accesses in order to raise all interrupts given in register map.
             Check behaviour of Interrupt Enable and Status Registers.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_intr_rd", "flash_ctrl_intr_wr"]
     }
     {
@@ -263,7 +263,7 @@
             Send invalid command in order to check that it does not affect memory content.
             Check that recovery alert is triggered.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_invalid_op"]
     }
     {
@@ -272,7 +272,7 @@
             Flash middle operation reset test. Send reset via power ready signal
             in the middle of operation program, read, erase and erase suspend.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_mid_op_rst"]
     }
     {
@@ -285,7 +285,7 @@
             Check fatal alert is asserted for reliability ecc errors (double bits) and
             integrity ECC errors.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_read_word_sweep_derr", "flash_ctrl_ro_derr",
               "flash_ctrl_rw_derr", "flash_ctrl_derr_detect", "flash_ctrl_integrity"]
     }
@@ -296,7 +296,7 @@
             All single bit error should be corrected and all read data should be
             matched with expected written value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_read_word_sweep_serr",
               "flash_ctrl_ro_serr", "flash_ctrl_rw_serr"]
     }
@@ -308,7 +308,7 @@
             saturated.
             Compare counter values for both bank with expected counter values.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_serr_counter"]
     }
     {
@@ -319,7 +319,7 @@
             transaction to be completed and compare ecc_single_err_addr register with the
             expected value. Do this for multiple rounds for both banks.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_serr_address"]
     }
     {
@@ -332,7 +332,7 @@
             the timing is correct (subsequent reads should be faster). When scrambling is not
             enabled, ensure that the raw data is written and read back.
             '''
-      milestone: V2
+      stage: V2
       tests: ["flash_ctrl_wo", "flash_ctrl_ro", "flash_ctrl_rw",
               "flash_ctrl_write_word_sweep", "flash_ctrl_read_word_sweep"]
     }
@@ -342,7 +342,7 @@
             Enable full randomization in order to fully stress DUT. Perform illegal accesses in
             order to gain robustness.
             '''
-      milestone: V3
+      stage: V3
       tests: []
     }
   ]

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -2,23 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-//  name: rma_hw_if
-//  desc: '''
-//        Perform RMA entry requests and check afterwards that the  software has no access to
-//        the Flash.  After RMA entry, verify that the content of the flash is wiped out.
-//        '''
-//  milestone: V2
-//  tests: ["flash_ctrl_hw_rma"]
-//
-//  name: isolation_partition
-//  desc: '''
-//        Verify the isolated information partitions. Accessablity is controlled by Life
-//        Cycle Controller.  Verify Partition can be erase, written and programmed, with
-//        HW control, and wipes after an RMA.
-//        '''
-//  milestone: V2
-//  tests: [flash_ctrl_hw_rma"]
-
 // flash_ctrl_hw_rma Test
 
 // Pseudo Code

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
@@ -2,15 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// name: sw_op
-// desc: '''
-//      Perform flash protocol controller read, program and erase on the single page of one
-//      bank within Data partition. Finally perform read on same location in order to test
-//      if previous operation was done successfully.
-//      '''
-// milestone: V2
-// tests: ["flash_ctrl_sw_op"]
-
+// Pseudo Code
 // Backdoor Write to FLASH (Initialize)
 // FLASH Read - Compare Frontdoor
 // FLASH Erase (Includes Backdoor Erase Check)

--- a/hw/ip/gpio/data/gpio_sec_cm_testplan.hjson
+++ b/hw/ip/gpio/data/gpio_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/gpio/data/gpio_testplan.hjson
+++ b/hw/ip/gpio/data/gpio_testplan.hjson
@@ -19,7 +19,7 @@
               reads data_in register after random delay
             - Configures all gpio pins as outputs, programs direct_out and direct_oe registers to
               random values and reads data_in register after random delay'''
-      milestone: V1
+      stage: V1
       tests: ["gpio_smoke",
               "gpio_smoke_no_pullup_pulldown"]
     }
@@ -31,7 +31,7 @@
             Every random iteration in this test would either:
             - Program one or more of `\*OUT\*` and `\*OE\*` registers, or
             - Drive new random value on GPIO pins'''
-      milestone: V2
+      stage: V2
       tests: ["gpio_random_dout_din",
               "gpio_random_dout_din_no_pullup_pulldown"]
     }
@@ -44,7 +44,7 @@
             - Drive new random value on GPIO pins
             - Write random value to any one of `\*OUT\*`, `\*OE\*` or `DATA_IN` registers
             - Read any one of `\*OUT\*`, `\*OE\*` or `DATA_IN` registers'''
-      milestone: V2
+      stage: V2
       tests: ["gpio_dout_din_regs_random_rw"]
     }
     {
@@ -57,7 +57,7 @@
             - Write random value to one or more interrupt registers that include `INTR_ENABLE`,
               `INTR_CTRL_EN_FALLING`, `INTR_CTRL_EN_LVL_LOW`, `INTR_CTRL_EN_LVL_HIGH` and
               `INTR_STATE`'''
-      milestone: V2
+      stage: V2
       tests: ["gpio_intr_rand_pgm"]
     }
     {
@@ -74,7 +74,7 @@
                  `DATA_IN` or `INTR_STATE` register value at randomized time interval
                  After every read, optionally perform random interrupt clearing operation by
                  writing to `INTR_STATE` register'''
-      milestone: V2
+      stage: V2
       tests: ["gpio_rand_intr_trigger"]
     }
     {
@@ -89,7 +89,7 @@
                  number of clock cycles within the range `[1:FILTER_CYCLES]`, and also predicts
                  updates in values of `DATA_IN` and `INTR_STATE` registers
                - multiple registers reads, each for either `DATA_IN` or `INTR_STATE`'''
-      milestone: V2
+      stage: V2
       tests: ["gpio_intr_with_filter_rand_intr_event"]
     }
     {
@@ -102,7 +102,7 @@
             2. Programs noise filter register with random value
             3. Drives each  GPIO pin with the mix of both synchronous and asynchronous driving,
                and each pin is driven independently of others'''
-      milestone: V2
+      stage: V2
       tests: ["gpio_filter_stress"]
     }
     {
@@ -113,7 +113,7 @@
             - Drive new random value on GPIO pins
             - Perform multiple random writes on randomly selected GPIO registers
             - Perform multiple random reads on randomly selected GPIO registers'''
-      milestone: V2
+      stage: V2
       tests: ["gpio_random_long_reg_writes_reg_reads"]
     }
     {
@@ -130,14 +130,14 @@
             - Write to other GPIO registers `DATA_IN`, `INTR_TEST`, `CTRL_EN_INPUT_FILTER`
             - Read any one of the GPIO registers
             - Apply hard reset'''
-      milestone: V2
+      stage: V2
       tests: ["gpio_full_random"]
     }
     {
       name: stress_all
       desc: '''Stress_all test is a random mix of all the test above except csr tests, gpio full
             random, intr_test and other gpio test that disabled scoreboard'''
-      milestone: V2
+      stage: V2
       tests: ["gpio_stress_all"]
     }
   ]

--- a/hw/ip/hmac/data/hmac_sec_cm_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/hmac/data/hmac_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_testplan.hjson
@@ -24,21 +24,21 @@
             - check status and interrupt
             - Trigger HMAC hash_process
             - After hmac_done interrupt, read and check digest data'''
-      milestone: V1
+      stage: V1
       tests: ["hmac_smoke"]
     }
     {
       name: long_msg
       desc: '''Long_msg test is based on the smoke test. The message length is between 0 and
             10,000 bytes.'''
-      milestone: V2
+      stage: V2
       tests: ["hmac_long_msg"]
     }
     {
       name: back_pressure
       desc: '''Back_pressure test is based on the long_msg test. The test disabled all the protocol
             delays to make sure to have high chance of hitting the FIFO_FULL status.'''
-      milestone: V2
+      stage: V2
       tests: ["hmac_back_pressure"]
     }
     {
@@ -47,21 +47,21 @@
             and [IETF](https://tools.ietf.org/html/rfc4868) websites, this test intends to use HMAC
             and SHA test vectors to check if the reference model predicts correct data, and check if
             DUT returns correct data.'''
-      milestone: V2
+      stage: V2
       tests: ["hmac_test_sha_vectors", "hmac_test_hmac_vectors"]
     }
     {
       name: burst_wr
       desc: '''Burst_wr test is based on the long_msg test. The test intends to test burst write a
             pre-defined size of message without any status or interrupt checking.'''
-      milestone: V2
+      stage: V2
       tests: ["hmac_burst_wr"]
     }
     {
       name: datapath_stress
       desc: '''Datapath_stress test is based on the long_msg test. It enabled HMAC and message length
             is set to N*64+1 in order to stress the datapath.'''
-      milestone: V2
+      stage: V2
       tests: ["hmac_datapath_stress"]
     }
     {
@@ -72,7 +72,7 @@
             - Update secret key when hash is in process
             - Set hash_start when hash is active
             - Write msg before hash_start is set'''
-      milestone: V2
+      stage: V2
       tests: ["hmac_error"]
     }
     {
@@ -91,19 +91,19 @@
             **Checks**:
             The scoreboard will check if digest data are corrupted.
             '''
-      milestone: V2
+      stage: V2
       tests: ["hmac_wipe_secret"]
     }
     {
       name: stress_all
       desc: "Stress_all test is a random mix of all the test above except csr tests."
-      milestone: V2
+      stage: V2
       tests: ["hmac_stress_all"]
     }
     {
       name: write_config_and_secret_key_during_msg_wr
       desc: "Change config registers and secret keys during msg write, make sure access is blocked."
-      milestone: V3
+      stage: V3
       tests: ["hmac_smoke"]
     }
   ]

--- a/hw/ip/hmac/dv/cov/hmac_cov_unr_excl.el
+++ b/hw/ip/hmac/dv/cov/hmac_cov_unr_excl.el
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Note that this UNR only generate exclusions related to tlul_adapter_sram and FSM unreachables.
-// A comprehensive UNR will be generated when achieving V3 milestone.
+// A comprehensive UNR will be generated when achieving V3 stage.
 //
 //==================================================
 // This file contains the Excluded objects

--- a/hw/ip/i2c/data/i2c_sec_cm_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -31,7 +31,7 @@
               - Check the timing behavior of START, STOP, ACK, NACK, and "repeated" START
               - Read and write transfer matching
             '''
-      milestone: V1
+      stage: V1
       tests: ["i2c_host_smoke"]
     }
     {
@@ -55,7 +55,7 @@
                 intr_sda_unstable interrupts are asserted and stay asserted until cleared
               - Ensure IP operation get back normal after on-the-fly reset finished
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_error_intr"]
     }
     {
@@ -73,7 +73,7 @@
               - Ensure transactions are transmitted/received correctly,
               - Ensure reset is handled correctly
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_stress_all"]
     }
     {
@@ -91,7 +91,7 @@
               - Ensure transactions are transmitted/received correctly
               - Ensure reset is handled correctly
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_stress_all_with_rand_reset"]
     }
     {
@@ -109,7 +109,7 @@
             Checking:
               - Ensure transactions are transmitted/received correctly
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_perf"]
     }
     {
@@ -124,7 +124,7 @@
             Checking:
               - Ensure scl_o, sda_o are overridden
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_override"]
     }
     {
@@ -142,7 +142,7 @@
               - Ensure the fmt_fifo and rx_fifo watermark interrupts stay asserted until cleared
               - Ensure receving correct number of fmt_fifo and rx_fifo watermark interrupts
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_fifo_watermark"]
     }
     {
@@ -159,7 +159,7 @@
               - Ensure excess format bytes are dropped
               - Ensure fmt_overflow and rx_overflow interrupt are asserted
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_fifo_overflow"]
     }
     {
@@ -175,7 +175,7 @@
             Checking:
               - Ensure the remaining entries are not show up after fmt_fifo is reset
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_fifo_reset_fmt", "i2c_host_fifo_reset_rx", "i2c_host_fifo_fmt_empty"]
     }
     {
@@ -191,7 +191,7 @@
             Checking:
               - Check fifo full states by reading status register
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_fifo_full"]
     }
     {
@@ -210,7 +210,7 @@
               - Ensure stretch_timeout is asserted and a correct number is received
 
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_timeout"]
     }
     {
@@ -225,7 +225,7 @@
             Checking:
               - Read rx data oversampled value and ensure it is same as driven value
             '''
-      milestone: V2
+      stage: V2
       tests: ["i2c_host_rx_oversample"]
     }
 
@@ -251,7 +251,7 @@
               - Check the timing behavior of START, STOP, ACK, NACK, and "repeated" START
               - Read and write transfer matching
             '''
-      milestone: V1
+      stage: V1
       tests: [""]
     }
     {
@@ -267,7 +267,7 @@
               - Ensure all acq_stop is asserted and stay asserted until cleared
               - Ensure IP operation get back normal after on-the-fly reset finished
             '''
-      milestone: V2
+      stage: V2
       tests: [""]
     }
     {
@@ -284,7 +284,7 @@
               - Ensure transactions are transmitted/received correctly,
               - Ensure reset is handled correctly
             '''
-      milestone: V2
+      stage: V2
       tests: [""]
     }
     {
@@ -302,7 +302,7 @@
               - Ensure transactions are transmitted/received correctly
               - Ensure reset is handled correctly
             '''
-      milestone: V2
+      stage: V2
       tests: [""]
     }
     {
@@ -320,7 +320,7 @@
             Checking:
               - Ensure transactions are transmitted/received correctly
             '''
-      milestone: V2
+      stage: V2
       tests: [""]
     }
     {
@@ -337,7 +337,7 @@
               - Ensure excess format bytes are dropped
               - Ensure tx_overflow and acq_overflow interrupt are asserted
             '''
-      milestone: V2
+      stage: V2
       tests: [""]
     }
     {
@@ -354,7 +354,7 @@
                 in tx_fifo
                 otherwise tx_empty interrupt must be asserted
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -370,7 +370,7 @@
             Checking:
               - Ensure the remaining entries are not show up after fmt_fifo is reset,
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -386,7 +386,7 @@
             Checking:
               - Check fifo full states by reading status register
             '''
-      milestone: V2
+      stage: V2
       tests: [""]
     }
     {
@@ -403,7 +403,7 @@
               - Ensure host_timeout is asserted and a correct number is received
 
             '''
-      milestone: V2
+      stage: V2
       tests: [""]
     }
   ]

--- a/hw/ip/keymgr/data/keymgr_sec_cm_testplan.hjson
+++ b/hw/ip/keymgr/data/keymgr_sec_cm_testplan.hjson
@@ -26,145 +26,145 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_config_shadow
       desc: "Verify the countermeasure(s) CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_op_config_regwen
       desc: "Verify the countermeasure(s) OP.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_reseed_config_regwen
       desc: "Verify the countermeasure(s) RESEED.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_sw_binding_config_regwen
       desc: "Verify the countermeasure(s) SW_BINDING.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_max_key_ver_config_regwen
       desc: "Verify the countermeasure(s) MAX_KEY_VER.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_lc_ctrl_intersig_mubi
       desc: "Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_constants_consistency
       desc: "Verify the countermeasure(s) CONSTANTS.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_intersig_consistency
       desc: "Verify the countermeasure(s) INTERSIG.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_hw_key_sw_noaccess
       desc: "Verify the countermeasure(s) HW.KEY.SW_NOACCESS."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_output_keys_ctrl_redun
       desc: "Verify the countermeasure(s) OUTPUT_KEYS.CTRL.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_fsm_sparse
       desc: "Verify the countermeasure(s) CTRL.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_fsm_sparse
       desc: "Verify the countermeasure(s) DATA.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_fsm_local_esc
       desc: "Verify the countermeasure(s) CTRL.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_fsm_consistency
       desc: "Verify the countermeasure(s) CTRL.FSM.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_fsm_global_esc
       desc: "Verify the countermeasure(s) CTRL.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_ctr_redun
       desc: "Verify the countermeasure(s) CTRL.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_kmac_if_fsm_sparse
       desc: "Verify the countermeasure(s) KMAC_IF.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_kmac_if_ctr_redun
       desc: "Verify the countermeasure(s) KMAC_IF.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_kmac_if_cmd_ctrl_consistency
       desc: "Verify the countermeasure(s) KMAC_IF_CMD.CTRL.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_kmac_if_done_ctrl_consistency
       desc: "Verify the countermeasure(s) KMAC_IF_DONE.CTRL.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_reseed_ctr_redun
       desc: "Verify the countermeasure(s) RESEED.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_side_load_sel_ctrl_consistency
       desc: "Verify the countermeasure(s) SIDE_LOAD_SEL.CTRL.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_key_integrity
       desc: "Verify the countermeasure(s) CTRL.KEY.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/keymgr/data/keymgr_testplan.hjson
+++ b/hw/ip/keymgr/data/keymgr_testplan.hjson
@@ -36,7 +36,7 @@
               any of saved meaningful data, which are collected from valid operations. This
               checking method is also applied to other error cases.
             '''
-      milestone: V1
+      stage: V1
       tests: ["keymgr_smoke"]
     }
     {
@@ -55,7 +55,7 @@
 
             Stimulus and checks are the same as smoke.
             '''
-      milestone: V1
+      stage: V1
       tests: ["keymgr_random"]
     }
     {
@@ -67,7 +67,7 @@
             Stimulus and checks:
             Test command and reg access gated by `cfg_regwen` is ignored during operation.
             '''
-      milestone: V2
+      stage: V2
       tests: ["keymgr_cfg_regwen"]
     }
     {
@@ -83,7 +83,7 @@
             Checks:
             Verify the sideload data and status for correctness.
             '''
-      milestone: V2
+      stage: V2
       tests: ["keymgr_sideload", "keymgr_sideload_kmac",
               "keymgr_sideload_aes", "keymgr_sideload_otbn"]
     }
@@ -93,7 +93,7 @@
             Stimulus and checks:
             Directly go to `StDisabled` from any state and check `StDisabled` is entered correctly.
             '''
-      milestone: V2
+      stage: V2
       tests: ["keymgr_direct_to_disabled"]
     }
     {
@@ -111,7 +111,7 @@
               and SW output will be invalid after OP is done.
             - If keymgr in disabled state, check the behavior is consistent with normal behavior.
             '''
-      milestone: V2
+      stage: V2
       tests: ["keymgr_lc_disable"]
     }
     {
@@ -126,7 +126,7 @@
             Checks:
             Same as above entry - "invalid_cmd".
             '''
-      milestone: V2
+      stage: V2
       tests: ["keymgr_kmac_rsp_err"]
     }
     {
@@ -143,7 +143,7 @@
             - Check alert `recov_operation_err` is triggered and err_code is `INVALID_KMAC_INPUT`.
             - Check KMAC output key is corrupted and working state remains the same.
             '''
-      milestone: V2
+      stage: V2
       tests: ["keymgr_sw_invalid_input"]
     }
     {
@@ -159,7 +159,7 @@
             - Check alert `recov_operation_err` is triggered and err_code is `INVALID_KMAC_DATA`.
             - Check SW output isn't updated and working state remains the same.
             '''
-      milestone: V2
+      stage: V2
       tests: ["keymgr_hwsw_invalid_input"]
     }
     {
@@ -177,7 +177,7 @@
             - Check alert `fatal_fault_err` is triggered.
             - Check `fault_status` is updated correctly.
             '''
-      milestone: V2
+      stage: V2
       tests: ["keymgr_sync_async_fault_cross"]
     }
     {
@@ -187,7 +187,7 @@
               keymgr_cfg_regwen (requires zero_delays).
             - Randomly add reset between each sequence.
             '''
-      milestone: V2
+      stage: V2
       tests: ["keymgr_stress_all"]
     }
     {
@@ -202,7 +202,7 @@
             - Besides checking alert and `fault_status`, issue an operation after injecting faults,
               then ensure that `op_status` is failed and design enters `StInvalid`.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["keymgr_sec_cm"]
     }
   ]

--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -43,7 +43,7 @@
                 during each hash operation and ensure that internal state is being updated
                 correctly
             '''
-      milestone: V1
+      stage: V1
       tests: ["{variant}_smoke"]
     }
     {
@@ -61,7 +61,7 @@
             Set function name as "KMAC" and enable full randomization of customization string (if
             applicable).
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_long_msg_and_output"]
     }
     {
@@ -70,7 +70,7 @@
             This is the same as the long_message test, except we burst-write chunks of the message
             into the msg_fifo, and disable intermediate status/CSR checks.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_burst_write"]
     }
     {
@@ -79,7 +79,7 @@
             These tests drive NIST test vectors for SHA3/SHAKE/KMAC into the design and check
             the output against the expected digest values.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_test_vectors_sha3_224", "{variant}_test_vectors_sha3_256",
               "{variant}_test_vectors_sha3_384", "{variant}_test_vectors_sha3_512",
               "{variant}_test_vectors_shake_128", "{variant}_test_vectors_shake_256",
@@ -93,7 +93,7 @@
             KMAC should operate on the sideloaded key regardless of the cfg_shadowed.sideload field
             value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_sideload"]
     }
     {
@@ -108,7 +108,7 @@
             In addition, read from the STATE window afterwards and confirm that this access is
             blocked and will return 0.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_app"]
     }
     {
@@ -120,7 +120,7 @@
             will not check `status` and `intr_state` registers, but will check other registers and
             all interface data including digest.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_app_with_partial_data"]
    }
    {
@@ -143,7 +143,7 @@
             //       added later.
             //       So this might be split into several error tests later on.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_error"]
     }
     {
@@ -162,7 +162,7 @@
             - Check keymgr interface responses with all zero digests and error bit is set.
             - Check kmac can resume normal functionalities after processing this error case.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_key_error"]
     }
     {
@@ -177,7 +177,7 @@
             - Check timeout error will not trigger if the `entropy_mode` is set to SW, or masking
               is disabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_edn_timeout_error"]
     }
      {
@@ -191,7 +191,7 @@
             - Check kmac can resume normal functionalities after processing this error case.
             - Check timeout error will not trigger if masking is disabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_entropy_mode_error"]
     }
    {
@@ -205,7 +205,7 @@
             - Kmac does not accept any SW or APP requests.
             - Digest window always output all 0s.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{variant}_lc_escalation"]
     }
     {
@@ -214,7 +214,7 @@
             - Combine above sequences in one test to run sequentially, except csr sequence and
               some error tests that disabled scoreboard.
             - Randomly add reset between each sequence'''
-      milestone: V2
+      stage: V2
       tests: ["kmac_stress_all"]
     }
     {
@@ -231,7 +231,7 @@
 
             This will be checked in the scoreboard using the cycle acurate model.
             '''
-      milestone: V3
+      stage: V3
       tests: ["{variant}_entropy"]
     }
     {
@@ -240,7 +240,7 @@
             Measure the throughput of the various hashing calculations and make sure they correspond
             to the expected throughput range for the design.
             '''
-      milestone: V3
+      stage: V3
       tests: ["{variant}_throughput"]
     }
   ]

--- a/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
@@ -26,85 +26,85 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_lc_escalate_en_intersig_mubi
       desc: "Verify global LC_ESCALATE_EN mubi"
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_sw_key_key_masking
       desc: "Verify the countermeasure(s) SW_KEY.KEY.MASKING."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_key_sideload
       desc: "Verify the key from KeyMgr is sideloaded."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_cfg_shadowed_config_shadow
       desc: "Verify the countermeasure(s) CFG_SHADOWED.CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_fsm_sparse
       desc: "Verify the countermeasure(s) FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctr_redun
       desc: "Verify the countermeasure(s) CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_packer_ctr_redun
       desc: "Verify the countermeasure(s) PACkER.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_cfg_shadowed_config_regwen
       desc: "Verify the countermeasure(s) CFG_SHADOWED.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_fsm_global_esc
       desc: "Verify the countermeasure(s) FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_fsm_local_esc
       desc: "Verify the countermeasure(s) FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_logic_integrity
       desc: "Verify the countermeasure(s) LOGIC.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_absorbed_ctrl_mubi
       desc: "Verify the countermeasure(s) ABSORBED.CTRL.INTEGRITY"
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_sw_cmd_ctrl_sparse
       desc: "Verify the countermeasure(s) SW_CMD.CTRL.INTEGRITY"
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/lc_ctrl/data/lc_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_sec_cm_testplan.hjson
@@ -29,7 +29,7 @@
 
       Verify this countermeasure with a standardized test.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_tl_intg_err"]
     }
     {
@@ -42,7 +42,7 @@
       JTAG interface, depending on which interface is being used to claim the
       mutex).
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_regwen_during_op"]
     }
     {
@@ -52,7 +52,7 @@
 
       Verify this countermeasure with a standardized test.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
@@ -62,7 +62,7 @@
 
       Verify this countermeasure with a standardized test.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
@@ -72,7 +72,7 @@
 
       Verify this countermeasure with a standardized test.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
@@ -82,7 +82,7 @@
 
       Verify this countermeasure with a standardized test.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
@@ -92,7 +92,7 @@
 
       Verify this countermeasure with a standardized test.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
@@ -102,7 +102,7 @@
 
       Verify this countermeasure with a standardized test.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
@@ -112,7 +112,7 @@
 
       Verify this countermeasure with a standardized test.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
@@ -130,7 +130,7 @@
       * the life cycle state vector and transition counter (from OTP) have an
         invalid encoding (MANUF.STATE.BKGN_CHK, TRANSITION.CTR.BKGN_CHK).
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
@@ -141,7 +141,7 @@
       Verify that the main FSM goes into the `EscalateSt` if
       any of the two escalation channels (`esc_scrap_state0/1`) is asserted.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_security_escalation"]
     }
     {
@@ -157,7 +157,7 @@
       Note: This is expected to be formally proven by FPV test lc_ctrl_sec_cm_fsm but
       there is currently no mechanism to include this in the testplan.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_state_post_trans", "lc_ctrl_jtag_state_post_trans"]
     }
     {
@@ -193,7 +193,7 @@
       The main life cycle FSM should not progress through the `TransProgSt` if
       this error occurs.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_mubi"]
     }
     {
@@ -206,7 +206,7 @@
       life cycle FSM should not progress through the `TransProgSt` if this
       error occurs.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_mubi"]
     }
     {
@@ -228,7 +228,7 @@
         `TokenCheck0St` and `TokenCheck1St`. Verify that a mismatch in any of
         these checks will lead to a TOKEN_ERROR.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_token_digest"]
     }
     {
@@ -245,7 +245,7 @@
 
       Note: the same test as for TOKEN_VALID.MUX.REDUN can be used.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_token_mux"]
     }
     {
@@ -263,7 +263,7 @@
 
       Note: the same test as for TOKEN_MUX.CTRL.REDUN can be used.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["lc_ctrl_sec_token_mux"]
     }
   ]

--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -29,7 +29,7 @@
             - Once the transition is successful, check lc_ctrl broadcast outputs are all turned
               off.
             '''
-      milestone: V1
+      stage: V1
       tests: ["lc_ctrl_smoke"]
     }
     {
@@ -41,7 +41,7 @@
             Use scoreboard to ensure lc_ctrl ignores this additional lc_state transition request
             and check state count.
             '''
-      milestone: V2
+      stage: V2
       tests: ["lc_ctrl_state_post_trans"]
     }
     {
@@ -54,7 +54,7 @@
             - Check `transition_regwen` register is set to 1 during lc_state transition request.
             - Check that accessing its locked CSRs is gated during the transition operation.
             '''
-      milestone: V2
+      stage: V2
       tests: ["lc_ctrl_regwen_during_op"]
     }
     {
@@ -67,7 +67,7 @@
             - Check if lc_program_failure alert is triggered.
             - Check if lc_state moves to escalation state.
             '''
-      milestone: V2
+      stage: V2
       tests: ["lc_ctrl_prog_failure"]
     }
     {
@@ -84,7 +84,7 @@
             - Check if lc_state_failure alert is triggered.
             - Check if lc_state moves to escalation state.
             '''
-      milestone: V2
+      stage: V2
       tests: ["lc_ctrl_state_failure"]
     }
     {
@@ -104,7 +104,7 @@
             - Check if lc_state moves to correct exit state.
             - Check if lc_trans_cnt is incremented.
             '''
-      milestone: V2
+      stage: V2
       tests: ["lc_ctrl_errors"]
     }
     {
@@ -115,7 +115,7 @@
             - scrap state: lc_ctrl moves to escalation state, check the state will be cleared up
                upon next power cycle
             '''
-      milestone: V2
+      stage: V2
       tests: ["lc_ctrl_security_escalation",
               "lc_ctrl_errors",
               "lc_ctrl_state_failure",
@@ -132,7 +132,7 @@
             This test will use both JTAG TAP and TLUL to access the CSR space.
             All above CSR sequences should be accessible via both interfaces.
             '''
-      milestone: V2
+      stage: V2
       tests: ["lc_ctrl_jtag_access",
               "lc_ctrl_jtag_smoke",
               "lc_ctrl_jtag_state_post_trans",
@@ -163,7 +163,7 @@
               from the CSR readings. This checking ensures there is no token leakage between
               interfaces.
             '''
-      milestone: V2
+      stage: V2
       tests: ["lc_ctrl_jtag_priority"]
     }
     {
@@ -173,7 +173,7 @@
             - Random selection of Tilelink or JTAG CSR for each sequence
             - Randomly add reset between each sequence.
             '''
-      milestone: V2
+      stage: V2
       tests: ["lc_ctrl_stress_all"]
     }
   ]

--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -26,91 +26,91 @@
     {
       name: sec_cm_mem_scramble
       desc: "Verify the countermeasure(s) MEM.SCRAMBLE."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_smoke"]
     }
     {
       name: sec_cm_data_mem_integrity
       desc: "Verify the countermeasure(s) DATA.MEM.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_imem_err", "otbn_dmem_err"]
     }
     {
       name: sec_cm_instruction_mem_integrity
       desc: "Verify the countermeasure(s) INSTRUCTION.MEM.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_imem_err", "otbn_dmem_err"]
     }
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_tl_intg_err"]
     }
     {
       name: sec_cm_controller_fsm_global_esc
       desc: "Verify the countermeasure(s) CONTROLLER.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_escalate"]
     }
     {
       name: sec_cm_controller_fsm_local_esc
       desc: "Verify the countermeasure(s) CONTROLLER.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_imem_err", "otbn_dmem_err", "otbn_zero_state_err_urnd", "otbn_illegal_mem_acc"]
     }
     {
       name: sec_cm_controller_fsm_sparse
       desc: "Verify the countermeasure(s) CONTROLLER.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_sec_cm"]
     }
     {
       name: sec_cm_scramble_key_sideload
       desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_single"]
     }
     {
       name: sec_cm_scramble_ctrl_fsm_local_esc
       desc: "Verify the countermeasure(s) SCRAMBLE_CTRL.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_imem_err", "otbn_dmem_err", "otbn_zero_state_err_urnd", "otbn_illegal_mem_acc"]
     }
     {
       name: sec_cm_scramble_ctrl_fsm_sparse
       desc: "Verify the countermeasure(s) SCRAMBLE_CTRL.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_sec_cm"]
     }
     {
       name: sec_cm_start_stop_ctrl_fsm_global_esc
       desc: "Verify the countermeasure(s) START_STOP_CTRL.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_escalate"]
     }
     {
       name: sec_cm_start_stop_ctrl_fsm_local_esc
       desc: "Verify the countermeasure(s) START_STOP_CTRL.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_imem_err", "otbn_dmem_err", "otbn_zero_state_err_urnd", "otbn_illegal_mem_acc"]
     }
     {
       name: sec_cm_start_stop_ctrl_fsm_sparse
       desc: "Verify the countermeasure(s) START_STOP_CTRL.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_sec_cm"]
     }
     {
       name: sec_cm_data_reg_sw_sca
       desc: "Verify the countermeasure(s) DATA_REG_SW.SCA."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_redun
       desc: "Verify the countermeasure(s) CTRL.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_ctrl_redun"]
     }
     {
@@ -119,7 +119,7 @@
                 Wait for a read request and istrn fetch request valid.
                 Corrupt the insn_prefetch_addr.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_pc_ctrl_flow_redun"]
     }
     {
@@ -128,7 +128,7 @@
       RND.BUS.CONSISTENCY:
       Expect to trigger RND_FIPS_CHK_FAIL recoverable error for FIPS bit being low in any word of the received RND data.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_rnd_sec_cm"]
     }
     {
@@ -138,115 +138,115 @@
       Randomly send the same EDN word for incoming RND data.
       Expect to trigger RND_REP_CHK_FAIL recoverable error for repeated EDN words.
       '''
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_rnd_sec_cm"]
     }
     {
       name: sec_cm_rf_base_data_reg_sw_integrity
       desc: "Verify the countermeasure(s) RF_BASE.DATA_REG_SW.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_csr_rw"]
     }
     {
       name: sec_cm_rf_base_data_reg_sw_glitch_detect
       desc: "Verify the countermeasure(s) RF_BASE.DATA_REG_SW.GLITCH_DETECT."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_stack_wr_ptr_ctr_redun
       desc: "Verify the countermeasure(s) STACK_WR_PTR.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_sec_cm"]
     }
     {
       name: sec_cm_rf_bignum_data_reg_sw_integrity
       desc: "Verify the countermeasure(s) RF_BIGNUM.DATA_REG_SW.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_csr_rw"]
     }
     {
       name: sec_cm_rf_bignum_data_reg_sw_glitch_detect
       desc: "Verify the countermeasure(s) RF_BIGNUM.DATA_REG_SW.GLITCH_DETECT."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_loop_stack_ctr_redun
       desc: "Verify the countermeasure(s) LOOP_STACK.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_sec_cm"]
     }
     {
       name: sec_cm_loop_stack_addr_integrity
       desc: "Verify the countermeasure(s) LOOP_STACK.ADDR.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_call_stack_addr_integrity
       desc: "Verify the countermeasure(s) CALL_STACK.ADDR.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_start_stop_ctrl_state_consistency
       desc: "Verify the countermeasure(s) START_STOP_CTRL.STATE.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_sec_wipe_err"]
     }
     {
       name: sec_cm_data_mem_sec_wipe
       desc: "Verify the countermeasure(s) DATA.MEM.SEC_WIPE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_instruction_mem_sec_wipe
       desc: "Verify the countermeasure(s) INSTRUCTION.MEM.SEC_WIPE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_reg_sw_sec_wipe
       desc: "Verify the countermeasure(s) DATA_REG_SW.SEC_WIPE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_write_mem_integrity
       desc: "Verify the countermeasure(s) WRITE.MEM.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_multi"]
     }
     {
       name: sec_cm_ctrl_flow_count
       desc: "Verify the countermeasure(s) CTRL_FLOW.COUNT."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_single"]
     }
     {
       name: sec_cm_ctrl_flow_sca
       desc: "Verify the countermeasure(s) CTRL_FLOW.SCA."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_mem_sw_noaccess
       desc: "Verify the countermeasure(s) DATA.MEM.SW_NOACCESS."
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_sw_no_acc"]
     }
     {
       name: sec_cm_key_sideload
       desc: "Verify the countermeasure(s) KEY.SIDELOAD."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_tlul_fifo_ctr_redun
       desc: "Verify the countermeasure(s) TLUL_FIFO.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -25,7 +25,7 @@
             appropriate for CI.
 
             '''
-      milestone: V1
+      stage: V1
       tests: ["otbn_smoke"]
     }
     {
@@ -43,7 +43,7 @@
             error interrupt work correctly.
 
             '''
-      milestone: V1
+      stage: V1
       tests: ["otbn_single"]
     }
 
@@ -59,7 +59,7 @@
             relevant FSM/toggle coverage.
 
             '''
-      milestone: V2
+      stage: V2
       tests: ["otbn_reset"]
     }
 
@@ -75,7 +75,7 @@
             compile and run all the binaries in a collection of ISS unit tests.
             We have coverage points to ensure we see every event we expect.
        '''
-      milestone: V2
+      stage: V2
       tests: ["otbn_multi_err"]
     }
 
@@ -84,7 +84,7 @@
       desc: '''
             Inject ECC errors into DMEM and IMEM and expect an alert
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_imem_err", "otbn_dmem_err"]
     }
     {
@@ -92,7 +92,7 @@
       desc: '''
         Corrupt internal state and expect an alert
       '''
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
@@ -105,7 +105,7 @@
             is cleared between programs when there's no reset.
 
             '''
-      milestone: V2
+      stage: V2
       tests: ["otbn_multi"]
     }
     {
@@ -113,7 +113,7 @@
       desc: '''
             Run assorted sequences back-to-back.
             '''
-      milestone: V2
+      stage: V2
       tests: ["otbn_stress_all"]
     }
     {
@@ -121,7 +121,7 @@
       desc: '''
             Trigger the life cycle escalation input.
             '''
-      milestone: V2
+      stage: V2
       tests: ["otbn_escalate"]
     }
     {
@@ -130,7 +130,7 @@
               Trigger the "state is zero" error in URND,
               Check that fatal error is asserted.
             '''
-      milestone: V2
+      stage: V2
       tests: ["otbn_zero_state_err_urnd"]
     }
     {
@@ -139,7 +139,7 @@
             Trigger reads and writes to both DMEM and IMEM and expect a fatal alert for
             ILLEGAL_BUS_ACCESS. Check that *mem_rdata_bus pins are at 0 when reads are done
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["otbn_illegal_mem_acc"]
     }
     {
@@ -148,7 +148,7 @@
               Set ctrl.software_errs_fatal.
               When set software errors produce fatal errors, rather than recoverable errors.
             '''
-      milestone: V2
+      stage: V2
       tests: ["otbn_sw_errs_fatal_chk"]
     }
   ]

--- a/hw/ip/otp_ctrl/data/otp_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_sec_cm_testplan.hjson
@@ -26,271 +26,271 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_tl_intg_err"]
     }
     {
       name: sec_cm_secret_mem_scramble
       desc: "Verify the countermeasure(s) SECRET.MEM.SCRAMBLE."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_smoke"]
     }
     {
       name: sec_cm_part_mem_digest
       desc: "Verify the countermeasure(s) PART.MEM.DIGEST."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_smoke"]
     }
     {
       name: sec_cm_dai_fsm_sparse
       desc: "Verify the countermeasure(s) DAI.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_kdi_fsm_sparse
       desc: "Verify the countermeasure(s) KDI.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_lci_fsm_sparse
       desc: "Verify the countermeasure(s) LCI.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_part_fsm_sparse
       desc: "Verify the countermeasure(s) PART.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_scrmbl_fsm_sparse
       desc: "Verify the countermeasure(s) SCRMBL.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_timer_fsm_sparse
       desc: "Verify the countermeasure(s) TIMER.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_dai_ctr_redun
       desc: "Verify the countermeasure(s) DAI.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_kdi_seed_ctr_redun
       desc: "Verify the countermeasure(s) KDI_SEED.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_kdi_entropy_ctr_redun
       desc: "Verify the countermeasure(s) KDI_ENTROPY.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_lci_ctr_redun
       desc: "Verify the countermeasure(s) LCI.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_part_ctr_redun
       desc: "Verify the countermeasure(s) PART.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_scrmbl_ctr_redun
       desc: "Verify the countermeasure(s) SCRMBL.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_timer_integ_ctr_redun
       desc: "Verify the countermeasure(s) TIMER_INTEG.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_timer_cnsty_ctr_redun
       desc: "Verify the countermeasure(s) TIMER_CNSTY.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_timer_lfsr_redun
       desc: "Verify the countermeasure(s) TIMER.LFSR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_dai_fsm_local_esc
       desc: "Verify the countermeasure(s) DAI.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc", "otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_lci_fsm_local_esc
       desc: "Verify the countermeasure(s) LCI.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc"]
     }
     {
       name: sec_cm_kdi_fsm_local_esc
       desc: "Verify the countermeasure(s) KDI.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc"]
     }
     {
       name: sec_cm_part_fsm_local_esc
       desc: "Verify the countermeasure(s) PART.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc", "otp_ctrl_macro_errs"]
     }
     {
       name: sec_cm_scrmbl_fsm_local_esc
       desc: "Verify the countermeasure(s) SCRMBL.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc"]
     }
     {
       name: sec_cm_timer_fsm_local_esc
       desc: "Verify the countermeasure(s) TIMER.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc", "otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_dai_fsm_global_esc
       desc: "Verify the countermeasure(s) DAI.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc", "otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_lci_fsm_global_esc
       desc: "Verify the countermeasure(s) LCI.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc"]
     }
     {
       name: sec_cm_kdi_fsm_global_esc
       desc: "Verify the countermeasure(s) KDI.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc"]
     }
     {
       name: sec_cm_part_fsm_global_esc
       desc: "Verify the countermeasure(s) PART.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc", "otp_ctrl_macro_errs"]
     }
     {
       name: sec_cm_scrmbl_fsm_global_esc
       desc: "Verify the countermeasure(s) SCRMBL.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc"]
     }
     {
       name: sec_cm_timer_fsm_global_esc
       desc: "Verify the countermeasure(s) TIMER.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_parallel_lc_esc", "otp_ctrl_sec_cm"]
     }
     {
       name: sec_cm_part_data_reg_integrity
       desc: "Verify the countermeasure(s) PART.DATA_REG.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_init_fail"]
     }
     {
       name: sec_cm_part_data_reg_bkgn_chk
       desc: "Verify the countermeasure(s) PART.DATA_REG.BKGN_CHK."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_check_fail"]
     }
     {
       name: sec_cm_part_mem_regren
       desc: "Verify the countermeasure(s) PART.MEM.REGREN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_dai_lock"]
     }
     {
       name: sec_cm_part_mem_sw_unreadable
       desc: "Verify the countermeasure(s) PART.MEM.SW_UNREADABLE."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_dai_lock"]
     }
     {
       name: sec_cm_part_mem_sw_unwritable
       desc: "Verify the countermeasure(s) PART.MEM.SW_UNWRITABLE."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_dai_lock"]
     }
     {
       name: sec_cm_lc_part_mem_sw_noaccess
       desc: "Verify the countermeasure(s) LC_PART.MEM.SW_NOACCESS."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_dai_lock"]
     }
     {
       name: sec_cm_access_ctrl_mubi
       desc: "Verify the countermeasure(s) ACCESS.CTRL.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_dai_lock"]
     }
     {
       name: sec_cm_token_valid_ctrl_mubi
       desc: "Verify the countermeasure(s) TOKEN_VALID.CTRL.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_smoke"]
     }
     {
       name: sec_cm_lc_ctrl_intersig_mubi
       desc: "Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_dai_lock"]
     }
     {
       name: sec_cm_test_bus_lc_gated
       desc: "Verify the countermeasure(s) TEST.BUS.LC_GATED."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_smoke"]
     }
     {
       name: sec_cm_direct_access_config_regwen
       desc: "Verify the countermeasure(s) DIRECT_ACCESS.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_regwen"]
     }
     {
       name: sec_cm_check_trigger_config_regwen
       desc: "Verify the countermeasure(s) CHECK_TRIGGER.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_smoke"]
     }
     {
       name: sec_cm_check_config_regwen
       desc: "Verify the countermeasure(s) CHECK.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_smoke"]
     }
     {
       name: sec_cm_macro_mem_integrity
       desc: "Verify the countermeasure(s) MACRO.MEM.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_macro_errs"]
     }
     {
       name: sec_cm_macro_mem_cm
       desc: "Verify the countermeasure(s) MACRO.MEM.CM."
-      milestone: V2S
+      stage: V2S
       tests: ["N/A"]
     }
   ]

--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -30,7 +30,7 @@
               without the OtpError interrupt
             - read out secrets through the hardware interfaces
             '''
-      milestone: V1
+      stage: V1
       tests: ["otp_ctrl_wake_up"]
     }
     {
@@ -56,7 +56,7 @@
               `otp_vendor_test_ctrl_i`, `cio_test_o`, and `cio_test_en_o` are connected currently
               with `lc_dft_en_i` On and Off.
             '''
-      milestone: V1
+      stage: V1
       tests: ["otp_ctrl_smoke"]
     }
     {
@@ -65,7 +65,7 @@
             Similar to UVM's memory walk test, this test ensures every address in each partition
             can be accessed successfully via DAI and TLUL interfacs according to its access policy.
             '''
-      milestone: V2
+      stage: V2
       tests: ["otp_ctrl_partition_walk"]
     }
     {
@@ -88,7 +88,7 @@
             - OTP initialization finishes with power init output goes to 1
             - `status`, `intr_state`, `err_code` CSRs reflect ECC correctable error
             '''
-      milestone: V2
+      stage: V2
       tests: ["otp_ctrl_init_fail"]
     }
     {
@@ -111,7 +111,7 @@
             Note that due to limited simulation time, for background checks, this test only write
             random value that is less than 20 to the check period.
             '''
-      milestone: V2
+      stage: V2
       tests: ["otp_ctrl_check_fail", "otp_ctrl_background_chks"]
     }
     {
@@ -127,7 +127,7 @@
             - verify that the writes to the registers controlled by it do not go through during OTP
               initialization
             '''
-      milestone: V2
+      stage: V2
       tests: ["otp_ctrl_regwen"]
     }
     {
@@ -137,7 +137,7 @@
             write. After locking the partitions, issue read or program sequences and check if the
             operations are locked correctly, and check if the `AccessError` is set.
             '''
-      milestone: V2
+      stage: V2
       tests: ["otp_ctrl_dai_lock"]
     }
     {
@@ -147,7 +147,7 @@
             Based on the DAI access sequence, this test will run key requests sequence in
             parallel, and check if correct keys are generated.
             '''
-      milestone: V2
+      stage: V2
       tests: ["otp_ctrl_parallel_key_req"]
     }
     {
@@ -165,7 +165,7 @@
             - if `lc_escalation_en` is enabled, verify that alert is triggered and OTP_CTRL entered
               terminal state
             '''
-      milestone: V2
+      stage: V2
       tests: ["otp_ctrl_parallel_lc_req", "otp_ctrl_parallel_lc_esc"]
     }
     { name: otp_dai_errors
@@ -180,7 +180,7 @@
             - `err_code` and `status` CSRs
             - `otp_error` interrupt
             '''
-      milestone: V2
+      stage: V2
       tests: ["otp_ctrl_dai_errs"]
     }
     { name: otp_macro_errors
@@ -196,7 +196,7 @@
             - if the error is unrecoverable, verify that alert is triggered and OTP_CTRL entered
               terminal state
             '''
-      milestone: V2
+      stage: V2
       tests: ["otp_ctrl_macro_errs"]
     }
     {
@@ -208,7 +208,7 @@
             - Write and check read results from the prim_tl_i/o.
             - Ensure no error or alert occurs from DUT.
             '''
-      milestone: V2
+      stage: V2
       tests: ["otp_ctrl_test_access"]
     }
     {
@@ -217,7 +217,7 @@
             - combine above sequences in one test to run sequentially, except csr sequence
             - randomly add reset between each sequence
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}_stress_all"]
     }
     {
@@ -233,7 +233,7 @@
             - Check OTP_CTRL is locked after the fatal fault injection by trying to access OTP_CTRL
               via dai, kdi, and lci interfaces.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["otp_ctrl_sec_cm"]
     }
     {
@@ -248,7 +248,7 @@
             - Use DAI access to read each memory address and compare if the value is correct.
             - If DAI address is in a SW partition, read and check again via TLUL interface.
             '''
-      milestone: V3
+      stage: V3
       tests: ["otp_ctrl_low_freq_read"]
     }
   ]

--- a/hw/ip/pattgen/data/pattgen_sec_cm_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/pattgen/data/pattgen_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_testplan.hjson
@@ -31,7 +31,7 @@
               - Check completion interrupts are asserted once a pattern
                 is completely generated on the active channels
             '''
-      milestone: V1
+      stage: V1
       tests: ["pattgen_smoke"]
     }
     {
@@ -49,7 +49,7 @@
               - Ensure patterns are correctly generated
               - Ensure interrupts are robust asserted and cleared (e.g. at the high data rate)
             '''
-      milestone: V2
+      stage: V2
       tests: ["pattgen_perf"]
     }
     {
@@ -72,7 +72,7 @@
               - Ensure patterns are correctly generated
               - Ensure interrupts are robust asserted and cleared (e.g. at the high data rate)
             '''
-      milestone: V2
+      stage: V2
       tests: ["cnt_rollover"]
     }
     {
@@ -89,7 +89,7 @@
               - Ensure patterns are dropped when re-enabled
               - Ensure the output channels get back normal after re-enable
             '''
-      milestone: V2
+      stage: V2
       tests: ["pattgen_error"]
     }
     {
@@ -97,7 +97,7 @@
       desc: '''
             Stress_all test is a random mix of all the test above except csr tests.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pattgen_stress_all"]
     }
   ]

--- a/hw/ip/pinmux/data/pinmux_fpv_testplan.hjson
+++ b/hw/ip/pinmux/data/pinmux_fpv_testplan.hjson
@@ -11,14 +11,14 @@
       name: InSel0_A
       desc: '''When register `periph_insel` is set to 0, which means the selected input is constant
              zero, the corresponding `mio_to_periph_o` must be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: InSel1_A
       desc: '''When register `periph_insel` is set to 1, which means the selected input is constant
             one, the corresponding `mio_to_periph_o` must be 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -26,14 +26,14 @@
       desc: '''When register `periph_insel` is set to any value between 2 and
             (2 + number of MioPads) and the select index is not jtag, the corresponding
             `mio_to_periph_o` must be equal to the related `mio_in_i` value.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: InSelOOB_A
       desc: '''When register `periph_insel` is set to any value larger than
             (2 + number of MioPads), the corresponding `mio_to_periph_o` must be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -46,7 +46,7 @@
             - The corresponding `mio_in_i` is 0.
             - Jtag is enabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
     {
@@ -56,7 +56,7 @@
             - The corresponding `mio_in_i` is 1.
             - Jtag is enabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -65,7 +65,7 @@
     {
       name: DioInSelN_A
       desc: "This assertion checks that `dio_to_periph_o` is directly connected to `dio_in_i`."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -75,21 +75,21 @@
       name: OutSel0_A
       desc: '''When register `mio_outsel` is set to 0 and is not in sleep mode or jtag, which means
             the selected output is constant zero, the corresponding `mio_out_o` must be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: OutSel1_A
       desc: '''When register `mio_outsel` is set to 1 and is not in sleep mode or jtag, which means
             the selected output is constant one, the corresponding `mio_out_o` must be 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: OutSel2_A
       desc: '''When register `mio_outsel` is set to 2 and is not in sleep mode or jtag, which means
             the selected output is driving high-Z, the corresponding `mio_out_o` must be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -97,7 +97,7 @@
       desc: '''When register `mio_outsel` is set to any value between 3 and
             (3 + Number of periph out) and is not in sleep mode or jtag, the corresponding
             `mio_out_o` must be equal to the related `periph_to_mio_i` value.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -105,7 +105,7 @@
       desc: '''When register `mio_outsel` is set to any value larger than
             (3 + Number of periph out) and is not in sleep mode, the corresponding `mio_out_o` must
             be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -118,7 +118,7 @@
             - The corresponding `periph_to_mio_i` is 0.
             - Sleep mode is enabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
     {
@@ -128,7 +128,7 @@
             - The corresponding `periph_to_mio_i` is 1.
             - Sleep mode is enabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -138,14 +138,14 @@
       name: OutSelOe0_A
       desc: '''When register `mio_outsel` is set to 0 and is not in sleep mode or jtag, the
             corresponding `mio_oe_o` must be 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: OutSelOe1_A
       desc: '''When register `mio_outsel` is set to 1 and is not in sleep mode or jtag, the
             corresponding `mio_oe_o` must be 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -153,7 +153,7 @@
       desc: '''When register `mio_outsel` is set to 2 and is not in sleep mode or jtag, which
             indicates driving high-Z to the selected output, the corresponding `mio_oe_o` must
             be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -161,7 +161,7 @@
       desc: '''When register `mio_outsel` is set to any value between 3 and
             (3 + Number of periph out) and is not in sleep mode or jtag, the corresponding
             `mio_oe_o` must be equal to the related `periph_to_mio_oe_i` value.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -169,7 +169,7 @@
       desc: '''When register `mio_outsel` is set to any value larger than
             (3 + Number of periph out) and is not in sleep mode, the corresponding `mio_oe_o` must
             be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -182,7 +182,7 @@
             - The corresponding `periph_to_mio_oe_i` is 0.
             - Sleep mode is enabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
     {
@@ -192,7 +192,7 @@
             - The corresponding `periph_to_mio_oe_i` is 1.
             - Sleep mode is enabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -204,7 +204,7 @@
             `mio_pad_sleep_mode` is 0, which means the pad is driven zero in deep sleep mode.
             If, in the meantime, register `mio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `mio_out_o` must be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -213,7 +213,7 @@
             `mio_pad_sleep_mode` is 1, which means the pad is driven one in deep sleep mode.
             In the meantime, if register `mio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `mio_out_o` must be 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -222,7 +222,7 @@
             `mio_pad_sleep_mode` is 2, which means the pad is driven high-Z in deep sleep mode.
             In the meantime, if register `mio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `mio_out_o` must be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -233,7 +233,7 @@
             In the meantime, if register `mio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `mio_out_o` should be stable.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -242,7 +242,7 @@
             `mio_pad_sleep_status` is not written via TLUL interface to clear the sleep status, the
             corresponding `mio_out_o` should be stable.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -254,7 +254,7 @@
             `mio_pad_sleep_mode` is 0, which means the pad is driven zero in deep sleep mode.
             In the meantime, if register `mio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `mio_oe_o` must be 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -263,7 +263,7 @@
             `mio_pad_sleep_mode` is 1, which means the pad is driven one in deep sleep mode.
             In the meantime, if register `mio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `mio_oe_o` must be 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -272,7 +272,7 @@
             `mio_pad_sleep_mode` is 2, which means the pad is driven high-Z in deep sleep mode.
             In the meantime, if register `mio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `mio_oe_o` must be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -283,7 +283,7 @@
             In the meantime, if register `mio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `mio_oe_o` should be stable.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -292,7 +292,7 @@
             `mio_pad_sleep_status` is not written via TLUL interface to clear the sleep status, the
             corresponding `mio_oe_o` should be stable.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -305,7 +305,7 @@
             - In sleep mode, previous `mio_out_o` is 0 and `mio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `mio_out_o` is 0 and input `sleep_en_i` is not at posedge.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
     {
@@ -315,7 +315,7 @@
             - In sleep mode, previous `mio_out_o` is 1 and `mio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `mio_out_o` is 1 and input `sleep_en_i` is not at posedge.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -328,7 +328,7 @@
             - In sleep mode, previous `mio_oe_o` is 0 and `mio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `mio_oe_o` is 0 and input `sleep_en_i` is not at posedge.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
     {
@@ -338,7 +338,7 @@
             - In sleep mode, previous `mio_oe_o` is 1 and `mio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `mio_oe_o` is 1 and input `sleep_en_i` is not at posedge.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -347,7 +347,7 @@
     {
       name: DOutSelN_A
       desc: "`dio_out_o` is connected to `periph_to_dio_i` if not in sleep mode."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -356,7 +356,7 @@
     {
       name: DOutSelOeN_A
       desc: "`dio_oe_o` is connected to `periph_to_dio_oe_i` if not in sleep mode."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -368,7 +368,7 @@
             `dio_pad_sleep_mode` is 0, which means the pad is driven zero in deep sleep mode.
             In the meantime, if register `dio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `dio_out_o` must be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -377,7 +377,7 @@
             `dio_pad_sleep_mode` is 1, which means the pad is driven one in deep sleep mode.
             In the meantime, if register `dmio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `dio_out_o` must be 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -386,7 +386,7 @@
             `dio_pad_sleep_mode` is 2, which means the pad is driven high-Z in deep sleep mode.
             In the meantime, if register `dio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `dio_out_o` must be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -397,7 +397,7 @@
             In the meantime, if register `dio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `dio_out_o` should be stable.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -406,7 +406,7 @@
             `dio_pad_sleep_status` is not written via TLUL interface to clear the sleep status, the
             corresponding `dio_out_o` should be stable.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -418,7 +418,7 @@
             `dio_pad_sleep_mode` is 0, which means the pad is driven zero in deep sleep mode.
             In the meantime, if register `dio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `dio_oe_o` must be 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -427,7 +427,7 @@
             `dio_pad_sleep_mode` is 1, which means the pad is driven one in deep sleep mode.
             In the meantime, if register `dio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `dio_oe_o` must be 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -436,7 +436,7 @@
             `dio_pad_sleep_mode` is 2, which means the pad is driven high-Z in deep sleep mode.
             In the meantime, if register `dio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `dio_oe_o` must be 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -447,7 +447,7 @@
             In the meantime, if register `dio_pad_sleep_status` is not written via TLUL interface
             to clear the sleep status, the corresponding `dio_oe_o` should be stable.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -456,7 +456,7 @@
             `dio_pad_sleep_status` is not written via TLUL interface to clear the sleep status, the
             corresponding `dio_oe_o` should be stable.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -470,7 +470,7 @@
             - In sleep mode, previous `dio_out_o` is 0 and `dio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `dio_out_o` is 0 and input `sleep_en_i` is not at posedge.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
     {
@@ -481,7 +481,7 @@
             - In sleep mode, previous `dio_out_o` is 1 and `dio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `dio_out_o` is 1 and input `sleep_en_i` is not at posedge.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -495,7 +495,7 @@
             - In sleep mode, previous `dio_oe_o` is 0 and `dio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `dio_oe_o` is 0 and input `sleep_en_i` is not at posedge.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
     {
@@ -506,7 +506,7 @@
             - In sleep mode, previous `dio_oe_o` is 1 and `dio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `dio_oe_o` is 1 and input `sleep_en_i` is not at posedge.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -515,13 +515,13 @@
       name: MioAttrO_A
       desc: '''`mio_attr_o` should be equal to corresponding `mio_pad_attr` register value and
             TargetCfg's mio_pad_type configuration.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: MioJtagAttrO_A
       desc: "If jtag is enabled, the jtag `mio_attr_o` index should be equal to 0."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -530,7 +530,7 @@
       name: DioAttrO_A
       desc: '''`dio_attr_o` should be equal to corresponding `dio_pad_attr` register value and
             TargetCfg's dio_pad_type configuration.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -543,7 +543,7 @@
       desc: '''When register `wkup_detector_en` is set to 1 and `wkup_detector.mode` is set to 0,
             which means rising edge is used to detect wakeup. If variable `final_pin_val` is at
             posedge then `wkup_cause` register's `de` attribute should be set to 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -551,7 +551,7 @@
       desc: '''When register `wkup_detector_en` is set to 1 and `wkup_detector.mode` is set to 1,
             which means falling edge is used to detect wakeup. If variable `final_pin_val` is at
             negedge, then `wkup_cause` register's `de` attribute should be set to 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -560,7 +560,7 @@
             which means either rising or falling edge is used to detect wakeup. If variable
             `final_pin_val` is at posedge or negedge, then `wkup_cause` register's `de` attribute
             should be set to 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -569,7 +569,7 @@
             which means postive pulse cycles are used to detect wakeup. If variable `final_pin_val`
             stays high longer than the threshold, then `wkup_cause` register's `de` attribute
             should be set to 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -578,21 +578,21 @@
             which means negative pulse cycles are used to detect wakeup. If variable `final_pin_val`
             stays low longer than the threshold, then `wkup_cause` register's `de` attribute should
             be set to 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: WkupCauseQ_A
       desc: '''When `wkup_cause` register's `de` attribute is set to 1 and user is not writing to
             `wkup_cause` at the same cycle, then `wkup_cause.q` should be set to 1.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: AonWkupO_A
       desc: '''When register `wkup_cause` is 1, `pin_wkup_req_o` should also be 1.
             `pin_wkup_req_o` is 0 only when all `wkup_cause` registers are 0.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -600,13 +600,13 @@
     {
       name: WkupCause0_A
       desc: "Register `wkup_cause` is 0 only when none of the above wakeup conditions is met."
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
     {
       name: WkupCause1_A
       desc: "Register `wkup_cause` is 1 when at least one of the above wakeup conditions is met."
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -615,7 +615,7 @@
       name: LcJtagWoScanmode_A
       desc: '''Not in scanmode, when tap_strap select LC_tap, `lc_jtag_o` must be equal to the
             corresponding `mio_in_i` pins based on the `TargetCfg` configuration.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -623,13 +623,13 @@
       desc: '''In scanmode, when tap_strap select LC_tap, `lc_jtag_o` must be equal to the
             corresponding `mio_in_i` pins based on the `TargetCfg` configuration except the
             `jtag_trst` pin, which must be equal to `rst_ni`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: LcJtagODefault_A
       desc: "`lc_jtag_o` should stay 0 if tap_strap did not select LC_tap."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -639,7 +639,7 @@
             - Lc Jtag is disabled and the corresponding pins are 0.
             - Lc Jtag is enabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -649,7 +649,7 @@
       desc: '''Not in scanmode, when tap_strap select RV_tap and `lc_hw_debug_en_i` input is On for
             the past two clock cycles due to the synchronizer, then `rv_jtag_o` must be equal to
             the corresponding `mio_in_i` pins based on the `TargetCfg` configuration.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -659,14 +659,14 @@
             corresponding `mio_in_i` pins based on the `TargetCfg` configuration except the
             `jtag_trst` pin, which must be equal to `rst_ni`.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: RvJtagODefault_A
       desc: '''`rv_jtag_o` should stay 0 if tap_strap did not select RV_tap or `lc_hw_debug_en_i`
             input is Off for the past two clock cycles due to the synchronizer.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -676,7 +676,7 @@
             - Rv Jtag is disabled and the corresponding pins are 0.
             - Rv Jtag is enabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -686,7 +686,7 @@
       desc: '''Not in scanmode, when tap_strap select DFT_tap and `lc_dft_en_i` is On for the past
             two clock cycles due to the synchronizer, `lc_jtag_o` must be equal to the
             corresponding `mio_in_i` pins based on the `TargetCfg` configuration.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -695,14 +695,14 @@
             two clock cycles due to the synchronizer, `lc_jtag_o` must be equal to the
             corresponding `mio_in_i` pins based on the `TargetCfg` configuration except the
             `jtag_trst` pin, which must be equal to `rst_ni`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: DftJtagODefault_A
       desc: '''`dft_jtag_o` should stay 0 if tap_strap did not select DFT_tap or the `lc_dft_en_i`
             input is Off for the past two clock cycles due to the synchronizer.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -712,7 +712,7 @@
             - Dft Jtag is disabled and the corresponding pins are 0.
             - Dft Jtag is enabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
     {
@@ -720,7 +720,7 @@
       desc: '''`dft_jtag_o` pins are ones if one of the following conditions are met:
             - Dft Jtag is enabled and the corresponding pins are 1.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pinmux_assert"]
     }
 
@@ -732,7 +732,7 @@
             the synchronizer, then tap_strap must be equal to the past value of corresponding
             `mio_in_i`.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -741,7 +741,7 @@
             due to the synchronizer, or `strap_en_i` is 1.
             Then tap_strap[0] must be equal to the past value of corresponding `mio_in_i`.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -750,7 +750,7 @@
       name: LcJtagI_A
       desc: '''When Lc tap is selected, the corresponding `mio_out_o` and `mio_out_oe` should be
             equal to `lc_jtag_i`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -758,7 +758,7 @@
       desc: '''When Rv tap is selected and `lc_hw_debug_en_i` is On for the past two clock cycles
             due to the synchronizer, the corresponding `mio_out_o` and `mio_out_oe` should be equal
             to `rv_jtag_i`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
@@ -766,7 +766,7 @@
       desc: '''When Dft tap is selected and `lc_dft_en_i` is On for the past two clock cycles
             due to the synchronizer, the corresponding `mio_out_o` and `mio_out_oe` should be equal
             to `dft_jtag_i`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -776,19 +776,19 @@
       desc: '''When `lc_dft_en_i` is On for the past two clock cycles due to the synchronizer,
             `dft_strap_test_o.valid` must be 1, and `dft_strap_test_o.straps` should be equal to
             the corresponding `mio_in_i` index.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: DftStrapTestOValidStable_A
       desc: "`dft_strap_test_o.valid` once set to 1 will stay high until reset."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: DftStrapTestOStrapStable_A
       desc: "`dft_strap_test_o.valid` once set, `dft_strap_test_o.straps` should stay stable."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
 
@@ -798,88 +798,86 @@
     {
       name: UsbSleepEnI_A
       desc: "`sleep_en_i` should be connected directly to usbdev's `low_power_alw_i`."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbDppullupEnUpwrI_A
       desc: '''`usb_dppullup_en_upwr_i` should be connected directly to usbdev's
             `usb_dppullup_en_upwr_i`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbDnpullupEnUpwrI_A
       desc: '''`usb_dnpullup_en_upwr_i` should be connected directly to usbdev's
             `usb_dnpullup_en_upwr_i`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbDppullupEnO_A
       desc: '''`usb_dppullup_en_o` should be connected directly to usbdev's
             `usb_dppullup_en_o`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbDnpullupEnO_A
       desc: '''`usb_dnpullup_en_o` should be connected directly to usbdev's
             `usb_dnpullup_en_o`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbOutOfRstI_A
       desc: "`usb_out_of_rst_i` should be connected directly to usbdev's `usb_out_of_rst_upwr_i`."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbAonWakeEnUpwrI_A
       desc: '''`usb_aon_wake_en_i` should be connected directly to usbdev's
             `usb_aon_wake_en_upwr_i`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbAonWakeAckUpwrI_A
       desc: '''`usb_aon_wake_ack_i` should be connected directly to usbdev's
             `usb_aon_woken_upwr_i`.'''
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbSuspendI_A
       desc: "`usb_suspend_i` should be connected directly to usbdev's `usb_suspended_upwr_i`."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbWkupReqO_A
       desc: "`usb_wkup_req_o` should be connected directly to usbdev's `wake_rep_alw_o`."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbBusResetO_A
       desc: "`usb_bus_reset_o` should be connected directly to usbdev's `bus_reset_alw_o`."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbSenseLostO_A
       desc: "`usb_sense_lost_o` should be connected directly to usbdev's `bus_lost_alw_o`."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
     {
       name: UsbStateDebugO_A
       desc: "`usb_state_debug_o` should be connected directly to usbdev's `bus_debug_o`."
-      milestone: V1
+      stage: V1
       tests: ["pinmux_assert"]
     }
  ]
 }
-
-

--- a/hw/ip/pinmux/data/pinmux_sec_cm_testplan.hjson
+++ b/hw/ip/pinmux/data/pinmux_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
+++ b/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
@@ -13,7 +13,7 @@
             - If the alert is fatal, verify if the alert continuous fires until a reset is
               issued.
             '''
-      milestone: V1
+      stage: V1
       tests: ["prim_async_alert",
               "prim_async_fatal_alert",
               "prim_sync_alert",
@@ -27,7 +27,7 @@
              - Send an alert test request by driving `alert_test` pin to 1.
              - Verify that alert handshake completes and `alert_ack` signal stays low.
             '''
-      milestone: V1
+      stage: V1
       tests: ["prim_async_alert",
               "prim_async_fatal_alert",
               "prim_sync_alert",
@@ -41,7 +41,7 @@
             - Send a ping request by driving `ping_req` pin to 1.
             - Verify that `ping_ok` signal is set and ping handshake completes.
             '''
-      milestone: V1
+      stage: V1
       tests: ["prim_async_alert",
               "prim_async_fatal_alert",
               "prim_sync_alert",
@@ -62,7 +62,7 @@
               drive `init_trigger_i` in prim_alert_receiver.
               Check `ping_ok` returns 1.
             '''
-      milestone: V2
+      stage: V2
       tests: ["prim_async_alert",
               "prim_async_fatal_alert",
               "prim_sync_alert",
@@ -84,7 +84,7 @@
                 - Verify that prim_alert_receiver can identify the integrity error by setting
                   `integ_fail_o` output to 1.
             '''
-      milestone: V1
+      stage: V1
       tests: ["prim_async_alert",
               "prim_async_fatal_alert",
               "prim_sync_alert",
@@ -101,7 +101,7 @@
               and verify we will never miss or drop an alert handshake by expecting `alert_ack_o`
               to return 1 after `alert_req` is sent.
             '''
-      milestone: V3
+      stage: V3
       tests: []
     }
   ]

--- a/hw/ip/prim/dv/prim_esc/data/prim_esc_testplan.hjson
+++ b/hw/ip/prim/dv/prim_esc/data/prim_esc_testplan.hjson
@@ -12,7 +12,7 @@
             - Wait random length of cycles and verify `esc_en` output is set and `integ_fail`
               output remains 0.
             '''
-      milestone: V1
+      stage: V1
       tests: ["prim_esc_test"]
     }
 
@@ -26,7 +26,7 @@
             - Wait for `ping_ok` to set and `esc_req_out` to set.
             - Check the sequence completes without any signal integrity error.
             '''
-      milestone: V1
+      stage: V1
       tests: ["prim_esc_test"]
     }
 
@@ -40,7 +40,7 @@
             - Release the `esc_n` signal.
             - Send a ping request and repeat the above sequence and checkings.
             '''
-      milestone: V1
+      stage: V1
       tests: ["prim_esc_test"]
     }
 
@@ -56,7 +56,7 @@
               to 1.
             - Reset the DUT to clear `esc_en` output.
             '''
-      milestone: V1
+      stage: V1
       tests: ["prim_esc_test"]
     }
 
@@ -70,7 +70,7 @@
             - Verify that prim_esc_receiver detects the counter mismatch and set `esc_en` signal to
               1.
             '''
-      milestone: V1
+      stage: V1
       tests: ["prim_esc_test"]
     }
 
@@ -83,7 +83,7 @@
             - Verify that after reset, the prim_esc_sender and prim_esc_receiver pair functions
               correctly by issuing the tests above.
             '''
-      milestone: V1
+      stage: V1
       tests: ["prim_esc_test"]
     }
 

--- a/hw/ip/pwm/data/pwm_sec_cm_testplan.hjson
+++ b/hw/ip/pwm/data/pwm_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/pwm/data/pwm_testplan.hjson
+++ b/hw/ip/pwm/data/pwm_testplan.hjson
@@ -23,7 +23,7 @@
               - ensure pulses are generated correctly in pulse or blink mode
 
             '''
-      milestone: V1
+      stage: V1
       tests: ["pwm_smoke"]
     }
     {
@@ -32,7 +32,7 @@
             Verify different duty cycle settings in Pulse, Blink and Heart Beat mode.
 
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwm_rand_output"]
     }
     {
@@ -41,7 +41,7 @@
             Verify the pulse mode of the PWM
             by de-asserting blink_en field in the PWM_PARAM register
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwm_rand_output"]
     }
     {
@@ -50,7 +50,7 @@
             Verify the blink mode of the PWM
             by asserting the blink_en field in the PWM_PARAM register
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwm_rand_output"]
     }
     {
@@ -59,7 +59,7 @@
             Verify the Heart Beat mode of the PWM
             by asserting the blink_en and HTBT field in the PWM_PARAM register
             '''
-        milestone: V2
+        stage: V2
         tests: ["pwm_rand_output"]
     }
    {
@@ -67,7 +67,7 @@
       desc: '''
             Verify the PWM generates correct duty cycle for different resolution settings
             '''
-        milestone: V2
+        stage: V2
         tests: ["pwm_rand_output"]
     }
     {
@@ -75,7 +75,7 @@
       desc: '''
             Verifies that PWM correctly generates pulses on multiple channels concurrently
             '''
-        milestone: V2
+        stage: V2
         tests: ["pwm_rand_output"]
     }
     {
@@ -83,7 +83,7 @@
       desc: '''
             Verify that the polarity of the pulse can be inverted by setting the invert channel bit in the invert register
             '''
-        milestone: V2
+        stage: V2
         tests: ["pwm_rand_output"]
     }
     {
@@ -91,7 +91,7 @@
       desc: '''
             Check that the relative phase between pulses matches the setting in the phase_delay field in the PWM_PARAM register.
             '''
-        milestone: V2
+        stage: V2
         tests: ["pwm_rand_output"]
     }
     {
@@ -105,7 +105,7 @@
             Checks:
                 - Ensure pulses are still generated when in LP mode
             '''
-        milestone: V2
+        stage: V2
         tests: ["pwm_rand_output"]
     }
     {
@@ -121,7 +121,7 @@
             Checks:
                 - Ensure the output pulses are correctly modulated for all channels
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwm_perf"]
     }
     {
@@ -135,7 +135,7 @@
             Checking:
                 - All sequences should be finished and checked by the scoreboard
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwm_stress_all"]
     }
   ]

--- a/hw/ip/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -31,7 +31,7 @@
             This will not trigger rst_req, but
             send fatal alert
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_tl_intg_err"]
     }
     {
@@ -52,7 +52,7 @@
               is set to '1' only when lc_dft_en_i or lc_hw_debug_en_i
               is high.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm_lc_ctrl_intersig_mubi"]
     }
     {
@@ -69,7 +69,7 @@
             - Collect coverage by binding cip_mubi_cov_if to
               tb.dut.rom_ctrl_i
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm_rom_ctrl_intersig_mubi"]
     }
     {
@@ -84,7 +84,7 @@
             - Collect coverage by binding cip_mubi_cov_if to
               tb.dut.sw_rst_req_i
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm_rstmgr_intersig_mubi"]
     }
     {
@@ -102,7 +102,7 @@
               is back to normal operation state.
 
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_esc_clk_rst_malfunc"]
     }
     {
@@ -118,7 +118,7 @@
             - Detect fast state transition to FastPwrStateResetPrep.
               And this will trigger rstreqs[ResetEscIdx].
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm"]
     }
     {
@@ -129,7 +129,7 @@
             /hw/dv/sv/cip_lib/doc/index.md#security-verification
             -for-common-countermeasure-primitives)
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm"]
     }
     {
@@ -145,7 +145,7 @@
             pwr_rst_o.rst_sys_req = 3 and pwr_clk_o = 0.
             Dut should be recovered by asserting rst_n = 0.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm"]
     }
     {
@@ -159,7 +159,7 @@
             - Check fast state transition to FastPwrStateResetPrep
               and get pwr_rst_req.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_global_esc"]
     }
     {
@@ -173,7 +173,7 @@
             - Check fast state transition to FastPwrStateResetPrep
               and get pwr_rst_req.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_glitch"]
     }
     {
@@ -191,7 +191,7 @@
               read back and check the value is not updated by
               the csr udate attempt.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm_ctrl_config_regwen"]
     }
     {
@@ -200,7 +200,7 @@
 
             This is covered by auto csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_csr_rw"]
     }
     {
@@ -209,7 +209,7 @@
 
             This is covered by auto csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_csr_rw"]
     }
   ]

--- a/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
@@ -41,7 +41,7 @@
               reset cause.
             - The output `pwr_rst_req.rstreqs` matches the enabled resets.
             '''
-      milestone: V1
+      stage: V1
       tests: ["pwrmgr_smoke"]
     }
     {
@@ -76,7 +76,7 @@
             - Check that `intr_wakeup_o` is set according to `intr_enable` CSR.
             - Coverage collected by `wakeup_cg` and `wakeup_intr_cg`.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwrmgr_wakeup"]
     }
     {
@@ -98,7 +98,7 @@
             - The usb clock enable is also checked during active mode against
               the control register.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwrmgr_wakeup"]
     }
     {
@@ -127,7 +127,7 @@
             - Check that the `wakeup_info` CSR flags either `fall_through` or
               `abort` events when capture is enabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwrmgr_aborted_low_power"]
     }
     {
@@ -156,7 +156,7 @@
              `pwr_rst_req.rstreqs` matches the unconditional and enabled
              conditional resets inputs.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwrmgr_reset"]
     }
     {
@@ -176,7 +176,7 @@
             - Checks the output `pwr_rst_req.reset_cause` matches HwReq.
             - Checks the output `pwr_rst_req.rstreqs` matches power glitch.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwrmgr_reset"]
     }
     {
@@ -198,7 +198,7 @@
             - Similar tests as for the wakeup and reset testpoints, except
               making sure they happen per the triggering order.
               '''
-      milestone: V2
+      stage: V2
       tests: ["pwrmgr_wakeup_reset"]
     }
     {
@@ -220,7 +220,7 @@
             - No timeout occurs.
             - Either pwrmgr remains active or a full low power cycle occurs.
             '''
-      milestone: V2
+      stage: V2
       tests: ["pwrmgr_lowpower_wakeup_race"]
     }
     {
@@ -235,7 +235,7 @@
             - pwrmgr_wakeup_reset_vseq
             - pwrmgr_wakeup_vseq
 	    '''
-      milestone: V2
+      stage: V2
       tests: ["pwrmgr_stress_all"]
     }
   ]

--- a/hw/ip/rom_ctrl/data/rom_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_sec_cm_testplan.hjson
@@ -30,7 +30,7 @@
              point at the top of ROM. The unexpected_counter_change signal in rom_ctrl_fsm goes high
              and generates a fatal alert if that counter is perturbed in any way. To test this,
              addr_q in the counter is corrupted with any value other than the ROM's top address.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_corrupt_sig_fatal_chk''']
     }
     {
@@ -40,14 +40,14 @@
              the KMAC response and its comparison counter. If any of these are asserted at times we
              don't expect, the FSM jumps to an invalid state. This triggers an alert and will not
              set the external 'done' signal for pwrmgr to continue boot.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_corrupt_sig_fatal_chk''']
     }
     {
       name: sec_cm_checker_fsm_local_esc
       desc: '''Verify the countermeasure(s) CHECKER.FSM.LOCAL_ESC.
              Check that fsm_state reaches invalid state whenever a fatal alert is signalled.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_corrupt_sig_fatal_chk''']
     }
     {
@@ -58,7 +58,7 @@
              we don't expect, the FSM jumps to an invalid state. This triggers an alert and will not
              set the external 'done' signal for pwrmgr to continue boot. To test this start_checker
              signal from rom_ctrl_fsm is asserted randomly.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_corrupt_sig_fatal_chk''']
     }
     {
@@ -67,52 +67,52 @@
              The hash comparison module has an internal count. If this glitches to a nonzero value
              before the comparison starts or to a value other than the last index after the
              comparison ends then a fatal alert is generated.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_corrupt_sig_fatal_chk''']
     }
     {
       name: sec_cm_compare_ctr_redun
       desc: '''Verify the countermeasure(s) COMPARE.CTR.REDUN.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_sec_cm''']
     },
     {
       name: sec_cm_fsm_sparse
       desc: '''Verify the countermeasure(s) FSM.SPARSE.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_sec_cm''']
     }
     {
       name: sec_cm_mem_scramble
       desc: '''Verify the countermeasure(s) MEM.SCRAMBLE.
              Check that The ROM is scrambled.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_smoke''']
     }
     {
       name: sec_cm_mem_digest
       desc: '''Verify the countermeasure(s) MEM.DIGEST.
              Check that a cSHAKE digest is computed of the ROM contents.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_smoke''']
     }
     {
       name: sec_cm_intersig_mubi
       desc: '''Verify the countermeasure(s) INTERSIG.MUBI.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_smoke''']
     }
     {
       name: sec_cm_bus_integrity
       desc: '''Verify the countermeasure(s) BUS.INTEGRITY.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_tl_intg_err''']
     }
     {
       name: sec_cm_bus_local_esc
       desc: '''Verify the countermeasure(s) BUS.LOCAL_ESC.
              Check that in invalid state, rvalid is not asserted.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_corrupt_sig_fatal_chk''', '''rom_ctrl_kmac_err_chk''']
     }
     {
@@ -122,7 +122,7 @@
              An invalid value generates a fatal alert with the sel_invalid signal in rom_ctrl_mux
              module. To test this rom_select_bus_o is forced with any value other than MuBi4True and
              MuBi4False.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_corrupt_sig_fatal_chk''']
     }
     {
@@ -133,7 +133,7 @@
              cause it to switch back, a fatal alert is generated with the sel_reverted or
              sel_q_reverted_q signals in the rom_ctrl_mux module. To test this rom_select_bus_o is
              forced to MuBi4False after rom check is completed.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_corrupt_sig_fatal_chk''']
     }
     {
@@ -142,20 +142,20 @@
              Inject errors into bus_rom_rom_index (which is how an attacker would get a different
              memory word) and then check that the data that gets read doesn't match the data stored
              at the glitched address.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_corrupt_sig_fatal_chk''']
     }
     {
       name: sec_cm_ctrl_mem_integrity
       desc: '''Verify the countermeasure(s) MEM.INTEGRITY.'''
-      milestone: V2S
+      stage: V2S
       tests: ['''rom_ctrl_passthru_mem_tl_intg_err''']
     }
     {
       name: sec_cm_tlul_fifo_ctr_redun
       desc: '''Verify the countermeasure(s) TLUL_FIFO.CTR.REDUN.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_sec_cm"]
     }
   ]

--- a/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
@@ -32,7 +32,7 @@
             - Check that pwrmgr_data_o.good is asserted in second iteration.
             - Check that tile link accesses are blocked till pwrmgr_data_o.done is asserted.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rom_ctrl_smoke"]
     }
     {
@@ -43,7 +43,7 @@
             **Checks**:
             - Check that fatal error is flagged.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rom_ctrl_corrupt_sig_fatal_chk"]
     }
     {
@@ -55,7 +55,7 @@
             **Checks**:
             - Check if N read accesses finish in N+1 cycles.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rom_ctrl_max_throughput_chk"]
     }
     {
@@ -63,7 +63,7 @@
       desc: '''
             - Combine above sequences in one test to run sequentially.
             - Randomly add reset between each sequence'''
-      milestone: V2
+      stage: V2
       tests: ["rom_ctrl_stress_all"]
     }
     {
@@ -71,7 +71,7 @@
       desc: '''
             - Generate error from KMAC when it responds with KMAC digest image.
             - Check that ROM controller goes into invalid state'''
-      milestone: V2
+      stage: V2
       tests: ["rom_ctrl_kmac_err_chk"]
     }
 

--- a/hw/ip/rstmgr/data/rstmgr_sec_cm_testplan.hjson
+++ b/hw/ip/rstmgr/data/rstmgr_sec_cm_testplan.hjson
@@ -28,7 +28,7 @@
       desc: '''Verify the countermeasure(s) BUS.INTEGRITY.
             This entry is covered by tl_access_test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_tl_intg_err"]
     }
     {
@@ -42,7 +42,7 @@
             **Check**:
             If dut accepts any of invalid values, test will fail by turing dut to scanmode.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_sec_cm_scan_intersig_mubi"]
     }
     {
@@ -59,7 +59,7 @@
             Upon asserting each reset consistency error,
             check alert_fatal_cnsty_fault is asserted.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_leaf_rst_cnsty"]
     }
     {
@@ -69,7 +69,7 @@
             Check if normal leaf reset module is not triggerred.
             Do over all {shadow, normal} leaf reset module pairs
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_leaf_rst_shadow_attack"]
     }
     {
@@ -79,7 +79,7 @@
             Force leaf rst check state to illegal value.
             This is triggered by common cm primitives
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_sec_cm"]
     }
     {
@@ -89,7 +89,7 @@
             RSTMGR.SW_RST_CTRL_N.
             This is covered by auto csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_csr_rw"]
     }
     {
@@ -99,7 +99,7 @@
             RSTMGR.ALERT_INFO_CTRL and RSTMGR.CPU_INFO_CTRL
             This is covered by auto csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_csr_rw"]
     }
   ]

--- a/hw/ip/rstmgr/data/rstmgr_testplan.hjson
+++ b/hw/ip/rstmgr/data/rstmgr_testplan.hjson
@@ -36,7 +36,7 @@
             - Checks the output reset pins corresponding to sw resettable
               units match `sw_rst_ctrl_n` CSR.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rstmgr_smoke"]
     }
     {
@@ -55,7 +55,7 @@
             - With SVA check the output reset is only set if the input reset
               has had at least 32 cycles of steady input reset active.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rstmgr_por_stretcher"]
     }
     {
@@ -81,7 +81,7 @@
               `sw_rst_regwen` have no effect on resets.
             - Check the `reset_info`, `cpu_info`, and `alert_info` CSRs are not modified.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rstmgr_sw_rst"]
     }
     {
@@ -99,7 +99,7 @@
             - Check the `reset_info` CSR.
             - Reset behavior is checked by SVA.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rstmgr_sw_rst_reset_race"]
     }
     {
@@ -115,7 +115,7 @@
             - Each bit was set at least once.
             - Each bit was cleared at least once.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rstmgr_reset"]
     }
     {
@@ -136,7 +136,7 @@
             - Verify the `cpu_info` contents at each `cpu_info_ctrl.index`
               matches the expected value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rstmgr_reset"]
     }
     {
@@ -157,7 +157,7 @@
             - Verify the `alert_info` contents at each `alert_info_ctrl.index`
               matches the expected value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rstmgr_reset"]
     }
     {
@@ -174,7 +174,7 @@
             **Checks**:
             - Non-AON resets prior to this event don't capture.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rstmgr_reset"]
     }
     {
@@ -186,7 +186,7 @@
             - rstmgr_smoke_vseq
             - rstmgr_sw_rst_vseq
 	    '''
-      milestone: V2
+      stage: V2
       tests: ["rstmgr_stress_all"]
     }
   ]

--- a/hw/ip/rstmgr/dv/rstmgr_cnsty_chk/data/rstmgr_cnsty_chk_testplan.hjson
+++ b/hw/ip/rstmgr/dv/rstmgr_cnsty_chk/data/rstmgr_cnsty_chk_testplan.hjson
@@ -8,35 +8,35 @@
       name: unexpected_child_reset_activity
       desc: '''Verify unexpected child_reset activity flags an error.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_cnsty_chk_smoke"]
     }
     {
       name: child_reset_asserts_late
       desc: '''Verify error triggered if child reset asserts late.
             '''
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: child_reset_releases_late
       desc: '''Verify error triggered if child reset releases late.
             '''
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: parent_reset_asserts_late
       desc: '''Verify error triggered if parent reset asserts late.
             '''
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: parent_reset_releases_late
       desc: '''Verify error triggered if parent reset releases late.
             '''
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex_sec_cm_testplan.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex_sec_cm_testplan.hjson
@@ -26,79 +26,79 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_scramble_key_sideload
       desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_core_data_reg_sw_sca
       desc: "Verify the countermeasure(s) CORE.DATA_REG_SW.SCA."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_pc_ctrl_flow_consistency
       desc: "Verify the countermeasure(s) PC.CTRL_FLOW.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_flow_unpredictable
       desc: "Verify the countermeasure(s) CTRL_FLOW.UNPREDICTABLE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_reg_sw_integrity
       desc: "Verify the countermeasure(s) DATA_REG_SW.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_reg_sw_glitch_detect
       desc: "Verify the countermeasure(s) DATA_REG_SW.GLITCH_DETECT."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_logic_shadow
       desc: "Verify the countermeasure(s) LOGIC.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_fetch_ctrl_lc_gated
       desc: "Verify the countermeasure(s) FETCH.CTRL.LC_GATED."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_exception_ctrl_flow_local_esc
       desc: "Verify the countermeasure(s) EXCEPTION.CTRL_FLOW.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_exception_ctrl_flow_global_esc
       desc: "Verify the countermeasure(s) EXCEPTION.CTRL_FLOW.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_icache_mem_scramble
       desc: "Verify the countermeasure(s) ICACHE.MEM.SCRAMBLE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_icache_mem_integrity
       desc: "Verify the countermeasure(s) ICACHE.MEM.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex_testplan.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex_testplan.hjson
@@ -14,7 +14,7 @@
               - Assert fetch enable to start the core execution
               - Terminate the test after ecall instructinon in detected
               - All instruction results are compared against spike simulation'''
-      milestones: V1
+      stage: V1
       tests: ["riscv_arithmetic_basic_test"]
     }
     {
@@ -29,7 +29,7 @@
               - fence instructions (treated as nop)
               - mret instruction
               - corner cases for each instruction (overflow, underflow, div by zero etc.)'''
-      milestones: V1
+      stage: V1
       tests: ["riscv_rand_instr_test"]
     }
     {
@@ -37,7 +37,7 @@
       desc: '''
             Fully randomized RV32IMC instructions
               - boot into Machine Mode'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_machine_mode_rand_test"]
     }
     {
@@ -45,7 +45,7 @@
       desc: '''
             Stresses I-Fetch operation:
               - Generates a large number of subprograms and frequently jumps between them'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_rand_jump_test"]
     }
     {
@@ -53,14 +53,14 @@
       desc: '''
             Stresses I-Fetch operation:
               - Generates sequences of many back-to-back jump instructions'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_jump_stress_test"]
     }
     {
       name: riscv_loop_test
       desc: '''
             Generate directed sequences of loops to test branch operations'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_loop_test"]
     }
     {
@@ -72,7 +72,7 @@
               - back-to-back load/store instructions
               - cover all byte/half-word/word load/store instructions
               - load/store with hazard conditions'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_mmu_stress_test"]
     }
     {
@@ -80,7 +80,7 @@
       desc: '''
             Random mis-aligned half-word/word load/store instruction
             Expect the core finishes the load/store properly with no exception raised'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_unaligned_load_store_test"]
     }
     {
@@ -91,7 +91,7 @@
             Verify the fault load instruction won't modify GPR
             Verify the context of the exception is captured correctly in privileged CSRs
               - mstatus, mcause, mepc'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_mem_error_test"]
     }
     {
@@ -105,7 +105,7 @@
             Verify the illlegal instruction exception is raised and the context is captured correctly in privieged mode CSRs
               - mstatus, mcause, mepc
             Verify the core can resume execution after returning from trap handling'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_illegal_instr_test"]
     }
     {
@@ -113,14 +113,14 @@
       desc: '''
             Randomly inject HINT instructions as specified in RISC-V user mode specification 5.4
             Verify the core execute it as NOP and no exception is raised'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_hint_instr_test"]
     }
     {
       name: riscv_ebreak_test
       desc: '''
             Generate random instructions including ebreak, expect core to raise ebreak exception'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_ebreak_test"]
     }
     {
@@ -131,7 +131,7 @@
                 excluding control transfer instructions
               - verify wfi instructions act as NOPs
               - ensure normal execution finishes successfully'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_debug_basic_test"]
     }
     {
@@ -141,7 +141,7 @@
               - debug rom will consist of just a dret instructions, so any switches into
               debug mode will immediately return
               - will use this jointly with full instruction checking with spike'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_debug_stress_test"]
     }
     {
@@ -151,7 +151,7 @@
               - in debug_rom, insert random instruction sequence,
                 including control transfer instructions and multiple subprograms to
                 jump between'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_debug_branch_jump_test"]
     }
     {
@@ -162,7 +162,7 @@
               - randomly toggle interrupts during debug code
               - verify that execution of debug_rom continues as normal, interrupts are
                 ignored'''
-      milestone: V2
+      stage: V2
       tests: ["riscv_debug_interrupt_test"]
     }
     {
@@ -171,7 +171,7 @@
             - insert illegal instruction into debug rom to trigger internal exception
             - verify that no registers have been updated
             - verify that execution of debug rom ends'''
-      milestone: V2
+      stage: V2
       tests: ["riscv_debug_illegal_instr_test"]
     }
     {
@@ -181,7 +181,7 @@
               - while core is in wfi sleep state, assert debug request
               - verify core jumps to debug mode
               - debug rom consists of random generation instructions'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_debug_wfi_test"]
     }
     {
@@ -189,7 +189,7 @@
       desc: '''
             Randomly insert dret instructions into M mode instructions
               - verify that ibex treats them as illegal instructions'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_dret_test"]
     }
     {
@@ -198,7 +198,7 @@
             - insert ebreak instructions in M mode code, should be handled normally
             - assert debug request
             - in debug mode, insert ebreak instruction, verify that ibex re-enter debug mode'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_debug_ebreak_test"]
     }
     {
@@ -208,7 +208,7 @@
             - randomly insert ebreak instructions in generated code
             - boot randomly into either M/U modes
             - verify that ebreak instructions (in either mode) now enter debug mode'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_debug_ebreakmu_test"]
     }
     {
@@ -218,7 +218,7 @@
               - in debug_rom, set dcsr.step
               - after exiting debug mode, core will execute one instruction and re-enter
                 debug mode'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_debug_single_step_test"]
     }
     {
@@ -226,7 +226,7 @@
       desc: '''
             Inject debug stimulus during CSR modification operations,
             core should jump to debug mode and return without any issues'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_debug_csr_entry_test"]
     }
     {
@@ -234,7 +234,7 @@
       desc: '''
             Randomly assert interrupt lines while the core is in debug mode execution,
             verify that these interrupts are all completely ignored'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_irq_in_debug_mode_test"]
     }
     {
@@ -242,7 +242,7 @@
       desc: '''
             Randomly assert a single interrupt line during program execution, core
             should jump to proper handler'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_single_interrupt_test"]
     }
     {
@@ -250,14 +250,14 @@
       desc: '''
             Randomly assert multiple interrupt lines during program execution,
             core should jump to handler of highest priority interrupt'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_multiple_interrupt_test"]
     }
     {
       name: riscv_interrupt_wfi_test
       desc: '''
             Randomly assert interrupt lines while the core is sleeping due to a WFI instruction'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_interrupt_wfi_test"]
     }
     {
@@ -265,7 +265,7 @@
       desc: '''
             Randomly assert interrupt lines during CSR modification operations,
             core should jump to proper handler'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_interrupt_csr_test"]
     }
     {
@@ -277,7 +277,7 @@
             - verify that core takes this nested interrupt and handles it, then restores previous interrupt
               state and finishes executing first interrupt handler - ibex implements nonstandard MSTACK csrs to
               save/restore state in case of nested interrupt'''
-      milestone: V2
+      stage: V2
       tests: ["riscv_interrupt_nested_test"]
     }
     {
@@ -286,7 +286,7 @@
             Perform all CSR instructions to implemented privileged CSR
             Verify the reset value of the privileged CSR
             Verify WARL field can be upated properly'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_csr_test"]
     }
     {
@@ -295,14 +295,14 @@
             Reset the core a random number of times during program execution, core
             should jump back to start address and re-enter the program.
             Ensure to flush all testbench state to prevent contamination after reset.'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_reset_test"]
     }
     {
       name: riscv_perf_counter_test
       desc: '''
             Run random instruction test, and dump performance counters for checking'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_perf_counter_test"]
     }
     {
@@ -310,7 +310,7 @@
       desc: '''
             Specify RV32IM architecture to compiler to generate target specific
             instructions (no compressed instructions).'''
-      milestone: V1
+      stage: V1
       tests: ["riscv_rv32im_instr_test"]
     }
     {
@@ -320,7 +320,7 @@
             test should finish successfully
               - includes all types of instructions
               - no external debug/irq stimulus, exceptions, security aspects are checked here'''
-      milestone: V2
+      stage: V2
       tests: ["riscv_user_mode_rand_test"]
     }
     {
@@ -329,7 +329,7 @@
             Set mstatus.tw, and enable random generation of WFI instructions.
             Upon encountering WFI in U-mode, core should trap to M-mode
             illegal instruction exception handler.'''
-      milestone: V2
+      stage: V2
       tests: ["riscv_umode_tw_test"]
     }
     {
@@ -337,7 +337,7 @@
       desc: '''
             Boot core into a random privilege mode and generate accesses to higher level CSRs,
             expect to throw an illegal instruction exception for each of these accesses.'''
-      milestone: V2
+      stage: V2
       tests: ["riscv_invalid_csr_test"]
     }
     {

--- a/hw/ip/rv_dm/data/rv_dm_sec_cm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_sec_cm_testplan.hjson
@@ -26,25 +26,25 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_lc_hw_debug_en_intersig_mubi
       desc: "Verify the countermeasure(s) LC_HW_DEBUG_EN.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_dm_en_ctrl_lc_gated
       desc: "Verify the countermeasure(s) DM_EN.CTRL.LC_GATED."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_exec_ctrl_mubi
       desc: "Verify the countermeasure(s) EXEC.CTRL.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -29,7 +29,7 @@
             - Wiggle the `unavailable` input and read the DTM register field dmstatus[allunavail]
               to verify that it reflects the same value as the input signal.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rv_dm_smoke"]
 
     }
@@ -44,7 +44,7 @@
             In these set of tests, the lc_hw_debug_en is set to true, scanmode & scan_rst_n inputs
             to false.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rv_dm_jtag_dtm_csr_hw_reset"]
     }
     {
@@ -55,7 +55,7 @@
             See hw/dv/tools/dvsim/testplans/csr_testplan.hjson for more description, This follows
             the same approach, but applies to the JTAG DTM regisers.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rv_dm_jtag_dtm_csr_rw"]
     }
     {
@@ -66,7 +66,7 @@
             See hw/dv/tools/dvsim/testplans/csr_testplan.hjson for more description, This follows
             the same approach, but applies to the JTAG DTM regisers.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rv_dm_jtag_dtm_csr_bit_bash"]
     }
     {
@@ -77,7 +77,7 @@
             See hw/dv/tools/dvsim/testplans/csr_testplan.hjson for more description, This follows
             the same approach, but applies to the JTAG DTM regisers.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rv_dm_jtag_dtm_csr_aliasing"]
     }
     {
@@ -94,7 +94,7 @@
             Also, the dmcontrol[dmactive] field is set to 1 at the start, to ensure CSR accesses to
             all other registers go through.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rv_dm_jtag_dmi_csr_hw_reset"]
     }
     {
@@ -105,7 +105,7 @@
             See hw/dv/tools/dvsim/testplans/csr_testplan.hjson for more description, This follows
             the same approach, but applies to the JTAG DMI regisers.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rv_dm_jtag_dmi_csr_rw"]
     }
     {
@@ -116,7 +116,7 @@
             See hw/dv/tools/dvsim/testplans/csr_testplan.hjson for more description, This follows
             the same approach, but applies to the JTAG DMI regisers.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rv_dm_jtag_dmi_csr_bit_bash"]
     }
     {
@@ -127,7 +127,7 @@
             See hw/dv/tools/dvsim/testplans/csr_testplan.hjson for more description, This follows
             the same approach, but applies to the JTAG DMI regisers.
             '''
-      milestone: V1
+      stage: V1
       tests: ["rv_dm_jtag_dmi_csr_aliasing"]
     }
     {
@@ -139,7 +139,7 @@
             - Read the IDCODE register in JTAG DTM register space, via JTAG.
             - Verify it reads back what was set.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rv_dm_smoke"]
     }
     {
@@ -151,7 +151,7 @@
               dtmcs[dmihardreset] bit.
             - Read the target DMI register to verify the write did not succeed.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -165,7 +165,7 @@
             - Issue random legal DMI accesses back to back and ensure that all of them complete
               successfully, without dmistat reflecting an error.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -181,7 +181,7 @@
               successfully by doing a read-check.
             - TBO - unclear how to generate other types of failed DMI transactions.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -193,7 +193,7 @@
             - Perform random writes to DMI registers while dmcontrol[dmactive] is 0 (exclude it).
             - Read all DMI registers back and verify they reflect POR values.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -216,7 +216,7 @@
               no alerts occur.
             - Hav.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rv_dm_sba_tl_access"]
     }
     {
@@ -235,7 +235,7 @@
             - pulp-platform/riscv-dbg#86: bad address (sberror = 2) is not defined or implemented.
             - 'Other' error cases (sberror = 7) is not defined.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rv_dm_bad_sba_tl_access"]
     }
     {
@@ -254,7 +254,7 @@
               the sbdata0 a randomized number of times - each read should trigger a new SBA TL read
               access.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rv_dm_autoincr_sba_tl_access"]
     }
     {
@@ -273,7 +273,7 @@
             - Set lc_hw_debug_en to true and again, read the DMI CSR - it should reflect the
               originally written value.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -291,7 +291,7 @@
             - Reapeat, a random number of times.
             - Verify via assertion checks, no transactions were seen on the SBA TL interface.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -309,7 +309,7 @@
             - Set lc_hw_debug_en to true and again, read the debug mem CSR - it should reflect the
               originally written value.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -325,7 +325,7 @@
               register in the debub memory.
             - Ensure that the polling in the loop above completes.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -347,7 +347,7 @@
             - Read the previously written registers back and verify that they reflect the previously
               written value, proving that ndmreset assertion had no effect on them.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -361,7 +361,7 @@
             - Periodically issue reads to dmstatus register to verify allunavail matches the
               `unavailable` input value
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -371,7 +371,7 @@
 
             - TBD.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -381,7 +381,7 @@
 
             - TBD
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -391,7 +391,7 @@
 
             - TBD
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -403,7 +403,7 @@
               Run the rest sequentially.
             - Randomly inject a full device reset intermittently.
             '''
-      milestone: V2
+      stage: V2
       tests: ["rv_dm_stress_all"]
     }
   ]

--- a/hw/ip/rv_timer/data/rv_timer_sec_cm_testplan.hjson
+++ b/hw/ip/rv_timer/data/rv_timer_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/rv_timer/data/rv_timer_testplan.hjson
+++ b/hw/ip/rv_timer/data/rv_timer_testplan.hjson
@@ -17,7 +17,7 @@
             - Program one to CTRL.active* (activate timer)
             - Wait for number of cycles to have mTime>= mTimeCmp
             - Check Interrupt state register and Interrupt signal (scoreboard logic)'''
-      milestone: V1
+      stage: V1
       tests: ["rv_timer_random"]
     }
     {
@@ -25,7 +25,7 @@
       desc: '''This test is to exercise on the fly reset(timer is active)
             - Assert reset randomly in the middle of random test steps
             - Scoreboard check for all register go back to reset value'''
-      milestone: V2
+      stage: V2
       tests: ["rv_timer_random_reset"]
     }
     {
@@ -35,7 +35,7 @@
             - Program 1 in interrupt enable and 0 in control register and random value for
               rest of the registers
             - Scoreboard check for no activity and no interrupt whatever is setting'''
-      milestone: V2
+      stage: V2
       tests: ["rv_timer_disabled"]
     }
     {
@@ -45,7 +45,7 @@
             - Program random values in interrrupt enable, prescaler, step, mtime and mtime cmp
             - After some clocks update timer config values
             - Check for interrupt as per new config set'''
-      milestone: V2
+      stage: V2
       tests: ["rv_timer_cfg_update_on_fly"]
     }
     {
@@ -56,7 +56,7 @@
             - Program random values in interrrupt enable, prescaler, step, mtime and mtime cmp
             - Update timer config values just before timer is about to expire
             - Check for no interrupt set'''
-      milestone: V2
+      stage: V2
       tests: ["rv_timer_cfg_update_on_fly"]
     }
     {
@@ -64,7 +64,7 @@
       desc: '''Do combinations of multiple of above scenarios to get multiple interrupts
             asserted at the same time. Scoreboard should be robust enough to deal with all
             scenarios.'''
-      milestone: V2
+      stage: V2
       tests: ["rv_timer_stress_all"]
     }
   ]

--- a/hw/ip/spi_device/data/spi_device_sec_cm_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -19,7 +19,7 @@
             - Read a word data from RX memory and update rptr
             - Compare the data and check no pending data in SRAM FIFO
             - Repeat above steps'''
-      milestone: V1
+      stage: V1
       tests: ["spi_device_smoke"]
     }
     {
@@ -29,7 +29,7 @@
             - Write random data to TX memory unless fifo is full
             - Send SPI transfer unless TX is empty or RX is full
             - Read RX memory unless RX is empty'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_txrx"]
     }
     {
@@ -38,7 +38,7 @@
             Increase the chance to have fifo full by following
             - Reduce delay to write TX memory
             - Increase delay to read RX memory'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_fifo_full"]
     }
     {
@@ -50,7 +50,7 @@
             - When RX is overflow, data will be lost and if SW update rptr, received data may be
               mis-aligned
             - Ensure underflow/overflow is triggered correctly'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_fifo_underflow_overflow"]
     }
     {
@@ -58,7 +58,7 @@
       desc: '''
             Drive dummy sck without csb or drive dummy csb without sck, and test no impact on the
             design'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_dummy_item_extra_dly"]
     }
     {
@@ -67,7 +67,7 @@
             Add extra delay between spi clock edge or extra delay between 2 words data
             This is to test host pause transfer for a while without turning off csb and then stream
             in data again'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_dummy_item_extra_dly"]
     }
     {
@@ -82,7 +82,7 @@
             - Fill TX SRAM FIFO with some other data and enable SPI transfer
             - Check SPI device sends and receives the correct data
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_tx_async_fifo_reset"]
     }
     {
@@ -99,7 +99,7 @@
             - Fill TX SRAM FIFO with some other data and start another SPI transfers
             - Check SPI device sends and receives the correct data
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_rx_async_fifo_reset"]
     }
     {
@@ -110,7 +110,7 @@
             - rx full
             - rx error
             - overflow/underflow'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_intr"]
     }
     {
@@ -121,13 +121,13 @@
             - Poll until abort_done in status register
             - TBD additional checking
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_abort"]
     }
     {
       name: byte_transfer_on_spi
       desc: '''send spi transfer on byte granularity, and make sure the timer never expires'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_byte_transfer"]
     }
     {
@@ -137,7 +137,7 @@
             - Only check data in sequence level when timer expires. Monitor and scoreboard don't
               model the timer feature
             - Note: Timeout only for RX'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_rx_timeout"]
     }
     {
@@ -146,19 +146,19 @@
             Send spi transfer on bit granularity
             - If TX drives < 7 bits, this byte will be sent in next CSB.
             - If TX drives 7 bits and set CSB to high, this byte won't be sent in next CSB'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_bit_transfer"]
     }
     {
       name: extreme_fifo_setting
       desc: '''Set fifo size to 4 bytes(minimum), 2k-4bytes(maximum) and others'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_extreme_fifo_size"]
     }
     {
       name: perf
       desc: '''Run spi_device_fifi_full_vseq with very small delays'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_perf"]
     }
     {
@@ -176,7 +176,7 @@
             - Check the read FIFO.
             - When available, confirm that the TPM submodule sends START followed by the register value.
             - Compare this value with the expected value.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_tpm_read"]
     }
     {
@@ -191,7 +191,7 @@
             - Based on FIFO status, check SPI bus to confirm WAIT or START sent.
             - Check that the TPM submodule accepts write data without the WAIT state if the write FIFO is empty.
             - Otherwise, check WAIT until the write FIFO becomes available (empty).'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_tpm_write"]
     }
     {
@@ -200,7 +200,7 @@
             - Make transactions of varying locality to the tpm submodule.
             - Ensure that the data returned is correct for the given locality.
             - Randomise TPM_CFG.invalid_locality and confirm response.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_tpm_locality"]
     }
     {
@@ -214,7 +214,7 @@
             - Set filter bit back to 0.
             - Check opcode and address are passing through again.
             - Invalid opcode is also filtered'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_pass_cmd_filtering", "spi_device_flash_all"]
     }
     {
@@ -227,7 +227,7 @@
             - Check proper address translation is applied.
             - Disable address translation for given command.
             - Check address is now passing unchanged.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_pass_addr_payload_swap", "spi_device_flash_all"]
     }
     {
@@ -239,7 +239,7 @@
             - Check proper payload translation is applied.
             - Disable payload translation for given command.
             - Check payload is now passing unchanged.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_pass_addr_payload_swap", "spi_device_flash_all"]
     }
     {
@@ -252,7 +252,7 @@
             - Check proper command propagation.
             - Disable some cmd info slots.
             - Check no propagation of disabled commands.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_flash_all"]
     }
     {
@@ -263,7 +263,7 @@
             - Check propagation of read status command.
             - Initiate response to the read status.
             - Check proper reception of response.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_intercept", "spi_device_flash_all"]
     }
     {
@@ -274,7 +274,7 @@
             - Check propagation of read jedec command.
             - Initiate response to the read jedec.
             - Check proper reception of response.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_intercept", "spi_device_flash_all"]
     }
     {
@@ -285,7 +285,7 @@
             - Check propagation of read sfdp command.
             - Initiate response to the read sfdp.
             - Check proper reception of response.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_intercept", "spi_device_flash_all"]
     }
     {
@@ -296,7 +296,7 @@
             - Check propagation of fast read command.
             - Initiate response to the fast read.
             - Check proper reception of response.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_intercept", "spi_device_flash_all"]
     }
     {
@@ -307,7 +307,7 @@
             - Set upload to 1 for some of 13 non fixed cmd info slots.
             - Host should poll busy field status to check if command is done.
             - Issue next command upload and poll busy status again.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_upload"]
     }
     {
@@ -317,7 +317,7 @@
             - Issue one of predefined read command targeting mailbox space.
             - Check response to read command.
             - Check if command is processed internally.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_mailbox"]
     }
     {
@@ -332,7 +332,7 @@
               address is outside the mailbox, data returns as follows
                 - returns high-z if the read command is filtered.
                 - returns from downstream port if read command is passed through.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_mailbox"]
     }
     {
@@ -340,7 +340,7 @@
       desc: '''
             - Similar to `mailbox_cross_outside_command`, except that start address is inside the
               mailbox.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_mailbox"]
     }
     {
@@ -354,7 +354,7 @@
             - Randomly issue read command that crosses read buffer boundary and switches back to
               index 0.
             - Check correctness of `last_read_addr`, `readbuf_watermark` and `readbuf_flip`.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_flash_mode", "spi_device_read_buffer_direct"]
     }
     {
@@ -368,7 +368,7 @@
             - Check proper read data.
             - Issue new read command that crosses read maibox boundary.
             - Check internal buffer index bit.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_mailbox", "spi_device_flash_all"]
     }
     {
@@ -379,7 +379,7 @@
             - Configure quad mode.
             - Issue supported command.
             - Check data on all four lines.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_flash_all"]
     }
     {
@@ -390,7 +390,7 @@
             - Configure dual mode.
             - Issue supported command.
             - Check data on both lines.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_flash_all"]
     }
     {
@@ -402,7 +402,7 @@
             - Randomize configuration of EN4B and EX4B register fields.
             - Issue supported command with required address.
             - Check proper address propagation.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_cfg_cmd"]
     }
     {
@@ -413,7 +413,7 @@
             - Issue WREN and WRDI commands along with read_status command and others.
             - Read flash status via TL interface.
             - Check WREN/WRDI sets/clears flash status correctly.'''
-      milestone: V2
+      stage: V2
       tests: ["spi_device_cfg_cmd"]
     }
     {
@@ -422,7 +422,7 @@
             - Enable TPM mode.
             - Configure passthrough or flash mode.
             - Issue TPM read/write interleaving with flash transactions.'''
-      milestone: V2
+      stage: V2
       tests: []
     }
   ]

--- a/hw/ip/spi_host/data/spi_host_sec_cm_testplan.hjson
+++ b/hw/ip/spi_host/data/spi_host_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["spi_host_tl_intg_err"]
     }
   ]

--- a/hw/ip/spi_host/data/spi_host_testplan.hjson
+++ b/hw/ip/spi_host/data/spi_host_testplan.hjson
@@ -24,7 +24,7 @@
             Checking:
               - Ensure transactions are transmitted/received correctly
             '''
-      milestone: V1
+      stage: V1
       tests: ["spi_host_smoke"]
     }
     {
@@ -40,7 +40,7 @@
             Checking:
               - Ensure transactions are transmitted/received correctly
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_performance"]
     }
     {
@@ -61,7 +61,7 @@
               - Ensure the matching between the bit-field values of ERROR_ENABLE
                 once the event interrupt pin is asserted
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_overflow_underflow", "spi_host_error_cmd", "spi_host_event"]
     }
     {
@@ -77,7 +77,7 @@
               - verify that merging of commands work correctly
               - verify that the DUT can handle different sck -> cs_n timings
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_speed"]
     }
     {
@@ -89,7 +89,7 @@
             Checking:
               - verify that all speeds are supported
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_speed"]
     }
     {
@@ -101,7 +101,7 @@
             Checking:
               - Check that the DUT operates correctly under different SPI clock speeds
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_speed"]
     }
     {
@@ -118,7 +118,7 @@
               - Ensure that transactions are dropped in both the scoreboard and spi_agent monitor
                 after the tx_fifo or spi_fsm is reset
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_sw_reset"]
     }
     {
@@ -131,7 +131,7 @@
             Checking:
               - Ensure Host to Device and Device to Host paths are switched to Passthrough ports
       '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_passthrough_mode"]
     }
     {
@@ -143,7 +143,7 @@
             Checking:
               - Check that the DUT operates correctly under different cs_n settings
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_speed"]
     }
     {
@@ -155,7 +155,7 @@
             Checking:
               - Check that the data can be read one full cycle after the data was asserted
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_speed"]
     }
     {
@@ -167,7 +167,7 @@
             Checking:
               - verify that the DUT support both half and full duplex in standard mode.
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_smoke"]
     }
     {
@@ -181,7 +181,7 @@
               - verify that the DUT ignores rx line when in tx only mode
               - verify that the DUT does not drain the tx fifo in rx only mode
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_smoke"]
     }
     {
@@ -198,7 +198,7 @@
               - Ensure transactions are transmitted/received correctly
               - Ensure reset is handled correctly
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_stress_all"]
     }
     {
@@ -214,7 +214,7 @@
               - Ensure Rxstall occurs and recovers
               - Ensure Txstall occurs and recovers
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_status_stall"]
     }
     {
@@ -227,7 +227,7 @@
               - Ensure transactions goes through even with a segment pause and idle wait
                 in the state IdleCsbActive
             '''
-      milestone: V2
+      stage: V2
       tests: ["spi_host_idlecsbactive"]
     }
     {
@@ -242,7 +242,7 @@
             - Verify the DUT against the WindBond bfm by making the spi agent passive
               to verify that we comply with the spi targeted for opentitan
             '''
-      milestone: V3
+      stage: V3
       tests: []
     }
   ]

--- a/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
@@ -27,7 +27,7 @@
               - Perform a number of random memory accesses to the SRAM, verify that all accesses
                 were executed correctly using the `mem_bkdr_util`
             '''
-      milestone: V1
+      stage: V1
       tests: ["{name}_smoke"]
     }
     {
@@ -45,7 +45,7 @@
               - Verify that all memory access succeed even if the scrambling key changes at arbitrary
                 intervals
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}_multiple_keys"]
     }
     {
@@ -55,7 +55,7 @@
             memory accesses at each random address in order to create read/write conflicts and
             stress the encryption pipeline.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}_stress_pipeline"]
     }
     {
@@ -76,7 +76,7 @@
 
             This process will be repeated for a number of new key seeds.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}_bijection"]
     }
     {
@@ -89,7 +89,7 @@
             TODO: Behavior might change in future to throw an error instead of ignore,
                   should be reflected in TB.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}_access_during_key_req"]
     }
     {
@@ -104,7 +104,7 @@
             We then issue a reset to the SRAM to get it out of the terminal state, and issue a
             couple of memory accesses just to make sure everything is still in working order.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}_lc_escalation"]
     }
     {
@@ -122,7 +122,7 @@
             error out, however `DataType` transactions should be successful when the SRAM is
             configured to be executable.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}_executable"]
     }
     {
@@ -133,7 +133,7 @@
 
             Reuse the `smoke` and `stress_pipeline` by setting `partial_access_pct` = 90%
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}_partial_access", "{name}_partial_access_b2b"]
     }
     {
@@ -145,7 +145,7 @@
             finish N SRAM read/write accesses.
             With partial write, it needs 2 extra cycles per partial write.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}_max_throughput", "{name}_throughput_w_partial_write"]
     }
     {
@@ -163,7 +163,7 @@
             at the beginning of each iteration. So when regwen is cleared, the related CSRs will be
             locked.
             '''
-      milestone: V2
+      stage: V2
       tests: ["{name}_regwen"]
     }
     {
@@ -172,7 +172,7 @@
             - Combine above sequences in one test to run sequentially, except csr sequence and
               sequences that require zero_delays or invoke reset (such as lc_escalation).
             - Randomly add reset between each sequence'''
-      milestone: V2
+      stage: V2
       tests: ["{name}_stress_all"]
     }
   ]

--- a/hw/ip/sram_ctrl/data/sram_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_tl_intg_err"]
     }
     {
@@ -37,13 +37,13 @@
              - When `ctrl_regwen` is 1, writting to `ctrl` can take effect.
              - When `ctrl_regwen` is 0, writting to `ctrl` has no effect.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_regwen"]
     }
     {
       name: sec_cm_exec_config_regwen
       desc: "Verify the countermeasure(s) EXEC.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_csr_rw"]
     }
     {
@@ -52,7 +52,7 @@
 
             Refer to the testpoint `executable` for the detail scenario.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_executable"]
     }
     {
@@ -62,7 +62,7 @@
             Refer to the testpoint `executable` for the detail scenario.
             `cip_mubi_cov_if` is bound to this port.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_executable"]
     }
     {
@@ -72,7 +72,7 @@
             Refer to the testpoint `executable` for the detail scenario.
             `cip_mubi_cov_if` is bound to this port.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_executable"]
     }
     {
@@ -82,13 +82,13 @@
             Refer to the testpoint `lc_escalation` for the detail scenario.
             `cip_lc_tx_cov_if` is bound to this port.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_lc_escalation"]
     }
     {
       name: sec_cm_mem_integrity
       desc: "Verify the countermeasure(s) MEM.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_passthru_mem_tl_intg_err"]
     }
     {
@@ -97,7 +97,7 @@
 
             This is verified in all non-CSR tests.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_smoke"]
     }
     {
@@ -106,7 +106,7 @@
 
             This is verified in all non-CSR tests.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_smoke"]
     }
     {
@@ -115,13 +115,13 @@
 
             Refer to the testpoint `executable` for the detail scenario.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_executable"]
     }
     {
       name: sec_cm_key_global_esc
       desc: "Verify the countermeasure(s) KEY.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_lc_escalation"]
     }
     {
@@ -133,7 +133,7 @@
             - Check internal key/nonce are reset to the default values.
             - Check SRAM access is blocked after a fault injection.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_sec_cm"]
     }
     {
@@ -144,7 +144,7 @@
             `sec_cm_key_local_esc`, also have following checks:
             - Check alert and `status.init_error` is set.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_sec_cm"]
     }
     {
@@ -155,14 +155,14 @@
             However, from defined CSRs and memory returned data, there is no way to read
             scramble key by SW.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_smoke"]
     }
     {
       name: sec_cm_tlul_fifo_ctr_redun
       desc: '''Verify the countermeasure(s) TLUL_FIFO.CTR.REDUN.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["{name}_sec_cm"]
     }
 

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl_testplan.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl_testplan.hjson
@@ -18,7 +18,7 @@
             * Write a random data to the input keys.
             * Read the data at the output pins and compare it with the input data.
             '''
-      milestone: V1
+      stage: V1
       tests: ["sysrst_ctrl_smoke"]
     }
 
@@ -33,7 +33,7 @@
             * Configure KEY_INVERT_CTL register to invert the output.
             * Check if the output is inverted form of input pins.
             '''
-      milestone: V1
+      stage: V1
       tests: ["sysrst_ctrl_in_out_inverted"]
     }
 
@@ -48,10 +48,10 @@
             * Set the pulse width via EC_RST_CTL register only to raise ec_rst action.
             * Read the COMBO_INTR_STATUS register to check if the interrupt is raised and
               clear the interrupt.
-            * NOTE: This is a directed test with no random values for V1 milestone,
+            * NOTE: This is a directed test with no random values for V1 stage,
               further this test will be randomized.
             '''
-      milestone: V1
+      stage: V1
       tests: ["sysrst_ctrl_combo_detect_ec_rst"]
     }
 
@@ -67,7 +67,7 @@
             * Read the COMBO_INTR_STATUS register to check if the interrupt is raised and clear the
               interrupt.
             '''
-      milestone: V2
+      stage: V2
       tests: ["sysrst_ctrl_combo_detect"]
     }
 
@@ -82,7 +82,7 @@
             * Check whether the input keys stays low for the selected debounce time.
             * Read the AUTO_BLOCK_OUT_CTL register to check if the output key is overridden.
             '''
-      milestone: V2
+      stage: V2
       tests: ["sysrst_ctrl_auto_blk_key_output"]
     }
 
@@ -97,7 +97,7 @@
             * Read the KEY_INTR_STATUS register to check if the interrupt caused and
               clear the interrupt.
             '''
-      milestone: V2
+      stage: V2
       tests: ["sysrst_ctrl_edge_detect"]
     }
 
@@ -110,7 +110,7 @@
             * Allow the output signals to override the value via PIN_ALLOWED_CTL register.
             * Set the override value to the output signal via PIN_OUT_VALUE register.
             '''
-      milestone: V2
+      stage: V2
       tests: ["sysrst_ctrl_override_test"]
     }
 
@@ -123,7 +123,7 @@
               values.
             * Read the PIN_IN_VALUE register and check if the read value is same as input value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["sysrst_ctrl_pin_access_test"]
     }
 
@@ -137,7 +137,7 @@
             * Make sure ec_rst_out_l is asserted even after opentitan reset is released.
             * Set PIN_OUT_CTL.EC_RST_L to 0 to release the ec_rst_out_l reset.
             '''
-      milestone: V2
+      stage: V2
       tests: ["sysrst_ctrl_ec_pwr_on_rst"]
     }
 
@@ -152,7 +152,7 @@
             * Check flash_wp_l_i does not have a bypass path to flash_wp_l_o.
             * Check if flash_wp_l_o is released only by the override function.
             '''
-      milestone: V2
+      stage: V2
       tests: ["sysrst_ctrl_flash_wr_prot_out"]
     }
 
@@ -170,7 +170,7 @@
             * Read the ULP_STATUS register and check if the ultra low power wakeup event is
               detected.
             '''
-      milestone: V2
+      stage: V2
       tests: ["sysrst_ctrl_ultra_low_pwr"]
     }
 
@@ -182,7 +182,7 @@
             * Combine above sequences in one test then randomly select for running.
             * All sequences should be finished and checked by the scoreboard.
       '''
-      milestone: V2
+      stage: V2
       tests: ["sysrst_ctrl_stress_all"]
     }
   ]

--- a/hw/ip/tlul/data/tlul_testplan.hjson
+++ b/hw/ip/tlul/data/tlul_testplan.hjson
@@ -9,13 +9,13 @@
     {
       name: xbar_smoke
       desc: '''Sequentially test each host to access any device'''
-      milestone: V1
+      stage: V1
       tests: ["xbar_{name}_smoke"]
     }
     {
       name: xbar_base_random_sequence
       desc: '''Enable all hosts to randomly send transactions to any device'''
-      milestone: V2
+      stage: V2
       tests: ["xbar_{name}_random"]
     }
     {
@@ -24,7 +24,7 @@
             - Zero delay for sending a/d_valid and a/d_ready
             - Large delay from 0 ~ 1000 cycles
             - Small delay (0-10 cycles) for a_channel, large delay (0-1000 cycles) for d_channel'''
-      milestone: V2
+      stage: V2
       tests: ["xbar_{name}_smoke_zero_delays", "xbar_{name}_smoke_large_delays", "xbar_{name}_smoke_slow_rsp",
               "xbar_{name}_random_zero_delays", "xbar_{name}_random_large_delays", "xbar_{name}_random_slow_rsp"]
     }
@@ -34,7 +34,7 @@
             - Host randomly drives transactions with mapped and unmapped address
             - Ensure DUT returns d_error=1 if address is unmapped and transaction isn't passed down
               to any device'''
-      milestone: V2
+      stage: V2
       tests: ["xbar_{name}_unmapped_addr", "xbar_{name}_error_and_unmapped_addr"]
     }
     {
@@ -42,7 +42,7 @@
       desc: '''
             - Drive any random value on size, mask, opcode in both channels
             - Ensure everything just pass through host to device or device to host'''
-      milestone: V2
+      stage: V2
       tests: ["xbar_{name}_error_random", "xbar_{name}_error_and_unmapped_addr"]
     }
     {
@@ -51,13 +51,13 @@
             - Randomly pick a device, make all hosts to access this device
             - If the device isn't accessible for the host, let the host randomly access the other
               devices'''
-      milestone: V2
+      stage: V2
       tests: ["xbar_{name}_access_same_device", "xbar_{name}_access_same_device_slow_rsp"]
     }
     {
       name: xbar_all_hosts_use_same_source_id
       desc: '''Test all hosts use same ID at the same same'''
-      milestone: V2
+      stage: V2
       tests: ["xbar_{name}_same_source"]
     }
     {
@@ -65,7 +65,7 @@
       desc: '''
             - Combine all sequences and run in parallel
             - Add random reset between each iteration'''
-      milestone: V2
+      stage: V2
       tests: ["xbar_{name}_stress_all", "xbar_{name}_stress_all_with_error"]
     }
     {
@@ -74,7 +74,7 @@
             - Inject reset while stress_all is running, after reset is completed, kill the
               stress seq and then start a new stress seq
             - Run a few iteration to ensure reset doesn't break the design'''
-      milestone: V2
+      stage: V2
       tests: ["xbar_{name}_stress_all_with_rand_reset", "xbar_{name}_stress_all_with_reset_error"]
     }
   ]

--- a/hw/ip/uart/data/uart_sec_cm_testplan.hjson
+++ b/hw/ip/uart/data/uart_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/uart/data/uart_testplan.hjson
+++ b/hw/ip/uart/data/uart_testplan.hjson
@@ -18,7 +18,7 @@
               -  program one Tx item in register and wait for it to complete at uart interface,
                  before send another one
               - sequencally send one Rx byte, then immediately read from register and check it'''
-      milestone: V1
+      stage: V1
       tests: ["uart_smoke"]
     }
     {
@@ -29,13 +29,13 @@
               - TX: keep programming csr wdata with random delay when fifo isn't full
               - RX: 2 processes. One is to send item through uart interface when fifo isn't full
                 and the other is to read csr rdata when fifo isn't empty'''
-      milestone: V2
+      stage: V2
       tests: ["uart_tx_rx"]
     }
     {
       name: parity
       desc: '''Send / receive bytes with parity and odd parity enabled randomly.'''
-      milestone: V2
+      stage: V2
       tests: ["uart_smoke", "uart_tx_rx"]
     }
     {
@@ -44,7 +44,7 @@
             - Enable parity and randomly set even/odd parity
             - Inject parity error randomly on data sent from rx and ensure the interrupt is
               raised'''
-      milestone: V2
+      stage: V2
       tests: ["uart_rx_parity_err", "uart_intr"]
     }
     {
@@ -57,13 +57,13 @@
               is asserted
             - Ensure interrupt stays asserted until cleared as well as fifo level dropped.
               The tx/rx watermark interrupt is sticky'''
-      milestone: V2
+      stage: V2
       tests: ["uart_tx_rx", "uart_intr"]
     }
     {
       name: fifo_full
       desc: '''Send over 32 bytes of data but stop when fifo is full'''
-      milestone: V2
+      stage: V2
       tests: ["uart_fifo_full"]
     }
     {
@@ -73,7 +73,7 @@
             - Ensure excess data bytes are dropped and check overflow interrupt
             - This uart_fifo_overflow_vseq is extent from uart_fifo_full_vseq and override the
               constraint to be able to send data over fifo size'''
-      milestone: V2
+      stage: V2
       tests: ["uart_fifo_overflow"]
     }
     {
@@ -83,7 +83,7 @@
               the fifo and ensure that the remaining data bytes do not show up
             - this sequence is extent from uart_fifo_overflow_vseq, so it can also reset when fifo
               is at any level, including full or overflow'''
-      milestone: V2
+      stage: V2
       tests: ["uart_fifo_reset"]
     }
     {
@@ -91,7 +91,7 @@
       desc: '''
             - Inject frame error in parity and non-parity cases by not setting stop bit = 1
             - Ensure the interrupt gets asserted'''
-      milestone: V2
+      stage: V2
       tests: ["uart_intr"]
     }
     {
@@ -101,7 +101,7 @@
             - create a frame error scenario and send random number of 0 bytes
             - If that random number exceeds the programmed break characters
             - Ensure that the break_err interrupt is asserted'''
-      milestone: V2
+      stage: V2
       tests: ["uart_intr"]
     }
     {
@@ -114,13 +114,13 @@
             - Wait until it's about to timeout, then use either read csr rdata or send RX item
               through uart interface to reset timeout timer in order to ensure timeout never
               fires'''
-      milestone: V2
+      stage: V2
       tests: ["uart_intr"]
     }
     {
       name: perf
       desc: '''Run fifo_full_vseq with very small delays'''
-      milestone: V2
+      stage: V2
       tests: ["uart_perf"]
     }
     {
@@ -129,7 +129,7 @@
             - Enable system looback, then drive uart TX and data will be loopbacked through RX
             - After loopback is done, uart.RDATA will be equal to the data programmed to
               uart.WDATA'''
-      milestone: V2
+      stage: V2
       tests: ["uart_loopback"]
     }
     {
@@ -138,7 +138,7 @@
              - Enable line loopback and drive uart_rx with random data and random delay
              - Check uart_tx has same value as uart_rx. There is not synchronizer register between
                uart_rx and uart_tx during line loopback'''
-      milestone: V2
+      stage: V2
       tests: ["uart_loopback"]
     }
     {
@@ -150,7 +150,7 @@
               3 clocks
             - Ensure the noise will be filterred out and it doesn't affect next normal
               transaction'''
-      milestone: V2
+      stage: V2
       tests: ["uart_noise_filter"]
     }
     {
@@ -159,14 +159,14 @@
             - Start bit should last for at least half baud clock, otherwise, it will be dropped
             - It's always enabled. Drive start bit for less than half cycle.
             - Ensure the start bit will be dropped'''
-      milestone: V2
+      stage: V2
       tests: ["uart_rx_start_bit_filter"]
     }
     {
       name: tx_overide
       desc: '''Enable override control and use register programming to drive uart output
             directly.'''
-      milestone: V2
+      stage: V2
       tests: ["uart_tx_ovrd"]
     }
     {
@@ -175,7 +175,7 @@
             - Use 16x baud clock to sample uart rx
             - Drive uart rx with 16 bits value, using 16x baud clock
             - Read RX oversampled value and ensure it's same as driven value'''
-      milestone: V2
+      stage: V2
       tests: ["uart_rx_oversample"]
     }
     {
@@ -184,7 +184,7 @@
             - Reduce delay to fill TX fifo and read RX fifo to ensure back2back transfers
             - Use long back2back transfer to ensure clock difference won't be accumulated across transactions
             - Uart monitor checks the clock offset between sender and receiver is never over 1/4 of the period'''
-      milestone: V2
+      stage: V2
       tests: ["uart_long_xfer_wo_dly"]
     }
     {
@@ -193,13 +193,13 @@
             - Combine above sequences in one test to run sequentially, except csr sequence and
               uart_rx_oversample_vseq (requires zero_delays)
             - Randomly add reset between each sequence'''
-      milestone: V2
+      stage: V2
       tests: ["uart_stress_all"]
     }
     {
       name: stress_all_with_reset
       desc: '''Have random reset in parallel with stress_all and tl_errors sequences'''
-      milestone: V2
+      stage: V2
       tests: ["uart_stress_all_with_rand_reset"]
     }
   ]

--- a/hw/ip/usbdev/data/usbdev_sec_cm_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -22,7 +22,7 @@
               describe second bullet
 
             Start a new paragraph.'''
-      milestone: V1
+      stage: V1
       tests: ["usbdev_smoke"]
     }
   ]

--- a/hw/ip_templates/alert_handler/data/alert_handler_sec_cm_testplan.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler_sec_cm_testplan.hjson
@@ -26,73 +26,73 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_tl_intg_err"]
     }
     {
       name: sec_cm_config_shadow
       desc: "Verify the countermeasure(s) CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_shadow_reg_errors"]
     }
     {
       name: sec_cm_ping_timer_config_regwen
       desc: "Verify the countermeasure(s) PING_TIMER.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_smoke"]
     }
     {
       name: sec_cm_alert_config_regwen
       desc: "Verify the countermeasure(s) ALERT.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_smoke"]
     }
     {
       name: sec_cm_alert_loc_config_regwen
       desc: "Verify the countermeasure(s) ALERT_LOC.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_smoke"]
     }
     {
       name: sec_cm_class_config_regwen
       desc: "Verify the countermeasure(s) CLASS.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_smoke"]
     }
     {
       name: sec_cm_alert_intersig_diff
       desc: "Verify the countermeasure(s) ALERT.INTERSIG.DIFF."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sig_int_fail"]
     }
     {
       name: sec_cm_lpg_intersig_mubi
       desc: "Verify the countermeasure(s) LPG.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_lpg"]
     }
     {
       name: sec_cm_esc_intersig_diff
       desc: "Verify the countermeasure(s) ESC.INTERSIG.DIFF."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sig_int_fail"]
     }
     {
       name: sec_cm_alert_rx_intersig_bkgn_chk
       desc: "Verify the countermeasure(s) ALERT_RX.INTERSIG.BKGN_CHK."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_entropy"]
     }
     {
       name: sec_cm_esc_tx_intersig_bkgn_chk
       desc: "Verify the countermeasure(s) ESC_TX.INTERSIG.BKGN_CHK."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_entropy"]
     }
     {
       name: sec_cm_esc_rx_intersig_bkgn_chk
       desc: "Verify the countermeasure(s) ESC_RX.INTERSIG.BKGN_CHK."
-      milestone: V2S
+      stage: V2S
       // This test entry is only valid with prim_esc_receiver module, which is not included in the
       // alert_handler testbench. Thus this test point will be checked in `prim_esc` testbench and
       // top-level testbench.
@@ -101,55 +101,55 @@
     {
       name: sec_cm_esc_timer_fsm_sparse
       desc: "Verify the countermeasure(s) ESC_TIMER.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_ping_timer_fsm_sparse
       desc: "Verify the countermeasure(s) PING_TIMER.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_esc_timer_fsm_local_esc
       desc: "Verify the countermeasure(s) ESC_TIMER.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_ping_timer_fsm_local_esc
       desc: "Verify the countermeasure(s) PING_TIMER.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_esc_timer_fsm_global_esc
       desc: "Verify the countermeasure(s) ESC_TIMER.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_accu_ctr_redun
       desc: "Verify the countermeasure(s) ACCU.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_esc_timer_ctr_redun
       desc: "Verify the countermeasure(s) ESC_TIMER.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_ping_timer_ctr_redun
       desc: "Verify the countermeasure(s) PING_TIMER.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_ping_timer_lfsr_redun
       desc: "Verify the countermeasure(s) PING_TIMER.LFSR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
   ]

--- a/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
@@ -24,7 +24,7 @@
               output values
             - Support both synchronous and asynchronous settings
             '''
-      milestone: V1
+      stage: V1
       tests: ["alert_handler_smoke"]
     }
     {
@@ -33,7 +33,7 @@
             Based on the smoke test, this test will focus on testing the escalation accumulation
             feature. So all the escalations in the test will be triggered by alert accumulation.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_esc_alert_accum"]
     }
     {
@@ -42,7 +42,7 @@
            Based on the smoke test, this test will focus on testing the escalation timeout
            feature. So all the escalations in the test will be triggered by interrupt timeout.
            '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_esc_intr_timeout"]
     }
     {
@@ -51,7 +51,7 @@
             Based on the smoke test, this test enables ping testing, and check if the ping feature
             correctly pings all devices within certain period of time.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_entropy"]
     }
     {
@@ -61,7 +61,7 @@
             escalator tx/rx pairs. Then check if integrity failure alert is triggered and
             escalated.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_sig_int_fail"]
     }
     {
@@ -70,19 +70,19 @@
             This test will randomly inject clock skew within the differential pairs. Then check no
             alert is raised.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_smoke"]
     }
     {
       name: random_alerts
       desc: "Input random alerts and randomly write phase cycles."
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_random_alerts"]
     }
     {
       name: random_classes
       desc: "Based on random_alerts test, this test will also randomly enable interrupt classes."
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_random_classes"]
     }
     {
@@ -96,7 +96,7 @@
             - Verify alert and local alert causes.
             - Verify escalation states and counts.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_ping_timeout"]
     }
     {
@@ -115,7 +115,7 @@
             - Expect no ping timeout error because the alert_receivers are disabled via low-power
               group, or because alert_handler's clk input is paused due to sleep mode.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_lpg", "alert_handler_lpg_stub_clk"]
     }
     {
@@ -125,7 +125,7 @@
             - CSR sequences: scoreboard disabled
             - Ping_corner_cases sequence: included reset in the sequence
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_stress_all"]
     }
   ]

--- a/hw/ip_templates/rv_plic/data/rv_plic_fpv_testplan.hjson.tpl
+++ b/hw/ip_templates/rv_plic/data/rv_plic_fpv_testplan.hjson.tpl
@@ -10,7 +10,7 @@
       desc: '''If interrupt pending (`ip`) is triggered, and the level indicator is set to
             level triggered (`le=0`), then in the prvious clock cycle, the interrupt source
             (`intr_src_i) should be set to 1.'''
-      milestone: V2
+      stage: V2
       tests: ["${module_instance_name}_assert"]
     }
     {
@@ -18,40 +18,40 @@
       desc: '''If interrupt pending (`ip`) is triggered, and the level indicator is set to
             edge triggered (`le=1`), then in the prvious clock cycle, the interrupt source
             (`intr_src_i) should be at the rising edge.'''
-      milestone: V2
+      stage: V2
       tests: ["${module_instance_name}_assert"]
     }
     {
       name: LevelTriggeredIpWithClaim_A
       desc: '''If `intr_src_i` is set to 1, level indicator is set to level triggered, and claim
             signal is not set, then at the next clock cycle `ip` will be triggered.'''
-      milestone: V2
+      stage: V2
       tests: ["${module_instance_name}_assert"]
     }
     {
       name: EdgeTriggeredIpWithClaim_A
       desc: '''If `intr_src_i` is at the rising edge, level indicator is set to edge triggered, and claim
             signal is not set, then at the next clock cycle `ip` will be triggered.'''
-      milestone: V2
+      stage: V2
       tests: ["${module_instance_name}_assert"]
     }
     {
       name: IpStableAfterTriggered_A
       desc: "Once `ip` is set, it stays stable until is being claimed."
-      milestone: V2
+      stage: V2
       tests: ["${module_instance_name}_assert"]
     }
     {
       name: IpClearAfterClaim_A
       desc: "Once `ip` is set and being claimed, its value is cleared to 0."
-      milestone: V2
+      stage: V2
       tests: ["${module_instance_name}_assert"]
     }
     {
       name: IpStableAfterClaimed_A
       desc: '''Once `ip` is cleared to 0, it stays stable until completed and being triggered
             again.'''
-      milestone: V2
+      stage: V2
       tests: ["${module_instance_name}_assert"]
     }
     {
@@ -60,7 +60,7 @@
             input has the highest priority among the rest of the inputs, and its priority is
             above the threshold. Then in the next clock clcye, the `irq_o` should be triggered,
             and the `irq_id_o` will reflect the input ID.'''
-      milestone: V2
+      stage: V2
       tests: ["${module_instance_name}_assert"]
     }
     {
@@ -68,7 +68,7 @@
       desc: '''If `irq_o` is set to 1, then in the previous clock cycle, the corresponding
             `ip` should be set, `ie` should be enabled, and the interrupt source should above the
             threshold and have the highest priority.'''
-      milestone: V2
+      stage: V2
       tests: ["${module_instance_name}_assert"]
 
     }
@@ -81,7 +81,7 @@
                - No interrupt triggered, `ip` is set and `ie` is enabled, interrupt source priority is the
                  largest among the rest of the interrupt, but the interrupt source
                  priority is smaller than the threshold'''
-      milestone: V2
+      stage: V2
       tests: ["${module_instance_name}_assert"]
     }
   ]

--- a/hw/ip_templates/rv_plic/data/rv_plic_sec_cm_testplan.hjson
+++ b/hw/ip_templates/rv_plic/data/rv_plic_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/top_earlgrey/data/chip_conn_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_conn_testplan.hjson
@@ -11,14 +11,14 @@
     {
       name: aon_timer_rst
       desc: '''Verify rstmgr's resets_o is connected to aon_timer's reset port.'''
-      milestone: V2
+      stage: V2
       tests: ["aon_timer_rst"]
       tags: ["conn"]
     }
     {
       name: aon_timer_rst_aon
       desc: '''Verify rstmgr's resets_o is connected to aon_timer's aon-reset port.'''
-      milestone: V2
+      stage: V2
       tests: ["aon_timer_rst_aon"]
       tags: ["conn"]
     }
@@ -33,7 +33,7 @@
             - spi_device
             - usbdev
             '''
-      milestone: V2
+      stage: V2
       tests: ["ast_dft_spi_device_ram_2p_cfg", "ast_dft_usbdev_ram_2p_cfg"]
       tags: ["conn"]
     }
@@ -51,7 +51,7 @@
             - sram_retention
             - rom
             '''
-      milestone: V2
+      stage: V2
       tests: ["ast_dft_otbn_imem_ram_1p_cfg",
               "ast_dft_otbn_dmem_ram_1p_cfg",
               "ast_dft_rv_core_ibex_tag0_ram_1p_cfg",
@@ -83,7 +83,7 @@
             - xbar_main
             - xbar_peri
             '''
-      milestone: V2
+      stage: V2
       tests: ["ast_scanmode_padring", "ast_scanmode_clkmgr", "ast_scanmode_flash_ctrl",
               "ast_scanmode_lc_ctrl", "ast_scanmode_otp_ctrl", "ast_scanmode_pinmux",
               "ast_scanmode_rstmgr", "ast_scanmode_rv_core_ibex", "ast_scanmode_rv_dm",
@@ -97,35 +97,35 @@
     {
       name: ast_sys_clk_clkmgr
       desc: '''Verify ast model's `clk_src_sys_o` is connected to clkmgr's main clock.'''
-      milestone: V2
+      stage: V2
       tests: ["ast_sys_clk_clkmgr"]
       tags: ["conn"]
     }
     {
       name: ast_io_clk_clkmgr
       desc: '''Verify ast model's `clk_src_io_o` is connected to clkmgr's io clock.'''
-      milestone: V2
+      stage: V2
       tests: ["ast_io_clk_clkmgr"]
       tags: ["conn"]
     }
     {
       name: ast_usb_clk_clkmgr
       desc: '''Verify ast model's `clk_src_usb_o` is connected to clkmgr's usb clock.'''
-      milestone: V2
+      stage: V2
       tests: ["ast_usb_clk_clkmgr"]
       tags: ["conn"]
     }
     {
       name: ast_aon_clk_clkmgr
       desc: '''Verify ast model's `clk_src_aon_o` is connected to clkmgr's aon clock.'''
-      milestone: V2
+      stage: V2
       tests: ["ast_aon_clk_clkmgr"]
       tags: ["conn"]
     }
     {
       name: clkmgr_jitter_ast
       desc: '''Verify clkmgr's jitter enable is connected to ast.'''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_jitter_ast"]
       tags: ["conn"]
     }
@@ -141,7 +141,7 @@
               - index 2 to kmac's `idle_o`
               - index 3 to otbn's `idle_o`
               '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_idle0", "clkmgr_idle1", "clkmgr_idle2", "clkmgr_idle3"]
       tags: ["conn"]
     }
@@ -161,7 +161,7 @@
             - sram_ctrl retention clk_otp_i
             - sysrst_ctrl clk_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_infra_clk_flash_ctrl_clk",
               "clkmgr_infra_clk_xbar_main_fixed_clk",
               "clkmgr_infra_clk_xbar_peri_peri_clk",
@@ -182,7 +182,7 @@
             - sram_ctrl main clk_i
             - xbar_main clk_main_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_infra_clk_flash_ctrl_clk",
               "clkmgr_infra_clk_rv_dm_clk",
               "clkmgr_infra_clk_rom_clk",
@@ -197,7 +197,7 @@
       desc: '''Verify clkmgr's `clk_aon_infra` is connected to the following block's clock input:
             - sysrst_ctrl clk_aon_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["infra_clk_sysrst_ctrl_aon_clk"]
       tags: ["conn"]
     }
@@ -206,7 +206,7 @@
       desc: '''Verify clkmgr's `clk_io_infra` is connected to the following block's clock input:
              - xbar_main's clk_spi_host0_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_infra_clk_xbar_main_spi_host0_clk"]
       tags: ["conn"]
     }
@@ -216,7 +216,7 @@
             input:
             - xbar_main clk_spi_host1_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_infra_clk_xbar_main_spi_host1_clk"]
       tags: ["conn"]
     }
@@ -241,7 +241,7 @@
             - uart3 clk_i
             - usbdev clk_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_peri_clk_adc_ctrl_aon_clk",
               "clkmgr_peri_clk_gpio_clk",
               "clkmgr_peri_clk_spi_device_clk",
@@ -263,7 +263,7 @@
             - spi_device's clk_scan_i
             - spi_host1 clk_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_peri_clk_spi_device_scan_clk",
               "clkmgr_peri_clk_spi_host1_clk"]
       tags: ["conn"]
@@ -273,14 +273,14 @@
       desc: '''Verify clkmgr's `clk_io_peri` is connected to the following block's clock input:
             - spi_host0's clk_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_peri_clk_spi_host0_clk"]
       tags: ["conn"]
     }
     {
       name: clkmgr_clk_usb_peri
       desc: '''Verify clkmgr's `clk_usb_peri` is connected to usbdev's usb clock.'''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_peri_clk_usbdev_usb_clk"]
       tags: ["conn"]
     }
@@ -290,7 +290,7 @@
             - adc_ctrl clk_aon_i
             - usbdev clk_aon_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_peri_clk_adc_ctrl_aon_clk",
               "clkmgr_peri_clk_usbdev_aon_clk"]
       tags: ["conn"]
@@ -310,7 +310,7 @@
             - rstmgr clk_i
             - rstmgr clk_io_div4_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_powerup_clk_clkmgr_clk",
               "clkmgr_powerup_clk_pinmux_clk",
               "clkmgr_powerup_clk_pwm_clk",
@@ -327,7 +327,7 @@
             - pwrmgr clk_slow_i
             - rstmgr clk_aon_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_powerup_clk_pinmux_aon_clk",
               "clkmgr_powerup_clk_pwm_core_clk",
               "clkmgr_powerup_clk_pwrmgr_slow_clk",
@@ -340,28 +340,28 @@
             input:
             - rstmgr's clock_main_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_powerup_clk_rstmgr_main_clk"]
       tags: ["conn"]
     }
     {
       name: clkmgr_clk_io_powerup
       desc: '''Verify clkmgr's `clk_io_powerup` is connected to rstmgr's io clock.'''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_powerup_clk_rstmgr_io_clk"]
       tags: ["conn"]
     }
     {
       name: clkmgr_clk_usb_powerup
       desc: '''Verify clkmgr's `clk_usb_powerup` is connected to rstmgr's usb clock.'''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_powerup_clk_rstmgr_usb_clk"]
       tags: ["conn"]
     }
     {
       name: clkmgr_clk_io_div2_powerup
       desc: '''Verify clkmgr's `clk_io_div2_powerup` is connected to rstmgr's io_div2 clock.'''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_powerup_clk_rstmgr_io2_clk"]
       tags: ["conn"]
     }
@@ -383,7 +383,7 @@
             - ast clk_alert_i
             - lc_ctrl clk_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_secure_clk_alert_handler_clk",
               "clkmgr_secure_clk_otp_ctrl_clk",
               "clkmgr_secure_clk_pwrmgr_clk",
@@ -411,7 +411,7 @@
             - otp_ctrl clk_edn_i
             - rv_plic clk_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_secure_clk_alert_handler_edn_clk",
               "clkmgr_secure_clk_ast_es_clk",
               "clkmgr_secure_clk_ast_rng_clk",
@@ -432,7 +432,7 @@
             - ast clk_adc_i
             - sensor_ctrl clk_aon_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_secure_clk_ast_adc_clk",
               "clkmgr_secure_clk_sensor_ctrl_aon_clk"]
       tags: ["conn"]
@@ -440,7 +440,7 @@
     {
       name: clkmgr_clk_usb_secure
       desc: '''Verify clkmgr's `clk_usb_secure` is connected to ast's usb clock.'''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_secure_clk_ast_usb_clk"]
       tags: ["conn"]
     }
@@ -455,14 +455,14 @@
             - aon_timer clk_i
             - rv_timer clk_i
             '''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_timers_clk_aon_timer_clk", "clkmgr_timers_clk_rv_timer_clk"]
       tags: ["conn"]
     }
     {
       name: clkmgr_clk_aon_timers
       desc: '''Verify clkmgr's `clk_aon_timers` is connected to aon_timer's aon clock.'''
-      milestone: V2
+      stage: V2
       tests: ["clkmgr_timers_clk_aon_timer_aon_clk"]
       tags: ["conn"]
     }
@@ -473,7 +473,7 @@
     {
       name: flash_ast_obs_ctrl
       desc: '''Verify ast's `obs_ctrl_o` is connected to flash_ctrl's `obs_ctrl_i`.'''
-      milestone: V2
+      stage: V2
       tests: ["flash_ast_obs_ctrl"]
       tags: ["conn"]
     }
@@ -484,7 +484,7 @@
     {
       name: flash_jtag
       desc: "Verify jtag interface is connected to flash_phy_req interface."
-      milestone: V2
+      stage: V2
       tests: ["pinmux_flash_ctrl_tck", "pinmux_flash_ctrl_tms", "pinmux_flash_ctrl_tdi",
               "pinmux_flash_ctrl_tdo", "pinmux_flash_ctrl_tdo_en"]
       tags: ["conn"]
@@ -492,7 +492,7 @@
     {
       name: lc_jtag_trst
       desc: "Verify jtag rst pin is connected to lc_ctrl interface."
-      milestone: V2
+      stage: V2
       tests: ["pinmux_lc_ctrl_jtag_req", "pinmux_lc_ctrl_jtag_rsp"]
       tags: ["conn"]
     }
@@ -503,14 +503,14 @@
     {
       name: lc_keymgr_en
       desc: "Verify LC_CTRL's lc_ctrl_lc_keymgr_en is connects correctly to keymgr."
-      milestone: V2
+      stage: V2
       tests: ["lc_keymgr_en_keymgr"]
       tags: ["conn"]
     }
     {
       name: lc_nvm_debug_en
       desc: "Verify lc_ctrl's lc_nvm_debug_en is connected correctly to flash_ctrl."
-      milestone: V2
+      stage: V2
       tests: ["lc_nvm_debug_en_flash_ctrl"]
       tags: ["conn"]
     }
@@ -527,7 +527,7 @@
             - kmac
             - otbn
             '''
-      milestone: V2
+      stage: V2
       tests: ["lc_escalate_en_otp",
               "lc_escalate_en_aon_timer",
               "lc_escalate_en_sram_main",
@@ -545,28 +545,28 @@
     {
       name: pwrmgr_rst_lc_req
       desc: '''Verify pwrmgr's `rst_lc_req` is connected to rstmgr's `rst_lc_req`.'''
-      milestone: V2
+      stage: V2
       tests: ["pwrmgr_rst_lc_req"]
       tags: ["conn"]
     }
     {
       name: pwrmgr_rst_sys_req
       desc: '''Verify pwrmgr's `rst_sys_req` is connected to rstmgr's `rst_sys_req`.'''
-      milestone: V2
+      stage: V2
       tests: ["pwrmgr_rst_sys_req"]
       tags: ["conn"]
     }
     {
       name: rstmgr_rst_lc_src_n
       desc: '''Verify rstmgr's `rst_lc_src_n` is connected to pwrmgr's `rst_lc_src_n`.'''
-      milestone: V2
+      stage: V2
       tests: ["rstmgr_rst_lc_src_n"]
       tags: ["conn"]
     }
     {
       name: rstmgr_rst_sys_src_n
       desc: '''Verify rstmgr's `rst_sys_src_n` is connected to rstmgr's `rst_sys_src_n`.'''
-      milestone: V2
+      stage: V2
       tests: ["rstmgr_rst_sys_src_n"]
       tags: ["conn"]
     }
@@ -577,7 +577,7 @@
     {
       name: otp_ctrl_external_voltage
       desc: "Verify the connectivity of the external voltage signal to OTP ctrl."
-      milestone: V2
+      stage: V2
       tests: []
       tags: ["conn"]
     }

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -32,7 +32,7 @@
             Verify each UART instance at the chip level independently. Verify there is no aliasing
             on all UART ports across the instances.
             '''
-      milestone: V1
+      stage: V1
       tests: ["chip_sw_uart_tx_rx"]
       tags: ["gls"]
     }
@@ -46,7 +46,7 @@
             Verify each UART instance at the chip level independently. Verify there is no aliasing
             on all UART ports across the instances.
             '''
-      milestone: V1
+      stage: V1
       tests: ["chip_sw_uart_tx_rx", "chip_sw_uart_tx_rx_idx1", "chip_sw_uart_tx_rx_idx2",
               "chip_sw_uart_tx_rx_idx3"]
     }
@@ -58,7 +58,7 @@
             rates - 9600bps, 115200bps, 230400bps, 128Kbps, 256Kbps, 1Mkbps, 1.5Mkbps.
 
             '''
-      milestone: V1
+      stage: V1
       tests: ["chip_sw_uart_rand_baudrate"]
     }
     {
@@ -71,7 +71,7 @@
             - Randomize `HI_SPEED_SEL`, so that uart core clock frequency can be either
               ext_clk_freq / 4 or ext_clk_freq / 2.
             '''
-      milestone: V1
+      stage: V1
       tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
     }
 
@@ -84,7 +84,7 @@
             pins. The testbench checks the value for correctness and verifies that there is no
             aliasing between the pins.
             '''
-      milestone: V1
+      stage: V1
       tests: ["chip_sw_gpio"]
     }
     {
@@ -94,7 +94,7 @@
             The SW test configures the GPIOs to be in input mode. The testbench walks a 1 through
             the pins. SW test ensures that the GPIO values read from the CSR is correct.
             '''
-      milestone: V1
+      stage: V1
       tests: ["chip_sw_gpio"]
     }
     {
@@ -105,7 +105,7 @@
             an interrupt. The testbench walks a 1 through the pins. SW test ensures that the
             interrupt corresponding to the right pin is seen.
             '''
-      milestone: V1
+      stage: V1
       tests: ["chip_sw_gpio"]
     }
 
@@ -127,7 +127,7 @@
             - TODO, consider to test this mode with a real use case. The actual use case of this
               mdoe is not clear right now.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_spi_device_tx_rx"]
     }
     {
@@ -140,7 +140,7 @@
               memory.
             - Ensure the image is executed correctly
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -159,7 +159,7 @@
               - Read Normal, Fast Read, Fast Dual, Fast Quad, Chip Erase, Program
 
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -173,7 +173,7 @@
             - Verify that only the payloads that are not filtered show up on the SPI host interface
               at chip IOs.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -187,7 +187,7 @@
             - Verify that the flash commands are received and interpreted correctly in the flash
               model
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -197,7 +197,7 @@
 
             TODO, add detail testplan once we have a conclusion on #5134
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -216,7 +216,7 @@
 
             Verify all SPI host instances in the chip.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -233,7 +233,7 @@
 
             Verify all instances of I2C in the chip.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -248,7 +248,7 @@
 
             Verify all instances of I2C in the chip.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -266,7 +266,7 @@
             - Check interrupts (connected, pkt_received, pkt_sent, av_empty, rx_full) are triggered
               correcly.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -281,7 +281,7 @@
             - Re-enable data transfer and ensure data correctness.
             - Observe valid reference pulse usb_ref_val/pulse_o.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -308,7 +308,7 @@
                   USB.
             - Re-enable data transfer and ensure data correctness.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -323,7 +323,7 @@
             - Stop sending any frame and check the `host_lost` interrupt. Ensure `use_ref_*` behave
               correctly.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -333,7 +333,7 @@
             - Drive random value on `usb_state_debug_i`.
             - Ensure the CSR `wake_debug` returns correctly value.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -342,7 +342,7 @@
 
             - TODO
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -354,7 +354,7 @@
             SW programs MIO INSEL and OUTSEL CSRs to connect and verify each muxed source. At the
             moment, GPIOs are the only mux inputs.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -368,7 +368,7 @@
             verifies the correctness of the reflected values once the chip goes into deep sleep.
             This is replicated for DIO pins as well.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -380,7 +380,7 @@
             level integration testing. Upon wake up, SW reads the wake cause CSR to verify
             correctness.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -399,7 +399,7 @@
             - Verify the pin value at the chip IOs is no longer holding the retention value once the
               chip is back in active power.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -416,7 +416,7 @@
             Verify top_earlgrey.dft_strap_test_o is always 0 in the states other than TEST_UNLOCKED*
             and RMA, regardless of the value on DFT SW straps.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
     }
 
@@ -425,7 +425,7 @@
       name: chip_sw_padctrl_attributes
       desc: '''Verify pad attribute settings for all MIO and DIO pads.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -440,7 +440,7 @@
             - Validate the reception of the done interrupt.
             - Verify both pattgen channels independently.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -457,7 +457,7 @@
               hooking up the PWM monitor.
             - Repeat the steps for all 6 PWM signals.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sleep_pwm_pulses"]
     }
 
@@ -483,7 +483,7 @@
             - Verify that the CPU detects the integrity violation causing an alert.
             - Verify the alert upto the NMI stage.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -500,7 +500,7 @@
               access policies.
             - Accesses to CSRs external to `rv_dm` go through RV_DM SBA interface into the `xbar`.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_jtag_csr_rw"]
     }
     {
@@ -520,7 +520,7 @@
               value for correctness. Pick some random addresses to verify in case of read-only
               memories.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_jtag_mem_access"]
     }
     {
@@ -529,7 +529,7 @@
 
             TODO, add stimulus and checks
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -537,7 +537,7 @@
       desc: '''
             - X-ref'ed with rom_rv_dm_perform_debug from rom testplan
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -550,7 +550,7 @@
               reset to the original values, while values under life cycle reset will be preserved.
             - Read CSRs / mem in the debug domain to ensure that the values survive the reset.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_rv_dm_ndm_reset_req"]
     }
     // TODO, this could be a block-level test. Put it here since we don't have block-level testplan.
@@ -563,7 +563,7 @@
             - Check that halted state is clear (dmstatus.anyhalted/dmstatus.allhalted should be
               de-asserted).
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -573,7 +573,7 @@
             - Put the chip into sleep mode and then wake up.
             - Access some RV_DM CSRs to ensure that RV_DM doesn't need a full reset to work.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -585,7 +585,7 @@
             - Verify the TAP is selected correctly.
             - TODO, X-ref'ed with the LC tests.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -598,7 +598,7 @@
             - Verify that the JTAG TAP is unavailable.
             - X-ref'ed with `chip_tap_strap_sampling`
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -612,7 +612,7 @@
             - Service the interrupt when it triggers; verify that it came from rv_timer.
             - Verify that the interrupt triggered only after the timeout elapsed.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_rv_timer_irq"]
     }
 
@@ -627,7 +627,7 @@
             - Service the interrupt when it triggers; verify that it came from AON timer.
             - Verify that the interrupt triggered only after the timeout elapsed.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aon_timer_irq"]
     }
     {
@@ -645,7 +645,7 @@
             - After the test sequence is complete, read the wake up threshold register - it should
               not be reset.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_smoketest"]
     }
     {
@@ -656,7 +656,7 @@
             - Program the AON timer wdog to 'bark' after some time and enable the bark interrupt.
             - Service the bark interrupt upon reception.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aon_timer_irq"]
     }
     {
@@ -673,7 +673,7 @@
             - After the reset ensure that the reset cause was due to the escalation to prove that
               the wdog was disabled.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aon_timer_wdog_lc_escalate"]
     }
     {
@@ -687,7 +687,7 @@
             - After reset, read the reset cause register in rstmgr to confirm that the SW is now in
               the wdog reset phase.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aon_timer_wdog_bite_reset"]
     }
     {
@@ -701,7 +701,7 @@
             - After reset, read the reset cause register in rstmgr to confirm that the SW is now in
               the wdog reset phase.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aon_timer_wdog_bite_reset"]
     }
     {
@@ -717,7 +717,7 @@
               that the AON timer woke up the chip, not the wdog reset.
             - Un-pause the wdog and service the bark interrupt.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aon_timer_sleep_wdog_sleep_pause"]
     }
 
@@ -733,7 +733,7 @@
             testing within which functionally asserting an interrupt is hard to achieve or not of
             high value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_plic_all_irqs"]
     }
     {
@@ -744,7 +744,7 @@
             Write to the MSIP CSR to generate a SW interrupt to the CPU. Verify that the only
             interrupt that is seen is the SW interrupt.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_plic_sw_irq"]
     }
 
@@ -757,7 +757,7 @@
             completes in the transactional IP.  Verify it is off via spinwait in hints_status CSR.
             Verify that turning off this clock does not affect the other derived clocks.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aes_idle",
               "chip_sw_hmac_enc_idle",
               "chip_sw_kmac_idle",
@@ -775,7 +775,7 @@
             the CSR access (stretch since it could be difficult to maintain this
             check).
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_clkmgr_off_aes_trans",
               "chip_sw_clkmgr_off_hmac_trans",
               "chip_sw_clkmgr_off_kmac_trans",
@@ -789,7 +789,7 @@
             timers, turn off a peripheral's clock, issue a CSR access to that peripheral, verify a
             watchdog event results, and verify the rstmgr crash dump info records the CSR address.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_clkmgr_off_peri"]
     }
     {
@@ -800,7 +800,7 @@
             Connectivity tests check peripherals are connected to the clock they expect.
             Use the clkmgr count measurement feature to verify clock division.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_clkmgr_external_clk_src_for_sw_fast",
               "chip_sw_clkmgr_external_clk_src_for_sw_slow",
               "chip_sw_clkmgr_external_clk_src_for_lc"]
@@ -813,7 +813,7 @@
             it when lc_program completes. This also triggers divided clocks to step down. It may be
             best to verify this via SVA, unless we implement clock cycle counters.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_clkmgr_external_clk_src_for_lc"]
     }
     {
@@ -826,7 +826,7 @@
             counters.
             X-ref with chip_sw_uart_tx_rx_alt_clk_freq, which needs to deal with this as well.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_clkmgr_external_clk_src_for_sw_fast",
               "chip_sw_clkmgr_external_clk_src_for_sw_slow"]
     }
@@ -840,7 +840,7 @@
 
             X-ref with various specific jitter enable tests.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_clkmgr_jitter",
               "chip_sw_flash_ctrl_ops_jitter_en",
               "chip_sw_flash_ctrl_access_jitter_en",
@@ -859,7 +859,7 @@
             clock measurements should be off, but the recoverable fault status should not
             be cleared.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_ast_clk_outputs"]
     }
     {
@@ -870,7 +870,7 @@
             keeping some clocks disabled. Upon wakeup the clock measurements should be on, and the
             recoverable fault status should show no errors for the disabled clocks.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_clkmgr_sleep_frequency"]
     }
     {
@@ -881,7 +881,7 @@
             After reset the clock measurements should be off and the recoverable fault status
             should be cleared.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_clkmgr_reset_frequency"]
     }
     {
@@ -892,7 +892,7 @@
             reset. Upon alert escalation reset, the internal status should be clear and clkmgr
             should not attempt to send out more alerts.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -905,7 +905,7 @@
             the processor ends up running. Also verify, the rstmgr recorded POR in `reset_info` CSR
             by checking retention SRAM for reset_reason.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_full_aon_reset"]
     }
     {
@@ -924,7 +924,7 @@
             dependent corner cases with wakeup interactions.
 
             '''
-      milestone: V2
+      stage: V2
       tests: [""]
     }
     {
@@ -939,7 +939,7 @@
             have the source issue a wakeup event and verify `wake_info` indicates the expected
             wakeup.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_normal_sleep_all_wake_ups"]
     }
     {
@@ -953,7 +953,7 @@
             rstmgr's `reset_info` indicated the expected reset by checking retention SRAM for
             reset_reason.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aon_timer_wdog_bite_reset"]
     }
     {
@@ -965,7 +965,7 @@
             working correctly as expected. X-ref'ed with all individual IP tests. Similar to
             chip_pwrmgr_sleep_all_wake_ups, except `control.main_pd_n` is set to 0.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_deep_sleep_all_wake_ups"]
     }
     {
@@ -978,7 +978,7 @@
             - POR (HW PAD) reset, SW POR, sysrst, wdog timer reset, esc rst, SW req
             - esc reset is followd by normal mode because it does not work with sleep mode
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_deep_sleep_all_reset_reqs"]
     }
     {
@@ -991,7 +991,7 @@
             - POR (HW PAD) reset, SW POR, sysrst, wdog timer reset, esc rst, SW req
             - esc reset is followed by normal mode and cleared by reset because it does not work with sleep mode
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_normal_sleep_all_reset_reqs"]
     }
     {
@@ -1002,7 +1002,7 @@
             working correctly as expected. X-ref'ed with all individual IP tests. Similar to
             chip_pwrmgr_sleep_all_reset_reqs, except the chip is not put in low power mode.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_wdog_reset"]
     }
     {
@@ -1015,7 +1015,7 @@
             the processor ends up running. Also verify, the rstmgr recorded POR in `reset_info` CSR
             by checking retention SRAM for reset_reason.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_full_aon_reset"]
     }
     {
@@ -1026,7 +1026,7 @@
             a MainPwr reset request, which is checked by reading retention SRAM's reset_reason to
             see that the reset_info CSR's POR bit is not set when the test restarts.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_main_power_glitch_reset"]
     }
     {
@@ -1046,7 +1046,7 @@
             Each test should perform a minimum of 2 low power transitions to ensure there are no
             state dependent corner cases with power glitch handling.
             '''
-      milestone: V2
+      stage: V2
       tests: [""]
     }
     {
@@ -1063,7 +1063,7 @@
             - If too late the hardware won't monitor main power okay so the glitch will have no
               effect, and the test will timeout.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_deep_sleep_power_glitch_reset"]
     }
     {
@@ -1075,7 +1075,7 @@
             reset_reason shows that the reset_info CSR's POR bit is not set when the
             test restarts.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_sleep_power_glitch_reset"]
     }
     {
@@ -1086,7 +1086,7 @@
             - POR (HW PAD) reset, SW POR, sysrst, wdog timer reset, esc rst, SW req
             - esc reset is followd by normal mode because it does not work with sleep mode
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_random_sleep_all_reset_reqs"]
     }
     {
@@ -1106,7 +1106,7 @@
               the wdog reset phase.
             - Program the AON timer wdog to 'bark' after some time.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_sysrst_ctrl_reset"]
     }
     {
@@ -1114,7 +1114,7 @@
       desc: '''Verify that the pwrmgr sequences sleep_req and reset req coming in almost at the same
             time, one after the other. Use POR_N PAD to trigger reset.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_b2b_sleep_reset_req"]
     }
     {
@@ -1124,7 +1124,7 @@
             This calls WFI with low_power_hint disabled and pwrmgr interrupts enabled,
             and fails if the pwrmgr ISR is called.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_sleep_disabled"]
     }
     {
@@ -1135,7 +1135,7 @@
                Upon alert escalation reset, the internal status should be clear and the
                pwrmgr should not attempt to send out more alerts.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1156,7 +1156,7 @@
             need special consideration.
             TODO(maturana) Add specific tests once they are developed.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_smoketest"]
     }
     {
@@ -1174,7 +1174,7 @@
             need special consideration.
             TODO(maturana) Add specific tests once they are developed.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1186,7 +1186,7 @@
             the `cpu_info` register contents when reset is handled.
             Refer to `chip_*sys_rstmgr_reset_info`.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_rstmgr_cpu_info"]
     }
     {
@@ -1198,7 +1198,7 @@
             After reset, the retention SRAM's reset_reason should show that the `reset_info` CSR
             reflects that a software request was the reset cause.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_rstmgr_sw_req"]
     }
     {
@@ -1211,7 +1211,7 @@
             verify the `alert_info` register contents when reset is handled.
             Refer to `chip_*sys_rstmgr_reset_info`.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_rstmgr_alert_info"]
     }
     {
@@ -1227,7 +1227,7 @@
 
             Notice the two `spi_host` IPs receive two different resets, `spi_host*`.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_rstmgr_sw_rst"]
     }
     {
@@ -1238,7 +1238,7 @@
                Upon alert escalation reset, the internal status should be clear and the
                rstmgr should not attempt to send out more alerts.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1252,7 +1252,7 @@
             - Ensure that all alerts are properly connected to the alert handler and cause the
               escalation paths to trigger.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_alert_test"]
     }
     {
@@ -1265,7 +1265,7 @@
             - Verify the third results in chip reset.
             - Ensure that all escalation handshakes complete without errors.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_alert_handler_escalation"]
     }
     {
@@ -1274,7 +1274,7 @@
 
             X-ref'ed with the automated PLIC test.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_plic_all_irqs"]
     }
     {
@@ -1287,7 +1287,7 @@
             - Ensure that the alert ping handshake to all alert sources and escalation receivers
               complete without errors.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_alert_handler_entropy"]
     }
     {
@@ -1297,7 +1297,7 @@
             When the chip resets due to alert escalating to cause the chip to reset, verify the
             reset cause to verify the alert crashdump.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1308,7 +1308,7 @@
             alert_handler detects the ping timeout and reflects it on the `loc_alert_cause`
             register.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_alert_handler_ping_timeout"]
     }
     {
@@ -1323,7 +1323,7 @@
               all alerts are still firing after waking up.
             - Repeat the previous steps for random number of iterations.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1344,7 +1344,7 @@
               This scenario ensures the ping mechanism will continue to send out pings after waking
               up from sleep modes.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1356,7 +1356,7 @@
             - Trigger fatal alerts in an IP then configure clkmgr to turn off the IP clock. Check
               the IP's fatal alert resumes after clock is turned back on.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1366,7 +1366,7 @@
             - Configure rstmgr to randomly toggle one IP block's SW reset and check alert_handler
               won't trigger a ping timeout error on that block.
            '''
-      milestone: V2
+      stage: V2
       tests: []
    }
    {
@@ -1376,7 +1376,7 @@
             Check that escalation receivers located inside always-on blocks do not auto-escalate
             due to the reverse ping feature while the system is in deep sleep.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1398,7 +1398,7 @@
             decoded outputs to other IPs.
             X-ref'ed with alert_handler's escalation test.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_alert_handler_escalation"]
     }
     {
@@ -1408,7 +1408,7 @@
             Using the JTAG agent, write and read LC ctrl CSRs, verify the read value for
             correctness.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
     }
     {
@@ -1419,7 +1419,7 @@
             - Read the device ID and the ID state CSRs to verify their correctness.
             - Reset the chip and repeat the first 2 steps to verify a different set of values.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_ctrl_otp_hw_cfg"]
     }
     {
@@ -1432,7 +1432,7 @@
             - Verify with connectivity assertion checks, the handshake signals are connected.
             - Ensure that no interrupts or alerts are triggered.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
@@ -1451,7 +1451,7 @@
 
             X-ref'ed chip_sw_otp_ctrl_program.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
@@ -1464,7 +1464,7 @@
 
             X-ref'ed with chip_kmac_lc_req.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
@@ -1476,7 +1476,7 @@
             - Force another KMAC reset after KMAC is done processing lc trantition tokens.
             - Verify that kmac reset won't affect LC state transition.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_ctrl_kmac_reset"]
     }
     {
@@ -1488,7 +1488,7 @@
 
             X-ref'ed with chip_keymgr_lc_key_div_o.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1517,7 +1517,7 @@
             - These outputs are enabled per the [life cycle architecture spec]({{< relref "doc/security/specs/device_life_cycle/#architecture" >}}).
             X-ref'ed with the respective IP tests that consume these signals.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1530,7 +1530,7 @@
               the chip inputs.
             - Read the pin_in_value CSR to check for correctness.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sysrst_ctrl_inputs"]
     }
     {
@@ -1550,7 +1550,7 @@
             - Via assertion checks (or equivalent) verify that the transitions at the inputs
               immediately reflect at the outputs, if not intercepted / debounced by sysrst_ctrl.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sysrst_ctrl_outputs"]
     }
     {
@@ -1566,7 +1566,7 @@
               key_intr_status for correctness and clears the interrupt status.
             - Verify separately, eack key combination sufccessfully generates an interrupt.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1588,7 +1588,7 @@
             - Read the pin input value and the combo_intr_status CSRs to verify the correct
               combination on inputs woke up the chip from sleep.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sysrst_ctrl_reset"]
     }
     {
@@ -1610,7 +1610,7 @@
             - Read the com_sel_ctl_* CSR in SYSRST ctrl we programmed earlier - it should have been
               reset.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sysrst_ctrl_reset"]
     }
     {
@@ -1634,7 +1634,7 @@
             - Read the com_sel_ctl_* CSR in SYSRST ctrl we programmed earlier - it should have been
               reset.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sysrst_ctrl_reset"]
     }
     {
@@ -1648,7 +1648,7 @@
             - Optionally, also verify ec_rst_l pulse stretching by setting the ec_rst_ctl register
               with a suitable pulse width.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1657,7 +1657,7 @@
 
             - Exactly the same as chip_sysrst_ctrl_ec_rst_l, but covers the flash_wp_l pin.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1674,7 +1674,7 @@
             - Read the ulp_wakeup register to verify that the wakeup event is detected this time.
             - Verify that the z3_wakeup output at the chip IOs is reflecting the value of 1.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1698,7 +1698,7 @@
               filter caused the interrupt to fire. Read the ADC channel value register to verify the
               correctness of the detected value that was forced in the AST for each channel.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1720,7 +1720,7 @@
               that was forced in the AST.
             - Repeat for both ADC channels.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup"]
     }
 
@@ -1738,7 +1738,7 @@
             computation to start. Wait for the AES operation to complete by polling the status
             register. Check the digest registers for correctness against the expected digest value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aes_enc",
               "chip_sw_aes_enc_jitter_en"]
     }
@@ -1758,7 +1758,7 @@
             - Assertion check verifies that the IV are also garbage, i.e. different from the originally
               written values.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aes_entropy"]
     }
     {
@@ -1775,7 +1775,7 @@
               clkmgr now reads 0 again (AES is disabled).
             - Write the AES clk hint to 1, read and check the AES output for correctness.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aes_idle"]
     }
     {
@@ -1793,7 +1793,7 @@
             - Clear the key in the keymgr and decrypt the ciphertext again.
             - Verify that output is not equal to the plain text.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aes_sideload"]
     }
 
@@ -1806,7 +1806,7 @@
             the NIST vectors). SW test verifies the digest against the pre-computed value. Verify
             the HMAC done and FIFO empty interrupts as a part of this test.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_hmac_enc",
               "chip_sw_hmac_enc_jitter_en"]
     }
@@ -1826,7 +1826,7 @@
             - This process is repeated for two hmac operations needed to verify the resulting hmac
               digest.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_hmac_enc_idle"]
     }
 
@@ -1838,7 +1838,7 @@
             SW test verifies SHA3 operation with a known key, plain text and digest (pick one of
             the NIST vectors). SW validates the reception of kmac done and fifo empty interrupts.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_kmac_mode_cshake", "chip_sw_kmac_mode_kmac",
               "chip_sw_kmac_mode_kmac_jitter_en"]
     }
@@ -1855,7 +1855,7 @@
 
             X-ref'ed with keymgr test.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1868,7 +1868,7 @@
 
             X-ref'ed with LC_CTRL test/env.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
@@ -1883,7 +1883,7 @@
 
             X-ref'ed with ROM_CTRL test/env.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_kmac_app_rom"]
     }
     {
@@ -1905,7 +1905,7 @@
 
             X-ref'ed with EDN test/env.
             '''
-      milestone: V3
+      stage: V3
       tests: []
     }
     {
@@ -1922,7 +1922,7 @@
             - After the KMAC operation is complete, verify the digest for correctness.
               Verify that the KMAC clk hint status within clkmgr now reads 0 again (KMAC is disabled).
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_kmac_idle"]
     }
 
@@ -1938,7 +1938,7 @@
               the AST RNG interface.
             - Verify the correctness of the received data with assertion based connectivity checks.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_entropy_src_ast_rng_req"]
     }
     {
@@ -1947,7 +1947,7 @@
 
             Details TBD.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1958,7 +1958,7 @@
             At the CSRNG, validate the reception of entropy req interrupt.
             Details TBD.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1967,7 +1967,7 @@
 
             Details TBD.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -1983,7 +1983,7 @@
             - Read and verify the OTP `HW_CFG.EN_ENTROPY_SRC_FW_READ` against the previous step expectation.
             - Read the internal state via SW; verify that the entropy valid bit is zero.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_entropy_src_fuse_en_fw_read_test"]
     }
     {
@@ -1994,7 +1994,7 @@
             - Feed NIST test-defined entropy sequences into the conditioner
             - Read the entropy_data_fifo via SW; verify that it reads the expected values.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_entropy_src_kat_test"]
     }
 
@@ -2009,7 +2009,7 @@
             - TODO: explore the ability to generate predictable data and verify the received value.
             Details TBD.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2022,7 +2022,7 @@
             - Reset the chip and repeat the steps above, but this time, with OTP fuse bit set to 0.
             - Verify that the SW reads back all zeros when reading the internal states.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2031,7 +2031,7 @@
 
             TODO: This is pending SCA security review and might be removed.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2045,7 +2045,7 @@
             - Perform generate operations as required by the test vector.
             - Compare the results to test expectations.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_csrng_kat_test"]
     }
 
@@ -2060,7 +2060,7 @@
             Ensure there are no deadlocks and everything works as expected.
             X'ref'ed with each IP test that requsts entropy from EDN.
             '''
-      milestone: V2
+      stage: V2
       tests: ['chip_sw_edn_entropy_reqs']
     }
 
@@ -2093,7 +2093,7 @@
 
             X-ref'ed with kmac test.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_keymgr_key_derivation", "chip_sw_keymgr_key_derivation_jitter_en"]
     }
     {
@@ -2108,7 +2108,7 @@
 
             X-ref'ed with chip_kmac_app_keymgr test.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_keymgr_sideload_kmac"]
     }
     {
@@ -2117,7 +2117,7 @@
 
                Same as `chip_keymgr_sideload_kmac`, except, sideload to AES.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aes_sideload"]
     }
     {
@@ -2127,7 +2127,7 @@
                Load OTBN binary image, the rest is similar to `chip_keymgr_sideload_kmac`, except
                sideloading to otbn.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -2141,7 +2141,7 @@
             - SW verifies the correctness of the result with the expected value which is
               pre-computed using a reference model.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_otbn_ecdsa_op_irq",
               "chip_sw_otbn_ecdsa_op_irq_jitter_en"]
     }
@@ -2155,7 +2155,7 @@
               all 0s or all 1s, as a basic measure to ensure that the entropy subsystem is returning
               some data.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_otbn_randomness"]
     }
     {
@@ -2164,7 +2164,7 @@
 
             - Similar to chip_otbn_rnd_entropy, but verifies the URND bits.
             '''
-      milestone: V2
+      stage: V2
       tests:  ["chip_sw_otbn_randomness"]
     }
     {
@@ -2182,7 +2182,7 @@
               clkmgr now reads 0 again (OTBN is disabled).
             - Write the OTBN clk hint to 1, read and check the OTBN output for correctness.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_otbn_randomness"]
     }
     {
@@ -2198,7 +2198,7 @@
             - Verify the validity of EDN's output to OTP_CTRL via assertions
               (unique, non-zero data).
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_otbn_mem_scramble"]
     }
 
@@ -2214,7 +2214,7 @@
 
             - Verify that the CPU can fetch instructions from the ROM.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_rom_ctrl_integrity_check"]
     }
     {
@@ -2226,7 +2226,7 @@
             - In PROD LC state, verify that the pwrmgr does not fully power up if the computed
               digest does not match the top 8 words of the ROM.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_rom_ctrl_integrity_check"]
     }
 
@@ -2245,7 +2245,7 @@
             - Verify the validity of EDN's output to OTP_CTRL via assertions
               (unique, non-zero data).
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sram_ctrl_ret_scrambled_access",
               "chip_sw_sram_ctrl_main_scrambled_access",
               "chip_sw_sram_ctrl_main_scrambled_access_jitter_en"]
@@ -2259,7 +2259,7 @@
 
             TODO: how to deal with the scramble keys on low power exit?
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sleep_sram_ret_contents"]
     }
     {
@@ -2295,7 +2295,7 @@
 
             For the retention SRAM, instruction fetch is completely disabled via design parameter.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sram_ctrl_execution_main"]
     }
     {
@@ -2308,7 +2308,7 @@
             - Re-initialize the SRAMs and verify that they can now respond correctly to
               any further memory requests.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -2323,7 +2323,7 @@
             - Verify with connectivity assertion checks, the handshake signals are connected.
             - Ensure that no interrupts or alerts are triggered.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
@@ -2339,7 +2339,7 @@
             - chip_sw_keymgr_key_derivation
             - chip_sw_otbn_mem_scramble
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sram_ctrl_ret_scrambled_access", "chip_sw_flash_init",
               "chip_sw_keymgr_key_derivation", "chip_sw_otbn_mem_scramble"]
     }
@@ -2350,7 +2350,7 @@
             This is X-ref'ed with the chip_otp_ctrl_keys test, which needs to handshake with the EDN
             to receive some entropy bits before the keys for SRAM ctrl and OTBN are computed.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sram_ctrl_ret_scrambled_access", "chip_sw_flash_init",
               "chip_sw_keymgr_key_derivation", "chip_sw_otbn_mem_scramble"]
     }
@@ -2367,7 +2367,7 @@
             - After reset, verify that the LC state transition completed successfully by reading the
               LC state and LC count CSRs.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
@@ -2378,7 +2378,7 @@
             - Verify that the LC ctrl triggers an alert when the OTP ctrl responds back with a
               program error.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_ctrl_program_error"]
     }
     {
@@ -2390,7 +2390,7 @@
 
             Xref'ed with corresponding IP tests that receive these bits.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_ctrl_otp_hw_cfg"]
     }
     {
@@ -2408,7 +2408,7 @@
             X-ref'ed with chip_lc_ctrl_broadcast test, which verifies the connectivity of the LC
             decoded outputs to other IPs.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2417,7 +2417,7 @@
 
             Details TBD.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2429,7 +2429,7 @@
             - Verify that when `lc_dft_en_i` is On, this region can be read / written to by the SW.
               When `lc_dft_en_i` is Off, accessing this region will result in a TLUL error.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_prim_tl_access"]
     }
 
@@ -2448,7 +2448,7 @@
 
             - This test needs to execute as a boot rom image.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_init"]
     }
     {
@@ -2457,7 +2457,7 @@
 
             Nothing extra to do here - most SW based tests fetch code from flash.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_ctrl_access",
               "chip_sw_flash_ctrl_access_jitter_en"]
     }
@@ -2469,7 +2469,7 @@
             all data and info partitions. Erase both, bank and page. SW validates the reception of
             prog empty, prog level, rd full, rd level and op done interrupts.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_ctrl_ops", "chip_sw_flash_ctrl_ops_jitter_en"]
     }
     {
@@ -2484,7 +2484,7 @@
             - RMA entry can be on the C side as well. This should be done over C - The JTAG
               interface to flash ctrl is actually for the closed src.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_rma_unlocked"]
     }
     {
@@ -2499,7 +2499,7 @@
               flash with new test image that is re-scrambled with the new key.
             - Need to understand the bootstrapping requirements.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_init"]
     }
     {
@@ -2511,7 +2511,7 @@
             - Issue a WFI.
             - Ensure that the low power entry does not happen due to the ongoing flash operation.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_ctrl_idle_low_power"]
     }
     {
@@ -2521,7 +2521,7 @@
 
             X-ref'ed with keymgr test.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_keymgr_key_derivation"]
     }
     {
@@ -2532,14 +2532,14 @@
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the SW
               accessibility of the corresponding partition depending on the signal value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {
       name: chip_sw_flash_creator_seed_wipe_on_rma
       desc: '''Verify that the creator seed is wiped by the flash ctrl on RMA entry.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_rma_unlocked"]
     }
     {
@@ -2550,7 +2550,7 @@
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the SW
               accessibility of the corresponding partition depending on the signal value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {
@@ -2561,7 +2561,7 @@
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the SW
               accessibility of the corresponding partition depending on the signal value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {
@@ -2572,7 +2572,7 @@
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the SW
               accessibility of the corresponding partition depending on the signal value.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {
@@ -2584,7 +2584,7 @@
               does (or does not) read the creator and owner partitions to fetch the seeds for the
               keymgr.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {
@@ -2598,7 +2598,7 @@
             - Use assertion based connectivity check to prove that this signal is connected to the
               flash ctrl.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2609,7 +2609,7 @@
               will be implemented in a translation 'shim'.
             - Verify that this region can be read / written to by the SW in any LC state.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_prim_tl_access"]
     }
     {
@@ -2620,7 +2620,7 @@
               to the flash.
             - This sets the test for closed source where the flash access timing matters.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_flash_ctrl_clock_freqs"]
     }
 
@@ -2638,7 +2638,7 @@
             and verify that upon wakeup reset the clock counters are turned off, measure ctrl
             regwen is enabled, and errors are not cleared.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_ast_clk_outputs"]
     }
     {
@@ -2647,7 +2647,7 @@
 
             Details TBD.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2656,7 +2656,7 @@
 
             Details TBD.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2670,7 +2670,7 @@
             - Note, while the above is ideal, usbdev chip level testing is not yet ready and this test fakes the usb portion through DV forces.
             - Note also the real AST calibration logic is not available, so the sof testing in the open source is effectively short-circuited.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_usb_ast_clk_calib"]
     }
     {
@@ -2679,7 +2679,7 @@
 
              X-ref'ed with `chip_sensor_ctrl_ast_alerts`.
              '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sensor_ctrl_alert"]
     }
 
@@ -2695,7 +2695,7 @@
                For the alert handler case, make sure to test each alert configured
                as either recoverable or fatal.
              '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup",
               "chip_sw_sensor_ctrl_alert"]
     }
@@ -2707,7 +2707,7 @@
                from sensor_ctrl.  After triggering, the IO status can be read
                from a sensor_ctrl register.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_sensor_ctrl_status"]
     }
     {
@@ -2716,7 +2716,7 @@
                from sleep mode when an alert event is triggered from
                AST. X-ref'ed chip_sw_pwrmgr_sleep_all_wake_ups.
              '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup"]
     }
 
@@ -2739,7 +2739,7 @@
             is not locked, check that alert_handler can clear this NMI escalation stage. Then make
             sure that the alert_handler won't move forward to the next escalation stage.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2755,7 +2755,7 @@
                - Perform repeated reads from `RND_DATA` without `RND_STATUS`
                  polling to check read when invalid doesn't block.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_rv_core_ibex_rnd"]
     }
     {
@@ -2771,7 +2771,7 @@
                - Turn off address translation and confirm regions are no longer
                  being remapped.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_rv_core_ibex_address_translation"]
    }
 
@@ -2782,7 +2782,7 @@
                - Purposely create an ibex exception during execution through reads to an ummapped address.
                - Ensure the rstmgr fault dump correctly captures the related addresses to the exception.
             '''
-      milestone: V2
+      stage: V2
       tests: []
    }
 
@@ -2793,7 +2793,7 @@
                - Purposely create an ibex double exception during execution, by performing an unmapped read and in the exception handler perform another unmapped read.
                - Ensure the rstmgr fault dump correctly captures both dumps correctly and indicates the previous dump is valid.
             '''
-      milestone: V2
+      stage: V2
       tests: []
    }
 
@@ -2809,7 +2809,7 @@
             develop example tests to demonstrate these capabilities, and need to
             run them in DV to ensure the integrity of our infrastructure.
             '''
-      milestone: V1
+      stage: V1
       tests: ["chip_sw_example_flash",
               "chip_sw_example_rom",
               ]
@@ -2822,7 +2822,7 @@
             alive, and can be actuated by the DIF. We need to ensure that they
             work in DV as well.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_aes_smoketest",
               "chip_sw_aon_timer_smoketest",
               "chip_sw_clkmgr_smoketest",
@@ -2851,13 +2851,13 @@
             test ROM. We need to ensure our test infrastructure and ROM can
             boot and run one (or a few) of the same tests our test ROM can.
             '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_uart_smoketest_signed"]
     }
     {
       name: chip_sw_coremark
       desc: '''Run the coremark benchmark on the full chip.'''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_coremark"]
     }
     {
@@ -2873,7 +2873,7 @@
              Note: This flow will be replaced by using spi_device flash mode.
              For detail, refer to chip_spi_device_flash_mode
              '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_uart_tx_rx_bootstrap"]
     }
     {
@@ -2882,7 +2882,7 @@
 
              Details TBD.
              '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2896,7 +2896,7 @@
                enabled.
              Verify that the features that should indeed be disabled are indeed disabled.
              '''
-      milestone: V2
+      stage: V2
       tests: ["chip_sw_lc_walkthrough_dev",
               "chip_sw_lc_walkthrough_prod",
               "chip_sw_lc_walkthrough_prodend",
@@ -2909,7 +2909,7 @@
 
              Details TBD.
              '''
-      milestone: V2
+      stage: V2
       tests: []
     }
     {
@@ -2921,7 +2921,7 @@
               and initiating another key request.
             - Verify that the RAMs are "wiped" once this operation completes.
             '''
-      milestone: V2
+      stage: V2
       tests: []
     }
   ]

--- a/hw/top_earlgrey/data/standalone_sw_testplan.hjson
+++ b/hw/top_earlgrey/data/standalone_sw_testplan.hjson
@@ -11,7 +11,7 @@
             It ensures the flash controller is able to program, read, and page erase fixed locations in multiple flash banks.
             It also performs a sanity region protection check to make sure a protected page cannot be modified.
             When the test passes, it will output "PASS!".'''
-      milestone: V1
+      stage: V1
       tests: ["flash_test"]
     }
     {
@@ -19,7 +19,7 @@
       desc: '''This test checks for basic functionality of the sha256 engine inside HMAC.
             It computes the hash of a known input and compares it against the known digest.
             When the test passes, it will output "PASS!".'''
-      milestone: V1
+      stage: V1
       tests: ["sha256_test"]
     }
     {
@@ -28,7 +28,7 @@
             The test rests in a loop and does not break out until the interrupt handling routine sets a specific value.
             If the interrupt handling is incorrect, the test will never complete.
             When the test passes, it will output "PASS!".'''
-      milestone: V1
+      stage: V1
       tests: ["rv_timer_test"]
     }
   ]

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson
@@ -28,7 +28,7 @@
       desc: '''Verify the countermeasure(s) BUS.INTEGRITY.
             This entry is covered by tl_access_test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_tl_intg_err"]
     }
     {
@@ -42,7 +42,7 @@
               clock.
             - Measurement error should trigger a recoverable alert
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_frequency"]
     }
     {
@@ -54,7 +54,7 @@
               and stopped. This will leads to timeout event.
             - Timeout should cause a recoverable alert
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_frequency_timeout"]
     }
     {
@@ -66,7 +66,7 @@
             (https://github.com/lowRISC/opentitan/blob/master/
             hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson)
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_shadow_reg_errors"]
     }
     {
@@ -87,7 +87,7 @@
               When clk_hints_status go to '0', check clocks_o
               to see if clock is really off
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_idle_intersig_mubi"]
     }
     {
@@ -101,7 +101,7 @@
             When dut sees invalid values of lc_hw_debug_en_i,
             all_clk_byp_req should not be asserted. Covered by assertion checker.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_lc_ctrl_intersig_mubi"]
     }
     {
@@ -115,7 +115,7 @@
             When dut sees invalid values of lc_clk_byp_req_i,
             io_clk_byp_req_o should not be asserted. Covered by assertion checker.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_lc_clk_byp_req_intersig_mubi"]
     }
     {
@@ -132,7 +132,7 @@
             When both are true, lc_clk_byp_req is assigned to lc_clk_byp_ack.
             Covered by assertion checker.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_clk_handshake_intersig_mubi"]
     }
     {
@@ -144,7 +144,7 @@
             **Check**:
             dut should ignore invalid req values. Covered by assertion checker.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_div_intersig_mubi"]
     }
     {
@@ -155,7 +155,7 @@
             jittery clock is enabled. So it can be covered by default
             csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_csr_rw"]
     }
     {
@@ -165,7 +165,7 @@
             **Check**:
             read check CLKMGR.FATAL_ERR_CODE.IDLE_CNT == 1
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_sec_cm"]
     }
     {
@@ -174,7 +174,7 @@
 
             This is covered by auto csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_csr_rw"]
     }
     {
@@ -183,7 +183,7 @@
 
             This is covered by auto csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["clkmgr_csr_rw"]
     }
   ]

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -26,163 +26,163 @@
     {
       name: sec_cm_reg_bus_integrity
       desc: "Verify the countermeasure(s) REG.BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_host_bus_integrity
       desc: "Verify the countermeasure(s) HOST.BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_bus_integrity
       desc: "Verify the countermeasure(s) MEM.BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_scramble_key_sideload
       desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_lc_ctrl_intersig_mubi
       desc: "Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_config_regwen
       desc: "Verify the countermeasure(s) CTRL.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_regions_config_regwen
       desc: "Verify the countermeasure(s) DATA_REGIONS.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_data_regions_config_shadow
       desc: "Verify the countermeasure(s) DATA_REGIONS.CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_info_regions_config_regwen
       desc: "Verify the countermeasure(s) INFO_REGIONS.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_info_regions_config_shadow
       desc: "Verify the countermeasure(s) INFO_REGIONS.CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_bank_config_regwen
       desc: "Verify the countermeasure(s) BANK.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_bank_config_shadow
       desc: "Verify the countermeasure(s) BANK.CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_ctrl_global_esc
       desc: "Verify the countermeasure(s) MEM.CTRL.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_ctrl_local_esc
       desc: "Verify the countermeasure(s) MEM.CTRL.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_disable_config_mubi
       desc: "Verify the countermeasure(s) MEM_DISABLE.CONFIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_exec_config_redun
       desc: "Verify the countermeasure(s) EXEC.CONFIG.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_scramble
       desc: "Verify the countermeasure(s) MEM.SCRAMBLE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_mem_integrity
       desc: "Verify the countermeasure(s) MEM.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_rma_entry_mem_sec_wipe
       desc: "Verify the countermeasure(s) RMA_ENTRY.MEM.SEC_WIPE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctrl_fsm_sparse
       desc: "Verify the countermeasure(s) CTRL.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_phy_fsm_sparse
       desc: "Verify the countermeasure(s) PHY.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_phy_prog_fsm_sparse
       desc: "Verify the countermeasure(s) PHY_PROG.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_ctr_redun
       desc: "Verify the countermeasure(s) CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_phy_arbiter_ctrl_redun
       desc: "Verify the countermeasure(s) PHY_ARBITER.CTRL.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_phy_host_grant_ctrl_consistency
       desc: "Verify the countermeasure(s) PHY_HOST_GRANT.CTRL.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_phy_ack_ctrl_consistency
       desc: "Verify the countermeasure(s) PHY_ACK.CTRL.CONSISTENCY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
     {
       name: sec_cm_fifo_ctr_redun
       desc: "Verify the countermeasure(s) FIFO.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr_sec_cm_testplan.hjson
@@ -29,7 +29,7 @@
             This entry is covered by tl_access_test
             (hw/dv/tools/dvsim/tests/tl_access_tests.hjson)
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_tl_intg_err"]
     }
     {
@@ -50,7 +50,7 @@
               is set to '1' only when lc_dft_en_i or lc_hw_debug_en_i
               is high.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm_lc_ctrl_intersig_mubi"]
     }
     {
@@ -67,7 +67,7 @@
             - Collect coverage by binding cip_mubi_cov_if to
               tb.dut.rom_ctrl_i
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm_rom_ctrl_intersig_mubi"]
     }
     {
@@ -83,7 +83,7 @@
             - Collect coverage by binding cip_mubi_cov_if to
               tb.dut.sw_rst_req_i
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm_rstmgr_intersig_mubi"]
     }
     {
@@ -102,7 +102,7 @@
               by asserting escalation reset,
               see if dut is back to normal operation state.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_esc_clk_rst_malfunc"]
     }
     {
@@ -119,7 +119,7 @@
             - Add assertion to check if u_sec_timeout happens, then
               rstreqs[ResetEscIdx] should be asserted.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm"]
     }
     {
@@ -130,7 +130,7 @@
             /hw/dv/sv/cip_lib/doc/index.md#security-verification
             -for-common-countermeasure-primitives)
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm"]
     }
     {
@@ -146,7 +146,7 @@
               pwr_rst_o.rst_sys_req is all one  and pwr_clk_o = 0.
               Dut should be recovered by asserting rst_n = 0.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm"]
     }
     {
@@ -161,7 +161,7 @@
             - Add assertion to see if we get pwr_rst_o.rstreqs[ResetEscIdx]
               set when dut receives esc_rst_tx_i
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_global_esc"]
     }
     {
@@ -176,7 +176,7 @@
             - Check fast state transition to FastPwrStateResetPrep
             - Add assertion to see if we get pwr_rst_o.rstreqs[ResetMainPwrIdx]
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_glitch"]
     }
     {
@@ -194,7 +194,7 @@
               read back and check the value is not updated by
               the csr update attempt.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_sec_cm_ctrl_config_regwen"]
     }
     {
@@ -203,7 +203,7 @@
 
             This is covered by auto csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_csr_rw"]
     }
     {
@@ -212,7 +212,7 @@
 
             This is covered by auto csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["pwrmgr_csr_rw"]
     }
   ]

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr_sec_cm_testplan.hjson
@@ -28,7 +28,7 @@
       desc: '''Verify the countermeasure(s) BUS.INTEGRITY.
             This entry is covered by tl_access_test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_tl_intg_err"]
     }
     {
@@ -42,7 +42,7 @@
             **Check**:
             If dut accepts any of invalid values, test will fail by turning dut to scanmode.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_sec_cm_scan_intersig_mubi"]
     }
     {
@@ -61,7 +61,7 @@
             Upon asserting each reset consistency error,
             check alert_fatal_cnsty_fault is asserted.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_leaf_rst_cnsty"]
     }
     {
@@ -71,7 +71,7 @@
             Check if normal leaf reset module is not triggerred.
             Do over all {shadow, normal} leaf reset module pairs
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_leaf_rst_shadow_attack"]
     }
     {
@@ -81,7 +81,7 @@
             Force leaf rst check state to illegal value.
             This is triggered by common cm primitives
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_sec_cm"]
     }
     {
@@ -91,7 +91,7 @@
             RSTMGR.SW_RST_CTRL_N.
             This is covered by auto csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_csr_rw"]
     }
     {
@@ -101,7 +101,7 @@
             RSTMGR.ALERT_INFO_CTRL and RSTMGR.CPU_INFO_CTRL
             This is covered by auto csr test.
             '''
-      milestone: V2S
+      stage: V2S
       tests: ["rstmgr_csr_rw"]
     }
   ]

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_sec_cm_testplan.hjson
@@ -26,73 +26,73 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_tl_intg_err"]
     }
     {
       name: sec_cm_config_shadow
       desc: "Verify the countermeasure(s) CONFIG.SHADOW."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_shadow_reg_errors"]
     }
     {
       name: sec_cm_ping_timer_config_regwen
       desc: "Verify the countermeasure(s) PING_TIMER.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_smoke"]
     }
     {
       name: sec_cm_alert_config_regwen
       desc: "Verify the countermeasure(s) ALERT.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_smoke"]
     }
     {
       name: sec_cm_alert_loc_config_regwen
       desc: "Verify the countermeasure(s) ALERT_LOC.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_smoke"]
     }
     {
       name: sec_cm_class_config_regwen
       desc: "Verify the countermeasure(s) CLASS.CONFIG.REGWEN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_smoke"]
     }
     {
       name: sec_cm_alert_intersig_diff
       desc: "Verify the countermeasure(s) ALERT.INTERSIG.DIFF."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sig_int_fail"]
     }
     {
       name: sec_cm_lpg_intersig_mubi
       desc: "Verify the countermeasure(s) LPG.INTERSIG.MUBI."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_lpg"]
     }
     {
       name: sec_cm_esc_intersig_diff
       desc: "Verify the countermeasure(s) ESC.INTERSIG.DIFF."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sig_int_fail"]
     }
     {
       name: sec_cm_alert_rx_intersig_bkgn_chk
       desc: "Verify the countermeasure(s) ALERT_RX.INTERSIG.BKGN_CHK."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_entropy"]
     }
     {
       name: sec_cm_esc_tx_intersig_bkgn_chk
       desc: "Verify the countermeasure(s) ESC_TX.INTERSIG.BKGN_CHK."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_entropy"]
     }
     {
       name: sec_cm_esc_rx_intersig_bkgn_chk
       desc: "Verify the countermeasure(s) ESC_RX.INTERSIG.BKGN_CHK."
-      milestone: V2S
+      stage: V2S
       // This test entry is only valid with prim_esc_receiver module, which is not included in the
       // alert_handler testbench. Thus this test point will be checked in `prim_esc` testbench and
       // top-level testbench.
@@ -101,55 +101,55 @@
     {
       name: sec_cm_esc_timer_fsm_sparse
       desc: "Verify the countermeasure(s) ESC_TIMER.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_ping_timer_fsm_sparse
       desc: "Verify the countermeasure(s) PING_TIMER.FSM.SPARSE."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_esc_timer_fsm_local_esc
       desc: "Verify the countermeasure(s) ESC_TIMER.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_ping_timer_fsm_local_esc
       desc: "Verify the countermeasure(s) PING_TIMER.FSM.LOCAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_esc_timer_fsm_global_esc
       desc: "Verify the countermeasure(s) ESC_TIMER.FSM.GLOBAL_ESC."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_accu_ctr_redun
       desc: "Verify the countermeasure(s) ACCU.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_esc_timer_ctr_redun
       desc: "Verify the countermeasure(s) ESC_TIMER.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_ping_timer_ctr_redun
       desc: "Verify the countermeasure(s) PING_TIMER.CTR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
     {
       name: sec_cm_ping_timer_lfsr_redun
       desc: "Verify the countermeasure(s) PING_TIMER.LFSR.REDUN."
-      milestone: V2S
+      stage: V2S
       tests: ["alert_handler_sec_cm"]
     }
   ]

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
@@ -24,7 +24,7 @@
               output values
             - Support both synchronous and asynchronous settings
             '''
-      milestone: V1
+      stage: V1
       tests: ["alert_handler_smoke"]
     }
     {
@@ -33,7 +33,7 @@
             Based on the smoke test, this test will focus on testing the escalation accumulation
             feature. So all the escalations in the test will be triggered by alert accumulation.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_esc_alert_accum"]
     }
     {
@@ -42,7 +42,7 @@
            Based on the smoke test, this test will focus on testing the escalation timeout
            feature. So all the escalations in the test will be triggered by interrupt timeout.
            '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_esc_intr_timeout"]
     }
     {
@@ -51,7 +51,7 @@
             Based on the smoke test, this test enables ping testing, and check if the ping feature
             correctly pings all devices within certain period of time.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_entropy"]
     }
     {
@@ -61,7 +61,7 @@
             escalator tx/rx pairs. Then check if integrity failure alert is triggered and
             escalated.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_sig_int_fail"]
     }
     {
@@ -70,19 +70,19 @@
             This test will randomly inject clock skew within the differential pairs. Then check no
             alert is raised.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_smoke"]
     }
     {
       name: random_alerts
       desc: "Input random alerts and randomly write phase cycles."
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_random_alerts"]
     }
     {
       name: random_classes
       desc: "Based on random_alerts test, this test will also randomly enable interrupt classes."
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_random_classes"]
     }
     {
@@ -96,7 +96,7 @@
             - Verify alert and local alert causes.
             - Verify escalation states and counts.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_ping_timeout"]
     }
     {
@@ -115,7 +115,7 @@
             - Expect no ping timeout error because the alert_receivers are disabled via low-power
               group, or because alert_handler's clk input is paused due to sleep mode.
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_lpg", "alert_handler_lpg_stub_clk"]
     }
     {
@@ -125,7 +125,7 @@
             - CSR sequences: scoreboard disabled
             - Ping_corner_cases sequence: included reset in the sequence
             '''
-      milestone: V2
+      stage: V2
       tests: ["alert_handler_stress_all"]
     }
   ]

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic_fpv_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic_fpv_testplan.hjson
@@ -10,7 +10,7 @@
       desc: '''If interrupt pending (`ip`) is triggered, and the level indicator is set to
             level triggered (`le=0`), then in the prvious clock cycle, the interrupt source
             (`intr_src_i) should be set to 1.'''
-      milestone: V2
+      stage: V2
       tests: ["rv_plic_assert"]
     }
     {
@@ -18,40 +18,40 @@
       desc: '''If interrupt pending (`ip`) is triggered, and the level indicator is set to
             edge triggered (`le=1`), then in the prvious clock cycle, the interrupt source
             (`intr_src_i) should be at the rising edge.'''
-      milestone: V2
+      stage: V2
       tests: ["rv_plic_assert"]
     }
     {
       name: LevelTriggeredIpWithClaim_A
       desc: '''If `intr_src_i` is set to 1, level indicator is set to level triggered, and claim
             signal is not set, then at the next clock cycle `ip` will be triggered.'''
-      milestone: V2
+      stage: V2
       tests: ["rv_plic_assert"]
     }
     {
       name: EdgeTriggeredIpWithClaim_A
       desc: '''If `intr_src_i` is at the rising edge, level indicator is set to edge triggered, and claim
             signal is not set, then at the next clock cycle `ip` will be triggered.'''
-      milestone: V2
+      stage: V2
       tests: ["rv_plic_assert"]
     }
     {
       name: IpStableAfterTriggered_A
       desc: "Once `ip` is set, it stays stable until is being claimed."
-      milestone: V2
+      stage: V2
       tests: ["rv_plic_assert"]
     }
     {
       name: IpClearAfterClaim_A
       desc: "Once `ip` is set and being claimed, its value is cleared to 0."
-      milestone: V2
+      stage: V2
       tests: ["rv_plic_assert"]
     }
     {
       name: IpStableAfterClaimed_A
       desc: '''Once `ip` is cleared to 0, it stays stable until completed and being triggered
             again.'''
-      milestone: V2
+      stage: V2
       tests: ["rv_plic_assert"]
     }
     {
@@ -60,7 +60,7 @@
             input has the highest priority among the rest of the inputs, and its priority is
             above the threshold. Then in the next clock clcye, the `irq_o` should be triggered,
             and the `irq_id_o` will reflect the input ID.'''
-      milestone: V2
+      stage: V2
       tests: ["rv_plic_assert"]
     }
     {
@@ -68,7 +68,7 @@
       desc: '''If `irq_o` is set to 1, then in the previous clock cycle, the corresponding
             `ip` should be set, `ie` should be enabled, and the interrupt source should above the
             threshold and have the highest priority.'''
-      milestone: V2
+      stage: V2
       tests: ["rv_plic_assert"]
 
     }
@@ -81,7 +81,7 @@
                - No interrupt triggered, `ip` is set and `ie` is enabled, interrupt source priority is the
                  largest among the rest of the interrupt, but the interrupt source
                  priority is smaller than the threshold'''
-      milestone: V2
+      stage: V2
       tests: ["rv_plic_assert"]
     }
   ]

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic_sec_cm_testplan.hjson
@@ -26,7 +26,7 @@
     {
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
   ]

--- a/sw/device/silicon_creator/rom/data/rom_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_testplan.hjson
@@ -26,7 +26,7 @@
             |   RMA    | 0x2739ce73 |        "RMA"         |           5          |
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -47,7 +47,7 @@
             |   0x48eb4bd9 (All)      | ffffffff |
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -65,7 +65,7 @@
               - Verify that watchdog is disabled when `WATCHDOG_BITE_THRESHOLD_CYCLES` is `0`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: ["rom_e2e_shutdown_watchdog"]
     }
 
@@ -86,7 +86,7 @@
               execution halts at `_rom_start_boot`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -102,7 +102,7 @@
               access fault in the interrupt module.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -117,7 +117,7 @@
               register.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -132,7 +132,7 @@
             - Verify that the chip responds to `READ_STATUS` (`0x05`) with `0x00`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -150,7 +150,7 @@
               - The data on the CIPO line must be `0xff`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -168,7 +168,7 @@
               - The data on the CIPO line must be `0xff`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -186,7 +186,7 @@
               - The data on the CIPO line must be `0xff`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -203,7 +203,7 @@
             See `rom_e2e_bootstrap_enabled_requested`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -225,7 +225,7 @@
               - Verify that there was no output from UART.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -243,7 +243,7 @@
               - density `0x14`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -262,7 +262,7 @@
               [spreadsheet](https://docs.google.com/spreadsheets/d/1cioU3HgsWZXD4-eoUiH9TuVLZeFpucSdjyq5HND-FpQ/edit#gid=0).
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -281,7 +281,7 @@
             - Verify that the chip responds with `0x00`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -301,7 +301,7 @@
               - The data on the CIPO line must be `0xff`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -322,7 +322,7 @@
               - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -350,7 +350,7 @@
             program on flash.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -373,7 +373,7 @@
               - The data on the CIPO line must be `0xff`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -394,7 +394,7 @@
               - The data on the CIPO line must be `0xff`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -416,7 +416,7 @@
             program on flash that verifies that the rest of the flash is empty after bootstrap.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -440,7 +440,7 @@
             program on flash.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -463,7 +463,7 @@
               - The data on the CIPO line must be `0xff`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -480,7 +480,7 @@
                 - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -494,7 +494,7 @@
             - Repeat for all life cycle states: TEST, DEV, PROD, PROD_END, and RMA.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -515,7 +515,7 @@
             |            1            |             1           |   a    |
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -561,7 +561,7 @@
             |   a  | `security_version = 0`            | `0142500d`                      |
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -583,7 +583,7 @@
             |  Good  |  Good  |   a    |
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -609,7 +609,7 @@
             |    1   |    1   |   a    |
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -634,7 +634,7 @@
 
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -653,7 +653,7 @@
             See `rom_e2e_boot_policy_valid`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -666,7 +666,7 @@
             - Verify that boot fails with `BFV:kErrorSigverifyBadKey`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -687,7 +687,7 @@
             |   RMA    | Test, Prod        |
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -709,7 +709,7 @@
             |   RMA    | Test, Prod        |
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -731,7 +731,7 @@
             | `0`                                | Failure |
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -760,7 +760,7 @@
               - Corrupt usage constraints data, e.g. wrong unselected word value.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -783,7 +783,7 @@
             |         Invalid     |   Virtual  |     B     |  Yes  |
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -799,7 +799,7 @@
               - Verify that ROM fails to boot with `BFV:0142500d`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -812,7 +812,7 @@
             - Verify that ROM cannot be debugged in PROD and PROD_END.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -834,7 +834,7 @@
             for detils.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -857,7 +857,7 @@
             - Verify that ROM fails to boot with `BFV:kErrorBootPolicyRollback`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -879,7 +879,7 @@
               security version.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -897,7 +897,7 @@
             - Verify that execution breaks at the asm handler.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -915,7 +915,7 @@
             - Verify that watchdog expires and execution breaks at the asm handler.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -936,7 +936,7 @@
             - Verify that chip resets with `BFV:kErrorInterrupt`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -964,7 +964,7 @@
                   functionality.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -982,7 +982,7 @@
             - Verify that all previously written sections are different.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
 
     }
@@ -1001,7 +1001,7 @@
             - Verify that all previously written sections are intact.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1014,7 +1014,7 @@
             - Bits 0-5 of the `cpuctrl` CSR: `CREATOR_SW_CFG_CPUCTRL`
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1026,7 +1026,7 @@
               PROD_END.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1040,7 +1040,7 @@
               `kWatchdogMinThreshold`, disabled otherwise.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1053,7 +1053,7 @@
               the OTP value.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1071,7 +1071,7 @@
             - Verify that flash_ctrl is initialized.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1089,7 +1089,7 @@
               - max creator key version equals the `max_key_version` field of the manifest,
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1104,7 +1104,7 @@
               `sec_mmio_check_counters()`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
 
@@ -1121,7 +1121,7 @@
             reused on the silicon.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      milestone: V2
+      stage: V2
       tests: []
     }
   ]

--- a/sw/device/silicon_creator/rom/docs/_index.md
+++ b/sw/device/silicon_creator/rom/docs/_index.md
@@ -48,7 +48,7 @@ tested separately, rather than having to test the whole boot system at once.
 
 The module descriptions below also include descriptions of: the dependencies
 that are required for that module to be implemented fully; the functionality
-expected at various milestones of the ROM's development; and, optionally,
+expected at various stages of the ROM's development; and, optionally,
 pseudo-code for any subroutines that make up their implementation.
 
 ## Boot Policy

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -310,8 +310,8 @@ class SimCfg(FlowCfg):
         if self.testplan != "":
             self.testplan = Testplan(self.testplan,
                                      repo_top=Path(self.proj_root))
-            # Extract tests in each milestone and add them as regression target.
-            self.regressions.extend(self.testplan.get_milestone_regressions())
+            # Extract tests in each stage and add them as regression target.
+            self.regressions.extend(self.testplan.get_stage_regressions())
         else:
             # Create a dummy testplan with no entries.
             self.testplan = Testplan(None, name=self.name)

--- a/util/dvsim/doc/testplanner.md
+++ b/util/dvsim/doc/testplanner.md
@@ -28,10 +28,10 @@ The following attributes are used to define each testpoint, at minimum:
     The recommended naming convention to follow is `<main_feature>_<sub_feature>_<sub_sub_feature_or_type>_...`.
     This is no need to suffix (or prefix) the testpoint name with "test".
 
-* **milestone: targeted verification milestone**
+* **stage: targeted verification stage**
 
     This is either `V1`, `V2`, `V2S` or `V3`.
-    It helps us track whether all of the testing requirements of a milestone have been achieved.
+    It helps us track whether all of the testing requirements of a verification stage have been achieved.
 
 * **desc: testpoint description**
 
@@ -45,7 +45,7 @@ The following attributes are used to define each testpoint, at minimum:
     The testplan is written in the initial work stage of the verification [life-cycle]({{< relref "doc/project/development_stages#hardware-verification-stages" >}}).
     Later, when the DV engineer writes the tests, they may not map one-to-one to a testpoint - it may be possible that a written test satisfactorilly addresses multiple testpoints; OR it may also be possible that a testpoint needs to be split into multiple smaller tests.
     To cater to these needs, we provide the ability to set a list of written tests for each testpoint.
-    It is used to not only indicate the current progress so far into each milestone, but also map the simulation results to the testpoints to generate the final report table.
+    It is used to not only indicate the current progress so far into each verification stage, but also map the simulation results to the testpoints to generate the final report table.
     This list is initially empty - it is gradually updated as tests are written.
     Setting this list to `["N/A"]` will prevent this testpoint entry from being mapped to the simulation results.
     The testpoint will however, still show up in the generated testplan table.
@@ -80,7 +80,7 @@ Here's an example:
   testpoints: [
     {
       name: feature1
-      milestone: V1
+      stage: V1
       desc: '''**Goal**: High level goal of this test.
 
             **Stimulus**: Describe the stimulus procedure.
@@ -90,7 +90,7 @@ Here's an example:
     }
     {
       name: feature2
-      milestone: V2
+      stage: V2
       desc: '''**Goal**: High level goal of this test.
 
             **Stimulus**: Describe the stimulus procedure.
@@ -296,4 +296,4 @@ from dvsim.Testplan import Testplan
 * Allow DUT and its imported testplans to have the same testpoint name as long as they are in separate files.
   * The list of written tests are appended from both files.
   * The descriptions are merged - its upto the user to ensure that it is still meaningful after the merge.
-  * Conflicting milestones are flagged as an error.
+  * Conflicting verification stages are flagged as an error.

--- a/util/dvsim/examples/testplanner/common_testplan.hjson
+++ b/util/dvsim/examples/testplanner/common_testplan.hjson
@@ -7,7 +7,7 @@
       name: csr
       desc: '''Standard CSR suite of tests run from all valid interfaces to prove SW
             accessibility.'''
-      milestone: V1
+      stage: V1
       // {name} and {intf} are wildcards in tests
       // importer needs to provide substitutions for these as string or a list
       // if list, then substitution occurs on all values in the list
@@ -19,4 +19,3 @@
     }
   ]
 }
-

--- a/util/dvsim/examples/testplanner/foo_testplan.hjson
+++ b/util/dvsim/examples/testplanner/foo_testplan.hjson
@@ -19,15 +19,15 @@
             the description on multiple lines like this (with 3 single-inverted commas.
             Note that the subsequent lines are indented right below where the inverted
             commas start.'''
-      // milestone for which this test is targeted for - V1, V2 or V3
-      milestone: V1
+      // verification stage for which this test is targeted for - V1, V2 or V3
+      stage: V1
       // tests of actual written tests that maps to this entry
       tests: ["{name}_smoke"]
     }
     {
       name: feature1
       desc: "A single line description with single double-inverted commas."
-      milestone: V2
+      stage: V2
       // testplan entry with no tests added
       tests: ["{name}_{intf}_feature1"]
     }
@@ -48,7 +48,7 @@
 
             Start a new paragraph with two newlines.
             '''
-      milestone: V2
+      stage: V2
       // testplan entry with multiple tests added
       tests: ["foo_feature2_type1",
               "foo_feature2_type2",

--- a/util/reggen/sec_cm_testplan.hjson.tpl
+++ b/util/reggen/sec_cm_testplan.hjson.tpl
@@ -32,7 +32,7 @@ def get_sec_cm_testpoint_name(cm):
     {
       name: ${get_sec_cm_testpoint_name(cm)}
       desc: "Verify the countermeasure(s) ${str(cm)}."
-      milestone: V2S
+      stage: V2S
       tests: []
     }
 % endfor

--- a/util/uvmdvgen/doc/index.md
+++ b/util/uvmdvgen/doc/index.md
@@ -169,7 +169,7 @@ Please see description for more details.
 The tool generates not only the UVM environment, but also the base test,
 testbench, top level fusesoc core file with sim target, Makefile that already
 includes the smoke and CSR test suite and more. With just a few tweaks, this
-enables the user to reach the V1 milestone much quicker.  Let's take `i2c_host`
+enables the user to reach the V1 stage much quicker.  Let's take `i2c_host`
 as the argument passed for the name of the IP. The following is the list of
 files generated with a brief description of their contents:
 

--- a/util/uvmdvgen/testplan.hjson.tpl
+++ b/util/uvmdvgen/testplan.hjson.tpl
@@ -20,13 +20,13 @@
             **Checks**:
             - TBD
             '''
-      milestone: V1
+      stage: V1
       tests: ["${name}_smoke"]
     }
     {
       name: feature1
       desc: '''Add more test entries here like above.'''
-      milestone: V1
+      stage: V1
       tests: []
     }
   ]


### PR DESCRIPTION
This switches the "milestone" terminology used throughout test plannig to "(verification) stage". 

The change may warrant some more discussion in the Silicon WG, so please consider this as a proposal. However, I think it would be good to do this in order to disambiguate between the project milestones (M1/2 etc) and IP development / verification stages.

Also note that some re-vendoring back into and from the ibex repo needs to be done to get this fully aligned.