### PR TITLE
[dvsim] Fix coverage upload URL

### DIFF
--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -754,7 +754,7 @@ class SimCfg(FlowCfg):
 
         if self.cov_report_deploy is not None:
             results_server_dir_url = self.results_server_dir.replace(
-                self.results_server_prefix, self.results_server_url_prefix)
+                self.results_server_prefix, "https://")
 
             log.info("Publishing coverage results to %s",
                      results_server_dir_url)


### PR DESCRIPTION
I unfortunately missed this part in the coverage upload function last week, and this currently causes an error during the results upload for the nightly simulation results.

Please merge once it passes CI.

Signed-off-by: Michael Schaffner <msf@google.com>