### PR TITLE
[rom/functest] use global Ibex exception enum in `rom_epmp_test`

### DIFF
--- a/sw/device/lib/runtime/ibex.h
+++ b/sw/device/lib/runtime/ibex.h
@@ -36,7 +36,7 @@ typedef enum ibex_exc {
   kIbexExcStoreAccessFault = 7,
   kIbexExcUserECall = 8,
   kIbexExcMachineECall = 11,
-  kIbexExcIdMax = 31
+  kIbexExcMax = 31
 } ibex_exc_t;
 
 /**

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -56,7 +56,7 @@ static void generic_fault_print(const char *reason, uint32_t mcause) {
 
 static void generic_fault_handler(void) {
   uint32_t mcause = ibex_mcause_read();
-  generic_fault_print(exception_reason[mcause & kIbexExcIdMax], mcause);
+  generic_fault_print(exception_reason[mcause & kIbexExcMax], mcause);
   abort();
 }
 
@@ -73,7 +73,7 @@ OT_WEAK
 void ottf_exception_handler(void) {
   uint32_t mcause = ibex_mcause_read();
 
-  switch ((ibex_exc_t)(mcause & kIbexExcIdMax)) {
+  switch ((ibex_exc_t)(mcause & kIbexExcMax)) {
     case kIbexExcInstrMisaligned:
       ottf_instr_misaligned_fault_handler();
       break;

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -7,9 +7,7 @@ load("//rules:exclude_files.bzl", "exclude_files")
 load("//rules:linker.bzl", "ld_library")
 load(
     "//rules:opentitan_test.bzl",
-    "cw310_params",
     "opentitan_functest",
-    "verilator_params",
 )
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
@@ -191,6 +189,7 @@ opentitan_functest(
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:sram_ctrl",
         "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing:pinmux_testutils",

--- a/sw/device/tests/rv_core_ibex_address_translation_test.c
+++ b/sw/device/tests/rv_core_ibex_address_translation_test.c
@@ -93,7 +93,7 @@ void ottf_exception_handler(void) {
   uintptr_t ret_addr = *(uintptr_t *)(mepc_stack_addr + OTTF_WORD_SIZE);
 
   uint32_t mcause = ibex_mcause_read();
-  ibex_exc_t exception = mcause & kIbexExcIdMax;
+  ibex_exc_t exception = mcause & kIbexExcMax;
 
   switch (exception) {
     case kIbexExcInstrAccessFault:

--- a/sw/device/tests/sim_dv/sram_ctrl_execution_test_main.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_execution_test_main.c
@@ -128,7 +128,7 @@ void ottf_exception_handler(void) {
            ibex_mepc_read(), ret_addr);
 
   uint32_t mcause = ibex_mcause_read();
-  ibex_exc_t exception = mcause & kIbexExcIdMax;
+  ibex_exc_t exception = mcause & kIbexExcMax;
 
   switch (exception) {
     case kIbexExcInstrAccessFault:


### PR DESCRIPTION
This updates the `rom_epmp_test` to use the shared (global) Ibex
exeception enum in the test, rather than re-defining an equivalent.

Signed-off-by: Timothy Trippel <ttrippel@google.com>