### PR TITLE
[kmac] Check `rst_storage` integrity

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -421,6 +421,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   logic                    sha3_state_error;
   logic                    sha3_count_error;
+  logic                    sha3_rst_storage_error;
   logic [EsEnableCopies-1:0] es_enable_q_fo;
   logic                      es_hw_regwen;
   logic                      recov_alert_state;
@@ -2378,8 +2379,13 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
     .error_o (sha3_err),
     .sparse_fsm_error_o (sha3_state_error),
-    .count_error_o  (sha3_count_error)
+    .count_error_o  (sha3_count_error),
+    .keccak_storage_rst_error_o (sha3_rst_storage_error)
   );
+
+  // TODO: Connect to an alert
+  logic unused_sha3_rst_storage_error;
+  assign unused_sha3_rst_storage_error = sha3_rst_storage_error;
 
 
   //--------------------------------------------

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -669,6 +669,11 @@ module kmac
                           | kmac_entropy_state_error
                           | kmac_state_error;
 
+  // Control Signal Integrity Errors
+  logic control_integrity_error;
+  logic sha3_storage_rst_error;
+  assign control_integrity_error = sha3_storage_rst_error;
+
   prim_intr_hw #(.Width(1)) intr_kmac_err (
     .clk_i,
     .rst_ni,
@@ -890,9 +895,10 @@ module kmac
     .state_valid_o (state_valid),
     .state_o       (state), // [Share]
 
-    .error_o            (sha3_err),
-    .sparse_fsm_error_o (sha3_state_error),
-    .count_error_o  (sha3_count_error)
+    .error_o                    (sha3_err),
+    .sparse_fsm_error_o         (sha3_state_error),
+    .count_error_o              (sha3_count_error),
+    .keccak_storage_rst_error_o (sha3_storage_rst_error)
   );
 
   // MSG_FIFO window interface to FIFO interface ===============================
@@ -1326,6 +1332,7 @@ module kmac
                      | alert_intg_err
                      | sparse_fsm_error
                      | counter_error
+                     | control_integrity_error
                      ;
 
   // Make the fatal alert observable via status register.

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -74,7 +74,10 @@ module sha3
   output logic sparse_fsm_error_o,
 
   // counter error
-  output logic count_error_o
+  output logic count_error_o,
+
+  // error on rst_storage in Keccak
+  output logic keccak_storage_rst_error_o
 
 );
   /////////////////
@@ -131,6 +134,10 @@ module sha3
   logic sha3pad_state_error;
 
   assign sparse_fsm_error_o = sha3_state_error | keccak_round_state_error | sha3pad_state_error;
+
+  // Keccak rst_storage is asserted unexpectedly
+  logic keccak_storage_rst_error;
+  assign keccak_storage_rst_error_o = keccak_storage_rst_error;
 
   /////////////////
   // Connections //
@@ -444,6 +451,7 @@ module sha3
 
     .sparse_fsm_error_o  (keccak_round_state_error),
     .round_count_error_o (round_count_error),
+    .rst_storage_error_o (keccak_storage_rst_error),
 
     .clear_i    (keccak_done)
   );


### PR DESCRIPTION
This commit adds a condition to the fatal error raised if `rst_storage`
is asserted unexpectedly.

`rst_storage` in `keccak_round` supposes to be high when `clear_i` is
high at `StIdle` state.


Addressing one of the items in https://github.com/lowRISC/opentitan/issues/13855