### PR TITLE
[top] Minor update of chip_rv_dm_perform_debug test point

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -535,7 +535,7 @@
     {
       name: chip_rv_dm_perform_debug
       desc: '''
-            - X-ref'ed with rom_rv_dm_perform_debug from rom testplan
+            - X-ref'ed with rom_e2e_jtag_inject from rom testplan
             '''
       stage: V2
       tests: []


### PR DESCRIPTION
The name of the x-ref'ed testpoint got out of date.

Signed-off-by: Michael Schaffner <msf@google.com>