### PR TITLE
feat(rdc): POK defined as a reset

### DIFF
--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
@@ -19,3 +19,6 @@ set_constant -value 4'h9 scanmode
 
 # Strap to FuncSel(2'b00)
 set_constant -value 2'b00 top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q
+
+# Define POK as reset
+create_reset -interval 10 -waveform AON_CLK u_ast.vcaon_pok

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -12,9 +12,16 @@
 
 
 # POR_N
-set_reset_scenario { {POR_N {reset { @t0 0 } { #10 1}}}} -name ScnPOR
+# When POR_N released, POK remains high (already released from reset)
+set_reset_scenario { \
+  { POR_N           { reset {#2 0} { #10 1} }} \
+  { u_ast.vcaon_pok { constraint {@t0 1} }} \
+} -name ScnPOR
 
 # AST POK
+set_reset_scenario { \
+  { u_ast.vcaon_pok { reset {@t0 0} { #2 1} } } \
+} -name ScnPOK
 
 # PWRMGR Reset Cause
 


### PR DESCRIPTION
This commit defines `vcaon_pok` as a reset (missed from auto recognition
by tool). POK is released right after Power is provided. So, the reset
scenario for the POK is to release with constraint that POR_N is still
in asserted.

As POK is introduced, POR_N has constraint with POK. There's no chance
POK and POR_N both are released.