### PR TITLE
[spi_device] Split xfer_size TPM_CAP

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -1058,23 +1058,43 @@
           resval: "1"
         } // f: locality
         { bits: "18:16"
-          name: "max_xfer_size"
-          desc: '''The maximum transfer size in bytes the TPM submodule supports.
+          name: "max_wr_size"
+          desc: '''The maximum write size in bytes the TPM submodule supports.
             The value is the exponent of the 2.
 
             - 3'b 010: Support up to 4B
             - 3'b 011: Support up to 8B
+            - 3'b 100: Support up to 16B
             - 3'b 101: Support up to 32B
             - 3'b 110: Support up to 64B
 
             All other values are reserved.
 
-            The SW may advertises as supporting more than `max_xfer_size` to the South Brige.
+            The SW may advertises as supporting more than `max_wr_size` to the South Brige.
             If the SW reports the transfer size more than the value described in this field,
             the SW must read the data from the write FIFO before the FIFO becomes full in order not to make FIFO overflow.
             '''
-          resval: "2"
-        } // f: max_xfer_size
+          resval: "6"
+        } // f: max_rd_size
+        { bits: "22:20"
+          name: "max_rd_size"
+          desc: '''The maximum read size in bytes the TPM submodule supports.
+            The value is the exponent of the 2.
+
+            - 3'b 010: Support up to 4B
+            - 3'b 011: Support up to 8B
+            - 3'b 100: Support up to 16B
+            - 3'b 101: Support up to 32B
+            - 3'b 110: Support up to 64B
+
+            All other values are reserved.
+
+            The SW may advertises as supporting more than `max_rd_size` to the South Brige.
+            If the SW reports the transfer size more than the value described in this field,
+            the SW must write data to the TPM Read FIFO before the FIFO becomes empty in order not to make FIFO underrun.
+            '''
+          resval: "4"
+        } // f: max_rd_size
       ]
       tags: [
         // Remove Read check (reset value)

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1755,9 +1755,10 @@ module spi_device
   // Register connection
   //  TPM_CAP:
   assign hw2reg.tpm_cap = '{
-    rev:           '{ de: 1'b 1, d: tpm_cap.rev           },
-    locality:      '{ de: 1'b 1, d: tpm_cap.locality      },
-    max_xfer_size: '{ de: 1'b 1, d: tpm_cap.max_xfer_size }
+    rev:         '{ de: 1'b 1, d: tpm_cap.rev         },
+    locality:    '{ de: 1'b 1, d: tpm_cap.locality    },
+    max_wr_size: '{ de: 1'b 1, d: tpm_cap.max_wr_size },
+    max_rd_size: '{ de: 1'b 1, d: tpm_cap.max_rd_size }
   };
 
   //  CFG:

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -488,7 +488,8 @@ package spi_device_pkg;
   typedef struct packed {
     logic [7:0] rev;
     logic       locality;
-    logic [2:0] max_xfer_size;
+    logic [2:0] max_wr_size;
+    logic [2:0] max_rd_size;
   } tpm_cap_t;
   // TPM ----------------------------------------------------------------------
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -638,7 +638,11 @@ package spi_device_reg_pkg;
     struct packed {
       logic [2:0]  d;
       logic        de;
-    } max_xfer_size;
+    } max_wr_size;
+    struct packed {
+      logic [2:0]  d;
+      logic        de;
+    } max_rd_size;
   } spi_device_hw2reg_tpm_cap_reg_t;
 
   typedef struct packed {
@@ -720,19 +724,19 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [285:262]
-    spi_device_hw2reg_cfg_reg_t cfg; // [261:260]
-    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [259:244]
-    spi_device_hw2reg_status_reg_t status; // [243:238]
-    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [237:221]
-    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [220:204]
-    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [203:172]
-    spi_device_hw2reg_flash_status_reg_t flash_status; // [171:148]
-    spi_device_hw2reg_upload_status_reg_t upload_status; // [147:132]
-    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [131:113]
-    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [112:105]
-    spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [104:73]
-    spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [72:58]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [289:266]
+    spi_device_hw2reg_cfg_reg_t cfg; // [265:264]
+    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [263:248]
+    spi_device_hw2reg_status_reg_t status; // [247:242]
+    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [241:225]
+    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [224:208]
+    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [207:176]
+    spi_device_hw2reg_flash_status_reg_t flash_status; // [175:152]
+    spi_device_hw2reg_upload_status_reg_t upload_status; // [151:136]
+    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [135:117]
+    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [116:109]
+    spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [108:77]
+    spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [76:58]
     spi_device_hw2reg_tpm_status_reg_t tpm_status; // [57:40]
     spi_device_hw2reg_tpm_cmd_addr_reg_t tpm_cmd_addr; // [39:8]
     spi_device_hw2reg_tpm_write_fifo_reg_t tpm_write_fifo; // [7:0]

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1496,7 +1496,8 @@ module spi_device_reg_top (
   logic cmd_info_wrdi_valid_wd;
   logic [7:0] tpm_cap_rev_qs;
   logic tpm_cap_locality_qs;
-  logic [2:0] tpm_cap_max_xfer_size_qs;
+  logic [2:0] tpm_cap_max_wr_size_qs;
+  logic [2:0] tpm_cap_max_rd_size_qs;
   logic tpm_cfg_we;
   logic tpm_cfg_en_qs;
   logic tpm_cfg_en_wd;
@@ -18241,12 +18242,12 @@ module spi_device_reg_top (
     .qs     (tpm_cap_locality_qs)
   );
 
-  //   F[max_xfer_size]: 18:16
+  //   F[max_wr_size]: 18:16
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (3'h2)
-  ) u_tpm_cap_max_xfer_size (
+    .RESVAL  (3'h6)
+  ) u_tpm_cap_max_wr_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -18255,8 +18256,8 @@ module spi_device_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.tpm_cap.max_xfer_size.de),
-    .d      (hw2reg.tpm_cap.max_xfer_size.d),
+    .de     (hw2reg.tpm_cap.max_wr_size.de),
+    .d      (hw2reg.tpm_cap.max_wr_size.d),
 
     // to internal hardware
     .qe     (),
@@ -18264,7 +18265,33 @@ module spi_device_reg_top (
     .ds     (),
 
     // to register interface (read)
-    .qs     (tpm_cap_max_xfer_size_qs)
+    .qs     (tpm_cap_max_wr_size_qs)
+  );
+
+  //   F[max_rd_size]: 22:20
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (3'h4)
+  ) u_tpm_cap_max_rd_size (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.tpm_cap.max_rd_size.de),
+    .d      (hw2reg.tpm_cap.max_rd_size.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (tpm_cap_max_rd_size_qs)
   );
 
 
@@ -21398,7 +21425,8 @@ module spi_device_reg_top (
       addr_hit[64]: begin
         reg_rdata_next[7:0] = tpm_cap_rev_qs;
         reg_rdata_next[8] = tpm_cap_locality_qs;
-        reg_rdata_next[18:16] = tpm_cap_max_xfer_size_qs;
+        reg_rdata_next[18:16] = tpm_cap_max_wr_size_qs;
+        reg_rdata_next[22:20] = tpm_cap_max_rd_size_qs;
       end
 
       addr_hit[65]: begin

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -136,9 +136,10 @@ module spi_tpm
 
   // Capability
   assign tpm_cap_o = '{
-    rev:           CapTpmRevision,
-    locality:      EnLocality,
-    max_xfer_size: (CapMaxWrSize > CapMaxRdSize) ? CapMaxRdSize : CapMaxWrSize
+    rev:         CapTpmRevision,
+    locality:    EnLocality,
+    max_wr_size: CapMaxWrSize,
+    max_rd_size: CapMaxRdSize
   };
 
   localparam int unsigned TpmRegisterSize = (AccessRegSize * NumLocality)

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -45,7 +45,8 @@ module spi_tpm
   localparam int unsigned NumBits        = $bits(spi_byte_t),
   localparam int unsigned CmdAddrSize    = 32, // Cmd 8bit + Addr 24bit
   localparam int unsigned FifoRegSize    = 12, // lower 12bit excluding locality
-  localparam int unsigned WrDataFifoSize = NumBits,
+
+  localparam int unsigned WrFifoWidth    = NumBits,
 
   // Read FIFO byte_offset calculation
   localparam int unsigned RdFifoNumBytes = RdDataFifoSize / NumBits,
@@ -113,9 +114,9 @@ module spi_tpm
   output logic [CmdAddrSize-1:0] sys_cmdaddr_rdata_o,
   input                          sys_cmdaddr_rready_i,
 
-  output logic                      sys_wrfifo_rvalid_o,
-  output logic [WrDataFifoSize-1:0] sys_wrfifo_rdata_o,
-  input                             sys_wrfifo_rready_i,
+  output logic                   sys_wrfifo_rvalid_o,
+  output logic [WrFifoWidth-1:0] sys_wrfifo_rdata_o,
+  input                          sys_wrfifo_rready_i,
 
   input                       sys_rdfifo_wvalid_i,
   input  [RdDataFifoSize-1:0] sys_rdfifo_wdata_i,
@@ -365,9 +366,9 @@ module spi_tpm
   // (sys_cmdaddr_rdepth > 0)
   assign sys_cmdaddr_notempty_o = |sys_cmdaddr_rdepth;
 
-  logic                      sck_wrfifo_wvalid, sck_wrfifo_wready;
-  logic [WrDataFifoSize-1:0] sck_wrfifo_wdata;
-  logic [WrFifoPtrW-1:0]     sys_wrfifo_rdepth, sck_wrfifo_wdepth;
+  logic                   sck_wrfifo_wvalid, sck_wrfifo_wready;
+  logic [WrFifoWidth-1:0] sck_wrfifo_wdata;
+  logic [WrFifoPtrW-1:0]  sys_wrfifo_rdepth, sck_wrfifo_wdepth;
 
   assign sys_wrfifo_depth_o = sys_wrfifo_rdepth;
 
@@ -1172,7 +1173,7 @@ module spi_tpm
   );
 
   prim_fifo_async #(
-    .Width (WrDataFifoSize),
+    .Width (WrFifoWidth),
     .Depth (WrFifoDepth),
     .OutputZeroIfEmpty (1'b 1)
   ) u_wrfifo (

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -1277,8 +1277,10 @@ dif_result_t dif_spi_device_get_tpm_capabilities(
   caps->revision = bitfield_field32_read(reg_val, SPI_DEVICE_TPM_CAP_REV_FIELD);
   caps->multi_locality =
       bitfield_bit32_read(reg_val, SPI_DEVICE_TPM_CAP_LOCALITY_BIT);
-  caps->max_transfer_size =
-      bitfield_field32_read(reg_val, SPI_DEVICE_TPM_CAP_MAX_XFER_SIZE_FIELD);
+  caps->max_write_size =
+      bitfield_field32_read(reg_val, SPI_DEVICE_TPM_CAP_MAX_WR_SIZE_FIELD);
+  caps->max_read_size =
+      bitfield_field32_read(reg_val, SPI_DEVICE_TPM_CAP_MAX_RD_SIZE_FIELD);
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -910,11 +910,17 @@ typedef struct dif_spi_device_tpm_caps {
    */
   bool multi_locality;
   /**
-   * The maximum transfer size, in bytes, of the data phase of TPM
+   * The maximum write size, in bytes, of the data phase of TPM
    * transactions. This represents the maximum amount of data the FIFO can
    * accept.
    */
-  uint8_t max_transfer_size;
+  uint8_t max_write_size;
+  /**
+   * The maximum read size, in bytes, of the data phase of TPM
+   * transactions. This represents the maximum amount of data the FIFO can
+   * accept.
+   */
+  uint8_t max_read_size;
 } dif_spi_device_tpm_caps_t;
 
 /**

--- a/sw/device/lib/dif/dif_spi_device_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_device_unittest.cc
@@ -1614,15 +1614,15 @@ TEST_F(TpmTest, NullArgs) {
 TEST_F(TpmTest, InitDevice) {
   dif_spi_device_tpm_caps_t caps;
   EXPECT_READ32(SPI_DEVICE_TPM_CAP_REG_OFFSET,
-                {
-                    {SPI_DEVICE_TPM_CAP_REV_OFFSET, 3},
-                    {SPI_DEVICE_TPM_CAP_LOCALITY_BIT, 1},
-                    {SPI_DEVICE_TPM_CAP_MAX_XFER_SIZE_OFFSET, 4},
-                });
+                {{SPI_DEVICE_TPM_CAP_REV_OFFSET, 3},
+                 {SPI_DEVICE_TPM_CAP_LOCALITY_BIT, 1},
+                 {SPI_DEVICE_TPM_CAP_MAX_WR_SIZE_OFFSET, 6},
+                 {SPI_DEVICE_TPM_CAP_MAX_RD_SIZE_OFFSET, 6}});
   EXPECT_DIF_OK(dif_spi_device_get_tpm_capabilities(&spi_, &caps));
   EXPECT_EQ(caps.revision, 3);
   EXPECT_TRUE(caps.multi_locality);
-  EXPECT_EQ(caps.max_transfer_size, 4);
+  EXPECT_EQ(caps.max_write_size, 6);
+  EXPECT_EQ(caps.max_read_size, 6);
 
   dif_spi_device_tpm_config_t config = {
       .interface = kDifSpiDeviceTpmInterfaceFifo,


### PR DESCRIPTION
This commit splits `max_xfer_size` into write/read transfer sizes.

The TPM design may have different write/read FIFO sizes. Previous design
only shows the maximum write FIFO size to SW.