### PR TITLE
[test, ibex] Addresss Translation Sim Config fix.

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1091,7 +1091,7 @@
     {
       name: chip_sw_rv_core_ibex_address_translation
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/rv_core_ibex_address_translation_test:1"]
+      sw_images: ["sw/device/tests:rv_core_ibex_address_translation_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       // Timeout based on a ~7 minute dvsim runtime.
       run_opts: ["+sw_test_timeout_ns=7_000_000"]


### PR DESCRIPTION
This fixes an error in the configuration file for the address translation chip level test.

The test still fails VCS at the following assertion:

```
'((~pending_dside_accesses_d[(MaxOutstandingDSideAccesses - 1)].valid) |
 data_rvalid_i)'
                UVM_ERROR @ 3808.070184 us: (ibex_top.sv:1105) [ASSERT FAILED] MaxOutstandingDSideAccesses
Correct
```

This looks like it was fixed in https://github.com/lowRISC/ibex/pull/1764 , so the test should pass when the latest version of ibex is next vendored in.