### PR TITLE
[entropy_src/rtl] Aggregate RepCnt & RepCnts events

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -442,7 +442,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic        ht_esbus_vld_dly2_q, ht_esbus_vld_dly2_d;
   logic        ht_failed_q, ht_failed_d;
   logic        ht_done_pulse_q, ht_done_pulse_d;
-  logic                    sha3_err_q, sha3_err_d;
+  logic        sha3_err_q, sha3_err_d;
   logic        cs_aes_halt_q, cs_aes_halt_d;
   logic [63:0] es_rdata_capt_q, es_rdata_capt_d;
   logic        es_rdata_capt_vld_q, es_rdata_capt_vld_d;
@@ -1442,6 +1442,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .clear_i             (health_test_clr),
     .active_i            (repcnt_active),
     .thresh_i            (repcnt_threshold),
+    .window_wrap_pulse_i (health_test_done_pulse),
     .test_cnt_o          (repcnt_event_cnt),
     .test_fail_pulse_o   (repcnt_fail_pulse),
     .count_err_o         (repcnt_cntr_err)
@@ -1503,6 +1504,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .clear_i             (health_test_clr),
     .active_i            (repcnts_active),
     .thresh_i            (repcnts_threshold),
+    .window_wrap_pulse_i (health_test_done_pulse),
     .test_cnt_o          (repcnts_event_cnt),
     .test_fail_pulse_o   (repcnts_fail_pulse),
     .count_err_o         (repcnts_cntr_err)
@@ -1949,13 +1951,12 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .err_o               (any_fails_cntr_err)
   );
 
-
   assign any_fail_pulse =
          repcnt_fail_pulse ||
          repcnts_fail_pulse ||
          adaptp_hi_fail_pulse || adaptp_lo_fail_pulse ||
          bucket_fail_pulse ||
-         markov_hi_fail_pulse ||markov_lo_fail_pulse ||
+         markov_hi_fail_pulse || markov_lo_fail_pulse ||
          extht_hi_fail_pulse || extht_lo_fail_pulse;
 
   assign ht_failed_d =

--- a/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
@@ -9,8 +9,8 @@ module entropy_src_repcnt_ht #(
   parameter int RegWidth = 16,
   parameter int RngBusWidth = 4
 ) (
-  input logic clk_i,
-  input logic rst_ni,
+  input logic                   clk_i,
+  input logic                   rst_ni,
 
    // ins req interface
   input logic [RngBusWidth-1:0] entropy_bit_i,
@@ -18,6 +18,7 @@ module entropy_src_repcnt_ht #(
   input logic                   clear_i,
   input logic                   active_i,
   input logic [RegWidth-1:0]    thresh_i,
+  input logic                   window_wrap_pulse_i,
   output logic [RegWidth-1:0]   test_cnt_o,
   output logic                  test_fail_pulse_o,
   output logic                  count_err_o
@@ -30,17 +31,26 @@ module entropy_src_repcnt_ht #(
   logic [RngBusWidth-1:0][RegWidth-1:0] rep_cntr;
   logic [RngBusWidth-1:0]               rep_cntr_err;
   logic [RegWidth-1:0]                  cntr_max;
+  logic                                 fail_sampled;
+  logic                                 fail_occurred_in_window;
 
   // flops
   logic [RngBusWidth-1:0] prev_sample_q, prev_sample_d;
+  logic fail_sample_mask_d, fail_sample_mask_q;
 
-  always_ff @(posedge clk_i or negedge rst_ni)
+  logic fail_smoothed_d, fail_smoothed_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      prev_sample_q    <= '0;
+      prev_sample_q       <= '0;
+      fail_smoothed_q     <= '0;
+      fail_sample_mask_q  <= '0;
     end else begin
-      prev_sample_q    <= prev_sample_d;
+      prev_sample_q       <= prev_sample_d;
+      fail_smoothed_q     <= fail_smoothed_d;
+      fail_sample_mask_q  <= fail_sample_mask_d;
     end
-
+  end
 
   // Repetitive Count Test
   //
@@ -97,8 +107,34 @@ module entropy_src_repcnt_ht #(
     .max_valid_o()
   );
 
-  // the pulses will be only one clock in length
-  assign test_fail_pulse_o = active_i && entropy_bit_vld_i && (|rep_cnt_fail);
+  // For the purposes of failure pulse generation, we want to sample
+  // the test output for only one cycle and do it immediately after
+  // the counter has been updated.
+  assign fail_sample_mask_d = entropy_bit_vld_i;
+  assign fail_sampled       = |rep_cnt_fail & fail_sample_mask_q;
+
+  // Within a HT window-period we collect all failure events into
+  // one long pulse, which ends at the falling edge of window_wrap_pulse_i
+  assign fail_smoothed_d =
+      !active_i ? 1'b0 :
+      window_wrap_pulse_i ? 1'b0 :
+      fail_sampled ? 1'b1 :
+      fail_smoothed_q;
+
+  // Some corner cases to consider when determining whether a failure occurred this
+  // window-period:
+  // 1. The failure need not be registered if disabled at the end of the window
+  //    (Same applies to the windowed HTs)
+  // 2. If a failure is observed during the very last window sample
+  //    (i.e., window_wrap_pulse and fail_sampled are coinicident) it should
+  //    still be counted in this window.
+  assign fail_occurred_in_window = active_i & (fail_smoothed_q | fail_sampled);
+
+  // the pulses will be only one clock in length, aligned with end of the
+  // current HT window.  If there are multiple failures in this window,
+  // there is still only one pulse.
+  assign test_fail_pulse_o = fail_occurred_in_window & window_wrap_pulse_i;
+
   assign test_cnt_o = cntr_max;
   assign count_err_o = (|rep_cntr_err);
 

--- a/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
@@ -18,6 +18,7 @@ module entropy_src_repcnts_ht #(
   input logic                   clear_i,
   input logic                   active_i,
   input logic [RegWidth-1:0]    thresh_i,
+  input logic                   window_wrap_pulse_i,
   output logic [RegWidth-1:0]   test_cnt_o,
   output logic                  test_fail_pulse_o,
   output logic                  count_err_o
@@ -29,17 +30,25 @@ module entropy_src_repcnts_ht #(
   logic  rep_cnt_fail;
   logic [RegWidth-1:0]    rep_cntr;
   logic                   rep_cntr_err;
+  logic                   fail_sampled;
+  logic                   fail_occurred_in_window;
 
   // flops
   logic [RngBusWidth-1:0] prev_sample_q, prev_sample_d;
+  logic fail_smoothed_d, fail_smoothed_q;
+  logic fail_sample_mask_d, fail_sample_mask_q;
 
-  always_ff @(posedge clk_i or negedge rst_ni)
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      prev_sample_q    <= '0;
+      prev_sample_q      <= '0;
+      fail_smoothed_q    <= '0;
+      fail_sample_mask_q <= '0;
     end else begin
-      prev_sample_q    <= prev_sample_d;
+      prev_sample_q      <= prev_sample_d;
+      fail_smoothed_q    <= fail_smoothed_d;
+      fail_sample_mask_q <= fail_sample_mask_d;
     end
-
+  end
 
   // Repetitive Count Test for symbols
   //
@@ -48,40 +57,64 @@ module entropy_src_repcnts_ht #(
   //  uses one as the starting value, just as the NIST algorithm does.
 
 
-    // NIST A sample
-    assign prev_sample_d = (!active_i || clear_i) ? '0 :
-                           entropy_bit_vld_i ? entropy_bit_i :
-                           prev_sample_q;
+  // NIST A sample
+  assign prev_sample_d = (!active_i || clear_i) ? '0 :
+                         entropy_bit_vld_i ? entropy_bit_i :
+                         prev_sample_q;
 
-    assign samples_match_pulse = entropy_bit_vld_i &&
-           (prev_sample_q == entropy_bit_i);
-    assign samples_no_match_pulse = entropy_bit_vld_i &&
-           (prev_sample_q != entropy_bit_i);
+  assign samples_match_pulse = entropy_bit_vld_i &&
+         (prev_sample_q == entropy_bit_i);
+  assign samples_no_match_pulse = entropy_bit_vld_i &&
+         (prev_sample_q != entropy_bit_i);
 
-    // NIST B counter
-    // SEC_CM: CTR.REDUN
-    prim_count #(
-      .Width(RegWidth)
-    ) u_prim_count_rep_cntr (
-      .clk_i,
-      .rst_ni,
-      .clr_i(1'b0),
-      .set_i(!active_i || clear_i || samples_no_match_pulse),
-      .set_cnt_i(RegWidth'(1)),
-      .incr_en_i(samples_match_pulse),
-      .decr_en_i(1'b0),
-      .step_i(RegWidth'(1)),
-      .cnt_o(rep_cntr),
-      .cnt_next_o(),
-      .err_o(rep_cntr_err)
-    );
+  // NIST B counter
+  // SEC_CM: CTR.REDUN
+  prim_count #(
+    .Width(RegWidth)
+  ) u_prim_count_rep_cntr (
+    .clk_i,
+    .rst_ni,
+    .clr_i(1'b0),
+    .set_i(!active_i || clear_i || samples_no_match_pulse),
+    .set_cnt_i(RegWidth'(1)),
+    .incr_en_i(samples_match_pulse),
+    .decr_en_i(1'b0),
+    .step_i(RegWidth'(1)),
+    .cnt_o(rep_cntr),
+    .cnt_next_o(),
+    .err_o(rep_cntr_err)
+  );
 
-    assign rep_cnt_fail = (rep_cntr >= thresh_i);
+  assign rep_cnt_fail = (rep_cntr >= thresh_i);
 
+  // For the purposes of failure pulse generation, we want to sample
+  // the test output for only one cycle and do it immediately after
+  // the counter has been updated.
+  assign fail_sample_mask_d = entropy_bit_vld_i;
+  assign fail_sampled       = rep_cnt_fail & fail_sample_mask_q;
 
+  // Within a HT window-period we collect all failure events into
+  // one long pulse, which ends at the falling edge of window_wrap_pulse_i
+  assign fail_smoothed_d =
+      !active_i ? 1'b0 :
+      window_wrap_pulse_i ? 1'b0 :
+      fail_sampled ? 1'b1 :
+      fail_smoothed_q;
 
-  // the pulses will be only one clock in length
-  assign test_fail_pulse_o = active_i && entropy_bit_vld_i && (|rep_cnt_fail);
+  // Some corner cases to consider when determining whether a failure occurred this
+  // window-period:
+  // 1. The failure need not be registered if disabled at the end of the window
+  //    (Same applies to the windowed HTs)
+  // 2. If a failure is observed during the very last window sample
+  //    (i.e., window_wrap_pulse and fail_sampled are coinicident) it should
+  //    still be counted in this window.
+  assign fail_occurred_in_window = active_i & (fail_smoothed_q | fail_sampled);
+
+  // The pulses will be only one clock in length, aligned with end of the
+  // current HT window.  If there are multiple failures in this window,
+  // there is still only one pulse.
+  assign test_fail_pulse_o = fail_occurred_in_window & window_wrap_pulse_i;
+
   assign test_cnt_o = rep_cntr;
   assign count_err_o = (|rep_cntr_err);
 


### PR DESCRIPTION
This commit changes the timing of the RepCnt & RepCnts failure pulses
to make it easier to predict alerts and total failure statistics.

The challenges of interpretting and predicting the statistics of these
tests prior to this commit are described in issue #14078 (where this fix
has been proposed).

When combined with the corresponding changes to the scoreboard, this
brings the pass rate to 100% for the entropy_src_rng test.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>