### PR TITLE
[bazel] fix chip_sw_uart_smoketest_signed

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -20,7 +20,7 @@
     {
       name: chip_sw_uart_smoketest_signed
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:uart_smoketest:1:signed"]
+      sw_images: ["//sw/device/tests:uart_smoketest_signed:1:signed"]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
     }

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -5,8 +5,17 @@
 load("@//rules:opentitan.bzl", "opentitan_flash_binary", "opentitan_rom_binary")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
-_EXIT_SUCCESS = r"PASS.*\n"
-_EXIT_FAILURE = r"(FAIL|FAULT).*\n"
+OTTF_SUCCESS_MSG = r"PASS.*\n"
+OTTF_FAILURE_MSG = r"(FAIL|FAULT).*\n"
+ROM_BOOT_FAILURE_MSG = "BFV:[0-9a-f]{8}"
+
+# These are defined for positive test cases and should be flipped for negative
+# test cases, i.e., when a test failure is the expected outcome.
+DEFAULT_TEST_SUCCESS_MSG = OTTF_SUCCESS_MSG
+DEFAULT_TEST_FAILURE_MSG = "({})|({})".format(
+    OTTF_FAILURE_MSG,
+    ROM_BOOT_FAILURE_MSG,
+)
 
 _BASE_PARAMS = {
     "args": [],
@@ -17,8 +26,8 @@ _BASE_PARAMS = {
     "tags": [],
     "test_runner": "@//util:opentitan_functest_runner.sh",
     "timeout": "moderate",  # 5 minutes
-    "exit_success": _EXIT_SUCCESS,
-    "exit_failure": _EXIT_FAILURE,
+    "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+    "exit_failure": DEFAULT_TEST_FAILURE_MSG,
 }
 
 def dv_params(

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -4,6 +4,8 @@
 
 load(
     "//rules:opentitan_test.bzl",
+    "DEFAULT_TEST_FAILURE_MSG",
+    "DEFAULT_TEST_SUCCESS_MSG",
     "cw310_params",
     "opentitan_functest",
     "verilator_params",
@@ -11,23 +13,15 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-BOOT_FAILURE_MSG = "BFV:[0-9a-f]{8}"
-
-BOOT_SUCCESS_MSG = "PASS!"
-
 opentitan_functest(
     name = "e2e_bootup_success",
     srcs = ["empty_test.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom",
-        exit_failure = BOOT_FAILURE_MSG,
-        exit_success = BOOT_SUCCESS_MSG,
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
     verilator = verilator_params(
-        exit_failure = BOOT_FAILURE_MSG,
-        exit_success = BOOT_SUCCESS_MSG,
         rom = "//sw/device/silicon_creator/rom",
         # Note: Leaving as broken since this test takes a long time and
         # we don't really need it as long as the CI runs the FPGA version.
@@ -47,8 +41,6 @@ opentitan_functest(
     srcs = ["empty_test.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_dev",
-        exit_failure = BOOT_FAILURE_MSG,
-        exit_success = BOOT_SUCCESS_MSG,
         # TODO(lowRISC/opentitan#13603): Remove this "manual" tag when the
         # bitstream target can fetch pre-spliced bitstream from GCP.
         tags = ["manual"],
@@ -66,13 +58,13 @@ opentitan_functest(
     srcs = ["empty_test.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom",
-        exit_failure = BOOT_SUCCESS_MSG,
-        exit_success = BOOT_FAILURE_MSG,
+        exit_failure = DEFAULT_TEST_SUCCESS_MSG,
+        exit_success = DEFAULT_TEST_FAILURE_MSG,
     ),
     signed = False,
     verilator = verilator_params(
-        exit_failure = BOOT_SUCCESS_MSG,
-        exit_success = BOOT_FAILURE_MSG,
+        exit_failure = DEFAULT_TEST_SUCCESS_MSG,
+        exit_success = DEFAULT_TEST_FAILURE_MSG,
         rom = "//sw/device/silicon_creator/rom",
     ),
     deps = [

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3,7 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")
-load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest", "verilator_params")
+load(
+    "//rules:opentitan_test.bzl",
+    "ROM_BOOT_FAILURE_MSG",
+    "cw310_params",
+    "dv_params",
+    "opentitan_functest",
+    "verilator_params",
+)
 
 # TODO(lowRISC:opentitan#13180): this is a temporary solution to enable writing
 # manufacturer specific tests in the `manufacturer_test_hooks` repository that
@@ -1345,10 +1352,35 @@ opentitan_functest(
 )
 
 opentitan_functest(
-    name = "uart_smoketest",
+    name = "uart_smoketest_signed",
     srcs = ["uart_smoketest.c"],
+    cw310 = cw310_params(
+        bitstream = "//hw/bitstream:rom",
+        exit_failure = ROM_BOOT_FAILURE_MSG,
+    ),
+    dv = dv_params(
+        rom = "//sw/device/silicon_creator/rom",
+    ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
+    verilator = verilator_params(
+        timeout = "eternal",
+        exit_failure = ROM_BOOT_FAILURE_MSG,
+        rom = "//sw/device/silicon_creator/rom",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
+    name = "uart_smoketest",
+    srcs = ["uart_smoketest.c"],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",


### PR DESCRIPTION
This fixes #14210 and gets the signed UART smoketest running in DV sim again. Additionally this demonstrates running a signed test with ROM in DV sim.

Note, the signed UART smoketest took around 27min to run on my workstation, and about 1hr 40min to run in VCS, albeit with dumping of waves (see screenshot below).

<img width="1268" alt="Screen Shot 2022-08-18 at 8 31 17 PM" src="https://user-images.githubusercontent.com/5633066/185539066-1c752355-c295-40a1-85da-27e26a045b92.png">

Signed-off-by: Timothy Trippel <ttrippel@google.com>