### PR TITLE
[entropy_src/dv] Relax RNG testing

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
@@ -154,35 +154,48 @@ class entropy_src_dut_cfg extends uvm_object;
   //        in the RNG source which means that the false positive rate is still > 1 in 2^40)
   //
   // The last bin captures this most relaxed
+  //
+  // TODO: Establish usable constraints for repcnt thresholds < 40
+  // Temporarily disable the tighter bins, to allow seeds to pass.  The previous bins were
+  // previously so tight that no seed outputs were ever observed.  Even though each individual HT
+  // may pass with reasonable probability, if multiple HT thresholds are set tightly, the
+  // probability of all passing approaches zero, and we never see any entropy outputs.
   constraint repcnt_thresh_bypass_c {repcnt_thresh_bypass dist {
-      [6  : 10] :/ 1,
-      [11 : 20] :/ 1,
-      [21 : 40] :/ 1,
-      41        :/ 1};}
+      [6  : 10] :/ 0,
+      [11 : 20] :/ 0,
+      [21 : 40] :/ 0,
+      41        :/ 10};}
 
+  // TODO: Establish usable constraints for repcnt thresholds < 40
+  // See similar TODO note above for further details
   constraint repcnt_thresh_fips_c {repcnt_thresh_fips dist {
-      [6  : 10] :/ 1,
-      [11 : 20] :/ 1,
-      [21 : 40] :/ 1,
-      41        :/ 1};}
+      [6  : 10] :/ 0,
+      [11 : 20] :/ 0,
+      [21 : 40] :/ 0,
+      41        :/ 10};}
 
   // Make the bin sizes for the repcnts test 1/4 as small as the corresponding repcnt bins sizes,
   // since the likelihood of coincidental
   // failure is comparable to that of gathering 4x more data with the repcnt
   // test.
   //
-  // As with the repcnt test, the highest bin would (for an assumed ideal RNG noice source
-  constraint repcnts_thresh_bypass_c {repcnts_thresh_bypass dist {
-      [2  :  3] :/ 1,
-      [4  :  5] :/ 1,
-      [6  : 10] :/ 1,
-      11       :/ 1};}
+  // As with the repcnt test, the highest bin would (for an assumed ideal RNG noice source)
 
+  // TODO: Establish usable constraints for repcnts thresholds < 10
+  // See similar TODO note above for further details
+  constraint repcnts_thresh_bypass_c {repcnts_thresh_bypass dist {
+      [2  :  3] :/ 0,
+      [4  :  5] :/ 0,
+      [6  : 10] :/ 0,
+      11       :/ 10};}
+
+  // TODO: Establish usable constraints for repcnts thresholds < 10
+  // See similar TODO note above for further details
   constraint repcnts_thresh_fips_c {repcnts_thresh_fips dist {
-      [2  :  3] :/ 1,
-      [4  :  5] :/ 1,
-      [6  : 10] :/ 1,
-      [11 : 80] :/ 1};}
+      [2  :  3] :/ 0,
+      [4  :  5] :/ 0,
+      [6  : 10] :/ 0,
+      [11 : 80] :/ 10};}
 
   // TODO: Update dist to satisfy cover points
   constraint alert_threshold_c {alert_threshold dist {

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -129,9 +129,7 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     // as well as the observe and entropy_data FIFOs
     // Clear all interupts here
     csr_wr(.ptr(ral.intr_state), .value(32'hf));
-    // Clear all recoverable alerts
-    // TODO: READ THE ALERTS FIRST to scoreboard them
-    csr_wr(.ptr(ral.recov_alert_sts), .value('0));
+    // Leave alerts alone as the handlers for those conditions need to see them
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_check_ht_diag)
     if (do_check_ht_diag) begin

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -22,18 +22,18 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.mean_rand_reconfig_time     = 1ms;
     // The random alerts only need to happen frequently enough to
     // close coverage
-    cfg.mean_rand_csr_alert_time    = 500ms;
+    cfg.mean_rand_csr_alert_time    = -1;
     cfg.soft_mtbf                   = 7500us;
 
     // Apply standards ranging from strict to relaxed
-    cfg.dut_cfg.adaptp_sigma_min            = 1.0;
+    cfg.dut_cfg.adaptp_sigma_min            = 3.0;
     cfg.dut_cfg.adaptp_sigma_max            = 6.0;
-    cfg.dut_cfg.bucket_sigma_min            = 1.0;
+    cfg.dut_cfg.bucket_sigma_min            = 3.0;
     cfg.dut_cfg.bucket_sigma_max            = 6.0;
-    cfg.dut_cfg.markov_sigma_min            = 1.0;
+    cfg.dut_cfg.markov_sigma_min            = 3.0;
     cfg.dut_cfg.markov_sigma_max            = 6.0;
 
-    cfg.dut_cfg.sw_regupd_pct               = 50;
+    cfg.dut_cfg.sw_regupd_pct               = 100;
 
     cfg.dut_cfg.entropy_data_reg_enable_pct = 50;
     cfg.dut_cfg.route_software_pct          = 50;


### PR DESCRIPTION
This commit relaxes the RNG test to be less abusive, and allow better
coverage through the generation of more seeds in regresion.

- Relaxes the HT thresholds to always provide a reasonable chance of
passing the health tests.
- Temporarily disables random CSR driven alerts.
- Fixes one bug in which the test thresholds were not correctly calculated
  to match their `threshold_scope`, leading to constant failures.
- The RNG vseq also makes more frequent use of the `disable_dut` task
  to avoid failures caused by uncleared interrupts

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>