### PR TITLE
[AST] Fix RNG srate_rng_val and update comments

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/ast_pulse_sync.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_pulse_sync.sv
@@ -17,7 +17,6 @@
 
 module ast_pulse_sync (
   input scan_mode_i,
-  input scan_reset_ni,
   // source clock domain
   input clk_src_i,
   input rst_src_ni,
@@ -55,8 +54,8 @@ prim_flop_2sync #(
   .q_o ( rst_src_da_n )
 );
 
-assign rst_src_n = scan_mode_i ? scan_reset_ni : rst_src_ni && rst_dst_da_n;
-assign rst_dst_n = scan_mode_i ? scan_reset_ni : rst_dst_ni && rst_src_da_n;
+assign rst_src_n = scan_mode_i ? rst_src_ni : rst_src_ni && rst_dst_da_n;
+assign rst_dst_n = scan_mode_i ? rst_dst_ni : rst_dst_ni && rst_src_da_n;
 
 
 // Pulse Rising Edge Detect & Block
@@ -103,7 +102,7 @@ prim_flop_2sync #(
 );
 
 
-// DST_REQ Synchronizertp SRC for ACK
+// DST_REQ Synchronizer to SRC for ACK
 ///////////////////////////////////////
 logic src_ack;
 
@@ -142,5 +141,7 @@ assign dst_pulse_o = (dst_req ^ dst_req_d);
 
 // A new PULSE can only be introduced when source is not BUSY.
 `ASSERT(NewPulseWhenSrcBusy, $rose(src_pulse_i) |-> !src_busy_o, clk_src_i, !rst_src_n)
+
+`ASSERT(DstPulseCheck_A, dst_pulse_o |=> !dst_pulse_o, clk_dst_i, !rst_dst_n)
 
 endmodule : ast_pulse_sync

--- a/hw/top_earlgrey/ip/ast/rtl/rglts_pdm_3p3v.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/rglts_pdm_3p3v.sv
@@ -21,7 +21,7 @@ module rglts_pdm_3p3v (
   output logic rglssm_vmppr_h_o,           // Regulators SM at VMPPR (vcmaim_pok_por_reset) @3.3v
   output logic rglssm_vcmon_h_o,           // Regulators state machine at VCMON @3.3v
   output logic rglssm_brout_h_o,           // Regulators state machine at BROUT @3.3v
-  output logic vcmain_pok_h_o,             // VCMAIN Exist @3.3v
+  output logic vcmain_pok_h_o,             // VCMAIN POK @3.3v
   output logic vcmain_pok_por_h_o,         // VCMAIN_POK_POR @3.3v
   output logic vcaon_pok_h_o,              // VCAON Exist @3.3v
   output logic vcaon_pok_1p1_h_o,          // VCAON Exist @3.3v for BE 1.1v (UPF issue)

--- a/hw/top_earlgrey/ip/ast/rtl/rng.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/rng.sv
@@ -75,9 +75,13 @@ assign srate_value = dv_srate_value;
 assign srate_value = 12'd120;
 `endif
 
+logic src_busy;
+
 always_ff @( posedge clk_i, negedge rst_n ) begin
   if ( !rst_n ) begin
     srate_cnt     <= 12'h000;
+    srate_rng_val <= 1'b0;
+  end else if ( (srate_cnt == srate_value) && src_busy ) begin
     srate_rng_val <= 1'b0;
   end else if ( srate_cnt == srate_value ) begin
     srate_cnt     <= 12'h000;
@@ -92,11 +96,10 @@ end
 ////////////////////////////////////////
 // Sychronize Bus & Valid to RNG Clock
 ////////////////////////////////////////
-logic sync_rng_val, srate_rng_val_en, src_busy;
+logic sync_rng_val, srate_rng_val_en;
 
 ast_pulse_sync u_rng_val_pulse_sync (
   .scan_mode_i ( scan_mode_i ),
-  .scan_reset_ni ( rst_n ),
   // source clock domain
   .clk_src_i ( clk_i ),
   .rst_src_ni ( rst_n ),
@@ -137,8 +140,7 @@ end
 ///////////////////////
 logic unused_sigs;
 assign unused_sigs = ^{
-                        rng_fips_i,  // Used in ASIC implementation
-                        src_busy
+                        rng_fips_i  // Used in ASIC implementation
                       };
 
 endmodule : rng


### PR DESCRIPTION
The following changes were included in this AST PR:
* Add new ASSERT to ast_pulse_sync.sv.
* Suspend srate_rng_val pulse generation when previous pulse still active (src_busy).
* Update comment in several files.

Signed-off-by: Jacob Levy <jacob.levy@nuvoton.com>