### PR TITLE
[dif] Fix enum reference in KMAC dif.

### DIFF
--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -483,11 +483,11 @@ dif_result_t dif_kmac_mode_kmac_start(
   // Set key strength and calculate rate (r).
   uint32_t kstrength;
   switch (mode) {
-    case kDifKmacModeCshakeLen128:
+    case kDifKmacModeKmacLen128:
       kstrength = KMAC_CFG_SHADOWED_KSTRENGTH_VALUE_L128;
       operation_state->r = calculate_rate_bits(128) / 32;
       break;
-    case kDifKmacModeCshakeLen256:
+    case kDifKmacModeKmacLen256:
       kstrength = KMAC_CFG_SHADOWED_KSTRENGTH_VALUE_L256;
       operation_state->r = calculate_rate_bits(256) / 32;
       break;


### PR DESCRIPTION
This looks like a copy/paste error in which the KMAC function references the cSHAKE enum; the enum values just happen to be the same, so nothing showed up on tests. The two enums are, for reference:

https://github.com/lowRISC/opentitan/blob/2820190ff574f8fffa62fda61ea80696c70dad1b/sw/device/lib/dif/dif_kmac.h#L265-L283

Practically the meaning is similar, but the `mode` in the KMAC function has type `dif_kmac_mode_kmac_t` so it seems reasonable to try to keep things consistent.