### PR TITLE
[dv/top] Add usb clock calibration test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2633,10 +2633,15 @@
       name: chip_sw_ast_usb_clk_calib
       desc: '''Verify the USB clk calibration signaling.
 
-            Details TBD.
+            - First place the AST into a mode where usb clock frequency significantly deviates from the ideal.
+            - Verify the clock is "off" using the clkmgr measurement mechanism.
+            - Then, turn on the usb sof calibration machinery and wait a few mS.
+            - Afterwards, measure the usb clock again using the clkmgr measurement controls, at this point the clock should be significantly more accurate.
+            - Note, while the above is ideal, usbdev chip level testing is not yet ready and this test fakes the usb portion through DV forces.
+            - Note also the real AST calibration logic is not available, so the sof testing in the open source is effectively short-circuited.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_usb_ast_clk_calib"]
     }
     {
       name: chip_sw_ast_alerts

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1108,6 +1108,14 @@
       // Timeout based on a ~7 minute dvsim runtime.
       run_opts: ["+sw_test_timeout_ns=7_000_000"]
     }
+    {
+      name: chip_sw_usb_ast_clk_calib
+      uvm_test_seq: "chip_sw_usb_ast_clk_calib_vseq"
+      sw_images: ["//sw/device/tests/sim_dv:ast_usb_clk_calib:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+usb_large_drift=1"]
+      reseed: 1
+    }
   ]
 
   // List of regressions.

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -84,6 +84,7 @@ filesets:
       - seq_lib/chip_rv_dm_ndm_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_entropy_src_fuse_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_usb_ast_clk_calib_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - ast_ext_clk_if.sv
       - ast_supply_if.sv

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -56,6 +56,12 @@ class chip_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get cpu_clk_rst_vif from uvm_config_db")
     end
 
+    if (!uvm_config_db#(virtual clk_rst_if)::get(
+            this, "", "usb_clk_rst_vif", cfg.usb_clk_rst_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get usb_clk_rst_vif from uvm_config_db")
+    end
+
     if (!uvm_config_db#(virtual pins_if #(1))::get(
             this, "", "pinmux_wkup_vif", cfg.pinmux_wkup_vif
         )) begin

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -25,6 +25,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   virtual pins_if#(3)   sw_straps_vif;
   virtual pins_if#(1)   rst_n_mon_vif;
   virtual clk_rst_if    cpu_clk_rst_vif;
+  virtual clk_rst_if    usb_clk_rst_vif;
   virtual pins_if#(1)   pinmux_wkup_vif;
   virtual pins_if#(1)   por_rstn_vif;
   virtual pins_if#(1)   pwrb_in_vif;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usb_ast_clk_calib_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usb_ast_clk_calib_vseq.sv
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_usb_ast_clk_calib_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_usb_ast_clk_calib_vseq)
+
+  `uvm_object_new
+
+  string usbdev_path = {`DV_STRINGIFY(`USBDEV_HIER)};
+
+  virtual task connect_usbdev();
+    int link_reset = 0;
+    string idle_det_path = {usbdev_path,
+           ".usbdev_impl.u_usb_fs_nb_pe.u_usb_fs_rx.rx_idle_det_o"};
+
+    // See if we can force this at usb_p/usb_n directly later.
+    string se0_path = {usbdev_path,
+           ".usbdev_impl.u_usbdev_linkstate.line_se0_raw"};
+
+    string link_reset_path = {usbdev_path,
+           ".usbdev_impl.u_usbdev_linkstate.link_reset_o"};
+
+    // Force idle to 0 so usbdev does not attempt to suspend.
+    `DV_CHECK_FATAL(uvm_hdl_force(idle_det_path, 1'b0));
+
+    // Manipulate single-ended input to create reset event.
+    `DV_CHECK_FATAL(uvm_hdl_force(se0_path, 1'b1));
+
+    // Hold reset event until internal state indicates link
+    // is reset, then release reset so the link state
+    // will advance to Active.
+    `DV_SPINWAIT(while (link_reset == 0) begin
+                 uvm_hdl_read(link_reset_path, link_reset);
+                 cfg.usb_clk_rst_vif.wait_clks(10);
+                 end,
+                  "timeout waiting for link reset",
+                 cfg.sw_test_timeout_ns)
+
+    // Release the line.
+    `DV_CHECK_FATAL(uvm_hdl_release(se0_path));
+  endtask
+
+  virtual task set_usbdev_sof_pulse();
+    string sof_path = {usbdev_path,
+           ".usbdev_impl.u_usb_fs_nb_pe.sof_valid_o"};
+
+    forever begin
+      #1ms;
+      @(posedge cfg.usb_clk_rst_vif.clk);
+      `DV_CHECK_FATAL(uvm_hdl_force(sof_path, 1'b1));
+      @(posedge cfg.usb_clk_rst_vif.clk);
+      `DV_CHECK_FATAL(uvm_hdl_release(sof_path));
+    end
+
+  endtask
+
+
+  virtual task body();
+    super.body();
+
+    // Wait for software synchronization.
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Enable usb");,
+                 "timeout waiting for C side trigger",
+                 cfg.sw_test_timeout_ns)
+     connect_usbdev();
+
+    // Wait for software synchronization.
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Wait for sof to calibrate clocks");,
+                 "timeout waiting for C side trigger",
+                 cfg.sw_test_timeout_ns)
+
+    // Spawn off a thread to continously create sof pulses.
+    fork set_usbdev_sof_pulse(); join_none
+
+    // Wait for software sychronization.
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "sof complete");,
+             "timeout waiting for C side completion",
+             cfg.sw_test_timeout_ns)
+  endtask
+
+endclass : chip_sw_usb_ast_clk_calib_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -50,3 +50,4 @@
 `include "chip_sw_alert_handler_escalation_vseq.sv"
 `include "chip_sw_lc_ctrl_program_error_vseq.sv"
 `include "chip_sw_entropy_src_fuse_vseq.sv"
+`include "chip_sw_usb_ast_clk_calib_vseq.sv"

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -51,10 +51,14 @@ module tb;
   wire cpu_rst_n = `CPU_HIER.rst_ni;
   wire alert_handler_clk = `ALERT_HANDLER_HIER.clk_i;
   wire alert_handler_rst_n = `ALERT_HANDLER_HIER.rst_ni;
+  wire usb_clk = `USBDEV_HIER.clk_i;
+  wire usb_rst_n = `USBDEV_HIER.rst_ni;
+
 
   // interfaces
   clk_rst_if clk_rst_if(.clk, .rst_n);
   clk_rst_if cpu_clk_rst_if(.clk(cpu_clk), .rst_n(cpu_rst_n));
+  clk_rst_if usb_clk_rst_if(.clk(usb_clk), .rst_n(usb_rst_n));
   alert_esc_if alert_if[NUM_ALERTS](.clk(alert_handler_clk), .rst_n(alert_handler_rst_n));
   pins_if #(NUM_GPIOS) gpio_if(.pins(gpio_pins));
   pins_if #(1) srst_n_if(.pins(srst_n));
@@ -319,6 +323,7 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env*", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env*", "cpu_clk_rst_vif", cpu_clk_rst_if);
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env*", "usb_clk_rst_vif", usb_clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(
         null, "*.env", "clk_rst_vif_rv_dm_debug_mem_reg_block", clk_rst_if);
 

--- a/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
@@ -27,6 +27,8 @@ real CLK_PERIOD;
 integer rand32;
 integer beacon_rdly;
 logic calibrate_usb_clk;
+logic large_drift;
+
 
 reg init_start;
 initial init_start = 1'b0;
@@ -45,6 +47,11 @@ initial begin
   end else begin
     calibrate_usb_clk = 1'b1;
   end
+
+  if ( !$value$plusargs("usb_large_drift=%0d", large_drift) ) begin
+    large_drift = 1'b0;
+  end
+
   //
   #1;
   init_start = 1'b1;
@@ -72,7 +79,9 @@ real CalUsbClkPeriod, UncUsbClkPeriod, UsbClkPeriod, drift;
 initial CalUsbClkPeriod = $itor( 1000000/48 );                    // ~20833.33333ps (48MHz)
 initial UncUsbClkPeriod = $itor( $urandom_range(55555, 25000) );  // 55555-25000ps (18-40MHz)
 
-assign drift = ref_val ? 0.0 : $itor(rand32);
+assign drift = ref_val      ? 0.0 :
+               large_drift  ? $itor(2000) :
+                              $itor(rand32);
 assign UsbClkPeriod = (usb_osc_cal_i && init_start) ? CalUsbClkPeriod :
                                                       UncUsbClkPeriod;
 assign CLK_PERIOD = (UsbClkPeriod + drift)/1000;

--- a/sw/device/lib/testing/clkmgr_testutils.c
+++ b/sw/device/lib/testing/clkmgr_testutils.c
@@ -39,7 +39,7 @@ static uint32_t cast_safely(uint64_t val) {
   return (uint32_t)val;
 }
 
-static void initialize_expected_counts() {
+void initialize_expected_counts() {
   // The expected counts depend on the device, per sw/device/lib/arch/device.h.
   // Notice the ratios are small enough to fit a uint32_t, even if the Hz number
   // is in uint64_t.

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -781,3 +781,21 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "ast_usb_clk_calib",
+    srcs = ["ast_usb_clk_calib.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:base",
+        "//sw/device/lib/dif:clkmgr",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:usbdev",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:clkmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/sim_dv/ast_usb_clk_calib.c
+++ b/sw/device/tests/sim_dv/ast_usb_clk_calib.c
@@ -1,0 +1,98 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_usbdev.h"
+#include "sw/device/lib/testing/clkmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_clkmgr_t clkmgr;
+static dif_usbdev_t usbdev;
+static dif_pinmux_t pinmux;
+
+static uint32_t cast_safely(uint64_t val) {
+  CHECK(val <= UINT32_MAX);
+  return (uint32_t)val;
+}
+
+static uint32_t device_usb_count;
+static uint32_t aon_clk_period_us;
+const static uint32_t kSoFPeriodUs = 1000;
+const static uint32_t kNumSoF = 2;
+
+static void enable_usb_meas_get_code(dif_clkmgr_t *clkmgr,
+                                     dif_clkmgr_recov_err_codes_t *codes) {
+  clkmgr_testutils_enable_clock_count(clkmgr, kDifClkmgrMeasureClockUsb,
+                                      device_usb_count - 2,
+                                      device_usb_count + 2);
+
+  // Wait for measurements to go through a few cycles.
+  busy_spin_micros(5 * aon_clk_period_us);
+
+  CHECK_DIF_OK(dif_clkmgr_recov_err_code_get_codes(clkmgr, codes));
+};
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_clkmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+
+  CHECK_DIF_OK(dif_usbdev_init(
+      mmio_region_from_addr(TOP_EARLGREY_USBDEV_BASE_ADDR), &usbdev));
+
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+
+  aon_clk_period_us =
+      cast_safely(udiv64_slow(1000 * 1000, kClockFreqAonHz, NULL));
+  LOG_INFO("Each aon clock is %d us", aon_clk_period_us);
+
+  device_usb_count =
+      cast_safely(udiv64_slow(kClockFreqUsbHz, kClockFreqAonHz, NULL));
+
+  // First, connect usb.
+  LOG_INFO("Enable usb");
+  CHECK_DIF_OK(dif_pinmux_input_select(
+      &pinmux, kTopEarlgreyPinmuxPeripheralInUsbdevSense,
+      kTopEarlgreyPinmuxInselConstantOne));
+
+  CHECK_DIF_OK(dif_usbdev_interface_enable(&usbdev, kDifToggleEnabled));
+
+  // Second, measure clocks before usb calibration.  They should be highly
+  // inaccurate.
+  dif_clkmgr_recov_err_codes_t codes;
+  enable_usb_meas_get_code(&clkmgr, &codes);
+  if ((codes & kDifClkmgrRecovErrTypeUsbMeas) == 0) {
+    LOG_FATAL("USB clock frequency is 48MHz when it should not be");
+  }
+
+  CHECK_DIF_OK(
+      dif_clkmgr_disable_measure_counts(&clkmgr, kDifClkmgrMeasureClockUsb));
+  CHECK_DIF_OK(dif_clkmgr_recov_err_code_clear_codes(&clkmgr, codes));
+  busy_spin_micros(5 * aon_clk_period_us);
+
+  // Third, wait for usbdev sof calibration to execute
+  LOG_INFO("Wait for sof to calibrate clocks");
+  // Wait for a few sofs.
+  busy_spin_micros(kNumSoF * kSoFPeriodUs);
+
+  // Last, measure clocks after usb calibration. They should be very accurate.
+  // re-enable measurements.
+  enable_usb_meas_get_code(&clkmgr, &codes);
+
+  if (codes) {
+    LOG_FATAL("Error code is non-zero 0x%h", codes);
+  }
+
+  LOG_INFO("sof complete");
+  return true;
+}


### PR DESCRIPTION
- addresses #14137 
- fake the usb portions since usb chip level test is not ready
- measurement the clocks pre/post calibration to ensure it is
  as expected
- tweak the ast logic slightly such that we can introduce a
  large "drift" using run time options

Signed-off-by: Timothy Chen <timothytim@google.com>