### PR TITLE
[dv/chip] Add prim_tl_access test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2379,7 +2379,7 @@
               When `lc_dft_en_i` is Off, accessing this region will result in a TLUL error.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_prim_tl_access"]
     }
 
     // FLASH (pre-verified IP) integration tests:
@@ -2556,12 +2556,10 @@
 
             - The prim tlul interface is a open source placeholder for the closed source CSRs that
               will be implemented in a translation 'shim'.
-            - Verify that when `lc_nvm_debug_en_i` is On, this region can be read / written to by
-              the SW. When `lc_nvm_debug_en_i` is Off, accessing this region will result in a TLUL
-              error.
+            - Verify that this region can be read / written to by the SW in any LC state.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_prim_tl_access"]
     }
     {
       name: chip_sw_flash_ctrl_clock_freqs

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -928,6 +928,14 @@
       reseed: 20
     }
     {
+      name: chip_prim_tl_access
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "chip_prim_tl_access_vseq"
+      en_run_modes: ["stub_cpu_mode"]
+      run_opts: ["+en_scb=0", "+en_scb_tl_err_chk=0"]
+      reseed: 1
+    }
+    {
       name: chip_plic_all_irqs
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests/autogen:plic_all_irqs_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -42,6 +42,7 @@ filesets:
       - seq_lib/chip_common_vseq.sv: {is_include_file: true}
       - seq_lib/chip_jtag_csr_rw_vseq.sv: {is_include_file: true}
       - seq_lib/chip_jtag_mem_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_prim_tl_access_vseq.sv: {is_include_file: true}
       - seq_lib/chip_tap_straps_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_jtag_base_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_prim_tl_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_prim_tl_access_vseq.sv
@@ -1,0 +1,88 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The prim_tlul register spaces are placeholders in open source environment.
+// This sequence access prim_tlul access with randomly backdoor-loaded LC state.
+// If the LC state gates the prim_tlul interface, we are expecting to see a TLUL d_error.
+// In current chip-level design, only otp_ctrl's prim_tl_i/o will be gated by lc_dft_en_i.
+class chip_prim_tl_access_vseq extends chip_stub_cpu_base_vseq;
+  `uvm_object_utils(chip_prim_tl_access_vseq)
+
+  `uvm_object_new
+
+  rand lc_state_e lc_state;
+
+  constraint num_trans_c {
+    num_trans inside {[2:10]};
+  }
+
+  // Add constraint to avoid lc_escalate_en being broadcasted and causes fatal alerts.
+  constraint lc_state_c {
+    lc_state != LcStScrap;
+  }
+
+  virtual function void backdoor_override_otp();
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(lc_state)
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(lc_state);
+  endfunction
+
+  virtual function void initialize_otp_sig_verify();
+    backdoor_override_otp();
+    super.initialize_otp_sig_verify();
+  endfunction
+
+  virtual function bit allow_otp_prim_tl_access();
+    if (lc_state inside {LcStTestUnlocked0, LcStTestUnlocked1, LcStTestUnlocked2,
+        LcStTestUnlocked3, LcStTestUnlocked4, LcStTestUnlocked5, LcStTestUnlocked6,
+        LcStTestUnlocked7, LcStRma}) begin
+      return 1;
+    end else begin
+      return 0;
+    end
+  endfunction
+
+  virtual task rw_csr_addr_with_gating(uvm_reg csr, bit gated);
+    bit [TL_AW-1:0] addr = csr.get_address();
+    bit [TL_DW-1:0] data = $urandom();
+    bit [TL_DW-1:0] exp_data;
+    tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(gated));
+    if (!gated) begin
+      void'(csr.predict(.value(data), .kind(UVM_PREDICT_WRITE)));
+    end
+    exp_data = gated ? '1 : `gmv(csr);
+    `uvm_info(`gfn, $sformatf("Write addr %0h, write adata %0h, expect data %0h",
+              addr, data, exp_data), UVM_HIGH);
+    tl_access(.addr(addr), .write(0), .data(data), .exp_err_rsp(gated), .exp_data(exp_data),
+              .check_exp_data(1));
+  endtask
+
+  virtual task rand_rw_prim_regs(uvm_reg prim_regs[$], bit gated);
+    `DV_CHECK_NE(prim_regs.size(), 0)
+    prim_regs.shuffle();
+    foreach (prim_regs[i]) rw_csr_addr_with_gating(prim_regs[i], gated);
+  endtask
+
+  virtual task body();
+    for (int trans_i = 1; trans_i <= num_trans; trans_i++) begin
+      uvm_reg otp_prim_regs[$], flash_prim_regs[$];
+
+      if (trans_i > 1 && $urandom_range(0, 4)) dut_init();
+      `uvm_info(`gfn, $sformatf("Run iterations %0d/%0d with lc_state %0s", trans_i, num_trans,
+                lc_state.name), UVM_LOW)
+
+      if ($urandom_range(0, 1)) begin
+        `uvm_info(`gfn, "Check OTP prim_tl access", UVM_HIGH)
+        ral.otp_ctrl_prim.get_registers(otp_prim_regs);
+        rand_rw_prim_regs(otp_prim_regs, ~allow_otp_prim_tl_access());
+      end
+
+      if ($urandom_range(0, 1)) begin
+        `uvm_info(`gfn, "Check FLASH_CTRL prim_tl access", UVM_HIGH)
+        ral.flash_ctrl_prim.get_registers(flash_prim_regs);
+        rand_rw_prim_regs(flash_prim_regs, 0);
+      end
+    end
+  endtask : body
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -11,6 +11,7 @@
 // This needs to be listed prior to all sequences that derive from it.
 `include "chip_sw_base_vseq.sv"
 `include "chip_jtag_base_vseq.sv"
+`include "chip_prim_tl_access_vseq.sv"
 `include "chip_sw_full_aon_reset_vseq.sv"
 `include "chip_sw_deep_power_glitch_vseq.sv"
 `include "chip_sw_main_power_glitch_vseq.sv"


### PR DESCRIPTION
This PR adds a prim_tl_access test that will do the following things in
the stub cpu mode:
1). randomly backdoor a lc state.
2). access prim_tl_o/i interface in OTP and LC_CTRL.
3). check if FLASH tl access can always be accessible
4). check if certain LC state can gate OTP access.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>