### PR TITLE
[spi_device/dv] Test WREN and WRDI commands

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_host_flash_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_host_flash_seq.sv
@@ -45,15 +45,20 @@ class spi_host_flash_seq extends spi_base_seq;
                                    foreach (address_q[i]) {
                                      address_q[i] == local::address_q[i];
                                    }
-                                   if (write_command) {
-                                     read_size == 0;
-                                     payload_q.size() == local::payload_q.size();
-                                     foreach (payload_q[i]) {
-                                       payload_q[i] == local::payload_q[i];
-                                     }
-                                   } else { // read
-                                     read_size == local::read_size;
-                                     payload_q.size() == 0;
+                                   if (num_lanes == 0) {
+                                    read_size == 0;
+                                    payload_q.size() == 0;
+                                   } else {
+                                    if (write_command) {
+                                      read_size == 0;
+                                      payload_q.size() == local::payload_q.size();
+                                      foreach (payload_q[i]) {
+                                        payload_q[i] == local::payload_q[i];
+                                      }
+                                    } else { // read
+                                      read_size == local::read_size;
+                                      payload_q.size() == 0;
+                                    }
                                    }
                                   // TODO, consolidate data and payload later
                                   data.size == 1;)

--- a/hw/dv/sv/spi_agent/spi_flash_cmd_info.sv
+++ b/hw/dv/sv/spi_agent/spi_flash_cmd_info.sv
@@ -8,6 +8,7 @@ class spi_flash_cmd_info extends uvm_sequence_item;
   rand bit [7:0] opcode;
   rand bit [2:0] addr_bytes;
   rand bit write_command;
+  // number of lanes when sending payload, set to 0 if no payload is expected
   rand bit [2:0] num_lanes;
   rand int dummy_cycles;
 
@@ -19,14 +20,14 @@ class spi_flash_cmd_info extends uvm_sequence_item;
 
   constraint num_lanes_c {
     write_command -> num_lanes == 1;
-    num_lanes inside {1, 2, 4};
+    num_lanes inside {0, 1, 2, 4};
   }
 
   constraint dummy_cycles_c {
     // for dual/quad read, need at least 2 dummy cycles
     num_lanes > 1 && !write_command -> dummy_cycles >= 2;
-    // write doesn't have dummy cycle
-    write_command -> dummy_cycles == 0;
+    // write or no payload doesn't have dummy cycle.
+    write_command || num_lanes == 0 -> dummy_cycles == 0;
     dummy_cycles dist {
       0     :/ 1,
       [2:7] :/ 1,

--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -87,6 +87,9 @@ class spi_host_driver extends spi_driver;
       bit [7:0] device_byte;
       int       which_bit;
       bit [3:0] num_bits;
+
+      if (transfer_data.size == 0) return;
+
       if (cfg.partial_byte == 1) begin
         num_bits = cfg.bits_to_transfer;
       end else begin
@@ -137,12 +140,14 @@ class spi_host_driver extends spi_driver;
 
     cmd_addr_bytes = {req.opcode, req.address_q};
     sck_pulses = cmd_addr_bytes.size() * 8 + req.dummy_cycles;
-    if (req.write_command) begin
-      `DV_CHECK_EQ(req.num_lanes, 1)
-      sck_pulses += req.payload_q.size * 8;
-    end else begin
-      `DV_CHECK_EQ(req.payload_q.size, 0)
-      sck_pulses += req.read_size * (8 / req.num_lanes);
+    if (req.num_lanes > 0) begin
+      if (req.write_command) begin
+        `DV_CHECK_EQ(req.num_lanes, 1)
+        sck_pulses += req.payload_q.size * 8;
+      end else begin
+        `DV_CHECK_EQ(req.payload_q.size, 0)
+        sck_pulses += req.read_size * (8 / req.num_lanes);
+      end
     end
 
     // for mode 1 and 3, get the leading edges out of the way

--- a/hw/dv/sv/spi_agent/spi_item.sv
+++ b/hw/dv/sv/spi_agent/spi_item.sv
@@ -16,7 +16,8 @@ class spi_item extends uvm_sequence_item;
   rand bit write_command;
   rand bit [7:0] address_q[$];
   rand bit [7:0] opcode;
-  rand bit [2:0] num_lanes; // 1,2 or 4 lanes for read response
+  // 1,2 or 4 lanes for read response, 0 means no data
+  rand bit [2:0] num_lanes;
   rand int dummy_cycles;
 
   // for dummy transaction
@@ -32,7 +33,7 @@ class spi_item extends uvm_sequence_item;
 
   constraint num_lanes_c {
     write_command -> num_lanes == 1;
-    num_lanes inside {1, 2, 4};
+    num_lanes inside {0, 1, 2, 4};
   }
 
   `uvm_object_utils_begin(spi_item)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_cfg_cmd_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_cfg_cmd_vseq.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test 4 cfg commands - wren, wrdi, en4b, ex4b
+class spi_device_cfg_cmd_vseq extends spi_device_intercept_vseq;
+  `uvm_object_utils(spi_device_cfg_cmd_vseq)
+  `uvm_object_new
+
+  function void pre_randomize();
+    // TODO, 2 more to add
+    intercept_ops[$] = {WREN, WRDI};
+  endfunction
+
+  virtual task pre_start();
+    allow_write_enable_disable = 1;
+    super.pre_start();
+  endtask
+endclass : spi_device_cfg_cmd_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_all_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_all_vseq.sv
@@ -20,6 +20,8 @@ class spi_device_pass_all_vseq extends spi_device_pass_base_vseq;
     allow_upload = 1;
     always_set_busy_when_upload_contain_payload = 1;
 
+    allow_write_enable_disable = 1;
+
     fork
       // this thread runs until the main_seq completes
       while (!main_seq_done) upload_fifo_read_seq();

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -28,4 +28,5 @@
 `include "spi_device_intercept_vseq.sv"
 `include "spi_device_mailbox_vseq.sv"
 `include "spi_device_upload_vseq.sv"
+`include "spi_device_cfg_cmd_vseq.sv"
 `include "spi_device_pass_all_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -44,6 +44,7 @@ filesets:
       - seq_lib/spi_device_intercept_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_mailbox_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_upload_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_cfg_cmd_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_pass_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -74,9 +74,9 @@ package spi_device_env_pkg;
   } read_addr_size_type_e;
 
   typedef struct packed {
-    bit busy;
-    bit WEL;
     bit [21:0] other_status;
+    bit wel;
+    bit busy;
   } flash_status_t;
 
   // alerts

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -166,6 +166,11 @@
     }
 
     {
+      name: spi_device_cfg_cmd
+      uvm_test_seq: spi_device_cfg_cmd_vseq
+    }
+
+    {
       name: spi_device_pass_all
       uvm_test_seq: spi_device_pass_all_vseq
     }


### PR DESCRIPTION
2 commits:
1. [spi_device/dv] Update spi agent to support flash item without payload

2. [spi_device/dv] Test WREN and WRDI commands
    1. add spi_device_cfg_cmd_vseq to test these 2 commands
    2. Update scb to support testing them
    3. Update base vseq to randomly enable them
    4. Fix the flash_status_t field order
    5. Rename `flash_status_tl_allow_q` to `flash_status_tl_pre_val_q`

Signed-off-by: Weicai Yang <weicai@google.com>