### PR TITLE
[ci] fix bug to run all smoketests in Verilator in CI

### DIFF
--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -7,8 +7,7 @@ set -e
 
 # Increase the test_timeout due to slow performance on CI
 
-./bazelisk.sh query "filter('sim_verilator\_.*\_smoketest', tests(//sw/device/...))" | \
-xargs ci/bazelisk.sh test \
+ci/bazelisk.sh test \
     --build_tests_only=true \
     --test_timeout=2400,2400,3600,-1 \
     --local_test_jobs=4 \
@@ -16,6 +15,8 @@ xargs ci/bazelisk.sh test \
     --test_tag_filters=verilator,-broken \
     --test_output=errors \
     --//hw:verilator_options=--threads,1 \
+    //sw/device/tests:aes_smoketest_sim_verilator \
+    //sw/device/tests:uart_smoketest_sim_verilator \
     //sw/device/tests:crt_test_sim_verilator \
     //sw/device/tests:otbn_randomness_test_sim_verilator \
     //sw/device/tests:otbn_irq_test_sim_verilator \

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1059,6 +1059,9 @@ opentitan_functest(
 opentitan_functest(
     name = "pwrmgr_smoketest",
     srcs = ["pwrmgr_smoketest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",


### PR DESCRIPTION
SW smoketests used to be run in Verilator in CI. However, a bug in the
shell script that runs said tests was not running them. This fixes said
bug and renables these tests to be run in CI.

Signed-off-by: Timothy Trippel <ttrippel@google.com>