### PR TITLE
[otbn, dv] Adds TC to verify missed grant fault in Imem / Dmem

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -151,5 +151,15 @@
       milestone: V2
       tests: ["otbn_sw_errs_fatal_chk"]
     }
+    {
+      name: otbn_mem_gnt_acc_err
+      desc: '''
+              Trigger a fault to cause the IMEM/DMEM grant signal to be false when req is asserted.
+              This in turn should cause dmem_missed_gnt/imem_missed_gnt to get asserted resulting
+              in a fatal alert (a bad_internal_state fatal error).
+            '''
+      milestone: V2S
+      tests: ["otbn_mem_gnt_acc_err"]
+    }
   ]
 }

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -58,6 +58,7 @@ filesets:
       - seq_lib/otbn_sec_wipe_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_urnd_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_sw_no_acc_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_mem_gnt_acc_err_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence to verify the countermeasure(s) PC.CTRL_FLOW.REDUN.
+
+class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
+  `uvm_object_utils(otbn_mem_gnt_acc_err_vseq)
+  `uvm_object_new
+
+  task body();
+    do_end_addr_check = 0;
+    fork
+      begin
+        super.body();
+      end
+      begin
+        inject_gnt_err();
+      end
+    join
+  endtask: body
+
+  task inject_gnt_err();
+    bit req;
+    bit choose_mem;
+    string gnt_path;
+    bit [31:0] err_val = 32'd1 << 20;
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(choose_mem)
+    cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+    case(choose_mem)
+      0: begin // Dmem
+        gnt_path = "tb.dut.u_dmem.gnt_o";
+        `DV_SPINWAIT(
+          do begin
+            @(cfg.clk_rst_vif.cb);
+            uvm_hdl_read("tb.dut.u_dmem.req_i", req);
+          end while(!req);
+        )
+        `DV_CHECK_FATAL(uvm_hdl_force(gnt_path, 0) == 1)
+      end
+      1: begin // Imem
+        gnt_path = "tb.dut.u_imem.gnt_o";
+        `DV_SPINWAIT(
+          do begin
+            @(cfg.clk_rst_vif.cb);
+            uvm_hdl_read("tb.dut.u_imem.req_i", req);
+          end while(!req);
+        )
+        `DV_CHECK_FATAL(uvm_hdl_force(gnt_path, 0) == 1)
+      end
+      default: begin
+        `uvm_fatal(`gfn, "randomization error")
+      end
+    endcase
+      `uvm_info(`gfn, "injecting bad internal state error into ISS", UVM_HIGH)
+      @(cfg.clk_rst_vif.cb);
+      cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+      `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked)
+      `DV_CHECK_FATAL(uvm_hdl_release(gnt_path) == 1);
+      reset_if_locked();
+  endtask: inject_gnt_err
+endclass : otbn_mem_gnt_acc_err_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -26,3 +26,4 @@
 `include "otbn_sec_wipe_err_vseq.sv"
 `include "otbn_urnd_err_vseq.sv"
 `include "otbn_sw_no_acc_vseq.sv"
+`include "otbn_mem_gnt_acc_err_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -310,6 +310,12 @@ name:
       en_run_modes: ["build_otbn_rig_binary_mode"]
       reseed: 5
     }
+    {
+      name: "otbn_mem_gnt_acc_err"
+      uvm_test_seq: "otbn_mem_gnt_acc_err_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 2
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This commit adds a new testcase called otbn_mem_gnt_acc_err to verify
missed grant from Imem and Dmem when there is a request to access the
memory.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>