### PR TITLE
[entropy_src/dv] Scoreboarding of REPCNT & REPCNTS

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -82,7 +82,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // Number of clock cycles between a TLUL disable signal, and deassertion
   // of enable on the RNG bus.
 
-  int tlul_to_rng_disable_delay = 1;
+  int tlul_to_rng_disable_delay = 0;
   int tlul_to_fifo_clr_delay    = 5;
 
   // When expecting an alert, the cip scoreboarding routines expect a to see the

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -139,7 +139,7 @@ package entropy_src_env_pkg;
   } err_code_test_val_e;
 
 
-  typedef enum { BOOT, STARTUP, CONTINUOUS, HALTED } entropy_phase_e;
+  typedef enum { BOOT, STARTUP, CONTINUOUS, HALTED, ERROR } entropy_phase_e;
   typedef bit [RNG_BUS_WIDTH-1:0] rng_val_t;
   typedef bit [TL_DW-1:0]         tl_val_t;
   typedef rng_val_t queue_of_rng_val_t[$];


### PR DESCRIPTION
This commit fixes many subtle in scoreboard accuracies regarding the
behavior of the REPCNT and REPCNTS tests.

Moreover in order to bring the entropy_src_rng test to 100% passing
these changes assume the fixes proposed in issue #14078 and implemented
in PR #14083.

Additionally this PR addresses a scoreboarding issue wherein HT alerts
will not fire if the DUT main SM has been forced into an error state
(notably due to a local escalation, which is the only SM error that
the scoreboard can predict).

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>