### PR TITLE
[ci] Enable skipping FPGA builds for qualified diffs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -409,9 +409,17 @@ jobs:
       downloadPartialBuildBinFrom:
         - cw310_sw_build
   - bash: |
+      ci/scripts/get-bitstream-strategy.sh "@bitstreams//:bitstream_test_rom" ':!/sw/' ':!/*testplan.hjson' ':!/site/' ':!/doc/' ':!/COMMITTERS' ':!/CLA' ':!/*.md' ':!/hw/**/dv/*'
+    displayName: Configure bitstream strategy
+  - bash: |
+      ci/scripts/prepare-cached-bitstream.sh
+    condition: eq(variables.bitstreamStrategy, 'cached')
+    displayName: Prepare cached bitstream
+  - bash: |
       set -e
       module load "xilinx/vivado/$(VIVADO_VERSION)"
       ci/scripts/build-bitstream-vivado.sh top_earlgrey cw310
+    condition: ne(variables.bitstreamStrategy, 'cached')
     displayName: Build bitstream with Vivado
   - bash: |
       . util/build_consts.sh
@@ -420,7 +428,7 @@ jobs:
 
       echo Implementation log
       cat $OBJ_DIR/hw/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.runs/impl_1/runme.log || true
-    condition: always()
+    condition: ne(variables.bitstreamStrategy, 'cached')
     displayName: Display synthesis & implementation logs
   - template: ci/upload-artifacts-template.yml
     parameters:

--- a/ci/scripts/get-bitstream-strategy.sh
+++ b/ci/scripts/get-bitstream-strategy.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+usage_string="
+Usage: get-bitstream-strategy.sh <cached-bitstream-target> [pathspec]...
+
+    cached-bitsream-target The bazel target for the cached bitstream. This script
+                           will retrieve the most recent image from a commit in this
+                           this branch's history.
+    pathspec A git pathspec (multiple instances permitted) indicating which files
+                   trigger building the bitstream. Please use only exclude pathspecs
+                   to cause new, unconsidered paths to trigger the build.
+"
+
+if [ $# -lt 1 ]; then
+  echo >&2 "ERROR: Unexpected number of arguments"
+  echo >&2 "${usage_string}"
+  exit 1
+fi
+
+. util/build_consts.sh
+
+bitstream_target=${*:1:1}
+
+if [ $# -gt 1 ]; then
+  excluded_files=( "${@:2}" )
+else
+  excluded_files=( "." )
+fi
+
+# Retrieve the most recent bitstream at or before HEAD.
+BITSTREAM="--refresh HEAD" ./bazelisk.sh build ${bitstream_target}
+
+# The directory containing the bitstream is named after the git hash.
+bitstream_file=$(ci/scripts/target-location.sh ${bitstream_target})
+bitstream_commit=$(basename "$(dirname ${bitstream_file})")
+
+echo "Checking for changes against pre-built bitstream from ${bitstream_commit}"
+echo "Files changed:"
+git diff --stat --name-only ${bitstream_commit}
+echo
+echo "Changed files after exclusions applied:"
+# Use the cached bitstream if no changed files remain.
+if git diff --exit-code --stat --name-only ${bitstream_commit} -- "${excluded_files[@]}"; then
+  bitstream_strategy=cached
+else
+  bitstream_strategy=build
+fi
+
+echo
+echo "Bitstream strategy is ${bitstream_strategy}"
+echo "##vso[task.setvariable variable=bitstreamStrategy]${bitstream_strategy}"

--- a/ci/scripts/prepare-cached-bitstream.sh
+++ b/ci/scripts/prepare-cached-bitstream.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script currently assumes it is used for chip_earlgrey_cw310.
+
+set -e
+
+. util/build_consts.sh
+
+TOPLEVEL=top_earlgrey
+TARGET=cw310
+
+TOPLEVEL_BIN_DIR="$BIN_DIR/hw/$TOPLEVEL"
+mkdir -p ${TOPLEVEL_BIN_DIR}
+
+BOOTROM_SUFFIX=.scr.39.vmem
+BOOTROM_VMEM_FNAME="test_rom_fpga_$TARGET$BOOTROM_SUFFIX"
+BOOTROM_VMEM="$BIN_DIR/sw/device/lib/testing/test_rom/$BOOTROM_VMEM_FNAME"
+test -f "$BOOTROM_VMEM" || {
+  echo >&2 "No such file: $BOOTROM_VMEM"
+  exit 1
+}
+
+OTP_VMEM_FNAME="otp_img_fpga_$TARGET.vmem"
+OTP_VMEM="$BIN_DIR/sw/device/otp_img/$OTP_VMEM_FNAME"
+test -f "$OTP_VMEM" || {
+  echo >&2 "No such file: $OTP_VMEM"
+  exit 1
+}
+
+bitstream_file=$(ci/scripts/target-location.sh @bitstreams//:bitstream_test_rom)
+otp_mmi_file=$(ci/scripts/target-location.sh @bitstreams//:otp_mmi)
+rom_mmi_file=$(ci/scripts/target-location.sh @bitstreams//:rom_mmi)
+
+# Copy over the cached bitstream and MMI files to BIN_DIR for splicing.
+cp "${bitstream_file}" "${TOPLEVEL_BIN_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+cp "${otp_mmi_file}" "${rom_mmi_file}" "${TOPLEVEL_BIN_DIR}/"
+
+# Splice in the test ROM. Note that OTP splicing is not handled for now.
+util/fpga/splice_rom.sh -t cw310 -T earlgrey -b DV
+
+# Remove extraneous copies.
+rm "${TOPLEVEL_BIN_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice"
+rm "${TOPLEVEL_BIN_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig"

--- a/ci/scripts/target-location.sh
+++ b/ci/scripts/target-location.sh
@@ -32,4 +32,6 @@ fi
 
 REL_PATH=$(${REPO_TOP}/bazelisk.sh outquery "$@" 2>$REDIR)
 readonly REL_PATH
-echo "${REPO_TOP}/${REL_PATH}"
+REPO_EXECROOT=$(${REPO_TOP}/bazelisk.sh info --show_make_env execution_root)
+readonly REPO_EXECROOT
+echo "${REPO_EXECROOT}/${REL_PATH}"

--- a/rules/bitstreams.bzl
+++ b/rules/bitstreams.bzl
@@ -34,7 +34,7 @@ def _bitstreams_repo_impl(rctx):
 # By default, the cache manager will configure the latest available bitstream
 # as the default bitstream.  It will refresh every 18 hours.
 #
-# The behavior of the cache manager can be constrolled via the BITSTREAM
+# The behavior of the cache manager can be controlled via the BITSTREAM
 # environment variable.  The environment variable can be any command line
 # arguments accepted by the cache manager script.
 #

--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -57,7 +57,7 @@ parser.add_argument('--repo',
                     help="Location of the source git repo")
 parser.add_argument(
     'bitstream',
-    default='latest',
+    default='HEAD',
     nargs='?',
     help='Bitstream to retrieve: "latest" or git commit identifier')
 


### PR DESCRIPTION
~Adjust the bitstreams_workspace.py tool to allow avoiding changes to the bazel workspace.~ Adjust the target-location.sh script to specify paths with the bazel execroot. Previously, it relied on the symlinks from the repo workspace root, and this gives only a partial view of the files.

Add scripts to determine the bitstream strategy. Grab the latest FPGA image from the cache, and compare the changes between the current head and the bitstream's commit. Remove files from the diff if they're on an approved exclusion list, and if no changes remain, select the cached bitstream. Otherwise, do the build.

If the cached bitstream is selected, splice in the test ROM from the current build. This allows skipping FPGA builds for test ROM changes as well.

Resolves #13374 