### PR TITLE
[otbn,sw] Fix data memory section for `barrett384`

### DIFF
--- a/sw/otbn/code-snippets/barrett384.s
+++ b/sw/otbn/code-snippets/barrett384.s
@@ -257,7 +257,7 @@ wrap_barrett384:
 
   ecall
 
-.bss
+.data
 
 /* First operand for Barrett modular multiplication. */
 .globl inp_a


### PR DESCRIPTION
The `.bss` section does not get loaded, but the `.data` section does.
The variables in this program have to be loaded though, because the test
afterwards writes only the actual data values, which is not always a
full 256-bit OTBN wide word.  If OTBN then accesses that data with wide
word operations, integrity errors are raised (also see #14552).  This is
fixed by this PR, which therefore resolves #14552.