### PR TITLE
[topgen, sw/silicon_creator] Generate defines for the MMIO region and use them for configuring ePMP

### DIFF
--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1689,6 +1689,16 @@ typedef enum top_earlgrey_hintable_clocks {
   kTopEarlgreyHintableClocksLast = 3, /**< \internal Last Valid Hintable Clock */
 } top_earlgrey_hintable_clocks_t;
 
+/**
+ * MMIO Region
+ *
+ * MMIO region excludes any memory that is separate from the module
+ * configuration space, i.e. ROM, main SRAM, and flash are excluded but
+ * retention SRAM, spi_device memory, or usbdev memory are included.
+ */
+#define TOP_EARLGREY_MMIO_BASE_ADDR 0x40000000u
+#define TOP_EARLGREY_MMIO_SIZE_BYTES 0x10000000u
+
 // Header Extern Guard
 #ifdef __cplusplus
 }  // extern "C"

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
@@ -913,6 +913,17 @@
  * `TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR + TOP_EARLGREY_RV_CORE_IBEX_CFG_SIZE_BYTES`.
  */
 #define TOP_EARLGREY_RV_CORE_IBEX_CFG_SIZE_BYTES 0x1000
+
+/**
+ * MMIO Region
+ *
+ * MMIO region excludes any memory that is separate from the module
+ * configuration space, i.e. ROM, main SRAM, and flash are excluded but
+ * retention SRAM, spi_device memory, or usbdev memory are included.
+ */
+#define TOP_EARLGREY_MMIO_BASE_ADDR 0x40000000
+#define TOP_EARLGREY_MMIO_SIZE_BYTES 0x10000000
+
 #endif  // __ASSEMBLER__
 
 #endif  // OPENTITAN_HW_TOP_EARLGREY_SW_AUTOGEN_TOP_EARLGREY_MEMORY_H_

--- a/sw/device/silicon_creator/rom/rom_epmp.c
+++ b/sw/device/silicon_creator/rom/rom_epmp.c
@@ -14,6 +14,21 @@ extern char _stack_start[];  // Lowest stack address.
 extern char _text_start[];   // Start of executable code.
 extern char _text_end[];     // End of executable code.
 
+// Note: Hardcoding these values since the way we generate this range is not
+// very robust at the moment. See #14345 and #14336.
+static_assert(TOP_EARLGREY_MMIO_BASE_ADDR == 0x40000000,
+              "MMIO region changed, update ePMP configuration if needed");
+static_assert(TOP_EARLGREY_MMIO_SIZE_BYTES == 0x10000000,
+              "MMIO region changed, update ePMP configuration if needed");
+
+static_assert(TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR >=
+                      TOP_EARLGREY_MMIO_BASE_ADDR &&
+                  TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR +
+                          TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES <
+                      TOP_EARLGREY_MMIO_BASE_ADDR +
+                          TOP_EARLGREY_MMIO_SIZE_BYTES,
+              "Retention SRAM must be in the MMIO address space.");
+
 void rom_epmp_state_init(epmp_state_t *state, lifecycle_state_t lc_state) {
   // Address space definitions.
   //
@@ -27,8 +42,9 @@ void rom_epmp_state_init(epmp_state_t *state, lifecycle_state_t lc_state) {
   const epmp_region_t eflash = {
       .start = TOP_EARLGREY_EFLASH_BASE_ADDR,
       .end = TOP_EARLGREY_EFLASH_BASE_ADDR + TOP_EARLGREY_EFLASH_SIZE_BYTES};
-  // TODO(#7117): generate MMIO addresses.
-  const epmp_region_t mmio = {.start = 0x40000000, .end = 0x50000000};
+  const epmp_region_t mmio = {
+      .start = TOP_EARLGREY_MMIO_BASE_ADDR,
+      .end = TOP_EARLGREY_MMIO_BASE_ADDR + TOP_EARLGREY_MMIO_SIZE_BYTES};
   const epmp_region_t debug_rom = {.start = TOP_EARLGREY_RV_DM_ROM_BASE_ADDR,
                                    .end = TOP_EARLGREY_RV_DM_ROM_BASE_ADDR +
                                           TOP_EARLGREY_RV_DM_ROM_SIZE_BYTES};

--- a/sw/device/silicon_creator/rom/rom_epmp_init.S
+++ b/sw/device/silicon_creator/rom/rom_epmp_init.S
@@ -74,9 +74,9 @@ rom_epmp_init:
   csrw pmpaddr5, t0
 
   // MMIO
-  li   t0, TOR(0x40000000) // TODO(#7117): generate MMIO start address.
+  li   t0, TOR(TOP_EARLGREY_MMIO_BASE_ADDR)
   csrw pmpaddr10, t0
-  li   t0, TOR(0x50000000) // TODO(#7117): generate MMIO end address.
+  li   t0, TOR(TOP_EARLGREY_MMIO_BASE_ADDR + TOP_EARLGREY_MMIO_SIZE_BYTES)
   csrw pmpaddr11, t0
 
   // Debug ROM

--- a/util/topgen/templates/toplevel.h.tpl
+++ b/util/topgen/templates/toplevel.h.tpl
@@ -193,6 +193,16 @@ ${helper.clkmgr_gateable_clocks.render()}
  */
 ${helper.clkmgr_hintable_clocks.render()}
 
+/**
+ * MMIO Region
+ *
+ * MMIO region excludes any memory that is separate from the module
+ * configuration space, i.e. ROM, main SRAM, and flash are excluded but
+ * retention SRAM, spi_device memory, or usbdev memory are included.
+ */
+#define ${helper.mmio.base_addr_name().as_c_define()} ${"0x{:X}u".format(helper.mmio.base_addr)}
+#define ${helper.mmio.size_bytes_name().as_c_define()} ${"0x{:X}u".format(helper.mmio.size_bytes)}
+
 // Header Extern Guard
 #ifdef __cplusplus
 }  // extern "C"

--- a/util/topgen/templates/toplevel_memory.h.tpl
+++ b/util/topgen/templates/toplevel_memory.h.tpl
@@ -78,6 +78,17 @@
  */
 #define ${size_bytes_name} ${hex_size_bytes}
 % endfor
+
+/**
+ * MMIO Region
+ *
+ * MMIO region excludes any memory that is separate from the module
+ * configuration space, i.e. ROM, main SRAM, and flash are excluded but
+ * retention SRAM, spi_device memory, or usbdev memory are included.
+ */
+#define ${helper.mmio.base_addr_name().as_c_define()} ${"0x{:X}".format(helper.mmio.base_addr)}
+#define ${helper.mmio.size_bytes_name().as_c_define()} ${"0x{:X}".format(helper.mmio.size_bytes)}
+
 #endif  // __ASSEMBLER__
 
 #endif  // ${helper.header_macro_prefix}_TOP_${top["name"].upper()}_MEMORY_H_


### PR DESCRIPTION
This is my attempt at fixing #7117. @tjaychen @cfrantz @moidx @mundaym @msfschaffner  plmk if you are comfortable with this or if this looks too fragile.
