### PR TITLE
[entropy_src/dv] New regression: "live"

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -98,6 +98,10 @@
       name: smoke
       tests: ["entropy_src_smoke"]
     }
+    {
+      name: live
+      tests: ["entropy_src_rng", "entropy_src_fw_ov"]
+    }
   ]
 
   component_a: "uvm_test_top.env.scoreboard"


### PR DESCRIPTION
For convenience this commit adds a new regression called "live" which
combines the entropy_src_rng and entropy_src_fw_ov tests, which
together make up much of the unit test coverage for entropy_src.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>