### PR TITLE
[dvsim] Handle same test added twice via `-i`

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -42,7 +42,8 @@ class FlowCfg():
 
     def __init__(self, flow_cfg_file, hjson_data, args, mk_config):
         # Options set from command line
-        self.items = args.items
+        # Uniquify input items, while preserving the order.
+        self.items = list(dict.fromkeys(args.items))
         self.list_items = args.list
         self.select_cfgs = args.select_cfgs
         self.flow_cfg_file = flow_cfg_file


### PR DESCRIPTION
Spotted a bug when I accidentally ran the same twice
via `-i foo bar baz foo`.

dvsim silently proceeds with simulating `foo` in this case,
but it merges `foo` into itself, causing all `run_opts`
to be duplicated twice, which is erroneous.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>