### PR TITLE
[mask_rom, status] Make `rom_error_t` compatible with `status_t`

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -284,6 +284,7 @@ cc_library(
         ":macros",
         "//sw/device/lib/base/internal:status",
         "//sw/device/lib/dif:base",
+        "//sw/device/silicon_creator/lib:error",
     ],
 )
 

--- a/sw/device/lib/base/status.h
+++ b/sw/device/lib/base/status.h
@@ -13,6 +13,7 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/silicon_creator/lib/error.h"
 
 #define USING_INTERNAL_STATUS
 #include "sw/device/lib/base/internal/status.h"
@@ -63,26 +64,30 @@ typedef struct status {
  * conversion.  Once a more thorough refactoring of the DIFs is done, this
  * can be eliminated.
  *
- * @param expr_ Either a `status_t` or `dif_result_t`.
+ * @param expr_ Either a `status_t`, `rom_error_t` or `dif_result_t`.
  * @return The `status_t` representation of the input.
  */
-#define INTO_STATUS(expr_)                                                     \
-  ({                                                                           \
-    typeof(expr_) ex_ = (expr_);                                               \
-    static_assert(__builtin_types_compatible_p(typeof(ex_), status_t) ||       \
-                      __builtin_types_compatible_p(typeof(ex_), dif_result_t), \
-                  "Expressions passed to INTO_STATUS() must be of type "       \
-                  "`status_t`, or `dif_result_t`");                            \
-    status_t status_;                                                          \
-    if (__builtin_types_compatible_p(typeof(ex_), status_t)) {                 \
-      memcpy(&status_, &ex_, sizeof(status_));                                 \
-    } else if (__builtin_types_compatible_p(typeof(ex_), dif_result_t)) {      \
-      absl_status_t code;                                                      \
-      memcpy(&code, &ex_, sizeof(code));                                       \
-      status_ = status_create(code, kStatusModuleId, __FILE__,                 \
-                              code == kOk ? 0 : __LINE__);                     \
-    }                                                                          \
-    status_;                                                                   \
+#define INTO_STATUS(expr_)                                                \
+  ({                                                                      \
+    typeof(expr_) ex_ = (expr_);                                          \
+    static_assert(                                                        \
+        __builtin_types_compatible_p(typeof(ex_), status_t) ||            \
+            __builtin_types_compatible_p(typeof(ex_), rom_error_t) ||     \
+            __builtin_types_compatible_p(typeof(ex_), dif_result_t),      \
+        "Expressions passed to INTO_STATUS() must be of type "            \
+        "`status_t`, `rom_error_t` or `dif_result_t`");                   \
+    status_t status_;                                                     \
+    if (__builtin_types_compatible_p(typeof(ex_), status_t)) {            \
+      memcpy(&status_, &ex_, sizeof(status_));                            \
+    } else if (__builtin_types_compatible_p(typeof(ex_), rom_error_t)) {  \
+      memcpy(&status_, &ex_, sizeof(status_));                            \
+    } else if (__builtin_types_compatible_p(typeof(ex_), dif_result_t)) { \
+      absl_status_t code;                                                 \
+      memcpy(&code, &ex_, sizeof(code));                                  \
+      status_ = status_create(code, kStatusModuleId, __FILE__,            \
+                              code == kOk ? 0 : __LINE__);                \
+    }                                                                     \
+    status_;                                                              \
   })
 
 /**

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -22,50 +22,50 @@ extern "C" {
  * Choose a two-letter identifier for each module and encode the module
  * identifier the concatenated ASCII representation of those letters.
  */
-#define MODULE_CODE(ch0_, ch1_) ((ch0_) << 8 | (ch1_))
 enum module_ {
   // clang-format off
   kModuleUnknown = 0,
-  kModuleAlertHandler = MODULE_CODE('A', 'H'),
-  kModuleUart =         MODULE_CODE('U', 'A'),
-  kModuleSigverify =    MODULE_CODE('S', 'V'),
-  kModuleKeymgr =       MODULE_CODE('K', 'M'),
-  kModuleManifest =     MODULE_CODE('M', 'A'),
-  kModuleRom =          MODULE_CODE('M', 'R'),
-  kModuleInterrupt =    MODULE_CODE('I', 'R'),
-  kModuleEpmp =         MODULE_CODE('E', 'P'),
-  kModuleOtp =          MODULE_CODE('O', 'P'),
-  kModuleOtbn =         MODULE_CODE('B', 'N'),
-  kModuleFlashCtrl =    MODULE_CODE('F', 'C'),
-  kModuleSecMmio =      MODULE_CODE('I', 'O'),
-  kModuleBootPolicy =   MODULE_CODE('B', 'P'),
-  kModuleRetSram =      MODULE_CODE('R', 'S'),
-  kModuleBootstrap =    MODULE_CODE('B', 'S'),
-  kModuleLog =          MODULE_CODE('L', 'G'),
-  kModuleBootData =     MODULE_CODE('B', 'D'),
-  kModuleShutdown =     MODULE_CODE('S', 'D'),
-  kModuleSpiDevice =    MODULE_CODE('S', 'P'),
-  kModuleAst =          MODULE_CODE('A', 'S'),
+  kModuleAlertHandler = MAKE_MODULE_ID('A', 'H', '_'),
+  kModuleUart =         MAKE_MODULE_ID('U', 'A', '_'),
+  kModuleSigverify =    MAKE_MODULE_ID('S', 'V', '_'),
+  kModuleKeymgr =       MAKE_MODULE_ID('K', 'M', '_'),
+  kModuleManifest =     MAKE_MODULE_ID('M', 'A', '_'),
+  kModuleRom =          MAKE_MODULE_ID('M', 'R', '_'),
+  kModuleInterrupt =    MAKE_MODULE_ID('I', 'R', '_'),
+  kModuleEpmp =         MAKE_MODULE_ID('E', 'P', '_'),
+  kModuleOtp =          MAKE_MODULE_ID('O', 'P', '_'),
+  kModuleOtbn =         MAKE_MODULE_ID('B', 'N', '_'),
+  kModuleFlashCtrl =    MAKE_MODULE_ID('F', 'C', '_'),
+  kModuleSecMmio =      MAKE_MODULE_ID('I', 'O', '_'),
+  kModuleBootPolicy =   MAKE_MODULE_ID('B', 'P', '_'),
+  kModuleRetSram =      MAKE_MODULE_ID('R', 'S', '_'),
+  kModuleBootstrap =    MAKE_MODULE_ID('B', 'S', '_'),
+  kModuleLog =          MAKE_MODULE_ID('L', 'G', '_'),
+  kModuleBootData =     MAKE_MODULE_ID('B', 'D', '_'),
+  kModuleShutdown =     MAKE_MODULE_ID('S', 'D', '_'),
+  kModuleSpiDevice =    MAKE_MODULE_ID('S', 'P', '_'),
+  kModuleAst =          MAKE_MODULE_ID('A', 'S', '_'),
   // clang-format on
 };
 
 /**
  * Field definitions for the different fields of the error word.
  */
-#define ROM_ERROR_FIELD_ERROR ((bitfield_field32_t){.mask = 0xFF, .index = 24})
-#define ROM_ERROR_FIELD_MODULE \
-  ((bitfield_field32_t){.mask = 0xFFFF, .index = 8})
-#define ROM_ERROR_FIELD_STATUS ((bitfield_field32_t){.mask = 0xFF, .index = 0})
+#define ROM_ERROR_FIELD_ERROR STATUS_FIELD_ARG
+#define ROM_ERROR_FIELD_MODULE STATUS_FIELD_MODULE_ID
+#define ROM_ERROR_FIELD_STATUS STATUS_FIELD_CODE
 
 /**
- * Helper macro for building up error codes.
+ * Helper macro for building up error codes.  This macro builds up error codes
+ * which are bit-compatible with `status_t`.
+ *
  * @param status_ An appropriate general status code from absl_staus.h.
  * @param module_ The module identifier which produces this error.
  * @param error_ The unique error id in that module.  Error ids must not
  *               repeat within a module.
  */
 #define ERROR_(error_, module_, status_) \
-  ((error_ << 24) | (module_ << 8) | (status_))
+  (0x80000000 | module_ | (error_ << 5) | status_)
 
 // clang-format off
 // Use an X-macro to facilitate writing unit tests.

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -88,12 +88,12 @@ static inline rom_error_t rom_irq_error(void) {
   // indicates whether the cause is an exception (0) or external interrupt (1),
   // and the 5 least significant bits indicate which exception/interrupt.
   //
-  // Preserve the MSB and shift the 7 LSBs into the upper byte.
-  // (we preserve 7 instead of 5 because the verilog hardcodes the unused bits
-  // as zero and those would be the next bits used should the number of
-  // interrupt causes increase).
-  mcause = (mcause & 0x80000000) | ((mcause & 0x7f) << 24);
-  return kErrorInterrupt + mcause;
+  // Preserve the MSB and shift it down to the lowest byte.  Preserve the
+  // the 7 LSBs into the lower byte. (we preserve 7 instead of 5 because the
+  // verilog hardcodes the unused bits as zero and those would be the next bits
+  // used should the number of interrupt causes increase).
+  mcause = ((mcause & 0x80000000) >> 24) | (mcause & 0x7f);
+  return bitfield_field32_write(kErrorInterrupt, ROM_ERROR_FIELD_ERROR, mcause);
 }
 
 /**


### PR DESCRIPTION
The original mask_rom error scheme was based on specializing codes from
`absl_status_t`.  This change shuffles the bit-arrangement of
`rom_error_t` so that it is bit-compatible with `status_t`.

This change will allow further refactors, such as making the mask_rom's
`EXECUTE_TEST` macro useful across the codebase and adding LOG_ or
printf statements in tests that can display a `rom_error_t` in
textual form.

Signed-off-by: Chris Frantz <cfrantz@google.com>

Note: this change builds on #14043.