### PR TITLE
feat(rdc): Define a few reset scnearios

### DIFF
--- a/hw/rdc/tools/meridianrdc/run-rdc.tcl
+++ b/hw/rdc/tools/meridianrdc/run-rdc.tcl
@@ -128,9 +128,9 @@ create_set_reset_scenario_script -output reset_scenarios.tcl -primary
 # Import hand-edited reset scenario file
 if {$RESET_SCENARIO_FILE != ""} {
   source $RESET_SCENARIO_FILE
+} else {
+  source reset_scenarios.tcl
 }
-
-source reset_scenarios.tcl
 
 #########################
 ## Run RDC             ##

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
@@ -9,3 +9,9 @@
 #
 #   1. Reset groups
 #   2. Set Constant
+
+# Set MuBi4False(4'h9) scanmode
+set_constant -value 4'h9 scanmode
+
+# Strap to FuncSel(2'b00)
+set_constant -value 2'b00 top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -4,8 +4,63 @@
 #
 # Meridian RDC Reset Scenario
 
+###############
+# Reset Group #
+###############
+
+# List of external reset group
+set ext_rst_lst {}
+# POR_N active low
+lappend ext_rst_lst [list { POR_N } {reset low}]
+
+foreach_in_collection j [get_pins top_earlgrey.rstmgr_aon_resets.*] {
+    lappend ext_rst_lst [list [get_attribute ${j} full_name] {reset low}]
+}
+
+set_reset_group $ext_rst_lst -name ext_rst
+
 ###################
 # Reset Scenarios #
 ###################
 
 # TODO: SPI_CSB asserted(release from reset) only when SYS_RST_N is not asserted
+
+
+# POR_N
+set_reset_scenario { {POR_N {reset { @t0 0 } { #10 1}}}} -name ScnPOR
+
+# AST POK
+
+# PWRMGR Reset Cause
+
+# RSTMGR SW Resets
+#set_reset_scenario { {{top_earlgrey.u_rstmgr_aon.u_ndm_sync.u_sync_2.gen_generic.u_impl_generic.q_o[0]} {reset  { @t0 1 } { #10 0}} }} -name Scenario8 -comment "functional reset"
+set_reset_scenario { \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_0.q[0]} {reset  { @t0 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_1.q[0]} {reset  { @t0 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_2.q[0]} {reset  { @t0 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_3.q[0]} {reset  { @t0 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_4.q[0]} {reset  { @t0 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_5.q[0]} {reset  { @t0 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_6.q[0]} {reset  { @t0 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_7.q[0]} {reset  { @t0 0 } { #10 1}} } \
+} -name RstMgrSwRst -comment "RSTMGR SW Controlled Resets"
+
+# SPI_DEVICE FIFO Reset (Sync)
+#  They can be asserted only in Generic Mode. Keep Mode in Generic then assert
+#  reset.
+#
+# Assume control_mode is Generic mode `{constraint {@t0 0}}`
+# Then `CONTROL.rst_rxfifo` 0 -> 1 {after 10 clks} -> 0 {after 4 clks}
+set_reset_scenario { \
+  { {top_earlgrey.u_spi_device.u_reg.u_control_rst_rxfifo.q[0]} \
+    {reset  { @t0 0 } { #10 1} { #4 0 }} } \
+  { top_earlgrey.u_spi_device.u_reg.u_control_mode.q \
+    {constraint {@t0 0}}} \
+  } -name SpidRstRxFifo -comment "SPI_DEVICE Async RX FIFO Functional Reset"
+set_reset_scenario { \
+  { {top_earlgrey.u_spi_device.u_reg.u_control_rst_txfifo.q[0]} \
+    {reset  { @t0 0 } { #10 1} { #4 0 }} } \
+  { top_earlgrey.u_spi_device.u_reg.u_control_mode.q \
+    {constraint {@t0 0}}} \
+  } -name SpidRstTxFifo -comment "SPI_DEVICE Async TX FIFO Functional Reset"


### PR DESCRIPTION
This commit defines scenarios of reset manager's sw controlled reset
signals and SPI_DEVICE FIFO reset signals.
