### PR TITLE
[packer, kmac] Add FI attack protection on packer pos

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -361,8 +361,9 @@ module hmac
   assign msg_fifo_wmask_endian = conv_endian(msg_fifo_wmask, endian_swap);
 
   prim_packer #(
-    .InW      (32),
-    .OutW     (32)
+    .InW          (32),
+    .OutW         (32),
+    .EnProtection (1'b 0)
   ) u_packer (
     .clk_i,
     .rst_ni,
@@ -378,7 +379,9 @@ module hmac
     .ready_i      (fifo_wready & ~hmac_fifo_wsel),
 
     .flush_i      (reg_hash_process),
-    .flush_done_o (packer_flush_done) // ignore at this moment
+    .flush_done_o (packer_flush_done), // ignore at this moment
+
+    .err_o  () // Not used
   );
 
 

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -188,6 +188,9 @@
       desc: '''Round counter, key index counter, sentmsg counter and hash counter
         use prim_count for redundancy'''
     }
+    { name: "PACKER.CTR.REDUN"
+      desc: "Packer Position counter uses prim_count for redundancy"
+    }
     { name: "CFG_SHADOWED.CONFIG.REGWEN"
       desc: "CFG_SHADOWED is protected by REGWEN"
     }

--- a/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
@@ -66,6 +66,12 @@
       tests: []
     }
     {
+      name: sec_cm_packer_ctr_redun
+      desc: "Verify the countermeasure(s) PACkER.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
       name: sec_cm_cfg_shadowed_config_regwen
       desc: "Verify the countermeasure(s) CFG_SHADOWED.CONFIG.REGWEN."
       milestone: V2S

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -382,7 +382,10 @@ package kmac_pkg;
     ErrShadowRegUpdate = 8'h C0,
 
     // Error due to lc_escalation_en_i or fatal fault
-    ErrFatalError = 8'h C1
+    ErrFatalError = 8'h C1,
+
+    // Error due to the counter integrity check failure inside MsgFifo.Packer
+    ErrPackerIntegrity = 8'h C2
   } err_code_e;
 
   typedef struct packed {
@@ -390,6 +393,7 @@ package kmac_pkg;
     err_code_e   code; // Type of error
     logic [23:0] info; // Additional Debug info
   } err_t;
+  parameter int unsigned ErrInfoW = 24 ; // err_t::info
 
   typedef struct packed {
     logic [AppDigestW-1:0] digest_share0;

--- a/hw/ip/prim/doc/prim_packer.md
+++ b/hw/ip/prim/doc/prim_packer.md
@@ -11,10 +11,11 @@ Specification section on shared primitives.
 
 ## Parameters
 
-Name | type | Description
------|------|-------------
-InW  | int  | Input data width
-OutW | int  | Output data width
+Name         | type | Description
+-------------|------|-------------------------------------
+InW          | int  | Input data width
+OutW         | int  | Output data width
+EnProtection | bit  | Check FI attack on position counter
 
 ## Signal Interfaces
 
@@ -30,6 +31,7 @@ mask_o[OutW] | output | Output bit mask.
 ready_i      | input  | Output data can be drained.
 flush_i      | input  | Send out stored data and clear state.
 flush_done_o | output | Indicates flush operation is completed.
+err_o        | output | When EnProtection is set, the error is reported through this port. This signal is asynchronous to the datapath.
 
 # Theory of Opeations
 

--- a/hw/ip/prim/fpv/tb/prim_packer_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_packer_tb.sv
@@ -23,7 +23,8 @@ module prim_packer_tb #(
   input                      ready_i,
 
   input                      flush_i,
-  output logic               flush_done_o
+  output logic               flush_done_o,
+  output logic               err_o
 );
 
   for (genvar k = 1; k <= 16; k++) begin : gen_prim_packer
@@ -40,7 +41,8 @@ module prim_packer_tb #(
       .mask_o (mask_o[16-k:0]),
       .ready_i,
       .flush_i,
-      .flush_done_o
+      .flush_done_o,
+      .err_o
     );
   end
 
@@ -57,7 +59,8 @@ module prim_packer_tb #(
       .mask_o (mask_o),
       .ready_i,
       .flush_i,
-      .flush_done_o
+      .flush_done_o,
+      .err_o
   );
 
 endmodule : prim_packer_tb

--- a/hw/ip/prim/rtl/prim_packer.sv
+++ b/hw/ip/prim/rtl/prim_packer.sv
@@ -8,9 +8,14 @@
 
 // ICEBOX(#12958): Revise to send out the empty status.
 module prim_packer #(
-  parameter int InW  = 32,
-  parameter int OutW = 32,
-  parameter int HintByteData = 0 // If 1, The input/output are byte granularity
+  parameter int unsigned InW  = 32,
+  parameter int unsigned OutW = 32,
+
+  // If 1, The input/output are byte granularity
+  parameter int HintByteData = 0,
+
+  // Turn on protect against FI for the pos variable
+  parameter bit EnProtection = 1'b 0
 ) (
   input clk_i ,
   input rst_ni,
@@ -26,14 +31,18 @@ module prim_packer #(
   input                   ready_i,
 
   input                   flush_i,  // If 1, send out remnant and clear state
-  output logic            flush_done_o
+  output logic            flush_done_o,
+
+  // When EnProtection is set, err_o raises an error case (position variable
+  // mismatch)
+  output logic            err_o
 );
 
-  localparam int Width = InW + OutW; // storage width
-  localparam int ConcatW = Width + InW; // Input concatenated width
-  localparam int PtrW = $clog2(ConcatW+1);
-  localparam int IdxW = prim_util_pkg::vbits(InW);
-  localparam int OnesCntW = $clog2(InW+1);
+  localparam int unsigned Width    = InW + OutW;  // storage width
+  localparam int unsigned ConcatW  = Width + InW; // Input concatenated width
+  localparam int unsigned PtrW     = $clog2(ConcatW+1);
+  localparam int unsigned IdxW     = prim_util_pkg::vbits(InW);
+  localparam int unsigned OnesCntW = $clog2(InW+1);
 
   logic valid_next, ready_next;
   logic [Width-1:0]   stored_data, stored_mask;
@@ -41,7 +50,7 @@ module prim_packer #(
   logic [ConcatW-1:0] shiftl_data, shiftl_mask;
   logic [InW-1:0]     shiftr_data, shiftr_mask;
 
-  logic [PtrW-1:0]     pos_q, pos_d; // Current write position
+  logic [PtrW-1:0]     pos_q;         // Current write position
   logic [IdxW-1:0]     lod_idx;       // result of Leading One Detector
   logic [OnesCntW-1:0] inmask_ones;   // Counting Ones for mask_i
 
@@ -60,29 +69,86 @@ module prim_packer #(
   end
 
   logic [PtrW-1:0] pos_with_input;
+  assign pos_with_input = pos_q + PtrW'(inmask_ones);
 
-  always_comb begin
-    pos_d = pos_q;
-    pos_with_input = pos_q + PtrW'(inmask_ones);
+  if (EnProtection == 1'b 0) begin : g_pos_nodup
+    logic [PtrW-1:0] pos_d;
 
-    unique case ({ack_in, ack_out})
-      2'b00: pos_d = pos_q;
-      2'b01: pos_d = (int'(pos_q) <= OutW) ? '0 : pos_q - PtrW'(unsigned'(OutW));
-      2'b10: pos_d = pos_with_input;
-      2'b11: pos_d = (int'(pos_with_input) <= OutW) ? '0 : pos_with_input - PtrW'(unsigned'(OutW));
-      default: pos_d = pos_q;
-    endcase
-  end
+    always_comb begin
+      pos_d = pos_q;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      pos_q <= '0;
-    end else if (flush_done) begin
-      pos_q <= '0;
-    end else begin
-      pos_q <= pos_d;
+      unique case ({ack_in, ack_out})
+        2'b00: pos_d = pos_q;
+        2'b01: pos_d = (int'(pos_q) <= OutW) ? '0 : pos_q - PtrW'(OutW);
+        2'b10: pos_d = pos_with_input;
+        2'b11: pos_d = (int'(pos_with_input) <= OutW) ? '0 : pos_with_input - PtrW'(OutW);
+        default: pos_d = pos_q;
+      endcase
     end
-  end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        pos_q <= '0;
+      end else if (flush_done) begin
+        pos_q <= '0;
+      end else begin
+        pos_q <= pos_d;
+      end
+    end
+
+    assign err_o = 1'b 0; // No checker logic
+
+  end else begin : g_pos_dupcnt // EnProtection == 1'b 1
+    // incr_en: Increase the pos by cnt_step. ack_in && !ack_out
+    // decr_en: Decrease the pos by cnt_step. !ack_in && ack_out
+    // set_en:  Set to specific value in case of ack_in && ack_out.
+    //          This case, the value could be increased or descreased based on
+    //          the input size (inmask_ones)
+    logic            cnt_incr_en, cnt_decr_en, cnt_set_en;
+    logic [PtrW-1:0] cnt_step, cnt_set;
+
+    assign cnt_incr_en =  ack_in && !ack_out;
+    assign cnt_decr_en = !ack_in &&  ack_out;
+    assign cnt_set_en  =  ack_in &&  ack_out;
+
+    // counter has underflow protection.
+    assign cnt_step = (cnt_incr_en) ? PtrW'(inmask_ones) : PtrW'(OutW);
+
+    always_comb begin : cnt_set_logic
+
+      // default, consuming all data
+      cnt_set = '0;
+
+      if (pos_with_input > PtrW'(OutW)) begin
+        // pos_q + inmask_ones is bigger than Output width. Still data remained.
+        cnt_set = pos_with_input - PtrW'(OutW);
+      end
+    end : cnt_set_logic
+
+
+    prim_count #(
+      .Width      (PtrW),
+      .ResetValue ('0  )
+    ) u_pos (
+      .clk_i,
+      .rst_ni,
+
+      .clr_i      (flush_done),
+
+      .set_i      (cnt_set_en),
+      .set_cnt_i  (cnt_set   ),
+
+      .incr_en_i  (cnt_incr_en),
+      .decr_en_i  (cnt_decr_en),
+      .step_i     (cnt_step   ),
+
+      .cnt_o      (pos_q     ), // Current counter state
+      .cnt_next_o (          ), // Next counter state
+
+      .err_o
+    );
+  end // g_pos_dupcnt
+
   //---------------------------------------------------------------------------
 
   // Leading one detector for mask_i


### PR DESCRIPTION
This commit protects the packer position variables against FI attacks.
It instantiates `prim_count` to duplicate the position counter.

If error occurs, KMAC reports the error via Alert interface and
ERR_CODE.

