### PR TITLE
[otbn,dv] Fixes around fatal error related covergroups

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -550,17 +550,17 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
   // alert. This gets sampled when we read a FATAL_ALERT_CAUSE with just FATAL_SOFTWARE and is given
   // last_err_bits (see comment above declaration of that variable for more details).
   covergroup promoted_err_cg
-    with function sample(logic [31:0] last_err_bits);
+    with function sample(logic [5:0] last_err_bits);
 
     // We're interested in the "one-hot" values corresponding to each error that wouldn't normally
     // be fatal.
     err_bits_cp: coverpoint last_err_bits {
-      bins bad_data_addr = {32'h1};
-      bins bad_insn_addr = {32'h2};
-      bins call_stack    = {32'h4};
-      bins illegal_insn  = {32'h8};
-      bins loop          = {32'h10};
-      bins key_invalid   = {32'h20};
+      bins bad_data_addr = {6'h1};
+      bins bad_insn_addr = {6'h2};
+      bins call_stack    = {6'h4};
+      bins illegal_insn  = {6'h8};
+      bins loop          = {6'h10};
+      bins key_invalid   = {6'h20};
     }
   endgroup
 
@@ -2200,6 +2200,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
         ext_csr_status_cg.sample(otbn_pkg::status_e'(data), access_type);
       end
       "err_bits": begin
+        last_err_bits = data;
         ext_csr_err_bits_cg.sample(otbn_pkg::err_bits_t'(data),
                                    csr.get_mirrored_value(), access_type, state);
       end
@@ -2211,7 +2212,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
         if ((state == OperationalStateLocked) &&
             (access_type == AccessSoftwareRead) &&
             (data == (1 << 7))) begin
-          promoted_err_cg.sample(last_err_bits);
+          promoted_err_cg.sample(last_err_bits[5:0]);
         end
       end
       "insn_cnt": begin

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -74,7 +74,7 @@ package otbn_env_pkg;
   parameter int unsigned MNEM_STR_LEN = 16;
   typedef bit [MNEM_STR_LEN*8-1:0] mnem_str_t;
 
-  parameter int unsigned CSR_STR_LEN = 16;
+  parameter int unsigned CSR_STR_LEN = 20;
   typedef bit [CSR_STR_LEN*8-1:0] csr_str_t;
 
   // A very simple wrapper around a word that has been loaded from the input binary and needs

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -206,6 +206,16 @@ class otbn_scoreboard extends cip_base_scoreboard #(
             expect_alert("recov");
           end
         end
+        "ctrl": begin
+          // Let model know that CTRL register has changed. This is not ideal since scoreboard
+          // ideally supposed be a passive component. Although we are still not affecting DUT in
+          // any way while doing this and an alternative way would include catching this register
+          // write in testbench level and sending a signal to otbn_core_model, which is not ideal
+          // as well.
+          if (item.is_write) begin
+            cfg.model_agent_cfg.vif.set_software_errs_fatal(item.a_data[0]);
+          end
+        end
         default: begin
           // No other special behaviour for writes
         end

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -434,8 +434,6 @@ class otbn_base_vseq extends cip_base_vseq #(
         _send_random_cmd();
       end
     end
-    csr_utils_pkg::csr_wr(ral.ctrl, 'b0);
-    cfg.model_agent_cfg.vif.set_software_errs_fatal(1'b0);
 
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(rd_pc, rd_pc inside {[0:100]};)
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(wr_pc, wr_pc inside {[0:100]};)

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sw_errs_fatal_chk_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sw_errs_fatal_chk_vseq.sv
@@ -10,11 +10,9 @@ class otbn_sw_errs_fatal_chk_vseq extends otbn_single_vseq;
     // Wait for OTBN to complete its secure wipe after reset and become Idle.  Otherwise, OTBN will
     // ignore writes of `CTRL.software_errs_fatal`.
     wait(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusIdle);
-    // Set ctrl.software_errs_fatal.
+    // Set ctrl.software_errs_fatal. This change also will be passed to our model through
+    // otbn_scoreboard.
     csr_utils_pkg::csr_wr(ral.ctrl, 'b1);
-    // When set software errors produce fatal errors, rather than recoverable errors.
-    cfg.model_agent_cfg.vif.set_software_errs_fatal(1'b1);
-    // We've loaded the binary. Run the processor to see what happens!
     super.body();
     reset_if_locked();
   endtask : body

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -272,7 +272,7 @@ name:
       name: "otbn_sw_errs_fatal_chk"
       uvm_test_seq: "otbn_sw_errs_fatal_chk_vseq"
       en_run_modes: ["build_otbn_rig_binary_mode"]
-      reseed: 5
+      reseed: 10
     }
     {
       name: "otbn_pc_ctrl_flow_redun"


### PR DESCRIPTION
Both commits works to close current coverage holes in `ext_csr_fatal_alert_cause_cg` and `promoted_err_cg` covergroups. 

I also think we need to increase sw_errs_fatal_chk ressed from 5 to 10 or 15 since it is the only time we'd enable promotion of sw errors to fatal errors and we count on `otbn_single` to introduce each type of software error. @prajwalaputtappa, WDYT? I can add that change to the PR as well, just wanted to hear your opinion first.