### PR TITLE
[entropy_src/dv] Scoreboarding (and stimuli) for bad Mubis

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
@@ -30,8 +30,6 @@ class entropy_src_err_vseq extends entropy_src_base_vseq;
     which_fifo_e     which_fifo;
     which_fifo_err_e which_fifo_err;
 
-    super.body();
-
     // Turn off fatal alert check
     expect_fatal_alerts = 1'b1;
 

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_fw_ov_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_fw_ov_vseq.sv
@@ -12,7 +12,6 @@ class entropy_src_fw_ov_vseq extends entropy_src_base_vseq;
   int word_cnt;
 
   task body();
-    super.body();
 
     // TODO: (Cleanup) do we want to change the cfg field "seed_cnt" to be more general?
     word_cnt = cfg.seed_cnt;

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
@@ -12,7 +12,6 @@ class entropy_src_smoke_vseq extends entropy_src_base_vseq;
   push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH) m_rng_push_seq;
 
   task body();
-    super.body();
 
     seed_cnt = cfg.seed_cnt;
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_alert_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_alert_test.sv
@@ -11,7 +11,7 @@ class entropy_src_alert_test extends entropy_src_base_test;
     super.configure_env();
 
     cfg.en_scb                              = 0;
-    cfg.dut_cfg.use_invalid_mubi            = 1;
+    cfg.dut_cfg.bad_mubi_cfg_pct            = 100;
     cfg.dut_cfg.route_software_pct          = 0;
     cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
     cfg.dut_cfg.fw_read_pct                 = 100;

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -27,7 +27,8 @@ class entropy_src_base_test extends cip_base_test #(
   // Overrides should happen in the specific testcase.
 
   virtual function void configure_env();
-    // TODO: randomize seed_cnt
+    // seed_cnt only used by smoke test
+    // so there is no need to randomize it.
     cfg.seed_cnt                  = 1;
     cfg.otp_en_es_fw_read_pct     = 100;
     cfg.otp_en_es_fw_over_pct     = 100;
@@ -43,6 +44,7 @@ class entropy_src_base_test extends cip_base_test #(
     cfg.soft_mtbf                 = -1.0;
     cfg.hard_mtbf                 = -1.0;
 
+    cfg.dut_cfg.bad_mubi_cfg_pct  = 0;
   endfunction
 
 endclass : entropy_src_base_test

--- a/hw/ip/entropy_src/dv/tests/entropy_src_intr_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_intr_test.sv
@@ -11,7 +11,6 @@ class entropy_src_intr_test extends entropy_src_base_test;
     super.configure_env();
 
     cfg.en_scb                              = 0;
-    cfg.dut_cfg.use_invalid_mubi            = 0;
     cfg.dut_cfg.route_software_pct          = 100;
     cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
     cfg.dut_cfg.route_software_pct          = 100;

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -53,6 +53,7 @@ class entropy_src_rng_test extends entropy_src_base_test;
 
     cfg.dut_cfg.fips_enable_pct             = 50;
     cfg.dut_cfg.module_enable_pct           = 100;
+    cfg.dut_cfg.bad_mubi_cfg_pct            = 50;
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)

--- a/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
@@ -18,7 +18,6 @@ class entropy_src_smoke_test extends entropy_src_base_test;
     cfg.dut_cfg.route_software_pct          = 100;
     cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
     cfg.dut_cfg.ht_threshold_scope_pct      = 100;
-    cfg.dut_cfg.use_invalid_mubi            = 0;
 
     // Disable tight HT thresholds, as the smoke vseq does
     // not expect HT failures.


### PR DESCRIPTION
With this commit the scoreboard can now comprehend bad MuBi entries,
as well as bad alert count thresholds.  Meanwhile the DUT_CFG
structure contraints are expanded to randomly inject bad Mubi
configurations, while the RNG and Base vseqs can recover
from them.

The goal of this commit is to not just confirm that the DUT can flag
bad register settings in the recov_alert_sts register, but also
that the alert is triggered when expected.  Furthermore the relevant
coverpoints for these alerts are only sampled when the alerts
are expected and seen.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>