### PR TITLE
[Bazel] add cheatsheet to website

### DIFF
--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -64,6 +64,8 @@ cd $REPO_TOP
 bazel build //hw/bitstream/vivado:fpga_cw310_rom
 ```
 
+Note, building these bitstreams will require Vivado be installed on your system, with access to the proper licenses, described [here]({{< relref "doc/getting_started/install_vivado" >}}).
+
 #### Dealing with FPGA Congestion Issues
 
 The default Vivado tool placement may sometimes result in congested FPGA floorplans.
@@ -145,7 +147,7 @@ Alternatively, for software build targets defined in Bazel BUILD files using the
 
 See below for details on both approaches.
 
-### Automatically loading FPGA bitstreams and bootstrapping software Bazel
+### Automatically loading FPGA bitstreams and bootstrapping software with Bazel
 
 A majority of on-device software tests are defined using the custom `opentitan_functest` Bazel macro, which under the hood, instantiates several Bazel [`native.sh_test` rules](https://docs.bazel.build/versions/main/be/shell.html#sh_test).
 In doing so, this macro provides a convenient interface for developers to run software tests on OpenTitan FPGA instances with a single invocation of `bazel test ...`.

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -532,12 +532,11 @@ def opentitan_binary(
       @param extract_sw_logs_db: Whether to emit a log database for DV testbench.
       @param **kwargs: Arguments to forward to `cc_binary`.
     Emits rules:
-      cc_binary             named: <name>
+      cc_binary             named: <name>.elf
       rv_preprocess         named: <name>_preproc
       rv_asm                named: <name>_asm
       rv_llvm_ir            named: <name>_ll
       rv_relink_with_map    named: <name>_map
-      obj_transform         named: <name>_elf
       obj_transform         named: <name>_bin
       elf_to_dissassembly   named: <name>_dis
       Optionally:


### PR DESCRIPTION
This adds more detailed Bazel notes (a sort of "cheatsheet") to the website to fix #13762.

Additionally this refactors some of the existing Bazel documentation that was specific to certain hardware platforms (like, Verilator and FPGA).

Signed-off-by: Timothy Trippel <ttrippel@google.com>