### PR TITLE
[entropy_src/dv] Disable RNG failures by default.

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -137,14 +137,15 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     // Thresholds for the continuous health checks:
     // REPCNT and REPCNTS
 
-    ral.repcnt_thresholds.bypass_thresh.set(newcfg.repcnt_thresh_bypass);
-    ral.repcnt_thresholds.fips_thresh.set(newcfg.repcnt_thresh_fips);
-    csr_update(.csr(ral.repcnt_thresholds));
+    if (!newcfg.default_ht_thresholds) begin
+      ral.repcnt_thresholds.bypass_thresh.set(newcfg.repcnt_thresh_bypass);
+      ral.repcnt_thresholds.fips_thresh.set(newcfg.repcnt_thresh_fips);
+      csr_update(.csr(ral.repcnt_thresholds));
 
-    ral.repcnts_thresholds.bypass_thresh.set(newcfg.repcnts_thresh_bypass);
-    ral.repcnts_thresholds.fips_thresh.set(newcfg.repcnts_thresh_fips);
-    csr_update(.csr(ral.repcnts_thresholds));
-
+      ral.repcnts_thresholds.bypass_thresh.set(newcfg.repcnts_thresh_bypass);
+      ral.repcnts_thresholds.fips_thresh.set(newcfg.repcnts_thresh_fips);
+      csr_update(.csr(ral.repcnts_thresholds));
+    end
     #50us;
 
     // Windowed health test thresholds managed in derived vseq classes

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -40,6 +40,8 @@ class entropy_src_base_test extends cip_base_test #(
     // in one of the derived test classes.
     cfg.mean_rand_reconfig_time   = -1.0;
     cfg.mean_rand_csr_alert_time  = -1.0;
+    cfg.soft_mtbf                 = -1.0;
+    cfg.hard_mtbf                 = -1.0;
 
   endfunction
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
@@ -20,6 +20,10 @@ class entropy_src_smoke_test extends entropy_src_base_test;
     cfg.dut_cfg.ht_threshold_scope_pct      = 100;
     cfg.dut_cfg.use_invalid_mubi            = 0;
 
+    // Disable tight HT thresholds, as the smoke vseq does
+    // not expect HT failures.
+    cfg.dut_cfg.default_ht_thresholds_pct   = 100;
+
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)


### PR DESCRIPTION
This commit ensures that RNG input sequence will not simulate hard or
soft AST RNG failures unless explicitly requested by the test.

Furthermore, the smoke test is configured to always use very relaxed
health test thresholds as the smoke VSEQ is not sophisticated enough to
recover from HT failures.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>