### PR TITLE
[spi_device/dv] Test addr 4b mode

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_host_flash_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_host_flash_seq.sv
@@ -19,7 +19,7 @@ class spi_host_flash_seq extends spi_base_seq;
   `uvm_object_new
 
   virtual task body();
-    int addr_bytes, num_lanes, dummy_cycles;
+    int num_addr_bytes, num_lanes, dummy_cycles;
     bit write_command;
 
     req = spi_item::type_id::create("req");
@@ -27,12 +27,12 @@ class spi_host_flash_seq extends spi_base_seq;
 
     cfg.extract_cmd_info_from_opcode(opcode,
         // output
-        addr_bytes, write_command, num_lanes, dummy_cycles);
+        num_addr_bytes, write_command, num_lanes, dummy_cycles);
     if (address_q.size() == 0) begin
       `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(address_q,
-          address_q.size == addr_bytes;)
+          address_q.size == num_addr_bytes;)
     end else begin
-      `DV_CHECK_EQ(address_q.size(), addr_bytes)
+      `DV_CHECK_EQ(address_q.size(), num_addr_bytes)
     end
 
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
@@ -41,7 +41,7 @@ class spi_host_flash_seq extends spi_base_seq;
                                    write_command == local::write_command;
                                    num_lanes == local::num_lanes;
                                    dummy_cycles == local::dummy_cycles;
-                                   address_q.size() == addr_bytes;
+                                   address_q.size() == num_addr_bytes;
                                    foreach (address_q[i]) {
                                      address_q[i] == local::address_q[i];
                                    }

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -55,6 +55,16 @@ package spi_agent_pkg;
     ReadSfdp   = 8'b01011010
   } spi_cmd_e;
 
+  typedef enum bit [1:0] {
+    SpiFlashAddrDisabled,
+    // Configurable 3b or 4b address
+    SpiFlashAddrCfg,
+    // Fixed 3b addr
+    SpiFlashAddr3b,
+    // Fixed 4b addr
+    SpiFlashAddr4b
+  } spi_flash_addr_mode_e;
+
   // forward declare classes to allow typedefs below
   typedef class spi_item;
   typedef class spi_agent_cfg;

--- a/hw/dv/sv/spi_agent/spi_flash_cmd_info.sv
+++ b/hw/dv/sv/spi_agent/spi_flash_cmd_info.sv
@@ -6,16 +6,15 @@
 // cmd, it knows how many addr_bytes, direction, dummy_cycles etc
 class spi_flash_cmd_info extends uvm_sequence_item;
   rand bit [7:0] opcode;
-  rand bit [2:0] addr_bytes;
+  rand spi_flash_addr_mode_e addr_mode;
   rand bit write_command;
   // number of lanes when sending payload, set to 0 if no payload is expected
   rand bit [2:0] num_lanes;
   rand int dummy_cycles;
 
-  constraint addr_bytes_c {
-    addr_bytes inside {0, 3, 4};
+  constraint addr_mode_c {
     // for dual/quad mode, it always contains address
-    num_lanes > 1 -> addr_bytes > 0;
+    num_lanes > 1 -> addr_mode != SpiFlashAddrDisabled;
   }
 
   constraint num_lanes_c {
@@ -37,7 +36,7 @@ class spi_flash_cmd_info extends uvm_sequence_item;
 
   `uvm_object_utils_begin(spi_flash_cmd_info)
     `uvm_field_int(opcode,        UVM_DEFAULT)
-    `uvm_field_int(addr_bytes,    UVM_DEFAULT)
+    `uvm_field_enum(spi_flash_addr_mode_e, addr_mode, UVM_DEFAULT)
     `uvm_field_int(write_command, UVM_DEFAULT)
     `uvm_field_int(dummy_cycles,  UVM_DEFAULT)
     `uvm_field_int(num_lanes,     UVM_DEFAULT)

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -195,7 +195,7 @@ class spi_monitor extends dv_base_monitor#(
             wait(cfg.vif.csb[cfg.csb_sel] == 1'b1);
           end
           begin: sample_thread
-            int addr_bytes;
+            int num_addr_bytes;
             opcode_received = 0;
             item.item_type = SpiFlashTrans;
             // for mode 1 and 3, get the leading edges out of the way
@@ -207,10 +207,10 @@ class spi_monitor extends dv_base_monitor#(
             opcode_received = 1;
             cfg.extract_cmd_info_from_opcode(item.opcode,
                 // output
-                addr_bytes, item.write_command, item.num_lanes, item.dummy_cycles);
+                num_addr_bytes, item.write_command, item.num_lanes, item.dummy_cycles);
             `uvm_info(`gfn, $sformatf("sampled flash opcode: 0x%0h", item.opcode), UVM_MEDIUM)
 
-            sample_flash_address(addr_bytes, item.address_q);
+            sample_flash_address(num_addr_bytes, item.address_q);
 
             repeat (item.dummy_cycles) begin
               cfg.wait_sck_edge(SamplingEdge);

--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -398,7 +398,7 @@
             - Issue supported command with required address.
             - Check proper address propagation.'''
       milestone: V2
-      tests: []
+      tests: ["spi_device_cfg_cmd"]
     }
   ]
   covergroups: [

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_cfg_cmd_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_cfg_cmd_vseq.sv
@@ -8,12 +8,19 @@ class spi_device_cfg_cmd_vseq extends spi_device_intercept_vseq;
   `uvm_object_new
 
   function void pre_randomize();
-    // TODO, 2 more to add
-    intercept_ops[$] = {WREN, WRDI};
+    intercept_ops[$] = {WREN, WRDI, EN4B, EX4B};
   endfunction
 
   virtual task pre_start();
     allow_write_enable_disable = 1;
+    allow_addr_cfg_cmd         = 1;
     super.pre_start();
+  endtask
+
+  // randomly set flash_status for every spi transaction
+  virtual task spi_host_xfer_flash_item(bit [7:0] op, uint payload_size,
+                                        bit [31:0] addr, bit wait_on_busy = 1);
+    super.spi_host_xfer_flash_item(op, payload_size, addr, wait_on_busy);
+    read_and_check_4b_en();
   endtask
 endclass : spi_device_cfg_cmd_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_all_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_all_vseq.sv
@@ -21,6 +21,7 @@ class spi_device_pass_all_vseq extends spi_device_pass_base_vseq;
     always_set_busy_when_upload_contain_payload = 1;
 
     allow_write_enable_disable = 1;
+    allow_addr_cfg_cmd = 1;
 
     fork
       // this thread runs until the main_seq completes
@@ -56,6 +57,8 @@ class spi_device_pass_all_vseq extends spi_device_pass_base_vseq;
         end else if ($urandom_range(0, 1)) begin
           random_access_flash_status(.write(0));
         end
+
+        if ($urandom_range(0, 1)) read_and_check_4b_en();
 
         randomize_op_addr_size();
         `uvm_info(`gfn, $sformatf("Testing op_num %0d/20, op = 0x%0h", j, opcode), UVM_MEDIUM)

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -53,13 +53,6 @@ package spi_device_env_pkg;
     PassthroughMode
   } device_mode_e;
 
-  typedef enum bit [1:0] {
-    AddrDisabled,
-    AddrCfg,
-    Addr3B,
-    Addr4B
-  } addr_mode_e;
-
   typedef enum bit {
     PayloadIn,
     PayloadOut

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -133,7 +133,11 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
               end
               InternalProcessCfgCmd: begin
                 if (`GET_OPCODE_VALID_AND_MATCH(cmd_info_en4b, item.opcode)) begin
+                  void'(ral.cfg.addr_4b_en.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
+                  `uvm_info(`gfn, "Enable 4b addr due to cmd EN4B", UVM_MEDIUM)
                 end else if (`GET_OPCODE_VALID_AND_MATCH(cmd_info_ex4b, item.opcode)) begin
+                  void'(ral.cfg.addr_4b_en.predict(.value(0), .kind(UVM_PREDICT_WRITE)));
+                  `uvm_info(`gfn, "Disable 4b addr due to cmd EX4B", UVM_MEDIUM)
                 end else if (`GET_OPCODE_VALID_AND_MATCH(cmd_info_wren, item.opcode)) begin
                   update_wel = 1;
                   wel_val = 1;


### PR DESCRIPTION
1. Update spi agent to support addr_mode - addrDisable, AddrCfg, Addr4b/3b
2. Update sequence to randomly configure en4b and ex4b commands, also send
  these 2 commands along with others
3. update scb to update addr mode when these 2 commands are received
4. rename `addr_bytes` -> `num_addr_bytes`

Signed-off-by: Weicai Yang <weicai@google.com>