### PR TITLE
[rdc] Waive combo reset errors for SPI_DEVICE Tx/Rx FIFO reset signal

### DIFF
--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
@@ -19,3 +19,6 @@ set_constant -value 4'h9 scanmode
 
 # Strap to FuncSel(2'b00)
 set_constant -value 2'b00 top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q
+
+# Define POK as reset
+create_reset -interval 10 -waveform AON_CLK u_ast.vcaon_pok

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -12,9 +12,16 @@
 
 
 # POR_N
-set_reset_scenario { {POR_N {reset { @t0 0 } { #10 1}}}} -name ScnPOR
+# When POR_N released, POK remains high (already released from reset)
+set_reset_scenario { \
+  { POR_N           { reset {#2 0} { #10 1} }} \
+  { u_ast.vcaon_pok { constraint {@t0 1} }} \
+} -name ScnPOR
 
 # AST POK
+set_reset_scenario { \
+  { u_ast.vcaon_pok { reset {@t0 0} { #2 1} } } \
+} -name ScnPOK
 
 # PWRMGR Reset Cause
 

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -23,6 +23,21 @@ set_reset_scenario { \
   { u_ast.vcaon_pok { reset {@t0 0} { #2 1} } } \
 } -name ScnPOK
 
+# AST Regulator Resets
+set_reset_scenario { \
+  { u_ast.u_rglts_pdm_3p3v.vcmain_pok_h { reset { @t0 0 } { #10 1}}} \
+} -name ScnMainPok
+
+set_reset_scenario { \
+  { u_ast.u_rglts_pdm_3p3v.rglssm_vmppr_h_o { reset { @t0 0 } { #10 1}}} \
+} -name ScnRglSsmVmppr
+
+set_reset_scenario { \
+  { u_ast.u_rglts_pdm_3p3v.deep_sleep_h_o \
+    { reset { @t0 1 } { #10 0} { #10 0 }} \
+  } \
+} -name ScnRglDeepSleep
+
 # PWRMGR Reset Cause
 
 # RSTMGR SW Resets

--- a/hw/top_earlgrey/rdc/rdc_waivers.spi_device.tcl
+++ b/hw/top_earlgrey/rdc/rdc_waivers.spi_device.tcl
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Meridian RDC Waivers for SPI_DEVICE
+#
+
+# W_RST_COMBO_LOGIC
+# rst_rx/txfifo signals are reset signals but also returns data to SW. it is
+# recognized as combo reset by tool but reset line is OK.
+# TODO: Add buffer to separate other logics from reset
+set_rule_status -rule {W_RST_COMBO_LOGIC} -status {Waived}  \
+  -expression {(SourceReset=~"*.u_spi_device.u_reg.u_control_rst_*xfifo.q*")} \
+  -comment {rst_rx,txfifo are reset signals directly connected to the registers.q}


### PR DESCRIPTION
This PR includes https://github.com/lowRISC/opentitan/pull/14405. Please review last one.

RX/TX FIFOS SW reset signals are recognized as combo logic by the RDC
tool. The reason is the outputs are also used to return data to SW. The
actual reset lines are directly connected to the registers' output (q).