### PR TITLE
[dvsim] Fix bug causing error in existing odirs

### DIFF
--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -600,7 +600,7 @@ def clean_odirs(odir: Path, max_odirs, ts_format=TS_FORMAT):
     if os.path.exists(odir):
         # If output directory exists, back it up.
         ts = datetime.fromtimestamp(os.stat(odir).st_ctime).strftime(ts_format)
-        shutil.move(odir, odir.with_name(ts))
+        shutil.move(odir, Path(odir).with_name(ts))
 
     # Get list of past output directories sorted by creation time.
     pdir = Path(odir).resolve().parent


### PR DESCRIPTION
I think without this, we cannot run same test back to back.

With the current master I am getting this error message:
```
  File "util/dvsim/dvsim.py", line 750, in <module>
    main()
  File "util/dvsim/dvsim.py", line 730, in main
    results = cfg.deploy_objects()
  File "/home/ctopal/projects/opentitan/util/dvsim/FlowCfg.py", line 392, in deploy_objects
    return Scheduler(deploy, get_launcher_cls()).run()
  File "/home/ctopal/projects/opentitan/util/dvsim/Scheduler.py", line 157, in run
    self._dispatch(hms)
  File "/home/ctopal/projects/opentitan/util/dvsim/Scheduler.py", line 463, in _dispatch
    item.launcher.launch()
  File "/home/ctopal/projects/opentitan/util/dvsim/Launcher.py", line 227, in launch
    self._pre_launch()
  File "/home/ctopal/projects/opentitan/util/dvsim/Launcher.py", line 216, in _pre_launch
    self._make_odir()
  File "/home/ctopal/projects/opentitan/util/dvsim/Launcher.py", line 175, in _make_odir
    clean_odirs(odir=self.deploy.odir, max_odirs=self.max_odirs)
  File "/home/ctopal/projects/opentitan/util/dvsim/utils.py", line 603, in clean_odirs
    backup_path = Path(odir.with_name(ts))
AttributeError: 'str' object has no attribute 'with_name'
```

This fix solves the error above.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>