### PR TITLE
[dv/chip] lc_ctrl_kmac_reset test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1424,10 +1424,11 @@
 
             - For a lc state transition, force a reset to KMAC when KMAC is processing lc
               transition tokens.
-            - Verify that LC won't transfer to next state upon KMAC reset glitch.
+            - Force another KMAC reset after KMAC is done processing lc trantition tokens.
+            - Verify that kmac reset won't affect LC state transition.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_lc_ctrl_kmac_reset"]
     }
     {
       name: chip_sw_lc_ctrl_key_div

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -448,6 +448,13 @@
       reseed: 15
     }
     {
+      name: chip_sw_lc_ctrl_kmac_reset
+      uvm_test_seq: chip_sw_lc_ctrl_kmac_reset_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_kmac_reset_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      reseed: 1
+    }
+    {
       name: chip_sw_lc_walkthrough_dev
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -63,6 +63,7 @@ filesets:
       - seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_flash_init_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_flash_rma_unlocked_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_lc_ctrl_kmac_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_base_vseq.sv
@@ -32,7 +32,6 @@ class chip_jtag_base_vseq extends chip_sw_base_vseq;
     cfg.clk_rst_vif.wait_clks(5);
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(1));
     cfg.clk_rst_vif.wait_clks(5);
-
   endtask
 
    task ndm_reset_off();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_kmac_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_kmac_reset_vseq.sv
@@ -1,0 +1,119 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence issues two kmac reset (sys domain reset) during and after LC requesting a kmac
+// data. Then we check lc state transition status to ensure the kmac reset does not affect the
+// result of lc state transition.
+class chip_sw_lc_ctrl_kmac_reset_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_lc_ctrl_kmac_reset_vseq)
+
+  `uvm_object_new
+
+  rand bit [7:0] lc_exit_token[TokenWidthByte];
+  rand bit [7:0] lc_unlock_token[TokenWidthByte];
+
+  localparam string LC_CTRL_KMAC_REQ =
+      "tb.dut.top_earlgrey.u_lc_ctrl.kmac_data_o.valid";
+
+  localparam string LC_CTRL_KMAC_DONE =
+      "tb.dut.top_earlgrey.u_lc_ctrl.kmac_data_i.done";
+
+  localparam string SYS_DOMAIN_RESET_REQ =
+      "tb.dut.top_earlgrey.u_rv_dm.ndmreset_req_o";
+
+  virtual function void backdoor_override_otp();
+    // Override the LC partition to TestUnlocked1 state.
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStTestUnlocked1);
+
+    // Override the test exit token to match SW test's input token.
+    cfg.mem_bkdr_util_h[Otp].otp_write_secret0_partition(
+        .unlock_token(dec_otp_token_from_lc_csrs(lc_unlock_token)),
+        .exit_token(dec_otp_token_from_lc_csrs(lc_exit_token)));
+  endfunction
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+    backdoor_override_otp();
+  endtask
+
+  virtual task body();
+    super.body();
+
+    // Override the C test kLcExitToken with random data.
+    sw_symbol_backdoor_overwrite("kLcExitToken", lc_exit_token);
+
+    // Attempt the LC state transition twice:
+    // The first time we expect to see a transition failure because the C side will load incorrect
+    // exit token data.
+    // The second time we expect to see the transition succsessful.
+    for (int trans = 1; trans <= 2; trans++) begin
+      bit kmac_req, kmac_done;
+      bit [TL_DW-1:0] lc_status;
+      `uvm_info(`gfn, $sformatf("Start transition %0d/2", trans), UVM_LOW)
+
+      // Wait for SW to finish power on set up.
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == "LC transition requested.")
+
+      // Wait until kmac request is sent by LC_CTRL.
+      `DV_SPINWAIT(
+        while (kmac_req == 0) begin
+          `DV_CHECK(uvm_hdl_read(LC_CTRL_KMAC_REQ, kmac_req))
+          cfg.clk_rst_vif.wait_clks(1);
+        end
+      )
+
+      // Issue sys domain reset.
+       force_sys_domain_reset(
+          "Attempt to force sys_domain reset request during LC_CTRL KMAC data request.");
+
+      // Wait for kmac data request complete.
+      `DV_SPINWAIT(
+        while (kmac_done == 0) begin
+          `DV_CHECK(uvm_hdl_read(LC_CTRL_KMAC_DONE, kmac_done))
+          cfg.clk_rst_vif.wait_clks(1);
+        end
+      )
+
+      // Issue another sys domain reset.
+      force_sys_domain_reset(
+          "Attempt to force sys_domain reset request after LC_CTRL KMAC data request completed.");
+
+      // For the first transition, expect a kmac token_error.
+      if (trans == 1) begin
+        `DV_SPINWAIT(
+          while (lc_status[LcTokenError] == 0) begin
+            csr_rd(.ptr(ral.lc_ctrl.status), .value(lc_status), .backdoor(1));
+            `DV_CHECK_EQ(lc_status[LcTransitionSuccessful], 0, $sformatf(
+                "LC status error, expect transition not successful but get status value %0h",
+                lc_status))
+            cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
+          end
+        )
+        `uvm_info(`gfn, "LC transition has expected token error.", UVM_LOW)
+
+      // For the second transition, expect the transition succeeds.
+      end else begin
+        `DV_SPINWAIT(
+          while (lc_status[LcTransitionSuccessful] == 0) begin
+            csr_rd(.ptr(ral.lc_ctrl.status), .value(lc_status), .backdoor(1));
+            cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
+          end
+        )
+        `uvm_info(`gfn, "LC transition is successful.", UVM_LOW)
+      end
+
+      apply_reset();
+      `uvm_info(`gfn, "Apply reset and wait for chip init.", UVM_HIGH)
+    end
+  endtask
+
+  virtual task force_sys_domain_reset(string msg);
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
+    `uvm_info(`gfn, msg, UVM_LOW)
+    `DV_CHECK(uvm_hdl_force(SYS_DOMAIN_RESET_REQ, 1))
+    cfg.clk_rst_vif.wait_clks($urandom_range(2_000, 3_000));
+    `DV_CHECK(uvm_hdl_release(SYS_DOMAIN_RESET_REQ))
+    `uvm_info(`gfn, "sys_domain reset released", UVM_LOW)
+  endtask
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -27,6 +27,7 @@
 `include "chip_sw_flash_ctrl_lc_rw_en_vseq.sv"
 `include "chip_sw_flash_init_vseq.sv"
 `include "chip_sw_flash_rma_unlocked_vseq.sv"
+`include "chip_sw_lc_ctrl_kmac_reset_vseq.sv"
 `include "chip_sw_lc_ctrl_transition_vseq.sv"
 `include "chip_sw_lc_walkthrough_vseq.sv"
 `include "chip_sw_lc_walkthrough_testunlocks_vseq.sv"

--- a/sw/device/lib/testing/lc_ctrl_testutils.c
+++ b/sw/device/lib/testing/lc_ctrl_testutils.c
@@ -35,9 +35,18 @@ void lc_ctrl_testutils_check_transition_count(const dif_lc_ctrl_t *lc_ctrl,
                                               uint8_t exp_lc_count) {
   LOG_INFO("Read LC count and check with expect_val=%0d", exp_lc_count);
   uint8_t lc_count;
-  CHECK(dif_lc_ctrl_get_attempts(lc_ctrl, &lc_count) == kDifOk,
-        "Read lc_count register failed!");
+  CHECK_DIF_OK(dif_lc_ctrl_get_attempts(lc_ctrl, &lc_count));
   CHECK(lc_count == exp_lc_count,
         "LC_count error, expected %0d but actual count is %0d", exp_lc_count,
         lc_count);
+}
+
+void lc_ctrl_testutils_check_lc_state(const dif_lc_ctrl_t *lc_ctrl,
+                                      dif_lc_ctrl_state_t exp_lc_state) {
+  LOG_INFO("Read LC state and check with expect_state=%0d", exp_lc_state);
+  dif_lc_ctrl_state_t lc_state;
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(lc_ctrl, &lc_state));
+  CHECK(lc_state == exp_lc_state,
+        "LC_state error, expected %0d but actual state is %0d", exp_lc_state,
+        lc_state);
 }

--- a/sw/device/lib/testing/lc_ctrl_testutils.h
+++ b/sw/device/lib/testing/lc_ctrl_testutils.h
@@ -27,4 +27,13 @@ bool lc_ctrl_testutils_debug_func_enabled(const dif_lc_ctrl_t *lc_ctrl);
 void lc_ctrl_testutils_check_transition_count(const dif_lc_ctrl_t *lc_ctrl,
                                               uint8_t exp_lc_count);
 
+/**
+ * Check if Lifecycle Controller current state is expected.
+ *
+ * This function will read out lc_state register and check the value
+ * against exp_lc_state value.
+ */
+void lc_ctrl_testutils_check_lc_state(const dif_lc_ctrl_t *lc_ctrl,
+                                      dif_lc_ctrl_state_t exp_lc_state);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_LC_CTRL_TESTUTILS_H_

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -241,6 +241,23 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "lc_ctrl_kmac_reset_test",
+    srcs = ["lc_ctrl_kmac_reset_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_test_config",
+    ],
+)
+
+opentitan_functest(
     name = "lc_walkthrough_testunlocks_test",
     srcs = ["lc_walkthrough_testunlocks_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/lc_ctrl_kmac_reset_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_kmac_reset_test.c
@@ -1,0 +1,106 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/lc_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define LC_TOKEN_SIZE 16
+
+static dif_lc_ctrl_t lc;
+
+// LC exit token value for LC state transition.
+// Use `volatile` type here because this variable will be overwritten by SV
+// testbench via `sw_symbol_backdoor_overwrite` function.
+// The SV testbench will encode the actual token value from randomly generated
+// OTP token image.
+static volatile const uint8_t kLcExitToken[LC_TOKEN_SIZE] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+};
+
+OTTF_DEFINE_TEST_CONFIG();
+
+/**
+ * Tests the kmac reset won't affect LC state transition.
+ *
+ * 1) OTP pre-load image with lc_count = `8`.
+ * 2) Backdoor write OTP's LC parition to `TestUnlocked1` state, and backdoor
+ * write OTP's `test_exit` token and `test_unlock` token to match the rand
+ * patterns.
+ * 3) Write a wrong KMAC exit token and trigger a LC state transition request
+ * to the DEV state.
+ * 4) In SV test sequence, wait until LC sends a kmac data
+ * request by probing LC_CTRL's `kmac_data_o` pin.
+ * 5) In SV test sequence, issue a reset in KMAC block by forcing the rv_dm's
+ * `ndmreset_req_o` pin, and it should reset the sys domain IPs only, which does
+ * not include LC_CTRL. We expect to see LC_CTRL sends another KMAC data request
+ * after the sys domain reset is deasserted.
+ * 6) In SV test sequence, wait until KMAC handshake completes, then issue
+ * another sys domain reset. Check if the `status.token_error` bit is set and LC
+ * state transition is not successfuly.
+ * 7) Reset the chip.
+ *
+ * Then repeat the above steps but load the correct exit token. After the two
+ * KMAC resets, this time the testbench expects the LC state transition
+ * completes without any error.
+ *
+ * In summary, this sequence walks through the following LC states:
+ * "TestUnlocked1", count = 8 -> "TestUnlocked1", count = 9 -> "Dev", count = 10
+ */
+
+bool test_main(void) {
+  LOG_INFO("Start initialization.");
+  // Device init.
+  mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
+  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
+
+  // Get LC count.
+  uint8_t lc_count;
+  CHECK_DIF_OK(dif_lc_ctrl_get_attempts(&lc, &lc_count));
+  LOG_INFO("LC_COUNT is %0d.", lc_count);
+
+  dif_lc_ctrl_token_t token;
+  switch (lc_count) {
+    case 8:
+      // Write incorrect token data and expect the LC transition to fail.
+      for (int i = 0; i < LC_TOKEN_SIZE; i++) {
+        token.data[i] = kLcExitToken[i] - 1;
+      }
+      lc_ctrl_testutils_check_lc_state(&lc, kDifLcCtrlStateTestUnlocked1);
+      break;
+    case 9:
+      // Write correct token data and expect the LC transition to pass.
+      for (int i = 0; i < LC_TOKEN_SIZE; i++) {
+        token.data[i] = kLcExitToken[i];
+      }
+      lc_ctrl_testutils_check_lc_state(&lc, kDifLcCtrlStateTestUnlocked1);
+      break;
+    case 10:
+      // Check if current status is correct then exit the test.
+      lc_ctrl_testutils_check_lc_state(&lc, kDifLcCtrlStateDev);
+      return true;
+    default:
+      // Unexpected value, exit test with error.
+      LOG_ERROR("Unexpected lc_count value %0d", lc_count);
+      return false;
+  }
+
+  // Trigger LC transition request
+  CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));
+  CHECK_DIF_OK(dif_lc_ctrl_configure(&lc, kDifLcCtrlStateDev, 0, &token),
+               "LC transition configuration failed!");
+  CHECK_DIF_OK(dif_lc_ctrl_transition(&lc), "LC transition failed!");
+
+  // SV testbench waits for this message.
+  LOG_INFO("LC transition requested.");
+  wait_for_interrupt();
+  return false;
+}


### PR DESCRIPTION
This PR implements the lc_ctrl_kmac_reset test.
This test includes the following sequence:
1). In SV side, pre-load OTP image with count 8. Backdoor override the
  image to `TestUnlocked1` state.
2). In C side, initiate a LC state transition to DEV state, but input
  incorrect exit token.
3). During and after the token handshake with KMAC, in SV side, force
  kmac's reset line.
4). Still expect to see a LC transition failure afterwards.

Then repeat the following sequence but let C side input correct exit
token. Then expect the LC state transition to pass.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>