### PR TITLE
[spi_device] TPM Read to wait full payload before send

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -1070,12 +1070,10 @@
 
             All other values are reserved.
 
-            The SW may advertises as supporting more than `max_wr_size` to the South Brige.
-            If the SW reports the transfer size more than the value described in this field,
-            the SW must read the data from the write FIFO before the FIFO becomes full in order not to make FIFO overflow.
+            It is not recommended for SW to advertise TPM supporting more than `max_wr_size` to the South Bridge.
             '''
           resval: "6"
-        } // f: max_rd_size
+        } // f: max_wr_size
         { bits: "22:20"
           name: "max_rd_size"
           desc: '''The maximum read size in bytes the TPM submodule supports.
@@ -1089,9 +1087,7 @@
 
             All other values are reserved.
 
-            The SW may advertises as supporting more than `max_rd_size` to the South Brige.
-            If the SW reports the transfer size more than the value described in this field,
-            the SW must write data to the TPM Read FIFO before the FIFO becomes empty in order not to make FIFO underrun.
+            It is not recommended for SW to advertise TPM supporting more than `max_rd_size` to the South Bridge.
             '''
           resval: "4"
         } // f: max_rd_size

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1698,9 +1698,9 @@ module spi_device
   // Instance of spi_tpm
   spi_tpm #(
     // CmdAddrFifoDepth
-    .WrFifoDepth    (TpmWrFifoDepth),
-    .RdFifoDepth    (TpmRdFifoDepth),
-    .RdDataFifoSize (TpmRdFifoWidth),
+    .WrFifoDepth (TpmWrFifoDepth),
+    .RdFifoDepth (TpmRdFifoDepth),
+    .RdFifoWidth (TpmRdFifoWidth),
     .EnLocality  (1)
   ) u_spi_tpm (
     .clk_in_i  (clk_spi_in_buf ),


### PR DESCRIPTION

This commit is a follow-up of https://github.com/lowRISC/opentitan/pull/14544

TPM, now, waits for the read FIFO having enough data.