### PR TITLE
feat(spid): Increase TPM RDFIFO depth to 16

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -107,15 +107,15 @@
       local:   "true"
     } // p: NumLocality
     { name:    "TpmWrFifoPtrW"
-      desc:    "TPM WrFIFO Pointer Bit Width. clog2(Depth(4+1))"
+      desc:    "TPM WrFIFO Pointer Bit Width. clog2(Depth(64+1))"
       type:    "int unsigned"
       default: "7"
       local:   "true"
     } // p: TpmWrFifoPtrW
     { name:    "TpmRdFifoPtrW"
-      desc:    "TPM RdFIFO Pointer Bit Width. clog2(Depth(4+1))"
+      desc:    "TPM RdFIFO Pointer Bit Width. clog2(Depth(16+1))"
       type:    "int unsigned"
-      default: "3"
+      default: "5"
       local:   "true"
     } // p: TpmRdFifoPtrW
     { name:    "TpmRdFifoWidth"

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -81,7 +81,7 @@ module spi_device
 
   localparam int unsigned TpmRdFifoWidth  = spi_device_reg_pkg::TpmRdFifoWidth;
   localparam int unsigned TpmWrFifoDepth  = 64; // 64B
-  localparam int unsigned TpmRdFifoDepth  = 4;
+  localparam int unsigned TpmRdFifoDepth  = 16;
   localparam int unsigned TpmWrFifoPtrW   = $clog2(TpmWrFifoDepth+1);
   localparam int unsigned TpmRdFifoPtrW   = $clog2(TpmRdFifoDepth+1);
   `ASSERT_INIT(TpmWrPtrMatch_A,

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -11,7 +11,7 @@ package spi_device_reg_pkg;
   parameter int unsigned NumCmdInfo = 24;
   parameter int unsigned NumLocality = 5;
   parameter int unsigned TpmWrFifoPtrW = 7;
-  parameter int unsigned TpmRdFifoPtrW = 3;
+  parameter int unsigned TpmRdFifoPtrW = 5;
   parameter int unsigned TpmRdFifoWidth = 32;
   parameter int NumAlerts = 1;
 
@@ -651,7 +651,7 @@ package spi_device_reg_pkg;
       logic        de;
     } rdfifo_notempty;
     struct packed {
-      logic [2:0]  d;
+      logic [4:0]  d;
       logic        de;
     } rdfifo_depth;
     struct packed {
@@ -720,20 +720,20 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [283:260]
-    spi_device_hw2reg_cfg_reg_t cfg; // [259:258]
-    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [257:242]
-    spi_device_hw2reg_status_reg_t status; // [241:236]
-    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [235:219]
-    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [218:202]
-    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [201:170]
-    spi_device_hw2reg_flash_status_reg_t flash_status; // [169:146]
-    spi_device_hw2reg_upload_status_reg_t upload_status; // [145:130]
-    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [129:111]
-    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [110:103]
-    spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [102:71]
-    spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [70:56]
-    spi_device_hw2reg_tpm_status_reg_t tpm_status; // [55:40]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [285:262]
+    spi_device_hw2reg_cfg_reg_t cfg; // [261:260]
+    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [259:244]
+    spi_device_hw2reg_status_reg_t status; // [243:238]
+    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [237:221]
+    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [220:204]
+    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [203:172]
+    spi_device_hw2reg_flash_status_reg_t flash_status; // [171:148]
+    spi_device_hw2reg_upload_status_reg_t upload_status; // [147:132]
+    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [131:113]
+    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [112:105]
+    spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [104:73]
+    spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [72:58]
+    spi_device_hw2reg_tpm_status_reg_t tpm_status; // [57:40]
     spi_device_hw2reg_tpm_cmd_addr_reg_t tpm_cmd_addr; // [39:8]
     spi_device_hw2reg_tpm_write_fifo_reg_t tpm_write_fifo; // [7:0]
   } spi_device_hw2reg_t;

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1510,7 +1510,7 @@ module spi_device_reg_top (
   logic tpm_cfg_invalid_locality_wd;
   logic tpm_status_cmdaddr_notempty_qs;
   logic tpm_status_rdfifo_notempty_qs;
-  logic [2:0] tpm_status_rdfifo_depth_qs;
+  logic [4:0] tpm_status_rdfifo_depth_qs;
   logic [6:0] tpm_status_wrfifo_depth_qs;
   logic tpm_access_0_we;
   logic [7:0] tpm_access_0_access_0_qs;
@@ -18453,11 +18453,11 @@ module spi_device_reg_top (
     .qs     (tpm_status_rdfifo_notempty_qs)
   );
 
-  //   F[rdfifo_depth]: 10:8
+  //   F[rdfifo_depth]: 12:8
   prim_subreg #(
-    .DW      (3),
+    .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (3'h0)
+    .RESVAL  (5'h0)
   ) u_tpm_status_rdfifo_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21412,7 +21412,7 @@ module spi_device_reg_top (
       addr_hit[66]: begin
         reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
         reg_rdata_next[1] = tpm_status_rdfifo_notempty_qs;
-        reg_rdata_next[10:8] = tpm_status_rdfifo_depth_qs;
+        reg_rdata_next[12:8] = tpm_status_rdfifo_depth_qs;
         reg_rdata_next[22:16] = tpm_status_wrfifo_depth_qs;
       end
 

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -1542,15 +1542,28 @@ dif_result_t dif_spi_device_tpm_write_data(dif_spi_device_handle_t *spi,
   }
   dif_spi_device_tpm_data_status_t status;
   dif_result_t result = dif_spi_device_tpm_get_data_status(spi, &status);
+  uint8_t offset = length & 0x3;  // lower two bits of length
+  uint32_t rdfifo_wdata;
+
   if (result != kDifOk) {
     return result;
   }
   if (DIF_SPI_DEVICE_TPM_FIFO_DEPTH - status.read_fifo_occupancy < length) {
     return kDifOutOfRange;
   }
-  for (int i = 0; i < length; i++) {
+  for (int i = 0; i < length; i += 4) {
+    if (i + 4 > length) {
+      // Send partial
+      rdfifo_wdata = 0;
+      for (int j = 0; j <= offset; j++) {
+        rdfifo_wdata |= buf[i + j] << (8 * j);
+      }
+    } else {
+      // Type casting to uint32_t then fetch
+      rdfifo_wdata = *((uint32_t *)buf + (i >> 2));
+    }
     mmio_region_write32(spi->dev.base_addr, SPI_DEVICE_TPM_READ_FIFO_REG_OFFSET,
-                        buf[i]);
+                        rdfifo_wdata);
   }
   return kDifOk;
 }

--- a/sw/device/lib/dif/dif_spi_device_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_device_unittest.cc
@@ -1815,9 +1815,9 @@ TEST_F(TpmTest, CommandAndData) {
                     {SPI_DEVICE_TPM_STATUS_RDFIFO_DEPTH_OFFSET, 1},
                     {SPI_DEVICE_TPM_STATUS_WRFIFO_DEPTH_OFFSET, 4},
                 });
-  for (int i = 0; i < 3; i++) {
-    EXPECT_WRITE32(SPI_DEVICE_TPM_READ_FIFO_REG_OFFSET, data[i]);
-  }
+  EXPECT_WRITE32(SPI_DEVICE_TPM_READ_FIFO_REG_OFFSET,
+                 (data[3] << 24) | (data[2] << 16) | (data[1] << 8) | data[0]);
+
   EXPECT_DIF_OK(dif_spi_device_tpm_write_data(&spi_, /*length=*/3, data));
 
   EXPECT_READ32(SPI_DEVICE_TPM_STATUS_REG_OFFSET,


### PR DESCRIPTION

This commit increases the TPM Read FIFO size to 64 Bytes (16 x 4B).

The previous impl of TPM Read FIFO relies on the SW latency. The SW
latency should not be long so that SW is able to write the Read data
continuously. In order to satisfy the assumption, SW shall turn off
interrupts.

The requirement above could not comply with SW architecture. So, this
commit increases the size for SW to write full 64 B at once.

Latter design change will follow. The design change is for HW to send
the TPM Read data only when full payload size is ready in the FIFO.