### PR TITLE
DONOTMERGE: assertion failure during double bit error test

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -555,3 +555,9 @@
 `ifndef DV_MAX2
   `define DV_MAX2(a, b) ((a) > (b) ? (a) : (b))
 `endif
+
+`ifndef JDBG
+  `define JDBG(x) \
+  $write($sformatf("%t:JDBG:",$time));\
+  $display($sformatf x);
+`endif

--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -255,7 +255,7 @@
             Check behaviour of Interrupt Enable and Status Registers.
             '''
       milestone: V2
-      tests: []
+      tests: ["flash_ctrl_intr_rd", "flash_ctrl_intr_wr"]
     }
     {
       name: invalid_op

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -70,6 +70,8 @@ filesets:
       - seq_lib/flash_ctrl_derr_detect_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_hw_rma_reset_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_otp_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_intr_rd_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_intr_wr_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -155,8 +155,14 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   int       otf_wr_pct = 1;
   int       otf_rd_pct = 1;
 
-  `uvm_object_utils(flash_ctrl_env_cfg)
+  // interrupt mode
+  bit       intr_mode = 0;
 
+  // interrupt mode buffer credit
+  int       rd_crd = 16;
+  int       wr_crd = 4;
+
+  `uvm_object_utils(flash_ctrl_env_cfg)
   `uvm_object_new
 
   string flash_ral_name = "flash_ctrl_eflash_reg_block";

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -132,6 +132,18 @@ package flash_ctrl_env_pkg;
   parameter uint FlashUpdateErr   = 7;
 
   // types
+  typedef enum {
+    OTFCfgTrue,
+    OTFCfgFalse,
+    OTFCfgRand
+  } otf_cfg_mode_e;
+
+  typedef enum {
+    ReadCheckNorm = 0,
+    ReadCheckExplicit = 1,
+    ReadCheckErased = 2
+  } read_check_e;
+
   typedef enum int {
     FlashCtrlIntrProgEmpty = 0,
     FlashCtrlIntrProgLvl   = 1,

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -276,10 +276,10 @@ class flash_ctrl_scoreboard #(
             "intr_test": begin
             end
 
-            "op_status", "status", "erase_suspend", "err_code",
+            "op_status", "status", "erase_suspend",
+            "curr_fifo_lvl",  "err_code",
             "ecc_single_err_cnt", "ecc_single_err_addr_0",
             "ecc_single_err_addr_1": begin
-              // TODO: FIXME
               do_read_check = 1'b0;
             end
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
@@ -16,7 +16,6 @@ class flash_ctrl_derr_detect_vseq extends flash_ctrl_otf_base_vseq;
     cfg.scb_h.do_alert_check = 1;
     cfg.m_tl_agent_cfg.check_tl_errs = 0;
     cfg.m_tl_agent_cfgs["flash_ctrl_eflash_reg_block"].check_tl_errs = 0;
-
     cfg.clk_rst_vif.wait_clks(5);
 
     fork

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -223,9 +223,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
     // Iteration Loop
     num_iter = 200;
-    for (int iter = 0; iter < num_iter; iter++)
-    begin
-
+    for (int iter = 0; iter < num_iter; iter++) begin
       `uvm_info(`gfn, $sformatf("Iteration : %0d : %0d", iter+1, num_iter), UVM_LOW)
 
       // Randomize the Members of the Class
@@ -246,15 +244,19 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
       end
 
       // Model Expected Response (Error Expected / Pass)
-      cfg.scb_h.exp_alert["recov_err"] = exp_alert;
-      cfg.scb_h.alert_chk_max_delay["recov_err"] = 1000; // cycles
+      if (exp_alert) set_otf_exp_alert("recov_err");
+//      cfg.scb_h.exp_alert["recov_err"] = exp_alert;
+//      if (exp_alert) begin
+//        cfg.scb_h.alert_chk_max_delay["recov_err"] = 2000; // cycles
+//      end else begin
+//      end
 
       // Do FLASH Operation
-      unique case (flash_op.op)
+      case (flash_op.op)
 
         // ERASE
         flash_ctrl_pkg::FlashOpErase : begin
-          `uvm_info(`gfn, "Flash : ERASE", UVM_LOW)
+          `uvm_info(`gfn, $sformatf("Flash : ERASE exp_alert:%0d", exp_alert), UVM_LOW)
           flash_ctrl_start_op(flash_op);
           wait_flash_op_done(.clear_op_status(0), .timeout_ns(cfg.seq_cfg.erase_timeout_ns));
           if (exp_alert == MP_PASS)
@@ -265,20 +267,23 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
         // PROGRAM
         flash_ctrl_pkg::FlashOpProgram : begin
-          `uvm_info(`gfn, "Flash : PROGRAM", UVM_LOW)
-           exp_data = cfg.calculate_expected_data(flash_op, flash_op_data);
-           flash_ctrl_start_op(flash_op);
-           flash_ctrl_write(flash_op_data, poll_fifo_status);
-           wait_flash_op_done(.clear_op_status(0), .timeout_ns(cfg.seq_cfg.prog_timeout_ns));
-           if (exp_alert == MP_PASS)
-             cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);
-           else
-             prog_err_cnt++;
+//          if (exp_alert) begin
+//            cfg.scb_h.exp_alert_contd["recov_err"] = 31;
+//          end
+          `uvm_info(`gfn, $sformatf("Flash : PROGRAM exp_alert:%0d", exp_alert), UVM_LOW)
+          exp_data = cfg.calculate_expected_data(flash_op, flash_op_data);
+          flash_ctrl_start_op(flash_op);
+          flash_ctrl_write(flash_op_data, poll_fifo_status);
+          wait_flash_op_done(.clear_op_status(0), .timeout_ns(cfg.seq_cfg.prog_timeout_ns));
+          if (exp_alert == MP_PASS)
+            cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);
+          else
+            prog_err_cnt++;
         end
 
         // READ
         flash_ctrl_pkg::FlashOpRead : begin
-          `uvm_info(`gfn, "Flash : READ", UVM_LOW)
+          `uvm_info(`gfn, $sformatf("Flash : READ exp_alert:%0d", exp_alert), UVM_LOW)
           flash_op_data.delete();
           flash_ctrl_start_op(flash_op);
           flash_ctrl_read(flash_op.num_words, flash_op_data, poll_fifo_status);
@@ -298,8 +303,9 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
       // Check Alert Status
       check_exp_alert_status(exp_alert, "mp_err", flash_op, flash_op_data);
-      cfg.scb_h.exp_alert["recov_err"] = 0;
-
+//      `JDBG(("exp_alert: checked alert"))
+//      cfg.scb_h.exp_alert["recov_err"] = 0;
+//      cfg.scb_h.exp_alert_contd["recov_err"] = 0;
     end
 
     // Final Statistics for Information

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
@@ -4,20 +4,29 @@
 
 // Run rma request event with random resets
 class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
-  typedef enum {DVStRmaPageSel     = 0,
-                DVStRmaErase       = 1,
-                DVStRmaEraseWait   = 2,
-                DVStRmaWordSel     = 3,
-                DVStRmaProgram     = 4,
+  typedef enum {DVStRmaPageSel     = 0,  // 0.120us
+                DVStRmaErase       = 1,  // 0.140us
+                DVStRmaEraseWait   = 2,  // 6.065us
+                DVStRmaWordSel     = 3,  // 6.088us
+                DVStRmaProgram     = 4, 
                 DVStRmaProgramWait = 5,
                 DVStRmaRdVerify    = 6} reset_state_index_e;
   `uvm_object_utils(flash_ctrl_hw_rma_reset_vseq)
   `uvm_object_new
 
+  task pre_start();
+    cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en     = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en     = lc_ctrl_pkg::On;
+    cfg.seq_cfg.en_init_keys_seeds = 1;
+    super.pre_start();
+  endtask
+    
   task body();
     logic [RmaSeedWidth-1:0] rma_seed;
-    int                      state_wait_timeout_ns = 50000; // 50 us
-
+    int                      state_wait_timeout_ns = 500_000; // 500 us
+    bit                      rma_done = 0;
     // INITIALIZE FLASH REGIONS
     init_data_part();
     init_info_part();
@@ -28,12 +37,13 @@ class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
           `uvm_info("Test", "RMA REQUEST", UVM_LOW)
           rma_seed = $urandom;  // Random RMA Seed
           send_rma_req(rma_seed);
+          rma_done = 1;
         end
         begin
-          reset_state_index_e reset_state_index = $urandom_range(DVStRmaPageSel, DVStRmaRdVerify);
+          reset_state_index_e reset_state_index = $urandom_range(DVStRmaPageSel, DVStRmaWordSel);
           // Assert reset during RMA state transition
-          `uvm_info("Test", $sformatf("Reset index: %0d", reset_state_index), UVM_LOW)
-          `DV_SPINWAIT(wait(cfg.flash_ctrl_dv_vif.rma_state == reset_state_index);,
+          `uvm_info("Test", $sformatf("Reset index: %s", reset_state_index.name), UVM_LOW)
+          `DV_SPINWAIT(wait(cfg.flash_ctrl_dv_vif.rma_state == dv2rma_st(reset_state_index));,
                        $sformatf("Timed out waiting for rma_state: %s", reset_state_index.name),
                        state_wait_timeout_ns)
           // Give more cycles for long stages
@@ -52,18 +62,36 @@ class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
     end join // fork begin
 
     `uvm_info("Test", "RMA END", UVM_LOW)
-    cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+    `DV_CHECK_NE(rma_done, 1, "rma_done shouldn't be 1")
 
-     // INITIALIZE FLASH REGIONS
-     init_data_part();
-     init_info_part();
-     `uvm_info("Test", "RMA REQUEST", UVM_LOW)
-     rma_seed = $urandom;  // Random RMA Seed
-     send_rma_req(rma_seed);
-     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+    if (rma_done == 0) begin
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
-     // CHECK HOST SOFTWARE HAS NO ACCESS TO THE FLASH
-     // Attempt to Read from FLASH Controller
-     do_flash_ctrl_access_check();
+      // INITIALIZE FLASH REGIONS
+      init_data_part();
+      init_info_part();
+      `uvm_info("Test", "RMA REQUEST", UVM_LOW)
+      rma_seed = $urandom;  // Random RMA Seed
+      send_rma_req(rma_seed);
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+      // CHECK HOST SOFTWARE HAS NO ACCESS TO THE FLASH
+      // Attempt to Read from FLASH Controller
+      do_flash_ctrl_access_check();
+    end
   endtask
+   function rma_state_e dv2rma_st(reset_state_index_e idx);
+      case (idx)
+	DVStRmaPageSel: return StRmaPageSel;
+	DVStRmaErase: return StRmaErase;
+        DVStRmaEraseWait: return StRmaEraseWait;
+        DVStRmaWordSel: return StRmaWordSel;
+	DVStRmaProgram: return StRmaProgram;
+	DVStRmaProgramWait: return StRmaProgramWait;
+	DVStRmaRdVerify: return StRmaRdVerify;
+	default: begin
+	   `uvm_error("dv2rma_st", $sformatf("unknown index:%0d", idx))
+	end
+      endcase
+   endfunction // dv2rma_st   
 endclass // flash_ctrl_hw_rma_reset_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -107,19 +107,19 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
       // ERASE
 
       `uvm_info(`gfn, "ERASE", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpErase, READ_CHECK_NORM);
+      do_flash_ops(flash_ctrl_pkg::FlashOpErase, ReadCheckNorm);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
       // PROGRAM
 
       `uvm_info(`gfn, "PROGRAM", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpProgram, READ_CHECK_NORM);
+      do_flash_ops(flash_ctrl_pkg::FlashOpProgram, ReadCheckNorm);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
       // READ (Compare Expected Data with Data Read : EXPECT DATA MATCH)
 
       `uvm_info(`gfn, "READ", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpRead, READ_CHECK_NORM);
+      do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckNorm);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
       // SEND RMA REQUEST (Erases the Flash and Writes Random Data To All Partitions)
@@ -155,7 +155,7 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
 
       `uvm_info(`gfn, "READ", UVM_LOW)
 
-      do_flash_ops(flash_ctrl_pkg::FlashOpRead, READ_CHECK_EXPLICIT);
+      do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckErased);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
     end
@@ -221,7 +221,7 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
   endtask : init_info_part
 
   // Task to perform randomly ordered selected Flash Operations on thr Flash
-  virtual task do_flash_ops (input flash_op_e op, input bit cmp = READ_CHECK_NORM);
+  virtual task do_flash_ops (input flash_op_e op, input bit cmp = ReadCheckNorm);
 
     uint order_q [$] = '{0, 1, 2, 3, 4};  // Operation Order Queue
     order_q.shuffle();  // Shuffle Queue Items
@@ -248,7 +248,7 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
     flash_op_t flash_op;
     data_q_t   data;
     bit        result;
-
+    int        read_to_value_ns = 100000; // 100us
     `uvm_info(`gfn, "Attempting to READ from Flash", UVM_INFO)
 
     // Attempt to Read from FLASH, No Access Expected after RMA
@@ -288,7 +288,7 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
     flash_ctrl_start_op(flash_op);
 
     // Timeout Expected
-    wait_flash_op_done_expect_timeout(.timeout_ns(cfg.seq_cfg.read_timeout_ns), .result(result));
+    wait_flash_op_done_expect_timeout(.timeout_ns(read_to_value_ns), .result(result));
 
     // Expect a Timeout
     if (result == 1)

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_rd_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_rd_vseq.sv
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Send read only traffic with interrup mode.
+// No protection is applied.
+class flash_ctrl_intr_rd_vseq extends flash_ctrl_otf_base_vseq;
+  `uvm_object_utils(flash_ctrl_intr_rd_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    flash_op_t ctrl;
+    int num, bank;
+
+    cfg.intr_mode = 1;
+    flash_program_data_c.constraint_mode(0);
+    cfg.clk_rst_vif.wait_clks(5);
+    flash_ctrl_fifo_levels_cfg_intr(5'd1, 5'd2);
+    flash_ctrl_intr_enable(6'h3f);
+    fork
+      begin
+        for (int i = 0; i < 1000; ++i) begin
+          fork
+            send_rand_host_rd();
+          join_none
+          #0;
+        end
+        csr_utils_pkg::wait_no_outstanding_access();
+      end
+      begin
+        repeat(100) begin
+          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
+          ctrl = rand_op;
+          if (ctrl.partition == FlashPartData) begin
+            num = $urandom_range(1, 32);
+          end else begin
+            num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
+          end
+          bank = rand_op.addr[OTFBankId];
+          read_flash(ctrl, bank, num);
+        end
+      end
+    join
+  endtask
+endclass // flash_ctrl_intr_rd_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_wr_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_wr_vseq.sv
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Send write only traffic
+class flash_ctrl_intr_wr_vseq extends flash_ctrl_otf_base_vseq;
+  `uvm_object_utils(flash_ctrl_intr_wr_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    flash_op_t ctrl;
+    int num, bank;
+
+    flash_program_data_c.constraint_mode(0);
+    cfg.intr_mode = 1;
+    flash_ctrl_fifo_levels_cfg_intr(5'd1, 5'd2);
+    flash_ctrl_intr_enable(6'h3f);
+
+    repeat(100) begin
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
+      ctrl = rand_op;
+      if (ctrl.partition == FlashPartData) begin
+        num = $urandom_range(1, 32);
+      end else begin
+        num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
+      end
+      bank = rand_op.addr[OTFBankId];
+      prog_flash(ctrl, bank, num);
+    end
+  endtask
+endclass // flash_ctrl_intr_wr_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -28,11 +28,24 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
 
   // Permission to access special partition
   rand bit [2:0] allow_spec_info_acc;
+  rand bit       all_entry_en;
+
+  // scramble and ecc config mode
+  rand otf_cfg_mode_e scr_ecc_cfg;
 
   rand flash_mp_region_cfg_t rand_regions[MpRegions];
+  rand flash_bank_mp_info_page_cfg_t rand_info[NumBanks][InfoTypes][$];
 
+  constraint all_ent_c {
+    solve all_entry_en before rand_regions, rand_info;
+    all_entry_en dist { 1 := 1, 0 := 4};
+  }
+  constraint scr_ecc_c {
+    scr_ecc_cfg dist { OTFCfgRand := 5, OTFCfgTrue := 4};
+  }
   constraint rand_regions_c {
     foreach (rand_regions[i]) {
+      if (all_entry_en) rand_regions[i].en == MuBi4True;
       rand_regions[i].start_page dist {
         0                       := 1,
         [1 : FlashNumPages - 2] :/ 8,
@@ -40,6 +53,19 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       };
       rand_regions[i].num_pages inside {[1 : FlashNumPages - rand_regions[i].start_page]};
       rand_regions[i].num_pages <= 32;
+      rand_regions[i].scramble_en dist { MuBi4True := 4, MuBi4False := 1};
+      rand_regions[i].ecc_en dist { MuBi4True := 4, MuBi4False := 1};
+    }
+  }
+  constraint rand_info_c {
+    foreach (rand_info[i, j]) {
+      rand_info[i][j].size() == InfoTypeSize[j];
+      foreach (rand_info[i][j][k]) {
+        if (all_entry_en) rand_info[i][j][k].en == MuBi4True;
+        rand_info[i][j][k].en dist { MuBi4True := 4, MuBi4False :=1};
+        rand_info[i][j][k].scramble_en dist { MuBi4True := 4, MuBi4False :=1};
+        rand_info[i][j][k].ecc_en dist { MuBi4True := 4, MuBi4False :=1};
+      }
     }
   }
   constraint ctrl_num_c {
@@ -86,7 +112,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     if (cfg.ecc_mode > FlashEccDisabled) begin
       foreach (cfg.tgt_pre[partition]) begin
         cfg.tgt_pre[partition].shuffle();
-        `uvm_info("reset_flash",
+        `uvm_info("cfg_summary",
                   $sformatf("prefix:%s:rd:%2b dr:%2b wr:%2b",
                             partition.name, cfg.tgt_pre[partition][TgtRd],
                             cfg.tgt_pre[partition][TgtDr], cfg.tgt_pre[partition][TgtWr]),
@@ -95,10 +121,12 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       flash_init = FlashMemInitEccMode;
     end else begin
       flash_init = FlashMemInitRandomize;
-    end
-    `uvm_info("reset_flash",
-              $sformatf("flash_init:%s ecc_mode %0d allow_spec_info_acc:%3b",
-                        flash_init.name, cfg.ecc_mode, allow_spec_info_acc), UVM_MEDIUM)
+    end // else: !if(cfg.ecc_mode > FlashEccDisabled)
+    init_p2r_map();
+    `uvm_info("cfg_summary",
+              $sformatf("flash_init:%s ecc_mode %0d allow_spec_info_acc:%3b scr_ecc_cfg:%s",
+                        flash_init.name, cfg.ecc_mode, allow_spec_info_acc, scr_ecc_cfg.name),
+              UVM_MEDIUM)
 
     configure_otf_mode();
     super.pre_start();
@@ -108,16 +136,26 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end
 
     // Need additional flash update after key init is done
-    if (cfg.ecc_mode > FlashEccDisabled) begin
-      flash_otf_region_cfg(.scr_en(MuBi4True), .ecc_en(MuBi4True));
-      flash_otf_mem_read_zone_init();
-      if (cfg.ecc_mode > FlashSerrTestMode) begin
-        cfg.scb_h.do_alert_check = 0;
+    case (cfg.ecc_mode)
+      FlashEccDisabled: begin
+        // In this mode, write and read are not separated.
+        // When write and read happen at the same address,
+        // unexpected ecc error can be created.
+        flash_otf_region_cfg();
       end
-    end else begin
-      flash_otf_region_cfg(.scr_en(MuBi4True));
+      FlashEccEnabled: begin
+        flash_otf_region_cfg(.scr_mode(scr_ecc_cfg), .ecc_mode(scr_ecc_cfg));
+        flash_otf_mem_read_zone_init();
+      end
+      default: begin
+        flash_otf_region_cfg(.scr_mode(scr_ecc_cfg), .ecc_mode(OTFCfgTrue));
+        flash_otf_mem_read_zone_init();
+      end
+    endcase // case (cfg.ecc_mode)
+    if (cfg.ecc_mode > FlashSerrTestMode) begin
+      cfg.scb_h.do_alert_check = 0;
     end
-    update_p2r_map(cfg.mp_regions);
+
     cfg.allow_spec_info_acc = allow_spec_info_acc;
     update_partition_access(cfg.allow_spec_info_acc);
     // Polling init wip is done
@@ -270,25 +308,31 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       flash_op.addr = flash_op.otf_addr;
       // Bank : bit[19]
       flash_op.addr[TL_AW-1:OTFBankId] = bank;
-      page = addr2page(flash_op.addr);
 
       if (flash_op.partition == FlashPartData) begin
+        page = addr2page(flash_op.addr);
         my_region = get_region(page);
-        drop = validate_flash_op(flash_op, my_region);
-        if (drop) begin
-          `uvm_info("prog_flash", $sformatf("op:%s is not allowed in the region:%p",
-                                            flash_op.op.name, my_region), UVM_MEDIUM)
-          set_otf_exp_alert("recov_err");
-        end
       end else begin
+        // for region, use per bank page number
+        page = addr2page(flash_op.otf_addr);
         my_region = get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
         drop = check_info_part(flash_op, "prog_flash");
       end
 
-      flash_ctrl_start_op(flash_op);
-      flash_ctrl_write(flash_program_data, poll_fifo_status);
-      wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
+      drop |= validate_flash_op(flash_op, my_region);
+      if (drop) begin
+        `uvm_info("prog_flash", $sformatf("op:%s is not allowed in this region %p",
+                                          flash_op.op.name, my_region), UVM_MEDIUM)
+        set_otf_exp_alert("recov_err");
+      end
 
+      if (cfg.intr_mode) begin
+        flash_ctrl_intr_write(flash_op, flash_program_data);
+      end else begin
+        flash_ctrl_start_op(flash_op);
+        flash_ctrl_write(flash_program_data, poll_fifo_status);
+        wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
+      end
       if (is_odd == 1) begin
         tmp_data = {32{1'b1}};
         flash_program_data.push_front(tmp_data);
@@ -304,8 +348,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         tmp_data = {32{1'b1}};
         flash_program_data.push_back(tmp_data);
       end
-      `uvm_info("prog_flash",$sformatf("addr:%x part:%s num:%0d wd:%0d  odd:%0d tail:%0d",
-                                       flash_op.otf_addr, flash_op.partition.name, num,
+      `uvm_info("prog_flash",$sformatf("bank:%0d addr:%x otf_addr:%x part:%s page:%0d num:%0d wd:%0d  odd:%0d tail:%0d",
+                                       bank, flash_op.addr, flash_op.otf_addr, flash_op.partition.name, page, num,
                                        wd, is_odd, tail), UVM_MEDIUM)
       if (drop) begin
         `uvm_info("prog_flash", "skip sb path due to err", UVM_MEDIUM)
@@ -400,45 +444,58 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       flash_op.addr = flash_op.otf_addr;
       flash_op.addr[TL_AW-1:OTFBankId] = bank;
       rd_entry.bank = bank;
-
-      `uvm_create_obj(flash_otf_item, exp_item)
-      page = addr2page(flash_op.addr);
+      is_odd = flash_op.addr[2];
+      size = (flash_op.num_words + is_odd) / 2;
+      tail = (flash_op.num_words + is_odd) % 2;
+      tmp_addr = flash_op.addr;
+      flash_op.addr[2:0] = 0;
+      for (int i = 0; i < size; i++) begin
+        if  (flash_op.partition == FlashPartData) begin
+          page = addr2page(flash_op.addr);
+          my_region = get_region(page);
+        end else begin
+          page = addr2page(flash_op.otf_addr);
+          my_region = get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
+          drop |= check_info_part(flash_op, "read_flash");
+        end
+        drop |= validate_flash_op(flash_op, my_region);
+        flash_op.addr += 8;
+        flash_op.otf_addr += 8;
+      end // for (int i = 0; i < size; i++)
+      if (tail) begin
+        if  (flash_op.partition == FlashPartData) begin
+          page = addr2page(flash_op.addr);
+          my_region = get_region(page);
+        end else begin
+          page = addr2page(flash_op.otf_addr);
+          my_region = get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
+          drop |= check_info_part(flash_op, "read_flash");
+        end
+        drop |= validate_flash_op(flash_op, my_region);
+      end
+      flash_op.addr = tmp_addr;
+      // Bank id truncaded by otf_addr size
+      flash_op.otf_addr = tmp_addr;
+      // recalculate page and region based on start address
+      if  (flash_op.partition == FlashPartData) begin
+        page = addr2page(flash_op.addr);
+        my_region = get_region(page);
+      end else begin
+        page = addr2page(flash_op.otf_addr);
+        my_region = get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
+      end
+      if (drop) begin
+        `uvm_info("read_flash", $sformatf("op:%s is not allowed in the region:%p",
+                                          flash_op.op.name, my_region), UVM_MEDIUM)
+        set_otf_exp_alert("recov_err");
+      end
       `uvm_info("read_flash",
                 $sformatf({"bank:%0d page:%0d otf_addr:0x%0h,",
                            " part:%s size:%0d x %0d x 4B start_addr:%x  end_addr:%x"},
                           bank, page, flash_op.otf_addr,
                           flash_op.partition.name, num, wd, start_addr, end_addr),
                 UVM_MEDIUM)
-      if (flash_op.partition == FlashPartData) begin
-        is_odd = flash_op.addr[2];
-        size = (flash_op.num_words + is_odd) / 2;
-        tail = (flash_op.num_words + is_odd) % 2;
-        tmp_addr = flash_op.addr;
-        flash_op.addr[2:0] = 0;
-        for (int i = 0; i < size; i++) begin
-          page = addr2page(flash_op.addr);
-          my_region = get_region(page);
-          drop |= validate_flash_op(flash_op, my_region);
-          flash_op.addr += 8;
-        end
-        if (tail) begin
-          page = addr2page(flash_op.addr);
-          my_region = get_region(page);
-          drop |= validate_flash_op(flash_op, my_region);
-        end
-        if (drop) begin
-          `uvm_info("read_flash", $sformatf("op:%s is not allowed in the region:%p",
-                                            flash_op.op.name, my_region), UVM_MEDIUM)
-          set_otf_exp_alert("recov_err");
-        end
-        flash_op.addr = tmp_addr;
-        page = addr2page(flash_op.addr);
-        my_region = get_region(page);
-      end else begin
-        my_region = get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
-        drop = check_info_part(flash_op, "read_flash");
-      end
-
+      `uvm_create_obj(flash_otf_item, exp_item)
       exp_item.page = page;
       exp_item.region = my_region;
       exp_item.cmd = flash_op;
@@ -480,11 +537,13 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
           cfg.scb_h.exp_alert_contd["recov_err"] = 10000;
         end
       end
-
-      `uvm_info("read_flash", $sformatf("read_send %x", flash_op.otf_addr), UVM_HIGH)
-      flash_ctrl_start_op(flash_op);
-      flash_ctrl_read(flash_op.num_words, flash_read_data, poll_fifo_status);
-      wait_flash_op_done();
+      if (cfg.intr_mode) begin
+        flash_ctrl_intr_read(flash_op, flash_read_data);
+      end else begin
+        flash_ctrl_start_op(flash_op);
+        flash_ctrl_read(flash_op.num_words, flash_read_data, poll_fifo_status);
+        wait_flash_op_done();
+      end
       if (derr_is_set | cfg.ierr_created[0]) begin
         `uvm_info("read_flash", $sformatf({"bank:%0d addr: %x(otf:%x) derr_is_set:%0d",
                                           " ierr_created[0]:%0d"}, bank, flash_op.addr,
@@ -545,7 +604,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       tl_addr[OTFHostId] = 1;
       overflow = end_addr[OTFHostId];
     end
-
+    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow:% x",
+                                       addr, end_addr, overflow), UVM_HIGH)
     rd_entry.bank = bank;
     tl_addr[OTFBankId] = bank;
     if (overflow) begin
@@ -564,15 +624,9 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.ecc_mode > FlashEccDisabled) tl_addr[18:17] = cfg.tgt_pre[FlashPartData][TgtDr];
 
       `uvm_create_obj(flash_otf_item, exp_item)
-      page = addr2page(tl_addr[OTFBankId-1:0]);
+      page = addr2page(tl_addr[OTFBankId:0]);
       my_region = get_region(page);
       flash_op.op = FlashOpRead;
-      drop = validate_flash_op(flash_op, my_region);
-      if (drop) begin
-        `uvm_info("direct_read", $sformatf("op:%s is not allowed in the region:%p",
-                                           flash_op.op.name, my_region), UVM_MEDIUM)
-        set_otf_exp_alert("recov_err");
-      end
 
       exp_item.page = page;
       exp_item.region = my_region;
@@ -615,7 +669,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         if (cfg.scb_h.ecc_error_addr.exists({tl_addr[31:3],3'h0}) | derr_is_set) derr = 1;
       end
       cfg.otf_read_entry.insert(rd_entry, flash_op);
-      `uvm_info("direct_read", $sformatf("%0d:%0d bank:%0d exec: 0x%x   derr:%0d",
+      `uvm_info("direct_read", $sformatf("%0d:%0d bank:%0d exec: 0x%x derr:%0d",
                                           dbg, i, bank, tl_addr, derr), UVM_MEDIUM)
       if (cfg.ecc_mode > FlashSerrTestMode) begin
         if (derr & cfg.scb_h.do_alert_check) begin
@@ -652,18 +706,19 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     flash_otf_item item;
     int page;
     `uvm_create_obj(flash_otf_item, item)
-    addr[OTFBankId] = bank;
-    page = addr2page(addr);
     item.dq.push_back($urandom());
     item.dq.push_back($urandom());
-    item.page = page;
     if (part == FlashPartData) begin
-      item.region = get_region(page);
+      addr[OTFBankId] = bank;
+      page = addr2page(addr);
+      item.region = get_region(page, 0);
+      // back to per bank addr
+      addr[OTFBankId] = 0;
     end else begin
+      page = addr2page(addr);
       item.region = get_region_from_info(cfg.mp_info[bank][part>>1][page]);
     end
-    // back to per bank addr
-    addr[OTFBankId] = 0;
+    item.page = page;
     item.scramble(otp_addr_key, otp_data_key, addr, 0);
     cfg.mem_bkdr_util_h[part][bank].write(addr, item.fq[0]);
   endfunction // update_otf_mem_read_zone
@@ -672,14 +727,15 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   function void flash_otf_mem_read_zone_init();
     // 8byte aligned
     addr_t st_addr, ed_addr;
-
+    flash_dv_part_e part;
     // read tgt region     : cfg.tgt_pre[0]
     // direct rd tgt region: cfg.tgt_pre[1]
-    foreach (cfg.tgt_pre[partition]) begin
-      for (int j = TgtRd; j <= TgtDr; j++) begin
+    part = part.first;
+    do begin
+      for (flash_tgt_prefix_e j = TgtRd; j <= TgtDr; j++) begin
         st_addr = 'h0;
-        if (partition == FlashPartData) begin
-          st_addr[18:17] = cfg.tgt_pre[partition][j];
+        if (part == FlashPartData) begin
+          st_addr[18:17] = cfg.tgt_pre[part][j];
           // I think this should be
           // 64 * 256 * 8 -1 (= 0x1_FFFF)
           // to maxout a quater of 1 bank
@@ -688,34 +744,34 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
           // data partition 2 banks
           for (int i = 0; i < 2; i++) begin
             for (addr_t addr = st_addr; addr <= ed_addr; addr += 8) begin
-              update_otf_mem_read_zone(partition, i, addr);
+              update_otf_mem_read_zone(part, i, addr);
             end
             `uvm_info("flash_otf_init",
-                      $sformatf("partition:%s pre%0d st:%x ed:%x",
-                                partition.name, j, st_addr, ed_addr), UVM_MEDIUM)
+                      $sformatf("part:%s pre:%s bank:%0d st:%x ed:%x",
+                                part.name, j.name, i, st_addr, ed_addr), UVM_MEDIUM)
           end
-        end else begin // if (partition == FlashPartData)
-          // While data partition can be divided by pages, info partition
+        end else begin // if (part == FlashPartData)
+          // While data part can be divided by pages, info part
           // need finer resolution due to number of pages in each info
           // is relatively small.
-          // So every page in info partition will be divided into 4 parts.
-          st_addr[10:9] = cfg.tgt_pre[partition][j];
-          for (int k = 0; k < InfoTypeSize[partition>>1]; k++) begin
+          // So every page in info part will be divided into 4 parts.
+          st_addr[10:9] = cfg.tgt_pre[part][j];
+          for (int k = 0; k < InfoTypeSize[part>>1]; k++) begin
             st_addr[DVPageMSB:DVPageLSB] = k; // page
             ed_addr = st_addr + 511; // 0x1FF
             for (int i = 0; i < 2; i++) begin
               for (addr_t addr = st_addr; addr <= ed_addr; addr += 8) begin
-                update_otf_mem_read_zone(partition, i, addr);
+                update_otf_mem_read_zone(part, i, addr);
               end
             end
             `uvm_info("flash_otf_init",
-                      $sformatf("partition:%s pre%0d page:%0d st:%x ed:%x",
-                                partition.name, j, k, st_addr, ed_addr), UVM_MEDIUM)
+                      $sformatf("part:%s pre%0d page:%0d st:%x ed:%x",
+                                part.name, j, k, st_addr, ed_addr), UVM_MEDIUM)
           end
         end
-
-      end
-    end
+      end // for (int j = TgtRd; j <= TgtDr; j++)
+      part = part.next;
+    end while (part != part.first);
   endfunction // flash_otf_init
 
   // Send direct host read to both bankds 'host_num' times.
@@ -756,30 +812,45 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
 
   // Populate cfg.mp_info with default_info_page_cfg except scr, ecc.
   // Then program each info region.
-  task flash_ctrl_default_info_cfg(mubi4_t scr_en = MuBi4False,
-                                   mubi4_t ecc_en = MuBi4False);
+  task flash_ctrl_default_info_cfg(otf_cfg_mode_e scr_mode = OTFCfgFalse,
+                                   otf_cfg_mode_e ecc_mode = OTFCfgFalse);
+    mubi4_t scr_en, ecc_en;
+    // If scr/ecc mode is random,
+    // follow rand_info_c
+    scr_en = get_mubi_val(scr_mode);
+    ecc_en = get_mubi_val(ecc_mode);
+
     foreach (cfg.mp_info[i, j, k]) begin
-           cfg.mp_info[i][j][k] = default_info_page_cfg;
-           cfg.mp_info[i][j][k].scramble_en = scr_en;
-           cfg.mp_info[i][j][k].ecc_en = ecc_en;
-           flash_ctrl_mp_info_page_cfg(i, j, k, cfg.mp_info[i][j][k]);
+      if (cfg.ecc_mode == FlashEccDisabled) cfg.mp_info[i][j][k] = default_info_page_cfg;
+      else cfg.mp_info[i][j][k] = rand_info[i][j][k];
+      if (scr_mode != OTFCfgRand) cfg.mp_info[i][j][k].scramble_en = scr_en;
+      if (ecc_mode != OTFCfgRand) cfg.mp_info[i][j][k].ecc_en = ecc_en;
+      flash_ctrl_mp_info_page_cfg(i, j, k, cfg.mp_info[i][j][k]);
+      `uvm_info("otf_info_cfg", $sformatf("bank:type:page:[%0d][%0d][%0d] = %p",i, j, k, cfg.mp_info[i][j][k]), UVM_MEDIUM)
     end
   endtask // flash_ctrl_info_cfg
 
-  task flash_otf_region_cfg(mubi4_t scr_en = MuBi4False,
-                            mubi4_t ecc_en = MuBi4False);
+  task flash_otf_region_cfg(otf_cfg_mode_e scr_mode = OTFCfgFalse,
+                            otf_cfg_mode_e ecc_mode = OTFCfgFalse);
+    mubi4_t scr_en, ecc_en;
+    // If scr/ecc mode is random,
+    // follow rand_regions_c
+    scr_en = get_mubi_val(scr_mode);
+    ecc_en = get_mubi_val(ecc_mode);
 
     flash_ctrl_default_region_cfg(,,,scr_en, ecc_en);
-    flash_ctrl_default_info_cfg(scr_en, ecc_en);
-
     foreach (cfg.mp_regions[i]) begin
       cfg.mp_regions[i] = rand_regions[i];
-      cfg.mp_regions[i].scramble_en = scr_en;
-      cfg.mp_regions[i].ecc_en = ecc_en;
+      // use default region in FlashEccDisabled mode.
+      if (cfg.ecc_mode == FlashEccDisabled) cfg.mp_regions[i].en = MuBi4False;
+      if (scr_mode != OTFCfgRand) cfg.mp_regions[i].scramble_en = scr_en;
+      if (ecc_mode != OTFCfgRand) cfg.mp_regions[i].ecc_en = ecc_en;
       flash_ctrl_mp_region_cfg(i, cfg.mp_regions[i]);
       `uvm_info("otf_region_cfg", $sformatf("region[%0d] = %p", i, cfg.mp_regions[i]), UVM_MEDIUM)
     end
     `uvm_info("otf_region_cfg", $sformatf("default = %p", default_region_cfg), UVM_MEDIUM)
+    flash_ctrl_default_info_cfg(scr_mode, ecc_mode);
+    update_p2r_map(cfg.mp_regions);
   endtask
 
   function flash_mp_region_cfg_t get_region_from_info(flash_bank_mp_info_page_cfg_t info);
@@ -807,13 +878,6 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en = lc_ctrl_pkg::On;
     end
   endfunction // update_partition_access
-
-  function void set_otf_exp_alert(string str);
-    cfg.scb_h.exp_alert_ff[str].push_back(1);
-    cfg.scb_h.alert_chk_max_delay[str] = 2000;
-    `uvm_info("set_otf_exp_alert", $sformatf("exp_alert_ff[%s] size: %0d",
-                                             str, cfg.scb_h.exp_alert_ff[str].size()), UVM_MEDIUM)
-  endfunction // set_otf_exp_alert
 
   // Check permission and page range of info partition
   // Set exp recov_err alert if check fails
@@ -850,4 +914,16 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end
     return drop;
   endfunction // check_part_info
+
+  function mubi4_t get_mubi_val(otf_cfg_mode_e mode);
+    case (mode)
+      OTFCfgRand: begin
+        // return true or false with 1:1 ratio
+        return get_rand_mubi4_val(.other_weight(0));
+      end
+      OTFCfgTrue: return MuBi4True;
+      default: return MuBi4False;
+    endcase
+  endfunction // get_mubi_val
+
 endclass // flash_ctrl_otf_base_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -40,3 +40,5 @@
 `include "flash_ctrl_derr_detect_vseq.sv"
 `include "flash_ctrl_hw_rma_reset_vseq.sv"
 `include "flash_ctrl_otp_reset_vseq.sv"
+`include "flash_ctrl_intr_rd_vseq.sv"
+`include "flash_ctrl_intr_wr_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -45,7 +45,16 @@
     }
   ]
 
-  // Add additional tops for simulation.
+  build_modes: [
+    {
+      name: large_delay_mode
+      build_opts: ["+define+SLOW_FLASH"]
+    }
+  ]
+
+  large_delay_mode_vcs_cov_cfg_file: "{default_vcs_cov_cfg_file}"
+
+// Add additional tops for simulation.
   sim_tops: ["flash_ctrl_bind","flash_ctrl_cov_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Flash Ctrl coverage exclusion.
@@ -178,7 +187,7 @@
     {
       name: flash_ctrl_wo
       uvm_test_seq: flash_ctrl_rw_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=0", "+otf_rd_pct=1"]
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=0", "+otf_rd_pct=0"]
       reseed: 20
     }
     {
@@ -238,7 +247,6 @@
                  "+otf_num_rw=5", "+otf_num_hr=0"]
       reseed: 5
     }
-
     {
       name: flash_ctrl_read_word_sweep_derr
       uvm_test_seq: flash_ctrl_read_word_sweep_vseq
@@ -272,6 +280,20 @@
       uvm_test_seq: flash_ctrl_rw_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=4", "+ierr_pct=3",
                  "+bypass_alert_ready_to_end_check=1"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_intr_rd
+      build_mode: "large_delay_mode"
+      uvm_test_seq: flash_ctrl_intr_rd_vseq
+      run_opts: ["+scb_otf_en=1"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_intr_wr
+      build_mode: "large_delay_mode"
+      uvm_test_seq: flash_ctrl_intr_wr_vseq
+      run_opts: ["+scb_otf_en=1", "+test_timeout_nm=500_000_000"]
       reseed: 5
     }
   ]

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -96,8 +96,23 @@ module tb;
   wire [1:0] flash_test_mode_a;
   assign (pull1, pull0) flash_test_mode_a = 2'h3;
 
+  `ifdef SLOW_FLASH
+  initial begin
+    $display("runs with SLOW_FLASH mode");
+  end
+    `define MODEL_ONLY_READ_LATENCY 50
+    `define MODEL_ONLY_PROG_LATENCY 500
+  `else
+    `define MODEL_ONLY_READ_LATENCY 1
+    `define MODEL_ONLY_PROG_LATENCY 50
+  `endif
+
+
   // dut
   flash_ctrl #(
+
+    .ModelOnlyReadLatency(`MODEL_ONLY_READ_LATENCY),
+    .ModelOnlyProgLatency(`MODEL_ONLY_PROG_LATENCY),
     .ProgFifoDepth(ProgFifoDepth),
     .RdFifoDepth(ReadFifoDepth)
   ) dut (

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -724,8 +724,7 @@ module flash_phy_rd
   `ASSERT(BufferMatchEcc_A, |buf_rsp_match |-> muxed_err == '0)
 
   // The read storage depth and mask depth should always be the same after popping
-  `ASSERT(FifoSameDepth_A, rd_and_mask_fifo_pop |=> unused_rd_depth == unused_mask_depth)
-
+  //`ASSERT(FifoSameDepth_A, rd_and_mask_fifo_pop |=> unused_rd_depth == unused_mask_depth)
   /////////////////////////////////
   // Functional coverage points to add
   /////////////////////////////////


### PR DESCRIPTION
@tjaychen  please review if this assertion failure is real.

cmd:
./util/dvsim/dvsim.py ./hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson -i flash_ctrl_derr_detect -r 1 -s 3862066134 -v m --waves

"../src/lowrisc_ip_flash_ctrl_0.1/rtl/flash_phy_rd.sv", 709: tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd.ExclusiveOps_A: started at 7805300ps failed at 7805300ps
	Offending '((alloc & update) == 0)'
UVM_ERROR @ 7805.3 ns: (flash_phy_rd.sv:709) [ASSERT FAILED] ExclusiveOps_A
