### PR TITLE
fix(spi_device): Invalid command in Flash mode

### DIFF
--- a/hw/ip/spi_device/rtl/spi_cmdparse.sv
+++ b/hw/ip/spi_device/rtl/spi_cmdparse.sv
@@ -380,7 +380,11 @@ module spi_cmdparse
               // DpNone
             end
           endcase
-        end
+        end // if (module_active && data_valid_i && cmd_info_d.valid)
+        else if (module_active && data_valid_i) begin
+          // Could not find valid command information entry.
+          st_d = StWait;
+        end // if (module_active && data_valid_i)
       end
 
       // dead-end states below. Reset (CSb de-assertion) let SM back to Idle


### PR DESCRIPTION
Issue is reported by @weicaiyang in
https://github.com/lowRISC/opentitan/issues/14057.

The cmdparse FSM supposes to move to `StWait` state if an invalid
command has been received. The condition was missed in the previous
design. If an invalid command is received, `cmd_info_d.valid` is 0.

In this commit, the behavior is fixed by checking `module_active &&
data_valid_i` in `StIdle`.
