### PR TITLE
[test] Enable passing arguments to the functest harness

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -81,12 +81,12 @@ opentitan_functest(
     srcs = ["empty_test.c"],
     args = [],
     cw310 = cw310_params(
-        args = [
+        bitstream = "//hw/bitstream:rom",
+        test_cmds = [
             "--bitstream=\"$(location //hw/bitstream:rom)\"",
             "--rom-kind=rom",
             "--rom-ext=\"$(location {flash})\"",
         ],
-        bitstream = "//hw/bitstream:rom",
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
@@ -102,12 +102,12 @@ opentitan_functest(
     srcs = ["chip_specific_startup.c"],
     args = [],
     cw310 = cw310_params(
-        args = [
+        bitstream = "//hw/bitstream:rom",
+        test_cmds = [
             "--bitstream=\"$(location //hw/bitstream:rom)\"",
             "--rom-kind=rom",
             "--bootstrap=\"$(location {flash})\"",
         ],
-        bitstream = "//hw/bitstream:rom",
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,

--- a/util/dvsim_test_runner.sh
+++ b/util/dvsim_test_runner.sh
@@ -11,4 +11,4 @@ set -e
 readonly DVSIM="util/dvsim/dvsim.py"
 
 echo "At this time, dvsim.py must be run manually (after building SW) via:
-${DVSIM} $*"
+${DVSIM} $* ${TEST_CMDS} "

--- a/util/opentitan_functest_runner.sh
+++ b/util/opentitan_functest_runner.sh
@@ -3,8 +3,21 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 #
-# A shell script for executing rust-based tests for functional and e2e tests.
-# The test runner should be passed in as the first argument.
+# A shell script for executing rust-based tests for functional and e2e tests,
+# especially for harnesses built atop opentitanlib.
+#
+# There are three components that make up the harness invocation:
+#   - test harness
+#   - arguments
+#   - test commands
+#
+# The test harness is invoked with arguments first, then the test commands.
+# The test harness and test commands are both passed in by environment variables.
+# Note that bazel passes user-specified test_arg arguments as arguments to this
+# script, and because the user-specified test_arg arguments come after the bazel
+# rule's arguments, they can override the ones coming from the bazel rule.
+# Thus, the test harness and test script represent portions of the invocation
+# that cannot be overridden, but the arguments in the middle can.
 
 set -e
 
@@ -13,5 +26,10 @@ if [ -z "$TEST_HARNESS" ]; then
     exit 1
 fi
 
-echo Invoking test: "${TEST_HARNESS}" "$@"
-RUST_BACKTRACE=1 ${TEST_HARNESS} "$@"
+# eval the environment variable string to break up the components and have bash
+# interpret quotes and other special characters in arguments. This happens
+# during the invocation line.
+eval "TEST_CMDS_ARRAY=( ${TEST_CMDS} )"
+
+echo Invoking test: "${TEST_HARNESS}" "$@" "${TEST_CMDS_ARRAY[@]}"
+RUST_BACKTRACE=1 ${TEST_HARNESS} "$@" "${TEST_CMDS_ARRAY[@]}"


### PR DESCRIPTION
Move the required args to the end and name them the "test script." Pass
the test script via an environment variable, and place them at the end
of the invocation.

This makes the test script argument unable to be overridden, and
simultaneously, it allows the user to specify test_arg arguments on the
bazel command line. Those test_arg arguments can override or supplement
the test harness arguments provided by the bazel rule.

Resolves #13042 