### PR TITLE
[crypto] Mandate hjson, template, output file arg

### DIFF
--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -224,7 +224,14 @@ def _cryptotest_header(ctx):
     ctx.actions.run(
         outputs = [header],
         inputs = [template, hjson],
-        arguments = ["--template", template.path, hjson.path, header.path],
+        arguments = [
+            "-t",
+            template.path,
+            "-j",
+            hjson.path,
+            "-o",
+            header.path,
+        ],
         executable = ctx.executable.tool,
     )
 

--- a/sw/device/silicon_creator/lib/sigverify/sigverify_tests/sigverify_set_testvectors.py
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify_tests/sigverify_set_testvectors.py
@@ -21,12 +21,6 @@ RSA_3072_NUMWORDS = int(3072 / 32)
 # Number of 32-bit words in a 256-bit number
 INT_256_NUMWORDS = int(256 / 32)
 
-# Default template file name
-DEFAULT_TEMPLATE = 'sigverify_testvectors.h.tpl'
-
-# Default output file name
-DEFAULT_OUTFILE = 'sigverify_testvectors.h'
-
 
 def compute_n0_inv(n):
     '''Compute -(n^-1) mod 2^256, a Montgomery constant.
@@ -105,18 +99,19 @@ def int_256_to_hexwords(x):
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('hjsonfile',
+    parser.add_argument('--hjsonfile', '-j',
                         metavar='FILE',
+                        required=True,
                         type=argparse.FileType('r'),
                         help='Read test vectors from this HJSON file.')
-    parser.add_argument('--template',
+    parser.add_argument('--template', '-t',
                         metavar='FILE',
-                        required=False,
+                        required=True,
                         type=argparse.FileType('r'),
                         help='Read header template from this file.')
-    parser.add_argument('headerfile',
+    parser.add_argument('--headerfile', '-o',
                         metavar='FILE',
-                        nargs='?',
+                        required=True,
                         type=argparse.FileType('w'),
                         help='Write output to this file.')
 

--- a/sw/device/tests/crypto/ecdsa_p256_verify_set_testvectors.py
+++ b/sw/device/tests/crypto/ecdsa_p256_verify_set_testvectors.py
@@ -17,12 +17,6 @@ generate a header file with these test vectors.
 # Number of 32-bit words in a coordinate or scalar
 P256_NUMWORDS = int(256 / 32)
 
-# Default template file name
-DEFAULT_TEMPLATE = 'ecdsa_p256_verify_testvectors.h.tpl'
-
-# Default output file name
-DEFAULT_OUTFILE = 'ecdsa_p256_verify_testvectors.h'
-
 
 def ecdsa_p256_int_to_hexwords(x):
     '''Convert a 256-bit integer to a list of 32-bit integers (little-endian).'''
@@ -37,18 +31,19 @@ def ecdsa_p256_int_to_hexwords(x):
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('hjsonfile',
+    parser.add_argument('--hjsonfile', '-j',
                         metavar='FILE',
+                        required=True,
                         type=argparse.FileType('r'),
                         help='Read test vectors from this HJSON file.')
-    parser.add_argument('--template',
+    parser.add_argument('--template', '-t',
                         metavar='FILE',
-                        required=False,
+                        required=True,
                         type=argparse.FileType('r'),
                         help='Read header template from this file.')
-    parser.add_argument('headerfile',
+    parser.add_argument('--headerfile', '-o',
                         metavar='FILE',
-                        nargs='?',
+                        required=True,
                         type=argparse.FileType('w'),
                         help='Write output to this file.')
 

--- a/sw/device/tests/crypto/rsa_3072_verify_set_testvectors.py
+++ b/sw/device/tests/crypto/rsa_3072_verify_set_testvectors.py
@@ -17,12 +17,6 @@ generate a header file with these test vectors.
 # Number of 32-bit words in a 3072-bit number
 RSA_3072_NUMWORDS = int(3072 / 32)
 
-# Template file name
-DEFAULT_TEMPLATE = 'rsa_3072_verify_testvectors.h.tpl'
-
-# Default output file name
-DEFAULT_OUTFILE = 'rsa_3072_verify_testvectors.h'
-
 
 def rsa_3072_int_to_hexwords(x):
     '''Convert a 3072-bit integer to a list of 32-bit integers (little-endian).'''
@@ -38,18 +32,19 @@ def rsa_3072_int_to_hexwords(x):
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('hjsonfile',
+    parser.add_argument('--hjsonfile', '-j',
                         metavar='FILE',
+                        required=True,
                         type=argparse.FileType('r'),
                         help='Read test vectors from this HJSON file.')
-    parser.add_argument('--template',
+    parser.add_argument('--template', '-t',
                         metavar='FILE',
-                        required=False,
+                        required=True,
                         type=argparse.FileType('r'),
                         help='Read header template from this file.')
-    parser.add_argument('headerfile',
+    parser.add_argument('--headerfile', '-o',
                         metavar='FILE',
-                        nargs='?',
+                        required=True,
                         type=argparse.FileType('w'),
                         help='Write output to this file.')
 


### PR DESCRIPTION
This commit mandates the hjson, template, and output arguments in crypto
header generation script.

This is a follow-up PR of https://github.com/lowRISC/opentitan/pull/14517