### PR TITLE
[otbn, dv] Adds testcase to verify OTBN.DATA.MEM.SW_NOACCESS

### DIFF
--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -235,7 +235,7 @@
       name: sec_cm_data_mem_sw_noaccess
       desc: "Verify the countermeasure(s) DATA.MEM.SW_NOACCESS."
       milestone: V2S
-      tests: []
+      tests: ["otbn_sw_no_acc"]
     }
     {
       name: sec_cm_key_sideload

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -57,6 +57,7 @@ filesets:
       - seq_lib/otbn_ctrl_redun_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_sec_wipe_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_urnd_err_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_sw_no_acc_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sw_no_acc_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sw_no_acc_vseq.sv
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that writes to 1st Kib of address in DMEM which is inaccessible on TLUL.
+
+class otbn_sw_no_acc_vseq extends otbn_single_vseq;
+  `uvm_object_utils(otbn_sw_no_acc_vseq)
+
+  `uvm_object_new
+
+  task body();
+    bit write;
+    bit [BUS_AW-1:0] addr;
+    bit [BUS_DW-1:0] data;
+    bit [BUS_DW-1:0] rdata;
+    logic [127:0]    key;
+    logic [63:0]     nonce;
+    bit [31:0] err_val = 32'd1 << 21;
+    bit [11:0] offset;
+
+    key = cfg.get_dmem_key();
+    nonce = cfg.get_dmem_nonce();
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(data, $countones(data) != BUS_DW;)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(write)
+    offset = $urandom_range('hC00, 'hFFC);
+    addr = cfg.ral.get_addr_from_offset('h8000 + offset);
+    `uvm_info(`gfn, $sformatf("addr = %h", addr), UVM_LOW)
+
+    super.body();
+    `DV_WAIT(cfg.model_agent_cfg.vif.status != otbn_pkg::StatusBusyExecute)
+      if (write) begin
+        tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(1));
+        `uvm_info(`gfn,
+                  $sformatf("\n\t ----| Writing %h to a memory", data),
+                  UVM_LOW)
+         rdata = cfg.read_dmem_word(offset / (4 * BaseWordsPerWLEN), key, nonce);
+        `DV_CHECK_FATAL(rdata != data)
+      end else begin
+        tl_access(.addr(addr), .write(0), .data(data), .exp_err_rsp(1));
+        `uvm_info(`gfn,
+                  $sformatf("\n\t ----| Reading %h from a memory", data),
+                  UVM_LOW)
+        `DV_CHECK_FATAL(data == '1)
+      end
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -25,3 +25,4 @@
 `include "otbn_ctrl_redun_vseq.sv"
 `include "otbn_sec_wipe_err_vseq.sv"
 `include "otbn_urnd_err_vseq.sv"
+`include "otbn_sw_no_acc_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -304,6 +304,12 @@ name:
       en_run_modes: ["build_otbn_rig_binary_mode"]
       reseed: 2
     }
+    {
+      name: "otbn_sw_no_acc"
+      uvm_test_seq: "otbn_sw_no_acc_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This commit adds a testcase to verify OTBN.DATA.MEM.SW_NOACCESS
countermeasure. It writes or reads from 1st Kib of address space in DMEM
whcih is inaccessible to Ibex.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>