### PR TITLE
[dv,flash_ctrl] last mile write scoreboard and new eviction test

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -111,6 +111,16 @@
       tests: ["flash_ctrl_rd_buff_evict"]
     }
     {
+      name: rd_buff_eviction_w_ecc
+      desc: '''
+            Run read eviction test with multiple memory protection configs.
+            Each config should enable read but randomize all other fields
+            including scramble and ecc enable.
+            '''
+      stage: V2
+      tests: ["flash_ctrl_rw_evict", "flash_ctrl_re_evict"]
+    }
+    {
       name: host_arb
       desc: '''
             Test arbitration within Flash Physical Controller by reading from both interfaces at

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -20,10 +20,12 @@ filesets:
       - flash_ctrl_env_pkg.sv
       - flash_ctrl_if.sv
       - flash_ctrl_dv_if.sv
+      - flash_ctrl_mem_if.sv
       - flash_mem_bkdr_util.sv: {is_include_file: true}
       - flash_mem_addr_attrs.sv: {is_include_file: true}
       - flash_otf_item.sv: {is_include_file: true}
       - flash_otf_read_entry.sv: {is_include_file: true}
+      - flash_otf_mem_entry.sv: {is_include_file: true}
       - flash_ctrl_seq_cfg.sv: {is_include_file: true}
       - flash_ctrl_env_cfg.sv: {is_include_file: true}
       - flash_ctrl_env_cov.sv: {is_include_file: true}
@@ -73,6 +75,9 @@ filesets:
       - seq_lib/flash_ctrl_intr_rd_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_intr_wr_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_prog_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_legacy_base_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_rw_evict_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_re_evict_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -34,6 +34,12 @@ class flash_ctrl_env #(
             this, "", "flash_ctrl_dv_vif", cfg.flash_ctrl_dv_vif)) begin
       `uvm_fatal(`gfn, "failed to get flash_ctrl_dv_vif from uvm_config_db")
     end
+    for (int i = 0; i < NumBanks; i++) begin
+      if (!uvm_config_db#(virtual flash_ctrl_mem_if)::get(
+              this, "", $sformatf("flash_ctrl_mem_vif[%0d]", i), cfg.flash_ctrl_mem_vif[i])) begin
+        `uvm_fatal(`gfn, "failed to get flash_ctrl_mem_vif from uvm_config_db")
+      end
+    end
     // Retrieve the mem backdoor util instances.
     for (
         int i = 0, flash_dv_part_e part = part.first(); i < part.num(); i++, part = part.next()
@@ -74,6 +80,8 @@ class flash_ctrl_env #(
                 m_otf_scb.eg_rtl_fifo[i].analysis_export);
         m_fpp_agent.monitor.rd_cmd_port[i].connect(
                 m_otf_scb.rd_cmd_fifo[i].analysis_export);
+        m_fpp_agent.monitor.eg_rtl_lm_port[i].connect(
+                m_otf_scb.eg_exp_lm_fifo[i].analysis_export);
      end
     end
 

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -61,12 +61,25 @@ class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
     }
   endgroup : fifo_lvl_cg
 
+  covergroup eviction_cg with function sample (int idx, bit[1:0] op,
+                                               bit [1:0] scr_ecc);
+    evic_idx_cp : coverpoint idx {
+      bins evic_idx[] = {1, 2, 4, 8};
+    }
+    evic_op_cp : coverpoint op {
+      bins evic_op[] = {1, 2};
+    }
+    evic_cfg_cp : coverpoint scr_ecc;
+    evic_all_cross : cross evic_idx_cp, evic_op_cp, evic_cfg_cp;
+  endgroup // eviction_cg
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
     control_cg = new();
     erase_susp_cg = new();
     error_cg = new();
     fifo_lvl_cg = new();
+    eviction_cg = new();
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -199,6 +199,7 @@ package flash_ctrl_env_pkg;
     TgtRd = 0,
     TgtDr = 1, // direct read
     TgtWr = 2, // program
+    TgtEr = 3, // erase
     NumTgt = 4
   } flash_tgt_prefix_e;
 
@@ -477,6 +478,7 @@ package flash_ctrl_env_pkg;
   `include "flash_mem_addr_attrs.sv"
   `include "flash_otf_item.sv"
   `include "flash_otf_read_entry.sv"
+  `include "flash_otf_mem_entry.sv"
   `include "flash_ctrl_seq_cfg.sv"
   `include "flash_ctrl_env_cfg.sv"
   `include "flash_ctrl_env_cov.sv"

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
@@ -8,6 +8,7 @@ interface flash_ctrl_if ();
   import lc_ctrl_pkg::*;
   import pwrmgr_pkg::*;
   import flash_ctrl_pkg::*;
+  import flash_phy_pkg::*;
   import otp_ctrl_pkg::*;
   import ast_pkg::*;
 
@@ -44,5 +45,12 @@ interface flash_ctrl_if ();
 
   // power ready
   logic                             power_ready_h = 1'b1;
+
+  // eviction
+  logic [flash_ctrl_pkg::NumBanks-1:0][NumBuf-1:0] hazard;
+  rd_buf_t [flash_ctrl_pkg::NumBanks-1:0][NumBuf-1:0] rd_buf;
+  logic [flash_ctrl_pkg::NumBanks-1:0]             evict_prog;
+  logic [flash_ctrl_pkg::NumBanks-1:0]             evict_erase;
+  logic                                            fatal_err;
 
 endinterface : flash_ctrl_if

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_mem_if.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_mem_if.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+import flash_ctrl_pkg::*;
+interface flash_ctrl_mem_if (
+  input logic clk_i,
+  input logic rst_ni,
+  input logic data_mem_req,
+  input logic mem_wr,
+  input logic [BankAddrW-1:0] mem_addr,
+  input logic [flash_phy_pkg::FullDataWidth-1:0] mem_wdata,
+  input flash_part_e mem_part,
+  input logic [InfoTypesWidth-1:0] mem_info_sel,
+  input logic info0_mem_req,
+  input logic info1_mem_req,
+  input logic info2_mem_req
+);
+endinterface

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -15,6 +15,16 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
   uvm_tlm_analysis_fifo #(flash_phy_prim_item) eg_rtl_fifo[NumBanks];
   uvm_tlm_analysis_fifo #(flash_phy_prim_item) rd_cmd_fifo[NumBanks];
 
+  // Check last mile write /erase transactions
+  uvm_tlm_analysis_fifo #(flash_phy_prim_item) eg_exp_lm_fifo[NumBanks];
+
+  // tb memory model
+  // This is used for the last mile write data integrity check
+  bit[flash_phy_pkg::FullDataWidth] data_mem[NumBanks][bit[BankAddrW-1:0]];
+  bit[flash_phy_pkg::FullDataWidth] info_mem[NumBanks][InfoTypes][bit[BankAddrW-1:0]];
+
+  // register double written entries
+  bit corrupt_entry[rd_cache_t];
   flash_ctrl_env_cfg cfg;
 
   int eg_exp_cnt = 0;
@@ -28,6 +38,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
       eg_rtl_host_fifo[i] = new($sformatf("eg_rtl_host_fifo[%0d]", i), this);
       eg_rtl_fifo[i] = new($sformatf("eg_rtl_fifo[%0d]", i), this);
       rd_cmd_fifo[i] = new($sformatf("rd_cmd_fifo[%0d]", i), this);
+      eg_exp_lm_fifo[i] = new($sformatf("eg_exp_lm_fifo[%0d]", i), this);
     end
   endfunction
 
@@ -42,6 +53,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
       while (eg_rtl_host_fifo[i].used() > 0) eg_rtl_host_fifo[i].get(dummy1);
       while (eg_rtl_fifo[i].used() > 0) eg_rtl_fifo[i].get(dummy2);
       while (rd_cmd_fifo[i].used() > 0) rd_cmd_fifo[i].get(dummy2);
+      while (eg_exp_lm_fifo[i].used() > 0) eg_exp_lm_fifo[i].get(dummy2);
     end
   endtask
 
@@ -57,40 +69,36 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     flash_phy_prim_item  phy_item[NumBanks];
     flash_phy_prim_item  rcmd[NumBanks];
 
-    fork
-      forever begin
-        eg_exp_ctrl_fifo[0].get(exp_ctrl_item[0]);
-        process_eg(exp_ctrl_item[0], 0);
-      end
-      forever begin
-        eg_exp_ctrl_fifo[1].get(exp_ctrl_item[1]);
-        process_eg(exp_ctrl_item[1], 1);
-      end
-      forever begin
-        eg_exp_host_fifo[0].get(exp_host_item[0]);
-        process_eg_host(exp_host_item[0], 0);
-      end
-      forever begin
-        eg_exp_host_fifo[1].get(exp_host_item[1]);
-        process_eg_host(exp_host_item[1], 1);
-      end
-      forever begin
-        eg_rtl_fifo[0].get(phy_item[0]);
-        process_phy_item(phy_item[0], 0);
-      end
-      forever begin
-        eg_rtl_fifo[1].get(phy_item[1]);
-        process_phy_item(phy_item[1], 1);
-      end
-      forever begin
-        rd_cmd_fifo[0].get(rcmd[0]);
-        process_rcmd(rcmd[0], 0);
-      end
-      forever begin
-        rd_cmd_fifo[1].get(rcmd[1]);
-        process_rcmd(rcmd[1], 1);
-      end
-    join_none
+    for (int i = 0; i < NumBanks; i++) begin
+      int j = i;
+      fork begin
+        forever begin
+          eg_exp_ctrl_fifo[j].get(exp_ctrl_item[j]);
+          process_eg(exp_ctrl_item[j], j);
+        end
+      end join_none
+      fork begin
+        forever begin
+          eg_exp_host_fifo[j].get(exp_host_item[j]);
+          process_eg_host(exp_host_item[j], j);
+        end
+      end join_none
+      fork begin
+        forever begin
+          eg_rtl_fifo[j].get(phy_item[j]);
+          process_phy_item(phy_item[j], j);
+        end
+      end join_none
+      fork begin
+        forever begin
+          rd_cmd_fifo[j].get(rcmd[j]);
+          process_rcmd(rcmd[j], j);
+        end
+      end join_none
+      fork begin
+        monitor_tb_mem(j);
+      end join_none
+    end
   endtask // run_phase
 
   task process_eg_host(flash_otf_item exp, int bank);
@@ -123,6 +131,8 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     obs.print("rtl_host: before");
     obs.region = exp.region;
     if (cfg.ecc_mode > FlashSerrTestMode) obs.skip_err_chk = 1;
+    obs.skip_err_chk |= exp.derr;
+
     // descramble needs 2 buswords
     obs.cmd.num_words = 2;
     obs.descramble(exp.addr_key, exp.data_key);
@@ -143,19 +153,34 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
                    $sformatf("unexpected double bit error 0x%x", err_addr))
       end
     end else begin
-      if (exp.start_addr[2]) begin
-        rcvd_data = obs.dq[1];
+      if (exp.derr & obs.derr) begin
+        `uvm_info("process_eg_host",
+                  $sformatf("expected double bit error by redundant write start:%x",
+                            exp.start_addr),
+                  UVM_MEDIUM)
       end else begin
-        rcvd_data = obs.dq[0];
-      end
+        if (!exp.derr) begin
+          if (exp.start_addr[2]) begin
+            rcvd_data = obs.dq[1];
+          end else begin
+            rcvd_data = obs.dq[0];
+          end
 
-      if (rcvd_data == exp.dq[0]) begin
-        `dv_info("data match!!", UVM_MEDIUM, str)
-      end else begin
-        `dv_error($sformatf(" : obs:exp    %8x:%8x mismatch!!", rcvd_data, exp.dq[0]), str)
+          if (rcvd_data == exp.dq[0]) begin
+            `dv_info("data match!!", UVM_MEDIUM, str)
+          end else begin
+            `dv_error($sformatf(" : obs:exp    %8x:%8x mismatch!!",
+                                rcvd_data, exp.dq[0]), str)
+          end
+        end else begin // if (!exp.derr)
+          `uvm_error("process_eg_host",
+                     $sformatf("expected double bit error does not occur start:%x",
+                               exp.start_addr))
+        end
       end
     end
     cfg.otf_host_rd_sent++;
+
   endtask // process_eg_host
 
   task process_eg(flash_otf_item item, int bank);
@@ -199,6 +224,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     cfg.flash_mem_otf_read(send.cmd, send.fq);
     send.print("exp_read: enc_data");
     if (cfg.ecc_mode > FlashSerrTestMode) send.skip_err_chk = 1;
+    send.skip_err_chk |= exp.derr;
 
     if (exp.cmd.addr[2]) begin
       send.head_pad = 1;
@@ -237,8 +263,26 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
                      $sformatf("unexpected double bit error 0x%x", err_addr))
         end
       end
-    end else begin
-      compare_data(send.raw_fq, exp.fq, bank, "rdata");
+    end else begin // if (cfg.ecc_mode > FlashSerrTestMode && send.derr == 1)
+      // Skip data comp for no ecc erase workd read
+      foreach (send.ctrl_rd_region_q[i]) begin
+        if (send.ctrl_rd_region_q[i].ecc_en != MuBi4True &&
+            (exp.fq[i][63:32] == ALL_ONES || exp.fq[i][31:0] == ALL_ONES)) begin
+          send.raw_fq[i] = exp.fq[i];
+        end
+      end
+      if (exp.derr & send.derr) begin
+        `uvm_info("process_read",
+                  $sformatf("expected double bit error by redundant write start:%x",
+                            exp.start_addr),
+                  UVM_MEDIUM)
+      end else begin
+        if (!exp.derr) compare_data(send.raw_fq, exp.fq, bank, "rdata");
+        else `uvm_error("process_read",
+                        $sformatf("expected double bit error does not occur start:%x",
+                                  exp.start_addr))
+
+      end
     end
   endtask
 
@@ -325,4 +369,112 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
       end
     end
   endtask
+
+  task monitor_tb_mem(int bank);
+    flash_phy_prim_item exp;
+    flash_otf_mem_entry rcv;
+    string name = $sformatf("mon_tb_mem%0d", bank);
+    forever begin
+      @(posedge cfg.flash_ctrl_mem_vif[bank].mem_wr);
+      `uvm_info("mem_if", "got posedge wr", UVM_MEDIUM)
+      `uvm_create_obj(flash_otf_mem_entry, rcv)
+      rcv.mem_addr = cfg.flash_ctrl_mem_vif[bank].mem_addr;
+      rcv.mem_wdata = cfg.flash_ctrl_mem_vif[bank].mem_wdata;
+      rcv.mem_part = cfg.flash_ctrl_mem_vif[bank].mem_part;
+      rcv.mem_info_sel = cfg.flash_ctrl_mem_vif[bank].mem_info_sel;
+      @(negedge cfg.flash_ctrl_mem_vif[bank].clk_i);
+      if (rcv.mem_part == FlashPartData) begin
+        `DV_CHECK_EQ(cfg.flash_ctrl_mem_vif[bank].data_mem_req, 1,,, name)
+      end else begin
+         case (rcv.mem_info_sel)
+           0: `DV_CHECK_EQ(cfg.flash_ctrl_mem_vif[bank].info0_mem_req, 1,,, name)
+           1: `DV_CHECK_EQ(cfg.flash_ctrl_mem_vif[bank].info1_mem_req, 1,,, name)
+           2: `DV_CHECK_EQ(cfg.flash_ctrl_mem_vif[bank].info2_mem_req, 1,,, name)
+           default: `uvm_error(name, $sformatf("bank%0d infosel%0d doesn't exists",
+                                               bank, rcv.mem_info_sel))
+         endcase
+      end
+
+      // collect ref data
+      eg_exp_lm_fifo[bank].get(exp);
+      lm_wdata_comp(exp, rcv, bank);
+    end
+  endtask // monitor_tb_mem
+
+  task lm_wdata_comp(flash_phy_prim_item exp, flash_otf_mem_entry rcv, int bank);
+    bit[flash_phy_pkg::FullDataWidth] rd_data;
+    rd_cache_t entry;
+    string name = $sformatf("lm_wdata_comp_bank%0d", bank);
+
+    if (rcv.mem_addr == exp.req.addr) begin
+      `dv_info($sformatf("addr match %x", rcv.mem_addr), UVM_MEDIUM, name)
+    end else begin
+      `DV_CHECK_EQ(rcv.mem_addr, exp.req.addr,,, name)
+    end
+
+   // check if this is page erase
+    if (exp.req.pg_erase_req | exp.req.bk_erase_req) begin
+      int cnt = 0;
+      int cnt_max = (exp.req.bk_erase_req)? 65536 : 256;
+
+      `uvm_info(name, $sformatf("erase detected  pg_erase:%0d bk_erase:%0d",
+                                exp.req.pg_erase_req, exp.req.bk_erase_req),
+                UVM_MEDIUM)
+      repeat (cnt_max) begin
+        rcv.mem_addr = cfg.flash_ctrl_mem_vif[bank].mem_addr;
+        rcv.mem_wdata = cfg.flash_ctrl_mem_vif[bank].mem_wdata;
+        rcv.mem_part = cfg.flash_ctrl_mem_vif[bank].mem_part;
+        rcv.mem_info_sel = cfg.flash_ctrl_mem_vif[bank].mem_info_sel;
+
+        entry.bank = bank;
+        entry.addr = (rcv.mem_addr<<3);
+        entry.part = cfg.get_part(rcv.mem_part, rcv.mem_info_sel);
+        corrupt_entry.delete(entry);
+
+        if (rcv.mem_addr == exp.req.addr) begin
+          `dv_info($sformatf("addr match %x", rcv.mem_addr), UVM_MEDIUM, name)
+        end else begin
+          `DV_CHECK_EQ(rcv.mem_addr, exp.req.addr,,, name)
+        end
+        `DV_CHECK_EQ(rcv.mem_wdata, {flash_phy_pkg::FullDataWidth{1'b1}},,, name)
+
+
+        if (rcv.mem_part == FlashPartData) begin
+          data_mem[bank].delete(rcv.mem_addr);
+        end else begin
+          info_mem[bank][rcv.mem_info_sel].delete(rcv.mem_addr);
+        end
+        exp.req.addr++;
+        @(negedge cfg.flash_ctrl_mem_vif[bank].clk_i);
+      end
+   end else begin
+     entry.bank = bank;
+     entry.addr = (rcv.mem_addr<<3);
+     entry.part = cfg.get_part(rcv.mem_part, rcv.mem_info_sel);
+
+     if (rcv.mem_part == FlashPartData) begin
+       if (data_mem[bank].exists(rcv.mem_addr)) begin
+         corrupt_entry[entry] = 1;
+         rd_data = data_mem[bank][rcv.mem_addr];
+         exp.req.prog_full_data &= rd_data;
+         data_mem[bank].delete(rcv.mem_addr);
+       end
+       data_mem[bank][rcv.mem_addr] = exp.req.prog_full_data;
+     end else begin
+       if (info_mem[bank][rcv.mem_info_sel].exists(rcv.mem_addr)) begin
+         corrupt_entry[entry] = 1;
+         rd_data = info_mem[bank][rcv.mem_info_sel][rcv.mem_addr];
+         exp.req.prog_full_data &= rd_data;
+         info_mem[bank][rcv.mem_info_sel].delete(rcv.mem_addr);
+       end
+       info_mem[bank][rcv.mem_info_sel][rcv.mem_addr] = exp.req.prog_full_data;
+     end
+
+     if (rcv.mem_wdata == exp.req.prog_full_data) begin
+       `dv_info($sformatf("wdata match %x", rcv.mem_wdata), UVM_MEDIUM, name)
+     end else begin
+       `DV_CHECK_EQ(rcv.mem_wdata, exp.req.prog_full_data,,, name)
+     end
+   end
+  endtask // lm_wdata_cmp
 endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_otf_mem_entry.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_otf_mem_entry.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_otf_mem_entry extends uvm_object;
+  `uvm_object_utils(flash_otf_mem_entry)
+  `uvm_object_new
+
+  logic [BankAddrW-1:0] mem_addr;
+  logic [flash_phy_pkg::FullDataWidth-1:0] mem_wdata;
+  flash_part_e mem_part;
+  logic [InfoTypesWidth-1:0] mem_info_sel;
+
+
+endclass // flash_otf_mem_entry

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
+
+  `uvm_object_utils(flash_ctrl_legacy_base_vseq)
+  `uvm_object_new
+  flash_op_t ctrl;
+  int num, bank;
+
+  virtual task pre_start();
+    super.pre_start();
+
+    for (int j = 0; j < NumBanks; j++) begin
+      for (int i = 0; i < PagesPerBank; i++) load_otf_mem_page(FlashPartData, j, i);
+      for (int i = 0; i < InfoTypeSize[0]; i++) load_otf_mem_page(FlashPartInfo, j, i);
+      for (int i = 0; i < InfoTypeSize[1]; i++) load_otf_mem_page(FlashPartInfo1, j, i);
+      for (int i = 0; i < InfoTypeSize[2]; i++) load_otf_mem_page(FlashPartInfo2, j, i);
+    end
+
+    cfg.scb_h.do_alert_check = 0;
+    expect_fatal_alerts = 1;
+  endtask
+endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -165,10 +165,10 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
 
     repeat (num_trans) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
-      default_region_cfg.read_en = default_region_read_en;
-      default_region_cfg.program_en = default_region_program_en;
-      default_region_cfg.erase_en = default_region_erase_en;
-      default_region_cfg.he_en = default_region_he_en;
+      cfg.default_region_cfg.read_en = default_region_read_en;
+      cfg.default_region_cfg.program_en = default_region_program_en;
+      cfg.default_region_cfg.erase_en = default_region_erase_en;
+      cfg.default_region_cfg.he_en = default_region_he_en;
       init_p2r_map();
       update_p2r_map(mp_regions);
 
@@ -256,11 +256,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
                                   size, tail, bank, tmp_addr), UVM_MEDIUM)
       for (int i = 0; i < size; i++) begin
         if  (flash_op.partition == FlashPartData) begin
-          page = addr2page(flash_op.addr);
-          my_region = get_region(page);
+          page = cfg.addr2page(flash_op.addr);
+          my_region = cfg.get_region(page);
         end else begin
-          page = addr2page(flash_op.addr[OTFBankId-1:0]);
-          my_region = get_region_from_info(mp_info_pages[bank][flash_op.partition>>1][page]);
+          page = cfg.addr2page(flash_op.addr[OTFBankId-1:0]);
+          my_region = cfg.get_region_from_info(mp_info_pages[bank][flash_op.partition>>1][page]);
           illegal_trans |= check_info_part(flash_op, "read_flash");
         end
         illegal_trans |= validate_flash_op(flash_op, my_region);
@@ -268,11 +268,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
       end // for (int i = 0; i < size; i++)
       if (tail) begin
         if  (flash_op.partition == FlashPartData) begin
-          page = addr2page(flash_op.addr);
-          my_region = get_region(page);
+          page = cfg.addr2page(flash_op.addr);
+          my_region = cfg.get_region(page);
         end else begin
-          page = addr2page(flash_op.otf_addr);
-          my_region = get_region_from_info(mp_info_pages[bank][flash_op.partition>>1][page]);
+          page = cfg.addr2page(flash_op.otf_addr);
+          my_region = cfg.get_region_from_info(mp_info_pages[bank][flash_op.partition>>1][page]);
           illegal_trans |= check_info_part(flash_op, "read_flash");
         end
         illegal_trans |= validate_flash_op(flash_op, my_region);
@@ -280,11 +280,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
       flash_op.addr = tmp_addr;
     end else begin // if (flash_op.op == FlashOpRead)
       if  (flash_op.partition == FlashPartData) begin
-        page = addr2page(flash_op.addr);
-        my_region = get_region(page);
+        page = cfg.addr2page(flash_op.addr);
+        my_region = cfg.get_region(page);
       end else begin
-        page = addr2page(flash_op.addr[OTFBankId-1:0]);
-        my_region = get_region_from_info(mp_info_pages[bank][flash_op.partition>>1][page]);
+        page = cfg.addr2page(flash_op.addr[OTFBankId-1:0]);
+        my_region = cfg.get_region_from_info(mp_info_pages[bank][flash_op.partition>>1][page]);
       end
       illegal_trans = validate_flash_op(flash_op, my_region);
     end
@@ -390,20 +390,5 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     //Enable Bank erase
     flash_ctrl_bank_erase_cfg(.bank_erase_en(bank_erase_en));
   endtask // configure_flash_protection
-
-  function flash_mp_region_cfg_t get_region(int page, bit dis = 1);
-    flash_mp_region_cfg_t my_region;
-    if (cfg.p2r_map[page] == 8) begin
-      my_region = default_region_cfg;
-    end else begin
-      my_region = mp_regions[cfg.p2r_map[page]];
-      if (my_region.en != MuBi4True) my_region = default_region_cfg;
-    end
-    if (dis) begin
-      `uvm_info("get_region", $sformatf("page:%0d --> region:%0d",
-                                        page, cfg.p2r_map[page]), UVM_MEDIUM)
-    end
-    return my_region;
-  endfunction // get_region
 
 endclass : flash_ctrl_mp_regions_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_re_evict_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_re_evict_vseq.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test creates read buffer eviction by erase operation.
+class flash_ctrl_re_evict_vseq extends flash_ctrl_rw_evict_vseq;
+  `uvm_object_utils(flash_ctrl_re_evict_vseq)
+  `uvm_object_new
+
+  task send_evict(flash_op_t ctrl, int bank);
+    erase_flash(ctrl, bank);
+  endtask
+endclass // flash_ctrl_re_evict_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_evict_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_evict_vseq.sv
@@ -1,0 +1,128 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test creates read buffer eviction by program_flash operation.
+class flash_ctrl_rw_evict_vseq extends flash_ctrl_legacy_base_vseq;
+  `uvm_object_utils(flash_ctrl_rw_evict_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    int page;
+    int evict_trans, idx = 0;
+    int evict_start = 0;
+
+    rd_cache_t addr_q[$];
+
+    flash_op_t init_ctrl;
+    flash_dv_part_e part;
+    bank = $urandom_range(0, 1);
+
+    fork
+      begin
+        rd_cache_t entry;
+
+        while (idx < 30 && cfg.flash_ctrl_vif.fatal_err == 0) begin
+          `DV_CHECK_RANDOMIZE_FATAL(this)
+          rand_op.addr[OTFBankId] = bank;
+          ctrl = rand_op;
+
+          if (evict_start) begin
+            addr_q.shuffle();
+            entry = addr_q[0];
+            ctrl.otf_addr = entry.addr;
+            ctrl.partition = entry.part;
+            init_ctrl = ctrl;
+            send_evict(ctrl, bank);
+            ctrl = init_ctrl;
+            if (ctrl.partition == FlashPartData) begin
+              randcase
+                1: readback_flash(ctrl, bank, 1, fractions);
+                1: direct_readback(ctrl.otf_addr, bank, 1);
+              endcase
+            end else begin
+              readback_flash(ctrl, bank, 1, fractions);
+            end
+
+          end else begin
+            entry.bank = bank;
+            entry.addr = ctrl.otf_addr;
+            entry.part = ctrl.partition;
+
+            if (ctrl.partition == FlashPartData) begin
+              randcase
+                1: begin
+                  int size, is_odd, tail;
+                  is_odd = ctrl.addr[2];
+                  size = (fractions + is_odd) / 2;
+                  tail = (fractions + is_odd) % 2;
+                  repeat (size) begin
+                    addr_q.push_back(entry);
+                    if (addr_q.size > 4) begin
+                      rd_cache_t old_ent = addr_q.pop_front();
+                    end
+                    entry.addr += 8;
+                  end
+                  if (tail) begin
+                    addr_q.push_back(entry);
+                    if (addr_q.size > 4) begin
+                      rd_cache_t old_ent = addr_q.pop_front();
+                    end
+                  end
+                  readback_flash(ctrl, bank, 1, fractions);
+                end
+                1: begin
+                  addr_q.push_back(entry);
+                  if (addr_q.size > 4) begin
+                    rd_cache_t old_ent = addr_q.pop_front();
+                  end
+                  direct_readback(ctrl.otf_addr, bank, 1);
+                end
+              endcase
+            end else begin
+              int size, is_odd, tail;
+              is_odd = ctrl.addr[2];
+              size = (fractions + is_odd) / 2;
+              tail = (fractions + is_odd) % 2;
+              repeat (size) begin
+                addr_q.push_back(entry);
+                if (addr_q.size > 4) begin
+                  rd_cache_t old_ent = addr_q.pop_front();
+                end
+                entry.addr += 8;
+              end
+              if (tail) begin
+                addr_q.push_back(entry);
+                if (addr_q.size > 4) begin
+                  rd_cache_t old_ent = addr_q.pop_front();
+                end
+              end
+              readback_flash(ctrl, bank, 1, fractions);
+            end
+            `uvm_info("seq", $sformatf("idx:%0d done",idx), UVM_HIGH)
+          end // else: !if(evct_start)
+           idx++;
+        end // while (idx < 30 && cfg.flash_ctrl_vif.fatal_err == 0)
+        `uvm_info("seq",
+                  $sformatf("read complete fatal:%0d", cfg.flash_ctrl_vif.fatal_err), UVM_HIGH)
+      end // fork begin
+      begin
+        time timeout_ns = 100_000_000;
+        evict_trans = $urandom_range(4, 20);
+        `uvm_info("seq", $sformatf("wait evict start %0d", evict_trans), UVM_MEDIUM)
+        `DV_SPINWAIT( wait(idx == evict_trans);,
+                      $sformatf("Timed out waiting for evict trans %0d idx:%0d",
+                                evict_trans, idx), timeout_ns,
+                      "seq")
+        evict_start = 1;
+      end
+    join
+    cfg.seq_cfg.disable_flash_init = 1;
+  endtask
+
+  virtual task send_evict(flash_op_t ctrl, int bank);
+    prog_flash(ctrl, bank, 1, fractions);
+  endtask // send_evict
+
+
+endclass // flash_ctrl_rw_evict_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -43,3 +43,6 @@
 `include "flash_ctrl_intr_rd_vseq.sv"
 `include "flash_ctrl_intr_wr_vseq.sv"
 `include "flash_ctrl_prog_reset_vseq.sv"
+`include "flash_ctrl_legacy_base_vseq.sv"
+`include "flash_ctrl_rw_evict_vseq.sv"
+`include "flash_ctrl_re_evict_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -309,6 +309,18 @@
       reseed: 30
      }
     {
+      name: flash_ctrl_rw_evict
+      uvm_test_seq: flash_ctrl_rw_evict_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_read=1"]
+      reseed: 40
+     }
+    {
+      name: flash_ctrl_re_evict
+      uvm_test_seq: flash_ctrl_re_evict_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_read=1"]
+      reseed: 20
+     }
+    {
       name: flash_ctrl_sec_cm
       run_timeout_mins: 120
     }

--- a/hw/ip/flash_ctrl/dv/sva/flash_ctrl_bind.sv
+++ b/hw/ip/flash_ctrl/dv/sva/flash_ctrl_bind.sv
@@ -19,4 +19,23 @@ module flash_ctrl_bind;
     .h2d    (core_tl_i),
     .d2h    (core_tl_o)
   );
+
+  if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_mif_bind
+    for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_per_bank
+      bind tb.dut.u_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[i].
+                    u_prim_flash_bank flash_ctrl_mem_if flash_ctrl_mem_if (
+        .clk_i,
+        .rst_ni,
+        .data_mem_req,
+        .mem_wr,
+        .mem_addr,
+        .mem_wdata,
+        .mem_part,
+        .mem_info_sel,
+        .info0_mem_req (gen_info_types[0].info_mem_req),
+        .info1_mem_req (gen_info_types[1].info_mem_req),
+        .info2_mem_req (gen_info_types[2].info_mem_req)
+      );
+    end
+  end
 endmodule

--- a/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
+++ b/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
@@ -62,6 +62,7 @@ class flash_ctrl_base_test #(
     void'($value$plusargs("otf_num_hr=%0d", cfg.otf_num_hr));
     void'($value$plusargs("otf_wr_pct=%0d", cfg.otf_wr_pct));
     void'($value$plusargs("otf_rd_pct=%0d", cfg.otf_rd_pct));
+    void'($value$plusargs("en_always_read=%0d", cfg.en_always_read));
   endfunction
 
   task run_phase(uvm_phase phase);


### PR DESCRIPTION
This PR has followings.
- Add 'last mile' write path checker and enable for all otf tests.
- Add eviction tests with random protection profile.
- Add a new cover group for eviction
- Update testplan for new eviction tests.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>