### PR TITLE
[chip dv] Increase tap_strap_* tests' runtime

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1119,17 +1119,20 @@
       uvm_test_seq: chip_tap_straps_vseq
       en_run_modes: ["strap_tests_mode"]
       run_opts: ["+use_otp_image=LcStDev"]
+      run_timeout_mins: 120
     }
     {
       name: chip_tap_straps_rma
       uvm_test_seq: chip_tap_straps_vseq
       en_run_modes: ["strap_tests_mode"]
+      run_timeout_mins: 120
     }
     {
       name: chip_tap_straps_prod
       uvm_test_seq: chip_tap_straps_vseq
       en_run_modes: ["strap_tests_mode"]
       run_opts: ["+lc_at_prod=1"]
+      run_timeout_mins: 120
     }
     {
       name: chip_sw_rv_core_ibex_address_translation


### PR DESCRIPTION
Set the run`timeout_mins` for these tests to 120 - some
random seeds get killed due to exceeding the timeout.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>