### PR TITLE
[top_earlgrey, dv] Add support for tiled OTBN Dmem memory

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -91,6 +91,9 @@ class chip_env extends cip_base_env #(
 
       is_invalid |= mem inside {[RamRet0:RamRet15]} && (int'(mem - RamRet0) >
                                                         cfg.num_ram_ret_tiles - 1);
+
+      is_invalid |= mem inside {[OtbnDmem0:OtbnDmem15]} && (int'(mem - OtbnDmem0) >
+                                                            cfg.num_otbn_dmem_tiles - 1);
       if (is_invalid) continue;
       if (!uvm_config_db#(mem_bkdr_util)::get(this, "", inst, cfg.mem_bkdr_util_h[mem])) begin
         `uvm_fatal(`gfn, {"failed to get ", inst, " from uvm_config_db"})

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -90,6 +90,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Number of RAM tiles for each RAM instance.
   uint num_ram_main_tiles;
   uint num_ram_ret_tiles;
+  uint num_otbn_dmem_tiles;
 
   // ext component cfgs
   rand uart_agent_cfg       m_uart_agent_cfgs[NUM_UARTS];
@@ -176,6 +177,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
     `DV_CHECK_LE_FATAL(num_ram_main_tiles, 16)
     `DV_CHECK_LE_FATAL(num_ram_ret_tiles, 16)
+    `DV_CHECK_LE_FATAL(num_otbn_dmem_tiles, 16)
 
     // Set external clock frequency.
     `DV_GET_ENUM_PLUSARG(ext_clk_type_e, ext_clk_type, ext_clk_type)

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -95,7 +95,7 @@ package chip_env_pkg;
     FlashBank1Data,
     FlashBank0Info,
     FlashBank1Info,
-    OtbnDmem,
+    OtbnDmem[16],
     OtbnImem,
     Otp,
     RamMain[16],

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -73,7 +73,9 @@ class chip_base_vseq #(
     // otbn_mem_scramble that may intentionally read memories before writing them. Reading these
     // memories still triggeres ECC integrity errors that need to be handled by the test.
     cfg.mem_bkdr_util_h[OtbnImem].clear_mem();
-    cfg.mem_bkdr_util_h[OtbnDmem].clear_mem();
+    for (int ram_idx = 0; ram_idx < cfg.num_otbn_dmem_tiles; ram_idx++) begin
+      cfg.mem_bkdr_util_h[chip_mem_e'(OtbnDmem0 + ram_idx)].clear_mem();
+    end
 
     // Bring the chip out of reset.
     super.dut_init(reset_kind);

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -508,16 +508,18 @@ module tb;
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[OtbnImem], `OTBN_IMEM_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTBN DMEM", UVM_MEDIUM)
-      m_mem_bkdr_util[OtbnDmem] = new(.name  ("mem_bkdr_util[OtbnDmem]"),
-                                      .path  (`DV_STRINGIFY(`OTBN_DMEM_HIER)),
-                                      .depth ($size(`OTBN_DMEM_HIER)),
-                                      .n_bits($bits(`OTBN_DMEM_HIER)),
-                                      .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[OtbnDmem], `OTBN_DMEM_HIER)
+      m_mem_bkdr_util[OtbnDmem0] = new(.name  ("mem_bkdr_util[OtbnDmem0]"),
+                                       .path  (`DV_STRINGIFY(`OTBN_DMEM_HIER)),
+                                       .depth ($size(`OTBN_DMEM_HIER)),
+                                       .n_bits($bits(`OTBN_DMEM_HIER)),
+                                       .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[OtbnDmem0], `OTBN_DMEM_HIER)
 
       mem = mem.first();
       do begin
-        if (mem inside {[RamMain1:RamMain15]} || mem inside {[RamRet1:RamRet15]}) begin
+        if (mem inside {[RamMain1:RamMain15]} ||
+            mem inside {[RamRet1:RamRet15]} ||
+            mem inside {[OtbnDmem1:OtbnDmem15]}) begin
           mem = mem.next();
           continue;
         end

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -30,6 +30,7 @@ class chip_base_test extends cip_base_test #(
     // Set the number of RAM tiles (1 each).
     cfg.num_ram_main_tiles = 1;
     cfg.num_ram_ret_tiles = 1;
+    cfg.num_otbn_dmem_tiles = 1;
 
     // Knob to set the UART baud rate (set to 2M by default).
     void'($value$plusargs("uart_baud_rate=%0d", cfg.uart_baud_rate));


### PR DESCRIPTION
This is a follow-up for #14362 and adds support for a tiled physical implementation for the OTBN Dmem.

Signed-off-by: Michael Schaffner <msf@google.com>