### PR TITLE
fix(sha3): Incorrect msg_ready_o timing

### DIFF
--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -384,8 +384,11 @@ module sha3pad
           keccak_run_o = 1'b 1;
           clr_sentmsg = 1'b 1;
           hold_msg = 1'b 1;
-        end else if (process_latched) begin
+        end else if (process_latched || process_i) begin
           st_d = StPad;
+
+          // Not asserting the msg_ready_o
+          hold_msg = 1'b 1;
         end else begin
           st_d = StMessage;
 
@@ -795,6 +798,9 @@ module sha3pad
 
   // Message can be fed in between start_i and process_i.
   `ASSUME(MessageCondition_M, msg_valid_i && msg_ready_o |-> process_valid && !process_i)
+
+  // Message ready should be asserted only in between start_i and process_i
+  `ASSERT(MsgReadyCondition_A, msg_ready_o |-> process_valid && !process_i)
 
   `ASSUME(ProcessCondition_M, process_i |-> process_valid)
   `ASSUME(StartCondition_M, start_i |-> start_valid)


### PR DESCRIPTION
As reported in https://github.com/lowRISC/opentitan/pull/13921#discussion_r935911685 and https://github.com/lowRISC/opentitan/issues/14090 , SHA3 asserted `msg_ready_o` when it moves to `StPad` state even after `process_i` has been asserted.

The behavior may cause incorrect process (the behavior is checked by an assumption though)