### PR TITLE
[kmac/rtl] Add key sharing to unmasked KMAC implementation

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -1441,11 +1441,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
           exp_keys = (sideload_en || (in_kmac_app && app_mode == AppKeymgr)) ?
                       get_keymgr_keys : keys;
           for (int i = 0; i < key_word_len; i++) begin
-            if (cfg.enable_masking) begin
-              unmasked_key.push_back(exp_keys[0][i] ^ exp_keys[1][i]);
-            end else begin
-              unmasked_key.push_back(exp_keys[0][i]);
-            end
+            unmasked_key.push_back(exp_keys[0][i] ^ exp_keys[1][i]);
             `uvm_info(`gfn, $sformatf("unmasked_key[%0d] = 0x%0x", i, unmasked_key[i]), UVM_HIGH)
           end
 


### PR DESCRIPTION
This enables SW to set the KMAC key in two shares even when
parameter EnMasking = 0. The key is computed by XORing of the two
shares. This feature was already possible for masked implementation
(EnMasking =1), but according to specifications it should also be
enabled for the unmasked version.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>