### PR TITLE
[otbn,dv] Verify `START_STOP_CTRL.STATE.CONSISTENCY` countermeasure

### DIFF
--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -193,7 +193,7 @@
       name: sec_cm_start_stop_ctrl_state_consistency
       desc: "Verify the countermeasure(s) START_STOP_CTRL.STATE.CONSISTENCY."
       milestone: V2S
-      tests: []
+      tests: ["otbn_sec_wipe_err"]
     }
     {
       name: sec_cm_data_mem_sec_wipe

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -283,10 +283,8 @@ class OTBNSim:
 
         # If something bad happened asynchronously (because of an escalation),
         # we want to finish the secure wipe but accept no further commands.  To
-        # this end, set `STATUS` to Locked and turn this into a "wipe because
-        # something bad happended".
+        # this end, turn this into a "wipe because something bad happended".
         if self.state.pending_halt:
-            self.state.ext_regs.write('STATUS', Status.LOCKED, True)
             self.state._fsm_state = FsmState.WIPING_BAD
 
         # Reflect wiping in STATUS register if it has not been updated yet.

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -55,6 +55,7 @@ filesets:
       - seq_lib/otbn_mac_bignum_acc_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_ctrl_redun_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_sec_wipe_err_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sec_wipe_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sec_wipe_err_vseq.sv
@@ -1,0 +1,157 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that injects different types of errors into the internal handshake on secure wipes
+// between the controller and the start-stop controller.
+
+class otbn_sec_wipe_err_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_sec_wipe_err_vseq)
+
+  `uvm_object_new
+
+  task body();
+    typedef enum int {
+      ERR_SPURIOUS_REQ,
+      ERR_DROPPED_REQ,
+      ERR_SPURIOUS_ACK
+    } err_type_e;
+    err_type_e err_type;
+
+    // Randomize error type.
+    `DV_CHECK_STD_RANDOMIZE_FATAL(err_type)
+
+    // Wait for deassertion of reset.
+    cfg.clk_rst_vif.wait_for_reset(.wait_negedge(1'b0), .wait_posedge(1'b1));
+
+    case (err_type)
+      ERR_SPURIOUS_REQ: begin // Spurious secure wipe request
+        string err_path = "tb.dut.u_otbn_core.u_otbn_start_stop_control.secure_wipe_req_i";
+
+        // Secure wipe requests are not allowed when OTBN is idle; so wait for OTBN to become idle.
+        wait(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusIdle);
+        @(cfg.clk_rst_vif.cbn);
+
+        // Disable assertion that would abort simulation when the fault is injected.
+        $assertoff(0,
+            "tb.dut.u_otbn_core.u_otbn_start_stop_control.StartSecureWipeImpliesRunning_A");
+        `uvm_info(`gfn, "Requesting secure wipe while OTBN is idle, which is not allowed.", UVM_LOW)
+
+        // Inject error.
+        `uvm_info(`gfn, "Injecting error by force.", UVM_LOW)
+        `DV_CHECK_FATAL(uvm_hdl_force(err_path, 1'b1) == 1)
+
+        // Let model escalate in next clock cycle.
+        @(cfg.clk_rst_vif.cbn);
+        cfg.model_agent_cfg.vif.send_err_escalation(32'd1 << 20);
+
+        `uvm_info(`gfn, "Releasing force.", UVM_LOW)
+        `DV_CHECK_FATAL(uvm_hdl_release(err_path) == 1)
+
+        `uvm_info(`gfn, "Waiting for OTBN to lock up.", UVM_LOW)
+        wait(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
+      end
+
+      ERR_DROPPED_REQ: begin // Dropped secure wipe request
+        string err_path = "tb.dut.u_otbn_core.u_otbn_start_stop_control.secure_wipe_req_i";
+        bit skip_err_injection = 0;
+
+        // The OTBN controller requests a secure wipe from the start-stop controller at the end of
+        // execution.  To reach that point, we must first execute a binary.
+        string elf_path = pick_elf_path();
+        load_elf(elf_path, 1'b1);
+        `uvm_info(`gfn, $sformatf("Executing OTBN binary `%0s'.", elf_path), UVM_LOW)
+        start_running_otbn(.check_end_addr(1'b0));
+
+        // Wait until binary has completed execution and OTBN does the internal secure wipe.
+        `uvm_info(`gfn, "Waiting for OTBN to complete execution.", UVM_LOW)
+        wait(cfg.model_agent_cfg.vif.status != otbn_pkg::StatusBusyExecute);
+        if (cfg.model_agent_cfg.vif.status != otbn_pkg::StatusBusySecWipeInt) begin
+          // If OTBN is no longer executing but also not performing the internal secure wipe, we
+          // have missed the opportunity (the `start_running_otbn()` function does not guarantee
+          // that it returns while OTBN is still running).  So we cannot inject the error anymore.
+          skip_err_injection = 1;
+        end
+        @(cfg.clk_rst_vif.cbn);
+
+        if (skip_err_injection) begin
+          `uvm_info(`gfn, "Skipping error injection.", UVM_LOW)
+        end else begin
+          // Inject error.
+          `uvm_info(`gfn, "Injecting error by force.", UVM_LOW)
+          `DV_CHECK_FATAL(uvm_hdl_force(err_path, 1'b0) == 1)
+
+          @(cfg.clk_rst_vif.cbn);
+
+          // Release force, but before doing so disable an assertion that would otherwise abort
+          // simulation with a fatal error.
+          $assertoff(0,
+              "tb.dut.u_otbn_core.u_otbn_start_stop_control.StartSecureWipeImpliesRunning_A");
+          `uvm_info(`gfn, "Releasing force.", UVM_LOW)
+          `DV_CHECK_FATAL(uvm_hdl_release(err_path) == 1)
+
+          // Let model escalate in next clock cycle.
+          @(cfg.clk_rst_vif.cbn);
+          cfg.model_agent_cfg.vif.send_err_escalation(32'd1 << 20);
+
+          `uvm_info(`gfn, "Waiting for OTBN to lock up.", UVM_LOW)
+          wait(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
+        end
+      end
+
+      ERR_SPURIOUS_ACK: begin // Spurious secure wipe acknowledge
+        string err_path = "tb.dut.u_otbn_core.u_otbn_controller.secure_wipe_ack_i";
+        bit skip_err_injection = 0;
+        bit while_executing;
+
+        `DV_CHECK_STD_RANDOMIZE_FATAL(while_executing)
+
+        if (while_executing) begin
+          // Secure wipe acknowledges are not allowed when OTBN is executing; so load and execute
+          // a binary.
+          string elf_path = pick_elf_path();
+          load_elf(elf_path, 1'b1);
+          `uvm_info(`gfn, $sformatf("Executing OTBN binary `%0s'.", elf_path), UVM_LOW)
+          start_running_otbn(.check_end_addr(1'b0));
+          @(cfg.clk_rst_vif.cbn);
+
+          // If we are unlucky, OTBN is now already securely wiping due to a different error.  In
+          // that case, we skip error injection.
+          if (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusBusySecWipeInt) begin
+            skip_err_injection = 1;
+          end
+        end else begin
+          // Secure wipe acknowledges are not allowed when OTBN is idle; so wait for OTBN to become
+          // idle.
+          wait(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusIdle);
+          @(cfg.clk_rst_vif.cbn);
+        end
+
+        if (skip_err_injection) begin
+          `uvm_info(`gfn, "Skipping error injection.", UVM_LOW)
+        end else begin
+          // Inject error.
+          `uvm_info(`gfn, "Injecting error by force.", UVM_LOW)
+          `DV_CHECK_FATAL(uvm_hdl_force(err_path, 1'b1) == 1)
+
+          // Let model escalate in next clock cycle.
+          @(cfg.clk_rst_vif.cbn);
+          cfg.model_agent_cfg.vif.send_err_escalation(32'd1 << 20);
+
+          // Release force.
+          `uvm_info(`gfn, "Releasing force.", UVM_LOW)
+          `DV_CHECK_FATAL(uvm_hdl_release(err_path) == 1)
+
+          `uvm_info(`gfn, "Waiting for OTBN to lock up.", UVM_LOW)
+          wait(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
+        end
+      end
+
+      default: `DV_CHECK_FATAL(0) // This case must never be reached.
+    endcase
+
+    reset_if_locked();
+
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -23,3 +23,4 @@
 `include "otbn_pc_ctrl_flow_redun_vseq.sv"
 `include "otbn_rnd_sec_cm_vseq.sv"
 `include "otbn_ctrl_redun_vseq.sv"
+`include "otbn_sec_wipe_err_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -292,6 +292,12 @@ name:
       en_run_modes: ["build_otbn_rig_binary_mode"]
       reseed: 12
     }
+    {
+      name: "otbn_sec_wipe_err"
+      uvm_test_seq: "otbn_sec_wipe_err_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 7
+    }
   ]
 
   // List of regressions.
@@ -336,6 +342,7 @@ name:
         "otbn_tl_intg_err", "otbn_sec_cm", "otbn_pc_ctrl_flow_redun",
         "otbn_rnd_sec_cm", "otbn_alu_bignum_mod_err",
         "otbn_controller_ispr_rdata_err", "otbn_mac_bignum_acc_err",
+        "otbn_sec_wipe_err",
         # V2S but known broken
         # "otbn_passthru_mem_tl_intg_err",
         # V3 thus not yet active


### PR DESCRIPTION
This PR adds a test sequence that injects faults into the handshake
between `otbn_controller` and `otbn_start_stop_control` used to request
and acknowledge a secure wipe.  When a fault is injected, OTBN is
expected to raise a fatal alert and lock up, and this expectation is
communicated to the model. Thereby, this PR resolves #13963.

This PR also fixes an incorrect behavior of the OTBN model, which immediately updates the `STATUS` register on an escalation which is not (or no longer) what RTL does. This causes the assertion that checks for equality of this register in
the model and the RTL to fail. This is a prerequisite for the test sequence added in this PR to pass, so the fix is included in this PR.