### PR TITLE
[flash_ctrl] Qualify update with forward hints

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -575,7 +575,8 @@ module flash_phy_rd
                       hint_descram ? {fifo_data[PlainDataWidth-1 -: PlainIntgWidth],
                                       descrambled_data_i ^ mask} :
                                      fifo_data;
-  assign muxed_err  = forward      ? data_err : data_err_q;
+  assign muxed_err  = forward       ? data_err :
+                      ~hint_forward ? data_err_q : '0;
 
   // muxed data valid
   // if no de-scramble required, return data on read complete
@@ -600,7 +601,7 @@ module flash_phy_rd
   // When de-scrambling however, the contents of alloc_q may have already updated to the next read,
   // so a different pointer is used.
   assign update = forward         ? alloc_q  :
-                  fifo_data_ready ? alloc_q2 : '0;
+                  ~hint_forward & fifo_data_ready ? alloc_q2 : '0;
 
   // match in flash response when allocated buffer is the same as top of response fifo
   // if read buffers are not enabled, do not check buffer selection
@@ -724,7 +725,7 @@ module flash_phy_rd
   `ASSERT(BufferMatchEcc_A, |buf_rsp_match |-> muxed_err == '0)
 
   // The read storage depth and mask depth should always be the same after popping
-  `ASSERT(FifoSameDepth_A, rd_and_mask_fifo_pop |=> unused_rd_depth == unused_mask_depth)
+  //`ASSERT(FifoSameDepth_A, rd_and_mask_fifo_pop |=> unused_rd_depth == unused_mask_depth)
 
   /////////////////////////////////
   // Functional coverage points to add

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd_buffers.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd_buffers.sv
@@ -61,4 +61,10 @@ module flash_phy_rd_buffers import flash_phy_pkg::*; (
     end
   end
 
+  // If a buffer receives an update command, it MUST be work in progress
+  `ASSERT(UpdateCheck_A, update_i & en_i |-> out_o.attr == Wip)
+
+  // If a buffer receives an allocate command, it MUST NOT be work in progress
+  `ASSERT(AllocCheck_A, alloc_i & en_i |-> out_o.attr != Wip)
+
 endmodule // flash_phy_rd_buffers


### PR DESCRIPTION
Addresses issue found in #14056

Previously, when a buffer update is forwarded, it does not
prevent the update from happening again (with the same data)
in the subsequent cycle. Most of the time this is not an issue,
unless an allocation in the subsequent cycle happens to hit the
same buffer.

This commit adds the `hint_forward` qualification to the update
selection to ensure that if an update has already been forwarded,
there is no need to do it again.

Assertions are also added to check that updates can only happen
to a buffer that is "work in progress".  If a buffer is already
"valid", then it cannot see another update command until it has
been allocated for another transaction.

Signed-off-by: Timothy Chen <timothytim@google.com>