### PR TITLE
[dv] use the correct label for e2e_bootup_success test

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -11,7 +11,7 @@
     {
       name: rom_e2e_bootup_success
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/silicon_creator/rom:e2e_bootup_success:1:signed"]
+      sw_images: ["//sw/device/silicon_creator/rom/e2e:e2e_bootup_success:1:signed"]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
     }

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules:opentitan_test.bzl",
     "cw310_params",
+    "dv_params",
     "opentitan_functest",
     "verilator_params",
 )
@@ -22,6 +23,9 @@ opentitan_functest(
         bitstream = "//hw/bitstream:rom",
         exit_failure = BOOT_FAILURE_MSG,
         exit_success = BOOT_SUCCESS_MSG,
+    ),
+    dv = dv_params(
+        rom = "//sw/device/silicon_creator/rom",
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,


### PR DESCRIPTION
This fixes #14209 by fixing the Bazel label that refers to the above
test in the dvsim config file that runs this test.

Signed-off-by: Timothy Trippel <ttrippel@google.com>