### PR TITLE
[otbn,rtl] Remove locking timing difference for secure wipe

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -367,8 +367,11 @@ module otbn_controller
   // Set the *locking* output when the next state is the *locked* state and no secure wipe is
   // running or there is a URND reseed error.  `locking_o` is thus set only after the secure wipe
   // has completed or if it cannot complete due to an URND reseed error (in which case
-  // `secure_wipe_req_o` and `urnd_reseed_err_i` will remain high).
-  assign locking_o = (state_d == OtbnStateLocked) & (~secure_wipe_req_o | urnd_reseed_err_i);
+  // `secure_wipe_req_o` and `urnd_reseed_err_i` will remain high).  The condition for secure wipe
+  // running involves `secure_wipe_running_i`, which is high for the initial secure wipe, and
+  // `secure_wipe_req_o`, which is high for post-execution secure wipes.
+  assign locking_o = (state_d == OtbnStateLocked) & (~(secure_wipe_running_i | secure_wipe_req_o) |
+                                                     urnd_reseed_err_i);
 
   assign start_secure_wipe = executing & (done_complete | err);
 


### PR DESCRIPTION
When `otbn_controller` enters the *Locked* state during an initial
(i.e., post-reset) secure wipe, it immediately sets the `locking_o`
output. When `otbn_controller` enters the *Locked* state during a
post-execution secure wipe, however, it waits for the secure wipe to
complete before setting the `locking_o` output (see #14269).

This PR changes the `locking_o` signal for the initial secure-wipe
to wait for the secure wipe to complete and thereby aligns it with the
post-execution secure wipe.

This resolves #14269.