### PR TITLE
[otbn,fcov] Coverage improvements around bad_internal_errors

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -622,6 +622,13 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     clr_C_cross: cross fg_cp, clr_C_cp;
   endgroup
 
+  covergroup insn_addr_cg with function sample(mnem_str_t mnemonic, logic [31:0] insn_addr);
+    `DEF_SEEN_CP(str_insn_at_top_cp, (insn_addr == ImemSizeByte - 4) &&
+                                      !(mnemonic inside {mnem_beq, mnem_bne, mnem_jal, mnem_jalr,
+                                                         mnem_ecall, mnem_loop, mnem_loopi}))
+
+  endgroup
+
   // Pairwise instructions /////////////////////////////////////////////////////
 
   covergroup pairwise_insn_cg with function sample(mnem_str_t last, mnem_str_t cur);
@@ -2043,6 +2050,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     promoted_err_cg = new;
     scratchpad_writes_cg = new;
 
+    insn_addr_cg = new;
     call_stack_cg = new;
     flag_write_cg = new;
     pairwise_insn_cg = new;
@@ -2313,6 +2321,10 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
 
     mnem = mnem_str_t'(iss_item.mnemonic);
     insn_data = rtl_item.insn_data;
+
+    // Track and catch when we are on the top of the instruction memory and have a straight-line
+    // instruction.
+    insn_addr_cg.sample(mnem, rtl_item.insn_addr);
 
     // Call stack tracking. Some instructions want to know whether they are over- or under-flowing
     // the call stack so, as well as sampling in the call_stack_cg covergroup, we also compute those

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -17,7 +17,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       begin
         inject_redun_err();
       end
-    join
+    join_any
   endtask: body
 
   task inject_redun_err();

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -157,6 +157,10 @@ module tb;
     .DmemAddrWidth (DmemAddrWidth)
   ) i_otbn_trace_if (.*);
 
+  assign dut.u_otbn_core.i_otbn_trace_if.scramble_state_err_i = dut.otbn_scramble_state_error;
+  assign dut.u_otbn_core.i_otbn_trace_if.missed_gnt_i.imem_gnt_missed_err = dut.imem_missed_gnt;
+  assign dut.u_otbn_core.i_otbn_trace_if.missed_gnt_i.dmem_gnt_missed_err = dut.dmem_missed_gnt;
+
   bind dut.u_otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
 
   bind dut.u_otbn_core.u_otbn_controller.u_otbn_loop_controller

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -173,6 +173,9 @@ module otbn_top_sim (
   bind otbn_core otbn_trace_if #(.ImemAddrWidth, .DmemAddrWidth) i_otbn_trace_if (.*);
   bind otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
 
+  assign u_otbn_core.i_otbn_trace_if.scramble_state_err_i = '0;
+  assign u_otbn_core.i_otbn_trace_if.missed_gnt_i = '0;
+
   // Convert from core_err_bits_t to err_bits_t
   assign otbn_err_bits = '{
     fatal_software:       core_err_bits.fatal_software,

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -110,6 +110,38 @@ package otbn_pkg;
     logic bad_data_addr;
   } err_bits_t;
 
+  // Wrappers for classifying bad internal states
+  typedef struct packed {
+    logic alu_bignum_err;
+    logic mac_bignum_err;
+    logic ispr_bignum_err;
+    logic controller_err;
+    logic rf_err;
+    logic rd_err;
+  } predec_err_t;
+
+  typedef struct packed {
+    logic spr_urnd_acks;
+    logic spr_secwipe_reqs;
+    logic mubi_rma_err;
+    logic mubi_urnd_err;
+    logic state_err;
+  } start_stop_bad_int_t;
+
+  typedef struct packed {
+    logic loop_hw_cnt_err;
+    logic loop_hw_stack_cnt_err;
+    logic loop_hw_intg_err;
+    logic rf_base_call_stack_err;
+    logic spr_secwipe_acks;
+    logic state_err;
+  } controller_bad_int_t;
+
+  typedef struct packed {
+    logic imem_gnt_missed_err;
+    logic dmem_gnt_missed_err;
+  } missed_gnt_t;
+
   // All the error signals that can be generated directly from the controller. Note that this is
   // organised to include every software error (including 'call_stack', which actually gets fed in
   // from the base register file)


### PR DESCRIPTION
I am not exactly sure if this will actually hit for all the cases defined in coverpoints. I managed to see `controller_predec_err` and `urnd_all_zero` get hit with core tests. So, I think might be worthwhile to have a look at least. I'd like to hear your feedbacks around hierarchical assignment that I did in `tb.sv` (I think it should work but couldn't quickly test it so if you think it wouldn't work please let me know) and about the place where we sample the new covergroup. We do it in `on_insn` but I am not exactly sure if it's a good enough approach.

Resolves https://github.com/lowRISC/opentitan/issues/8129
Resolves https://github.com/lowRISC/opentitan/issues/11544