### PR TITLE
[spi_device/dv] Enhance seq/scb for upload cmd and busy bit

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -261,6 +261,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
     `uvm_create_on(m_spi_host_seq, p_sequencer.spi_sequencer_h)
     `DV_SPINWAIT(
       while (1) begin
+        cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
         `DV_CHECK_RANDOMIZE_WITH_FATAL(m_spi_host_seq,
                                       opcode == READ_STATUS_1;
                                       address_q.size() == 0;
@@ -269,7 +270,6 @@ class spi_device_base_vseq extends cip_base_vseq #(
         `uvm_send(m_spi_host_seq)
         // bit 0 is busy bit
         if (m_spi_host_seq.rsp.payload_q[0][0] === 0) break;
-        cfg.clk_rst_vif.wait_clks(1);
       end
     )
   endtask

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_all_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_all_vseq.sv
@@ -8,18 +8,49 @@ class spi_device_pass_all_vseq extends spi_device_pass_base_vseq;
   `uvm_object_new
 
   int write_flash_status_pct = 30;
+
   virtual task body();
+    bit main_seq_done;
+
     allow_addr_swap    = 1;
     allow_payload_swap = 1;
     allow_intercept    = 1;
 
+    // enable upload
+    allow_upload = 1;
+    always_set_busy_when_upload_contain_payload = 1;
+
+    fork
+      // this thread runs until the main_seq completes
+      while (!main_seq_done) upload_fifo_read_seq();
+      // main seq that sends spi items
+      begin
+        main_seq();
+        main_seq_done = 1;
+      end
+    join
+  endtask : body
+
+  virtual task upload_fifo_read_seq();
+    int upload_read_dly;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(upload_read_dly,
+        upload_read_dly dist {
+            [0:10]      :/ 1,
+            [11:100]    :/ 2,
+            [101:1000]  :/ 2,
+            [1000:5000] :/ 1};)
+    cfg.clk_rst_vif.wait_clks(upload_read_dly);
+    read_upload_fifos();
+  endtask : upload_fifo_read_seq
+
+  virtual task main_seq();
     for (int i = 0; i < num_trans; ++i) begin
       `uvm_info(`gfn, $sformatf("running iteration %0d/%0d", i, num_trans), UVM_LOW)
-      spi_device_flash_pass_init(PassthroughMode);
 
+      spi_device_flash_pass_init(PassthroughMode);
       for (int j = 0; j < 20; ++j) begin
         if ($urandom_range(0, 99) < write_flash_status_pct) begin
-          random_access_flash_status(.write(1));
+          random_access_flash_status(.write(1), .busy(1));
         end else if ($urandom_range(0, 1)) begin
           random_access_flash_status(.write(0));
         end
@@ -31,6 +62,5 @@ class spi_device_pass_all_vseq extends spi_device_pass_base_vseq;
         cfg.clk_rst_vif.wait_clks(10);
       end
     end
-
-  endtask : body
+  endtask : main_seq
 endclass : spi_device_pass_all_vseq


### PR DESCRIPTION
1. update pass_all_vseq to 2 threads, both sides (upstream and SW) can updata
 and read busy bit independently
2. upload scb
  1. handle racing condition case on busy bit
  2. handle upload content is read out before spi item completes
  3. block passthrough when busy is set

Signed-off-by: Weicai Yang <weicai@google.com>