### PR TITLE
[chip,dv,pwrmgr] fix pwrmgr_deep_sleep_all_reset_reqs

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -547,18 +547,23 @@
       uvm_test_seq: chip_sw_random_sleep_all_reset_vseq
       sw_images: ["//sw/device/tests/sim_dv:pwrmgr_random_sleep_all_reset_reqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=50_000_000"]
+      run_timeout_mins: 120
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_all_reset_reqs
       uvm_test_seq: chip_sw_deep_sleep_all_reset_vseq
       sw_images: ["//sw/device/tests/sim_dv:pwrmgr_deep_sleep_all_reset_reqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=50_000_000"]
+      run_timeout_mins: 120
     }
     {
       name: chip_sw_pwrmgr_normal_sleep_all_reset_reqs
       uvm_test_seq: chip_sw_deep_sleep_all_reset_vseq
       sw_images: ["//sw/device/tests/sim_dv:pwrmgr_normal_sleep_all_reset_reqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
+      run_timeout_mins: 120
     }
     {
       name: chip_sw_pwrmgr_sleep_power_glitch_reset

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_sleep_all_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_deep_sleep_all_reset_vseq.sv
@@ -24,7 +24,6 @@ class chip_sw_deep_sleep_all_reset_vseq extends chip_sw_base_vseq;
   rand int cycles_after_trigger;
   rand int cycles_till_reset;
   rand int reset_delay;
-  int loop_num;
 
   constraint cycles_after_trigger_c {cycles_after_trigger inside {[0 : 9]};}
   constraint cycles_tll_reset_c {cycles_till_reset inside {[0 : 200]};}
@@ -37,26 +36,20 @@ class chip_sw_deep_sleep_all_reset_vseq extends chip_sw_base_vseq;
 
   virtual task cpu_init();
     bit[7:0] rst_idx[NumRound];
-    loop_num = 0;
     for (int i=0; i< NumRound; i = i+1) begin
       if (i == (NumRound-1)) begin
         rst_idx[i] = i;
       end
       else begin
         rst_idx[i] = assa[i];
-        if (rst_idx[i] inside {[0:1]}) begin
-          loop_num = loop_num + 1;
-        end
       end
     end
-
-    `uvm_info(`gfn, $sformatf("HW rst loop # : %d", loop_num), UVM_MEDIUM)
-
     super.cpu_init();
     sw_symbol_backdoor_overwrite("RST_IDX", rst_idx);
   endtask
 
   virtual task body();
+    int loop_idx = 0;
     super.body();
     // mimic external pull up in key in0
     cfg.ast_supply_vif.force_key0_i(1'b1);
@@ -64,37 +57,56 @@ class chip_sw_deep_sleep_all_reset_vseq extends chip_sw_base_vseq;
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
     `uvm_info(`gfn, "SW test ready", UVM_MEDIUM)
 
-    repeat (loop_num) begin
+    repeat (NumRound) begin
+      `uvm_info(`gfn, $sformatf("loop: %0d / %0d", loop_idx++, NumRound), UVM_MEDIUM)
       `DV_WAIT(
-            cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" |
-            cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by hw por" |
-            cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" |
-            cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by sysrst" |
-            cfg.sw_logger_vif.printed_log == "Last Booting" |
-            cfg.sw_logger_vif.printed_log == "Test finish")
+         cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" ||
+         cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by hw por" ||
+         cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" ||
+         cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by sysrst" ||
+         // From the c test, RST_IDX uses randomized index, such that
+         // valid wait event from SV perspective may not happen for multiple rounds.
+         // This can causes false timeout.
+         // To avoid this false faliure, Add dummy log to each invalid wait event to c test
+         // as below to make sure this wait event ends each round of c test.
+         cfg.sw_logger_vif.printed_log == "Let SV wait timer reset" ||
+         cfg.sw_logger_vif.printed_log == "Last Booting" ||
+         cfg.sw_logger_vif.printed_log == "Test finish")
 
-       if (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" |
-                cfg.sw_logger_vif.printed_log ==
-                                    "Booting and setting normal sleep followed by sysrst") begin
-         `uvm_info(`gfn, "SW message delivered to TB", UVM_MEDIUM)
-         repeat (10) @cfg.pwrmgr_low_power_vif.cb;  //
+      `uvm_info(`gfn, $sformatf("SW message delivered to TB\n >> %0s",
+                                cfg.sw_logger_vif.printed_log), UVM_MEDIUM)
+       if (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by sysrst" ||
+           cfg.sw_logger_vif.printed_log ==
+           "Booting and setting normal sleep followed by sysrst") begin
+         repeat (10) @cfg.pwrmgr_low_power_vif.cb;
          repeat (cycles_till_reset) @cfg.pwrmgr_low_power_vif.cb;
          `uvm_info(`gfn, $sformatf("sysrst req set after fixed delay : %d + variable delay : %d",
                                     10, cycles_till_reset), UVM_MEDIUM)
          cfg.ast_supply_vif.pulse_key0_i_next_trigger(50 + cycles_after_trigger);
-       end
-       else if (cfg.sw_logger_vif.printed_log ==
-                "Booting and setting deep sleep followed by hw por" |
-                cfg.sw_logger_vif.printed_log ==
-                "Booting and setting normal sleep followed by hw por") begin
-         `uvm_info(`gfn, "SW message delivered to TB", UVM_MEDIUM)
+       end else if (cfg.sw_logger_vif.printed_log ==
+                    "Booting and setting deep sleep followed by hw por" ||
+                    cfg.sw_logger_vif.printed_log ==
+                    "Booting and setting normal sleep followed by hw por") begin
          repeat (10) @cfg.pwrmgr_low_power_vif.cb;
          repeat (cycles_till_reset) @cfg.pwrmgr_low_power_vif.cb;
          `uvm_info(`gfn, $sformatf("sysrst req set after fixed delay : %d + variable delay : %d",
                                     10, cycles_till_reset), UVM_MEDIUM)
          execute_reset();
+       end else if (cfg.sw_logger_vif.printed_log == "Let SV wait timer reset") begin
+         // Wait until c test finishes the current round and goes to reset.
+         `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
+       end else begin
+         // Add some time slap for dummy wait event
+         repeat (10) @cfg.pwrmgr_low_power_vif.fast_cb;
        end
-    end
+
+      // Wait for reboot except the last round
+      if (cfg.sw_logger_vif.printed_log != "Last Booting" &&
+          cfg.sw_logger_vif.printed_log != "Test finish") begin
+        `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
+      end
+      `uvm_info(`gfn, "loop end", UVM_MEDIUM)
+    end // repeat (loop_num)
   endtask
 
   task execute_reset();

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
@@ -33,6 +33,12 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+// In dvsim, one run
+// with --waves can take
+// 1.874h  | 38.068ms
+// without --waves,
+// 38.072m | 39.484ms
+
 OTTF_DEFINE_TEST_CONFIG();
 static volatile const uint8_t RST_IDX[7] = {0, 1, 2, 3, 4, 5, 6};
 static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
@@ -141,8 +147,9 @@ void ottf_external_isr(void) {
           "AON Timer Wdog should not bark");
 
   } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
-    irq = (irq_id -
-           (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAlertHandlerClassa);
+    irq = (dif_rv_plic_irq_id_t)(irq_id -
+                                 (dif_rv_plic_irq_id_t)
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassa);
 
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(&alert_handler, alert));
 
@@ -326,6 +333,7 @@ static void low_power_sysrst(const dif_pwrmgr_t *pwrmgr) {
   pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceOne,
                                     0);
   LOG_INFO("Low power set for sysrst");
+
   // Enter in low power mode.
   wait_for_interrupt();
 }
@@ -420,6 +428,7 @@ static void low_power_por(const dif_pwrmgr_t *pwrmgr) {
        kDifPwrmgrWakeupRequestSourceFive | kDifPwrmgrWakeupRequestSourceSix),
       0);
   LOG_INFO("ready for pad por");
+
   // Enter in low power mode.
   wait_for_interrupt();
   // If we arrive here the test must fail.
@@ -495,6 +504,7 @@ bool test_main(void) {
       LOG_INFO(
           "Booting and setting deep sleep mode followed for low_power entry "
           "reset");
+      LOG_INFO("Let SV wait timer reset");
       // Executing the wdog bite reset during sleep test.
       // actually the same test as deep sleep + watchdog
       rstmgr_testutils_pre_reset(&rstmgr);
@@ -506,14 +516,19 @@ bool test_main(void) {
           "Booting and setting deep sleep followed by watchdog reset "
           "combined "
           "with sw_req");
+      LOG_INFO("Let SV wait timer reset");
       // Executing the wdog bite reset during sleep test.
       rstmgr_testutils_pre_reset(&rstmgr);
+
+      // Assert reeset req
       CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+      LOG_INFO("Device reset from sw");
       sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
       low_power_wdog(&pwrmgr);
       break;
     case 4:
       LOG_INFO("Booting and setting deep sleep followed by watchdog reset");
+      LOG_INFO("Let SV wait timer reset");
       // Executing the wdog bite reset during sleep test.
       rstmgr_testutils_pre_reset(&rstmgr);
       sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
@@ -521,6 +536,7 @@ bool test_main(void) {
       break;
     case 5:
       LOG_INFO("Booting and running normal sleep followed by escalation reset");
+      LOG_INFO("Let SV wait timer reset");
       trigger_escalate(&aon_timer, &pwrmgr);
       timer_on(kEscalationPhase0MicrosCpu);
       break;

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -141,8 +141,9 @@ void ottf_external_isr(void) {
           "AON Timer Wdog should not bark");
 
   } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
-    irq = (irq_id -
-           (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAlertHandlerClassa);
+    irq = (dif_aon_timer_irq_t)(irq_id -
+                                (dif_rv_plic_irq_id_t)
+                                    kTopEarlgreyPlicIrqIdAlertHandlerClassa);
 
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(&alert_handler, alert));
 
@@ -321,15 +322,6 @@ static void config_sysrst(const dif_pwrmgr_t *pwrmgr,
       kTopEarlgreyPinmuxInselIor13));
 }
 
-static void low_power_sysrst(const dif_pwrmgr_t *pwrmgr) {
-  // Program the pwrmgr to go to deep sleep state (clocks off).
-  pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceOne,
-                                    0);
-  LOG_INFO("Low power set for sysrst");
-  // Enter in low power mode.
-  wait_for_interrupt();
-}
-
 static void normal_sleep_sysrst(const dif_pwrmgr_t *pwrmgr) {
   // Place device into low power and immediately wake.
   dif_pwrmgr_domain_config_t config;
@@ -340,6 +332,7 @@ static void normal_sleep_sysrst(const dif_pwrmgr_t *pwrmgr) {
   pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceOne,
                                     config);
   LOG_INFO("Normal sleep set for sysrst");
+
   // Enter in low power mode.
   wait_for_interrupt();
 }
@@ -364,7 +357,6 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
   LOG_INFO("Wdog will bark after %u us and bite after %u us",
            (uint32_t)bark_time_us, (uint32_t)bite_time_us);
   // Setup the wdog bark and bite timeouts.
-
   aon_timer_testutils_watchdog_config(aon_timer, bark_cycles, bite_cycles,
                                       false);
   // Set wdog as a reset source.
@@ -411,17 +403,6 @@ static void sleep_wdog_bite_test(const dif_aon_timer_t *aon_timer,
   config_wdog(aon_timer, pwrmgr, bark_time_us, bite_time_us);
 }
 
-static void low_power_wdog(const dif_pwrmgr_t *pwrmgr) {
-  // Program the pwrmgr to go to deep sleep state (clocks off).
-  // Enter in low power mode.
-  pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceTwo,
-                                    0);
-  LOG_INFO("Low power set for watch dog");
-  wait_for_interrupt();
-  // If we arrive here the test must fail.
-  CHECK(false, "Fail to enter in low power mode!");
-}
-
 static void normal_sleep_wdog(const dif_pwrmgr_t *pwrmgr) {
   // Place device into low power and immediately wake.
   dif_pwrmgr_domain_config_t config;
@@ -435,26 +416,6 @@ static void normal_sleep_wdog(const dif_pwrmgr_t *pwrmgr) {
                                     config);
   LOG_INFO("Normal sleep set for watchdog");
   wait_for_interrupt();
-}
-
-static void low_power_por(const dif_pwrmgr_t *pwrmgr) {
-  // Set por as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
-
-  // Program the pwrmgr to go to deep sleep state (clocks off).
-  pwrmgr_testutils_enable_low_power(
-      pwrmgr,
-      (kDifPwrmgrWakeupRequestSourceOne | kDifPwrmgrWakeupRequestSourceTwo |
-       kDifPwrmgrWakeupRequestSourceThree | kDifPwrmgrWakeupRequestSourceFour |
-       kDifPwrmgrWakeupRequestSourceFive | kDifPwrmgrWakeupRequestSourceSix),
-      0);
-  LOG_INFO("ready for pad por");
-  // Enter in low power mode.
-  wait_for_interrupt();
-  // If we arrive here the test must fail.
-  CHECK(false, "Fail to enter in low power mode!");
 }
 
 static void normal_sleep_por(const dif_pwrmgr_t *pwrmgr) {
@@ -477,7 +438,6 @@ static void normal_sleep_por(const dif_pwrmgr_t *pwrmgr) {
        kDifPwrmgrWakeupRequestSourceThree | kDifPwrmgrWakeupRequestSourceFour |
        kDifPwrmgrWakeupRequestSourceFive | kDifPwrmgrWakeupRequestSourceSix),
       config);
-
   LOG_INFO("ready for pad por");
   // Enter in low power mode.
   wait_for_interrupt();
@@ -554,6 +514,7 @@ bool test_main(void) {
       LOG_INFO(
           "Booting and setting normal sleep mode followed for low_power "
           "entry reset");
+      LOG_INFO("Let SV wait timer reset");
       // actually the same test as normal sleep + watchdog
       rstmgr_testutils_pre_reset(&rstmgr);
       sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
@@ -565,15 +526,20 @@ bool test_main(void) {
           "Booting and setting normal sleep followed by watchdog reset "
           "combined "
           "with sw_req");
+      LOG_INFO("Let SV wait timer reset");
       // Executing the wdog bite reset during sleep test.
       rstmgr_testutils_pre_reset(&rstmgr);
+
+      // Assert reeset req
       CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+      LOG_INFO("Device reset from sw");
       sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
       normal_sleep_wdog(&pwrmgr);
       timer_on(kEscalationPhase0MicrosCpu);
       break;
     case 4:
       LOG_INFO("Booting and setting normal sleep followed by watchdog reset");
+      LOG_INFO("Let SV wait timer reset");
       // Executing the wdog bite reset during sleep test.
       rstmgr_testutils_pre_reset(&rstmgr);
       sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
@@ -582,6 +548,7 @@ bool test_main(void) {
       break;
     case 5:
       LOG_INFO("Booting and running normal sleep followed by escalation reset");
+      LOG_INFO("Let SV wait timer reset");
       config_escalate(&aon_timer, &pwrmgr);
       timer_on(kEscalationPhase0MicrosCpu);
       break;

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
@@ -142,8 +142,9 @@ void ottf_external_isr(void) {
           "AON Timer Wdog should not bark");
 
   } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
-    irq = (irq_id -
-           (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAlertHandlerClassa);
+    irq = (dif_rv_plic_irq_id_t)(irq_id -
+                                 (dif_rv_plic_irq_id_t)
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassa);
 
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(&alert_handler, alert));
 
@@ -326,7 +327,6 @@ static void low_power_sysrst(const dif_pwrmgr_t *pwrmgr) {
   // Program the pwrmgr to go to deep sleep state (clocks off).
   pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceOne,
                                     0);
-  LOG_INFO("Low power set for sysrst");
   // Enter in low power mode.
   wait_for_interrupt();
 }
@@ -340,7 +340,6 @@ static void normal_sleep_sysrst(const dif_pwrmgr_t *pwrmgr) {
            kDifPwrmgrDomainOptionMainPowerInLowPower;
   pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceOne,
                                     config);
-  LOG_INFO("Normal sleep set for sysrst");
   // Enter in low power mode.
   wait_for_interrupt();
 }
@@ -451,7 +450,6 @@ static void low_power_por(const dif_pwrmgr_t *pwrmgr) {
        kDifPwrmgrWakeupRequestSourceThree | kDifPwrmgrWakeupRequestSourceFour |
        kDifPwrmgrWakeupRequestSourceFive | kDifPwrmgrWakeupRequestSourceSix),
       0);
-  LOG_INFO("ready for pad por");
   // Enter in low power mode.
   wait_for_interrupt();
   // If we arrive here the test must fail.
@@ -478,8 +476,6 @@ static void normal_sleep_por(const dif_pwrmgr_t *pwrmgr) {
        kDifPwrmgrWakeupRequestSourceThree | kDifPwrmgrWakeupRequestSourceFour |
        kDifPwrmgrWakeupRequestSourceFive | kDifPwrmgrWakeupRequestSourceSix),
       config);
-
-  LOG_INFO("ready for pad por");
   // Enter in low power mode.
   wait_for_interrupt();
 }
@@ -567,6 +563,7 @@ bool test_main(void) {
         LOG_INFO(
             "Booting and setting normal sleep mode followed for low_power "
             "entry reset");
+        LOG_INFO("Let SV wait timer reset");
         // actually the same test as normal sleep + watchdog
         rstmgr_testutils_pre_reset(&rstmgr);
         sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
@@ -576,6 +573,7 @@ bool test_main(void) {
         LOG_INFO(
             "Booting and setting deep sleep mode followed for low_power entry "
             "reset");
+        LOG_INFO("Let SV wait timer reset");
         // Executing the wdog bite reset during sleep test.
         // actually the same test as deep sleep + watchdog
         rstmgr_testutils_pre_reset(&rstmgr);
@@ -590,9 +588,11 @@ bool test_main(void) {
             "Booting and setting normal sleep followed by watchdog reset "
             "combined "
             "with sw_req");
+        LOG_INFO("Let SV wait timer reset");
         // Executing the wdog bite reset during sleep test.
         rstmgr_testutils_pre_reset(&rstmgr);
         CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+        LOG_INFO("Device reset from sw");
         sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
         normal_sleep_wdog(&pwrmgr);
         timer_on(kEscalationPhase0MicrosCpu);
@@ -601,9 +601,11 @@ bool test_main(void) {
             "Booting and setting deep sleep followed by watchdog reset "
             "combined "
             "with sw_req");
+        LOG_INFO("Let SV wait timer reset");
         // Executing the wdog bite reset during sleep test.
         rstmgr_testutils_pre_reset(&rstmgr);
         CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+        LOG_INFO("Device reset from sw");
         sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
         low_power_wdog(&pwrmgr);
       }
@@ -611,6 +613,7 @@ bool test_main(void) {
     case 4:
       if (RST_IDX[event_idx] % 2) {
         LOG_INFO("Booting and setting normal sleep followed by watchdog reset");
+        LOG_INFO("Let SV wait timer reset");
         // Executing the wdog bite reset during sleep test.
         rstmgr_testutils_pre_reset(&rstmgr);
         sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
@@ -618,6 +621,7 @@ bool test_main(void) {
         timer_on(kEscalationPhase0MicrosCpu);
       } else {
         LOG_INFO("Booting and setting deep sleep followed by watchdog reset");
+        LOG_INFO("Let SV wait timer reset");
         // Executing the wdog bite reset during sleep test.
         rstmgr_testutils_pre_reset(&rstmgr);
         sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);


### PR DESCRIPTION
This test is timed out for multiple reasons.
R1. SV sequence wait for either hw por or sysrst to generate
      external reset triggering event.
      But event gets randomized and these two event are not
      always show up at the c test. This can causes timeout event
      at the sv sequence.
R2. Another issue was from the c test, after the test prints
      a LOG_INFO sv sequence is waiting for, if the c test put another
      LOG_INFO, before sv sequence goes back to the beginning of the loop,
      sv sequence misses the LOG_INFO.

This PR address those two issues as below.
1. Create a dummy wait state in the sv sequence s.t. the number of iteration
   is same as the c test.
   This can remove spurious timeout event caused by r1.
2. Add wait 'SwTestStatusInBootRom' at the end of the sv seq loop to make
    a loop in the c test and the sv test be in sync at each iteration.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>