### PR TITLE
[prim] Fix missing case from prim_reg_cdc_arb assert

### DIFF
--- a/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
@@ -165,8 +165,10 @@ module prim_reg_cdc_arb #(
       clk_dst_i, !rst_dst_ni)
 
     // if hw select was chosen, then it must be the case there was a destination update
-    // indication
-    `ASSERT(HwIdSelCheck_A, $rose(id_q == SelHwReq) |-> $past(dst_update_i, 1),
+    // indication or there was a difference between the transit register and the
+    // latest incoming value.
+    `ASSERT(HwIdSelCheck_A, $rose(id_q == SelHwReq) |-> $past(dst_update_i, 1) ||
+      $past(dst_lat_q, 1),
       clk_dst_i, !rst_dst_ni)
 
 


### PR DESCRIPTION
- should fix #14526

- The assertion forgot to account for the case where a hardware update
  request was received while there is already an ongoing handshake
  either from software or from a previous hardware update.

Signed-off-by: Timothy Chen <timothytim@google.com>