### PR TITLE
[dv/kmac] Work on code TODO items

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_if.sv
@@ -14,6 +14,8 @@ interface kmac_if(input clk_i, input rst_ni);
     lc_escalate_en_i = val;
   endfunction
 
+  `ASSERT(KmacMaskingO_A, `EN_MASKING == en_masking_o)
+
   // TODO(#10804): confirm with designer if we need to set app_err_o as error.
   // `ASSERT(LcEscalationAppErr_A, lc_escalate_en_i != lc_ctrl_pkg::Off |->
   //        ##3 ((app_err_o == 3'b111) throughout (rst_ni == 1)))

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -109,7 +109,6 @@ class kmac_base_vseq extends cip_base_vseq #(
   rand bit [TL_DBW-1:0] data_mask;
 
   // Error control fields
-  rand bit en_kmac_err;
   rand kmac_pkg::err_code_e kmac_err_type;
   // When creating errors by issue the wrong SW command, we need to have access
   // to what operational state to send an erroneous command in,
@@ -199,7 +198,7 @@ class kmac_base_vseq extends cip_base_vseq #(
   // Create an appropriate incorrect command based on what state to send an error in
   constraint err_sw_cmd_seq_c {
     solve err_sw_cmd_seq_st before err_sw_cmd_seq_cmd;
-    if (en_kmac_err && kmac_err_type == kmac_pkg::ErrSwCmdSequence) {
+    if (kmac_err_type == kmac_pkg::ErrSwCmdSequence) {
       if (err_sw_cmd_seq_st == sha3_pkg::StIdle) {
         err_sw_cmd_seq_cmd inside {CmdProcess, CmdManualRun, CmdDone};
       } else if (err_sw_cmd_seq_st == sha3_pkg::StAbsorb) {
@@ -291,7 +290,7 @@ class kmac_base_vseq extends cip_base_vseq #(
     cfg_interrupts(.interrupts(enable_intr));
     // For error cases that does not support in scb, predict its value so can be used in
     // `check_err` task.
-    if (cfg.en_scb == 0) ral.intr_enable.predict(enable_intr);
+    if (cfg.en_scb == 0) void'(ral.intr_enable.predict(enable_intr));
     `uvm_info(`gfn, $sformatf("intr[KmacDone] = %0b", enable_intr[KmacDone]), UVM_HIGH)
     `uvm_info(`gfn, $sformatf("intr[KmacFifoEmpty] = %0b", enable_intr[KmacFifoEmpty]), UVM_HIGH)
     `uvm_info(`gfn, $sformatf("intr[KmacErr] = %0b", enable_intr[KmacErr]), UVM_HIGH)

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
@@ -18,19 +18,8 @@ class kmac_edn_timeout_error_vseq extends kmac_app_vseq;
   }
 
   constraint kmac_err_type_c {
-    if (en_kmac_err) {
-      kmac_err_type == kmac_pkg::ErrWaitTimerExpired;
-      entropy_fast_process == 0;
-    } else {
-      kmac_err_type == kmac_pkg::ErrNone;
-    }
-  }
-
-  constraint en_err_c {
-    en_kmac_err dist {
-      0 :/ 2,
-      1 :/ 8
-    };
+    kmac_err_type dist {kmac_pkg::ErrWaitTimerExpired :/ 4, kmac_pkg::ErrNone :/ 1};
+    kmac_err_type == kmac_pkg::ErrWaitTimerExpired -> entropy_fast_process == 0;
   }
 
   function void pre_randomize();

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_entropy_mode_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_entropy_mode_error_vseq.sv
@@ -14,11 +14,7 @@ class kmac_entropy_mode_error_vseq extends kmac_edn_timeout_error_vseq;
   `uvm_object_new
 
   constraint kmac_err_type_c {
-    if (en_kmac_err) {
-      kmac_err_type == kmac_pkg::ErrIncorrectEntropyMode;
-    } else {
-      kmac_err_type == kmac_pkg::ErrNone;
-    }
+    kmac_err_type dist {kmac_pkg::ErrIncorrectEntropyMode :/ 4, kmac_pkg::ErrNone :/ 1};
   }
 
   // No assertions to disable.
@@ -36,7 +32,7 @@ class kmac_entropy_mode_error_vseq extends kmac_edn_timeout_error_vseq;
     fork begin
       while (cfg.en_scb == 0 && entropy_fetched == 0) begin
         wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.done == 1);
-        if (cfg.enable_masking && entropy_mode == ErrIncorrectEntropyMode) begin
+        if (cfg.enable_masking && kmac_err_type == ErrIncorrectEntropyMode) begin
           if (entropy_fetched == 0) begin
             `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.error, 1)
           end

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
@@ -8,40 +8,18 @@ class kmac_error_vseq extends kmac_app_vseq;
   `uvm_object_new
 
   virtual function string convert2string();
-    return {$sformatf("en_kmac_err: %0b\n", en_kmac_err),
-            $sformatf("kmac_err_type: %0s\n", kmac_err_type.name()),
+    return {$sformatf("kmac_err_type: %0s\n", kmac_err_type.name()),
             $sformatf("err_sw_cmd_seq_st: %0s\n", err_sw_cmd_seq_st.name()),
             $sformatf("err_sw_cmd_seq_cmd: %0s\n", err_sw_cmd_seq_cmd.name()),
             super.convert2string()};
   endfunction
 
-  virtual task pre_start();
-    disable_err_c.constraint_mode(0);
-    en_app_c.constraint_mode(0);
-    super.pre_start();
-  endtask
-
-  constraint en_err_c {
-    en_kmac_err dist {
-      0 :/ 3,
-      1 :/ 7
-    };
-  }
-
-  constraint kmac_err_type_c {
-    kmac_err_type != ErrUnexpectedModeStrength;
-    if (en_kmac_err) {
-      (kmac_err_type inside
-          {kmac_pkg::ErrNone,
-           // Below error cases are verified in separate testbench.
-           kmac_pkg::ErrKeyNotValid,
-           kmac_pkg::ErrWaitTimerExpired,
-           kmac_pkg::ErrIncorrectEntropyMode}) == 0;
-    } else {
-      kmac_err_type == kmac_pkg::ErrNone;
-    }
-    // TODO: remove this constraint when scb error found.
-    (kmac_err_type == kmac_pkg:: ErrUnexpectedModeStrength) -> (en_unsupported_modestrength == 1);
+  constraint disable_err_c {
+    (kmac_err_type inside
+        {// Below error cases are verified in separate testbench.
+         kmac_pkg::ErrKeyNotValid,
+         kmac_pkg::ErrWaitTimerExpired,
+         kmac_pkg::ErrIncorrectEntropyMode}) == 0;
 
     (kmac_err_type == kmac_pkg::ErrSwPushedMsgFifo) -> (en_app == 1);
 
@@ -53,5 +31,10 @@ class kmac_error_vseq extends kmac_app_vseq;
 
     (kmac_err_type == kmac_pkg::ErrSwCmdSequence) -> (en_app == 0);
   }
+
+  virtual task pre_start();
+    en_app_c.constraint_mode(0);
+    super.pre_start();
+  endtask
 
 endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -48,7 +48,6 @@ class kmac_smoke_vseq extends kmac_base_vseq;
   }
 
   constraint disable_err_c {
-    en_kmac_err == 0;
     kmac_err_type == kmac_pkg::ErrNone;
   }
 
@@ -281,6 +280,11 @@ class kmac_smoke_vseq extends kmac_base_vseq;
 
         // issue Process cmd
         issue_cmd(CmdProcess);
+
+        if (kmac_err_type == kmac_pkg::ErrUnexpectedModeStrength &&
+            en_unsupported_modestrength == 0) begin
+          continue;
+        end
 
         wait_for_kmac_done();
         kmac_done = 1;

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -68,11 +68,8 @@ module tb;
     .keymgr_key_i       (kmac_sideload_key),
 
     // KeyMgr KDF datapath
-    //
-    // TODO: this is set to 0 for the time being to get the csr tests passing.
-    //       this will eventually be hooked up to the kmac<->keymgr agent.
-    .app_i       (app_req ),
-    .app_o       (app_rsp ),
+    .app_i              (app_req ),
+    .app_o              (app_rsp ),
 
     // Interrupts
     .intr_kmac_done_o   (interrupts[KmacDone]      ),
@@ -82,7 +79,6 @@ module tb;
     // Idle interface
     .idle_o             (kmac_if.idle_o ),
 
-    // TODO: check this output signal.
     .en_masking_o       (kmac_if.en_masking_o ),
 
     // EDN interface


### PR DESCRIPTION
This PR works on a few TODO items in the code:
1). Add assertions to check `masking_o`.
2). Remove error mode to only set `en_unsupported_modestrength = 1`
3). Remove a TODO comment that is already implemented.
4). Simplify the sequence by remove the knob: `en_kmac_err`

Signed-off-by: Cindy Chen <chencindy@opentitan.org>