### PR TITLE
Ti50Emulator minor fixes and cleanup

### DIFF
--- a/sw/host/opentitanlib/src/app/config/mod.rs
+++ b/sw/host/opentitanlib/src/app/config/mod.rs
@@ -61,9 +61,9 @@ lazy_static! {
     static ref BUILTINS: HashMap<&'static str, &'static str> = collection! {
         "/__builtin__/h1dx_devboard.json" => include_str!("h1dx_devboard.json"),
         "/__builtin__/h1dx_devboard_ultradebug.json" => include_str!("h1dx_devboard_ultradebug.json"),
+        "/__builtin__/ti50emulator.json" => include_str!("ti50emulator.json"),
         "/__builtin__/opentitan_cw310.json" => include_str!("opentitan_cw310.json"),
         "/__builtin__/opentitan.json" => include_str!("opentitan.json"),
-        "/__builtin__/opentitan_ti50emulator.json" => include_str!("opentitan_ti50emulator.json"),
         "/__builtin__/opentitan_ultradebug.json" => include_str!("opentitan_ultradebug.json"),
         "/__builtin__/opentitan_verilator.json" => include_str!("opentitan_verilator.json"),
     };

--- a/sw/host/opentitanlib/src/app/config/ti50emulator.json
+++ b/sw/host/opentitanlib/src/app/config/ti50emulator.json
@@ -1,12 +1,11 @@
 {
-  "includes": ["/__builtin__/opentitan.json"],
   "interface": "ti50emulator",
   "pins": [
   ],
   "uarts": [
     {
       "name": "console",
-      "alias_of": "0"
+      "alias_of": "GSC"
     }
   ]
 }

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -69,7 +69,7 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
         ),
         "ti50emulator" => (
             ti50emulator::create(&args.ti50emulator_opts)?,
-            Some(Path::new("/__builtin__/opentitan_ti50emulator.json")),
+            Some(Path::new("/__builtin__/ti50emulator.json")),
         ),
         "ultradebug" => (
             ultradebug::create(args)?,

--- a/sw/host/opentitanlib/src/transport/ti50emulator/mod.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/mod.rs
@@ -79,25 +79,26 @@ impl Ti50Emulator {
     fn configure_devices(&self) -> Result<()> {
         let conf = self.inner.borrow().process.get_configurations()?;
         for (name, state) in conf.gpio.iter() {
-            let gpio: Rc<dyn GpioPin> = Rc::new(Ti50GpioPin::open(self, name, state)?);
+            let path = format!("gpio{}", name);
+            let gpio: Rc<dyn GpioPin> = Rc::new(Ti50GpioPin::open(self, &path, state)?);
             self.inner
                 .borrow_mut()
                 .gpio_map
-                .insert(name.clone(), Rc::clone(&gpio));
+                .insert(name.to_uppercase(), Rc::clone(&gpio));
         }
         for (name, path) in conf.uart.iter() {
             let uart: Rc<dyn Uart> = Rc::new(Ti50Uart::open(self, path)?);
             self.inner
                 .borrow_mut()
                 .uart_map
-                .insert(name.clone(), Rc::clone(&uart));
+                .insert(name.to_uppercase(), Rc::clone(&uart));
         }
         for (name, path) in conf.i2c.iter() {
             let i2c: Rc<dyn Bus> = Rc::new(Ti50I2cBus::open(self, path)?);
             self.inner
                 .borrow_mut()
                 .i2c_map
-                .insert(name.clone(), Rc::clone(&i2c));
+                .insert(name.to_uppercase(), Rc::clone(&i2c));
         }
         Ok(())
     }


### PR DESCRIPTION
Ti50Emulator minor fixes and cleanup.

* Split opentitantool configuration file 
between OpenTitan and Ti50emulator.
* Add prefix to GPIO socket path.
* Correct timeout handling in UART
* Fix sub-process start sequence