### PR TITLE
[silicon_creator,silicon_owner] move stack symbols to common linker scripts

### DIFF
--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -16,6 +16,11 @@ OUTPUT_ARCH(riscv)
  */
 __DYNAMIC = 0;
 
+/* Reserving space at the top of the RAM for the stack. */
+_stack_size = 0x2000;
+_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_stack_start = _stack_end - _stack_size;
+
 /**
  * Symbols to be used in the setup of the address translation for ROM_EXT.
  */

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_a.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_a.ld
@@ -14,11 +14,6 @@
 
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
 /* Slot A starts at begining of the eFlash. */
 _rom_ext_size = LENGTH(eflash) / 2;
 _rom_ext_start_address = ORIGIN(eflash);

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_b.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_b.ld
@@ -14,11 +14,6 @@
 
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
 /* Slot B starts at the half-size mark of the eFlash. */
 _rom_ext_size = LENGTH(eflash) / 2;
 _rom_ext_start_address = ORIGIN(eflash) + _rom_ext_size;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_virtual_addr.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_virtual_addr.ld
@@ -16,11 +16,6 @@
 
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
 /**
  * Symbols to be used in the setup of the address translation for ROM_EXT.
  */

--- a/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
@@ -16,6 +16,11 @@ OUTPUT_ARCH(riscv)
  */
 __DYNAMIC = 0;
 
+/* Reserving space at the top of the RAM for the stack. */
+_stack_size = 0x2000;
+_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_stack_start = _stack_end - _stack_size;
+
 /**
  * Marking the entry point correctly for the ELF file. The signer tool will
  * transfer this value to the `entry_point` field of the manifest, which will

--- a/sw/device/silicon_owner/bare_metal/bare_metal_slot_a.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_slot_a.ld
@@ -14,11 +14,6 @@
 
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
 /* Slot A starts at the start of the eFlash plus the fixed size of the first
  * Silicon Owner stage */
  /* TODO(#9045): Move ROM_EXT size to a common location. */

--- a/sw/device/silicon_owner/bare_metal/bare_metal_slot_b.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_slot_b.ld
@@ -14,11 +14,6 @@
 
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
 /* Slot B starts at the half-size mark of the eFlash plus the fixed size of the
  * ROM_EXT.
  */

--- a/sw/device/silicon_owner/bare_metal/bare_metal_virtual_addr.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_virtual_addr.ld
@@ -14,11 +14,6 @@
 
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
 /**
  * Symbols to be used in the setup of the address translation for ROM_EXT.
  */


### PR DESCRIPTION
This updates the linker scripts for both the ROM_EXT and example bare metal silicon owner stages to define the symbols for the stack start/end offsets in the common linker scripts, since they are the same between the various slot-specific linker scripts.