### PR TITLE
[chip/dv] Constrain uart baudrate to > 115k

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -348,8 +348,6 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+calibrate_usb_clk=1"]
       reseed: 20
-      // slow baudrate may be used, it needs longer time
-      run_timeout_mins: 240
     }
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq
@@ -359,8 +357,6 @@
       run_opts: ["+sw_test_timeout_ns=80_000_000",
                  "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1", "+calibrate_usb_clk=1"]
       reseed: 5
-      // slow baudrate may be used, it needs longer time
-      run_timeout_mins: 240
     }
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq_low_speed
@@ -370,8 +366,6 @@
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+calibrate_usb_clk=1",
                  "+ext_clk_type=ExtClkLowSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
       reseed: 5
-      // slow baudrate may be used, it needs longer time
-      run_timeout_mins: 240
     }
     {
       name: chip_sw_spi_device_tx_rx

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
@@ -24,6 +24,8 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
   constraint baud_rate_c {
     // constrain nco not over nco width
     `CALC_NCO(baud_rate, NCO_WIDTH, uart_clk_freq_khz) < (1 << NCO_WIDTH);
+    // only test 4 other speeds, <= 115k is slow which may take a few hours to complete the test
+    baud_rate > BaudRate115200;
   }
 
   function void pre_randomize();


### PR DESCRIPTION
This constrains not to use 2 out of 6 defined baudrates, otherwise, some tests
may run a few hours.
Randomly using 4 baudrates is good enough for chip-level

Signed-off-by: Weicai Yang <weicai@google.com>