### PR TITLE
[dv/top] Update dmem copy resolution

### DIFF
--- a/sw/device/tests/otbn_smoketest.c
+++ b/sw/device/tests/otbn_smoketest.c
@@ -67,7 +67,7 @@ static void check_otbn_insn_cnt(otbn_t *otbn_ctx, uint32_t expected_insn_cnt) {
  * convention described in the OTBN assembly code file.
  */
 static void test_barrett384(otbn_t *otbn_ctx) {
-  enum { kDataSizeBytes = 48 };
+  enum { kDataSizeBytes = 64 };
 
   CHECK(otbn_load_app(otbn_ctx, kAppBarrett) == kOtbnOk);
 


### PR DESCRIPTION
fixes #14552

Pad dmem copy to 64B.
It's not clear this is the right fix, but it gets around the problem
for now.

Signed-off-by: Timothy Chen <timothytim@google.com>