### PR TITLE
[kmac] Define per App Entropy constraint

### DIFF
--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -284,6 +284,8 @@ module kmac
   entropy_mode_e entropy_mode;
   logic entropy_fast_process;
 
+  prim_mubi_pkg::mubi4_t entropy_configured;
+
   // Message Masking
   logic msg_mask_en, cfg_msg_mask;
   logic [MsgWidth-1:0] msg_mask;
@@ -1018,6 +1020,9 @@ module kmac
     .sw_cmd_i (checked_sw_cmd),
     .cmd_o    (kmac_cmd),
 
+    // Status
+    .entropy_ready_i (entropy_configured),
+
     // LC escalation
     .lc_escalate_en_i (lc_escalate_en[3]),
 
@@ -1188,6 +1193,8 @@ module kmac
       .hash_cnt_clr_i   (entropy_hash_clr),
       .hash_threshold_i (entropy_hash_threshold),
 
+      .entropy_configured_o (entropy_configured),
+
       // LC escalation
       .lc_escalate_en_i (lc_escalate_en[5]),
 
@@ -1235,6 +1242,9 @@ module kmac
 
     logic [1:0] unused_entropy_status;
     assign unused_entropy_status = entropy_in_keyblock;
+
+    // If Masking is off, always entropy configured
+    assign entropy_configured = prim_mubi_pkg::MuBi4True;
   end
 
   // Register top

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -92,6 +92,11 @@ module kmac_app
   // To status
   output logic app_active_o,
 
+  // Status
+  // - entropy_ready_i: Entropy configured by SW. It is used to check if App
+  //                    is OK to request.
+  input prim_mubi_pkg::mubi4_t entropy_ready_i,
+
   // Error input
   // This error comes from KMAC/SHA3 engine.
   // KeyMgr interface delivers the error signal to KeyMgr to drop the current op
@@ -158,7 +163,7 @@ module kmac_app
   };
 
   // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 10 -n 10 \
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 11 -n 10 \
   //      -s 155490773 --language=sv
   //
   // Hamming distance histogram:
@@ -166,12 +171,12 @@ module kmac_app
   //  0: --
   //  1: --
   //  2: --
-  //  3: |||||||||| (13.33%)
-  //  4: |||||||||||||||||||| (24.44%)
-  //  5: |||||||||||||||||||| (24.44%)
-  //  6: |||||||||||||| (17.78%)
-  //  7: |||||||||||||| (17.78%)
-  //  8: | (2.22%)
+  //  3: ||||||||||||| (14.55%)
+  //  4: |||||||||||||||||||| (21.82%)
+  //  5: |||||||||||||||||| (20.00%)
+  //  6: |||||||||||||||||||| (21.82%)
+  //  7: |||||||||||||||||| (20.00%)
+  //  8: | (1.82%)
   //  9: --
   // 10: --
   //
@@ -181,8 +186,18 @@ module kmac_app
   // Maximum Hamming weight: 9
   //
   localparam int StateWidth = 10;
-
   // States
+  //  StIdle                  = 10'b0101110011,
+  //  StAppCfg                = 10'b0001010000,
+  //  StAppMsg                = 10'b0001011111,
+  //  StAppOutLen             = 10'b1011001111,
+  //  StAppProcess            = 10'b1000100110,
+  //  StAppWait               = 10'b0010010110,
+  //  StSw                    = 10'b0111111111,
+  //  StKeyMgrErrKeyNotValid  = 10'b1001110100,
+  //  StError                 = 10'b1101011101,
+  //  StServiceRejectedError  = 10'b1110000110,
+  //  StTerminalError         = 10'b0010001001
   typedef enum logic [StateWidth-1:0] {
     StIdle = 10'b0101110011,
 
@@ -222,7 +237,9 @@ module kmac_app
 
     StError = 10'b1101011101,
 
-    // This state is used for terminal errors
+    StServiceRejectedError = 10'b1110000110,
+
+    // This state is used for termiNal errors
     StTerminalError = 10'b0010001001
   } st_e;
 
@@ -263,6 +280,15 @@ module kmac_app
 
   kmac_pkg::err_t fsm_err, mux_err;
 
+  logic service_rejected_error;
+  logic service_rejected_error_set, service_rejected_error_clr;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)                         service_rejected_error <= 1'b 0;
+    else if (service_rejected_error_set) service_rejected_error <= 1'b 1;
+    else if (service_rejected_error_clr) service_rejected_error <= 1'b 0;
+  end
+
   ////////////////////////////
   // Application Mux/ Demux //
   ////////////////////////////
@@ -281,6 +307,7 @@ module kmac_app
           digest_share1: app_digest[1],
           // if fsm asserts done, should be an error case.
           error:         error_i | fsm_digest_done_q | sparse_fsm_error_o
+                         | service_rejected_error
         };
       end else begin
         app_o[i] = '{
@@ -378,6 +405,9 @@ module kmac_app
     fsm_err = '{valid: 1'b 0, code: ErrNone, info: '0};
     sparse_fsm_error_o = 1'b 0;
 
+    service_rejected_error_set = 1'b 0;
+    service_rejected_error_clr = 1'b 0;
+
     // If error happens, FSM asserts data ready but discard incoming msg
     fsm_data_ready = 1'b 0;
     fsm_digest_done_d = 1'b 0;
@@ -399,8 +429,19 @@ module kmac_app
       end
 
       StAppCfg: begin
+        if (AppCfg[app_id].EnRstEntropy == 1'b 0 &&
+          prim_mubi_pkg::mubi4_test_false_strict(entropy_ready_i)) begin
+          // Check if the entropy is configured or not along with
+          // `EnRstEntropy` in `AppCfg[app_id]`
+          //
+          // SW is not properly configured, report and not request Hashing
+          // Return the app with errors
+          st_d = StError;
 
-        if ((AppCfg[app_id].Mode == AppKMAC) && !keymgr_key_i.valid) begin
+          service_rejected_error_set = 1'b 1;
+
+        end else if ((AppCfg[app_id].Mode == AppKMAC) &&
+          !keymgr_key_i.valid) begin
           st_d = StKeyMgrErrKeyNotValid;
 
           // As mux_sel is not set to SelApp, app_data_ready is still 0.
@@ -494,8 +535,24 @@ module kmac_app
         if (app_i[app_id].valid && app_i[app_id].last) begin
           // Send garbage digest to the app interface to complete transaction
           fsm_digest_done_d = 1'b 1;
+
+          if (service_rejected_error) begin
+            // If service was rejected, it is assumed the SW is not loaded
+            // yet. In this case, return the request with error and keep
+            // moving, hoping SW may handle the errors later
+            st_d = StServiceRejectedError;
+          end
         end
 
+      end
+
+      StServiceRejectedError: begin
+        // Clear the error and move to Idle
+        // At this state, the app returns requste with error.
+        st_d = StIdle;
+
+        clr_appid = 1'b 1;
+        service_rejected_error_clr = 1'b 1;
       end
 
       StTerminalError: begin
@@ -800,5 +857,11 @@ module kmac_app
   `COVER(AppIntfUseDifferentSizeKey_C,
     (st == StAppCfg && kmac_en_o) |-> reg_key_len_i != SideloadedKey)
 
+  for (genvar i = 0 ; i < NumAppIntf ; i++) begin : g_assert_mode_and_entropy
+    // Check if EnRstEntropy and Mode are expected values
+    `ASSERT_INIT(KmacModeMustNotSetEnRstEntropy_A,
+      !((AppCfg[i].Mode == AppKMAC) && (AppCfg[i].EnRstEntropy == 1'b1))
+    )
+  end : g_assert_mode_and_entropy
 
 endmodule

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -67,6 +67,8 @@ module kmac_entropy
   input                       hash_cnt_clr_i,
   input        [HashCntW-1:0] hash_threshold_i,
 
+  output prim_mubi_pkg::mubi4_t entropy_configured_o,
+
   // Life cycle
   input  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
 
@@ -211,6 +213,9 @@ module kmac_entropy
   // If the SW wants to change the mode, it requires resetting the IP.
   logic mode_latch;
   entropy_mode_e mode_q;
+
+  // Status out: entropy configured
+  prim_mubi_pkg::mubi4_t entropy_configured;
 
   //////////////
   // Datapath //
@@ -687,6 +692,21 @@ module kmac_entropy
       ready_phase_q <= ready_phase_d;
     end
   end
+
+  // mubi4 sender
+
+  assign entropy_configured = (st != StRandReset)
+                            ? prim_mubi_pkg::MuBi4True
+                            : prim_mubi_pkg::MuBi4False ;
+  prim_mubi4_sender #(
+    .AsyncOn(1'b0)
+  ) u_entropy_configured (
+    .clk_i,
+    .rst_ni,
+
+    .mubi_i (entropy_configured  ),
+    .mubi_o (entropy_configured_o)
+  );
 
   ////////////////
   // Assertions //


### PR DESCRIPTION
_Related Issue: https://github.com/lowRISC/opentitan/issues/11116_

This commit defines `EnRstEntropy` to allow applications to run KMAC
(SHA3) operations without proper entropy configurations. Any
applications may request the hashing operations right out from the reset
state if the field is set.

It cannot be enabled with `AppKMAC` mode.
