### PR TITLE
[otbn,rtl] Fix locking on RMA request while refreshing URND

### DIFF
--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -92,7 +92,7 @@ module otbn_start_stop_control
   // SEC_CM: CONTROLLER.FSM.GLOBAL_ESC
   logic esc_request, rma_request, should_lock_d, should_lock_q, stop;
   assign esc_request   = mubi4_test_true_loose(escalate_en_i);
-  assign rma_request   = mubi4_test_true_loose(rma_req_i);
+  assign rma_request   = mubi4_test_true_strict(rma_req_i);
   assign stop          = esc_request | rma_request | secure_wipe_req_i;
   assign should_lock_d = should_lock_q | esc_request | rma_request;
 


### PR DESCRIPTION
Prior to this PR, when `otbn_start_stop_controller` got an RMA
request during a pre-execution URND refresh, it would start executing as
soon as the URND refresh is completed.  This is wrong: when OTBN gets an
RMA request during a pre-execution URND refresh, it must securely wipe
as soon as the URND refresh is completed (and then lock).

This bug was caused by the `if` condition on line 169 of
`otbn_start_stop_controller.sv`, which, if `rma_request` is true, is
false and thus the `else` branch on line 180 is taken.

This PR removes this bug by explicitly splitting the `if` statement
for proceeding after an URND refresh on the `stop` signal: if that
signal is high, OTBN either locks immediately or waits for the URND
refresh to complete and then securely wipes (and then locks).  The
behavior of the `else` branch is preserved.

The code is not fully DRY as the inner `else` bodies are redundant.
However, I explicitly prefer this implementation to a fully DRY one,
because it keeps the `stop` and the non-`stop` cases clearly separated.

This PR contains a second commit with a small improvement on handling Mubi-encoded RMA requests:
OTBN should only handle a Mubi-encoded RMA request if it is strictly
true, thereby reducing the potential for FI on RMA requests.  OTBN
already detected Mubi-invalid RMA requests and would lock if such a
(likely tampered) request is detected.  This commit only adds another
safety net to this mechanism.

## DV Note

The first commit causes the `otbn_escalate` test to fail. As that test anyway currently fails for many seeds, I don't consider this to be a blocker for this PR, though. I'll continue improving that test in separate PR(s).