### PR TITLE
[flash_ctrl] fix rma loaded word count

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -632,7 +632,7 @@ module flash_ctrl_lcmgr
     .rst_ni,
     .clr_i(word_cnt_clr),
     .set_i(word_cnt_ld),
-    .set_cnt_i(WordCntWidth'(BusWordsPerPage)),
+    .set_cnt_i('0),
     .incr_en_i(word_cnt_incr),
     .decr_en_i(1'b0),
     .step_i(WordCntWidth'(WidthMultiple)),


### PR DESCRIPTION
Address issue found in #14214

Previously, the rma program counter was loading an incorrect value
and causing the rma process to only erase but not randomly program.

This change should now cause rma entry to both erase and program.
As a result, the test now takes MUCH longer to run.

Signed-off-by: Timothy Chen <timothytim@google.com>