### PR TITLE
[dv] Exclude FSM transitions that can only happen on reset

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -150,6 +150,7 @@
   // Project defaults for VCS
   vcs_cov_cfg_file: "{{build_mode}_vcs_cov_cfg_file}"
   vcs_unr_cfg_file: "{dv_root}/tools/vcs/unr.cfg"
+  vcs_fsm_reset_cov_cfg_file: "{dv_root}/tools/vcs/fsm_reset_cov.cfg"
   vcs_cov_excl_files: []
 
   // Build-specific coverage cfg files for VCS.

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -242,6 +242,9 @@
   // Include hierarchies for both code coverage and assertions.
   vcs_cov_cfg_file: ""
 
+  // Supply cov configuration file for -cm_fsmresetfilter.
+  vcs_fsm_reset_cov_cfg_file: ""
+
   // Supply the cov exclusion files.
   vcs_cov_excl_files: []
 
@@ -297,7 +300,9 @@
                    // Coverage database output location
                    "-cm_dir {cov_db_dir}",
                    // The following option is to improve runtime performance
-                   "-Xkeyopt=rtopt"
+                   "-Xkeyopt=rtopt",
+                   // Exclude FSM transitions that can only happen on reset
+                   "-cm_fsmresetfilter {vcs_fsm_reset_cov_cfg_file}",
                    ]
 
       run_opts:   [// Enable the required cov metrics

--- a/hw/dv/tools/vcs/fsm_reset_cov.cfg
+++ b/hw/dv/tools/vcs/fsm_reset_cov.cfg
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is used with -cm_fsmresetfilter to exclude FSM transitions that can only happen on
+// reset.
+// Format: signal=<reset_signal_name> case=TRUE/FALSE (indicates reset is high/low active)
+
+signal=rst_n      case=FALSE
+signal=rst_ni     case=FALSE
+signal=rst_aon_ni case=FALSE


### PR DESCRIPTION
This flow applies to all blocks that runs with VCS
Need to enable xcelium for this too

Signed-off-by: Weicai Yang <weicai@google.com>