### PR TITLE
[otbn,rtl] Relax assertions on DMEM and IMEM blanking

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1217,6 +1217,13 @@ module otbn
   `ASSERT(NonIdleDmemReadsZero_A,
           (hw2reg.status.d != StatusIdle) & dmem_rvalid_bus |-> dmem_rdata_bus == 'd0)
 
+  // From the cycle the core is told to start to when it is done, it must always be busy executing,
+  // locking, or both -- even if the core is never done.  We use this property to enable blanking
+  // while the core is executing or locking, and this assertion ensures that there is no gap
+  // between execution and locking.
+  `ASSERT(BusyOrLockingFromStartToDone_A,
+          $rose(start_q) |-> (busy_execute_d | locking) |-> ##[0:$] $rose(done_core))
+
   // Error handling: if we pass an error signal down to the core then we should also be setting an
   // error flag. Note that this uses err_bits, not err_bits_q, because the latter signal only gets
   // asserted when an operation finishes.

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1212,10 +1212,12 @@ module otbn
   // when accessed from the bus. For INSN_CNT, we use "|=>" so that the assertion lines up with
   // "status.q" (a signal that isn't directly accessible here).
   `ASSERT(LockedInsnCntReadsZero_A, (hw2reg.status.d == StatusLocked) |=> insn_cnt == 'd0)
-  `ASSERT(NonIdleImemReadsZero_A,
-          (hw2reg.status.d != StatusIdle) & imem_rvalid_bus |-> imem_rdata_bus == 'd0)
-  `ASSERT(NonIdleDmemReadsZero_A,
-          (hw2reg.status.d != StatusIdle) & dmem_rvalid_bus |-> dmem_rdata_bus == 'd0)
+  `ASSERT(ExecuteOrLockedImemReadsZero_A,
+          (hw2reg.status.d inside {StatusBusyExecute, StatusLocked}) & imem_rvalid_bus
+          |-> imem_rdata_bus == 'd0)
+  `ASSERT(ExecuteOrLockedDmemReadsZero_A,
+          (hw2reg.status.d inside {StatusBusyExecute, StatusLocked}) & dmem_rvalid_bus
+          |-> dmem_rdata_bus == 'd0)
 
   // From the cycle the core is told to start to when it is done, it must always be busy executing,
   // locking, or both -- even if the core is never done.  We use this property to enable blanking


### PR DESCRIPTION
DMEM and IMEM are blanked during execution, during a secure wipe that
ends up in a locked state, and when OTBN is locked.  There are other
non-Idle states, though, so the `NonIdle{D,I}memReadsZero_A` assertions
are not correct.  In particular, DMEM and IMEM are not blanked during
the secure wipe after reset or during the secure wipe after execution
that does not end up in a locked state.  As argued in https://github.com/lowRISC/opentitan/issues/14066, this is
not a problem because DMEM and IMEM are either re-scrambled in this case
(after reset) or would be readable anyway as soon as the secure wipe has
finished.

This PR relaxes the assertion so that it matches the behavior of the
RTL.

This PR also adds an assertion to ensure that there is no gap between
`busy_execute_d` and `locking`, so that an OR combination of those
signals can be used to blank outputs without a risk of slipping a
non-blanked value in any cycle.

This resolves #13896 and it resolves #14195. It also implements Option A of #14066, so that issue will have to be updated to track Option B, which could but does not have to be implemented later.