### PR TITLE
[sw/silicon_creator] Add missing register to alert_config_crc32()

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -257,7 +257,7 @@
                 },
                 {
                     name: "OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA",
-                    value: "0xce5c49ce",
+                    value: "0x727ca8ae",
                 }
             ],
         }

--- a/sw/device/silicon_creator/lib/drivers/alert.c
+++ b/sw/device/silicon_creator/lib/drivers/alert.c
@@ -261,6 +261,8 @@ uint32_t alert_config_crc32(void) {
   uint32_t ctx;
   crc32_init(&ctx);
 
+  crc32_add_regs(&ctx, ALERT_HANDLER_ALERT_REGWEN_0_REG_OFFSET,
+                 ALERT_HANDLER_ALERT_REGWEN_MULTIREG_COUNT);
   crc32_add_regs(&ctx, ALERT_HANDLER_ALERT_EN_SHADOWED_0_REG_OFFSET,
                  ALERT_HANDLER_ALERT_EN_SHADOWED_MULTIREG_COUNT);
   crc32_add_regs(&ctx, ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_REG_OFFSET,

--- a/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
@@ -338,6 +338,8 @@ class AlertConfigCheckTest : public AlertTest {
   void ExpectConfigCrc32(uint32_t exp_crc32) {
     std::vector<uint32_t> reg_offsets;
     auto iter = std::back_inserter(reg_offsets);
+    std::generate_n(iter, ALERT_HANDLER_ALERT_REGWEN_MULTIREG_COUNT,
+                    WordStepper(ALERT_HANDLER_ALERT_REGWEN_0_REG_OFFSET));
     std::generate_n(iter, ALERT_HANDLER_ALERT_EN_SHADOWED_MULTIREG_COUNT,
                     WordStepper(ALERT_HANDLER_ALERT_EN_SHADOWED_0_REG_OFFSET));
     std::generate_n(


### PR DESCRIPTION
Thanks for catching this @jon-flatley!

Signed-off-by: Alphan Ulusoy <alphan@google.com>