### PR TITLE
[otbn,dv] Unset `recov_alert_seen` on reset in `otbn_scoreboard`

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -482,7 +482,9 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     num_alert_wait_counters--;
 
     if (cfg.under_reset) begin
-      // If we're in reset, exit immediately. No need to check anything or update any state
+      // If we're in reset, exit immediately. No need to check anything or update any state, except
+      // that we have not seen a recoverable alert since the last reset.
+      recov_alert_seen = 1'b0;
       return;
     end
 


### PR DESCRIPTION
Prior to this PR, the OTBN scoreboard would not reset the flag that
tracks if a recoverable alert has been seen (`recov_alert_seen`) on a
reset.  This caused errors (such as "Double recoverable alert seen") in
tests that reset before the recoverable alert has been handled (such as
`otbn_reset`).  This could be reproduced with `otbn_reset` and the seeds
`2209004860` and `542535943`.

This PR adds the missing reset.