### PR TITLE
[dv,chip] Remove duplicate uvm_config_db get and set

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -160,9 +160,6 @@ class chip_env extends cip_base_env #(
         )) begin
       `uvm_fatal(`gfn, "failed to get por_rstn_vif from uvm_config_db")
     end
-    if (!uvm_config_db#(virtual pins_if #(1))::get(this, "", "pwrb_in_vif", cfg.pwrb_in_vif)) begin
-      `uvm_fatal(`gfn, "failed to get pwrb_in_vif from uvm_config_db")
-    end
 
     // disable alert_esc_agent's driver and only use its monitor
     foreach (LIST_OF_ALERTS[i]) begin

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -372,9 +372,6 @@ module tb;
        null, "*.env", "por_rstn_vif", por_rstn_if);
 
     uvm_config_db#(virtual pins_if #(1))::set(
-       null, "*.env", "pwrb_in_vif", pwrb_in_if);
-
-    uvm_config_db#(virtual pins_if #(1))::set(
         null, "*.env", "ec_rst_vif", ec_rst_if);
 
     uvm_config_db#(virtual pins_if #(1))::set(


### PR DESCRIPTION
Remove the duplicate set in tb.sv and get in chip_env.sv for pwrb_in_vif.

Signed-off-by: Guillermo Maturana <maturana@google.com>