### PR TITLE
[flash_ctrl,dv] overwrite overread test

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -211,6 +211,23 @@
       tests: ["flash_ctrl_error_prog_type"]
     }
     {
+      name: read_write_overflow
+      desc: '''
+            Send following error transactions with normal traffic and see
+            any catastrophic event happens.
+              - Program flash size longer than 64 bytes.
+                This wil cause prog_win_err.
+              - Read flash from controller without settting start op.
+              - Issue rd_fifo read more thatn CONTROL.NUM field value.
+                Both will cause d_error in tlul response.
+            Each transaction is terminated gracefully and should not cause
+            data path lock up. Also error status should be check per each
+            transaction.
+            '''
+      stage: V2
+      tests: ["flash_ctrl_oversize_error"]
+    }
+    {
       name: stress_all
       desc: '''
             - combine above sequences in one test to run sequentially, except csr sequence

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -78,6 +78,7 @@ filesets:
       - seq_lib/flash_ctrl_legacy_base_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_rw_evict_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_re_evict_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_oversize_error_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -158,6 +158,9 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   int       otf_num_hr = 2500;
   int       otf_wr_pct = 1;
   int       otf_rd_pct = 1;
+  // overflow error rate
+  int       otf_bwr_pct = 1;
+  int       otf_brd_pct = 1;
 
   // interrupt mode
   bit       intr_mode = 0;

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -28,6 +28,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
   flash_ctrl_env_cfg cfg;
 
   int eg_exp_cnt = 0;
+  bit comp_off = 0;
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
@@ -319,6 +320,8 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
   task compare_data(fdata_q_t obs, fdata_q_t exp, int bank, string rw, bit is_ecc = 0);
     string str = $sformatf("%s_comp_bank%0d", rw, bank);
     bit    err = 0;
+
+    if (comp_off) return;
 
     foreach (obs[i]) begin
       if(is_ecc) begin

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -345,7 +345,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // Read data from flash, stopping whenever empty.
   // The flash op is assumed to have already commenced.
-  virtual task flash_ctrl_read(uint num_words, ref data_q_t data, input bit poll_fifo_status);
+  virtual task flash_ctrl_read(uint num_words, ref data_q_t data,
+                               input bit poll_fifo_status, bit dis = 0);
     for (int i = 0; i < num_words; i++) begin
       // Check if rd fifo is empty. If yes, then wait for data to become available.
       // Note that this polling is not needed since the interface is backpressure enabled.
@@ -354,6 +355,9 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       end
       mem_rd(.ptr(ral.rd_fifo), .offset(0), .data(data[i]));
       `uvm_info(`gfn, $sformatf("flash_ctrl_read: 0x%0h", data[i]), UVM_HIGH)
+      if (dis) begin
+        `uvm_info(`gfn, $sformatf("dis:flash_ctrl_read: 0x%0h", data[i]), UVM_MEDIUM)
+      end
     end
   endtask : flash_ctrl_read
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_oversize_error_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_oversize_error_vseq.sv
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Send errored traffic with normal traffic.
+// Asserted error traffics are three kinds
+// 1. Oversized (more than 16 bus words) program traffic
+// 2. Oversized Read traffic: issue rd_fifo read more than
+//    it is supposed to.
+// 3. Issue rd_fifo read without starting op.
+
+class flash_ctrl_oversize_error_vseq extends flash_ctrl_otf_base_vseq;
+  `uvm_object_utils(flash_ctrl_oversize_error_vseq)
+  `uvm_object_new
+  flash_op_t ctrl;
+  int num, bank;
+
+  virtual task body();
+    cfg.scb_h.do_alert_check = 0;
+    cfg.otf_scb_h.comp_off = 0;
+
+    fork
+      begin
+        repeat(cfg.otf_num_rw) begin
+          `DV_CHECK_RANDOMIZE_FATAL(this)
+          ctrl = rand_op;
+          bank = rand_op.addr[OTFBankId];
+          if (ctrl.partition == FlashPartData) begin
+            num = ctrl_num;
+          end else begin
+            num = ctrl_info_num;
+          end
+          randcase
+            cfg.otf_wr_pct:prog_flash(ctrl, bank, num, fractions);
+            cfg.otf_rd_pct:read_flash(ctrl, bank, num, fractions);
+            cfg.otf_bwr_pct: begin
+              `uvm_info("seq", $sformatf("inj:prog_err: %0d", fractions + 16), UVM_MEDIUM)
+              prog_flash(ctrl, bank, 1, fractions + 16);
+            end
+            cfg.otf_brd_pct: begin
+              int sz = $urandom_range(1, 16);
+              randcase
+                1: begin
+                  `uvm_info("seq", $sformatf("inj:overread %0d",sz), UVM_MEDIUM)
+                  overread(ctrl, bank, 1, sz);
+                end
+                4: begin
+                  `uvm_info("seq", $sformatf("inj:read_err %0d", fractions + sz), UVM_MEDIUM)
+                  read_flash(ctrl, bank, 1, fractions, sz);
+                end
+              endcase
+             end
+          endcase
+        end
+      end
+      begin
+        for (int i = 0; i < cfg.otf_num_hr; ++i) begin
+          fork
+            send_rand_host_rd();
+          join_none
+          #0;
+        end
+        csr_utils_pkg::wait_no_outstanding_access();
+      end
+    join
+  endtask
+
+endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -46,3 +46,4 @@
 `include "flash_ctrl_legacy_base_vseq.sv"
 `include "flash_ctrl_rw_evict_vseq.sv"
 `include "flash_ctrl_re_evict_vseq.sv"
+`include "flash_ctrl_oversize_error_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -272,6 +272,14 @@
       reseed: 5
     }
     {
+      name: flash_ctrl_oversize_error
+      uvm_test_seq: flash_ctrl_oversize_error_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+serr_pct=0",
+                 "+otf_num_hr=1000", "+otf_num_rw=100",
+		 "+otf_wr_pct=4", "+otf_rd_pct=4"]
+      reseed: 5
+    }
+    {
       name: flash_ctrl_integrity
       uvm_test_seq: flash_ctrl_rw_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=4", "+ierr_pct=3",


### PR DESCRIPTION
Oversize write / read test
- Oversize write: Send program command and push more data then 64bytes.
- Oversize read: 
> Send read command and issue read fifo command more then the number in the read command.
> Send read fifo command without sending start_op.
  
Signed-off-by: Jaedon Kim <jdonjdon@google.com>