### PR TITLE
[spi_device/dv] Update read buffer sequence

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -257,6 +257,16 @@ class spi_device_base_vseq extends cip_base_vseq #(
       cfg.spi_host_agent_cfg.flash_addr_4b_en   = 0;
     end
 
+    if (cfg.is_read_buffer_cmd(m_spi_host_seq.rsp)) begin
+      cfg.read_buffer_addr = convert_addr_from_byte_queue(m_spi_host_seq.rsp.address_q) +
+                             m_spi_host_seq.rsp.payload_q.size();
+      cfg.clk_rst_vif.wait_clks(10);
+
+      csr_rd_check(.ptr(ral.last_read_addr), .compare_value(cfg.read_buffer_addr));
+      `uvm_info(`gfn, $sformatf("Updated read_buffer_addr to 0x%0x", cfg.read_buffer_addr),
+                UVM_MEDIUM)
+    end
+
     if (wait_on_busy) begin
       spi_device_reg_cmd_info cmd_info = cfg.get_cmd_info_reg_by_opcode(op);
       if (cmd_info != null && `gmv(cmd_info.upload) && `gmv(cmd_info.busy)) begin

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_mode_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_mode_vseq.sv
@@ -20,7 +20,20 @@ class spi_device_flash_mode_vseq extends spi_device_intercept_vseq;
     // increase the chance (15%->50%) to send large payload,
     // in order to exercise watermark and flip events
     large_payload_weight = 6;
+
+    mailbox_addr_size_c.constraint_mode(0);
     forever_read_buffer_update_nonblocking();
-    super.body();
+
+    allow_set_cmd_info_invalid = 1;
+    allow_use_invalid_opcode = 1;
+    spi_device_flash_pass_init();
+
+    for (int i = 0; i < num_trans; ++i) begin
+      randomize_op_addr_size();
+      `uvm_info(`gfn, $sformatf("sending op 0x%0h addr: 0x%0x", opcode, read_start_addr),
+                UVM_MEDIUM)
+      spi_host_xfer_flash_item(opcode, payload_size, read_start_addr);
+      cfg.clk_rst_vif.wait_clks(10);
+    end
   endtask
 endclass : spi_device_flash_mode_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_cmd_filtering_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_cmd_filtering_vseq.sv
@@ -22,7 +22,8 @@ class spi_device_pass_cmd_filtering_vseq extends spi_device_pass_base_vseq;
       // - enable cmd filter, test cmd is blocked
       for (int cmd_filter = 0; cmd_filter < 2;  cmd_filter++) begin
         // Make sure filter is not blocking command opcode
-        `uvm_info(`gfn, $sformatf("sending op 0x%0h with filter = %0d", opcode, cmd_filter),
+        `uvm_info(`gfn, $sformatf("sending op 0x%0h addr: 0x%0x with filter = %0d",
+                  opcode, read_start_addr, cmd_filter),
                   UVM_MEDIUM)
         cfg_cmd_filter(cmd_filter, opcode);
         // Prepare data for transfer

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -10,6 +10,10 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
 
   // read buffer needs to be read with incremental address, otherwise, watermark/fip won't work
   bit [TL_AW-1:0]     read_buffer_addr;
+  // read_buffer_addr is updated after a transaction is done
+  // this ptr is updated when a flip event occurs, so that we could know which part is
+  // read by the SPI host, in order to update the other part
+  bit [TL_AW-1:0]     read_buffer_ptr;
 
   `uvm_object_utils_begin(spi_device_env_cfg)
     `uvm_field_object(spi_host_agent_cfg, UVM_DEFAULT)

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -85,6 +85,7 @@ package spi_device_env_pkg;
   parameter uint ASYNC_FIFO_SIZE                 = 8;
   parameter uint READ_BUFFER_START_ADDR          = SRAM_OFFSET;
   parameter uint READ_BUFFER_SIZE                = 2048;
+  parameter uint READ_BUFFER_HALF_SIZE           = READ_BUFFER_SIZE / 2;
   // MAILBOX_START_ADDR is 0x800
   parameter uint MAILBOX_START_ADDR              = READ_BUFFER_START_ADDR + READ_BUFFER_SIZE;
   parameter uint MAILBOX_BUFFER_SIZE             = 1024;


### PR DESCRIPTION
1. Simplify mem update thread to depend on flip interrupt only. Will have
scb to check both flip and watermark event
2. Update constraint to have higher change to test read buffer and its interrupts
3. Store read_buffer_addr in cfg as read buffer needs to use incremental address
and constrain address of read buffer cmd equal to it.

Signed-off-by: Weicai Yang <weicai@google.com>