### PR TITLE
[test_rom] remove clkmgr reenables

### DIFF
--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -119,7 +119,6 @@ cc_library(
         ":chip_info",
         ":target_test_rom_lib",
         ":test_rom_manifest",
-        "//hw/ip/clkmgr/data:clkmgr_regs",
         "//hw/ip/csrng/data:csrng_regs",
         "//hw/ip/edn/data:edn_regs",
         "//hw/ip/entropy_src/data:entropy_src_regs",

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -6,7 +6,6 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits_asm.h"
 #include "ast_regs.h"
-#include "clkmgr_regs.h"
 #include "csrng_regs.h"
 #include "edn_regs.h"
 #include "entropy_src_regs.h"
@@ -145,13 +144,6 @@ _reset_start:
   .global _start
   .type _start, @function
 _start:
-  // Re-enable all SW gateable clocks in case the clkmgr was not reset.
-  li   a0, TOP_EARLGREY_CLKMGR_AON_BASE_ADDR
-  li   t0, CLKMGR_CLK_ENABLES_REG_RESVAL
-  sw   t0, CLKMGR_CLK_ENABLES_REG_OFFSET(a0)
-  li   t0, CLKMGR_CLK_HINTS_REG_RESVAL
-  sw   t0, CLKMGR_CLK_HINTS_REG_OFFSET(a0)
-
 #if !OT_IS_ENGLISH_BREAKFAST
   // Check if AST initialization should be skipped.
   li   a0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \


### PR DESCRIPTION
The hardware has been updated to reenable/reset clocks/hints on a reset,
so the test ROM no longer needs this functionality (it does not exist in
the ROM either).

This fixes #11081.

Signed-off-by: Timothy Trippel <ttrippel@google.com>