### PR TITLE
[chip,dv,flash_ctrl] rma test failure fix

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -439,7 +439,8 @@
       uvm_test_seq: chip_sw_flash_rma_unlocked_vseq
       sw_images: ["//sw/device/tests/sim_dv:flash_rma_unlocked_test:0:test_in_rom"]
       en_run_modes: ["sw_test_mode_common"]
-      run_opts: ["+sw_test_timeout_ns=200_000_000"]
+      run_opts: ["+sw_test_timeout_ns=150_000_000"]
+      run_timeout_mins: 200
     }
     {
       name: chip_sw_flash_ctrl_clock_freqs

--- a/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
+++ b/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
@@ -27,6 +27,9 @@ static dif_lc_ctrl_t lc;
 
 // TODO(lowRISC/opentitan:#11795): when the sw_symbol_backdoor_overwrite
 // is fixed for ROM, this can be overriden by the testbench as a SW variable.
+// Since rma process takes more than 100ms in dvsim,
+// the test runs 1.6h (110ms in simtime).
+
 static mmio_region_t sram_region_ret_base_addr;
 
 enum {


### PR DESCRIPTION
 rma test was timed out due to not enough time out value.
 In sim dv, rma requires about 110 msec to complete.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>