### PR TITLE
[sw/silicon_creator, ibex] Shrink the initial ePMP RX region at reset

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/ibex_pmp_reset.svh
+++ b/hw/ip/rv_core_ibex/rtl/ibex_pmp_reset.svh
@@ -31,10 +31,13 @@ localparam pmp_cfg_t pmp_cfg_rst[16] = '{
 // Addresses are given in byte granularity for readibility. A minimum of two
 // bits will be stripped off the bottom (PMPGranularity == 0) with more stripped
 // off at coarser granularities.
+//
+// Note: The size of region 2 below must match `_epmp_reset_rx_size` in
+// `sw/device/silicon_creator/rom/rom.ld`
 localparam [33:0] pmp_addr_rst[16] = '{
   34'h00000000, // rgn 0
   34'h00000000, // rgn 1
-  34'h0000bffc, // rgn 2  [ROM: base=0x0000_8000 size=0x8000 (32KiB)]
+  34'h000081fc, // rgn 2  [ROM: base=0x0000_8000 size=0x400 (1KiB)]
   34'h00000000, // rgn 3
   34'h00000000, // rgn 4
   34'h00000000, // rgn 5

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -196,6 +196,19 @@ _start:
          (MULTIBIT_ASM_BOOL4_FALSE << EDN_CTRL_CMD_FIFO_RST_OFFSET)
   sw t0, EDN_CTRL_REG_OFFSET(a0)
 #endif
+  // Remove address space protections by configuring entry 15 as
+  // read-write-execute for the entire address space and then clearing
+  // all other entries.
+  // NOTE: This should happen before attemting to access any address outside
+  // the initial ePMP RX region at reset, e.g. `kDeviceType` which is in
+  // .rodata.
+  li   t0, (0x9f << 24) // Locked NAPOT read-write-execute.
+  csrw pmpcfg3, t0
+  li   t0, 0x7fffffff   // NAPOT encoded region covering entire 34-bit address space.
+  csrw pmpaddr15, t0
+  csrw pmpcfg0, zero
+  csrw pmpcfg1, zero
+  csrw pmpcfg2, zero
 
   // Scramble and initialize main memory (main SRAM).
   // Memory accesses will stall until initialization is complete.
@@ -208,17 +221,6 @@ _start:
   sw    t0, SRAM_CTRL_CTRL_REG_OFFSET(a0)
 
 .L_sram_init_skip:
-  // Remove address space protections by configuring entry 15 as
-  // read-write-execute for the entire address space and then clearing
-  // all other entries.
-  li   t0, (0x9f << 24) // Locked NAPOT read-write-execute.
-  csrw pmpcfg3, t0
-  li   t0, -1           // NAPOT encoded region covering entire 32-bit address space.
-  csrw pmpaddr15, t0
-  csrw pmpcfg0, zero
-  csrw pmpcfg1, zero
-  csrw pmpcfg2, zero
-
   // Zero out the `.bss` segment.
   la   a0, _bss_start
   la   a1, _bss_end

--- a/sw/device/silicon_creator/lib/irq_asm.S
+++ b/sw/device/silicon_creator/lib/irq_asm.S
@@ -7,12 +7,12 @@
 #include "flash_ctrl_regs.h"
 #include "rstmgr_regs.h"
 
-  // Place this code into the .shutdown section together with the other
-  // code that resets the chip.
+  // Place this code into the .crt section to be able to call it early in
+  // the boot process before ePMP is reconfigured.
   //
   // NOTE: The "ax" flag below is necessary to ensure that this section
   // is allocated executable space in ROM by the linker.
-  .section .shutdown, "ax"
+  .section .crt, "ax"
 
   /**
    * Exception handler that is safe to call before the C runtime has been

--- a/sw/device/silicon_creator/rom/rom.ld
+++ b/sw/device/silicon_creator/rom/rom.ld
@@ -24,6 +24,15 @@ INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 _rom_boot_address = ORIGIN(rom);
 
 /**
+ * Size of the initial ePMP RX region at reset. This region must be large
+ * enough to cover the .crt section.
+ *
+ * NOTE: This value must match the size of the RX region in
+ * hw/ip/rv_core_ibex/rtl/ibex_pmp_reset.svh.
+ */
+_epmp_reset_rx_size = 0x400;
+
+/**
  * Symbols to be used in the setup of the address translation for ROM_EXT.
  */
 _rom_ext_virtual_start_address = ORIGIN(rom_ext_virtual);
@@ -92,7 +101,14 @@ SECTIONS {
    * will fit into the instruction encoding.
    */
   .crt : ALIGN(4) {
+    /* Pad with zeros. */
+    FILL(0x0000)
     KEEP(*(.crt))
+    /* .crt must fit in the ePMP RX region at reset. */
+    ASSERT(
+        SIZEOF(.vectors) + SIZEOF(.crt) <= _epmp_reset_rx_size,
+        "Error: .crt overflows reset ePMP region");
+    . = MAX(., _epmp_reset_rx_size - SIZEOF(.vectors));
   } > rom
 
   /**

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -51,7 +51,7 @@
    *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
    */
   .section .vectors, "ax"
-  .balign 256
+  .balignl 256, 0xc0001073
   .global _rom_interrupt_vector_asm
   .type _rom_interrupt_vector_asm, @function
 _rom_interrupt_vector_asm:
@@ -70,7 +70,7 @@ _rom_interrupt_vector_asm:
   /**
    * Post C runtime initialization RISC-V vectored exception/interrupt handlers.
    */
-  .balign 256
+  .balignl 256, 0xc0001073
   .global _rom_interrupt_vector_c
   .type _rom_interrupt_vector_c, @function
 _rom_interrupt_vector_c:
@@ -95,7 +95,7 @@ _rom_interrupt_vector_c:
    * ROM shadow stack.
    */
   .section .bss
-  .balign 4
+  .balignl 4, 0xc0001073
   .global _rom_shadow_stack
   .type _rom_shadow_stack, @object
 _rom_shadow_stack:
@@ -121,7 +121,7 @@ _rom_shadow_stack:
   /**
    * Entry point after reset.
    */
-  .balign 4
+  .balignl 4, 0xc0001073
   .global _rom_start_boot
   .type _rom_start_boot, @function
 _rom_start_boot:


### PR DESCRIPTION
This PR shrinks the initial ePMP RX region at reset and updates the rom linker file to assert that the .crt section fits into this region.

Fixes #5771