### PR TITLE
[opentitantool] Update rom detection regex after mask rom renaming

### DIFF
--- a/sw/host/opentitanlib/src/util/rom_detect.rs
+++ b/sw/host/opentitanlib/src/util/rom_detect.rs
@@ -44,7 +44,7 @@ impl RomDetect {
             usr_access: Self::scan_usr_access(bitstream)?,
             console: UartConsole {
                 timeout: timeout,
-                exit_success: Some(Regex::new(r"(\w+ROM):([^\r\n]+)[\r\n]").unwrap()),
+                exit_success: Some(Regex::new(r"(\w*ROM):([^\r\n]+)[\r\n]").unwrap()),
                 ..Default::default()
             },
         })


### PR DESCRIPTION
#14259 broke the regex used in Opentitantool to detect the ROM type/version which looks for one or more words before `ROM` (e.g. MaskROM or TestROM). This updates the regex to expect >= 0 words before `ROM`.

This functionality is important for reducing CI runtime.