### PR TITLE
[entropy_src/dv] Support One-way Thresholds

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -322,5 +322,13 @@
             must be checked in the scoreboard.
             '''
     }
+    {
+      name: one_way_ht_threshold_cg
+      desc: '''
+            Checks that all of the health test registers have been exercised and that the one-way
+            update feature (which prohibits thresholds being relaxed after reset) works for both
+            the FIPS and Bypass thresholds.
+            '''
+    }
   ]
 }

--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -634,6 +634,35 @@ interface entropy_src_cov_if
 
   endgroup : observe_fifo_threshold_cg
 
+  covergroup one_way_ht_threshold_reg_cg with function sample(int offset,
+                                                              bit rejected,
+                                                              bit is_fips);
+
+    option.name         = "one_way_ht_threshold_cg";
+    option.per_instance = 1;
+
+    cp_offset : coverpoint offset {
+      bins one_way_regs[] = {
+        entropy_src_reg_pkg::ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET,
+        entropy_src_reg_pkg::ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET,
+        entropy_src_reg_pkg::ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET,
+        entropy_src_reg_pkg::ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET,
+        entropy_src_reg_pkg::ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET,
+        entropy_src_reg_pkg::ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET,
+        entropy_src_reg_pkg::ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET,
+        entropy_src_reg_pkg::ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET,
+        entropy_src_reg_pkg::ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET
+      };
+    }
+
+    cp_rejected : coverpoint rejected;
+
+    cp_is_fips : coverpoint is_fips;
+
+    cr_cross : cross cp_rejected, cp_offset, cp_is_fips;
+
+  endgroup : one_way_ht_threshold_reg_cg
+
   `DV_FCOV_INSTANTIATE_CG(err_test_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(mubi_err_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(sm_err_cg, en_full_cov)
@@ -648,6 +677,7 @@ interface entropy_src_cov_if
   `DV_FCOV_INSTANTIATE_CG(win_ht_deep_threshold_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(alert_cnt_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(observe_fifo_threshold_cg, en_full_cov)
+  `DV_FCOV_INSTANTIATE_CG(one_way_ht_threshold_reg_cg, en_full_cov)
 
   // Sample functions needed for xcelium
   function automatic void cg_err_test_sample(bit [4:0] err_code);
@@ -773,6 +803,10 @@ interface entropy_src_cov_if
 
   function automatic void cg_observe_fifo_threshold_sample(int threshold);
     observe_fifo_threshold_cg_inst.sample(threshold);
+  endfunction
+
+  function automatic void cg_one_way_ht_threshold_reg_sample(int offset, bit rejected, bit fips);
+    one_way_ht_threshold_reg_cg_inst.sample(offset, rejected, fips);
   endfunction
 
   // Sample the csrng_hw_cg whenever data is output on the csrng pins


### PR DESCRIPTION
This commit provides support for the one-way threshold registers, which
prohibit updates to the HT registers which relax previously-programmed
thresholds.

In addition to scoreboarding, this commit adds a coverpoint to ensure
that this feature is exercised for all registers and modes.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>