### PR TITLE
[rom_ctrl] Switch padding scheme to zeroes

### DIFF
--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -358,9 +358,8 @@ class Scrambler:
         '''
         digest_size_words = 8
         initial_len = self.rom_size_words - digest_size_words
-        seed = self.key + self.nonce
 
-        flattened = mem.flatten(initial_len, seed)
+        flattened = mem.flatten(initial_len)
         assert len(flattened.chunks) == 1
         assert len(flattened.chunks[0].words) == initial_len
 


### PR DESCRIPTION
As elaborated in #5771, we decided to switch the padding scheme so that the ROM is padded out with zeroes as opposed to pseudo-random data. This has been deemed the better approach, since confidentiality is not required, and padding out with zero makes sure that there are no "gadget" instructions in invalid ROM regions, since zeroes are interpreted as invalid instructions in Ibex.

Signed-off-by: Michael Schaffner <msf@google.com>