### PR TITLE
[entropy_src/rtl] Shift repcnt HT sampling pulse

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
@@ -29,17 +29,21 @@ module entropy_src_repcnts_ht #(
   logic  rep_cnt_fail;
   logic [RegWidth-1:0]    rep_cntr;
   logic                   rep_cntr_err;
+  logic                   fail_sampled;
 
   // flops
   logic [RngBusWidth-1:0] prev_sample_q, prev_sample_d;
+  logic fail_sample_mask_d, fail_sample_mask_q;
 
-  always_ff @(posedge clk_i or negedge rst_ni)
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      prev_sample_q    <= '0;
+      prev_sample_q      <= '0;
+      fail_sample_mask_q <= '0;
     end else begin
-      prev_sample_q    <= prev_sample_d;
+      prev_sample_q      <= prev_sample_d;
+      fail_sample_mask_q <= fail_sample_mask_d;
     end
-
+  end
 
   // Repetitive Count Test for symbols
   //
@@ -48,40 +52,44 @@ module entropy_src_repcnts_ht #(
   //  uses one as the starting value, just as the NIST algorithm does.
 
 
-    // NIST A sample
-    assign prev_sample_d = (!active_i || clear_i) ? '0 :
-                           entropy_bit_vld_i ? entropy_bit_i :
-                           prev_sample_q;
+  // NIST A sample
+  assign prev_sample_d = (!active_i || clear_i) ? '0 :
+                         entropy_bit_vld_i ? entropy_bit_i :
+                         prev_sample_q;
 
-    assign samples_match_pulse = entropy_bit_vld_i &&
-           (prev_sample_q == entropy_bit_i);
-    assign samples_no_match_pulse = entropy_bit_vld_i &&
-           (prev_sample_q != entropy_bit_i);
+  assign samples_match_pulse = entropy_bit_vld_i &&
+         (prev_sample_q == entropy_bit_i);
+  assign samples_no_match_pulse = entropy_bit_vld_i &&
+         (prev_sample_q != entropy_bit_i);
 
-    // NIST B counter
-    // SEC_CM: CTR.REDUN
-    prim_count #(
-      .Width(RegWidth)
-    ) u_prim_count_rep_cntr (
-      .clk_i,
-      .rst_ni,
-      .clr_i(1'b0),
-      .set_i(!active_i || clear_i || samples_no_match_pulse),
-      .set_cnt_i(RegWidth'(1)),
-      .incr_en_i(samples_match_pulse),
-      .decr_en_i(1'b0),
-      .step_i(RegWidth'(1)),
-      .cnt_o(rep_cntr),
-      .cnt_next_o(),
-      .err_o(rep_cntr_err)
-    );
+  // NIST B counter
+  // SEC_CM: CTR.REDUN
+  prim_count #(
+    .Width(RegWidth)
+  ) u_prim_count_rep_cntr (
+    .clk_i,
+    .rst_ni,
+    .clr_i(1'b0),
+    .set_i(!active_i || clear_i || samples_no_match_pulse),
+    .set_cnt_i(RegWidth'(1)),
+    .incr_en_i(samples_match_pulse),
+    .decr_en_i(1'b0),
+    .step_i(RegWidth'(1)),
+    .cnt_o(rep_cntr),
+    .cnt_next_o(),
+    .err_o(rep_cntr_err)
+  );
 
-    assign rep_cnt_fail = (rep_cntr >= thresh_i);
+  assign rep_cnt_fail = (rep_cntr >= thresh_i);
 
+  // For the purposes of failure pulse generation, we want to sample
+  // the test output for only one cycle and do it immediately after
+  // the counter has been updated.
+  assign fail_sample_mask_d = entropy_bit_vld_i;
+  assign fail_sampled       = rep_cnt_fail & fail_sample_mask_q;
 
+  assign test_fail_pulse_o = active_i & fail_sampled;
 
-  // the pulses will be only one clock in length
-  assign test_fail_pulse_o = active_i && entropy_bit_vld_i && (|rep_cnt_fail);
   assign test_cnt_o = rep_cntr;
   assign count_err_o = (|rep_cntr_err);
 


### PR DESCRIPTION
In the repcnt_ht and repcnts_ht modules, this commit adjusts the timing
of the test_fail_pulse_o pulses to put them as close as possible to the
failing samples.  Previous to this commit the failure pulses would
be lined up with the sample after the failing sample.  This extra
delay could allow a window to pass with a failing REPCNT test.

It also creates several scoreboarding challenges in predicting
failing REPCNT outputs and statistics.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>