### PR TITLE
[chip dv] Fix chip level DV with Xcelium...again

### DIFF
--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_indefinite_host_seq.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_indefinite_host_seq.sv
@@ -29,7 +29,7 @@ class push_pull_indefinite_host_seq #(parameter int HostDataWidth = 32,
 
   task wait_for_items_processed(int n);
     wait(items_processed >= n);
-  endtask;
+  endtask
 
   virtual task body();
     items_processed = 0;

--- a/hw/dv/sv/sec_cm/prim_count_if.sv
+++ b/hw/dv/sv/sec_cm/prim_count_if.sv
@@ -60,4 +60,5 @@ interface prim_count_if #(
 
     `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
   end
+
 endinterface

--- a/hw/dv/sv/sec_cm/sec_cm_pkg.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_pkg.sv
@@ -25,4 +25,18 @@ package sec_cm_pkg;
 
   // store all the sec_cm proxy classes
   sec_cm_base_if_proxy sec_cm_if_proxy_q[$];
+
+  // Finds and returns a sec_cm interface proxy class instance from the sec_cm_if_proxy_q queue.
+  //
+  // This function matches the first instance whose `path` matches the input argument `path`.
+  // A fatal error is thrown if there is no instance in the queue that matches the path.
+  // TODO: Allow partial path matching with `uvm_re_match`.
+  function automatic sec_cm_base_if_proxy find_sec_cm_if_proxy(string path);
+    sec_cm_base_if_proxy proxies[$];
+    // Search singleton queue of proxies in sec_cm_pkg
+    proxies = sec_cm_pkg::sec_cm_if_proxy_q.find_first() with (item.path == path);
+    if (proxies.size > 0) return proxies[0];
+    else `uvm_fatal(msg_id, $sformatf("find_sec_cm_if_proxy: no proxy with path %s", path))
+  endfunction
+
 endpackage

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -246,14 +246,4 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
               ), UVM_MEDIUM)
   endfunction
 
-
-  // Find sec_cm_base_if_proxy for a given path
-  virtual function sec_cm_base_if_proxy find_sec_cm_base_if_proxy(string path);
-    sec_cm_base_if_proxy proxies[$];
-    // Search singleton queue of proxies in sec_cm_pkg
-    proxies = sec_cm_pkg::sec_cm_if_proxy_q.find_first() with (item.path == path);
-    if (proxies.size > 0) return proxies[0];
-    else `uvm_fatal(`gfn, $sformatf("find_sec_cm_base_if_proxy: no proxy with path %s", path))
-  endfunction
-
 endclass : lc_ctrl_base_vseq

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
@@ -769,36 +769,32 @@ class lc_ctrl_errors_vseq extends lc_ctrl_smoke_vseq;
   // Flip bits in LC FSM registers
   protected virtual task lc_fsm_backdoor_err_inj();
     logic [FsmStateWidth-1:0] state;
-    sec_cm_base_if_proxy if_proxy = find_sec_cm_base_if_proxy(
-        "tb.dut.u_lc_ctrl_fsm.u_fsm_state_regs"
-    );
-
+    sec_cm_base_if_proxy if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(
+        "tb.dut.u_lc_ctrl_fsm.u_fsm_state_regs");
     if_proxy.inject_fault();
   endtask
 
   // Flip bits in KMAC FSM registers
   protected virtual task kmac_fsm_backdoor_err_inj();
     logic [KMAC_FSM_WIDTH-1:0] state;
-    sec_cm_base_if_proxy if_proxy = find_sec_cm_base_if_proxy(
-        "tb.dut.u_lc_ctrl_kmac_if.u_state_regs"
-    );
-
+    sec_cm_base_if_proxy if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(
+        "tb.dut.u_lc_ctrl_kmac_if.u_state_regs");
     if_proxy.inject_fault();
   endtask
 
   // Flip bits in OTP State input
   protected virtual task state_backdoor_err_inj();
     logic [LcStateWidth-1:0] state;
-    sec_cm_base_if_proxy if_proxy = find_sec_cm_base_if_proxy("tb.dut.u_lc_ctrl_fsm.u_state_regs");
-
+    sec_cm_base_if_proxy if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(
+        "tb.dut.u_lc_ctrl_fsm.u_state_regs");
     if_proxy.inject_fault();
   endtask
 
   // Flip bits OTP Count input
   protected virtual task count_backdoor_err_inj();
     logic [LcCountWidth-1:0] count;
-    sec_cm_base_if_proxy if_proxy = find_sec_cm_base_if_proxy("tb.dut.u_lc_ctrl_fsm.u_cnt_regs");
-
+    sec_cm_base_if_proxy if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(
+        "tb.dut.u_lc_ctrl_fsm.u_cnt_regs");
     if_proxy.inject_fault();
   endtask
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1129,5 +1129,10 @@
               "chip_sw_sram_ctrl_main_scrambled_access_jitter_en"
              ]
     }
+    {
+      name: xcelium_ci
+      tests: ["chip_plic_all_irqs"]
+      reseed: 1
+    }
   ]
 }

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -160,11 +160,6 @@ class chip_env extends cip_base_env #(
         )) begin
       `uvm_fatal(`gfn, "failed to get por_rstn_vif from uvm_config_db")
     end
-    if (!uvm_config_db#(virtual prim_count_if)::get(
-            this, "", "clkmgr_prim_count_vif", cfg.clkmgr_prim_count_vif
-        )) begin
-      `uvm_fatal(`gfn, "failed to get clkmgr_prim_count_vif from uvm_config_db")
-    end
 
     // disable alert_esc_agent's driver and only use its monitor
     foreach (LIST_OF_ALERTS[i]) begin

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -31,7 +31,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   virtual pins_if#(1)   ec_rst_vif;
   virtual pins_if#(1)   flash_wp_vif;
   virtual pins_if#(8)   sysrst_ctrl_vif;
-  virtual prim_count_if clkmgr_prim_count_vif;
 
   // pwrmgr probe interface
   virtual pwrmgr_low_power_if   pwrmgr_low_power_vif;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -241,23 +241,22 @@ class chip_sw_base_vseq extends chip_base_vseq;
     `DV_CHECK_EQ_FATAL((sw_byte_q.size % SPI_FRAME_BYTE_SIZE), 0,
                        "SPI data isn't aligned with frame size")
 
-    `DV_SPINWAIT(
-      while (sw_byte_q.size > byte_cnt) begin
-        `uvm_create_on(m_spi_host_seq, p_sequencer.spi_sequencer_h)
-        for (int i = byte_cnt; i < SPI_FRAME_BYTE_SIZE; i++) begin
-          `uvm_info(`gfn, $sformatf("SPI flash data[%0d] = 0x%0x", i, sw_byte_q[i]), UVM_LOW)
-        end
-        `DV_CHECK_RANDOMIZE_WITH_FATAL(m_spi_host_seq,
-                                      data.size() == SPI_FRAME_BYTE_SIZE;
-                                      foreach (data[i]) {data[i] == sw_byte_q[byte_cnt+i];})
-        `uvm_send(m_spi_host_seq)
-        `DV_WAIT(string'(cfg.sw_logger_vif.printed_log) ==
-              $sformatf("Frame #%0d processed done", num_frame))
-        num_frame++;
-
-        byte_cnt += SPI_FRAME_BYTE_SIZE;
+    while (sw_byte_q.size > byte_cnt) begin
+      `uvm_create_on(m_spi_host_seq, p_sequencer.spi_sequencer_h)
+      for (int i = byte_cnt; i < SPI_FRAME_BYTE_SIZE; i++) begin
+        `uvm_info(`gfn, $sformatf("SPI flash data[%0d] = 0x%0x", i, sw_byte_q[i]), UVM_LOW)
       end
-    )
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(m_spi_host_seq,
+                                    data.size() == SPI_FRAME_BYTE_SIZE;
+                                    foreach (data[i]) {data[i] == sw_byte_q[byte_cnt+i];})
+      `uvm_send(m_spi_host_seq)
+      `DV_WAIT(string'(cfg.sw_logger_vif.printed_log) ==
+            $sformatf("Frame #%0d processed done", num_frame))
+      num_frame++;
+
+      byte_cnt += SPI_FRAME_BYTE_SIZE;
+    end
+
   endtask
 
   virtual function void read_sw_frames(string sw_image, ref byte sw_byte_q[$]);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_clkmgr_escalation_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_clkmgr_escalation_reset_vseq.sv
@@ -8,12 +8,19 @@ class chip_sw_clkmgr_escalation_reset_vseq extends chip_sw_base_vseq;
   `uvm_object_new
 
   virtual task body();
+    sec_cm_pkg::sec_cm_base_if_proxy if_proxy;
+
     // This sequence will trigger a fatal sec_cm failure.
     super.body();
 
     `uvm_info(`gfn, "Waiting to inject error", UVM_MEDIUM)
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "Ready for error injection",
              "Timeout waiting for error injection request.")
-    cfg.clkmgr_prim_count_vif.if_proxy.inject_fault();
+
+    // TODO: Find a better way to pass the path. Referencing full chip hierarchies in UVM code
+    // is generally not a good idea.
+    if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(
+        "tb.dut.top_earlgrey.u_clkmgr_aon.u_clk_main_aes_trans.u_idle_cnt");
+    if_proxy.inject_fault();
    endtask
 endclass

--- a/hw/top_earlgrey/dv/env/top_earlgrey_error_injection_ifs_bind.sv
+++ b/hw/top_earlgrey/dv/env/top_earlgrey_error_injection_ifs_bind.sv
@@ -6,5 +6,6 @@
 module top_earlgrey_error_injection_ifs_bind;
 
   // This is used to inject count errors in clkmgr.
-  bind top_earlgrey.u_clkmgr_aon.u_clk_main_aes_trans.u_idle_cnt prim_count_if prim_count_if(.*);
+  bind tb.dut.top_earlgrey.u_clkmgr_aon.u_clk_main_aes_trans.u_idle_cnt prim_count_if
+    prim_count_if(.*);
 endmodule

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -380,10 +380,6 @@ module tb;
     uvm_config_db#(virtual pins_if #(8))::set(
         null, "*.env", "sysrst_ctrl_vif", sysrst_ctrl_if);
 
-    uvm_config_db#(virtual prim_count_if)::set(
-        null, "*.env", "clkmgr_prim_count_vif",
-        dut.top_earlgrey.u_clkmgr_aon.u_clk_main_aes_trans.u_idle_cnt.prim_count_if);
-
     // temp disable pinmux assertion AonWkupReqKnownO_A because driving X in spi_device.sdi and
     // WkupPadSel choose IO_DPS1 in MIO will trigger this assertion
     // TODO: remove this assertion once pinmux is templatized


### PR DESCRIPTION
The first 3 commits are fixes to 3 separate issues. The last commit adds a new regression target for Xcelium CI that will eventually be used to run chip level sims with Xcelium in presubmit CI so that we will no longer have Xcelium related fallouts. One test is added at the moment - it will be scaled up once the backend infra is ready to accept more tests.