### PR TITLE
[dv/chip] Increase run timeout value

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -467,7 +467,6 @@
       uvm_test_seq: chip_sw_lc_ctrl_kmac_reset_vseq
       sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_kmac_reset_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      reseed: 1
     }
     {
       name: chip_sw_lc_walkthrough_dev
@@ -477,7 +476,7 @@
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStDev",
                  // The test takes long time because it will transit to RMA state
                  "+sw_test_timeout_ns=200_000_000"]
-      reseed: 1
+      run_timeout_mins: 240
     }
     {
       name: chip_sw_lc_walkthrough_prod
@@ -487,7 +486,7 @@
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProd",
                  // The test takes long time because it will transit to RMA state
                  "+sw_test_timeout_ns=200_000_000"]
-      reseed: 1
+      run_timeout_mins: 240
     }
     {
       name: chip_sw_lc_walkthrough_prodend
@@ -504,6 +503,7 @@
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStRma",
                  // The test takes long time because it will transit to RMA state
                  "+sw_test_timeout_ns=200_000_000"]
+      run_timeout_mins: 240
     }
     {
       name: chip_sw_lc_walkthrough_testunlocks
@@ -511,7 +511,6 @@
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_testunlocks_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStTestUnlock7"]
-      reseed: 1
     }
     {
       name: chip_sw_rstmgr_sw_req
@@ -951,7 +950,6 @@
       uvm_test_seq: "chip_prim_tl_access_vseq"
       en_run_modes: ["stub_cpu_mode"]
       run_opts: ["+en_scb=0", "+en_scb_tl_err_chk=0"]
-      reseed: 1
     }
     {
       name: chip_plic_all_irqs


### PR DESCRIPTION
For LC transition tests that go into RMA mode, it takes a long time to
erase flash memory and finish chip init. So we increase the run_timeout
value to 4 hours.
This PR also removes the redundant declaration `reseed:1` because it is
default to 1 in chip level test.
This PR fixes issue #14389 

Signed-off-by: Cindy Chen <chencindy@opentitan.org>