### PR TITLE
[entropy_src/dv] Exercise REPCNT & REPCNTS tests

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -132,9 +132,22 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     ral.entropy_control.es_route.set(newcfg.route_software);
     csr_update(.csr(ral.entropy_control));
 
-    // Thresholds managed in derived vseq classes
+    #50us;
+
+    // Thresholds for the continuous health checks:
+    // REPCNT and REPCNTS
+
+    ral.repcnt_thresholds.bypass_thresh.set(newcfg.repcnt_thresh_bypass);
+    ral.repcnt_thresholds.fips_thresh.set(newcfg.repcnt_thresh_fips);
+    csr_update(.csr(ral.repcnt_thresholds));
+
+    ral.repcnts_thresholds.bypass_thresh.set(newcfg.repcnts_thresh_bypass);
+    ral.repcnts_thresholds.fips_thresh.set(newcfg.repcnts_thresh_fips);
+    csr_update(.csr(ral.repcnts_thresholds));
 
     #50us;
+
+    // Windowed health test thresholds managed in derived vseq classes
 
 
     // FW_OV registers

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -107,7 +107,6 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
       csr_update(.csr(ral.module_enable));
     end
 
-    // TODO: RepCnt and RepCntS thresholds
     // TODO: Separate sigmas for bypass and FIPS operation
     // TODO: cfg for threshold_rec per_line arguments
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -17,9 +17,12 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.dut_cfg.bypass_window_size          = 384;
     cfg.dut_cfg.boot_mode_retry_limit       = 10;
     cfg.sim_duration                = 20ms;
-    cfg.hard_mtbf                   = 100s;
+    // On average two hard failures per simulation
+    cfg.hard_mtbf                   = 10ms;
     cfg.mean_rand_reconfig_time     = 1ms;
-    cfg.mean_rand_csr_alert_time    = 10ms;
+    // The random alerts only need to happen frequently enough to
+    // close coverage
+    cfg.mean_rand_csr_alert_time    = 500ms;
     cfg.soft_mtbf                   = 7500us;
 
     // Apply standards ranging from strict to relaxed


### PR DESCRIPTION
This commit randomizes the thresholds for the REPCNT & REPCNTS tests and
activates random hard failures in the RNG stream to introduce alert
conditions.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>