### PR TITLE
[otbn,dv] Fix `otbn_controller_ispr_rdata_err` test

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_alu_bignum_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_alu_bignum_if.sv
@@ -24,18 +24,19 @@ interface otbn_alu_bignum_if (
   endfunction
 
   // Wait for the `mod_used` signal to be high (outside a reset) or until `max_cycles` clock cycles
-  // have passed.  When this task returns, the `success` output is set to `1'b1` if the `mod_used`
-  // signal was high and to `1'b0` otherwise.
-  task automatic wait_for_mod_used(input int unsigned max_cycles, output bit success);
+  // have passed.  When this task returns, the `used_words` output indicates which words are being
+  // used.
+  task automatic wait_for_mod_used(input int unsigned max_cycles,
+                                   output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
     int unsigned cycle_cnt = 0;
     while (1) begin
       @(negedge clk_i);
       if (rst_ni && mod_used) begin
-        success = 1'b1;
+        used_words = '1;
         break;
       end
       if (max_cycles != 0 && cycle_cnt >= max_cycles) begin
-        success = 1'b0;
+        used_words = '0;
         break;
       end
       cycle_cnt++;

--- a/hw/ip/otbn/dv/uvm/env/otbn_controller_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_controller_if.sv
@@ -28,18 +28,19 @@ interface otbn_controller_if
   endfunction
 
   // Wait until some ISPR data is being used (outside a reset) or until `max_cycles` clock cycles
-  // have passed. When this task returns, the `success` output is set to `1'b1` if the data is being
-  // used and to `1'b0` otherwise.
-  task automatic wait_for_ispr_rdata_used(input int unsigned max_cycles, output bit success);
+  // have passed. When this task returns, the `used_words` output indicates which words are being
+  // used.
+  task automatic wait_for_ispr_rdata_used(input int unsigned max_cycles,
+                                          output bit [BaseWordsPerWLEN-1:0] used_words);
     int unsigned cycle_cnt = 0;
     while (1) begin
       @(negedge clk_i);
       if (rst_ni && |ispr_read_mask && non_prefetch_insn_running) begin
-        success = 1'b1;
+        used_words = ispr_read_mask;
         break;
       end
       if (max_cycles != 0 && cycle_cnt >= max_cycles) begin
-        success = 1'b0;
+        used_words = '0;
         break;
       end
       cycle_cnt++;

--- a/hw/ip/otbn/dv/uvm/env/otbn_mac_bignum_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_mac_bignum_if.sv
@@ -32,18 +32,19 @@ interface otbn_mac_bignum_if (
   endfunction
 
   // Wait for the `acc_used` signal to be high (outside a reset) or until `max_cycles` clock cycles
-  // have passed.  When this task returns, the `success` output is set to `1'b1` if the `acc_used`
-  // signal was high and to `1'b0` otherwise.
-  task automatic wait_for_acc_used(input int unsigned max_cycles, output bit success);
+  // have passed.  When this task returns, the `used_words` output indicates which words are being
+  // used.
+  task automatic wait_for_acc_used(input int unsigned max_cycles,
+                                   output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
     int unsigned cycle_cnt = 0;
     while (1) begin
       @(negedge clk_i);
       if (rst_ni && acc_used) begin
-        success = 1'b1;
+        used_words = '1;
         break;
       end
       if (max_cycles != 0 && cycle_cnt >= max_cycles) begin
-        success = 1'b0;
+        used_words = '0;
         break;
       end
       cycle_cnt++;

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_alu_bignum_mod_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_alu_bignum_mod_err_vseq.sv
@@ -10,16 +10,18 @@ class otbn_alu_bignum_mod_err_vseq extends otbn_intg_err_vseq;
 
   `uvm_object_new
 
-  task await_use(output bit used);
-    used = 1'b0;
+  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+    used_words = '0;
     `uvm_info(`gfn, "Waiting for `mod_intg_q` to be used", UVM_LOW)
-    cfg.alu_bignum_vif.wait_for_mod_used(200, used);
+    cfg.alu_bignum_vif.wait_for_mod_used(200, used_words);
   endtask
 
-  task inject_errors(output bit corrupted);
-    bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.alu_bignum_vif.mod_intg_q, 50,
-                                                        corrupted);
-    if (corrupted) begin
+  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+    bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.alu_bignum_vif.mod_intg_q,
+                                                        '{default: 50},
+                                                        corrupted_words);
+    if (corrupted_words != '0) begin
       `uvm_info(`gfn, "Injecting errors into `mod_intg_q` of `otbn_alu_bignum`", UVM_LOW)
       cfg.alu_bignum_vif.force_mod_intg_q(new_data);
     end else begin

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_controller_ispr_rdata_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_controller_ispr_rdata_err_vseq.sv
@@ -10,16 +10,32 @@ class otbn_controller_ispr_rdata_err_vseq extends otbn_intg_err_vseq;
 
   `uvm_object_new
 
-  task await_use(output bit used);
-    used = 1'b0;
+  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+    used_words = '0;
     `uvm_info(`gfn, "Waiting for `ispr_rdata_intg` to be used", UVM_LOW)
-    cfg.controller_vif.wait_for_ispr_rdata_used(200, used);
+    cfg.controller_vif.wait_for_ispr_rdata_used(200, used_words);
   endtask
 
-  task inject_errors(output bit corrupted);
-    bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.controller_vif.ispr_rdata_intg_i, 50,
-                                                        corrupted);
-    if (corrupted) begin
+  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+    int unsigned corrupt_word_pct[otbn_pkg::BaseWordsPerWLEN];
+    bit [otbn_pkg::ExtWLEN-1:0] new_data;
+
+    for (int i_word = 0; i_word < otbn_pkg::BaseWordsPerWLEN; i_word++) begin
+      if (used_words[i_word]) begin
+        // Corrupt used words with a fairly high chance.
+        corrupt_word_pct[i_word] = 75;
+      end else begin
+        // Corrupt unused words with a lower chance.
+        corrupt_word_pct[i_word] = 10;
+      end
+    end
+
+    new_data = corrupt_data(cfg.controller_vif.ispr_rdata_intg_i,
+                            corrupt_word_pct,
+                            corrupted_words);
+
+    if (corrupted_words != '0) begin
       `uvm_info(`gfn, "Injecting errors into `ispr_rdata_intg_i` of `otbn_controller`", UVM_LOW)
       cfg.controller_vif.force_ispr_rdata_intg_i(new_data);
     end else begin

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_intg_err_vseq.sv
@@ -12,39 +12,40 @@ class otbn_intg_err_vseq extends otbn_base_vseq;
   `uvm_object_new
 
   // Wait until the integrity-checked signal is used (otherwise an injected error would not have any
-  // consequences) or an internal timeout expires.  The `used` output indicates whether the signal
-  // was used during the call of this task.
-  protected virtual task await_use(output bit used);
+  // consequences) or an internal timeout expires.  The `used_words` output indicates which words
+  // were used during the call of this task.
+  protected virtual task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
   endtask
 
   // Probabilistically corrupt 1 to 2 bits of each word of `orig_data`, with a probability of
-  // `corrupt_word_pct` (in percent) per word.  The `corrupted` output indicates if any word was
-  // corrupted.
+  // `corrupt_word_pct` (in percent) per word.  The `corrupted_words` output indicates which words
+  // were corrupted.
   protected function bit [otbn_pkg::ExtWLEN-1:0] corrupt_data(
       input bit [otbn_pkg::ExtWLEN-1:0] orig_data,
-      input int unsigned corrupt_word_pct,
-      output bit corrupted
+      input int unsigned corrupt_word_pct[otbn_pkg::BaseWordsPerWLEN],
+      output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words
     );
     bit [otbn_pkg::ExtWLEN-1:0] new_data;
-    corrupted = 1'b0;
     for (int i_word = 0; i_word < otbn_pkg::BaseWordsPerWLEN; i_word++) begin
       bit [BaseIntgWidth-1:0] orig_word = orig_data[i_word*39+:39];
-      bit corrupt_word = $urandom_range(100) < corrupt_word_pct;
+      bit corrupt_word = $urandom_range(100) < corrupt_word_pct[i_word];
       if (corrupt_word) begin
         bit [BaseIntgWidth-1:0] good_word = cfg.fix_integrity_32(orig_word);
         bit [BaseIntgWidth-1:0] mask;
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
         new_data[i_word*39+:39] = good_word ^ mask;
-        corrupted = 1'b1;
+        corrupted_words[i_word] = 1'b1;
       end else begin
         new_data[i_word*39+:39] = orig_word;
+        corrupted_words[i_word] = 1'b0;
       end
     end
     return new_data;
   endfunction
 
   // Inject errors into the integrity-checked signal by `force`ing it.
-  protected virtual task inject_errors(output bit corrupted);
+  protected virtual task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                                       output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
   endtask
 
   // Release the `force`ing of the integrity-checked signal.
@@ -52,11 +53,11 @@ class otbn_intg_err_vseq extends otbn_base_vseq;
   endtask
 
   task body();
-    uvm_reg_data_t    act_val;
-    string            elf_path;
-    bit               used;
-    bit               corrupted;
-    bit [ExtWLEN-1:0] new_data;
+    uvm_reg_data_t             act_val;
+    string                     elf_path;
+    bit [BaseWordsPerWLEN-1:0] used_words;
+    bit [BaseWordsPerWLEN-1:0] corrupted_words;
+    bit [ExtWLEN-1:0]          new_data;
 
     elf_path = pick_elf_path();
     `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
@@ -66,11 +67,11 @@ class otbn_intg_err_vseq extends otbn_base_vseq;
     start_running_otbn(.check_end_addr(1'b0));
 
     // Wait until the register containing the integrity-checked value is being used.
-    await_use(used);
+    await_use(used_words);
 
     // If the binary we are running does not use the integrity-checked register, there is no point
     // in continuing this sequence.
-    if (!used) begin
+    if (used_words == '0) begin
       `uvm_info(`gfn,
           {"Skipping test: we happened to run a binary that does not use ",
           "the register into which we want to inject an integrity error."},
@@ -78,10 +79,10 @@ class otbn_intg_err_vseq extends otbn_base_vseq;
       return;
     end
 
-    inject_errors(corrupted);
+    inject_errors(used_words, corrupted_words);
 
     // Notify the model about the integrity violation error.
-    if (corrupted) begin
+    if (|(corrupted_words & used_words)) begin
       otbn_pkg::err_bits_t err_bits;
       err_bits = '{reg_intg_violation: 1'b1, default: 1'b0};
       cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
@@ -90,27 +91,30 @@ class otbn_intg_err_vseq extends otbn_base_vseq;
     @(cfg.clk_rst_vif.cbn);
     release_force();
 
-    // OTBN should now do a secure wipe. Give it up to 400 cycles to do so (because it needs to go
-    // twice over all registers and reseed URND in between, the time of which depends on the delay
-    // configured in the EDN model).
-    repeat (400) @(cfg.clk_rst_vif.cbn);
+    if (|(corrupted_words & used_words)) begin
+      // OTBN should now do a secure wipe. Give it up to 400 cycles to do so (because it needs to go
+      // twice over all registers and reseed URND in between, the time of which depends on the delay
+      // configured in the EDN model).
+      repeat (400) @(cfg.clk_rst_vif.cbn);
 
-    // We should now be in a locked state after the secure wipe.
-    `DV_CHECK_FATAL(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
+      // We should now be in a locked state after the secure wipe.
+      `DV_CHECK_FATAL(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
 
-    // The scoreboard will have seen the transition to locked state and inferred that it should see
-    // a fatal alert. However, it doesn't really have a way to ensure that we keep generating them.
-    // Wait for 3 fatal alerts and also read STATUS, ERR_BITS and FATAL_ALERT_CAUSE in parallel.
-    fork
-      begin
-        csr_utils_pkg::csr_rd(.ptr(ral.status), .value(act_val));
-        csr_utils_pkg::csr_rd(.ptr(ral.err_bits), .value(act_val));
-        csr_utils_pkg::csr_rd(.ptr(ral.fatal_alert_cause), .value(act_val));
-      end
-      begin
-        repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
-      end
-    join
+      // The scoreboard will have seen the transition to locked state and inferred that it should
+      // see a fatal alert. However, it doesn't really have a way to ensure that we keep generating
+      // them.  Wait for 3 fatal alerts and also read STATUS, ERR_BITS and FATAL_ALERT_CAUSE in
+      // parallel.
+      fork
+        begin
+          csr_utils_pkg::csr_rd(.ptr(ral.status), .value(act_val));
+          csr_utils_pkg::csr_rd(.ptr(ral.err_bits), .value(act_val));
+          csr_utils_pkg::csr_rd(.ptr(ral.fatal_alert_cause), .value(act_val));
+        end
+        begin
+          repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
+        end
+      join
+    end
 
     // Reset and finish sequence.
     do_apply_reset = 1'b1;

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mac_bignum_acc_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mac_bignum_acc_err_vseq.sv
@@ -10,16 +10,18 @@ class otbn_mac_bignum_acc_err_vseq extends otbn_intg_err_vseq;
 
   `uvm_object_new
 
-  task await_use(output bit used);
-    used = 1'b0;
+  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+    used_words = '0;
     `uvm_info(`gfn, "Waiting for `acc_intg_q` to be used", UVM_LOW)
-    cfg.mac_bignum_vif.wait_for_acc_used(200, used);
+    cfg.mac_bignum_vif.wait_for_acc_used(200, used_words);
   endtask
 
-  task inject_errors(output bit corrupted);
-    bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.mac_bignum_vif.acc_intg_q, 50,
-                                                        corrupted);
-    if (corrupted) begin
+  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+    bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.mac_bignum_vif.acc_intg_q,
+                                                        '{default: 50},
+                                                        corrupted_words);
+    if (corrupted_words != '0) begin
       `uvm_info(`gfn, "Injecting errors into `acc_intg_q` of `otbn_mac_bignum`", UVM_LOW)
       cfg.mac_bignum_vif.force_acc_intg_q(new_data);
     end else begin


### PR DESCRIPTION
Since 64bf228e401a5b927f676bfdaf9bef1a1fa6d48e, `otbn_controller`
determines for each word of `ispr_rdata` if that word was used or not
and ignores integrity errors for unused words.
`otbn_controller_ispr_rdata_err_vseq`, however, randomly injected errors
into *any* word of `ispr_rdata_intg_i` and was not aware of used and
unused bytes.  Thus, if the test sequence injected an error into an
unused word, `otbn_controller` correctly ignores it, but the test
signals an expected error to the model, causing a mismatch between model
and RTL and a test failure.

This PR fixes these spurious failures of the
`otbn_controller_ispr_rdata_err` test.  For this, the base class
`otbn_intg_err_vseq` is extended to track used and corrupted words.  It
now only signals an expected error to the model if there are words that
are corrupted *and* used.  The function that randomly corrupts words,
`corrupt_data()` is extended to take a per-word chance of corruption.
This allows to corrupt used words with a higher probability than unused
words (to improve coverage).

The other two test sequences that use the same base class,
`otbn_alu_bignum_mod_err_vseq` and `otbn_mac_bignum_acc_err_vseq` are
updated.  The three interfaces that probe the signals inside the DUT,
`otbn_alu_bignum_if`, `otbn_controller_if`, and `otbn_mac_bignum_if`
are updated to report per-word usage.