### PR TITLE
[dvsim] Make sure odir is of type Path

### DIFF
--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -587,7 +587,7 @@ def mk_symlink(path, link):
             rm_path(link)
 
 
-def clean_odirs(odir: Path, max_odirs, ts_format=TS_FORMAT):
+def clean_odirs(odir, max_odirs, ts_format=TS_FORMAT):
     """Clean previous output directories.
 
     When running jobs, we may want to maintain a limited history of
@@ -597,13 +597,15 @@ def clean_odirs(odir: Path, max_odirs, ts_format=TS_FORMAT):
     remain after deletion.
     """
 
+    odir = Path(odir)
+
     if os.path.exists(odir):
         # If output directory exists, back it up.
         ts = datetime.fromtimestamp(os.stat(odir).st_ctime).strftime(ts_format)
-        shutil.move(odir, Path(odir).with_name(ts))
+        shutil.move(odir, odir.with_name(ts))
 
     # Get list of past output directories sorted by creation time.
-    pdir = Path(odir).resolve().parent
+    pdir = odir.resolve().parent
     if not pdir.exists():
         return []
 


### PR DESCRIPTION
I ran into the error below when cancelling a Dvsim run.
Making sure that odir is of type path will fix this.
```
INFO: [FlowCfg] [scratch_path]: [chip] [/workspaces/repo/scratch/master/chip_earlgrey_asic-sim-vcs]
Traceback (most recent call last):
  File "util/dvsim/dvsim.py", line 750, in <module>
    main()
  File "util/dvsim/dvsim.py", line 733, in main
    cfg.gen_results(results)
  File "/workspaces/repo/util/dvsim/FlowCfg.py", line 416, in gen_results
    item.write_results_html(self.results_html_name, item.results_md)
  File "/workspaces/repo/util/dvsim/FlowCfg.py", line 435, in write_results_html
    clean_odirs(odir=self.results_dir, max_odirs=89)
  File "/workspaces/repo/util/dvsim/utils.py", line 603, in clean_odirs
    shutil.move(odir, Path(odir).with_name(ts))
  File "/usr/lib64/python3.6/shutil.py", line 546, in move
    real_dst = os.path.join(dst, _basename(src))
  File "/usr/lib64/python3.6/shutil.py", line 510, in _basename
    return os.path.basename(path.rstrip(sep))
AttributeError: 'PosixPath' object has no attribute 'rstrip'
```
