### PR TITLE
[otbn,dv] Fix alert cause for faults in TLUL adapter counters

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -115,7 +115,14 @@ class otbn_common_vseq extends otbn_base_vseq;
     if (if_proxy.sec_cm_type == SecCmPrimOnehot) begin
       fatal_cause = ral.fatal_alert_cause.reg_intg_violation;
     end else begin
-      fatal_cause = ral.fatal_alert_cause.bad_internal_state;
+      if (if_proxy.sec_cm_type == SecCmPrimCount &&
+          if_proxy.path.match("^tb\.dut\.u_tlul_adapter_sram_[di]mem.*$")) begin
+        // Faults injected into the counters of an OTBN TLUL adapter manifest as bus integrity
+        // violation.
+        fatal_cause = ral.fatal_alert_cause.bus_intg_violation;
+      end else begin
+        fatal_cause = ral.fatal_alert_cause.bad_internal_state;
+      end
     end
     csr_utils_pkg::csr_rd_check(.ptr(fatal_cause), .compare_value(1));
     csr_utils_pkg::csr_rd_check(.ptr(ral.status), .compare_value('hFF));


### PR DESCRIPTION
Faults injected into the counters of an OTBN TLUL adapter manifest as bus integrity violation and not as bad internal state.  This PR fixes `check_sec_cm_fi_resp()` in `otbn_common_vseq` accordingly, resolving failures in the `otbn_sec_cm` test.