### PR TITLE
[otbn,dv] Relax assert for DMEM/IMEM in SecWipeInt

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -631,8 +631,9 @@ class otbn_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   virtual function void mem_compare(string ral_name, uvm_reg_addr_t addr, tl_seq_item item);
-    // We can only compare the contents inside memories when the OTBN is not operating
-    if (model_status == otbn_pkg::StatusIdle) begin
+    // We can only compare the contents inside memories when the OTBN is not busy executing
+    // or wiping the memories
+    if (model_status inside {otbn_pkg::StatusIdle, otbn_pkg::StatusBusySecWipeInt}) begin
       super.mem_compare(ral_name, addr, item);
     // Otherwise the contents will read out as zeros so compare expected memory with zero.
     end else begin

--- a/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
@@ -129,7 +129,7 @@ module otbn_idle_checker
           running_q |-> ##[0:1] (idle_o_i == prim_mubi_pkg::MuBi4False))
 
   `ASSERT(IdleIfNotRunningOrLocked_A,
-          !(running_qq || status_q_i == otbn_pkg::StatusLocked) |->
+          !(running_qq || busy_secure_wipe || status_q_i == otbn_pkg::StatusLocked) |->
           (idle_o_i == prim_mubi_pkg::MuBi4True))
 
   `ASSERT(NotIdleIfLockedAndRotatingKeys_A,
@@ -158,7 +158,8 @@ module otbn_idle_checker
   // with status_q reporting 'StatusLocked'. So expected bus read data depends upon locked status
   // when running.
   `ASSERT(NoMemRdataWhenBusy_A,
-    running_q |-> ((status_q_i == otbn_pkg::StatusLocked) ?
+    running_q && !(status_q_i == otbn_pkg::StatusBusySecWipeInt) |->
+      ((status_q_i == otbn_pkg::StatusLocked) ?
       imem_rdata_bus == EccZeroWord && dmem_rdata_bus == EccWideZeroWord :
       imem_rdata_bus == 'b0 && dmem_rdata_bus == 'b0))
 


### PR DESCRIPTION
Update to idle checker is needed to reflect OTBN not doing blanking
while doing an internal secure wipe. Also, doing the internal secure
wipe affects idle_o output. So, we need to add that condition to our
checkers as well.

Fixes assertion failures regarding `otbn_mem_walk` test.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>