### PR TITLE
[test, otbn] Adapt otbn_mem_scramble_test for new ECC integrity error behavior

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -689,7 +689,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_mem_scramble_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15_000_000"]
+      run_opts: ["+sw_test_timeout_ns=15_000_000", "+en_scb_tl_err_chk=0", "+bypass_alert_ready_to_end_check=1"]
     }
     {
       name: chip_sw_rv_core_ibex_rnd

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -165,7 +165,7 @@ dif_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
 dif_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                 void *dest, size_t len_bytes) {
   if (otbn == NULL || dest == NULL ||
-      !check_offset_len(offset_bytes, len_bytes, OTBN_IMEM_SIZE_BYTES)) {
+      !check_offset_len(offset_bytes, len_bytes, OTBN_DMEM_SIZE_BYTES)) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -7,7 +7,7 @@
 
 /**
  * @file
- * @brief <a href="/hw/ip/otbn/doc/">OTBN</a> Device Interface Functions
+ * @brief <a href="/hw/ip/otbn/doc/">OTBN</a> Device Interface Functions.
  */
 
 #include <stddef.h>
@@ -23,7 +23,7 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * OTBN commands
+ * OTBN commands.
  */
 typedef enum dif_otbn_cmd {
   kDifOtbnCmdExecute = 0xd8,
@@ -32,7 +32,7 @@ typedef enum dif_otbn_cmd {
 } dif_otbn_cmd_t;
 
 /**
- * OTBN status
+ * OTBN status.
  */
 typedef enum dif_otbn_status {
   kDifOtbnStatusIdle = 0x00,
@@ -44,7 +44,7 @@ typedef enum dif_otbn_status {
 } dif_otbn_status_t;
 
 /**
- * OTBN Errors
+ * OTBN Errors.
  *
  * OTBN uses a bitfield to indicate which errors have been seen. Multiple errors
  * can be seen at the same time. This enum gives the individual bits that may be
@@ -86,7 +86,7 @@ typedef enum dif_otbn_err_bits {
  * Resets the given OTBN device by setting its configuration registers to
  * reset values. Disables interrupts, output, and input filter.
  *
- * @param otbn OTBN instance
+ * @param otbn OTBN instance.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -105,8 +105,8 @@ dif_result_t dif_otbn_write_cmd(const dif_otbn_t *otbn, dif_otbn_cmd_t cmd);
 /**
  * Gets the current status of OTBN.
  *
- * @param otbn OTBN instance
- * @param[out] status OTBN status
+ * @param otbn OTBN instance.
+ * @param[out] status OTBN status.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -116,7 +116,7 @@ dif_result_t dif_otbn_get_status(const dif_otbn_t *otbn,
 /**
  * Get the error bits set by the device if the operation failed.
  *
- * @param otbn OTBN instance
+ * @param otbn OTBN instance.
  * @param[out] err_bits The error bits returned by the hardware.
  * @return The result of the operation.
  */
@@ -131,7 +131,7 @@ dif_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
  * there is one. Otherwise, gets the number executed in total in the previous
  * OTBN run.
  *
- * @param otbn OTBN instance
+ * @param otbn OTBN instance.
  * @param[out] insn_cnt The number of instructions executed by OTBN.
  * @return The result of the operation.
  */
@@ -139,12 +139,12 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_get_insn_cnt(const dif_otbn_t *otbn, uint32_t *insn_cnt);
 
 /**
- * Write an OTBN application into its instruction memory (IMEM)
+ * Write an OTBN application into its instruction memory (IMEM).
  *
  * Only 32b-aligned 32b word accesses are allowed.
  *
- * @param otbn OTBN instance
- * @param offset_bytes the byte offset in IMEM the first word is written to
+ * @param otbn OTBN instance.
+ * @param offset_bytes the byte offset in IMEM the first word is written to.
  * @param src the main memory location to start reading from.
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
@@ -154,13 +154,13 @@ dif_result_t dif_otbn_imem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                  const void *src, size_t len_bytes);
 
 /**
- * Read from OTBN's instruction memory (IMEM)
+ * Read from OTBN's instruction memory (IMEM).
  *
  * Only 32b-aligned 32b word accesses are allowed.
  *
  * @param otbn OTBN instance
- * @param offset_bytes the byte offset in IMEM the first word is read from
- * @param[out] dest the main memory location to copy the data to (preallocated)
+ * @param offset_bytes the byte offset in IMEM the first word is read from.
+ * @param[out] dest the main memory location to copy the data to (preallocated).
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
  */
@@ -169,12 +169,12 @@ dif_result_t dif_otbn_imem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                 void *dest, size_t len_bytes);
 
 /**
- * Write to OTBN's data memory (DMEM)
+ * Write to OTBN's data memory (DMEM).
  *
  * Only 32b-aligned 32b word accesses are allowed.
  *
- * @param otbn OTBN instance
- * @param offset_bytes the byte offset in DMEM the first word is written to
+ * @param otbn OTBN instance.
+ * @param offset_bytes the byte offset in DMEM the first word is written to.
  * @param src the main memory location to start reading from.
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
@@ -184,13 +184,13 @@ dif_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
                                  const void *src, size_t len_bytes);
 
 /**
- * Read from OTBN's data memory (DMEM)
+ * Read from OTBN's data memory (DMEM).
  *
  * Only 32b-aligned 32b word accesses are allowed.
  *
  * @param otbn OTBN instance
- * @param offset_bytes the byte offset in DMEM the first word is read from
- * @param[out] dest the main memory location to copy the data to (preallocated)
+ * @param offset_bytes the byte offset in DMEM the first word is read from.
+ * @param[out] dest the main memory location to copy the data to (preallocated).
  * @param len_bytes number of bytes to copy.
  * @return The result of the operation.
  */
@@ -204,7 +204,7 @@ dif_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
  * When set any software error becomes a fatal error. The bit can only be
  * changed when the OTBN status is IDLE.
  *
- * @param otbn OTBN instance
+ * @param otbn OTBN instance.
  * @param enable Enable or disable whether software errors are fatal.
  * @return The result of the operation, `kDifUnavailable` is returned when the
  * requested change cannot be made.
@@ -216,16 +216,16 @@ dif_result_t dif_otbn_set_ctrl_software_errs_fatal(const dif_otbn_t *otbn,
 /**
  * Get the size of OTBN's data memory in bytes.
  *
- * @param otbn OTBN instance
- * @return data memory size in bytes
+ * @param otbn OTBN instance.
+ * @return data memory size in bytes.
  */
 size_t dif_otbn_get_dmem_size_bytes(const dif_otbn_t *otbn);
 
 /**
  * Get the size of OTBN's instruction memory in bytes.
  *
- * @param otbn OTBN instance
- * @return instruction memory size in bytes
+ * @param otbn OTBN instance.
+ * @return instruction memory size in bytes.
  */
 size_t dif_otbn_get_imem_size_bytes(const dif_otbn_t *otbn);
 

--- a/sw/device/tests/otbn_mem_scramble_test.c
+++ b/sw/device/tests/otbn_mem_scramble_test.c
@@ -16,12 +16,12 @@ static const otbn_app_t kOtbnAppCfiTest = OTBN_APP_T_INIT(randomness);
 
 OTTF_DEFINE_TEST_CONFIG();
 
-static volatile bool has_exception_fired;
+static volatile bool has_irq_fired;
 
 /**
- * This overrides the default OTTF load/store fault exception handler.
+ * This overrides the default OTTF load integrity handler.
  */
-void ottf_load_store_fault_handler(void) { has_exception_fired = true; }
+void ottf_load_integrity_error_handler(void) { has_irq_fired = true; }
 
 typedef dif_result_t (*otbn_read_t)(const dif_otbn_t *otbn,
                                     uint32_t offset_bytes, void *dest,
@@ -47,15 +47,15 @@ static void otbn_check_mem(otbn_t *ctx, const uint8_t *addr, size_t mem_size,
       remainder = ARRAYSIZE(local_buf);
     }
 
-    // If the memory has been scrambled we will expect to receive an exception,
+    // If the memory has been scrambled we will expect to receive an IRQ,
     // otherwise we compare the memory value.
-    has_exception_fired = false;
+    has_irq_fired = false;
     CHECK_DIF_OK(otbn_read(&ctx->dif, offset, local_buf, remainder));
     if (match_expected) {
-      CHECK(!has_exception_fired, "Unexpected exception");
+      CHECK(!has_irq_fired, "Unexpected IRQ");
       CHECK_ARRAYS_EQ(addr + offset, local_buf, remainder);
     } else {
-      CHECK(has_exception_fired, "Expected exception haven't fired");
+      CHECK(has_irq_fired, "Expected IRQ hasn't fired");
       break;
     }
 


### PR DESCRIPTION
Previously, the test was expecting ECC integrity errors to trigger exceptions in Ibex but instead, these now trigger internal interrupts. In addition, this PR disables some SVA checks related to ECC integrity errors to make sure the test is not aborted early.

Note, this PR does not yet completely fix the otbn_mem_scramble_test but it contained commits are all essential to get the test working. I suggest to merge this and then implement further changes on top.

This is related to https://github.com/lowRISC/opentitan/issues/14196 and https://github.com/lowRISC/opentitan/issues/13974 .