### PR TITLE
[aes/pre_syn] Fixed module parameters bug in syn_setup.example.sh

### DIFF
--- a/hw/ip/aes/pre_syn/syn_setup.example.sh
+++ b/hw/ip/aes/pre_syn/syn_setup.example.sh
@@ -12,8 +12,8 @@ export LR_SYNTH_TOP_MODULE=aes
 
 # Setup module parameters.
 export LR_SYNTH_AES_192_ENABLE=1
-export LR_SYNTH_MASKING=1
-export LR_SYNTH_S_BOX_IMPL=4
+export LR_SYNTH_SEC_MASKING=1
+export LR_SYNTH_SEC_S_BOX_IMPL=4
 
 # Setup cell library path.
 # Uncomment the lines below and set the path to an appropriate .lib file


### PR DESCRIPTION
Found bug in hw/ip/aes/pre_syn/syn_setup.example.sh:
- "SEC_" was missing in the name of two module parameter variables (LR_SYNTH_SEC_MASKING and LR_SYNTH_SEC_S_BOX_IMPL)
- This caused that the default module parameters in the RTL files were not overwritten

Signed-off-by: Moritz Wettermann <moritz.wettermann@gi-de.com>