### PR TITLE
[chip dv] Add more chip level tests to smoke

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1153,7 +1153,13 @@
   regressions: [
     {
       name: smoke
-      tests: ["chip_sw_uart_tx_rx", "chip_plic_all_irqs"]
+      tests: ["xbar_chip_smoke",
+              "chip_sw_uart_tx_rx",
+              "chip_plic_all_irqs",
+              "chip_sw_example_flash",
+              "chip_sw_example_rom",
+              "chip_sw_example_manufacturer"]
+              // TODO: add this test after enabling HW verification: "rom_e2e_bootup_success"]
     }
     {
       name: jitter


### PR DESCRIPTION
We need to add a representative test for each chip level testbench
testing "mode". This commit adds a few more tests that should never
fail in CI.

The `xbar_chip_smoke` is a mode where TL hosts and devices are replaced
with TL agents.

The SW "example" tests should never break - especially since our bazel
framework is being constantly enhanced.

We also ought to run a representative real ROM test in smoke to ensure
that setup works fine as well.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>