### PR TITLE
[chip testplan] Remove chip_sw_pwrmgr_debug_sleep

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1079,15 +1079,6 @@
       tests: ["chip_sw_pwrmgr_b2b_sleep_reset_req"]
     }
     {
-      name: chip_sw_pwrmgr_debug_sleep
-      desc: '''Verify low power entry is prevented when the chip is in "debuggable" state.
-
-            This is an open issue: https://github.com/lowRISC/opentitan/issues/7215
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
       name: chip_sw_pwrmgr_sleep_disabled
       desc: '''Verify that the chip does not go to sleep on WFI when low power hint is 0.
 


### PR DESCRIPTION
This commit removes the chip_sw_pwrmgr_debug_sleep test
from the chip testplan as discussed in #14153.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>