### PR TITLE
[rom_ctrl] Protect digest comparison address counter with prim_count

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -131,6 +131,15 @@
       '''
     },
     {
+      name: "COMPARE.CTR.REDUN",
+      desc: '''
+        The hash comparison module has an internal count (indexing 32-bit words
+        in the 256-bit digests) implemented using a redundant counter module.
+        In case a mismatch is detected between the redundant counters a fatal
+        alert is generated.
+      '''
+    },
+    {
       name: "FSM.SPARSE",
       desc: '''
         FSMs are sparsely encoded. There are two FSMs. The first is in

--- a/hw/ip/rom_ctrl/data/rom_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_sec_cm_testplan.hjson
@@ -71,6 +71,12 @@
       tests: ['''rom_ctrl_corrupt_sig_fatal_chk''']
     }
     {
+      name: sec_cm_compare_ctr_redun
+      desc: '''Verify the countermeasure(s) COMPARE.CTR.REDUN.'''
+      milestone: V2S
+      tests: ['''rom_ctrl_sec_cm''']
+    },
+    {
       name: sec_cm_fsm_sparse
       desc: '''Verify the countermeasure(s) FSM.SPARSE.'''
       milestone: V2S

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -97,8 +97,9 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
           dut_init();
           wait (cfg.rom_ctrl_vif.pwrmgr_data.done == MuBi4True);
           wait_with_bound(10);
-          // EndAddr has been set to 8
-          `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(invalid_addr, (invalid_addr > 0 && invalid_addr < 8););
+          // LastAddr has been set to 7
+          `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(invalid_addr,
+                                             (invalid_addr >= 0 && invalid_addr < 7););
           force_sig("tb.dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.addr_q", invalid_addr);
           check_for_alert();
           chk_fsm_state();

--- a/hw/ip/rom_ctrl/rom_ctrl.core
+++ b/hw/ip/rom_ctrl/rom_ctrl.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:buf
       - lowrisc:prim:cipher
+      - lowrisc:prim:count
       - lowrisc:prim:rom_adv
       - lowrisc:prim:sec_anchor
       - lowrisc:prim:sparse_fsm

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -494,6 +494,10 @@ module rom_ctrl
                                          gen_fsm_scramble_enabled.
                                          u_checker_fsm.u_state_regs,
                                          alert_tx_o[AlertFatal])
+    `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CompareAddrCtrCheck_A,
+                                           gen_fsm_scramble_enabled.
+                                           u_checker_fsm.u_compare.u_prim_count_addr,
+                                           alert_tx_o[AlertFatal])
   end
 
   // The pwrmgr_data_o output (the "done" and "good" signals) should have a known value when out of


### PR DESCRIPTION
This is related to #14097.