### PR TITLE
[ci] Increase FPGA test timeout in Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -507,7 +507,7 @@ jobs:
   displayName: CW310 Tests
   # Execute tests on ChipWhisperer CW310 FPGA board
   pool: FPGA
-  timeoutInMinutes: 30
+  timeoutInMinutes: 45
   dependsOn:
     - chip_earlgrey_cw310
     - chip_earlgrey_cw310_splice_rom


### PR DESCRIPTION
#14280 is timing out on tests because it's running up against the 30-minute timeout.

Signed-off-by: Miles Dai <milesdai@google.com>