### PR TITLE
[chip-level tests] add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/chip-level-test.yml
+++ b/.github/ISSUE_TEMPLATE/chip-level-test.yml
@@ -1,0 +1,54 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Chip-Level Test
+description: Issue to track the development of a chip-level test.
+title: "[chip-test] "
+labels: ["Component:ChipLevelTest"]
+body:
+  - type: input
+    id: name
+    attributes:
+      label: Test point name
+      description: Test point name with link to entry in test plan.
+      placeholder: >
+        Example: [chip_sw_uart_tx_rx](https://github.com/lowRISC/opentitan/blob/65e2c995beb96806d13bf04dcd8ef25ca64ac6c5/hw/top_earlgrey/data/chip_testplan.hjson#L24)
+    validations:
+      required: true
+  - type: dropdown
+    id: host-side-component
+    attributes:
+      label: Host side component
+      description: Does this test require development of a host side component? (In other words, does the test require an external stimulus, like receiving UART or SPI transactions?)
+      options:
+        - Unknown
+        - SystemVerilog
+        - Rust
+        - SystemVerilog+Rust
+  - type: dropdown
+    id: opentitantool-infra-done
+    attributes:
+      label: OpenTitanTool infrastructure implemented
+      description: Does the required opentitantool infrastructure exist so that the Rust component can be developed? If not, this must be developed in SV. 'None' means that there is no Rust component for this test.
+      options:
+        - Unknown
+        - "Yes"
+        - "No"
+  - type: input
+    id: contact
+    attributes:
+      label: Contact person
+      description: GitHub username for a hardware engineer who can answer questions.
+  - type: markdown
+    id: checklist
+    attributes:
+      value: |
+        # Checklist
+        Please fill out this checklist as items are completed. Link to PRs and issues as appropriate.
+        - [ ] Check if existing test covers most or all of this testpoint (if so, either extend said test to cover all points, or skip the next 3 checkboxes)
+        - [ ] Device-side (C) component developed
+        - [ ] Bazel build rules developed
+        - [ ] Host-side component developed
+        - [ ] HJSON test plan updated with test name (so it shows up in the dashboard)
+        - [ ] Test added to dvsim nightly regression (and passing at time of checking)


### PR DESCRIPTION
This adds an issue temlate for chip-level tests to better categorize and track development progress.

Thanks to @mundaym for turning this into YAML!

Signed-off-by: Timothy Trippel <ttrippel@google.com>