### PR TITLE
[rtl] Randomize dv_srate_value in AST RNG

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -819,7 +819,8 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_edn_reqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15_000_000","+rng_srate_value=30"]
+      run_opts: ["+sw_test_timeout_ns=15000000", "+rng_srate_value_min=15",
+                 "+rng_srate_value_max=30"]
     }
     {
       name: chip_sw_hmac_enc

--- a/hw/top_earlgrey/dv/chip_smoketests.hjson
+++ b/hw/top_earlgrey/dv/chip_smoketests.hjson
@@ -37,7 +37,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_smoketest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+rng_srate_value=30"]
+      run_opts: ["+rng_srate_value_min=15", "+rng_srate_value_max=30"]
     }
     {
       name: chip_sw_gpio_smoketest

--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -17,6 +17,7 @@ filesets:
       - lowrisc:prim:lfsr
       - lowrisc:ip:pinmux_reg
       - lowrisc:ip:pinmux_component
+      - lowrisc:prim:assert
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:mubi
       - lowrisc:ip:lc_ctrl_pkg

--- a/hw/top_earlgrey/ip/ast/rtl/rng.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/rng.sv
@@ -6,6 +6,8 @@
 // *Module Description:  Random (bit/s) Generator (Pseudo Model)
 //############################################################################
 
+`include "prim_assert.sv"
+
 module rng #(
   parameter int EntropyStreams = 4
 ) (
@@ -63,11 +65,20 @@ logic [EntropyStreams-1:0] rng_b;
 
 `ifndef SYNTHESIS
 logic [12-1:0] dv_srate_value;
+// 4-bit rng_b needs at least 5 clocks. While the limit for these min and max values is 5:500, the
+// default is set to a shorter window of 32:128 to avoid large runtimes.
+logic [12-1:0] rng_srate_value_min = 12'd32;
+logic [12-1:0] rng_srate_value_max = 12'd128;
 
 initial begin
-  if ( !$value$plusargs("rng_srate_value=%0d", dv_srate_value) ) begin
-    dv_srate_value = 12'd120;
-  end
+  void'($value$plusargs("rng_srate_value_min=%0d", rng_srate_value_min));
+  void'($value$plusargs("rng_srate_value_max=%0d", rng_srate_value_max));
+  `ASSERT_I(DvRngSrateMinCheck, rng_srate_value_min inside {[5:500]})
+  `ASSERT_I(DvRngSrateMaxCheck, rng_srate_value_max inside {[5:500]})
+  `ASSERT_I(DvRngSrateBoundsCheck, rng_srate_value_max >= rng_srate_value_min)
+  dv_srate_value = 12'($urandom_range(rng_srate_value_min, rng_srate_value_max));
+  void'($value$plusargs("rng_srate_value=%0d", dv_srate_value));
+  `ASSERT_I(DvSrateValueCheck, dv_srate_value inside {[5:500]})
 end
 
 assign srate_value = dv_srate_value;


### PR DESCRIPTION
This commit randomizes the dv_srate_value in
AST RNG model so that the randomness fetched from
AST is different for different simulation seeds.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>