### PR TITLE
[entropy_src/rtl] Corrections to Main SM

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -2438,7 +2438,6 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .ht_done_pulse_i      (ht_done_pulse_q),
     .ht_fail_pulse_i      (ht_failed_q),
     .alert_thresh_fail_i  (alert_threshold_fail),
-    .sfifo_esfinal_full_i (sfifo_esfinal_full),
     .rst_alert_cntr_o     (rst_alert_cntr),
     .bypass_mode_i        (es_bypass_mode),
     .main_stage_rdy_i     (pfifo_cond_not_empty),


### PR DESCRIPTION
This commit fixes a number of deviations from spec in the main SM

- The most important fixes come in the exit from the `ContHTRunning`
state.  Previously this state moved to start SHA processing of
the raw entropy at the end of each HT window, regardless of the HT
results.   Errors or alerts were to be handled in later states
as the SHA engine shut down.  This had two big problems:
  1. Data from failing windows would be permitted in the conditioned
     output, rather than being blocked.
  2. Since the SM clears the failure counter and issues the alert
     from different states, there is a possiblity that an alert
     can be cleared before action is taken.  This provides a pathway
     for the _release_ of low-grade entropy, with _no alert_.
- The `CondHTRunning` state also did not go straight to Idle once
  disabled, instead it would close out the SHA processing pipline
  first. (This "clean exit" was also the motivation for moving to SHA
  processing even in HT error condictions).  Unfortunately this is
  the only situation where the SHA is shut down cleanly like this,
  making it hard to predict whether old data will be squeezed from
  the SHA or not.
- Having a full esfinal FIFO would cause the SM to take different
  tranitions than normal.  Given that this condition is impossible
  to predict, this leads to unverifiable outputs.
- Though no data is to be output after the single BOOT mode seed
  is generated, health test data still needs to be processed and
  --unless in FW_OV mode-- alerts need to be signalled.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>