### PR TITLE
[doc] Correct hash requirements for TPM use case

### DIFF
--- a/doc/use_cases/tpm/index.md
+++ b/doc/use_cases/tpm/index.md
@@ -33,7 +33,7 @@ peripherals.
 *   Hash Algorithms:
     *   An approved hash algorithm with approximately the same security strength
         as its strongest asymmetric algorithm. For OpenTitan the target is
-        SHA2-256 (hardware), SHA3-384 (software implementation).
+        SHA2-256, SHA2-384.
     *   A TPM should support the extend function to make incremental updates to
         a digest value.
 *   Symmetric Key Algorithms:


### PR DESCRIPTION
Remove hardware versus software distinction as this is an implementation
detail that will be abstracted by the crypto library.

s/SHA3-384/SHA2-384/ as this is the expected integration requirement.
