### PR TITLE
[test, top_earlgrey] Reduce timeout values for otbn_ecdsa_op_irq_test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -674,16 +674,16 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_ecdsa_op_irq_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=28_000_000"]
-      run_timeout_mins: 400
+      run_opts: ["+sw_test_timeout_ns=22_000_000"]
+      run_timeout_mins: 300
     }
     {
       name: chip_sw_otbn_ecdsa_op_irq_jitter_en
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_ecdsa_op_irq_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=35_000_000", "+en_jitter=1"]
-      run_timeout_mins: 400
+      run_opts: ["+sw_test_timeout_ns=29_000_000", "+en_jitter=1"]
+      run_timeout_mins: 300
     }
     {
       name: chip_sw_otbn_mem_scramble


### PR DESCRIPTION
lowRISC/OpenTitan#14428 helped to reduce both the simulated and wall clock time for these tests. This PR adjusts the specified timeout values accordingly.