### PR TITLE
[sw] Optimize functions in //sw/device/lib/base:memory

### DIFF
--- a/sw/device/lib/base/memory.c
+++ b/sw/device/lib/base/memory.c
@@ -4,6 +4,8 @@
 
 #include "sw/device/lib/base/memory.h"
 
+#include <stdint.h>
+
 #include "sw/device/lib/base/macros.h"
 
 #ifdef OT_PLATFORM_RV32
@@ -12,25 +14,86 @@
 #define OT_PREFIX_IF_NOT_RV32(name) ot_##name
 #endif
 
-// The symbols below are all provided by the host libc. To avoid linker clashes,
-// they are all marked as `OT_WEAK`.
+static size_t compute_num_leading_bytes(const void *left, const void *right,
+                                        size_t len) {
+  if (len < alignof(uint32_t)) {
+    return len;
+  }
+  const size_t left_ahead = misalignment32_of((uintptr_t)left);
+  const size_t right_ahead = misalignment32_of((uintptr_t)right);
+  if (right == NULL || left_ahead == right_ahead) {
+    return (4 - left_ahead) & 0x3;
+  }
+  return len;
+}
 
-OT_WEAK
+/**
+ * Compute the bounds of the word-aligned region for the given buffers.
+ *
+ * It's more efficient for our memory functions to operate on `uint32_t` values
+ * than individual bytes, but we can only read `uint32_t` values from aligned
+ * addresses. This function effectively breaks the given buffers into three
+ * consecutive chunks: the unaligned "head", the aligned "body", and the
+ * unaligned "tail".
+ *
+ * @param[in] left The memory function's first buffer argument. Cannot be NULL.
+ * @param[in] right The memory function's second buffer argument. May be NULL.
+ * @param[in] len The length in bytes of both `left` and `right.`
+ * @param[out] out_body_offset The start of the body region.
+ * @param[out] out_tail_offset The start of the tail region.
+ */
+static void compute_alignment(const void *left, const void *right, size_t len,
+                              size_t *out_body_offset,
+                              size_t *out_tail_offset) {
+  const size_t num_leading_bytes = compute_num_leading_bytes(left, right, len);
+  *out_body_offset = num_leading_bytes;
+
+  const size_t num_words = (len - num_leading_bytes) / sizeof(uint32_t);
+  *out_tail_offset = num_leading_bytes + num_words * sizeof(uint32_t);
+}
+
+static uint32_t repeat_byte_to_u32(uint8_t byte) {
+  return byte << 24 | byte << 16 | byte << 8 | byte;
+}
+
 void *OT_PREFIX_IF_NOT_RV32(memcpy)(void *restrict dest,
                                     const void *restrict src, size_t len) {
-  uint8_t *dest8 = (uint8_t *)dest;
-  uint8_t *src8 = (uint8_t *)src;
-  for (size_t i = 0; i < len; ++i) {
+  if (dest == NULL || src == NULL) {
+    return dest;
+  }
+  unsigned char *dest8 = (unsigned char *)dest;
+  const unsigned char *src8 = (const unsigned char *)src;
+  size_t body_offset, tail_offset;
+  compute_alignment(dest, src, len, &body_offset, &tail_offset);
+  size_t i = 0;
+  for (; i < body_offset; ++i) {
+    dest8[i] = src8[i];
+  }
+  for (; i < tail_offset; i += sizeof(uint32_t)) {
+    uint32_t word = read_32(&src8[i]);
+    write_32(word, &dest8[i]);
+  }
+  for (; i < len; ++i) {
     dest8[i] = src8[i];
   }
   return dest;
 }
 
-OT_WEAK
 void *OT_PREFIX_IF_NOT_RV32(memset)(void *dest, int value, size_t len) {
-  uint8_t *dest8 = (uint8_t *)dest;
-  uint8_t value8 = (uint8_t)value;
-  for (size_t i = 0; i < len; ++i) {
+  unsigned char *dest8 = (unsigned char *)dest;
+  const uint8_t value8 = (uint8_t)value;
+
+  size_t body_offset, tail_offset;
+  compute_alignment(dest, NULL, len, &body_offset, &tail_offset);
+  size_t i = 0;
+  for (; i < body_offset; ++i) {
+    dest8[i] = value8;
+  }
+  const uint32_t value32 = repeat_byte_to_u32(value8);
+  for (; i < tail_offset; i += sizeof(uint32_t)) {
+    write_32(value32, &dest8[i]);
+  }
+  for (; i < len; ++i) {
     dest8[i] = value8;
   }
   return dest;
@@ -42,12 +105,32 @@ enum {
   kMemCmpGt = 42,
 };
 
-OT_WEAK
 int OT_PREFIX_IF_NOT_RV32(memcmp)(const void *lhs, const void *rhs,
                                   size_t len) {
-  const uint8_t *lhs8 = (uint8_t *)lhs;
-  const uint8_t *rhs8 = (uint8_t *)rhs;
-  for (size_t i = 0; i < len; ++i) {
+  const unsigned char *lhs8 = (const unsigned char *)lhs;
+  const unsigned char *rhs8 = (const unsigned char *)rhs;
+  size_t body_offset, tail_offset;
+  compute_alignment(lhs, rhs, len, &body_offset, &tail_offset);
+  size_t i = 0;
+  for (; i < body_offset; ++i) {
+    if (lhs8[i] < rhs8[i]) {
+      return kMemCmpLt;
+    } else if (lhs8[i] > rhs8[i]) {
+      return kMemCmpGt;
+    }
+  }
+  for (; i < tail_offset; i += sizeof(uint32_t)) {
+    uint32_t word_left = __builtin_bswap32(read_32(&lhs8[i]));
+    uint32_t word_right = __builtin_bswap32(read_32(&rhs8[i]));
+    static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+                  "memcmp assumes that the system is little endian.");
+    if (word_left < word_right) {
+      return kMemCmpLt;
+    } else if (word_left > word_right) {
+      return kMemCmpGt;
+    }
+  }
+  for (; i < len; ++i) {
     if (lhs8[i] < rhs8[i]) {
       return kMemCmpLt;
     } else if (lhs8[i] > rhs8[i]) {
@@ -57,42 +140,120 @@ int OT_PREFIX_IF_NOT_RV32(memcmp)(const void *lhs, const void *rhs,
   return kMemCmpEq;
 }
 
-OT_WEAK
 int memrcmp(const void *lhs, const void *rhs, size_t len) {
-  const uint8_t *lhs8 = (uint8_t *)lhs;
-  const uint8_t *rhs8 = (uint8_t *)rhs;
-  size_t j;
-  for (size_t i = 0; i < len; ++i) {
-    j = len - 1 - i;
-    if (lhs8[j] < rhs8[j]) {
+  const unsigned char *lhs8 = (const unsigned char *)lhs;
+  const unsigned char *rhs8 = (const unsigned char *)rhs;
+  size_t body_offset, tail_offset;
+  compute_alignment(lhs, rhs, len, &body_offset, &tail_offset);
+  size_t end = len;
+  for (; end > tail_offset; --end) {
+    const size_t i = end - 1;
+    if (lhs8[i] < rhs8[i]) {
       return kMemCmpLt;
-    } else if (lhs8[j] > rhs8[j]) {
+    } else if (lhs8[i] > rhs8[i]) {
+      return kMemCmpGt;
+    }
+  }
+  for (; end > body_offset; end -= sizeof(uint32_t)) {
+    const size_t i = end - sizeof(uint32_t);
+    uint32_t word_left = read_32(&lhs8[i]);
+    uint32_t word_right = read_32(&rhs8[i]);
+    static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+                  "memrcmp assumes that the system is little endian.");
+    if (word_left < word_right) {
+      return kMemCmpLt;
+    } else if (word_left > word_right) {
+      return kMemCmpGt;
+    }
+  }
+  for (; end > 0; --end) {
+    const size_t i = end - 1;
+    if (lhs8[i] < rhs8[i]) {
+      return kMemCmpLt;
+    } else if (lhs8[i] > rhs8[i]) {
       return kMemCmpGt;
     }
   }
   return kMemCmpEq;
 }
 
-OT_WEAK
 void *OT_PREFIX_IF_NOT_RV32(memchr)(const void *ptr, int value, size_t len) {
-  uint8_t *ptr8 = (uint8_t *)ptr;
-  uint8_t value8 = (uint8_t)value;
-  for (size_t i = 0; i < len; ++i) {
+  const unsigned char *ptr8 = (const unsigned char *)ptr;
+  const uint8_t value8 = (uint8_t)value;
+
+  size_t body_offset, tail_offset;
+  compute_alignment(ptr, NULL, len, &body_offset, &tail_offset);
+  size_t i = 0;
+  for (; i < body_offset; ++i) {
     if (ptr8[i] == value8) {
-      return ptr8 + i;
+      return (void *)&ptr8[i];
+    }
+  }
+  const uint32_t value32 = repeat_byte_to_u32(value8);
+  for (; i < tail_offset; i += sizeof(uint32_t)) {
+    uint32_t word = read_32(&ptr8[i]);
+    uint32_t bits_eq = ~(word ^ value32);
+    static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+                  "memchr assumes that the system is little endian.");
+    if ((bits_eq & UINT8_MAX) == UINT8_MAX) {
+      return (void *)&ptr8[i];
+    }
+    if (((bits_eq >> 8) & UINT8_MAX) == UINT8_MAX) {
+      return (void *)&ptr8[i + 1];
+    }
+    if (((bits_eq >> 16) & UINT8_MAX) == UINT8_MAX) {
+      return (void *)&ptr8[i + 2];
+    }
+    if (((bits_eq >> 24) & UINT8_MAX) == UINT8_MAX) {
+      return (void *)&ptr8[i + 3];
+    }
+  }
+  for (; i < len; ++i) {
+    if (ptr8[i] == value8) {
+      return (void *)&ptr8[i];
     }
   }
   return NULL;
 }
 
-OT_WEAK
 void *OT_PREFIX_IF_NOT_RV32(memrchr)(const void *ptr, int value, size_t len) {
-  uint8_t *ptr8 = (uint8_t *)ptr;
-  uint8_t value8 = (uint8_t)value;
-  for (size_t i = 0; i < len; ++i) {
-    size_t idx = len - i - 1;
-    if (ptr8[idx] == value8) {
-      return ptr8 + idx;
+  const unsigned char *ptr8 = (const unsigned char *)ptr;
+  const uint8_t value8 = (uint8_t)value;
+
+  size_t body_offset, tail_offset;
+  compute_alignment(ptr, NULL, len, &body_offset, &tail_offset);
+
+  size_t end = len;
+  for (; end > tail_offset; --end) {
+    const size_t i = end - 1;
+    if (ptr8[i] == value8) {
+      return (void *)&ptr8[i];
+    }
+  }
+  const uint32_t value32 = repeat_byte_to_u32(value8);
+  for (; end > body_offset; end -= sizeof(uint32_t)) {
+    const size_t i = end - sizeof(uint32_t);
+    uint32_t word = read_32(&ptr8[i]);
+    uint32_t bits_eq = ~(word ^ value32);
+    static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+                  "memrchr assumes that the system is little endian.");
+    if (((bits_eq >> 24) & UINT8_MAX) == UINT8_MAX) {
+      return (void *)&ptr8[i + 3];
+    }
+    if (((bits_eq >> 16) & UINT8_MAX) == UINT8_MAX) {
+      return (void *)&ptr8[i + 2];
+    }
+    if (((bits_eq >> 8) & UINT8_MAX) == UINT8_MAX) {
+      return (void *)&ptr8[i + 1];
+    }
+    if ((bits_eq & UINT8_MAX) == UINT8_MAX) {
+      return (void *)&ptr8[i];
+    }
+  }
+  for (; end > 0; --end) {
+    const size_t i = end - 1;
+    if (ptr8[i] == value8) {
+      return (void *)&ptr8[i];
     }
   }
   return NULL;

--- a/sw/device/lib/base/memory.h
+++ b/sw/device/lib/base/memory.h
@@ -66,7 +66,7 @@ inline ptrdiff_t misalignment32_of(uintptr_t addr) {
  * well-defined.
  *
  * Of course, `ptr` must point to word-aligned memory that is at least one word
- * wide. To do otherwise is Undefined Behavior. It goes eithout saying that the
+ * wide. To do otherwise is Undefined Behavior. It goes without saying that the
  * memory this function intents to read must be initialized.
  *
  * This function has reordering properties as weak as a normal, non-atomic,
@@ -81,7 +81,7 @@ inline uint32_t read_32(const void *ptr) {
   // the pointer points to four bytes of four-byte-aligned memory.
   //
   // Failing to get that particular codegen in either GCC or Clang with -O2 or
-  // -Os set shall be considred a bug in this function. The same applies to
+  // -Os set shall be considered a bug in this function. The same applies to
   // `write32()`.
   ptr = __builtin_assume_aligned(ptr, alignof(uint32_t));
   uint32_t val;
@@ -98,7 +98,7 @@ inline uint32_t read_32(const void *ptr) {
  * is well-defined.
  *
  * Of course, `ptr` must point to word-aligned memory that is at least one
- * 64-bit word wide. To do otherwise is Undefined Behavior. It goes eithout
+ * 64-bit word wide. To do otherwise is Undefined Behavior. It goes without
  * saying that the memory this function intents to read must be initialized.
  *
  * This function has reordering properties as weak as a normal, non-atomic,
@@ -241,7 +241,8 @@ int OT_PREFIX_IF_NOT_RV32(memcmp)(const void *lhs, const void *rhs, size_t len);
 int memrcmp(const void *lhs, const void *rhs, size_t len);
 
 /**
- * Search a region of memory for the first occurence of a particular byte value.
+ * Search a region of memory for the first occurrence of a particular byte
+ * value.
  *
  * This function conforms to the semantics defined in ISO C11 S7.24.5.1.
  *
@@ -259,7 +260,7 @@ int memrcmp(const void *lhs, const void *rhs, size_t len);
 void *OT_PREFIX_IF_NOT_RV32(memchr)(const void *ptr, int value, size_t len);
 
 /**
- * Search a region of memory for the last occurence of a particular byte value.
+ * Search a region of memory for the last occurrence of a particular byte value.
  *
  * This function is not specified by C11, but is named for a well-known glibc
  * extension.

--- a/sw/device/lib/base/memory_perftest.c
+++ b/sw/device/lib/base/memory_perftest.c
@@ -148,70 +148,70 @@ static const perf_test_t kPerfTests[] = {
         .setup_buf1 = &fill_buf_deterministic_values,
         .setup_buf2 = &fill_buf_deterministic_values,
         .func = &test_memcpy,
-        .expected_num_cycles = 210280,
+        .expected_num_cycles = 33270,
     },
     {
         .label = "memcpy_zeroes",
         .setup_buf1 = &fill_buf_deterministic_values,
         .setup_buf2 = &fill_buf_zeroes,
         .func = &test_memcpy,
-        .expected_num_cycles = 210280,
+        .expected_num_cycles = 33270,
     },
     {
         .label = "memset",
         .setup_buf1 = &fill_buf_zeroes,
         .setup_buf2 = &fill_buf_deterministic_values,
         .func = &test_memset,
-        .expected_num_cycles = 130310,
+        .expected_num_cycles = 23200,
     },
     {
         .label = "memset_zeroes",
         .setup_buf1 = &fill_buf_zeroes,
         .setup_buf2 = &fill_buf_zeroes,
         .func = &test_memset,
-        .expected_num_cycles = 130310,
+        .expected_num_cycles = 23200,
     },
     {
         .label = "memcmp_pathological",
         .setup_buf1 = &fill_buf_zeroes_then_one,
         .setup_buf2 = &fill_buf_zeroes,
         .func = &test_memcmp,
-        .expected_num_cycles = 210310,
+        .expected_num_cycles = 110740,
     },
     {
         .label = "memcmp_zeroes",
         .setup_buf1 = &fill_buf_zeroes,
         .setup_buf2 = &fill_buf_zeroes,
         .func = &test_memcmp,
-        .expected_num_cycles = 210280,
+        .expected_num_cycles = 110740,
     },
     {
         .label = "memrcmp_pathological",
         .setup_buf1 = &fill_buf_zeroes,
         .setup_buf2 = &fill_buf_one_then_zeroes,
         .func = &test_memrcmp,
-        .expected_num_cycles = 200330,
+        .expected_num_cycles = 50740,
     },
     {
         .label = "memrcmp_zeroes",
         .setup_buf1 = &fill_buf_zeroes,
         .setup_buf2 = &fill_buf_zeroes,
         .func = &test_memrcmp,
-        .expected_num_cycles = 200300,
+        .expected_num_cycles = 50850,
     },
     {
         .label = "memchr_pathological",
         .setup_buf1 = &fill_buf_deterministic_values,
         .setup_buf2 = &fill_buf_zeroes,
         .func = &test_memchr,
-        .expected_num_cycles = 12820,
+        .expected_num_cycles = 7250,
     },
     {
         .label = "memrchr_pathological",
         .setup_buf1 = &fill_buf_deterministic_values,
         .setup_buf2 = &fill_buf_deterministic_values,
         .func = &test_memrchr,
-        .expected_num_cycles = 47890,
+        .expected_num_cycles = 23850,
     },
 };
 
@@ -230,9 +230,20 @@ bool test_main(void) {
       // cannot print `uint64_t`.
       CHECK(test->expected_num_cycles < UINT32_MAX);
       CHECK(num_cycles < UINT32_MAX);
-      LOG_WARNING("Expected %s to run in %d cycles. Actually took %d cycles.",
-                  test->label, (uint32_t)test->expected_num_cycles,
-                  (uint32_t)num_cycles);
+      const uint32_t expected_num_cycles_u32 =
+          (uint32_t)test->expected_num_cycles;
+      const uint32_t num_cycles_u32 = (uint32_t)num_cycles;
+
+      CHECK(num_cycles < UINT32_MAX / 100);
+      const uint32_t percent_change =
+          (100 * num_cycles_u32) / expected_num_cycles_u32;
+
+      LOG_WARNING(
+          "%s:\n"
+          "  Expected:        %10d cycles\n"
+          "  Actual:          %10d cycles\n"
+          "  Actual/Expected: %10d%%\n",
+          test->label, expected_num_cycles_u32, num_cycles_u32, percent_change);
     }
   }
   return all_expectations_match;


### PR DESCRIPTION
This commit optimizes the implementations of memcpy() and friends. They
now operate on 32-bit words instead of bytes.

To compare the performance impact of my optimizations, I ran the
perftest without updating the cycle count expectations.

```
./bazelisk.sh test  --test_output=streamed //sw/device/lib/base:memory_perftest_fpga_cw310

  W00001 memory_perftest.c:246] memcpy:
    Expected:            210280 cycles
    Actual:               33270 cycles
    Actual/Expected:         15%

  W00002 memory_perftest.c:246] memcpy_zeroes:
    Expected:            210280 cycles
    Actual:               33270 cycles
    Actual/Expected:         15%

  W00003 memory_perftest.c:246] memset:
    Expected:            130310 cycles
    Actual:               23200 cycles
    Actual/Expected:         17%

  W00004 memory_perftest.c:246] memset_zeroes:
    Expected:            130310 cycles
    Actual:               23200 cycles
    Actual/Expected:         17%

  W00005 memory_perftest.c:246] memcmp_pathological:
    Expected:            210310 cycles
    Actual:              110740 cycles
    Actual/Expected:         52%

  W00006 memory_perftest.c:246] memcmp_zeroes:
    Expected:            210280 cycles
    Actual:              110740 cycles
    Actual/Expected:         52%

  W00007 memory_perftest.c:246] memrcmp_pathological:
    Expected:            200330 cycles
    Actual:               50740 cycles
    Actual/Expected:         25%

  W00008 memory_perftest.c:246] memrcmp_zeroes:
    Expected:            200300 cycles
    Actual:               50850 cycles
    Actual/Expected:         25%

  W00009 memory_perftest.c:246] memchr_pathological:
    Expected:             12820 cycles
    Actual:                7250 cycles
    Actual/Expected:         56%

  W00010 memory_perftest.c:246] memrchr_pathological:
    Expected:             47890 cycles
    Actual:               23850 cycles
    Actual/Expected:         49%
```
Issue https://github.com/lowRISC/opentitan/issues/13471