### PR TITLE
[rom_ctrl] Correct documentation

### DIFF
--- a/hw/ip/rom_ctrl/doc/_index.md
+++ b/hw/ip/rom_ctrl/doc/_index.md
@@ -140,12 +140,10 @@ However, `rom_ctrl` also controls bus access to ROM data and interacts with othe
 To avoid attacks propagating into the rest of the system, we take the following extra hardening steps:
 
 - All internal FSMs are sparsely encoded, with a minimum Hamming distance of 3.
-- The "good" signal passed to the power manager is multi-bit encoded. (*)
-- The switching signals for the mux are multi-bit encoded (using `mubi4_t`) (*)
+- The "good" signal passed to the power manager is multi-bit encoded (using `mubi4_t`).
+- The switching signals for the mux are multi-bit encoded (using `mubi4_t`).
 - We check to ensure the mux doesn't switch back to the checker after giving access to the bus.
 - The main FSM has internal consistency checking to ensure that other blocks don't signal completion when the FSM is in a state that doesn't expect them to be running.
-
-Items with (*) next to them are not yet implemented in the RTL.
 
 ## Hardware Interfaces
 


### PR DESCRIPTION
This PR corrects the documentation regarding some signals to be hardened using a multi-bit encoding. However, the corresponding signals are already using MuBi types. It seems we just forgot to update the documentation accordingly.

This is related to #14097.