### PR TITLE
[p256/p384, otbn] Switch RND usage to URND where possible

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -687,7 +687,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_ecdsa_op_irq_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=22_000_000"]
+      run_opts: ["+sw_test_timeout_ns=28_000_000", "+rng_srate_value=30"]
       run_timeout_mins: 300
     }
     {
@@ -695,7 +695,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_ecdsa_op_irq_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=29_000_000", "+en_jitter=1"]
+      run_opts: ["+sw_test_timeout_ns=33_000_000", "+rng_srate_value=30", "+en_jitter=1"]
       run_timeout_mins: 300
     }
     {

--- a/sw/device/tests/otbn_ecdsa_op_irq_test.c
+++ b/sw/device/tests/otbn_ecdsa_op_irq_test.c
@@ -433,7 +433,7 @@ static void test_ecdsa_p256_roundtrip(void) {
 }
 
 bool test_main(void) {
-  entropy_testutils_boot_mode_init();
+  entropy_testutils_auto_mode_init();
 
   test_ecdsa_p256_roundtrip();
 

--- a/sw/otbn/crypto/p256.s
+++ b/sw/otbn/crypto/p256.s
@@ -838,8 +838,8 @@ mod_inv:
  */
 fetch_proj_randomize:
 
-  /* get random number */
-  bn.wsrr   w2, 1
+  /* get random number from URND */
+  bn.wsrr   w2, 2
 
   /* reduce random number
      w26 = z <= w2 mod p */
@@ -1056,15 +1056,15 @@ scalar_mult_int:
     bn.rshi   w0, w0, w0 >> 255
     bn.rshi   w1, w1, w1 >> 255
 
-    /* init regs with random numbers */
-    bn.wsrr   w11, 1
-    bn.wsrr   w12, 1
-    bn.wsrr   w13, 1
+    /* init regs with random numbers from URND */
+    bn.wsrr   w11, 2
+    bn.wsrr   w12, 2
+    bn.wsrr   w13, 2
 
-    /* get a fresh random number and scale the coordinates of
+    /* get a fresh random number from URND and scale the coordinates of
        2P = (w3, w4, w5) (scaling each projective coordinate with same
        factor results in same point) */
-    bn.wsrr   w2, 1
+    bn.wsrr   w2, 2
 
     /* w3 = w3 * w2 */
     bn.mov    w24, w3

--- a/sw/otbn/crypto/p384_sign.s
+++ b/sw/otbn/crypto/p384_sign.s
@@ -299,10 +299,10 @@ proj_to_affine_p384:
  */
 store_proj_randomize:
 
-  /* get a 384-bit random number
+  /* get a 384-bit random number from URND
     [w3, w2] = random(384) */
-  bn.wsrr   w2, 1
-  bn.wsrr   w3, 1
+  bn.wsrr   w2, 2
+  bn.wsrr   w3, 2
   bn.rshi   w3, w31, w3 >> 128
 
   /* reduce random number
@@ -584,12 +584,12 @@ scalar_mult_int_p384:
     bn.sid    x2++, 480(x30)
 
 
-    /* Get a fresh random number and scale the coordinates of 2P.
+    /* Get a fresh random number from URND and scale the coordinates of 2P.
        (scaling each proj. coordinate by same factor results in same point) */
 
-    /* get a 384-bit random number */
-    bn.wsrr   w2, 1
-    bn.wsrr   w3, 1
+    /* get a 384-bit random number from URND */
+    bn.wsrr   w2, 2
+    bn.wsrr   w3, 2
     bn.rshi   w3, w31, w3 >> 128
 
     /* reduce random number


### PR DESCRIPTION
Previously, RND was used everywhere as when the p256/p384 libraries have been implemented, URND wasn't available. As RND delivers high-quality entropy which results in many reseeds of CSRNG, this is bad for performance. Instead, URND should be used unless high-quality randomness is strictly required.

This PR changes the library to use URND for register initialization, scalar blinding and point rotation. For the nonce, we keep using RND (see p256_ecdsa_setup_rand() in p256_ecdsa.s).
