### PR TITLE
 [dv/kmac] Increase test timeout min                                                                 

### DIFF
--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -121,12 +121,14 @@
       uvm_test_seq: kmac_test_vectors_shake_vseq
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0",
                  "+test_vectors_shake_variant=128"]
+      run_timeout_mins: 120
     }
     {
       name: "{variant}_test_vectors_shake_256"
       uvm_test_seq: kmac_test_vectors_shake_vseq
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0",
                  "+test_vectors_shake_variant=256"]
+      run_timeout_mins: 120
     }
     {
       name: "{variant}_test_vectors_kmac"


### PR DESCRIPTION
 This PR increases the test runttime timeout limit to 2 hours for the                                
 following tests:                                                                                    
 kmac_masked_test_vectors_shake_128                                                                  
 kmac_masked_test_vectors_shake_256                                                                  
                                                                                                     
 Signed-off-by: Cindy Chen <chencindy@opentitan.org>   