### PR TITLE
[dv/chip] Fix chip_sw_alert_handler_entropy failure

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1281,7 +1281,7 @@
       name: chip_sw_alert_handler_entropy
       desc: '''Verify the alert handler entropy input to ensure pseudo-random ping timer.
 
-            - Force `alert_handler_ping_timer` input signal `wait_cyc_mask_i` to `16'h07ff` to
+            - Force `alert_handler_ping_timer` input signal `wait_cyc_mask_i` to `8'h07` to
               shorten the simulation time.
             - Verify that the alert_handler can request EDN to provide entropy.
             - Ensure that the alert ping handshake to all alert sources and escalation receivers

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -770,7 +770,7 @@
       // Disable scoreboard to avoid incorrect alert prediction from the alert_monitor. Due to the
       // cross-domain alert senders and receivers, the monitor from the chip level did not support
       // processing alerts accurately from both ends.
-      run_opts: ["+en_scb=0"]
+      run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
     }
     {
       name: chip_sw_aes_entropy

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_entropy_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_entropy_vseq.sv
@@ -14,7 +14,7 @@ class chip_sw_alert_handler_entropy_vseq extends chip_sw_base_vseq;
   virtual task pre_start();
     string wait_cyc_mask_path = {`DV_STRINGIFY(`ALERT_HANDLER_HIER),
                                  ".u_ping_timer.wait_cyc_mask_i"};
-    `DV_CHECK(uvm_hdl_force(wait_cyc_mask_path, 'h7ff))
+    `DV_CHECK(uvm_hdl_force(wait_cyc_mask_path, 'h7))
     super.pre_start();
   endtask
 


### PR DESCRIPTION
This PR fixes regression failure for alert_handler_entropy by:
1). Force the wait_cycs to a even smaller value to reduce the ping wait
  time.
2). Disable the final alert check, because responsing to pings will be
  categorized as an alert in ready_to_end alert check.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>