### PR TITLE
[dv/chip] implement alert_handler_entropy_test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1251,14 +1251,14 @@
       name: chip_sw_alert_handler_entropy
       desc: '''Verify the alert handler entropy input to ensure pseudo-random ping timer.
 
-            - Force `alert_handler_ping_timer` input signal `wait_cyc_mask_i` to `4'bff` to shorten
-              the simulation time.
+            - Force `alert_handler_ping_timer` input signal `wait_cyc_mask_i` to `16'h07ff` to
+              shorten the simulation time.
             - Verify that the alert_handler can request EDN to provide entropy.
             - Ensure that the alert ping handshake to all alert sources and escalation receivers
               complete without errors.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_alert_handler_entropy"]
     }
     {
       name: chip_sw_alert_handler_crashdump

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -748,6 +748,16 @@
       run_opts: ["+en_scb=0"]
     }
     {
+      name: chip_sw_alert_handler_entropy
+      uvm_test_seq: chip_sw_alert_handler_entropy_vseq
+      sw_images: ["//sw/device/tests/sim_dv:alert_handler_entropy_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      // Disable scoreboard to avoid incorrect alert prediction from the alert_monitor. Due to the
+      // cross-domain alert senders and receivers, the monitor from the chip level did not support
+      // processing alerts accurately from both ends.
+      run_opts: ["+en_scb=0"]
+    }
+    {
       name: chip_sw_aes_entropy
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aes_entropy_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -46,6 +46,7 @@ filesets:
       - seq_lib/chip_tap_straps_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_jtag_base_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_alert_handler_entropy_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_alert_handler_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_clkmgr_escalation_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_full_aon_reset_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_entropy_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_entropy_vseq.sv
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence forces the `wait_cyc_mask` input from alert_handler_ping_timer so alert_handler
+// will send out pings more frequently.
+// Then the sequence waits until all alerts are pinged at least once.
+// Finally it checks alert cause register to make sure there is no error in alert_handler.
+class chip_sw_alert_handler_entropy_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_alert_handler_entropy_vseq)
+
+  `uvm_object_new
+
+  virtual task pre_start();
+    string wait_cyc_mask_path = {`DV_STRINGIFY(`ALERT_HANDLER_HIER),
+                                 ".u_ping_timer.wait_cyc_mask_i"};
+    `DV_CHECK(uvm_hdl_force(wait_cyc_mask_path, 'h7ff))
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    super.body();
+
+    fork begin : isolation_fork
+      int num_alerts = LIST_OF_ALERTS.size();
+      foreach (LIST_OF_ALERTS[i]) begin
+        automatic int index = i;
+        fork begin
+          cfg.m_alert_agent_cfg[LIST_OF_ALERTS[index]].vif.wait_alert_ping();
+          num_alerts--;
+          `uvm_info(`gfn, $sformatf("alert %0s received ping request.\n %0d alerts remaining.",
+                    LIST_OF_ALERTS[index], num_alerts), UVM_LOW);
+        end join_none
+      end
+      wait fork;
+    end join
+
+    cfg.clk_rst_vif.wait_clks($urandom_range(50, 500));
+
+    // Check alert_handler cause registers to make sure there is no error from alert_handler.
+    foreach (ral.alert_handler.alert_cause[i]) begin
+      csr_rd_check(.ptr(ral.alert_handler.alert_cause[i]), .compare_value(0), .backdoor(1));
+    end
+    foreach (ral.alert_handler.loc_alert_cause[i]) begin
+      csr_rd_check(.ptr(ral.alert_handler.loc_alert_cause[i]), .compare_value(0), .backdoor(1));
+    end
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -48,5 +48,6 @@
 `include "chip_sw_rstmgr_alert_info_vseq.sv"
 `include "chip_rv_dm_ndm_reset_vseq.sv"
 `include "chip_sw_alert_handler_escalation_vseq.sv"
+`include "chip_sw_alert_handler_entropy_vseq.sv"
 `include "chip_sw_lc_ctrl_program_error_vseq.sv"
 `include "chip_sw_entropy_src_fuse_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -743,6 +743,24 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "alert_handler_entropy_test",
+    srcs = ["alert_handler_entropy_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey:alert_handler_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "lc_ctrl_program_error",
     srcs = ["lc_ctrl_program_error.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/alert_handler_entropy_test.c
+++ b/sw/device/tests/sim_dv/alert_handler_entropy_test.c
@@ -1,0 +1,91 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "alert_handler_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/*
+  In SV test, force the alert_handler's wait_cyc_mask_i input to shorten the
+  ping request intervals. In C test, configure alert_handler to enable all
+  alerts and local alerts. Then in SV test, wait until all alerts are pinged and
+  check no alerts or local alert errors.
+*/
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_alert_handler_t alert_handler;
+
+static void alert_handler_config(void) {
+  dif_alert_handler_alert_t alerts[ALERT_HANDLER_PARAM_N_ALERTS];
+  dif_alert_handler_class_t alert_classes[ALERT_HANDLER_PARAM_N_ALERTS];
+
+  // Enable all incoming alerts and configure them to classa.
+  // This alert should never fire because we do not expect any incoming alerts.
+  for (int i = 0; i < ALERT_HANDLER_PARAM_N_ALERTS; ++i) {
+    alerts[i] = i;
+    alert_classes[i] = kDifAlertHandlerClassA;
+  }
+
+  // Enable all local alerts and configure them to classb.
+  dif_alert_handler_alert_t loc_alerts[ALERT_HANDLER_PARAM_N_LOC_ALERT];
+  dif_alert_handler_class_t loc_alert_classes[ALERT_HANDLER_PARAM_N_LOC_ALERT];
+  for (int i = 0; i < ALERT_HANDLER_PARAM_N_LOC_ALERT; ++i) {
+    loc_alerts[i] = i;
+    loc_alert_classes[i] = kDifAlertHandlerClassB;
+  }
+
+  dif_alert_handler_escalation_phase_t esc_phases[] = {
+      {.phase = kDifAlertHandlerClassStatePhase0,
+       .signal = 0,
+       .duration_cycles = 2000}};
+
+  dif_alert_handler_class_config_t class_config = {
+      .auto_lock_accumulation_counter = kDifToggleDisabled,
+      .accumulator_threshold = 0,
+      .irq_deadline_cycles = 10000,
+      .escalation_phases = esc_phases,
+      .escalation_phases_len = ARRAYSIZE(esc_phases),
+      .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase1,
+  };
+
+  dif_alert_handler_class_config_t class_configs[] = {class_config,
+                                                      class_config};
+
+  dif_alert_handler_class_t classes[] = {kDifAlertHandlerClassA,
+                                         kDifAlertHandlerClassB};
+  dif_alert_handler_config_t config = {
+      .alerts = alerts,
+      .alert_classes = alert_classes,
+      .alerts_len = ARRAYSIZE(alerts),
+      .local_alerts = loc_alerts,
+      .local_alert_classes = loc_alert_classes,
+      .local_alerts_len = ARRAYSIZE(loc_alerts),
+      .classes = classes,
+      .class_configs = class_configs,
+      .classes_len = ARRAYSIZE(class_configs),
+      .ping_timeout = 1000,
+  };
+
+  alert_handler_testutils_configure_all(&alert_handler, config,
+                                        kDifToggleEnabled);
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_alert_handler_init(
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
+      &alert_handler));
+
+  alert_handler_config();
+  return true;
+}


### PR DESCRIPTION
This PR implements chip level alert_handler_entropy_test with a C test
and a SV sequence.
The C test configures alert_handler, the SV test force alert_handler to
send ping more frequently and make sure all alerts are being pinged at
least once without any error.

This PR implements the chip level item: https://github.com/lowRISC/opentitan/issues/14138

Signed-off-by: Cindy Chen <chencindy@opentitan.org>