### PR TITLE
[hw] Accept "scr" files in gen_vivado_mem_image.py

### DIFF
--- a/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
+++ b/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
@@ -43,7 +43,7 @@ def main() -> int:
     args = parser.parse_args()
 
     # Extract width from ROM file name.
-    match = re.search(r'([0-9]+).vmem', args.infile.name)
+    match = re.search(r'([0-9]+)(\.scr)?\.vmem', args.infile.name)
     if not match:
         raise ValueError('Cannot extract ROM word width from file name ' +
                          args.infile.name)


### PR DESCRIPTION
@milesdai noticed that `//hw/bitstream:gcp_spliced_rom_otp_dev` failed to build with this error: `ValueError: Cannot extract ROM word width from file name bazel-out/k8-fastbuild-ST97f470ee3b14/bin/sw/device/silicon_creator/rom/rom_fpga_cw310.39.scr.vmem`.

It appears that scrambled files now have `.scr` in their filenames, which a regex in `gen_vivado_mem_image.py` did not account for.