### PR TITLE
[sw/entropy] Various clean-up to entropy_testutil

### DIFF
--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -341,7 +341,13 @@ module csrng_cmd_stage import csrng_pkg::*; #(
         cmd_stage_sm_err_o = 1'b1;
       end
       default: state_d = Error;
-    endcase
+    endcase // unique case (state_q)
+
+    // if disable, cycle back to Idle
+    if (!cs_enable_i && state_q != Idle) begin
+      state_d = Idle;
+    end
+
   end
 
   //---------------------------------------------------------

--- a/sw/device/lib/dif/dif_edn.c
+++ b/sw/device/lib/dif/dif_edn.c
@@ -342,6 +342,12 @@ dif_result_t dif_edn_stop(const dif_edn_t *edn) {
 
   mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, EDN_CTRL_REG_RESVAL);
 
+  // clear command fifo, see #14506
+  uint32_t reg = bitfield_field32_write(
+      EDN_CTRL_REG_RESVAL, EDN_CTRL_CMD_FIFO_RST_FIELD, kMultiBitBool4True);
+  mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, reg);
+  mmio_region_write32(edn->base_addr, EDN_CTRL_REG_OFFSET, EDN_CTRL_REG_RESVAL);
+
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_edn_unittest.cc
+++ b/sw/device/lib/dif/dif_edn_unittest.cc
@@ -364,6 +364,10 @@ TEST_F(StopTest, BadArgs) { EXPECT_DIF_BADARG(dif_edn_stop(nullptr)); }
 TEST_F(StopTest, Stop) {
   EXPECT_READ32(EDN_REGWEN_REG_OFFSET, 1);
   EXPECT_WRITE32(EDN_CTRL_REG_OFFSET, EDN_CTRL_REG_RESVAL);
+  uint32_t ctrl_reg = bitfield_field32_write(
+      EDN_CTRL_REG_RESVAL, EDN_CTRL_CMD_FIFO_RST_FIELD, kMultiBitBool4True);
+  EXPECT_WRITE32(EDN_CTRL_REG_OFFSET, ctrl_reg);
+  EXPECT_WRITE32(EDN_CTRL_REG_OFFSET, EDN_CTRL_REG_RESVAL);
   EXPECT_DIF_OK(dif_edn_stop(&edn_));
 }
 

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -469,6 +469,16 @@ typedef enum dif_entropy_src_error {
 } dif_entropy_src_error_t;
 
 /**
+ * Stops the current mode of operation and disables the entropy_src module
+ *
+ *
+ * @param entropy_src An entropy source handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_stop(const dif_entropy_src_t *entropy_src);
+
+/**
  * Configures entropy source with runtime information.
  *
  * This function should only need to be called once for the lifetime of the

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -27,7 +27,7 @@ class ConfigTest : public EntropySrcTest {
       .fips_enable = false,
       .route_to_firmware = false,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
-  };
+      .health_test_window_size = 1};
 };
 
 TEST_F(ConfigTest, NullHandle) {
@@ -154,10 +154,10 @@ INSTANTIATE_TEST_SUITE_P(
         ConfigParams{false, false, kDifEntropySrcSingleBitMode3, false, 64, 2,
                      kDifToggleEnabled},
         // Test alerts disabled.
-        ConfigParams{false, false, kDifEntropySrcSingleBitMode0, false, 0, 0,
+        ConfigParams{false, false, kDifEntropySrcSingleBitMode0, false, 1, 0,
                      kDifToggleDisabled},
         // Test all disabled.
-        ConfigParams{false, false, kDifEntropySrcSingleBitMode0, false, 0, 2,
+        ConfigParams{false, false, kDifEntropySrcSingleBitMode0, false, 1, 2,
                      kDifToggleDisabled},
         // Test all enabled.
         ConfigParams{true, true, kDifEntropySrcSingleBitMode0, true, 32, 2,

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -78,6 +78,8 @@ static void setup_entropy_src(void) {
       .fips_enable = true,
       .route_to_firmware = false,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+      .health_test_window_size = 0x0200, /*default*/
+      .alert_threshold = 2,              /*default*/
   };
   CHECK_DIF_OK(
       dif_entropy_src_configure(&entropy_src, config, kDifToggleEnabled));

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -213,6 +213,7 @@ void test_initialize(entropy_src_test_context_t *ctx) {
 
   mmio_region_t addr =
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR);
+  CHECK_DIF_OK(dif_entropy_src_init(addr, &ctx->entropy_src));
 
   addr = mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR);
   CHECK_DIF_OK(dif_rv_core_ibex_init(addr, &ctx->ibex));
@@ -240,6 +241,10 @@ void test_initialize(entropy_src_test_context_t *ctx) {
   alert_handler_configure(ctx);
 
   entropy_testutils_auto_mode_init();
+
+  // ensure health tests are actually running
+  entropy_testutils_wait_for_state(&ctx->entropy_src,
+                                   kDifEntropySrcMainFsmStateContHTRunning);
 }
 
 /**

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -209,8 +209,6 @@ static void alert_handler_test(entropy_src_test_context_t *ctx) {
 void test_initialize(entropy_src_test_context_t *ctx) {
   LOG_INFO("%s", __func__);
 
-  entropy_testutils_boot_mode_init();
-
   mmio_region_t addr =
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR);
   CHECK_DIF_OK(dif_entropy_src_init(addr, &ctx->entropy_src));


### PR DESCRIPTION
- the previous entropy_src_edn_req_test set the health check window to 0, which
  created all kinds of articifical entropy behavior that
  ended up masking other problems.  Set the window count
  to default.
- Add back state polling to ensure healthchecks are actually
  running.
- remove entropy_testutil's direct access to entropy complex registers
- added dis_entropy_src_stop to emulate the function in edn / csrng
- sever the dependency between entropy_testutil_boot_mode and auto_mode
- edn1 is currently set to reseed once every 4 generates, this is because
  if it were set to 1, artificial test conditions could end up significantly
  stalling entropy distribution due to https://github.com/lowRISC/opentitan/issues/14505.
