### PR TITLE
[entropy_src/rtl] Suppress watermarks after disable

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -62,7 +62,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   localparam int ObserveFifoDepth = 64;
   localparam int PreCondWidth = 64;
   localparam int Clog2ObserveFifoDepth = $clog2(ObserveFifoDepth);
-  localparam int EsEnableCopies = 36;
+  localparam int EsEnableCopies = 37;
 
   //-----------------------
   // SHA3parameters
@@ -442,7 +442,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic        ht_esbus_vld_dly2_q, ht_esbus_vld_dly2_d;
   logic        ht_failed_q, ht_failed_d;
   logic        ht_done_pulse_q, ht_done_pulse_d;
-  logic                    sha3_err_q, sha3_err_d;
+  logic        sha3_err_q, sha3_err_d;
   logic        cs_aes_halt_q, cs_aes_halt_d;
   logic [63:0] es_rdata_capt_q, es_rdata_capt_d;
   logic        es_rdata_capt_vld_q, es_rdata_capt_vld_d;
@@ -1395,7 +1395,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   );
 
   // Window wrap condition
-  assign health_test_done_pulse = (window_cntr >= health_test_window);
+  assign health_test_done_pulse = es_enable_q_fo[21] & (window_cntr >= health_test_window);
 
   // Summary of counter errors
   assign es_cntr_err =
@@ -1949,17 +1949,16 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .err_o               (any_fails_cntr_err)
   );
 
-
   assign any_fail_pulse =
          repcnt_fail_pulse ||
          repcnts_fail_pulse ||
          adaptp_hi_fail_pulse || adaptp_lo_fail_pulse ||
          bucket_fail_pulse ||
-         markov_hi_fail_pulse ||markov_lo_fail_pulse ||
+         markov_hi_fail_pulse || markov_lo_fail_pulse ||
          extht_hi_fail_pulse || extht_lo_fail_pulse;
 
   assign ht_failed_d =
-         (!es_enable_q_fo[21]) ? 1'b0 :
+         (!es_enable_q_fo[22]) ? 1'b0 :
          ht_done_pulse_q ? 1'b0 :
          any_fail_pulse ? 1'b1 :
          ht_failed_q;
@@ -2186,7 +2185,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign pfifo_postht_push = ht_esbus_vld_dly_q;
   assign pfifo_postht_wdata = ht_esbus_dly_q;
 
-  assign pfifo_postht_clr = !es_enable_q_fo[22];
+  assign pfifo_postht_clr = !es_enable_q_fo[23];
   assign pfifo_postht_pop = ht_esbus_vld_dly2_q &&
          pfifo_postht_not_empty;
 
@@ -2237,7 +2236,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign hw2reg.fw_ov_rd_fifo_overflow.de = 1'b1;
 
   assign observe_fifo_thresh_met = fw_ov_mode && (observe_fifo_thresh != '0) &&
-         (observe_fifo_thresh <= sfifo_observe_depth) && es_enable_q_fo[23];
+         (observe_fifo_thresh <= sfifo_observe_depth) && es_enable_q_fo[24];
 
   assign hw2reg.observe_fifo_depth.d = sfifo_observe_depth;
 
@@ -2245,7 +2244,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign sfifo_observe_push = fw_ov_mode && pfifo_postht_pop && !sfifo_observe_full &&
                               (sfifo_observe_gate_q || !sfifo_observe_not_empty);
 
-  assign sfifo_observe_clr  = !es_enable_q_fo[24];
+  assign sfifo_observe_clr  = !es_enable_q_fo[25];
 
   assign sfifo_observe_wdata = pfifo_postht_rdata;
 
@@ -2288,7 +2287,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
          (fw_ov_mode_entropy_insert ? fw_ov_wr_data : pfifo_postht_rdata) :
          pfifo_postht_rdata;
 
-  assign pfifo_precon_clr = !es_enable_q_fo[25];
+  assign pfifo_precon_clr = !es_enable_q_fo[26];
   assign pfifo_precon_pop = es_bypass_mode ? pfifo_precon_not_empty :
          (pfifo_precon_not_empty && sha3_msgfifo_ready);
 
@@ -2329,7 +2328,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   assign pfifo_cond_rdata = sha3_state[0][SeedLen-1:0];
   assign pfifo_cond_not_empty = sha3_state_vld;
-  assign sha3_msgfifo_ready = es_enable_q_fo[26] & sha3_msg_rdy & sha3_msg_rdy_mask;
+  assign sha3_msgfifo_ready = es_enable_q_fo[27] & sha3_msg_rdy & sha3_msg_rdy_mask;
 
   // SHA3 hashing engine
   sha3 #(
@@ -2406,7 +2405,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign pfifo_bypass_push = pfifo_precon_pop && es_bypass_mode;
   assign pfifo_bypass_wdata = pfifo_precon_rdata;
 
-  assign pfifo_bypass_clr = !es_enable_q_fo[27];
+  assign pfifo_bypass_clr = !es_enable_q_fo[28];
   assign pfifo_bypass_pop =
          (es_bypass_mode && fw_ov_mode_entropy_insert) ? pfifo_bypass_not_empty : bypass_stage_pop;
 
@@ -2425,7 +2424,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     u_entropy_src_main_sm (
     .clk_i                (clk_i),
     .rst_ni               (rst_ni),
-    .enable_i             (es_enable_q_fo[28]),
+    .enable_i             (es_enable_q_fo[29]),
     .fw_ov_ent_insert_i   (fw_ov_mode_entropy_insert),
     .fw_ov_sha3_start_i   (fw_ov_sha3_start_pfe),
     .ht_done_pulse_i      (ht_done_pulse_q),
@@ -2479,14 +2478,14 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .err_o          ()
   );
 
-  assign fips_compliance = !es_bypass_mode && es_enable_q_fo[29] && !rng_bit_en;
+  assign fips_compliance = !es_bypass_mode && es_enable_q_fo[30] && !rng_bit_en;
 
   // fifo controls
   assign sfifo_esfinal_push_enable =
          (es_bypass_mode && fw_ov_mode_entropy_insert) ? pfifo_bypass_not_empty : main_stage_push;
 
   assign sfifo_esfinal_push = sfifo_esfinal_not_full && sfifo_esfinal_push_enable;
-  assign sfifo_esfinal_clr  = !es_enable_q_fo[30];
+  assign sfifo_esfinal_clr  = !es_enable_q_fo[31];
   assign sfifo_esfinal_wdata = {fips_compliance,final_es_data};
   assign sfifo_esfinal_pop = es_route_to_sw ? pfifo_swread_push :
          es_hw_if_fifo_pop;
@@ -2508,7 +2507,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   entropy_src_ack_sm u_entropy_src_ack_sm (
     .clk_i            (clk_i),
     .rst_ni           (rst_ni),
-    .enable_i         (es_enable_q_fo[31]),
+    .enable_i         (es_enable_q_fo[32]),
     .req_i            (es_hw_if_req),
     .ack_o            (es_hw_if_ack),
     .fifo_not_empty_i (sfifo_esfinal_not_empty && !es_route_to_sw),
@@ -2532,7 +2531,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign es_rdata_capt_d = es_rdata_capt_vld ? sfifo_esfinal_rdata[63:0] : es_rdata_capt_q;
 
   assign es_rdata_capt_vld_d =
-         !es_enable_q_fo[32] ? 1'b0 :
+         !es_enable_q_fo[33] ? 1'b0 :
          es_rdata_capt_vld ? 1'b1 :
          es_rdata_capt_vld_q;
 
@@ -2565,11 +2564,11 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign pfifo_swread_push = es_route_to_sw && pfifo_swread_not_full && sfifo_esfinal_not_empty;
   assign pfifo_swread_wdata = esfinal_data;
 
-  assign pfifo_swread_clr = !(es_enable_q_fo[33] && es_data_reg_rd_en);
-  assign pfifo_swread_pop =  es_enable_q_fo[34] && sw_es_rd_pulse;
+  assign pfifo_swread_clr = !(es_enable_q_fo[34] && es_data_reg_rd_en);
+  assign pfifo_swread_pop =  es_enable_q_fo[35] && sw_es_rd_pulse;
 
   // set the es entropy to the read reg
-  assign es_data_reg_rd_en = es_enable_q_fo[35] && efuse_es_sw_reg_en && entropy_data_reg_en_pfe;
+  assign es_data_reg_rd_en = es_enable_q_fo[36] && efuse_es_sw_reg_en && entropy_data_reg_en_pfe;
   assign hw2reg.entropy_data.d = es_data_reg_rd_en ? pfifo_swread_rdata : '0;
   assign sw_es_rd_pulse = es_data_reg_rd_en && reg2hw.entropy_data.re;
 


### PR DESCRIPTION
Prior to this commit the HT watermarks are set to update even after
the IP is disabled.  This makes the watermark behavior different
from the alert and failure counter, because all of the test
failure pulses are masked once the IP is turned off.

This state of affairs means that the dataset used for watermarking
is effectively different then the data set used in calculating
failures and alerts, which creates big challenges for
verification.

By masking health_test_done_pulse with a copy of es enable,
this stops the watermarks from updating after disable and
makes the watermarks agree with the failure counters.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>