### PR TITLE
[aes/pre_syn] Added missing files to re-enable Yosys synthesis for AES

### DIFF
--- a/hw/ip/aes/pre_syn/syn_yosys.sh
+++ b/hw/ip/aes/pre_syn/syn_yosys.sh
@@ -68,6 +68,8 @@ OT_DEP_SOURCES=(
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_lfsr.sv
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_flop_2sync.sv
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_cdc_rand_delay.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_reg_we_check.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_onehot_check.sv
     "$LR_SYNTH_SRC_DIR"/../prim_generic/rtl/prim_generic_flop.sv
     "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xilinx_flop.sv
     "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xilinx_flop_en.sv


### PR DESCRIPTION
The following errors occured during Yosys synthesis:
ERROR: Module `\prim_reg_we_check' referenced in module
`\aes_reg_top' in cell `\u_prim_reg_we_check' is not part
of the design.
ERROR: Module `\prim_onehot_check' referenced in module
`\prim_reg_we_check' in cell `\u_prim_onehot_check' is not part
of the design.

Solution was to add the corresponding files to the Yosys synthesis
script.

Signed-off-by: Moritz Wettermann <moritz.wettermann@gi-de.com>