### PR TITLE
[sw, otbn] Speed up ECDSA P-256 test

### DIFF
--- a/sw/device/lib/runtime/otbn.c
+++ b/sw/device/lib/runtime/otbn.c
@@ -92,12 +92,6 @@ otbn_result_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
     return kOtbnError;
   }
 
-  // Zero all of DMEM
-  otbn_result_t err = otbn_zero_data_memory(ctx);
-  if (err != kOtbnOk) {
-    return err;
-  }
-
   // Write initialized data
   if (data_size > 0) {
     if (dif_otbn_dmem_write(&ctx->dif, 0, ctx->app.dmem_data_start,

--- a/sw/device/tests/otbn_ecdsa_op_irq_test.c
+++ b/sw/device/tests/otbn_ecdsa_op_irq_test.c
@@ -168,6 +168,9 @@ static void otbn_wait_for_done_irq(otbn_t *otbn_ctx) {
   // Disable Done interrupt.
   CHECK_DIF_OK(dif_otbn_irq_set_enabled(&otbn_ctx->dif, kDifOtbnIrqDone,
                                         kDifToggleDisabled));
+
+  // Acknowledge Done interrupt. This clears INTR_STATE.done back to 0.
+  CHECK_DIF_OK(dif_otbn_irq_acknowledge(&otbn_ctx->dif, kDifOtbnIrqDone));
 }
 
 static void otbn_init_irq(void) {

--- a/sw/device/tests/otbn_smoketest.c
+++ b/sw/device/tests/otbn_smoketest.c
@@ -69,7 +69,6 @@ static void check_otbn_insn_cnt(otbn_t *otbn_ctx, uint32_t expected_insn_cnt) {
 static void test_barrett384(otbn_t *otbn_ctx) {
   enum { kDataSizeBytes = 48 };
 
-  CHECK(otbn_zero_data_memory(otbn_ctx) == kOtbnOk);
   CHECK(otbn_load_app(otbn_ctx, kAppBarrett) == kOtbnOk);
 
   // a, first operand


### PR DESCRIPTION
This PR replaces the clearing of the OTBN DMEM with zeros through Ibex with a secure wipe of DMEM by changing the DMEM scrambling key. This massively speeds up the test and hopefully also the chip-level simulation test we run nightly (currently taking around 5 hours). 

Here some numbers from the FPGA. Previously:
```console
I00000 ottf_main.c:82] Running sw/device/tests/otbn_ecdsa_op_irq_test.c
I00001 otbn_ecdsa_op_irq_test.c:236] Initialization took 362266 cycles or 3622 us @ 100 MHz.
I00002 otbn_ecdsa_op_irq_test.c:396] Signing
I00003 otbn_ecdsa_op_irq_test.c:236] Sign took 9183 cycles or 91 us @ 100 MHz.
I00004 otbn_ecdsa_op_irq_test.c:402] Clearing OTBN memory and reloading app
I00005 otbn_ecdsa_op_irq_test.c:236] Clear and Reload took 585467 cycles or 5854 us @ 100 MHz.
I00006 otbn_ecdsa_op_irq_test.c:411] Verifying
I00007 otbn_ecdsa_op_irq_test.c:236] Verify took 12850 cycles or 128 us @ 100 MHz.
I00008 otbn_ecdsa_op_irq_test.c:423] Clearing OTBN memory
I00009 otbn_ecdsa_op_irq_test.c:236] Clear took 223607 cycles or 2236 us @ 100 MHz.
I00010 ottf_main.c:56] Finished sw/device/tests/otbn_ecdsa_op_irq_test.c
I00011 status.c:28] PASS!
```
With this PR:
```console
I00001 otbn_ecdsa_op_irq_test.c:246] Initialization took 362375 cycles or 3623 us @ 100 MHz.
I00002 otbn_ecdsa_op_irq_test.c:406] Signing
I00003 otbn_ecdsa_op_irq_test.c:246] Sign took 9256 cycles or 92 us @ 100 MHz.
I00004 otbn_ecdsa_op_irq_test.c:412] Wiping OTBN DMEM and reloading app
I00005 otbn_ecdsa_op_irq_test.c:246] Wipe and Reload took 362930 cycles or 3629 us @ 100 MHz.
I00006 otbn_ecdsa_op_irq_test.c:421] Verifying
I00007 otbn_ecdsa_op_irq_test.c:246] Verify took 12912 cycles or 129 us @ 100 MHz.
I00008 otbn_ecdsa_op_irq_test.c:433] Wiping OTBN DMEM
I00009 otbn_ecdsa_op_irq_test.c:246] Wipe took 956 cycles or 9 us @ 100 MHz.
I00010 ottf_main.c:56] Finished sw/device/tests/otbn_ecdsa_op_irq_test.c
I00011 status.c:28] PASS!
```
As you can see, this PR saves roughly 2x 222000 clock cycles ("Wipe and reload" as well as the final "Wipe"). The actual signing and signature verification just takes 9200 and 13000 cycles, respectively. 

This is related to #14385 .