### PR TITLE
fix(crypto): Change direct python call

### DIFF
--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -223,9 +223,9 @@ def _cryptotest_header(ctx):
     hjson = ctx.file.hjson
     ctx.actions.run(
         outputs = [header],
-        inputs = [ctx.executable.test_setter, template, hjson],
+        inputs = [template, hjson],
         arguments = ["--template", template.path, hjson.path, header.path],
-        executable = ctx.executable.test_setter,
+        executable = ctx.executable.tool,
     )
 
     return [
@@ -246,10 +246,9 @@ autogen_cryptotest_header = rule(
         "deps": attr.label_list(allow_files = True),
         "template": attr.label(mandatory = True, allow_single_file = [".tpl"]),
         "hjson": attr.label(mandatory = True, allow_single_file = [".hjson"]),
-        "test_setter": attr.label(
-            allow_single_file = True,
+        "tool": attr.label(
+            default = "//sw/device/tests/crypto:ecdsa_p256_verify_set_testvectors",
             executable = True,
-            mandatory = True,
             cfg = "exec",
         ),
     },

--- a/sw/device/silicon_creator/lib/sigverify/sigverify_tests/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify_tests/BUILD
@@ -10,19 +10,32 @@ package(default_visibility = ["//visibility:public"])
 autogen_cryptotest_header(
     name = "sigverify_testvectors_hardcoded",
     hjson = "//sw/device/tests/crypto/testvectors:rsa_3072_verify_testvectors_hardcoded",
-    template = "sigverify_testvectors.h.tpl",
-    test_setter = "sigverify_set_testvectors.py",
-    deps = [
-        requirement("hjson"),
-    ],
+    template = ":sigverify_testvectors.h.tpl",
+    tool = ":sigverify_set_testvectors",
 )
 
 autogen_cryptotest_header(
     name = "sigverify_testvectors_wycheproof",
     hjson = "//sw/device/tests/crypto/testvectors:rsa_3072_verify_testvectors_wycheproof",
-    template = "sigverify_testvectors.h.tpl",
-    test_setter = "sigverify_set_testvectors.py",
+    template = ":sigverify_testvectors.h.tpl",
+    tool = ":sigverify_set_testvectors",
+)
+
+py_binary(
+    name = "sigverify_set_testvectors",
+    srcs = ["sigverify_set_testvectors.py"],
+    imports = ["."],
     deps = [
+        "//util/design/lib:common",
         requirement("hjson"),
+        requirement("mako"),
+        requirement("pycryptodome"),
+    ],
+)
+
+filegroup(
+    name = "template_files",
+    srcs = [
+        "sigverify_testvectors.h.tpl",
     ],
 )

--- a/sw/device/silicon_creator/lib/sigverify/sigverify_tests/sigverify_set_testvectors.py
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify_tests/sigverify_set_testvectors.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import os
 import sys
 
 import hjson
@@ -45,10 +44,10 @@ def compute_n0_inv(n):
     n0 = n & ((1 << 256) - 1)
     # maski = 2^i - 1 (start with i=2)
     maski = 3
-    for i in range(2, w+1):
+    for i in range(2, w + 1):
         # (n * y) mod 2^i = (n0 * y) mod 2^i because i <= 256
         if (n0 * y) & maski != 1:
-            y = y + (1 << (i-1))
+            y = y + (1 << (i - 1))
         maski <<= 1
         maski += 1
     return (1 << w) - y
@@ -110,20 +109,14 @@ def main() -> int:
                         metavar='FILE',
                         type=argparse.FileType('r'),
                         help='Read test vectors from this HJSON file.')
-    tpl_default = open(
-        os.path.join(os.path.dirname(__file__), DEFAULT_TEMPLATE), 'r')
     parser.add_argument('--template',
                         metavar='FILE',
                         required=False,
-                        default=tpl_default,
                         type=argparse.FileType('r'),
                         help='Read header template from this file.')
-    out_default = open(
-        os.path.join(os.path.dirname(__file__), DEFAULT_OUTFILE), 'w')
     parser.add_argument('headerfile',
                         metavar='FILE',
                         nargs='?',
-                        default=out_default,
                         type=argparse.FileType('w'),
                         help='Write output to this file.')
 
@@ -151,9 +144,7 @@ def main() -> int:
 
     args.headerfile.write(Template(args.template.read()).render(tests=testvecs))
     args.headerfile.close()
-    out_default.close()
     args.template.close()
-    tpl_default.close()
 
     return 0
 

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -28,11 +28,8 @@ opentitan_functest(
 autogen_cryptotest_header(
     name = "ecdsa_p256_verify_testvectors_hardcoded_header",
     hjson = "//sw/device/tests/crypto/testvectors:ecdsa_p256_verify_testvectors_hardcoded",
-    template = "ecdsa_p256_verify_testvectors.h.tpl",
-    test_setter = "ecdsa_p256_verify_set_testvectors.py",
-    deps = [
-        requirement("hjson"),
-    ],
+    template = ":ecdsa_p256_verify_testvectors.h.tpl",
+    tool = "//sw/device/tests/crypto:ecdsa_p256_verify_set_testvectors",
 )
 
 opentitan_functest(
@@ -55,11 +52,8 @@ opentitan_functest(
 autogen_cryptotest_header(
     name = "rsa_3072_verify_testvectors_wycheproof_header",
     hjson = "//sw/device/tests/crypto/testvectors:rsa_3072_verify_testvectors_wycheproof",
-    template = "rsa_3072_verify_testvectors.h.tpl",
-    test_setter = "rsa_3072_verify_set_testvectors.py",
-    deps = [
-        requirement("hjson"),
-    ],
+    template = ":rsa_3072_verify_testvectors.h.tpl",
+    tool = "//sw/device/tests/crypto:rsa_3072_verify_set_testvectors",
 )
 
 opentitan_functest(
@@ -82,8 +76,8 @@ opentitan_functest(
 autogen_cryptotest_header(
     name = "rsa_3072_verify_testvectors_hardcoded_header",
     hjson = "//sw/device/tests/crypto/testvectors:rsa_3072_verify_testvectors_hardcoded",
-    template = "rsa_3072_verify_testvectors.h.tpl",
-    test_setter = "rsa_3072_verify_set_testvectors.py",
+    template = ":rsa_3072_verify_testvectors.h.tpl",
+    tool = "//sw/device/tests/crypto:rsa_3072_verify_set_testvectors",
 )
 
 opentitan_functest(
@@ -100,5 +94,35 @@ opentitan_functest(
         "//sw/device/lib/crypto/rsa_3072:rsa_3072_verify",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+py_binary(
+    name = "ecdsa_p256_verify_set_testvectors",
+    srcs = ["ecdsa_p256_verify_set_testvectors.py"],
+    imports = ["."],
+    deps = [
+        "//util/design/lib:common",
+        requirement("hjson"),
+        requirement("mako"),
+    ],
+)
+
+py_binary(
+    name = "rsa_3072_verify_set_testvectors",
+    srcs = ["rsa_3072_verify_set_testvectors.py"],
+    imports = ["."],
+    deps = [
+        "//util/design/lib:common",
+        requirement("hjson"),
+        requirement("mako"),
+    ],
+)
+
+filegroup(
+    name = "template_files",
+    srcs = [
+        "ecdsa_p256_verify_testvectors.h.tpl",
+        "rsa_3072_verify_testvectors.h.tpl",
     ],
 )

--- a/sw/device/tests/crypto/ecdsa_p256_verify_set_testvectors.py
+++ b/sw/device/tests/crypto/ecdsa_p256_verify_set_testvectors.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import os
 import sys
 
 import hjson
@@ -42,20 +41,14 @@ def main() -> int:
                         metavar='FILE',
                         type=argparse.FileType('r'),
                         help='Read test vectors from this HJSON file.')
-    tpl_default = open(
-        os.path.join(os.path.dirname(__file__), DEFAULT_TEMPLATE), 'r')
     parser.add_argument('--template',
                         metavar='FILE',
                         required=False,
-                        default=tpl_default,
                         type=argparse.FileType('r'),
                         help='Read header template from this file.')
-    out_default = open(
-        os.path.join(os.path.dirname(__file__), DEFAULT_OUTFILE), 'w')
     parser.add_argument('headerfile',
                         metavar='FILE',
                         nargs='?',
-                        default=out_default,
                         type=argparse.FileType('w'),
                         help='Write output to this file.')
 
@@ -76,9 +69,7 @@ def main() -> int:
 
     args.headerfile.write(Template(args.template.read()).render(tests=testvecs))
     args.headerfile.close()
-    out_default.close()
     args.template.close()
-    tpl_default.close()
 
     return 0
 

--- a/sw/device/tests/crypto/rsa_3072_verify_set_testvectors.py
+++ b/sw/device/tests/crypto/rsa_3072_verify_set_testvectors.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import os
 import sys
 
 import hjson
@@ -43,20 +42,14 @@ def main() -> int:
                         metavar='FILE',
                         type=argparse.FileType('r'),
                         help='Read test vectors from this HJSON file.')
-    tpl_default = open(
-        os.path.join(os.path.dirname(__file__), DEFAULT_TEMPLATE), 'r')
     parser.add_argument('--template',
                         metavar='FILE',
                         required=False,
-                        default=tpl_default,
                         type=argparse.FileType('r'),
                         help='Read header template from this file.')
-    out_default = open(
-        os.path.join(os.path.dirname(__file__), DEFAULT_OUTFILE), 'w')
     parser.add_argument('headerfile',
                         metavar='FILE',
                         nargs='?',
-                        default=out_default,
                         type=argparse.FileType('w'),
                         help='Write output to this file.')
 
@@ -78,9 +71,7 @@ def main() -> int:
     tpl = Template(args.template.read())
     args.headerfile.write(tpl.render(tests=testvecs))
     args.headerfile.close()
-    out_default.close()
     args.template.close()
-    tpl_default.close()
 
     return 0
 


### PR DESCRIPTION
Previously crypo testvector header gen directly calls python script from
bazel. In that case, python from system environment is being used. The
system python doesn't have correct python packages in air-gapped
environment.

This commit revises the BUILD and autogen.bzl rules to call the
generator via `py_binary()` rule.