### PR TITLE
[dv, hmac] Remove the `chip_sw_hmac_enc_irq` from config file

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -780,12 +780,6 @@
       run_opts: ["+sw_test_timeout_ns=15000000","+rng_srate_value=30"]
     }
     {
-      name: chip_sw_hmac_enc_irq
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests:hmac_enc_irq_test:1"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
-    {
       name: chip_sw_hmac_enc
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:hmac_enc_test:1"]


### PR DESCRIPTION
 Removing the tests entry since the `chip_sw_hmac_enc` test
 implement it already.

Fixes #13999
Fixes #14201