### PR TITLE
[otbn,dv] Fix FIFO assertion for `otbn_sec_cm`

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -136,6 +136,26 @@ class otbn_common_vseq extends otbn_base_vseq;
       $assertoff(0, "tb.dut.u_otbn_core.u_otbn_controller.u_otbn_loop_controller.loop_info_stack\
                .next_stack_top_idx_correct");
       $assertoff(0, "tb.dut.u_otbn_core.u_otbn_rf_base.u_call_stack.next_stack_top_idx_correct");
+      if (if_proxy.path == {"tb.dut.u_tlul_adapter_sram_dmem.u_rspfifo.gen_normal_fifo.u_fifo_cnt.",
+                            "gen_secure_ptrs.u_wptr"} ||
+          if_proxy.path == {"tb.dut.u_tlul_adapter_sram_dmem.u_rspfifo.gen_normal_fifo.u_fifo_cnt.",
+                            "gen_secure_ptrs.u_rptr"}) begin
+        if (enable) begin
+          $asserton(0, "tb.dut.u_tlul_adapter_sram_dmem.u_rspfifo.DataKnown_A");
+        end else begin
+          $assertoff(0, "tb.dut.u_tlul_adapter_sram_dmem.u_rspfifo.DataKnown_A");
+        end
+      end
+      if (if_proxy.path == {"tb.dut.u_tlul_adapter_sram_imem.u_rspfifo.gen_normal_fifo.u_fifo_cnt.",
+                            "gen_secure_ptrs.u_wptr"} ||
+          if_proxy.path == {"tb.dut.u_tlul_adapter_sram_imem.u_rspfifo.gen_normal_fifo.u_fifo_cnt.",
+                            "gen_secure_ptrs.u_rptr"}) begin
+        if (enable) begin
+          $asserton(0, "tb.dut.u_tlul_adapter_sram_imem.u_rspfifo.DataKnown_A");
+        end else begin
+          $assertoff(0, "tb.dut.u_tlul_adapter_sram_imem.u_rspfifo.DataKnown_A");
+        end
+      end
     end
 
   endfunction: sec_cm_fi_ctrl_svas


### PR DESCRIPTION
The generic countermeasure test for `prim_count` manipulates the
redundant counter register to check if a fault injected into one of the
counter registers gets detected.  When this test exercises the counters
inside the response FIFO of the TLUL adapter at the instruction memory,
the `DataKnown_A` assertion in the response FIFO fails.  This is
correct, but it prevents the test from checking the countermeasure.
This commit disables that assertion for the described test case.

This should fix the following recent nightly regression failures:
```
Offending '(!$isunknown(rdata_o))' has 2 failures:
    Test otbn_sec_cm has 2 failures.

        2.otbn_sec_cm.721253074
        Line 515, in log /container/opentitan-public/scratch/os_regression/otbn-sim-vcs/2.otbn_sec_cm/out/run.log
              Offending '(!$isunknown(rdata_o))'
          UVM_ERROR @  27139447 ps: (prim_fifo_sync.sv:193) [ASSERT FAILED] DataKnown_A
          UVM_INFO @  27139447 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
          --- UVM Report catcher Summary ---   

        3.otbn_sec_cm.1517587881
        Line 433, in log /container/opentitan-public/scratch/os_regression/otbn-sim-vcs/3.otbn_sec_cm/out/run.log
              Offending '(!$isunknown(rdata_o))'
          UVM_ERROR @  10847019 ps: (prim_fifo_sync.sv:193) [ASSERT FAILED] DataKnown_A
          UVM_INFO @  10847019 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
          --- UVM Report catcher Summary ---
```

> estimate 2