### PR TITLE
[tests] Add mask ROM shutdown e2e tests to the test plan

### DIFF
--- a/sw/device/silicon_creator/mask_rom/data/mask_rom_testplan.hjson
+++ b/sw/device/silicon_creator/mask_rom/data/mask_rom_testplan.hjson
@@ -13,6 +13,126 @@
   name: "mask_rom"
 
   testpoints: [
+    // Shutdown: Error reporting
+    {
+      name: mask_rom_e2e_shutdown_output
+      desc: '''Verify that mask ROM can properly report errors over UART.
+
+            - Attempt to boot without a valid ROM_EXT.
+            - Verify that we can receive 28 characters (LCV:xxxxxxxx\r\nBFV:xxxxxxxx\r\n) of error
+              output in all life cycle states where Ibex is enabled, i.e. TEST_UNLOCKED*, PROD,
+              PROD_END, DEV, and RMA.
+                - BFV should be 0x142500d for all life cycle states.
+                - See the table below for the expected LCV value.
+
+            | LC State |     LCV    | OTP LIFE_CYCLE state | OTP LIFE_CYCLE count |
+            |:--------:|:----------:|:--------------------:|:--------------------:|
+            |   TEST   | 0x02108421 |   "TEST_UNLOCKED0"   |           5          |
+            |   DEV    | 0x21084210 |        "DEV"         |           5          |
+            |   PROD   | 0x2318c631 |        "PROD"        |           5          |
+            | PROD_END | 0x25294a52 |      "PROD_END"      |           5          |
+            |   RMA    | 0x2739ce73 |        "RMA"         |           5          |
+            '''
+      tags: ["verilator", "dv", "fpga", "silicon"]
+      milestone: V2
+      tests: []
+    }
+
+    // Shutdown: Redaction
+    {
+      name: mask_rom_e2e_shutdown_redact
+      desc: '''Verify that mask ROM redacts errors properly.
+
+            - Attempt to boot without a valid ROM_EXT.
+            - Verify that there is no redaction in TEST_UNLOCKED* and RMA.
+            - For DEV, PROD, and PROD_END:
+              - Verify that BFV value is redacted according to the ROM_ERROR_REPORTING OTP item.
+
+            | OTP ROM_ERROR_REPORTING |     BFV    |
+            |:-----------------------:|:----------:|
+            |   0xe2290aa5 (None)     | 0x0142500d |
+            |   0x3367d3d4 (Error)    | 0x0042500d |
+            |   0x1e791123 (Module)   | 0x0100000d |
+            |   0x48eb4bd9 (All)      | 0xffffffff |
+            '''
+      tags: ["verilator", "dv", "fpga", "silicon"]
+      milestone: V2
+      tests: []
+    }
+
+    // Shutdown: Watchdog
+    {
+      name: mask_rom_e2e_shutdown_watchdog
+      desc: '''Verify that mask ROM configures the watchdog properly.
+
+            - Attempt to boot with a valid ROM_EXT.
+              - ROM_EXT needs to print something and busy loop (bounded) until watchdog resets the
+                chip.
+            - Verify that the chip does not reset in TEST and RMA.
+            - For DEV, PROD, and PROD_END:
+              - Verify that the chip resets when the `WATCHDOG_BITE_THRESHOLD_CYCLES` OTP item is
+               `0x00061a80` (2 s).
+              - Verify that watchdog is disabled when `WATCHDOG_BITE_THRESHOLD_CYCLES` is `0`.
+            '''
+      tags: ["verilator", "dv", "fpga", "silicon"]
+      milestone: V2
+      tests: ["mask_rom_e2e_shutdown_watchdog"]
+    }
+
+    // Shutdown: ASM exception handlers
+    {
+      name: mask_rom_e2e_shutdown_exception_asm
+      desc: '''Verify that mask ROM asm exception handler resets the chip.
+
+            - Power on with the `CREATOR_SW_CFG_ROM_EXEC_EN` OTP item set to `0`.
+              - Execution should halt very early in `_mask_rom_start_boot`.
+            - Connect the debugger and set a breakpoint at `_asm_exception_handler`.
+              - Note: We need to use a debugger for this test since `mtvec` points to C handlers
+                when `mask_rom_main()` starts executing.
+            - Set `pc` to `0x10000000` (start of main SRAM) and execute one machine instruction,
+              i.e. `stepi`.
+            - Verify that execution stops at `_asm_exception_handler` since code execution from SRAM is
+              not enabled.
+            - Continue and verify that the asm exception handler resets the chip by confirming that
+              execution halts at `_mask_rom_start_boot`.
+            '''
+      tags: ["verilator", "dv", "fpga", "silicon"]
+      milestone: V2
+      tests: []
+    }
+
+    // Shutdown: C exception handlers
+    {
+      name: mask_rom_e2e_shutdown_exception_c
+      desc: '''Verify that mask ROM C exception handler triggers shutdown.
+
+            - Boot a valid _fake_ ROM_EXT that doesn't register any interrupt handlers.
+            - Trigger an exception in the second stage.
+              - Set `pc` to `0x10000000` (start of main SRAM). This should trigger an exception
+                since code execution from SRAM is not enabled.
+            - Verify that the chip resets with the correct `BFV`: 0x01495202, i.e. instruction
+              access fault in the interrupt module.
+            '''
+      tags: ["verilator", "dv", "fpga", "silicon"]
+      milestone: V2
+      tests: []
+    }
+
+    // Shutdown: Verify alert configuration
+    {
+      name: mask_rom_e2e_shutdown_exception_c
+      desc: '''Verify that alerts trigger a chip reset when enabled.
+
+            - For PROD, PROD_END, DEV, and RMA life cycle states
+              - Use an OTP image with an alert enabled.
+            - Boot a ROM_EXT that triggers this alert by writing to a ALERT_TEST register.
+            - Verify that the chip resets.
+            '''
+      tags: ["verilator", "dv", "fpga", "silicon"]
+      milestone: V2
+      tests: []
+    }
+    
     // Functests
     {
       name: mask_rom_functests


### PR DESCRIPTION
This PR adds the shutdown e2e tests that we identifier in the test plan meeting to the ROM test plan.

Signed-off-by: Alphan Ulusoy <alphan@google.com>