### PR TITLE
[kmac] Change `done` to `mubi4_t`

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -395,7 +395,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     sha3_msg_rdy_mask_q;
   logic                     sha3_msg_rdy_mask;
   logic                     sha3_block_processed;
-  logic                     sha3_done;
+  prim_mubi_pkg::mubi4_t    sha3_done;
   prim_mubi_pkg::mubi4_t    sha3_absorbed;
   logic                     sha3_squeezing;
   logic [2:0]               sha3_fsm;

--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -29,7 +29,7 @@ module entropy_src_main_sm #(
   output logic                  boot_phase_done_o,
   output logic                  sha3_start_o,
   output logic                  sha3_process_o,
-  output logic                  sha3_done_o,
+  output prim_mubi_pkg::mubi4_t sha3_done_o,
   output logic                  cs_aes_halt_req_o,
   input logic                   cs_aes_halt_ack_i,
   input logic                   local_escalate_i,
@@ -100,7 +100,7 @@ module entropy_src_main_sm #(
     boot_phase_done_o = 1'b0;
     sha3_start_o = 1'b0;
     sha3_process_o = 1'b0;
-    sha3_done_o = 1'b0;
+    sha3_done_o = prim_mubi_pkg::MuBi4False;
     cs_aes_halt_req_o = 1'b0;
     main_sm_alert_o = 1'b0;
     main_sm_idle_o = 1'b0;
@@ -270,11 +270,11 @@ module entropy_src_main_sm #(
       end
       Sha3Done: begin
         if (!enable_i) begin
-          sha3_done_o = 1'b1;
+          sha3_done_o = prim_mubi_pkg::MuBi4True;
           state_d = Idle;
         end else begin
           if (main_stage_rdy_i) begin
-            sha3_done_o = 1'b1;
+            sha3_done_o = prim_mubi_pkg::MuBi4True;
             main_stage_push_o = 1'b1;
             if (fw_ov_ent_insert_i) begin
               state_d = Idle;

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -54,7 +54,7 @@ module keccak_round
   output logic             sparse_fsm_error_o,
   output logic             round_count_error_o,
 
-  input                    clear_i     // Clear internal state to '0
+  input  prim_mubi_pkg::mubi4_t clear_i     // Clear internal state to '0
 );
 
   /////////////////////
@@ -212,7 +212,7 @@ module keccak_round
 
           xor_message    = 1'b 1;
           update_storage = 1'b 1;
-        end else if (clear_i) begin
+        end else if (prim_mubi_pkg::mubi4_test_true_strict(clear_i)) begin
           // Opt1. State machine allows resetting the storage only in Idle
           // Opt2. storage resets regardless of states but clear_i
           // Both are added in the design at this time. Will choose the
@@ -473,7 +473,9 @@ module keccak_round
   `ASSUME(ValidRunAssertStIdle_A, valid_i || run_i |-> keccak_st == StIdle, clk_i, !rst_ni)
 
   // clear_i is assumed to be asserted in Idle state
-  `ASSUME(ClearAssertStIdle_A, clear_i |-> keccak_st == StIdle, clk_i, !rst_ni)
+  `ASSUME(ClearAssertStIdle_A,
+    prim_mubi_pkg::mubi4_test_true_strict(clear_i)
+     |-> keccak_st == StIdle, clk_i, !rst_ni)
 
   // EnMasking controls the valid states
   if (EnMasking) begin : gen_mask_st_chk

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -44,7 +44,7 @@ module kmac_core
   // Controls : same to SHA3 core
   input start_i,
   input process_i,
-  input done_i,
+  input prim_mubi_pkg::mubi4_t done_i,
 
   // Control to SHA3 core
   output logic process_o,
@@ -212,7 +212,7 @@ module kmac_core
       end
 
       StKmacFlush: begin
-        if (done_i) begin
+        if (prim_mubi_pkg::mubi4_test_true_strict(done_i)) begin
           st_d = StKmacIdle;
         end else begin
           st_d = StKmacFlush;
@@ -267,7 +267,8 @@ module kmac_core
       process_latched <= 1'b 0;
     end else if (process_i && !process_o) begin
       process_latched <= 1'b 1;
-    end else if (process_o || done_i) begin
+    end else if (process_o ||
+      prim_mubi_pkg::mubi4_test_true_strict(done_i)) begin
       process_latched <= 1'b 0;
     end
   end

--- a/hw/ip/kmac/rtl/kmac_msgfifo.sv
+++ b/hw/ip/kmac/rtl/kmac_msgfifo.sv
@@ -41,7 +41,7 @@ module kmac_msgfifo
   output logic [MsgDepthW-1:0] fifo_depth_o,
 
   // Control
-  input clear_i,
+  input prim_mubi_pkg::mubi4_t clear_i,
 
   // process_i --> process_o
   // process_o asserted after all internal messages are flushed out to MSG interface
@@ -149,7 +149,7 @@ module kmac_msgfifo
   ) u_msgfifo (
     .clk_i,
     .rst_ni,
-    .clr_i   (clear_i),
+    .clr_i   (prim_mubi_pkg::mubi4_test_true_strict(clear_i)),
 
     .wvalid_i(fifo_wvalid),
     .wready_o(fifo_wready),
@@ -219,7 +219,7 @@ module kmac_msgfifo
       end
 
       FlushClear: begin
-        if (clear_i) begin
+        if (prim_mubi_pkg::mubi4_test_true_strict(clear_i)) begin
           flush_st_d = FlushIdle;
         end else begin
           flush_st_d = FlushClear;

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -45,8 +45,8 @@ module sha3
   // run_i is a pulse signal to trigger the keccak_round manually by SW.
   // It is used to run additional keccak_f after sponge absorbing is completed.
   // See `keccak_run` signal
-  input run_i,
-  input done_i,    // see sha3pad for details
+  input                        run_i,
+  input prim_mubi_pkg::mubi4_t done_i,    // see sha3pad for details
 
   output prim_mubi_pkg::mubi4_t absorbed_o,
   output logic                  squeezing_o,
@@ -119,7 +119,8 @@ module sha3
   sha3_st_sparse_e st, st_d;
 
   // Keccak control signal (filtered by State Machine)
-  logic keccak_start, keccak_process, keccak_done;
+  logic keccak_start, keccak_process;
+  prim_mubi_pkg::mubi4_t keccak_done;
 
   // alert signals
   logic round_count_error, msg_count_error;
@@ -199,7 +200,7 @@ module sha3
     keccak_start = 1'b 0;
     keccak_process = 1'b 0;
     sw_keccak_run = 1'b 0;
-    keccak_done = 1'b 0;
+    keccak_done = prim_mubi_pkg::MuBi4False;
 
     squeezing = 1'b 0;
 
@@ -241,10 +242,10 @@ module sha3
           st_d = StManualRun_sparse;
 
           sw_keccak_run = 1'b 1;
-        end else if (done_i) begin
+        end else if (prim_mubi_pkg::mubi4_test_true_strict(done_i)) begin
           st_d = StFlush_sparse;
 
-          keccak_done = 1'b 1;
+          keccak_done = done_i;
         end else begin
           st_d = StSqueeze_sparse;
         end
@@ -309,7 +310,8 @@ module sha3
 
     unique case (st)
       StIdle_sparse: begin
-        if (process_i || run_i || done_i) begin
+        if (process_i || run_i ||
+          prim_mubi_pkg::mubi4_test_true_loose(done_i)) begin
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
@@ -319,7 +321,8 @@ module sha3
       end
 
       StAbsorb_sparse: begin
-        if (start_i || run_i || done_i || (process_i && processing)) begin
+        if (start_i || run_i || prim_mubi_pkg::mubi4_test_true_loose(done_i)
+          || (process_i && processing)) begin
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
@@ -339,7 +342,8 @@ module sha3
       end
 
       StManualRun_sparse: begin
-        if (start_i || process_i || run_i || done_i) begin
+        if (start_i || process_i || run_i ||
+          prim_mubi_pkg::mubi4_test_true_loose(done_i)) begin
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
@@ -349,7 +353,8 @@ module sha3
       end
 
       StFlush_sparse: begin
-        if (start_i || process_i || run_i || done_i) begin
+        if (start_i || process_i || run_i ||
+          prim_mubi_pkg::mubi4_test_true_loose(done_i)) begin
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,


### PR DESCRIPTION
_Related Issue: https://github.com/lowRISC/opentitan/issues/13855_

`clear_i` triggers `rst_storage` in `keccak_round`. `rst_storage`
signal integrity is checked in the PR
https://github.com/lowRISC/opentitan/pull/14103

However, `clear_i` may be a victim of FI attacks. Then the consequences
are same to the FI attacks on `rst_storage`. Whenever the hashing
operation is completed and early `clear_i` signal is issued prior to SW
read, the result digest is 0. (It will be great if SW checks two shares
of the digests are not all zero)

This commit converts the `sha3_done` to `mubi4_t` and following logics
to check the signal to `prim_mubi_pkg::MuBi4True` strictly.

