### PR TITLE
[dv/kmac] remove cycle accurate model [Part1]

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -87,18 +87,6 @@ package kmac_env_pkg;
   // log_2(W)
   localparam int L = $clog2(W);
 
-  // number of rounds performed by keccak logic
-  parameter int KECCAK_NUM_ROUNDS = 12 + 2 * L;
-
-  // After seeding the LFSRs, the internal auxiliary storage is filled up in 1 clock cycle.
-  parameter int CYCLES_TO_FILL_ENTROPY = 1;
-
-  // 4 cycles total: 4 cycles (for core) - entropy generation can be fully overlapped with core.
-  parameter int ENTROPY_FULL_EXPANSION_CYCLES = 4;
-
-  // 4 cycles total:                             4 cycles (for core)
-  parameter int ENTROPY_FAST_PROCESSING_CYCLES = 4;
-
   // interrupt types
   typedef enum int {
     KmacDone = 0,


### PR DESCRIPTION
This PR removes the scb logic for cycle-accurate prediction in kmac
processing fifo status.

Upcoming work:
To make sure we still check the status fifo, upcoming PRs here use
directly sequence to check:
1). When KMAC is still processing keys, check fifo depth increment until
  fifo full.
2). When KMAC does not need to process key, check kmac empty status and
  interrupt.
The following PRs will also support:
1). Add a timeout to check when kmac done is asserted.
2). Simplify the error detection logic.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>