### PR TITLE
[otbn,dv] Change string match to uvm_re_match

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -116,7 +116,7 @@ class otbn_common_vseq extends otbn_base_vseq;
       fatal_cause = ral.fatal_alert_cause.reg_intg_violation;
     end else begin
       if (if_proxy.sec_cm_type == SecCmPrimCount &&
-          if_proxy.path.match("^tb\.dut\.u_tlul_adapter_sram_[di]mem.*$")) begin
+          !uvm_re_match("*.u_tlul_adapter_sram_*", if_proxy.path)) begin
         // Faults injected into the counters of an OTBN TLUL adapter manifest as bus integrity
         // violation.
         fatal_cause = ral.fatal_alert_cause.bus_intg_violation;


### PR DESCRIPTION
It looks like in XCelium using string.match is only allowed when
we pass a flag. In other parts of the codebase we use uvm_re_match
and that seems to work with both VCS and XCelium.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>