### PR TITLE
[RDC] Tie BROUT to 0

### DIFF
--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
@@ -10,6 +10,10 @@
 #   1. Reset groups
 #   2. Set Constant
 
+# BROUT to 0 for reset testing
+# BROUT OR-ed with POR_N inside AST. Need to tie to 0 for POR_N to take effect
+set_constant -value 1'b0 u_ast.rglssm_brout
+
 # Set MuBi4False(4'h9) scanmode
 set_constant -value 4'h9 scanmode
 

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -4,21 +4,6 @@
 #
 # Meridian RDC Reset Scenario
 
-###############
-# Reset Group #
-###############
-
-# List of external reset group
-set ext_rst_lst {}
-# POR_N active low
-lappend ext_rst_lst [list { POR_N } {reset low}]
-
-foreach_in_collection j [get_pins top_earlgrey.rstmgr_aon_resets.*] {
-    lappend ext_rst_lst [list [get_attribute ${j} full_name] {reset low}]
-}
-
-set_reset_group $ext_rst_lst -name ext_rst
-
 ###################
 # Reset Scenarios #
 ###################


### PR DESCRIPTION
`u_ast.rglssm_brout` is OR-ed with POR_N. Tying the signal to make POR_N
to take effect.