### PR TITLE
[top_earlgrey, dv] Allow initializing selected memories with plus arg

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -95,6 +95,8 @@ package chip_env_pkg;
     FlashBank1Data,
     FlashBank0Info,
     FlashBank1Info,
+    OtbnDmem,
+    OtbnImem,
     Otp,
     RamMain[16],
     RamRet[16],

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -69,6 +69,12 @@ class chip_base_vseq #(
     callback_vseq.pre_dut_init();
     // Randomize the ROM image. Subclasses that have an actual ROM image will load it later.
     cfg.mem_bkdr_util_h[Rom].randomize_mem();
+    // Initialize selected memories to all 0. This is required for some chip-level tests such as
+    // otbn_mem_scramble that may intentionally read memories before writing them. Reading these
+    // memories still triggeres ECC integrity errors that need to be handled by the test.
+    cfg.mem_bkdr_util_h[OtbnImem].clear_mem();
+    cfg.mem_bkdr_util_h[OtbnDmem].clear_mem();
+
     // Bring the chip out of reset.
     super.dut_init(reset_kind);
     alert_ping_en_shorten();

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -25,6 +25,7 @@
 `define UART_HIER             `CHIP_HIER.u_uart
 `define USBDEV_HIER           `CHIP_HIER.u_usbdev
 `define PWRMGR_HIER           `CHIP_HIER.u_pwrmgr_aon
+`define OTBN_HIER             `CHIP_HIER.u_otbn
 
 // The path to the actual memory array in rom_ctrl. This is a bit of a hack to allow a long path
 // without overflowing 100 characters or including any whitespace (which breaks a DV_STRINGIFY call
@@ -47,3 +48,5 @@
 `define ROM_MEM_HIER          `ROM_CTRL_HIER.`ROM_CTRL_INT_PATH
 `define OTP_GENERIC_HIER      `OTP_CTRL_HIER.u_otp.gen_generic.u_impl_generic
 `define OTP_MEM_HIER          `OTP_GENERIC_HIER.u_prim_ram_1p_adv.u_mem.`MEM_ARRAY_SUB
+`define OTBN_IMEM_HIER        `OTBN_HIER.u_imem.u_prim_ram_1p_adv.u_mem.`MEM_ARRAY_SUB
+`define OTBN_DMEM_HIER        `OTBN_HIER.u_dmem.u_prim_ram_1p_adv.u_mem.`MEM_ARRAY_SUB

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -504,6 +504,22 @@ module tb;
                                  .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom], `ROM_MEM_HIER)
 
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTBN IMEM", UVM_MEDIUM)
+      m_mem_bkdr_util[OtbnImem] = new(.name  ("mem_bkdr_util[OtbnImem]"),
+                                      .path  (`DV_STRINGIFY(`OTBN_IMEM_HIER)),
+                                      .depth ($size(`OTBN_IMEM_HIER)),
+                                      .n_bits($bits(`OTBN_IMEM_HIER)),
+                                      .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[OtbnImem], `OTBN_IMEM_HIER)
+
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTBN DMEM", UVM_MEDIUM)
+      m_mem_bkdr_util[OtbnDmem] = new(.name  ("mem_bkdr_util[OtbnDmem]"),
+                                      .path  (`DV_STRINGIFY(`OTBN_DMEM_HIER)),
+                                      .depth ($size(`OTBN_DMEM_HIER)),
+                                      .n_bits($bits(`OTBN_DMEM_HIER)),
+                                      .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[OtbnDmem], `OTBN_DMEM_HIER)
+
       mem = mem.first();
       do begin
         if (mem inside {[RamMain1:RamMain15]} || mem inside {[RamRet1:RamRet15]}) begin


### PR DESCRIPTION
For some chip-level tests such as otbn_mem_scramble selected memories may need to be initialized to enable these tests reading the memories before writing. Obviously, this will then trigger ECC integrity errors, this is what these tests usually want to observe. Therefore, this commit adds a plus arg "+init_mems" to initialize OTBN IMEM and DMEM with all 0.

Without initializing these memories, software running on Ibex and OTBN has to write these memories which is rather slow. Otherwise, assertions related to unknown values on the bus will fire and abort the test.

This is related to lowRISC/OpenTitan#14196.