### PR TITLE
[bazel] fix airgapped env prep script

### DIFF
--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -140,10 +140,10 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   ${BAZELISK} fetch \
     --repository_cache=${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR} \
     //... \
-    @bazel_embedded_upstream_toolchain//... \
     @local_config_cc_toolchains//... \
     @local_config_platform//... \
     @local_config_sh//... \
+    @lowrisc_rv32imcb_files//... \
     @python3_toolchains//... \
     @remotejdk11_linux//... \
     @riscv-compliance//... \


### PR DESCRIPTION
PR #14081 updated the Bazel workspace but missed updating the airgapped
image preparation script.

Signed-off-by: Timothy Trippel <ttrippel@google.com>