### PR TITLE
[prim] Assertion update for prim_reg_cdc

### DIFF
--- a/hw/ip/clkmgr/rtl/clkmgr_meas_chk.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_meas_chk.sv
@@ -76,7 +76,8 @@ module clkmgr_meas_chk
     src_cfg_meas_en_valid_o = '0;
     src_cfg_meas_en_o = src_cfg_meas_en_i;
 
-    if (!src_calib_rdy) begin
+    // disable if the current value is not false
+    if (!src_calib_rdy && prim_mubi_pkg::mubi4_test_true_loose(src_cfg_meas_en_o)) begin
       src_cfg_meas_en_valid_o = 1'b1;
       src_cfg_meas_en_o = prim_mubi_pkg::MuBi4False;
     end


### PR DESCRIPTION
- The assertion was not updated to account for the latest
  prim_reg_cdc design.
- The dst_update_i only takes effect if there are no
  conflicting higher priority requests. If the value
  differs after high priority requests are completed, then
  a separate synchronization event is generated.

Signed-off-by: Timothy Chen <timothytim@google.com>