### PR TITLE
[silicon_creator] Adjust OTBN driver to read back data after writing.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -81,6 +81,14 @@ static void otbn_write(uint32_t dest_addr, const uint32_t *src,
     HARDENED_CHECK_LT(i, num_words);
   }
   HARDENED_CHECK_EQ(iter_cnt, num_words);
+
+  /* Read back what we just wrote to check for tampering. */
+  i = 0;
+  for (; i < num_words; ++i) {
+    uint32_t readback = abs_mmio_read32(dest_addr + i * sizeof(uint32_t));
+    HARDENED_CHECK_EQ(readback, src[i]);
+  }
+  HARDENED_CHECK_EQ(i, num_words);
 }
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -139,6 +139,9 @@ TEST_F(ImemWriteTest, SuccessWithoutOffset) {
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + 4, test_data[1]);
 
+  EXPECT_ABS_READ32(base_ + OTBN_IMEM_REG_OFFSET, test_data[0]);
+  EXPECT_ABS_READ32(base_ + OTBN_IMEM_REG_OFFSET + 4, test_data[1]);
+
   EXPECT_EQ(otbn_imem_write(0, test_data.data(), 2), kErrorOk);
 }
 
@@ -151,6 +154,9 @@ TEST_F(ImemWriteTest, SuccessWithOffset) {
   EXPECT_CALL(rnd_, Uint32()).WillOnce(Return(0));
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + 4, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + 8, test_data[1]);
+
+  EXPECT_ABS_READ32(base_ + OTBN_IMEM_REG_OFFSET + 4, test_data[0]);
+  EXPECT_ABS_READ32(base_ + OTBN_IMEM_REG_OFFSET + 8, test_data[1]);
 
   EXPECT_EQ(otbn_imem_write(4, test_data.data(), 2), kErrorOk);
 }
@@ -181,6 +187,9 @@ TEST_F(DmemWriteTest, SuccessWithoutOffset) {
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + 4, test_data[1]);
 
+  EXPECT_ABS_READ32(base_ + OTBN_DMEM_REG_OFFSET, test_data[0]);
+  EXPECT_ABS_READ32(base_ + OTBN_DMEM_REG_OFFSET + 4, test_data[1]);
+
   EXPECT_EQ(otbn_dmem_write(0, test_data.data(), 2), kErrorOk);
 }
 
@@ -193,6 +202,9 @@ TEST_F(DmemWriteTest, SuccessWithOffset) {
   EXPECT_CALL(rnd_, Uint32()).WillOnce(Return(0));
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + 4, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + 8, test_data[1]);
+
+  EXPECT_ABS_READ32(base_ + OTBN_DMEM_REG_OFFSET + 4, test_data[0]);
+  EXPECT_ABS_READ32(base_ + OTBN_DMEM_REG_OFFSET + 8, test_data[1]);
 
   EXPECT_EQ(otbn_dmem_write(4, test_data.data(), 2), kErrorOk);
 }


### PR DESCRIPTION
This adds an extra layer of protection against fault-injection attacks that might attempt to tamper with IMEM or DMEM data in transit.

I checked the performance by adding a timing profile to the tests using `ibex_mcycle_read()`. With the change in this PR, I see `sigverify_mod_exp_otbn` taking about 257K cycles per successful test, compared to about 245K cycles without the change. At 100MHz that translates to about 0.1ms (2.57ms with the change or 2.45ms without).

@alphan , I'll leave the call up to you whether the performance/security tradeoff is worth it. Since we already randomize the writes, it's hard for an attacker to get much use out of attacking the data in transit already. On the other hand, this is a simple way to potentially head off attacks we haven't thought of yet.