### PR TITLE
[cryptolib] csrng driver

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -20,6 +20,21 @@ cc_library(
     ],
 )
 
+opentitan_functest(
+    name = "aes_test",
+    srcs = ["aes_test.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        ":aes",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 cc_library(
     name = "kmac",
     srcs = ["kmac.c"],
@@ -51,21 +66,6 @@ opentitan_functest(
     deps = [
         ":kmac",
         ":kmac_test_vectors",
-        "//sw/device/lib/base:macros",
-        "//sw/device/lib/base:memory",
-        "//sw/device/lib/testing/test_framework:check",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-    ],
-)
-
-opentitan_functest(
-    name = "aes_test",
-    srcs = ["aes_test.c"],
-    verilator = verilator_params(
-        timeout = "long",
-    ),
-    deps = [
-        ":aes",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -33,6 +33,15 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "kmac_test_vectors",
+    srcs = ["kmac_test_vectors.c"],
+    hdrs = ["kmac_test_vectors.h"],
+    deps = [
+        ":kmac",
+    ],
+)
+
 opentitan_functest(
     name = "kmac_test",
     srcs = ["kmac_test.c"],
@@ -65,11 +74,51 @@ opentitan_functest(
 )
 
 cc_library(
-    name = "kmac_test_vectors",
-    srcs = ["kmac_test_vectors.c"],
-    hdrs = ["kmac_test_vectors.h"],
+    name = "entropy",
+    srcs = ["entropy.c"],
+    hdrs = ["entropy.h"],
     deps = [
-        ":kmac",
+        "//hw/ip/csrng/data:csrng_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+    ],
+)
+
+cc_library(
+    name = "entropy_kat",
+    srcs = ["entropy_kat.c"],
+    hdrs = ["entropy_kat.h"],
+    deps = [
+        ":entropy",
+        "//hw/ip/csrng/data:csrng_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:log",
+    ],
+)
+
+opentitan_functest(
+    name = "entropy_test",
+    srcs = ["entropy_test.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        ":entropy",
+        ":entropy_kat",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
 

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -158,7 +158,7 @@ status_t entropy_csrng_generate_data_get(uint32_t *buf, size_t len) {
     // Block until there is more data available in the genbits buffer. CSRNG
     // generates data in 128bit chunks (i.e. 4 words).
     static_assert(kEntropyCsrngBitsBufferNumWords == 4,
-      "kEntropyCsrngBitsBufferNumWords must be a power of 2.");
+                  "kEntropyCsrngBitsBufferNumWords must be a power of 2.");
     if (i & (kEntropyCsrngBitsBufferNumWords - 1)) {
       uint32_t reg;
       do {

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -1,0 +1,186 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/entropy.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+
+#include "csrng_regs.h"  // Generated
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+enum {
+  kBaseCsrng = TOP_EARLGREY_CSRNG_BASE_ADDR,
+
+  /**
+   * CSRNG genbits buffer size in uint32_t words.
+   */
+  kEntropyCsrngBitsBufferNumWords = 4,
+};
+
+/**
+ * Supported CSRNG application commands.
+ * See https://docs.opentitan.org/hw/ip/csrng/doc/#command-header for
+ * details.
+ */
+// TODO(#14542): Harden csrng/edn command fields.
+typedef enum entropy_csrng_op {
+  kEntropyDrbgOpInstantiate = 1,
+  kEntropyDrbgOpReseed = 2,
+  kEntropyDrbgOpGenerate = 3,
+  kEntropyDrbgOpUpdate = 4,
+  kEntropyDrbgOpUnisntantiate = 5,
+} entropy_csrng_op_t;
+
+/**
+ * CSRNG application interface command header parameters.
+ */
+typedef struct entropy_csrng_cmd {
+  /**
+   * Application command ID.
+   */
+  entropy_csrng_op_t id;
+  /**
+   * Entropy source enable.
+   *
+   * Mapped to flag0 in the hardware command interface.
+   */
+  hardened_bool_t disable_trng_input;
+  const entropy_seed_material_t *seed_material;
+  /**
+   * Generate length. Specified as number of 128bit blocks.
+   */
+  uint32_t generate_len;
+} entropy_csrng_cmd_t;
+
+#define ENTROPY_CMD(m, i) ((bitfield_field32_t){.mask = m, .index = i})
+
+OT_WARN_UNUSED_RESULT
+static status_t csrng_send_app_cmd(uint32_t reg_address,
+                                   entropy_csrng_cmd_t cmd) {
+  uint32_t reg;
+  bool cmd_ready;
+  bool cmd_error;
+  do {
+    reg = abs_mmio_read32(kBaseCsrng + CSRNG_SW_CMD_STS_REG_OFFSET);
+    cmd_ready = bitfield_bit32_read(reg, CSRNG_SW_CMD_STS_CMD_RDY_BIT);
+  } while (!cmd_ready);
+
+  // The application command header is not specified as a register in the
+  // hardware specification, so the fields are mapped here by hand. The
+  // command register also accepts arbitrary 32bit data.
+  static const uint32_t kAppCmdBitFlag0 = 8;
+  static const bitfield_field32_t kAppCmdFieldCmdId = ENTROPY_CMD(0xf, 0);
+  static const bitfield_field32_t kAppCmdFieldCmdLen = ENTROPY_CMD(0xf, 4);
+  static const bitfield_field32_t kAppCmdFieldGlen = ENTROPY_CMD(0x7ffff, 12);
+
+  uint32_t cmd_len = cmd.seed_material == NULL ? 0 : cmd.seed_material->len;
+
+  if (cmd_len & ~kAppCmdFieldCmdLen.mask) {
+    return INTERNAL();
+  }
+
+  // TODO: Consider removing this since the driver will be constructing these
+  // commands internally.
+  // Ensure the `seed_material` array is word-aligned, so it can be loaded to a
+  // CPU register with natively aligned loads.
+  if (cmd.seed_material != NULL &&
+      misalignment32_of((uintptr_t)cmd.seed_material->data) != 0) {
+    return INTERNAL();
+  }
+
+  // Build and write application command header.
+  reg = bitfield_field32_write(0, kAppCmdFieldCmdId, cmd.id);
+  reg = bitfield_field32_write(reg, kAppCmdFieldCmdLen, cmd_len);
+  reg = bitfield_field32_write(reg, kAppCmdFieldGlen, cmd.generate_len);
+
+  if (launder32(cmd.disable_trng_input) == kHardenedBoolTrue) {
+    reg = bitfield_bit32_write(reg, kAppCmdBitFlag0, true);
+  }
+
+  abs_mmio_write32(reg_address, reg);
+
+  for (size_t i = 0; i < cmd_len; ++i) {
+    abs_mmio_write32(reg_address, cmd.seed_material->data[i]);
+  }
+  return OK_STATUS();
+}
+
+status_t entropy_csrng_instantiate(
+    hardened_bool_t disable_trng_input,
+    const entropy_seed_material_t *seed_material) {
+  return csrng_send_app_cmd(kBaseCsrng + CSRNG_CMD_REQ_REG_OFFSET,
+                            (entropy_csrng_cmd_t){
+                                .id = kEntropyDrbgOpInstantiate,
+                                .disable_trng_input = disable_trng_input,
+                                .seed_material = seed_material,
+                                .generate_len = 0,
+                            });
+}
+
+status_t entropy_csrng_reseed(hardened_bool_t disable_trng_input,
+                              const entropy_seed_material_t *seed_material) {
+  return csrng_send_app_cmd(kBaseCsrng + CSRNG_CMD_REQ_REG_OFFSET,
+                            (entropy_csrng_cmd_t){
+                                .id = kEntropyDrbgOpReseed,
+                                .disable_trng_input = disable_trng_input,
+                                .seed_material = seed_material,
+                                .generate_len = 0,
+                            });
+}
+
+status_t entropy_csrng_update(const entropy_seed_material_t *seed_material) {
+  return csrng_send_app_cmd(kBaseCsrng + CSRNG_CMD_REQ_REG_OFFSET,
+                            (entropy_csrng_cmd_t){
+                                .id = kEntropyDrbgOpUpdate,
+                                .seed_material = seed_material,
+                                .generate_len = 0,
+                            });
+}
+
+status_t entropy_csrng_generate_start(
+    const entropy_seed_material_t *seed_material, size_t len) {
+  // Round up the number of 128bit blocks. Aligning with respect to uint32_t.
+  // TODO(#6112): Consider using a canonical reference for alignment operations.
+  const uint32_t num_128bit_blocks = (len + 3) / 4;
+  return csrng_send_app_cmd(kBaseCsrng + CSRNG_CMD_REQ_REG_OFFSET,
+                            (entropy_csrng_cmd_t){
+                                .id = kEntropyDrbgOpGenerate,
+                                .seed_material = seed_material,
+                                .generate_len = num_128bit_blocks,
+                            });
+}
+
+status_t entropy_csrng_generate_data_get(uint32_t *buf, size_t len) {
+  for (size_t i = 0; i < len; ++i) {
+    // Block until there is more data available in the genbits buffer. CSRNG
+    // generates data in 128bit chunks (i.e. 4 words).
+    static_assert(kEntropyCsrngBitsBufferNumWords == 4,
+      "kEntropyCsrngBitsBufferNumWords must be a power of 2.");
+    if (i & (kEntropyCsrngBitsBufferNumWords - 1)) {
+      uint32_t reg;
+      do {
+        reg = abs_mmio_read32(kBaseCsrng + CSRNG_GENBITS_VLD_REG_OFFSET);
+      } while (!bitfield_bit32_read(reg, CSRNG_GENBITS_VLD_GENBITS_VLD_BIT));
+    }
+    buf[i] = abs_mmio_read32(kBaseCsrng + CSRNG_GENBITS_REG_OFFSET);
+  }
+  return OK_STATUS();
+}
+
+status_t entropy_csrng_generate(const entropy_seed_material_t *seed_material,
+                                uint32_t *buf, size_t len) {
+  TRY(entropy_csrng_generate_start(seed_material, len));
+  return entropy_csrng_generate_data_get(buf, len);
+}
+
+status_t entropy_csrng_uninstantiate(void) {
+  return csrng_send_app_cmd(kBaseCsrng + CSRNG_CMD_REQ_REG_OFFSET,
+                            (entropy_csrng_cmd_t){
+                                .id = kEntropyDrbgOpUpdate,
+                                .seed_material = NULL,
+                                .generate_len = 0,
+                            });
+}

--- a/sw/device/lib/crypto/drivers/entropy.h
+++ b/sw/device/lib/crypto/drivers/entropy.h
@@ -1,0 +1,139 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_ENTROPY_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_ENTROPY_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Seed material as specified in NIST SP 800-90Ar1 section 10.2.1.3.1. Up to 12
+ * words of seed material can be provided using this interface.
+ */
+typedef struct entropy_seed_material {
+  /**
+   * Number of words set in `data`. CSRNG will extend the `data` to zeros if the
+   * provided value is less than 12.
+   */
+  size_t len;
+  /**
+   * Seed material in unsigned word format.
+   */
+  uint32_t data[12];
+} entropy_seed_material_t;
+
+/**
+ * Instantiate the SW CSRNG with a new seed value.
+ *
+ * SW CSRNG refers to the CSRNG hardware instance available for software use.
+ *
+ * @param disable_trng_input Set to kHardenedTrue to disable the random seed
+ * data provided by hardware. This enables the use of the CSRNG in deterministic
+ * mode.
+ * @param seed_material Data used to seed the CSRNG. XOR'ed entropy provided by
+ * hardware when `disable_trng_input` is set to `kHardenedFalse`, otherwise used
+ * directly as the seed.
+ * @return Operation status in `status_t` format.
+ */
+OT_WARN_UNUSED_RESULT
+status_t entropy_csrng_instantiate(
+    hardened_bool_t disable_trng_input,
+    const entropy_seed_material_t *seed_material);
+
+/**
+ * Reseed the SW CSRNG.
+ *
+ * @param disable_trng_intput Set to kHardenedTrue to disable the entropy
+ * provided by hardware.
+ * @param seed_material Data used to reseed the CSRNG. XOR'ed with entropy
+ * provided by hardware when `disable_trng_input` is set to `kHardenedFalse`,
+ * otherwise used directly as the seed
+ * @return Operation status in `status_t` format.
+ */
+OT_WARN_UNUSED_RESULT
+status_t entropy_csrng_reseed(hardened_bool_t disable_trng_input,
+                              const entropy_seed_material_t *seed_material);
+
+/**
+ * Update the SW CSRNG state.
+ *
+ * This command does not update the CSRNG internal reseed counter.
+ *
+ * @param seed_material Additional data used in the CSRNG update operation.
+ * There is no additional entropy loaded from hardware.
+ * @return Operation status in `status_t` format.
+ */
+OT_WARN_UNUSED_RESULT
+status_t entropy_csrng_update(const entropy_seed_material_t *seed_material);
+
+/**
+ * Request data from the SW CSRNG.
+ *
+ * Use `entropy_csrng_generate_data_get()` to read the data from the CSRNG
+ * output buffer.
+ *
+ * See `entropy_csrng_generate()` for requesting and reading the CSRNG output in
+ * a single call.
+ *
+ * @param seed_material Additional data used in the CSRNG generate operation.
+ * There is no additional entropy loaded from hardware.
+ * @param len Number of uint32_t words to generate.
+ * @return Operation status in `status_t` format.
+ */
+OT_WARN_UNUSED_RESULT
+status_t entropy_csrng_generate_start(
+    const entropy_seed_material_t *seed_material, size_t len);
+
+/**
+ * Read SW CSRNG output.
+ *
+ * Requires the `entropy_csrng_generate_start()` function to be called in
+ * advance, otherwise the function will block indefinitely.
+ *
+ * @param buf A buffer to fill with words from the CSRNG output buffer.
+ * @param len The number of words to read into `buf`.
+ * @return Operation status in `status_t` format.
+ */
+OT_WARN_UNUSED_RESULT
+status_t entropy_csrng_generate_data_get(uint32_t *buf, size_t len);
+
+/**
+ * Request and read data from the SW CSRNG.
+ *
+ * @param seed_material Additional data used in the CSRNG generate operation.
+ * There is not additional entropy loaded from hardware.
+ * @param buf A buffer to fill with words from the CSRNG output buffer.
+ * @param len The number of words to read into `buf`.
+ * @return Operation status in `status_t` format.
+ */
+OT_WARN_UNUSED_RESULT
+status_t entropy_csrng_generate(const entropy_seed_material_t *seed_material,
+                                uint32_t *buf, size_t len);
+
+/**
+ * Uninstantiate the SW CSRNG.
+ *
+ * Thia operation effectively resets the state of the SW CSRNG instance,
+ * clearing any errors that it may have encountered due to bad command syntax or
+ * entropy source failures.
+ *
+ * @return Operation status in `status_t` format.
+ */
+OT_WARN_UNUSED_RESULT
+status_t entropy_csrng_uninstantiate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_ENTROPY_H_

--- a/sw/device/lib/crypto/drivers/entropy_kat.c
+++ b/sw/device/lib/crypto/drivers/entropy_kat.c
@@ -1,0 +1,165 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include "sw/device/lib/crypto/drivers/entropy_kat.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/runtime/log.h"
+
+#include "csrng_regs.h"  // Generated
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+enum {
+  kBaseCsrng = TOP_EARLGREY_CSRNG_BASE_ADDR,
+};
+
+/**
+ * CSRNG internal state selector ID.
+ */
+typedef enum entropy_csrng_internal_state_id {
+  /**
+   * CSRNG instance assigned to Entropy Distribution Network (EDN) 0.
+   */
+  kCsrngInternalStateIdEdn0 = 0,
+  /**
+   * CSRNG instance assigned to Entropy Distribution Network (EDN) 1.
+   */
+  kCsrngInternalStateIdEdn1 = 1,
+  /**
+   * CSRNG instance assigned to software interface.
+   */
+  kCsrngInternalStateIdSw = 2,
+} entropy_csrng_internal_state_id_t;
+
+/**
+ * CSRNG internal state.
+ */
+typedef struct entropy_csrng_internal_state {
+  /**
+   * Indicates the number of requests for pseudorandom bits since instantiation
+   * or reseeding.
+   */
+  uint32_t reseed_counter;
+  /**
+   * Internal V working state with a 128bit block size.
+   */
+  uint32_t v[4];
+  /**
+   * Internal key used to configure the internal CSRNG cipher.
+   */
+  uint32_t key[8];
+  /**
+   * Set to true when the CSRNG instance has been instantiated.
+   */
+  bool instantiated;
+  /**
+   * Set to true when FIPS compliant entropy was provided directly by the
+   * entropy source to instantiate or reseed the CSRNG instance.
+   */
+  bool fips_compliance;
+} entropy_csrng_internal_state_t;
+
+static void entropy_csrng_internal_state_get(
+    entropy_csrng_internal_state_id_t instance_id,
+    entropy_csrng_internal_state_t *state) {
+  // Select the instance id to read the internal state from, request a state
+  // machine halt, and wait for the internal registers to be ready to be read.
+  uint32_t reg = bitfield_field32_write(
+      0, CSRNG_INT_STATE_NUM_INT_STATE_NUM_FIELD, instance_id);
+  abs_mmio_write32(kBaseCsrng + CSRNG_INT_STATE_NUM_REG_OFFSET, reg);
+
+  // Read the internal state.
+  state->reseed_counter =
+      abs_mmio_read32(kBaseCsrng + CSRNG_INT_STATE_VAL_REG_OFFSET);
+
+  for (size_t i = 0; i < ARRAYSIZE(state->v); ++i) {
+    state->v[i] = abs_mmio_read32(kBaseCsrng + CSRNG_INT_STATE_VAL_REG_OFFSET);
+  }
+
+  for (size_t i = 0; i < ARRAYSIZE(state->key); ++i) {
+    state->key[i] =
+        abs_mmio_read32(kBaseCsrng + CSRNG_INT_STATE_VAL_REG_OFFSET);
+  }
+
+  uint32_t flags = abs_mmio_read32(kBaseCsrng + CSRNG_INT_STATE_VAL_REG_OFFSET);
+
+  // The following bit indexes are defined in
+  // https://docs.opentitan.org/hw/ip/csrng/doc/#working-state-values
+  state->instantiated = bitfield_bit32_read(flags, /*bit_index=*/0u);
+  state->fips_compliance = bitfield_bit32_read(flags, /*bit_index=*/1u);
+}
+
+/**
+ * Checks the CSRNG internal state against `expected` values.
+ *
+ * @param csrng A CSRNG handle.
+ * @param expected Expected CSRNG internal state.
+ */
+static status_t check_internal_state(
+    const entropy_csrng_internal_state_t *expected) {
+  entropy_csrng_internal_state_t got = {0};
+  entropy_csrng_internal_state_get(kCsrngInternalStateIdSw, &got);
+  if (memcmp(&got, expected, sizeof(entropy_csrng_internal_state_t)) == 0) {
+    return OK_STATUS();
+  }
+  return INTERNAL();
+}
+
+status_t entropy_csrng_kat(void) {
+  TRY(entropy_csrng_uninstantiate());
+
+  const entropy_seed_material_t kEntropyInput = {
+      .data = {0x73bec010, 0x9262474c, 0x16a30f76, 0x531b51de, 0x2ee494e5,
+               0xdfec9db3, 0xcb7a879d, 0x5600419c, 0xca79b0b0, 0xdda33b5c,
+               0xa468649e, 0xdf5d73fa},
+      .len = 12,
+  };
+  TRY(entropy_csrng_instantiate(
+      /*disable_trng_input=*/kHardenedBoolTrue, &kEntropyInput));
+
+  const entropy_csrng_internal_state_t kExpectedStateInstantiate = {
+      .reseed_counter = 1,
+      .v = {0x06b8f59e, 0x43c0b2c2, 0x21052502, 0x217b5214},
+      .key = {0x941709fd, 0xd8a25860, 0x861aecf3, 0x98a701a1, 0x0eb2c33b,
+              0x74c08fad, 0x632d5227, 0x8c52f901},
+      .instantiated = true,
+      .fips_compliance = false,
+  };
+  TRY(check_internal_state(&kExpectedStateInstantiate));
+
+  enum {
+    kExpectedOutputLen = 16,
+  };
+
+  uint32_t got[kExpectedOutputLen];
+  TRY(entropy_csrng_generate(/*seed_material=*/NULL, got, kExpectedOutputLen));
+  TRY(entropy_csrng_generate(/*seed_material=*/NULL, got, kExpectedOutputLen));
+
+  const entropy_csrng_internal_state_t kExpectedStateGenerate = {
+      .reseed_counter = 3,
+      .v = {0xe73e3392, 0x7d2e92b1, 0x1a0bac9d, 0x53c78ac6},
+
+      .key = {0x66d1b85a, 0xc19d4dfd, 0x053b73e3, 0xe9dc0f90, 0x3f015bc8,
+              0x4436e5fd, 0x1cccc697, 0x1a1c6e5f},
+      .instantiated = true,
+      .fips_compliance = false,
+  };
+  TRY(check_internal_state(&kExpectedStateGenerate));
+
+  // TODO(#13342): csrng does not provide a linear output order. For example,
+  // note the test vector output word order: 12,13,14,15 8,9,10,11 4,5,6,7
+  // 0,1,2,3.
+  const uint32_t kExpectedOutput[kExpectedOutputLen] = {
+      0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9, 0xdf82ab22, 0x771c619b,
+      0xd40fccb1, 0x87189e99, 0x510494b3, 0x64f7ac0c, 0x2581f391, 0x80b1dc2f,
+      0x793e01c5, 0x87b107ae, 0xdb17514c, 0xa43c41b7,
+  };
+  if (!memcmp(got, kExpectedOutput, sizeof(kExpectedOutput))) {
+    return OK_STATUS();
+  }
+
+  return INTERNAL();
+}

--- a/sw/device/lib/crypto/drivers/entropy_kat.h
+++ b/sw/device/lib/crypto/drivers/entropy_kat.h
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_ENTROPY_KAT_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_ENTROPY_KAT_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Run CTR DRBG Known-Answer-Tests (KATs) on SW CSRNG instance.
+ *
+ * Test vector sourced from NIST's CAVP website:
+ * https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/random-number-generators
+ *
+ * The number format in this docstring follows the CAVP format to simplify
+ * auditing of the implementation.
+ *
+ * Test vector: CTR_DRBG AES-256 no DF.
+ *
+ * - EntropyInput =
+ * df5d73faa468649edda33b5cca79b0b05600419ccb7a879ddfec9db32ee494e5531b51de16a30f769262474c73bec010
+ * - Nonce = EMPTY
+ * - PersonalizationString = EMPTY
+ *
+ * Command: Instantiate
+ * - Key = 8c52f901632d522774c08fad0eb2c33b98a701a1861aecf3d8a25860941709fd
+ * - V   = 217b52142105250243c0b2c206b8f59e
+ *
+ * Command: Generate (first call):
+ * - Key = 72f4af5c93258eb3eeec8c0cacea6c1d1978a4fad44312725f1ac43b167f2d52
+ * - V   = e86f6d07dfb551cebad80e6bf6830ac4
+ *
+ * Command: Generate (second call):
+ * - Key = 1a1c6e5f1cccc6974436e5fd3f015bc8e9dc0f90053b73e3c19d4dfd66d1b85a
+ * - V   = 53c78ac61a0bac9d7d2e92b1e73e3392
+ * - ReturnedBits =
+ * d1c07cd95af8a7f11012c84ce48bb8cb87189e99d40fccb1771c619bdf82ab2280b1dc2f2581f39164f7ac0c510494b3a43c41b7db17514c87b107ae793e01c5
+ *
+ * @return Operation status in `status_t` format.
+ */
+status_t entropy_csrng_kat(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_ENTROPY_KAT_H_

--- a/sw/device/lib/crypto/drivers/entropy_test.c
+++ b/sw/device/lib/crypto/drivers/entropy_test.c
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/drivers/entropy_kat.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+bool test_main(void) {
+  status_t result = entropy_csrng_kat();
+  if (!status_ok(result)) {
+    LOG_ERROR("entropy_csrng_kat: %r\n", result);
+    return false;
+  }
+  return true;
+}

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -81,12 +81,12 @@ opentitan_functest(
     srcs = ["empty_test.c"],
     args = [],
     cw310 = cw310_params(
-        args = [
+        bitstream = "//hw/bitstream:rom",
+        test_cmds = [
             "--bitstream=\"$(location //hw/bitstream:rom)\"",
             "--rom-kind=rom",
             "--rom-ext=\"$(location {flash})\"",
         ],
-        bitstream = "//hw/bitstream:rom",
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
@@ -102,12 +102,12 @@ opentitan_functest(
     srcs = ["chip_specific_startup.c"],
     args = [],
     cw310 = cw310_params(
-        args = [
+        bitstream = "//hw/bitstream:rom",
+        test_cmds = [
             "--bitstream=\"$(location //hw/bitstream:rom)\"",
             "--rom-kind=rom",
             "--bootstrap=\"$(location {flash})\"",
         ],
-        bitstream = "//hw/bitstream:rom",
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,

--- a/util/dvsim_test_runner.sh
+++ b/util/dvsim_test_runner.sh
@@ -11,4 +11,4 @@ set -e
 readonly DVSIM="util/dvsim/dvsim.py"
 
 echo "At this time, dvsim.py must be run manually (after building SW) via:
-${DVSIM} $*"
+${DVSIM} $* ${TEST_CMDS} "

--- a/util/opentitan_functest_runner.sh
+++ b/util/opentitan_functest_runner.sh
@@ -3,8 +3,21 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 #
-# A shell script for executing rust-based tests for functional and e2e tests.
-# The test runner should be passed in as the first argument.
+# A shell script for executing rust-based tests for functional and e2e tests,
+# especially for harnesses built atop opentitanlib.
+#
+# There are three components that make up the harness invocation:
+#   - test harness
+#   - arguments
+#   - test commands
+#
+# The test harness is invoked with arguments first, then the test commands.
+# The test harness and test commands are both passed in by environment variables.
+# Note that bazel passes user-specified test_arg arguments as arguments to this
+# script, and because the user-specified test_arg arguments come after the bazel
+# rule's arguments, they can override the ones coming from the bazel rule.
+# Thus, the test harness and test script represent portions of the invocation
+# that cannot be overridden, but the arguments in the middle can.
 
 set -e
 
@@ -13,5 +26,10 @@ if [ -z "$TEST_HARNESS" ]; then
     exit 1
 fi
 
-echo Invoking test: "${TEST_HARNESS}" "$@"
-RUST_BACKTRACE=1 ${TEST_HARNESS} "$@"
+# eval the environment variable string to break up the components and have bash
+# interpret quotes and other special characters in arguments. This happens
+# during the invocation line.
+eval "TEST_CMDS_ARRAY=( ${TEST_CMDS} )"
+
+echo Invoking test: "${TEST_HARNESS}" "$@" "${TEST_CMDS_ARRAY[@]}"
+RUST_BACKTRACE=1 ${TEST_HARNESS} "$@" "${TEST_CMDS_ARRAY[@]}"


### PR DESCRIPTION
This commit introduces the a driver for the software instance of the
csrng. The driver interface supports regular DRBG functions, i.e.
instantiate, reseed, update and generate functions.

This driver uses the `status.h` module for error reporting/handling.

The focus of this commit is basic functionality. There are a few things that
will be implemented in follow up commits:

- Handling of blocking operations. This is currently an area where we
  need to come up with a strategy for the crypto library as indefinite
  blocking operations may need an unconditional timeout when called in
  higher application layers.
- alert and state checks.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>