### PR TITLE
[dvsim] Fix run timeout override in hjson

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -287,7 +287,7 @@ class Deploy():
 
     def get_timeout_mins(self):
         """Returns the timeout in minutes."""
-        return 0
+        return None
 
     def extract_info_from_log(self, log_text: List):
         """Extracts information pertaining to the job from its log.
@@ -378,8 +378,8 @@ class CompileSim(Deploy):
         if self.sim_cfg.args.build_timeout_mins is not None:
             self.build_timeout_mins = self.sim_cfg.args.build_timeout_mins
         if self.build_timeout_mins:
-            log.log(VERBOSE, "Compile timeout for job \"%s\" is %d minutes",
-                    self.name, self.build_timeout_mins)
+            log.debug("Timeout for job \"%s\" is %d minutes.",
+                      self.name, self.build_timeout_mins)
 
     def pre_launch(self):
         # Delete old coverage database directories before building again. We
@@ -387,8 +387,11 @@ class CompileSim(Deploy):
         rm_path(self.cov_db_dir)
 
     def get_timeout_mins(self):
-        """Returns the timeout in minutes."""
-        return self.build_timeout_mins
+        """Returns the timeout in minutes.
+
+        Limit build jobs to 60 minutes if the timeout is not set.
+        """
+        return self.build_timeout_mins if self.build_timeout_mins else 60
 
 
 class CompileOneShot(Deploy):
@@ -439,12 +442,15 @@ class CompileOneShot(Deploy):
         if self.sim_cfg.args.build_timeout_mins is not None:
             self.build_timeout_mins = self.sim_cfg.args.build_timeout_mins
         if self.build_timeout_mins:
-            log.log(VERBOSE, "Compile timeout for job \"%s\" is %d minutes",
-                    self.name, self.build_timeout_mins)
+            log.debug("Timeout for job \"%s\" is %d minutes.",
+                      self.name, self.build_timeout_mins)
 
     def get_timeout_mins(self):
-        """Returns the timeout in minutes."""
-        return self.build_timeout_mins
+        """Returns the timeout in minutes.
+
+        Limit build jobs to 60 minutes if the timeout is not set.
+        """
+        return self.build_timeout_mins if self.build_timeout_mins else 60
 
 
 class RunTest(Deploy):
@@ -518,8 +524,8 @@ class RunTest(Deploy):
         if self.sim_cfg.args.run_timeout_mins is not None:
             self.run_timeout_mins = self.sim_cfg.args.run_timeout_mins
         if self.run_timeout_mins:
-            log.log(VERBOSE, "Run timeout for job \"%s\" is %d minutes",
-                    self.name, self.run_timeout_mins)
+            log.debug("Timeout for job \"%s\" is %d minutes.",
+                      self.full_name, self.run_timeout_mins)
 
     def pre_launch(self):
         self.launcher.renew_odir = True
@@ -543,8 +549,11 @@ class RunTest(Deploy):
         return RunTest.seeds.pop(0)
 
     def get_timeout_mins(self):
-        """Returns the timeout in minutes."""
-        return self.run_timeout_mins
+        """Returns the timeout in minutes.
+
+        Limit run jobs to 60 minutes if the timeout is not set.
+        """
+        return self.run_timeout_mins if self.run_timeout_mins else 60
 
     def extract_info_from_log(self, log_text: List):
         """Extracts the time the design was simulated for, from the log."""

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -269,7 +269,7 @@ class BuildModes(Modes):
         self.post_build_cmds = []
         self.en_build_modes = []
         self.build_opts = []
-        self.build_timeout_mins = 60
+        self.build_timeout_mins = None
         self.pre_run_cmds = []
         self.post_run_cmds = []
         self.run_opts = []
@@ -305,7 +305,7 @@ class RunModes(Modes):
         self.uvm_test = ""
         self.uvm_test_seq = ""
         self.build_mode = ""
-        self.run_timeout_mins = 60
+        self.run_timeout_mins = None
         self.sw_images = []
         self.sw_build_device = ""
         self.sw_build_opts = []
@@ -335,7 +335,8 @@ class Tests(RunModes):
         "build_mode": "",
         "sw_images": [],
         "sw_build_device": "",
-        "sw_build_opts": []
+        "sw_build_opts": [],
+        "run_timeout_mins": None
     }
 
     def __init__(self, tdict):


### PR DESCRIPTION
When recursively merging scalar attributes across modes
that enable sub-modes, dvsim requires the attribute to
be set uniquely once. For example, if run mode `foo`
enables run mode `bar`, then `foo` and `bar` cannot
both set a non-default value to a scalar attribute.
For example, the `run_timeout_mins` cannot be set to
40 in `foo` and `100` in `bar`. If that is found to be
the case, then dvsim throws an error and exits, because
it does not know which to pick. There is no notion
of priority across modes that are enabled recursively
into other modes.

`Modes.py` assumes `-1` as the default value for
integral attributes, because it is the "lowest common
denominator". The existing `Modes.py` set the
`*_timeout_mins` to 60 as the default value, if not set
in the hjson. The end result of this is - if `foo` does
not set `run_timeout_mins`, then for `foo` it gets set
to 60. If it is set differently in `bar`, then bam,
we end up having a problem.

The fix in this commit changes the default value to
`*_timeout_mins` to `None` instead, so that it can be
properly set to a desired value in modes, test
specifications and globally in the hjson. The Deploy
class then limits builds and runs to 60 minutes if
it was not set in the hjson.

This unfortunately does not completely fix the problem
because `build_timeout_mins` is not overridable in the
hjson at the moment. It will be fixed in a future PR
when the need / urgency arises. The whole `Modes.py`
code needs a significant refactor to ensure it works
as expected.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>