### PR TITLE
[chip dv, dvsim] Fix chip level coverage collection

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -169,6 +169,8 @@
                      "-grade index testfile",
                      // Use simple ratio of total covered bins over total bins across cps & crs,
                      "-group ratio",
+                     // Follow LRM naming conventions for array bins.
+                     "-group lrm_bin_name",
                      // Compute overall coverage for per-instance covergroups individually rather
                      // than cumulatively.
                      "-group instcov_for_score",
@@ -279,10 +281,15 @@
                    "-cm_line contassign",
                    // Dump toggle coverage on mdas, array of structs and on ports only
                    "-cm_tgl mda+structarr+portsonly",
+                   // Report condition coverage within tasks, functions and for loops.
+                   "-cm_cond for+tf",
                    // Ignore initial blocks for coverage
                    "-cm_report noinitial",
-                   // Filter unreachable/statically constant blocks
-                   "-cm_noconst",
+                   // Filter unreachable/statically constant blocks. seqnoconst does a more
+                   // sophisticated analysis including NBA / assignment with delays.
+                   "-cm_seqnoconst",
+                   // Creates a constfile.txt indicating a list of detected constants.
+                   "-diag noconst"
                    // Don't count coverage that's coming from zero-time glitches
                    "-cm_glitch 0",
                    // Ignore warnings about not applying cm_glitch to path and FSM

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -69,11 +69,11 @@
     // `hw/dv/tools/dvsim/common_sim_cfg.hjson` for the default value.
     {
       name: cover_reg_top_vcs_cov_cfg_file
-      value: "-cm_hier {proj_root}/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg"
+      value: "-cm_hier {proj_root}/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg+{proj_root}/hw/top_earlgrey/dv/autogen/xbar_tgl_excl.cfg"
     }
     {
       name: xbar_build_mode_vcs_cov_cfg_file
-      value: "-cm_hier {proj_root}/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg"
+      value: "-cm_hier {proj_root}/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg+{proj_root}/hw/top_earlgrey/dv/autogen/xbar_tgl_excl.cfg"
     }
     // Used by the UNR flow.
     {

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -605,11 +605,15 @@ class CovMerge(Deploy):
 
     def __init__(self, run_items, sim_cfg):
         # Construct the cov_db_dirs right away from the run_items. This is a
-        # special variable used in the HJson.
+        # special variable used in the HJson. The coverage associated with
+        # the primary build mode needs to be first in the list.
         self.cov_db_dirs = []
         for run in run_items:
             if run.cov_db_dir not in self.cov_db_dirs:
-                self.cov_db_dirs.append(run.cov_db_dir)
+                if sim_cfg.primary_build_mode == run.build_mode:
+                    self.cov_db_dirs.insert(0, run.cov_db_dir)
+                else:
+                    self.cov_db_dirs.append(run.cov_db_dir)
 
         # Early lookup the cov_merge_db_dir, which is a mandatory misc
         # attribute anyway. We need it to compute additional cov db dirs.


### PR DESCRIPTION
The coverage collected at the chip level is incorrect. This is filed in https://github.com/lowRISC/opentitan/issues/13344. 

This PR fixes this issue in 2 places. The first commit adds new switches to VCS coverage collection system (very mildly related to this change). The second commit fixes chip level coverage hierarchy specification. The third commit enhances dvsim to designate a `primary_build_mode`. The generated coverage database associated with the primary build mode is supposed to be supplied first to VCS's URG tool which merges the coverage across build configurations (which was the real issue). Please see individual commit descriptions for more details. 