### PR TITLE
[dv/kmac] remove KMAC cycle accurate scb [Part2]

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -345,10 +345,10 @@ class kmac_base_vseq extends cip_base_vseq #(
   virtual task check_state();
     bit [TL_DW-1:0] data;
 
+    csr_rd(.ptr(ral.status), .value(data));
+
     csr_rd(.ptr(ral.intr_state), .value(data));
     csr_wr(.ptr(ral.intr_state), .value(data));
-
-    csr_rd(.ptr(ral.status), .value(data));
   endtask
 
   virtual task check_err(bit clear_err = 1'b1);

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -233,6 +233,9 @@ class kmac_smoke_vseq extends kmac_base_vseq;
             check_err();
             csr_utils_pkg::wait_no_outstanding_access();
           end
+
+          // If no error, wait a few cycles until Idle status is reflected to the status register.
+          cfg.clk_rst_vif.wait_clks($urandom_range(5, 10));
         end
       end else begin
         // normal hashing operation


### PR DESCRIPTION
This PR finishes two TODOs:
1). From issue #14286, remove the check where when fifo empty is not
  set, the fifo depth cannot be 0.
2). Re-enable checkings for status register with masked value on FIFO
  status.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>