### PR TITLE
[dv/sw/top] Re-write entropy_smoketest for better resilience.

### DIFF
--- a/hw/top_earlgrey/dv/chip_smoketests.hjson
+++ b/hw/top_earlgrey/dv/chip_smoketests.hjson
@@ -32,12 +32,12 @@
      sw_images: ["//sw/device/tests:csrng_smoketest:1"]
      en_run_modes: ["sw_test_mode_test_rom"]
     }
-    // TODO(lowrisc/opentitan#10092): Remove dependency on uncontrolled environment.
     {
       name: chip_sw_entropy_src_smoketest
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_smoketest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+rng_srate_value=30"]
     }
     {
       name: chip_sw_gpio_smoketest

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -551,14 +551,6 @@ opentitan_functest(
 opentitan_functest(
     name = "entropy_src_smoketest",
     srcs = ["entropy_src_smoketest.c"],
-    cw310 = cw310_params(
-        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-        tags = ["broken"],
-    ),
-    verilator = verilator_params(
-        timeout = "long",
-        tags = ["broken"],
-    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
@@ -566,6 +558,7 @@ opentitan_functest(
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:entropy_src",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )


### PR DESCRIPTION
fixes #13981

prior to this fix, the entropy_src_smoketest would fail frequently
due to expected values changing. This commit removes the need for a
fixed expected value.

Signed-off-by: Timothy Chen <timothytim@google.com>