### PR TITLE
[bazel] Fix argument passing in bitstream splicing rule

### DIFF
--- a/rules/splice.bzl
+++ b/rules/splice.bzl
@@ -18,7 +18,7 @@ def _bitstream_splice_impl(ctx):
         arguments = [
             ctx.file.data.path,
             update.path,
-        ] + ["--swap-nibbles"] if ctx.attr.swap_nybbles else [],
+        ] + (["--swap-nibbles"] if ctx.attr.swap_nybbles else []),
         executable = ctx.executable._tool,
         use_default_shell_env = True,
         execution_requirements = {


### PR DESCRIPTION
Previously, if `ctx.attr.swap_nybbles` is set to `False`, the entire arguments parameter gets passed an empty list.

Signed-off-by: Miles Dai <milesdai@google.com>