### PR TITLE
[dif] Add functions to read rstmgr and pwrmgr fatal errors

### DIFF
--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -119,7 +119,7 @@ typedef uint32_t dif_clkmgr_recov_err_codes_t;
 
 typedef enum dif_clkmgr_fatal_err_type {
   /**
-   * A recoverable update error for one of the clocks.
+   * A fatal error for regfile integrity.
    */
   kDifClkmgrFatalErrTypeRegfileIntegrity = 1u << 0,
   /**
@@ -135,7 +135,7 @@ typedef enum dif_clkmgr_fatal_err_type {
 /**
  * A set of fatal errors.
  *
- * This type is used to clear and read the fatal error codes.
+ * This type is used to read the fatal error codes.
  */
 typedef uint32_t dif_clkmgr_fatal_err_codes_t;
 
@@ -382,7 +382,8 @@ dif_result_t dif_clkmgr_recov_err_code_clear_codes(
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_clkmgr_fatal_err_code_get_codes(
-    const dif_clkmgr_t *clkmgr, dif_clkmgr_fatal_err_type_t *codes);
+    const dif_clkmgr_t *clkmgr, dif_clkmgr_fatal_err_codes_t *codes);
+
 /**
  * Wait for external clock switch to finish.
  *

--- a/sw/device/lib/dif/dif_clkmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_clkmgr_unittest.cc
@@ -570,14 +570,14 @@ TEST_F(RecovErrorTest, ClearCodes) {
 class FatalErrorTest : public ClkMgrTest {};
 
 TEST_F(FatalErrorTest, GetBadArgs) {
-  dif_clkmgr_fatal_err_type_t codes;
+  dif_clkmgr_fatal_err_codes_t codes;
   EXPECT_DIF_BADARG(dif_clkmgr_fatal_err_code_get_codes(nullptr, nullptr));
   EXPECT_DIF_BADARG(dif_clkmgr_fatal_err_code_get_codes(nullptr, &codes));
   EXPECT_DIF_BADARG(dif_clkmgr_fatal_err_code_get_codes(&clkmgr_, nullptr));
 }
 
 TEST_F(FatalErrorTest, GetCodes) {
-  dif_clkmgr_fatal_err_type_t codes;
+  dif_clkmgr_fatal_err_codes_t codes;
   EXPECT_READ32(CLKMGR_FATAL_ERR_CODE_REG_OFFSET, 6);
   EXPECT_DIF_OK(dif_clkmgr_fatal_err_code_get_codes(&clkmgr_, &codes));
   EXPECT_EQ(codes, 6);

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -451,3 +451,13 @@ dif_result_t dif_pwrmgr_wakeup_reason_clear(const dif_pwrmgr_t *pwrmgr) {
 
   return kDifOk;
 }
+
+dif_result_t dif_pwrmgr_fatal_err_code_get_codes(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_fatal_err_codes_t *codes) {
+  if (pwrmgr == NULL || codes == NULL) {
+    return kDifBadArg;
+  }
+  *codes =
+      mmio_region_read32(pwrmgr->base_addr, PWRMGR_FAULT_STATUS_REG_OFFSET);
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -158,6 +158,28 @@ typedef enum dif_pwrmgr_wakeup_type {
  */
 typedef uint8_t dif_pwrmgr_wakeup_types_t;
 
+typedef enum dif_pwrmgr_fatal_err_type {
+  /**
+   * A fatal error for regfile integrity.
+   */
+  kDifPwrmgrFatalErrTypeRegfileIntegrity = 1u << 0,
+  /**
+   * A fatal error for escalation timeout.
+   */
+  kDifPwrmgrFatalErrTypeEscalationTimeout = 1u << 1,
+  /**
+   * A fatal error for main power glitch.
+   */
+  kDifPwrmgrFatalErrTypeMainPowerGlitch = 1u << 2,
+} dif_pwrmgr_fatal_err_type_t;
+
+/**
+ * A set of fatal errors.
+ *
+ * This type is used to read the fatal error codes.
+ */
+typedef uint32_t dif_pwrmgr_fatal_err_codes_t;
+
 /**
  * Wakeup types and requests from sources since the last time recording started.
  */
@@ -366,6 +388,17 @@ dif_result_t dif_pwrmgr_wakeup_reason_get(const dif_pwrmgr_t *pwrmgr,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_pwrmgr_wakeup_reason_clear(const dif_pwrmgr_t *pwrmgr);
+
+/**
+ * Read the fatal error codes.
+ *
+ * @param pwrmgr Power Manager Handle.
+ * @param[out] codes The fatal error codes.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_fatal_err_code_get_codes(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_fatal_err_codes_t *codes);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_pwrmgr_unittest.cc
@@ -766,5 +766,21 @@ TEST_F(WakeupRecording, ClearReason) {
   EXPECT_DIF_OK(dif_pwrmgr_wakeup_reason_clear(&pwrmgr_));
 }
 
+class FatalErrorTest : public DifPwrmgrInitialized {};
+
+TEST_F(FatalErrorTest, GetBadArgs) {
+  dif_pwrmgr_fatal_err_codes_t codes;
+  EXPECT_DIF_BADARG(dif_pwrmgr_fatal_err_code_get_codes(nullptr, nullptr));
+  EXPECT_DIF_BADARG(dif_pwrmgr_fatal_err_code_get_codes(nullptr, &codes));
+  EXPECT_DIF_BADARG(dif_pwrmgr_fatal_err_code_get_codes(&pwrmgr_, nullptr));
+}
+
+TEST_F(FatalErrorTest, GetCodes) {
+  dif_pwrmgr_fatal_err_codes_t codes;
+  EXPECT_READ32(PWRMGR_FAULT_STATUS_REG_OFFSET, 6);
+  EXPECT_DIF_OK(dif_pwrmgr_fatal_err_code_get_codes(&pwrmgr_, &codes));
+  EXPECT_EQ(codes, 6);
+}
+
 }  // namespace
 }  // namespace dif_pwrmgr_unittest

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -405,3 +405,12 @@ dif_result_t dif_rstmgr_software_device_reset(const dif_rstmgr_t *handle) {
 
   return kDifOk;
 }
+
+dif_result_t dif_rstmgr_fatal_err_code_get_codes(
+    const dif_rstmgr_t *rstmgr, dif_rstmgr_fatal_err_codes_t *codes) {
+  if (rstmgr == NULL || codes == NULL) {
+    return kDifBadArg;
+  }
+  *codes = mmio_region_read32(rstmgr->base_addr, RSTMGR_ERR_CODE_REG_OFFSET);
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -110,6 +110,24 @@ typedef enum dif_rstmgr_reset_info {
  */
 typedef uint32_t dif_rstmgr_peripheral_t;
 
+typedef enum dif_rstmgr_fatal_err_type {
+  /**
+   * A fatal error for regfile integrity.
+   */
+  kDifRstmgrFatalErrTypeRegfileIntegrity = 1u << 0,
+  /**
+   * A fatal error for reset consistency.
+   */
+  kDifRstmgrFatalErrTypeResetConsistency = 1u << 1,
+} dif_rstmgr_fatal_err_type_t;
+
+/**
+ * A set of fatal errors.
+ *
+ * This type is used to read the fatal error codes.
+ */
+typedef uint32_t dif_rstmgr_fatal_err_codes_t;
+
 /**
  * Resets the Reset Manager registers to sane defaults.
  *
@@ -347,6 +365,17 @@ dif_result_t dif_rstmgr_software_reset_is_held(
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_rstmgr_software_device_reset(const dif_rstmgr_t *handle);
+
+/**
+ * Read the fatal error codes.
+ *
+ * @param rstmgr Reset Manager Handle.
+ * @param[out] codes The fatal error codes.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rstmgr_fatal_err_code_get_codes(
+    const dif_rstmgr_t *rstmgr, dif_rstmgr_fatal_err_codes_t *codes);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_rstmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_rstmgr_unittest.cc
@@ -644,6 +644,21 @@ TEST_F(SoftwareResetIsHeldTest, Success) {
     EXPECT_FALSE(asserted);
   }
 }
+class FatalErrorTest : public RstmgrTest {};
+
+TEST_F(FatalErrorTest, GetBadArgs) {
+  dif_rstmgr_fatal_err_codes_t codes;
+  EXPECT_DIF_BADARG(dif_rstmgr_fatal_err_code_get_codes(nullptr, nullptr));
+  EXPECT_DIF_BADARG(dif_rstmgr_fatal_err_code_get_codes(nullptr, &codes));
+  EXPECT_DIF_BADARG(dif_rstmgr_fatal_err_code_get_codes(&rstmgr_, nullptr));
+}
+
+TEST_F(FatalErrorTest, GetCodes) {
+  dif_rstmgr_fatal_err_codes_t codes;
+  EXPECT_READ32(RSTMGR_ERR_CODE_REG_OFFSET, 6);
+  EXPECT_DIF_OK(dif_rstmgr_fatal_err_code_get_codes(&rstmgr_, &codes));
+  EXPECT_EQ(codes, 6);
+}
 
 }  // namespace
 }  // namespace dif_rstmgr_unittest


### PR DESCRIPTION
Also fix minor issues in clkmgr for this functionality.

Signed-off-by: Guillermo Maturana <maturana@google.com>