### PR TITLE
[test, otbn] Rework otbn_mem_scramble_test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2195,10 +2195,17 @@
 
             - Initialize the entropy_src subsystem to enable OTP_CTRL fetch random data (already
               done by the test_rom startup code).
-            - Have OTBN fetch a new key and nonce from the OTP_CTRL.
-            - Write and read-check OTBN and IMEM for consistency.
-            - Fetch a new key from the OTP_CTRL and ensure that previous contents in the IMEM and
-              DMEM cannot be read anymore.
+            - Extract random address offsets from RV_CORE_IBEX_RND_DATA.
+            - Wait for OTBN to be idle.
+            - Write random address offsets in OTBN imem and dmem.
+            - Read back the written address offsets and compare against expected values. All values
+              must match, no integrity errors must be triggered.
+            - Have OTBN fetch new keys and nonces from the OTP_CTRL.
+            - Wait for OTBN to be idle.
+            - Read back the written address offsets. Most reads should trigger integrity errors. It
+              is possible that after re-scrambling the integrity bits are still valid. But this is
+              expected to happen rarely. If the number of observed integrity errors is below a
+              chosen threshold, the test fails.
             - Verify the validity of EDN's output to OTP_CTRL via assertions
               (unique, non-zero data).
             '''

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -929,10 +929,10 @@ opentitan_functest(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:otbn",
         "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/otbn/code-snippets:randomness",
     ],
 )
 


### PR DESCRIPTION
This PR reworks the otbn_mem_scramble_test to:
1. Not check the entire IMEM and DMEM as this can be very slow. Instead a set of random addresses for both IMEM and DMEM are chosen.
2. Allow for a certain number of valid integrity bits even after re-scrambling. There is a non-zero chance that this happens. Some basic testing showed that roughly 1 out of 100 checked addresses has still valid integrity bits after re-scrambling.

This resolves lowRISC/OpenTitan#13974.