### PR TITLE
[chip dv] Enhance SW symbol override functionality

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -8,6 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:systems:top_earlgrey
+      - lowrisc:systems:top_earlgrey_pkg
       - lowrisc:systems:chip_earlgrey_asic
       - lowrisc:ibex:ibex_tracer
 

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -392,4 +392,19 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     end
   endfunction
 
+  // Returns the chip memory instance to which the address belongs.
+  virtual function bit get_mem_from_addr(input uint addr, output chip_mem_e mem);
+    chip_mem_e mem_iter = mem_iter.first();
+    do begin
+      if (mem_bkdr_util_h[mem_iter] != null) begin
+        if (mem_bkdr_util_h[mem_iter].is_valid_addr(addr)) begin
+          mem = mem_iter;
+          return 1;
+        end
+      end
+      mem_iter = mem_iter.next();
+    end while (mem_iter != mem_iter.first());
+    return 0;
+  endfunction
+
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
@@ -263,7 +263,7 @@ class chip_sw_flash_init_vseq extends chip_sw_base_vseq;
     for (int current_phase = 0; current_phase < NUM_TEST_PHASES; current_phase++) begin
       // Backdoor overwrite the SW variable for the test phase.
       array_data[0] = current_phase;
-      sw_symbol_backdoor_overwrite("kTestPhase", array_data, Rom, SwTypeRom);
+      sw_symbol_backdoor_overwrite("kTestPhase", array_data, SwTypeRom);
       if (current_phase < NUM_TEST_PHASES - 1) begin
         // Backdoor write to the flash only for the backdoor tests.
         if (current_phase < BACKDOOR_TEST0) begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_rma_unlocked_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_rma_unlocked_vseq.sv
@@ -81,7 +81,7 @@ class chip_sw_flash_rma_unlocked_vseq extends chip_sw_base_vseq;
 
   virtual task cpu_init();
     super.cpu_init();
-    sw_symbol_backdoor_overwrite("kLcRmaUnlockToken", rma_unlock_token, Rom, SwTypeRom);
+    sw_symbol_backdoor_overwrite("kLcRmaUnlockToken", rma_unlock_token, SwTypeRom);
   endtask
 
   virtual task body();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
@@ -22,8 +22,9 @@ class chip_sw_gpio_smoke_vseq extends chip_sw_base_vseq;
   function void pre_randomize();
     int addr;
     // Find how many bytes the SW allocate for SW_SYM_GPIO_VALS, then convert to word size.
-    sw_symbol_get_addr_size({p_sequencer.cfg.sw_images[SwTypeTest], ".elf"},
-                            SW_SYM_GPIO_VALS, addr, num_gpio_vals);
+    void'(sw_symbol_get_addr_size(.elf_file({p_sequencer.cfg.sw_images[SwTypeTest], ".elf"}),
+                                  .symbol(SW_SYM_GPIO_VALS), .does_not_exist_ok(0), .addr(addr),
+                                  .size(num_gpio_vals)));
     num_gpio_vals /= 4;
   endfunction
 

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -442,7 +442,8 @@ module tb;
           .path  (`DV_STRINGIFY(`FLASH0_DATA_MEM_HIER)),
           .depth ($size(`FLASH0_DATA_MEM_HIER)),
           .n_bits($bits(`FLASH0_DATA_MEM_HIER)),
-          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
+          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68),
+          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_EFLASH_BASE_ADDR));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank0Data], `FLASH0_DATA_MEM_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for flash 0 info", UVM_MEDIUM)
@@ -451,7 +452,8 @@ module tb;
           .path  (`DV_STRINGIFY(`FLASH0_INFO_MEM_HIER)),
           .depth ($size(`FLASH0_INFO_MEM_HIER)),
           .n_bits($bits(`FLASH0_INFO_MEM_HIER)),
-          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
+          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68),
+          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_EFLASH_BASE_ADDR));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank0Info], `FLASH0_INFO_MEM_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for flash 1 data", UVM_MEDIUM)
@@ -460,48 +462,59 @@ module tb;
           .path  (`DV_STRINGIFY(`FLASH1_DATA_MEM_HIER)),
           .depth ($size(`FLASH1_DATA_MEM_HIER)),
           .n_bits($bits(`FLASH1_DATA_MEM_HIER)),
-          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
+          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68),
+          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_EFLASH_BASE_ADDR +
+              top_earlgrey_pkg::TOP_EARLGREY_EFLASH_SIZE_BYTES / flash_ctrl_pkg::NumBanks));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank1Data], `FLASH0_DATA_MEM_HIER)
 
-      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for flash 0 info", UVM_MEDIUM)
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for flash 1 info", UVM_MEDIUM)
       m_mem_bkdr_util[FlashBank1Info] = new(
           .name  ("mem_bkdr_util[FlashBank1Info]"),
           .path  (`DV_STRINGIFY(`FLASH1_INFO_MEM_HIER)),
           .depth ($size(`FLASH1_INFO_MEM_HIER)),
           .n_bits($bits(`FLASH1_INFO_MEM_HIER)),
-          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
+          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68),
+          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_EFLASH_BASE_ADDR +
+              top_earlgrey_pkg::TOP_EARLGREY_EFLASH_SIZE_BYTES / flash_ctrl_pkg::NumBanks));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank1Info], `FLASH1_INFO_MEM_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTP", UVM_MEDIUM)
-      m_mem_bkdr_util[Otp] = new(.name  ("mem_bkdr_util[Otp]"),
-                                 .path  (`DV_STRINGIFY(`OTP_MEM_HIER)),
-                                 .depth ($size(`OTP_MEM_HIER)),
-                                 .n_bits($bits(`OTP_MEM_HIER)),
-                                 .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_22_16));
+      m_mem_bkdr_util[Otp] = new(
+          .name  ("mem_bkdr_util[Otp]"),
+          .path  (`DV_STRINGIFY(`OTP_MEM_HIER)),
+          .depth ($size(`OTP_MEM_HIER)),
+          .n_bits($bits(`OTP_MEM_HIER)),
+          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_22_16));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Otp], `OTP_MEM_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for RAM", UVM_MEDIUM)
-      m_mem_bkdr_util[RamMain0] = new(.name  ("mem_bkdr_util[RamMain0]"),
-                                      .path  (`DV_STRINGIFY(`RAM_MAIN_MEM_HIER)),
-                                      .depth ($size(`RAM_MAIN_MEM_HIER)),
-                                      .n_bits($bits(`RAM_MAIN_MEM_HIER)),
-                                      .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
+      m_mem_bkdr_util[RamMain0] = new(
+          .name  ("mem_bkdr_util[RamMain0]"),
+          .path  (`DV_STRINGIFY(`RAM_MAIN_MEM_HIER)),
+          .depth ($size(`RAM_MAIN_MEM_HIER)),
+          .n_bits($bits(`RAM_MAIN_MEM_HIER)),
+          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
+          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_RAM_MAIN_BASE_ADDR));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamMain0], `RAM_MAIN_MEM_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for RAM RET", UVM_MEDIUM)
-      m_mem_bkdr_util[RamRet0] = new(.name  ("mem_bkdr_util[RamRet0]"),
-                                     .path  (`DV_STRINGIFY(`RAM_RET_MEM_HIER)),
-                                     .depth ($size(`RAM_RET_MEM_HIER)),
-                                     .n_bits($bits(`RAM_RET_MEM_HIER)),
-                                     .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
+      m_mem_bkdr_util[RamRet0] = new(
+          .name  ("mem_bkdr_util[RamRet0]"),
+          .path  (`DV_STRINGIFY(`RAM_RET_MEM_HIER)),
+          .depth ($size(`RAM_RET_MEM_HIER)),
+          .n_bits($bits(`RAM_RET_MEM_HIER)),
+          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
+          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_RAM_RET_AON_BASE_ADDR));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamRet0], `RAM_RET_MEM_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for ROM", UVM_MEDIUM)
-      m_mem_bkdr_util[Rom] = new(.name  ("mem_bkdr_util[Rom]"),
-                                 .path  (`DV_STRINGIFY(`ROM_MEM_HIER)),
-                                 .depth ($size(`ROM_MEM_HIER)),
-                                 .n_bits($bits(`ROM_MEM_HIER)),
-                                 .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
+      m_mem_bkdr_util[Rom] = new(
+          .name  ("mem_bkdr_util[Rom]"),
+          .path  (`DV_STRINGIFY(`ROM_MEM_HIER)),
+          .depth ($size(`ROM_MEM_HIER)),
+          .n_bits($bits(`ROM_MEM_HIER)),
+          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
+          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_ROM_BASE_ADDR));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom], `ROM_MEM_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTBN IMEM", UVM_MEDIUM)


### PR DESCRIPTION
Ignore the first commit - its a part of a different PR. 

Commits 2-4 slightly enhances the chip SW symbol override functionality. The original motivation for this enhancement was to override the SW symbol LFSR seed which may or may not exist in the ELF. 