### PR TITLE
[dif,clkmgr] Add difs to get fatal error code

### DIFF
--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -385,6 +385,16 @@ dif_result_t dif_clkmgr_recov_err_code_clear_codes(
   return kDifOk;
 }
 
+dif_result_t dif_clkmgr_fatal_err_code_get_codes(
+    const dif_clkmgr_t *clkmgr, dif_clkmgr_fatal_err_codes_t *codes) {
+  if (clkmgr == NULL || codes == NULL) {
+    return kDifBadArg;
+  }
+  *codes =
+      mmio_region_read32(clkmgr->base_addr, CLKMGR_FATAL_ERR_CODE_REG_OFFSET);
+  return kDifOk;
+}
+
 dif_result_t dif_clkmgr_wait_for_ext_clk_switch(const dif_clkmgr_t *clkmgr) {
   if (clkmgr == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -117,6 +117,28 @@ typedef enum dif_clkmgr_recov_err_type {
  */
 typedef uint32_t dif_clkmgr_recov_err_codes_t;
 
+typedef enum dif_clkmgr_fatal_err_type {
+  /**
+   * A recoverable update error for one of the clocks.
+   */
+  kDifClkmgrFatalErrTypeRegfileIntegrity = 1u << 0,
+  /**
+   * A fatal error for a duplicate idle counter.
+   */
+  kDifClkmgrFatalErrTypeIdleCount = 1u << 1,
+  /**
+   * A fatal error for a shadow register storage.
+   */
+  kDifClkmgrFatalErrTypeShadowStorage = 1u << 2,
+} dif_clkmgr_fatal_err_type_t;
+
+/**
+ * A set of fatal errors.
+ *
+ * This type is used to clear and read the fatal error codes.
+ */
+typedef uint32_t dif_clkmgr_fatal_err_codes_t;
+
 /**
  * Check if jitter is Enabled.
  * @param clkmgr Clock Manager Handle.
@@ -351,6 +373,16 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_clkmgr_recov_err_code_clear_codes(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_recov_err_codes_t codes);
 
+/**
+ * Read the fatal error codes.
+ *
+ * @param clkmgr Clock Manager Handle.
+ * @param[out] codes The fatal error codes.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_fatal_err_code_get_codes(
+    const dif_clkmgr_t *clkmgr, dif_clkmgr_fatal_err_type_t *codes);
 /**
  * Wait for external clock switch to finish.
  *

--- a/sw/device/lib/dif/dif_clkmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_clkmgr_unittest.cc
@@ -541,5 +541,46 @@ TEST_F(MeasureCountTest, GetThresholds) {
     EXPECT_EQ(max_threshold, 9);
   }
 }
+
+class RecovErrorTest : public ClkMgrTest {};
+
+TEST_F(RecovErrorTest, GetBadArgs) {
+  dif_clkmgr_recov_err_codes_t codes;
+  EXPECT_DIF_BADARG(dif_clkmgr_recov_err_code_get_codes(nullptr, nullptr));
+  EXPECT_DIF_BADARG(dif_clkmgr_recov_err_code_get_codes(nullptr, &codes));
+  EXPECT_DIF_BADARG(dif_clkmgr_recov_err_code_get_codes(&clkmgr_, nullptr));
+}
+
+TEST_F(RecovErrorTest, GetCodes) {
+  dif_clkmgr_recov_err_codes_t codes;
+  EXPECT_READ32(CLKMGR_RECOV_ERR_CODE_REG_OFFSET, 6);
+  EXPECT_DIF_OK(dif_clkmgr_recov_err_code_get_codes(&clkmgr_, &codes));
+  EXPECT_EQ(codes, 6);
+}
+
+TEST_F(RecovErrorTest, ClearBadArgs) {
+  EXPECT_DIF_BADARG(dif_clkmgr_recov_err_code_clear_codes(nullptr, 4));
+}
+
+TEST_F(RecovErrorTest, ClearCodes) {
+  EXPECT_WRITE32(CLKMGR_RECOV_ERR_CODE_REG_OFFSET, 6);
+  EXPECT_DIF_OK(dif_clkmgr_recov_err_code_clear_codes(&clkmgr_, 6));
+}
+
+class FatalErrorTest : public ClkMgrTest {};
+
+TEST_F(FatalErrorTest, GetBadArgs) {
+  dif_clkmgr_fatal_err_type_t codes;
+  EXPECT_DIF_BADARG(dif_clkmgr_fatal_err_code_get_codes(nullptr, nullptr));
+  EXPECT_DIF_BADARG(dif_clkmgr_fatal_err_code_get_codes(nullptr, &codes));
+  EXPECT_DIF_BADARG(dif_clkmgr_fatal_err_code_get_codes(&clkmgr_, nullptr));
+}
+
+TEST_F(FatalErrorTest, GetCodes) {
+  dif_clkmgr_fatal_err_type_t codes;
+  EXPECT_READ32(CLKMGR_FATAL_ERR_CODE_REG_OFFSET, 6);
+  EXPECT_DIF_OK(dif_clkmgr_fatal_err_code_get_codes(&clkmgr_, &codes));
+  EXPECT_EQ(codes, 6);
+}
 }  // namespace
 }  // namespace dif_clkmgr_unittest


### PR DESCRIPTION
Add missing unit tests for recov error codes.

Signed-off-by: Guillermo Maturana <maturana@google.com>