### PR TITLE
[sw/silicon_creator] Shutdown cleanups

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -70,13 +70,20 @@ cc_library(
 )
 
 cc_library(
+    name = "epmp_defs",
+    hdrs = [
+        "epmp_defs.h",
+    ],
+)
+
+cc_library(
     name = "epmp",
     srcs = ["epmp.c"],
     hdrs = [
         "epmp.h",
-        "epmp_defs.h",
     ],
     deps = [
+        ":epmp_defs",
         ":error",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:hardened",
@@ -291,6 +298,7 @@ dual_cc_library(
         ],
         shared = [
             ":error",
+            ":epmp_defs",
             "//sw/device/lib/base:hardened",
             "//sw/device/lib/base:macros",
             "//sw/device/silicon_creator/lib/drivers:lifecycle",

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -416,6 +416,11 @@ SHUTDOWN_FUNC(NO_MODIFIERS, shutdown_keymgr_kill(void)) {
   abs_mmio_write32(kBase + KEYMGR_SIDELOAD_CLEAR_REG_OFFSET, 1);
 }
 
+SHUTDOWN_FUNC(NO_MODIFIERS, shutdown_reset(void)) {
+  enum { kBase = TOP_EARLGREY_RSTMGR_AON_BASE_ADDR };
+  abs_mmio_write32(kBase + RSTMGR_RESET_REQ_REG_OFFSET, kMultiBitBool4True);
+}
+
 SHUTDOWN_FUNC(NO_MODIFIERS, shutdown_flash_kill(void)) {
   enum { kBase = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR };
   // Setting DIS (rw0c) to a value other than 5 will disable flash permanently.
@@ -479,6 +484,8 @@ void shutdown_finalize(rom_error_t reason) {
   shutdown_report_error(reason);
   shutdown_software_escalate();
   shutdown_keymgr_kill();
+  // Reset before killing the flash to be able to use this also in flash.
+  shutdown_reset();
   shutdown_flash_kill();
   // If we get here, we'll wait for the watchdog to reset the chip.
   shutdown_hang();

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -18,6 +18,7 @@
 #include "sw/device/silicon_creator/lib/drivers/alert.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/epmp_defs.h"
 
 #include "alert_handler_regs.h"
 #include "flash_ctrl_regs.h"
@@ -443,33 +444,48 @@ SHUTDOWN_FUNC(noreturn, shutdown_hang(void)) {
 
   // Switch to assembly as RAM (incl. stack) is about to get scrambled.
 #ifdef OT_PLATFORM_RV32
-  while (true) {
-    asm volatile(
-        "1:"
-        // Request a new scrambling key.
-        "sw %[kSramRenewKey], %[kSramCtrlCtrlReg](%[kSramCtrlBase]);"
-        // Request a system reset.
-        "sw %[kMultiBitBool4True], %[kRstmgrResetReqReg](%[kRstmgrBase]);"
+  asm volatile(
+      ".L_shutdown_hang_asm_start:"
+      // Request a new scrambling key.
+      "sw %[kSramRenewKey], %[kSramCtrlCtrlReg](%[kSramCtrlBase]);"
+      // Request a system reset.
+      "sw %[kMultiBitBool4True], %[kRstmgrResetReqReg](%[kRstmgrBase]);"
 
-        // TODO(lowRISC/opentitan#7148): restrict the ePMP such that only
-        // ROM may execute.  mundaym's suggestion: set entry 2 as a NAPOT
-        // region covering the entire address space, clear all its permission
-        // bits and set the lock bit, and then finally disable RLB to prevent
-        // any further modifications.
+      // Reconfigure ePMP such that only this inline asm is executable:
+      // - Entry 1: TOR, LRX, [.L_shutdown_hang_asm_start,
+      // .L_shutdown_hang_asm_end).
+      // - Entry 2: NAPOT, L, entire address space.
+      // - MSECCFG: MMWP set RLB unset to prevent any further modifications.
+      "la   t0, .L_shutdown_hang_asm_start;"
+      "srli t0, t0, 2;"
+      "csrw pmpaddr0, t0;"
+      "la   t0, .L_shutdown_hang_asm_end;"
+      "srli t0, t0, 2;"
+      "csrw pmpaddr1, t0;"
+      "csrw pmpaddr2, %[kNapotEntireAddressSpace];"
+      "csrw pmpcfg0, %[kPmpCfg0];"
+      "csrw pmpcfg1, zero;"
+      "csrw pmpcfg2, zero;"
+      "csrw pmpcfg3, zero;"
+      "csrw %[kMSecCfgReg], %[kMSecCfgVal];"
 
-        // Generate a halt-maze.
-        "wfi; wfi; wfi; wfi; j 1b;"
-        "wfi; wfi; j 1b;"
-        "wfi; j 1b;"
-        "wfi;"
-        :
-        : [kSramRenewKey] "r"(1 << SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT),
-          [kSramCtrlCtrlReg] "I"(SRAM_CTRL_CTRL_REG_OFFSET),
-          [kSramCtrlBase] "r"(kSramCtrlBase),
-          [kMultiBitBool4True] "r"(kMultiBitBool4True),
-          [kRstmgrBase] "r"(kRstmgrBase),
-          [kRstmgrResetReqReg] "I"(RSTMGR_RESET_REQ_REG_OFFSET));
-  }
+      // Generate a halt-maze.
+      "wfi; wfi; wfi; wfi; j .L_shutdown_hang_asm_start;"
+      "wfi; wfi; j .L_shutdown_hang_asm_start;"
+      "wfi; j .L_shutdown_hang_asm_start;"
+      ".L_shutdown_hang_asm_end:"
+      :
+      : [kSramRenewKey] "r"(1 << SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT),
+        [kSramCtrlCtrlReg] "I"(SRAM_CTRL_CTRL_REG_OFFSET),
+        [kSramCtrlBase] "r"(kSramCtrlBase),
+        [kMultiBitBool4True] "r"(kMultiBitBool4True),
+        [kRstmgrResetReqReg] "I"(RSTMGR_RESET_REQ_REG_OFFSET),
+        [kRstmgrBase] "r"(kRstmgrBase),
+        [kNapotEntireAddressSpace] "r"(0x7fffffff),
+        [kPmpCfg0] "r"((EPMP_CFG_A_TOR | EPMP_CFG_LRX) << 8 |
+                       (EPMP_CFG_A_NAPOT | EPMP_CFG_L) << 16),
+        [kMSecCfgReg] "I"(EPMP_MSECCFG), [kMSecCfgVal] "r"(EPMP_MSECCFG_MMWP));
+  OT_UNREACHABLE();
 #endif
 }
 

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -40,6 +40,7 @@ class MockShutdownImpl : public ::global_mock::GlobalMock<MockShutdownImpl> {
   MOCK_METHOD(void, shutdown_report_error, (rom_error_t));
   MOCK_METHOD(void, shutdown_software_escalate, ());
   MOCK_METHOD(void, shutdown_keymgr_kill, ());
+  MOCK_METHOD(void, shutdown_reset, ());
   MOCK_METHOD(void, shutdown_flash_kill, ());
   MOCK_METHOD(void, shutdown_hang, ());
 };
@@ -55,6 +56,9 @@ void shutdown_software_escalate(void) {
 }
 void shutdown_keymgr_kill(void) {
   return MockShutdownImpl::Instance().shutdown_keymgr_kill();
+}
+void shutdown_reset(void) {
+  return MockShutdownImpl::Instance().shutdown_reset();
 }
 void shutdown_flash_kill(void) {
   return MockShutdownImpl::Instance().shutdown_flash_kill();
@@ -351,6 +355,7 @@ class ShutdownTest : public rom_test::RomTest {
     EXPECT_CALL(shutdown_, shutdown_report_error(error));
     EXPECT_CALL(shutdown_, shutdown_software_escalate());
     EXPECT_CALL(shutdown_, shutdown_keymgr_kill());
+    EXPECT_CALL(shutdown_, shutdown_reset());
     EXPECT_CALL(shutdown_, shutdown_flash_kill());
     EXPECT_CALL(shutdown_, shutdown_hang());
   }


### PR DESCRIPTION
* **[sw/silicon_creator] Reset before disabling flash for proper shutdown in ROM_EXT:** Currently, shutdowns in ROM_EXT result in a hang instead of resetting the chip since flash_ctrl is disabled before we request a reset. This change adds a reset request before disabling flash_ctrl so that shutdowns reset the chip in ROM_EXT as well.

* **[sw/silicon_creator] Restrict ePMP in shutdown_hang():** This commit updates the ePMP configuration `shutdown_hang()` so that the only RX region is the inline asm block in that function. TOR configuration uses labels so that the same library can be used in ROM_EXT as well.

Disassemblies: [ROM](https://gist.github.com/alphan/5a24482469452d316d3524b392dde206), [ROM_EXT](https://gist.github.com/alphan/e105d00ba4a5e6e110cc4cb5ab94300b).

Fixes #7148

In ROM (RX enabled only for [0xcdb4, 0xce14)):
```
    cda4:                       80000737                lui     a4,0x80000
    cda8:                       177d                    addi    a4,a4,-1
    cdaa:                       009897b7                lui     a5,0x989
    cdae:                       d0078793                addi    a5,a5,-768 # 988d00 <_rom_ext_virtual_size+0x908d00>
    cdb2:                       4509                    li      a0,2
shutdown_hang():
/proc/self/cwd/sw/device/silicon_creator/lib/shutdown.c:447
  asm volatile(
    cdb4:                   /-> cacc                    sw      a1,20(a3)
    cdb6:                   |   00c82223                sw      a2,4(a6)
    cdba:                   |   00000297                auipc   t0,0x0
    cdbe:                   |   ffa28293                addi    t0,t0,-6 # cdb4 <shutdown_finalize+0x238>
    cdc2:                   |   0022d293                srli    t0,t0,0x2
    cdc6:                   |   3b029073                csrw    pmpaddr0,t0
    cdca:                   |   00000297                auipc   t0,0x0
    cdce:                   |   04a28293                addi    t0,t0,74 # ce14 <_text_end>
    cdd2:                   |   0022d293                srli    t0,t0,0x2
    cdd6:                   |   3b129073                csrw    pmpaddr1,t0
    cdda:                   |   3b271073                csrw    pmpaddr2,a4
    cdde:                   |   3a079073                csrw    pmpcfg0,a5
    cde2:                   |   3a101073                csrw    pmpcfg1,zero
    cde6:                   |   3a201073                csrw    pmpcfg2,zero
    cdea:                   |   3a301073                csrw    pmpcfg3,zero
    cdee:                   |   74751073                csrw    0x747,a0
    cdf2:                   |   10500073                wfi
    cdf6:                   |   10500073                wfi
    cdfa:                   |   10500073                wfi
    cdfe:                   |   10500073                wfi
    ce02:                   +-- bf4d                    j       cdb4 <shutdown_finalize+0x238>
    ce04:                   |   10500073                wfi
    ce08:                   |   10500073                wfi
    ce0c:                   +-- b765                    j       cdb4 <shutdown_finalize+0x238>
    ce0e:                   |   10500073                wfi
    ce12:                   \-- b74d                    j       cdb4 <shutdown_finalize+0x238>
```

In ROM_EXT (RX enabled only for [0x20002358, 0x200023b8)):
```
20002348:                       80000737                lui     a4,0x80000
2000234c:                       177d                    addi    a4,a4,-1
2000234e:                       009897b7                lui     a5,0x989
20002352:                       d0078793                addi    a5,a5,-768 # 988d00 <_owner_virtual_size+0x908d00>
20002356:                       4509                    li      a0,2
shutdown_hang():
/proc/self/cwd/sw/device/silicon_creator/lib/shutdown.c:447
  asm volatile(
20002358:                   /-> cacc                    sw      a1,20(a3)
2000235a:                   |   00c82223                sw      a2,4(a6)
2000235e:                   |   00000297                auipc   t0,0x0
20002362:                   |   ffa28293                addi    t0,t0,-6 # 20002358 <shutdown_finalize+0x238>
20002366:                   |   0022d293                srli    t0,t0,0x2
2000236a:                   |   3b029073                csrw    pmpaddr0,t0
2000236e:                   |   00000297                auipc   t0,0x0
20002372:                   |   04a28293                addi    t0,t0,74 # 200023b8 <_text_end>
20002376:                   |   0022d293                srli    t0,t0,0x2
2000237a:                   |   3b129073                csrw    pmpaddr1,t0
2000237e:                   |   3b271073                csrw    pmpaddr2,a4
20002382:                   |   3a079073                csrw    pmpcfg0,a5
20002386:                   |   3a101073                csrw    pmpcfg1,zero
2000238a:                   |   3a201073                csrw    pmpcfg2,zero
2000238e:                   |   3a301073                csrw    pmpcfg3,zero
20002392:                   |   74751073                csrw    0x747,a0
20002396:                   |   10500073                wfi
2000239a:                   |   10500073                wfi
2000239e:                   |   10500073                wfi
200023a2:                   |   10500073                wfi
200023a6:                   +-- bf4d                    j       20002358 <shutdown_finalize+0x238>
200023a8:                   |   10500073                wfi
200023ac:                   |   10500073                wfi
200023b0:                   +-- b765                    j       20002358 <shutdown_finalize+0x238>
200023b2:                   |   10500073                wfi
200023b6:                   \-- b74d                    j       20002358 <shutdown_finalize+0x238>
```

Signed-off-by: Alphan Ulusoy <alphan@google.com>