### PR TITLE
[chip, dv] Link chip_sw_kmac_app_keymgr with chip_sw_keymgr_key_derivation

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1856,7 +1856,7 @@
             X-ref'ed with keymgr test.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_keymgr_key_derivation"]
     }
     {
       name: chip_sw_kmac_app_lc


### PR DESCRIPTION
From the test description, this just needs keymgr to do a key derivation
and check KMAC output is correct.
chip_sw_keymgr_key_derivation calls KMAC C model to generate expected
digest and compare with design KMAC outputs.

Signed-off-by: Weicai Yang <weicai@google.com>