### PR TITLE
[dv, Csrng] Add chip_sw_csrng_fuse_en_sw_app_read test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1978,14 +1978,12 @@
       name: chip_sw_entropy_src_fuse_en_fw_read
       desc: '''Verify the fuse input entropy_src.
 
-            - Initialize the OTP with the `HW_CFG.EN_ENTROPY_SRC_FW_READ` fuse bit set to enabled in the
-              `uvm_test_seq`.
-            - Read and verify the OTP `HW_CFG.EN_ENTROPY_SRC_FW_READ` against the previous step expectation.
-            - Read the entropy_data_fifo via SW; verify that it reads valid values.
-            - Reset the chip, but this time, initialize the OTP with with the `HW_CFG.EN_ENTROPY_SRC_FW_READ`
-              fuse bit set to disable.
-            - Read and verify the OTP `HW_CFG.EN_ENTROPY_SRC_FW_READ` against the previous step expectation.
-            - Read the internal state via SW; verify that the entropy valid bit is zero.
+            - Initialize the OTP with the fuse that controls whether the SW can read the entropy src enabled.
+            - Read the OTP and verify that the fuse is enabled.
+            - Read the entropy_data_fifo via SW and verify that it reads valid values.
+            - Reset the chip, but this time, initialize the OTP with with the fuse disabled.
+            - Read the OTP and verify that fuse is disabled.
+            - Read the internal state via SW and verify that the entropy valid bit is zero.
             '''
       stage: V2
       tests: ["chip_sw_entropy_src_fuse_en_fw_read_test"]
@@ -2020,11 +2018,11 @@
       name: chip_sw_csrng_fuse_en_sw_app_read
       desc: '''Verify the fuse input to CSRNG.
 
-            - Initialize the OTP with this fuse bit set to 1.
+            - Initialize the OTP with the fuse that control whether the SW can read the CSRNG state enabled.
             - Issue an instantiate command to request entropy.
-            - Verify that SW can read the internal states.
-            - Reset the chip and repeat the steps above, but this time, with OTP fuse bit set to 0.
-            - Verify that the SW reads back all zeros when reading the internal states.
+            - Verify that SW can read the internal state values.
+            - Reset the chip and repeat the steps above, but this time, initialized the OTP with fuse disabled.
+            - Verify that the SW reads back all zeros when reading the internal state values.
             '''
       stage: V2
       tests: []

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2025,7 +2025,7 @@
             - Verify that the SW reads back all zeros when reading the internal state values.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_csrng_fuse_en_sw_app_read_test"]
     }
     {
       name: chip_sw_csrng_lc_hw_debug_en

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -801,6 +801,13 @@
       run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
     {
+      name: chip_sw_csrng_fuse_en_sw_app_read_test
+      uvm_test_seq: chip_sw_entropy_src_fuse_vseq
+      sw_images: ["//sw/device/tests/sim_dv:csrng_fuse_en_sw_app_read:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=15_000_000"]
+    }
+    {
       name: chip_sw_entropy_src_ast_rng_req
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_ast_rng_req_test:1"]
@@ -812,7 +819,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_edn_reqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15000000","+rng_srate_value=30"]
+      run_opts: ["+sw_test_timeout_ns=15_000_000","+rng_srate_value=30"]
     }
     {
       name: chip_sw_hmac_enc

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_entropy_src_fuse_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_entropy_src_fuse_vseq.sv
@@ -28,11 +28,11 @@ class chip_sw_entropy_src_fuse_vseq extends chip_sw_base_vseq;
     super.body();
 
     forever begin
-      `DV_WAIT(cfg.sw_logger_vif.printed_log == "Software reseting!",
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == "Software resetting!",
         // 20ms
         20_000_000)
 
-      if (cfg.sw_logger_vif.printed_log == "Software reseting!") begin
+      if (cfg.sw_logger_vif.printed_log == "Software resetting!") begin
         cfg.mem_bkdr_util_h[Otp].otp_write_hw_cfg_partition(
           .device_id(DEVICE_ID), .manuf_state(MANUF_STATE),
           .en_sram_ifetch(MUBI8FALSE), .en_csrng_sw_app_read(MUBI8TRUE),

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_entropy_src_fuse_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_entropy_src_fuse_vseq.sv
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// This class is used for the testes `chip_sw_entropy_src_fuse_en_fw_read_test` and
+// `chip_sw_csrng_fuse_en_sw_app_read_test`. Please refer to the testplan for more
+ // details regarding the OTP initialization values.
 class chip_sw_entropy_src_fuse_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_entropy_src_fuse_vseq)
 
@@ -35,7 +38,7 @@ class chip_sw_entropy_src_fuse_vseq extends chip_sw_base_vseq;
       if (cfg.sw_logger_vif.printed_log == "Software resetting!") begin
         cfg.mem_bkdr_util_h[Otp].otp_write_hw_cfg_partition(
           .device_id(DEVICE_ID), .manuf_state(MANUF_STATE),
-          .en_sram_ifetch(MUBI8FALSE), .en_csrng_sw_app_read(MUBI8TRUE),
+          .en_sram_ifetch(MUBI8FALSE), .en_csrng_sw_app_read(MUBI8FALSE),
           .en_entropy_src_fw_read(MUBI8FALSE),
           .en_entropy_src_fw_over(MUBI8TRUE));
           break;

--- a/sw/device/lib/testing/csrng_testutils.c
+++ b/sw/device/lib/testing/csrng_testutils.c
@@ -27,3 +27,118 @@ void csrng_testutils_cmd_generate_run(const dif_csrng_t *csrng,
 
   CHECK_DIF_OK(dif_csrng_generate_read(csrng, output, output_len));
 }
+
+void csrng_testutils_check_internal_state(
+    const dif_csrng_t *csrng, const dif_csrng_internal_state_t *expected) {
+  csrng_testutils_cmd_ready_wait(csrng);
+  dif_csrng_internal_state_t got;
+  CHECK_DIF_OK(
+      dif_csrng_get_internal_state(csrng, kCsrngInternalStateIdSw, &got));
+
+  CHECK(got.instantiated == expected->instantiated);
+  CHECK(got.reseed_counter == expected->reseed_counter);
+  CHECK(got.fips_compliance == expected->fips_compliance);
+
+  CHECK_ARRAYS_EQ(got.v, expected->v, ARRAYSIZE(expected->v),
+                  "CSRNG internal V buffer mismatch.");
+
+  CHECK_ARRAYS_EQ(got.key, expected->key, ARRAYSIZE(expected->key),
+                  "CSRNG internal K buffer mismatch.");
+}
+
+/**
+ * CTR DRBG Known-Answer-Tests (KATs).
+ *
+ * Test vector sourced from NIST's CAVP website:
+ * https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/random-number-generators
+ *
+ * The number format in this docstring follows the CAVP format to simplify
+ * auditing of this test case.
+ *
+ * Test vector: CTR_DRBG AES-256 no DF.
+ *
+ * - EntropyInput =
+ * df5d73faa468649edda33b5cca79b0b05600419ccb7a879ddfec9db32ee494e5531b51de16a30f769262474c73bec010
+ * - Nonce = EMPTY
+ * - PersonalizationString = EMPTY
+ *
+ * Command: Instantiate
+ * - Key = 8c52f901632d522774c08fad0eb2c33b98a701a1861aecf3d8a25860941709fd
+ * - V   = 217b52142105250243c0b2c206b8f59e
+ *
+ * Command: Generate (first call):
+ * - Key = 72f4af5c93258eb3eeec8c0cacea6c1d1978a4fad44312725f1ac43b167f2d52
+ * - V   = e86f6d07dfb551cebad80e6bf6830ac4
+ *
+ * Command: Generate (second call):
+ * - Key = 1a1c6e5f1cccc6974436e5fd3f015bc8e9dc0f90053b73e3c19d4dfd66d1b85a
+ * - V   = 53c78ac61a0bac9d7d2e92b1e73e3392
+ * - ReturnedBits =
+ * d1c07cd95af8a7f11012c84ce48bb8cb87189e99d40fccb1771c619bdf82ab2280b1dc2f2581f39164f7ac0c510494b3a43c41b7db17514c87b107ae793e01c5
+ */
+void csrng_testutils_fips_instantiate_kat(const dif_csrng_t *csrng,
+                                          bool fail_expected) {
+  LOG_INFO("%s", __func__);
+
+  CHECK_DIF_OK(dif_csrng_uninstantiate(csrng));
+  const dif_csrng_seed_material_t kEntropyInput = {
+      .seed_material = {0x73bec010, 0x9262474c, 0x16a30f76, 0x531b51de,
+                        0x2ee494e5, 0xdfec9db3, 0xcb7a879d, 0x5600419c,
+                        0xca79b0b0, 0xdda33b5c, 0xa468649e, 0xdf5d73fa},
+      .seed_material_len = 12,
+  };
+  csrng_testutils_cmd_ready_wait(csrng);
+
+  CHECK_DIF_OK(dif_csrng_instantiate(csrng, kDifCsrngEntropySrcToggleDisable,
+                                     &kEntropyInput));
+
+  const dif_csrng_internal_state_t kExpectedState = {
+      .reseed_counter = 1,
+      .v = {0x06b8f59e, 0x43c0b2c2, 0x21052502, 0x217b5214},
+      .key = {0x941709fd, 0xd8a25860, 0x861aecf3, 0x98a701a1, 0x0eb2c33b,
+              0x74c08fad, 0x632d5227, 0x8c52f901},
+      .instantiated = true,
+      .fips_compliance = false,
+  };
+  const dif_csrng_internal_state_t kZeroState = {};
+
+  csrng_testutils_check_internal_state(
+      csrng, fail_expected ? &kZeroState : &kExpectedState);
+}
+
+/**
+ * CTR DRBG Known-Answer-Test (KAT) for GENERATE command.
+ */
+void csrng_testutils_fips_generate_kat(const dif_csrng_t *csrng) {
+  LOG_INFO("Generate KAT");
+
+  enum {
+    kExpectedOutputLen = 16,
+  };
+  uint32_t got[kExpectedOutputLen];
+
+  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
+  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
+  const dif_csrng_internal_state_t kExpectedState = {
+      .reseed_counter = 3,
+      .v = {0xe73e3392, 0x7d2e92b1, 0x1a0bac9d, 0x53c78ac6},
+
+      .key = {0x66d1b85a, 0xc19d4dfd, 0x053b73e3, 0xe9dc0f90, 0x3f015bc8,
+              0x4436e5fd, 0x1cccc697, 0x1a1c6e5f},
+      .instantiated = true,
+      .fips_compliance = false,
+  };
+  csrng_testutils_check_internal_state(csrng, &kExpectedState);
+
+  // TODO(#13342): csrng does not provide a linear output order. For example,
+  // note the test vector output word order: 12,13,14,15 8,9,10,11 4,5,6,7
+  // 0,1,2,3.
+  const uint32_t kExpectedOutput[kExpectedOutputLen] = {
+      0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9, 0xdf82ab22, 0x771c619b,
+      0xd40fccb1, 0x87189e99, 0x510494b3, 0x64f7ac0c, 0x2581f391, 0x80b1dc2f,
+      0x793e01c5, 0x87b107ae, 0xdb17514c, 0xa43c41b7,
+  };
+
+  CHECK_ARRAYS_EQ(got, kExpectedOutput, kExpectedOutputLen,
+                  "Generate command KAT output mismatch");
+}

--- a/sw/device/lib/testing/csrng_testutils.h
+++ b/sw/device/lib/testing/csrng_testutils.h
@@ -23,4 +23,29 @@ void csrng_testutils_cmd_ready_wait(const dif_csrng_t *csrng);
 void csrng_testutils_cmd_generate_run(const dif_csrng_t *csrng,
                                       uint32_t *output, size_t output_len);
 
+/**
+ * Checks the CSRNG internal state against `expected` values.
+ *
+ * @param csrng A CSRNG handle.
+ * @param expected Expected CSRNG internal state.
+ */
+void csrng_testutils_check_internal_state(
+    const dif_csrng_t *csrng, const dif_csrng_internal_state_t *expected);
+
+/**
+ * CTR DRBG Known-Answer-Test (KAT) for INSTANTIATE command.
+ *
+ * @param csrng Handle.
+ * @param fail_expected Expected fail.
+ */
+void csrng_testutils_fips_instantiate_kat(const dif_csrng_t *csrng,
+                                          bool fail_expected);
+
+/**
+ * CTR DRBG Known-Answer-Test (KAT) for GENERATE command.
+ *
+ * @param csrng Handle.
+ */
+void csrng_testutils_fips_generate_kat(const dif_csrng_t *csrng);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_CSRNG_TESTUTILS_H_

--- a/sw/device/tests/csrng_kat_test.c
+++ b/sw/device/tests/csrng_kat_test.c
@@ -14,95 +14,6 @@
 
 OTTF_DEFINE_TEST_CONFIG();
 
-enum {
-  kExpectedOutputLen = 16,
-};
-
-/**
- * Checks the CSRNG internal state against `expected` values.
- *
- * @param csrng A CSRNG handle.
- * @param expected Expected CSRNG internal state.
- */
-static void check_internal_state(const dif_csrng_t *csrng,
-                                 const dif_csrng_internal_state_t *expected) {
-  csrng_testutils_cmd_ready_wait(csrng);
-  dif_csrng_internal_state_t got;
-  CHECK_DIF_OK(
-      dif_csrng_get_internal_state(csrng, kCsrngInternalStateIdSw, &got));
-
-  CHECK(got.instantiated == expected->instantiated);
-  CHECK(got.reseed_counter == expected->reseed_counter);
-  CHECK(got.fips_compliance == expected->fips_compliance);
-
-  CHECK_ARRAYS_EQ(got.v, expected->v, ARRAYSIZE(expected->v),
-                  "CSRNG internal V buffer mismatch.");
-
-  CHECK_ARRAYS_EQ(got.key, expected->key, ARRAYSIZE(expected->key),
-                  "CSRNG internal K buffer mismatch.");
-}
-
-/**
- * CTR DRBG Known-Answer-Test (KAT) for INSTANTIATE command.
- */
-static void fips_instantiate_kat(const dif_csrng_t *csrng) {
-  LOG_INFO("Instantiate KAT");
-
-  const dif_csrng_seed_material_t kEntropyInput = {
-      .seed_material = {0x73bec010, 0x9262474c, 0x16a30f76, 0x531b51de,
-                        0x2ee494e5, 0xdfec9db3, 0xcb7a879d, 0x5600419c,
-                        0xca79b0b0, 0xdda33b5c, 0xa468649e, 0xdf5d73fa},
-      .seed_material_len = 12,
-  };
-  csrng_testutils_cmd_ready_wait(csrng);
-
-  CHECK_DIF_OK(dif_csrng_instantiate(csrng, kDifCsrngEntropySrcToggleDisable,
-                                     &kEntropyInput));
-  const dif_csrng_internal_state_t kExpectedState = {
-      .reseed_counter = 1,
-      .v = {0x06b8f59e, 0x43c0b2c2, 0x21052502, 0x217b5214},
-      .key = {0x941709fd, 0xd8a25860, 0x861aecf3, 0x98a701a1, 0x0eb2c33b,
-              0x74c08fad, 0x632d5227, 0x8c52f901},
-      .instantiated = true,
-      .fips_compliance = false,
-  };
-  check_internal_state(csrng, &kExpectedState);
-}
-
-/**
- * CTR DRBG Known-Answer-Test (KAT) for GENERATE command.
- */
-static void fips_generate_kat(const dif_csrng_t *csrng) {
-  LOG_INFO("Generate KAT");
-
-  uint32_t got[kExpectedOutputLen];
-
-  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
-  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
-  const dif_csrng_internal_state_t kExpectedState = {
-      .reseed_counter = 3,
-      .v = {0xe73e3392, 0x7d2e92b1, 0x1a0bac9d, 0x53c78ac6},
-
-      .key = {0x66d1b85a, 0xc19d4dfd, 0x053b73e3, 0xe9dc0f90, 0x3f015bc8,
-              0x4436e5fd, 0x1cccc697, 0x1a1c6e5f},
-      .instantiated = true,
-      .fips_compliance = false,
-  };
-  check_internal_state(csrng, &kExpectedState);
-
-  // TODO(#13342): csrng does not provide a linear output order. For example,
-  // note the test vector output word order: 12,13,14,15 8,9,10,11 4,5,6,7
-  // 0,1,2,3.
-  const uint32_t kExpectedOutput[kExpectedOutputLen] = {
-      0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9, 0xdf82ab22, 0x771c619b,
-      0xd40fccb1, 0x87189e99, 0x510494b3, 0x64f7ac0c, 0x2581f391, 0x80b1dc2f,
-      0x793e01c5, 0x87b107ae, 0xdb17514c, 0xa43c41b7,
-  };
-
-  CHECK_ARRAYS_EQ(got, kExpectedOutput, kExpectedOutputLen,
-                  "Generate command KAT output mismatch");
-}
-
 /**
  * Run CTR DRBG Known-Answer-Tests (KATs).
  *
@@ -135,8 +46,8 @@ static void fips_generate_kat(const dif_csrng_t *csrng) {
  */
 void test_ctr_drbg_ctr0(const dif_csrng_t *csrng) {
   CHECK_DIF_OK(dif_csrng_uninstantiate(csrng));
-  fips_instantiate_kat(csrng);
-  fips_generate_kat(csrng);
+  csrng_testutils_fips_instantiate_kat(csrng, /*fail_expected=*/false);
+  csrng_testutils_fips_generate_kat(csrng);
 }
 
 bool test_main(void) {

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -833,3 +833,22 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "csrng_fuse_en_sw_app_read",
+    srcs = ["csrng_fuse_en_sw_app_read.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:base",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:csrng_testutils",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/sim_dv/csrng_fuse_en_sw_app_read.c
+++ b/sw/device/tests/sim_dv/csrng_fuse_en_sw_app_read.c
@@ -1,0 +1,166 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/csrng_testutils.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include "otp_ctrl_regs.h"                            // Generated
+
+OTTF_DEFINE_TEST_CONFIG();
+
+/**
+ * OTP HW partition relative IFETCH offset in bytes.
+ *
+ * x = OTP_CTRL_PARAM_EN_SRAM_IFETCH_OFFSET (1728)
+ * y = OTP_CTRL_PARAM_HW_CFG_OFFSET (1664)
+ * IFETCH_OFFSET = (x - y) = 64
+ */
+static const uint32_t kOtpIfetchHwRelativeOffset =
+    OTP_CTRL_PARAM_EN_SRAM_IFETCH_OFFSET - OTP_CTRL_PARAM_HW_CFG_OFFSET;
+
+/**
+ * OTP can only be accessed by 32b aligned addresses. As `csrng_sw_app_read` is
+ * not aligned, we read from the previous aligned address and use the following
+ * offset in bits to access the `csrng_sw_app_read` byte.
+ */
+static const uint32_t kOtpCsrngFwReadBitOffset =
+    (OTP_CTRL_PARAM_EN_CSRNG_SW_APP_READ_OFFSET -
+     OTP_CTRL_PARAM_EN_SRAM_IFETCH_OFFSET) *
+    8;
+
+enum {
+  kExpectedOutputLen = 16,
+};
+
+/**
+ * CTR DRBG Known-Answer-Test (KAT) for GENERATE command.
+ */
+static void test_fuse_enable(const dif_csrng_t *csrng) {
+  csrng_testutils_fips_instantiate_kat(csrng, /*fail_expected=*/false);
+  LOG_INFO("%s", __func__);
+
+  uint32_t got[kExpectedOutputLen];
+
+  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
+  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
+  const dif_csrng_internal_state_t kExpectedState = {
+      .reseed_counter = 3,
+      .v = {0xe73e3392, 0x7d2e92b1, 0x1a0bac9d, 0x53c78ac6},
+
+      .key = {0x66d1b85a, 0xc19d4dfd, 0x053b73e3, 0xe9dc0f90, 0x3f015bc8,
+              0x4436e5fd, 0x1cccc697, 0x1a1c6e5f},
+      .instantiated = true,
+      .fips_compliance = false,
+  };
+  csrng_testutils_check_internal_state(csrng, &kExpectedState);
+
+  // TODO(#13342): csrng does not provide a linear output order. For example,
+  // note the test vector output word order: 12,13,14,15 8,9,10,11 4,5,6,7
+  // 0,1,2,3.
+  const uint32_t kExpectedOutput[kExpectedOutputLen] = {
+      0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9, 0xdf82ab22, 0x771c619b,
+      0xd40fccb1, 0x87189e99, 0x510494b3, 0x64f7ac0c, 0x2581f391, 0x80b1dc2f,
+      0x793e01c5, 0x87b107ae, 0xdb17514c, 0xa43c41b7,
+  };
+
+  CHECK_ARRAYS_EQ(got, kExpectedOutput, kExpectedOutputLen,
+                  "Generate command KAT output mismatch");
+}
+
+/**
+ * Check that the internal states will read zero.
+ */
+static void test_fuse_disable(const dif_csrng_t *csrng) {
+  LOG_INFO("%s", __func__);
+  csrng_testutils_fips_instantiate_kat(csrng, /*fail_expected=*/true);
+}
+
+/**
+ * Read the otp at `HW_CFG.OTP_CTRL_PARAM_EN_CSRNG_SW_APP_READ_OFFSET` address
+ * and check whether is configured by the `uvm_test_seq` as expected.
+ *
+ * @param expected Define the expected value for the
+ * HW_CFG.EN_ENTROPY_SRC_FW_READ flag.
+ */
+static void check_csrng_fuse_enabled(bool expected) {
+  dif_otp_ctrl_t otp;
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));
+
+  dif_otp_ctrl_config_t config = {
+      .check_timeout = 100000,
+      .integrity_period_mask = 0x3ffff,
+      .consistency_period_mask = 0x3ffffff,
+  };
+  CHECK_DIF_OK(dif_otp_ctrl_configure(&otp, config));
+  otp_ctrl_testutils_wait_for_dai(&otp);
+
+  uint32_t value;
+  // Read the current value of the partition.
+  CHECK_DIF_OK(dif_otp_ctrl_dai_read_start(&otp, kDifOtpCtrlPartitionHwCfg,
+                                           kOtpIfetchHwRelativeOffset));
+  otp_ctrl_testutils_wait_for_dai(&otp);
+  CHECK_DIF_OK(dif_otp_ctrl_dai_read32_end(&otp, &value));
+  multi_bit_bool_t enable = bitfield_field32_read(
+      value,
+      (bitfield_field32_t){.mask = 0xff, .index = kOtpCsrngFwReadBitOffset});
+  CHECK((enable == kMultiBitBool8True) == expected,
+        "`fw_enable` not expected (%x)", enable);
+}
+
+/**
+ * This test takes the following steps:
+ *
+ * - Initialize the OTP with `HW_CFG.OTP_CTRL_PARAM_EN_CSRNG_SW_APP_READ_OFFSET`
+ * fuse bit set to enabled in the `uvm_test_seq`.
+ * - Issue an instantiate command to request entropy.
+ * - Verify that SW can read the internal states.
+ * - Reset the chip and repeat the steps above, but this time, with
+ *   `HW_CFG.OTP_CTRL_PARAM_EN_CSRNG_SW_APP_READ_OFFSET` fuse bit set to 0.
+ * - Verify that the SW reads back all zeros when reading the internal states.
+ */
+bool test_main(void) {
+  dif_csrng_t csrng;
+  CHECK_DIF_OK(dif_csrng_init(
+      mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
+  CHECK_DIF_OK(dif_csrng_configure(&csrng));
+
+  dif_rstmgr_t rstmgr;
+  dif_rstmgr_reset_info_bitfield_t info;
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  info = rstmgr_testutils_reason_get();
+
+  if (info == kDifRstmgrResetInfoPor) {
+    LOG_INFO("Powered up for the first time");
+    check_csrng_fuse_enabled(true);
+    test_fuse_enable(&csrng);
+
+    // Reboot device.
+    rstmgr_testutils_reason_clear();
+    CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+    // This log message is extremely important for the test, as the
+    // `uvm_test_seq` uses it to change the otp values.
+    LOG_INFO("Software resetting!");
+    // Wait here until device reset.
+    wait_for_interrupt();
+  } else if (info == kDifRstmgrResetInfoSw) {
+    LOG_INFO("Powered up for the second time");
+
+    check_csrng_fuse_enabled(false);
+    test_fuse_disable(&csrng);
+    return true;
+  }
+  return false;
+}

--- a/sw/device/tests/sim_dv/entropy_src_fuse_en_fw_read_test.c
+++ b/sw/device/tests/sim_dv/entropy_src_fuse_en_fw_read_test.c
@@ -190,7 +190,7 @@ bool test_main(void) {
 
     // This log message is extremely important for the test, as the
     // `uvm_test_seq` uses it to change the otp values.
-    LOG_INFO("Software reseting!");
+    LOG_INFO("Software resetting!");
 
     // Wait here until device reset.
     wait_for_interrupt();


### PR DESCRIPTION
Add `chip_sw_csrng_fuse_en_sw_app_read` chip level test:
 - Initialize the OTP with `HW_CFG.OTP_CTRL_PARAM_EN_CSRNG_SW_APP_READ_OFFSET` fuse bit set to enabled in the `uvm_test_seq`.
- Issue an instantiate command to request entropy.
- Verify that SW can read the internal states.
- Reset the chip and repeat the steps above, but this time, with `HW_CFG.OTP_CTRL_PARAM_EN_CSRNG_SW_APP_READ_OFFSET` fuse bit set to 0.
- Verify that the SW reads back all zeros when reading the internal states.

Fixes: #13221