### PR TITLE
[otbn,dv] Move default simulator to XCelium

### DIFF
--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -13,7 +13,7 @@ name:
   tb: tb
 
   // Simulator used to sign off this block
-  tool: vcs
+  tool: xcelium
 
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:otbn_sim:0.1


### PR DESCRIPTION
I remember talking about this and I've been using XCelium for the tests for a long time, I think this moving to different simulator change got missed somehow.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>