### PR TITLE
[entropy_src/rtl] Fine-tune SHA3 intake pipline

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -62,7 +62,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   localparam int ObserveFifoDepth = 64;
   localparam int PreCondWidth = 64;
   localparam int Clog2ObserveFifoDepth = $clog2(ObserveFifoDepth);
-  localparam int EsEnableCopies = 37;
+  localparam int EsEnableCopies = 34;
 
   //-----------------------
   // SHA3parameters
@@ -2192,7 +2192,10 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign pfifo_postht_push = ht_esbus_vld_dly_q;
   assign pfifo_postht_wdata = ht_esbus_dly_q;
 
-  assign pfifo_postht_clr = !es_enable_q_fo[23];
+  // For verification purposes, let post-disable data continue through to the SHA engine if it has
+  // made it past the health checks.  This allows scoreboards to use the same data set for the
+  // SHA engine and the health-checks.
+  assign pfifo_postht_clr = health_test_clr;
   assign pfifo_postht_pop = ht_esbus_vld_dly2_q &&
          pfifo_postht_not_empty;
 
@@ -2243,7 +2246,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign hw2reg.fw_ov_rd_fifo_overflow.de = 1'b1;
 
   assign observe_fifo_thresh_met = fw_ov_mode && (observe_fifo_thresh != '0) &&
-         (observe_fifo_thresh <= sfifo_observe_depth) && es_enable_q_fo[24];
+         (observe_fifo_thresh <= sfifo_observe_depth) && es_enable_q_fo[23];
 
   assign hw2reg.observe_fifo_depth.d = sfifo_observe_depth;
 
@@ -2251,7 +2254,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign sfifo_observe_push = fw_ov_mode && pfifo_postht_pop && !sfifo_observe_full &&
                               (sfifo_observe_gate_q || !sfifo_observe_not_empty);
 
-  assign sfifo_observe_clr  = !es_enable_q_fo[25];
+  assign sfifo_observe_clr  = !es_enable_q_fo[24];
 
   assign sfifo_observe_wdata = pfifo_postht_rdata;
 
@@ -2294,7 +2297,10 @@ module entropy_src_core import entropy_src_pkg::*; #(
          (fw_ov_mode_entropy_insert ? fw_ov_wr_data : pfifo_postht_rdata) :
          pfifo_postht_rdata;
 
-  assign pfifo_precon_clr = !es_enable_q_fo[26];
+  // For verification purposes, let post-disable data continue through to the SHA engine if it has
+  // made it past the health checks.  This allows scoreboards to use the same data set for the
+  // SHA engine and the health-checks.
+  assign pfifo_precon_clr = health_test_clr;
   assign pfifo_precon_pop = es_bypass_mode ? pfifo_precon_not_empty :
          (pfifo_precon_not_empty && sha3_msgfifo_ready);
 
@@ -2335,7 +2341,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   assign pfifo_cond_rdata = sha3_state[0][SeedLen-1:0];
   assign pfifo_cond_not_empty = sha3_state_vld;
-  assign sha3_msgfifo_ready = es_enable_q_fo[27] & sha3_msg_rdy & sha3_msg_rdy_mask;
+  assign sha3_msgfifo_ready = sha3_msg_rdy & sha3_msg_rdy_mask;
 
   // SHA3 hashing engine
   sha3 #(
@@ -2413,7 +2419,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign pfifo_bypass_push = pfifo_precon_pop && es_bypass_mode;
   assign pfifo_bypass_wdata = pfifo_precon_rdata;
 
-  assign pfifo_bypass_clr = !es_enable_q_fo[28];
+  assign pfifo_bypass_clr = !es_enable_q_fo[25];
   assign pfifo_bypass_pop =
          (es_bypass_mode && fw_ov_mode_entropy_insert) ? pfifo_bypass_not_empty : bypass_stage_pop;
 
@@ -2432,7 +2438,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     u_entropy_src_main_sm (
     .clk_i                (clk_i),
     .rst_ni               (rst_ni),
-    .enable_i             (es_enable_q_fo[29]),
+    .enable_i             (es_enable_q_fo[26]),
     .fw_ov_ent_insert_i   (fw_ov_mode_entropy_insert),
     .fw_ov_sha3_start_i   (fw_ov_sha3_start_pfe),
     .ht_done_pulse_i      (ht_done_pulse_q),
@@ -2486,14 +2492,14 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .err_o          ()
   );
 
-  assign fips_compliance = !es_bypass_mode && es_enable_q_fo[30] && !rng_bit_en;
+  assign fips_compliance = !es_bypass_mode && es_enable_q_fo[27] && !rng_bit_en;
 
   // fifo controls
   assign sfifo_esfinal_push_enable =
          (es_bypass_mode && fw_ov_mode_entropy_insert) ? pfifo_bypass_not_empty : main_stage_push;
 
   assign sfifo_esfinal_push = sfifo_esfinal_not_full && sfifo_esfinal_push_enable;
-  assign sfifo_esfinal_clr  = !es_enable_q_fo[31];
+  assign sfifo_esfinal_clr  = !es_enable_q_fo[28];
   assign sfifo_esfinal_wdata = {fips_compliance,final_es_data};
   assign sfifo_esfinal_pop = es_route_to_sw ? pfifo_swread_push :
          es_hw_if_fifo_pop;
@@ -2515,7 +2521,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   entropy_src_ack_sm u_entropy_src_ack_sm (
     .clk_i            (clk_i),
     .rst_ni           (rst_ni),
-    .enable_i         (es_enable_q_fo[32]),
+    .enable_i         (es_enable_q_fo[29]),
     .req_i            (es_hw_if_req),
     .ack_o            (es_hw_if_ack),
     .fifo_not_empty_i (sfifo_esfinal_not_empty && !es_route_to_sw),
@@ -2539,7 +2545,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign es_rdata_capt_d = es_rdata_capt_vld ? sfifo_esfinal_rdata[63:0] : es_rdata_capt_q;
 
   assign es_rdata_capt_vld_d =
-         !es_enable_q_fo[33] ? 1'b0 :
+         !es_enable_q_fo[30] ? 1'b0 :
          es_rdata_capt_vld ? 1'b1 :
          es_rdata_capt_vld_q;
 
@@ -2572,11 +2578,11 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign pfifo_swread_push = es_route_to_sw && pfifo_swread_not_full && sfifo_esfinal_not_empty;
   assign pfifo_swread_wdata = esfinal_data;
 
-  assign pfifo_swread_clr = !(es_enable_q_fo[34] && es_data_reg_rd_en);
-  assign pfifo_swread_pop =  es_enable_q_fo[35] && sw_es_rd_pulse;
+  assign pfifo_swread_clr = !(es_enable_q_fo[31] && es_data_reg_rd_en);
+  assign pfifo_swread_pop =  es_enable_q_fo[32] && sw_es_rd_pulse;
 
   // set the es entropy to the read reg
-  assign es_data_reg_rd_en = es_enable_q_fo[36] && efuse_es_sw_reg_en && entropy_data_reg_en_pfe;
+  assign es_data_reg_rd_en = es_enable_q_fo[33] && efuse_es_sw_reg_en && entropy_data_reg_en_pfe;
   assign hw2reg.entropy_data.d = es_data_reg_rd_en ? pfifo_swread_rdata : '0;
   assign sw_es_rd_pulse = es_data_reg_rd_en && reg2hw.entropy_data.re;
 


### PR DESCRIPTION
Since the SHA3 conditioner is not cleared on disable, it is important
in verification to carefully predict which words actually get inserted
into it as disable events occur.

This type of verification problem has already been solved for the health
test statistics.   Therefore this commit lets all samples that have
already been health checked into the SHA engine, so that verification
can use the complete health-checked dataset when predicting conditioning
outputs.

This will also preserve a handful of observe-fifo words that were
previously being marked as "Dropped" by verification.  Also some bypass
words will also be preserved in the pipeline for one additional cycle as
they linger in the precon FIFO, but they will be cleared immediately
afterwards, and thus should not impact verification.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>