### PR TITLE
[otbn,dv,rtl] Verify spurious URND acknowledge

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -1022,6 +1022,10 @@ In addition, it can be triggered by the [Life Cycle Controller]({{<relref "/hw/i
 
 A secure wipe of the internal state only is triggered automatically after reset and when OTBN [ends the software execution](#design-details-software-execution), either successfully, or unsuccessfully due to a [recoverable error](#design-details-recoverable-errors).
 
+If OTBN cannot complete a secure wipe of the internal state (e.g., due to failing to obtain the required randomness), it immediately becomes locked.
+In this case, OTBN must be reset and will then retry the secure wipe.
+The secure wipe after reset must succeed before OTBN can be used.
+
 #### Data Memory (DMEM) Secure Wipe {#design-details-secure-wipe-dmem}
 
 The wiping is performed by securely replacing the memory scrambling key, making all data stored in the memory unusable.

--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -529,9 +529,10 @@ void ISSWrapper::reset(bool gen_trace) {
   mirrored_.reset();
 }
 
-void ISSWrapper::send_err_escalation(uint32_t err_val) {
+void ISSWrapper::send_err_escalation(uint32_t err_val, bool lock_immediately) {
   std::ostringstream oss;
-  oss << "send_err_escalation " << std::hex << "0x" << err_val << "\n";
+  oss << "send_err_escalation " << std::hex << "0x" << err_val << " "
+      << lock_immediately << "\n";
   run_command(oss.str(), nullptr);
 }
 

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -136,7 +136,7 @@ struct ISSWrapper {
   void reset(bool gen_trace);
 
   // Send an error escalation
-  void send_err_escalation(uint32_t err_val);
+  void send_err_escalation(uint32_t err_val, bool lock_immediately);
 
   const MirroredRegs &get_mirrored() const { return mirrored_; }
 

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -98,6 +98,8 @@ module otbn_core_model
   bit unused_raw_err_bits;
   logic unused_edn_rsp_fips;
 
+  logic lock_immediately_q; // No `_d` because model IF deposits directly into the `_q`.
+
   // EDN RND Request Logic
   logic edn_rnd_req_q, edn_rnd_req_d;
 
@@ -203,13 +205,18 @@ module otbn_core_model
 
       default: urnd_state_d = OtbnCoreModelUrndStateReset;
     endcase
+
+    if (lock_immediately_q) begin
+      urnd_state_d = OtbnCoreModelUrndStateReset;
+    end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      start_q        <= 1'b0;
-      urnd_state_q   <= OtbnCoreModelUrndStateReset;
-      wipe_cyc_cnt_q <= '0;
+      lock_immediately_q <= 1'b0;
+      start_q            <= 1'b0;
+      urnd_state_q       <= OtbnCoreModelUrndStateReset;
+      wipe_cyc_cnt_q     <= '0;
     end else begin
       start_q        <= start_d;
       urnd_state_q   <= urnd_state_d;

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -324,7 +324,10 @@ module otbn_core_model
       end
       if (new_escalation) begin
         // Setting LIFECYCLE_ESCALATION bit
-        failed_lc_escalate <= (otbn_model_send_err_escalation(model_handle, 32'd1 << 22) != 0);
+        failed_lc_escalate <= (otbn_model_send_err_escalation(model_handle,
+                                                              32'd1 << 22,
+                                                              1'b0)
+                               != 0);
       end
       if (!$stable(keymgr_key_i) || $rose(rst_ni)) begin
         failed_keymgr_value <= (otbn_model_set_keymgr_value(model_handle,

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -616,13 +616,14 @@ int OtbnModel::reset(svBitVecVal *status /* bit [7:0] */,
   return 0;
 }
 
-int OtbnModel::send_err_escalation(svBitVecVal *err_val /* bit [31:0] */) {
+int OtbnModel::send_err_escalation(svBitVecVal *err_val /* bit [31:0] */,
+                                   svBit lock_immediately) {
   ISSWrapper *iss = ensure_wrapper();
   if (!iss)
     return -1;
 
   try {
-    iss->send_err_escalation(err_val[0]);
+    iss->send_err_escalation(err_val[0], lock_immediately);
   } catch (const std::exception &err) {
     std::cerr << "Error when sending error escalation signal to ISS: "
               << err.what() << "\n";
@@ -1034,9 +1035,10 @@ int otbn_model_reset(OtbnModel *model, svBitVecVal *status /* bit [7:0] */,
 }
 
 int otbn_model_send_err_escalation(OtbnModel *model,
-                                   svBitVecVal *err_val /* bit [31:0] */) {
+                                   svBitVecVal *err_val /* bit [31:0] */,
+                                   svBit lock_immediately) {
   assert(model);
-  return model->send_err_escalation(err_val);
+  return model->send_err_escalation(err_val, lock_immediately);
 }
 
 int otbn_model_initial_secure_wipe(OtbnModel *model) {

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -113,7 +113,8 @@ class OtbnModel {
             svBitVecVal *stop_pc /* bit [31:0] */);
 
   // Escalate errors. Returns 0 on success; -1 on failure.
-  int send_err_escalation(svBitVecVal *err_val /* bit [31:0] */);
+  int send_err_escalation(svBitVecVal *err_val /* bit [31:0] */,
+                          svBit lock_immediately);
 
   // Returns true if we have an ISS wrapper and it has the START_WIPE flag
   // asserted

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -136,7 +136,8 @@ int otbn_model_reset(OtbnModel *model, svBitVecVal *status /* bit [7:0] */,
 
 // React to an error escalation. Returns 0 on success or -1 on failure.
 int otbn_model_send_err_escalation(OtbnModel *model,
-                                   svBitVecVal *err_val /* bit [31:0] */);
+                                   svBitVecVal *err_val /* bit [31:0] */,
+                                   svBit lock_immediately);
 
 // Trigger initial secure wipe.
 int otbn_model_initial_secure_wipe(OtbnModel *model);

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.svh
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.svh
@@ -66,7 +66,9 @@ import "DPI-C" context function int otbn_model_reset(chandle          model,
                                                      inout bit [31:0] err_bits,
                                                      inout bit [31:0] stop_pc);
 
-import "DPI-C" function int otbn_model_send_err_escalation(chandle model, bit [31:0] err_val);
+import "DPI-C" function int otbn_model_send_err_escalation(chandle    model,
+                                                           bit [31:0] err_val,
+                                                           bit        lock_immediately);
 
 import "DPI-C" function int otbn_model_initial_secure_wipe(chandle model);
 

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -299,11 +299,8 @@ class OTBNSim:
         if self.state.ext_regs.read('WIPE_START', True):
             self.state.ext_regs.write('WIPE_START', 0, True)
 
-        # Zero INSN_CNT if we're in state WIPING_BAD. This is a bit silly
-        # because we'll send that update on every cycle, but it correctly
-        # handles the situation where we switch from WIPING_GOOD to WIPING_BAD
-        # half way through a secure wipe because of an incoming escalation.
-        if not is_good:
+        # Zero INSN_CNT once if we're in state WIPING_BAD.
+        if not is_good and self.state.ext_regs.read('INSN_CNT', True) != 0:
             self.state.ext_regs.write('INSN_CNT', 0, True)
 
         if self.state.wipe_cycles == 1:

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -56,6 +56,7 @@ filesets:
       - seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_ctrl_redun_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_sec_wipe_err_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_urnd_err_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_urnd_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_urnd_err_vseq.sv
@@ -1,0 +1,98 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that injects a spurious acknowledge to URND requests.
+
+class otbn_urnd_err_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_urnd_err_vseq)
+
+  `uvm_object_new
+
+  task body();
+    // Inject error on signal after `prim_edn_req`, which may at some point implement its own
+    // countermeasure against spurious ACKs.
+    string err_path = "tb.dut.edn_urnd_ack";
+    bit skip_err_injection = 1'b0;
+    bit while_executing;
+
+    // Wait for deassertion of reset.
+    cfg.clk_rst_vif.wait_for_reset(.wait_negedge(1'b0), .wait_posedge(1'b1));
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(while_executing)
+
+    if (while_executing) begin
+      // Inject spurious URND acknowledge while OTBN is executing.
+
+      // The OTBN controller requests a secure wipe from the start-stop controller at the end of
+      // execution.  To reach that point, we must first execute a binary.
+      string elf_path = pick_elf_path();
+      load_elf(elf_path, 1'b1);
+      `uvm_info(`gfn, $sformatf("Executing OTBN binary `%0s'.", elf_path), UVM_LOW)
+      start_running_otbn(.check_end_addr(1'b0));
+
+      if (!(cfg.model_agent_cfg.vif.status inside {otbn_pkg::StatusBusyExecute,
+                                                   otbn_pkg::StatusBusySecWipeInt})) begin
+        // If OTBN is no longer executing, we have missed the opportunity (the
+        // `start_running_otbn()` function does not guarantee that it returns while OTBN is still
+        // running).  So we cannot inject the error anymore.
+        skip_err_injection = 1'b1;
+      end else begin
+        // OTBN does an URND request when it starts executing as well as between secure wipes.  We
+        // must wait for that request to complete before we can inject a spurious acknowledge.
+        logic urnd_req;
+        string path = "tb.dut.edn_urnd_req";
+        `DV_SPINWAIT(
+          do begin
+            @(cfg.clk_rst_vif.cbn); // Align to clock.
+            `DV_CHECK_FATAL(uvm_hdl_read(path, urnd_req))
+          end while (urnd_req);,
+          "Timeout while waiting for URND request",
+          100_000_000 /* timeout in ns */)
+      end
+
+      if (skip_err_injection) begin
+        `uvm_info(`gfn, "Skipping error injection.", UVM_LOW)
+      end else begin
+        // Inject error.
+        `uvm_info(`gfn, "Injecting error by force.", UVM_LOW)
+        `DV_CHECK_FATAL(uvm_hdl_force(err_path, 1'b1) == 1)
+        `uvm_info(`gfn, "Locking model immediately.", UVM_LOW)
+        cfg.model_agent_cfg.vif.lock_immediately(32'd1 << 20);
+
+        // Wait one clock cycle to have force applied during one cycle.
+        @(cfg.clk_rst_vif.cbn);
+      end
+
+    end else begin
+      // Inject spurious URND acknowledge while OTBN is idle.
+      `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusIdle)
+      @(cfg.clk_rst_vif.cbn);
+
+      if (skip_err_injection) begin
+        `uvm_info(`gfn, "Skipping error injection.", UVM_LOW)
+      end else begin
+        // Inject error.
+        `uvm_info(`gfn, "Injecting error by force.", UVM_LOW)
+        `DV_CHECK_FATAL(uvm_hdl_force(err_path, 1'b1) == 1)
+
+        // Let model escalate in same clock cycle.
+        cfg.model_agent_cfg.vif.send_err_escalation(32'd1 << 20);
+
+        // Wait one clock cycle to have force applied during one cycle.
+        @(cfg.clk_rst_vif.cbn);
+      end
+    end
+
+    if (!skip_err_injection) begin
+      `uvm_info(`gfn, "Releasing force.", UVM_LOW)
+      `DV_CHECK_FATAL(uvm_hdl_release(err_path) == 1)
+
+      `uvm_info(`gfn, "Waiting for OTBN to lock up.", UVM_LOW)
+      `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked)
+    end
+
+    reset_if_locked();
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -24,3 +24,4 @@
 `include "otbn_rnd_sec_cm_vseq.sv"
 `include "otbn_ctrl_redun_vseq.sv"
 `include "otbn_sec_wipe_err_vseq.sv"
+`include "otbn_urnd_err_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -298,6 +298,12 @@ name:
       en_run_modes: ["build_otbn_rig_binary_mode"]
       reseed: 7
     }
+    {
+      name: "otbn_urnd_err"
+      uvm_test_seq: "otbn_urnd_err_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 2
+    }
   ]
 
   // List of regressions.
@@ -342,7 +348,7 @@ name:
         "otbn_tl_intg_err", "otbn_sec_cm", "otbn_pc_ctrl_flow_redun",
         "otbn_rnd_sec_cm", "otbn_alu_bignum_mod_err",
         "otbn_controller_ispr_rdata_err", "otbn_mac_bignum_acc_err",
-        "otbn_sec_wipe_err",
+        "otbn_sec_wipe_err", "otbn_urnd_err",
         # V2S but known broken
         # "otbn_passthru_mem_tl_intg_err",
         # V3 thus not yet active

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -222,6 +222,7 @@ module otbn_core
 
   logic            urnd_reseed_req;
   logic            urnd_reseed_ack;
+  logic            urnd_reseed_err;
   logic            urnd_advance;
   logic            urnd_advance_start_stop_control;
   logic [WLEN-1:0] urnd_data;
@@ -279,6 +280,7 @@ module otbn_core
 
     .urnd_reseed_req_o (urnd_reseed_req),
     .urnd_reseed_ack_i (urnd_reseed_ack),
+    .urnd_reseed_err_o (urnd_reseed_err),
     .urnd_advance_o    (urnd_advance_start_stop_control),
 
     .secure_wipe_req_i (secure_wipe_req),
@@ -507,6 +509,8 @@ module otbn_core
     .rnd_req_o         (rnd_req),
     .rnd_prefetch_req_o(rnd_prefetch_req),
     .rnd_valid_i       (rnd_valid),
+
+    .urnd_reseed_err_i(urnd_reseed_err),
 
     // Secure wipe
     .secure_wipe_req_o     (secure_wipe_req),

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -302,7 +302,10 @@ module otbn_start_stop_control
 
   assign done_o = ((state_q == OtbnStartStopSecureWipeComplete && init_sec_wipe_done_q) ||
                    (stop && (state_q == OtbnStartStopStateUrndRefresh) &&
-                    mubi4_test_false_strict(wipe_after_urnd_refresh_q)));
+                    mubi4_test_false_strict(wipe_after_urnd_refresh_q)) ||
+                   (spurious_urnd_ack_error && !(state_q inside {OtbnStartStopStateHalt,
+                                                                 OtbnStartStopStateLocked}) &&
+                    init_sec_wipe_done_q));
 
   assign addr_cnt_d = addr_cnt_inc ? (addr_cnt_q + 5'd1) : 5'd0;
 

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -38,6 +38,7 @@ module otbn_start_stop_control
 
   output logic urnd_reseed_req_o,
   input  logic urnd_reseed_ack_i,
+  output logic urnd_reseed_err_o,
   output logic urnd_advance_o,
 
   input   logic secure_wipe_req_i,
@@ -67,6 +68,7 @@ module otbn_start_stop_control
   mubi4_t wipe_after_urnd_refresh_q, wipe_after_urnd_refresh_d;
   mubi4_t rma_ack_d, rma_ack_q;
   logic mubi_err_q, mubi_err_d;
+  logic urnd_reseed_err_q, urnd_reseed_err_d;
 
   logic addr_cnt_inc;
   logic [4:0] addr_cnt_q, addr_cnt_d;
@@ -342,11 +344,17 @@ module otbn_start_stop_control
     if (!rst_ni) begin
       mubi_err_q          <= 1'b0;
       secure_wipe_error_q <= 1'b0;
+      urnd_reseed_err_q   <= 1'b0;
     end else begin
       mubi_err_q          <= mubi_err_d;
       secure_wipe_error_q <= secure_wipe_error_d;
+      urnd_reseed_err_q   <= urnd_reseed_err_d;
     end
   end
+
+  assign urnd_reseed_err_d = spurious_urnd_ack_error ? 1'b1 // set
+                                                     : urnd_reseed_err_q; // hold
+  assign urnd_reseed_err_o = urnd_reseed_err_d;
 
   assign fatal_error_o = spurious_urnd_ack_error | state_error | secure_wipe_error_q | mubi_err_q;
 


### PR DESCRIPTION
This PR adds a test sequence that injects a spurious acknowledge into
the EDN URND handshake in OTBN.  When a fault is injected, OTBN is expected
to raise a fatal alert and immediately lock up (i.e., without completing
the secure wipe, because it cannot use the entropy it got on the
manipulated URND interface).

This PR also extends the OTBN model to implement the immediate locking.

This PR makes two RTL changes/fixes:
- **Set `locking_o` after URND reseed error**
The `locking_o` signal is high when OTBN is locked, except while a secure
wipe is ongoing (i.e., `secure_wipe_req_o` of `otbn_controller` is high).
When an URND reseed error happens during a secure wipe, however, that
secure wipe cannot always complete and OTBN locks without having completed
the secure wipe.  Prior to this commit, `locking_o` would never be set
in this case.  This commit fixes that problem by setting `locking_o` as
soon as an URND reseed error is latched.
- **Set `done_o` on a spurious URND ACK error**
OTBN locks immediately when it gets a spurious URND ACK.  If OTBN has been
executing, it must send the `done_o` signal when it locks after a spurious
URND ACK.

This PR implements the *trigger errors* part of #11546.