### PR TITLE
[entropy_src/rtl] Adjustment to main SM for FW_OV mode.

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -110,7 +110,12 @@ module entropy_src_main_sm #(
         if (enable_i) begin
           // running fw override mode and in sha3 mode
           if (fw_ov_ent_insert_i && !bypass_mode_i) begin
-            state_d = FWInsertStart;
+            if (fw_ov_sha3_start_i || !enable_i) begin
+              sha3_start_o = 1'b1;
+              state_d = FWInsertMsg;
+            end else begin
+              state_d = FWInsertStart;
+            end
           // running in bypass_mode and not fw override mode
           end else if (bypass_mode_i && !fw_ov_ent_insert_i) begin
             state_d = BootHTRunning;


### PR DESCRIPTION
This commit makes it possible to jump straight from IDLE to the FWInsertMsg
state, sending a SHA3 start pulse in the process.  This is for cases when
the SHA3_Start signal in sent immediately after `module_enable` is inserted.
This change is neccessary as the module_enable signal passes through a 2-clock
synchronizer in the fanout module, and thus may be delayed to catch up with the
SHA3 start signal.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>