### PR TITLE
[sw] Include <string.h> in memory.h for host builds

### DIFF
--- a/sw/device/lib/base/memory.c
+++ b/sw/device/lib/base/memory.c
@@ -58,8 +58,7 @@ int OT_PREFIX_IF_NOT_RV32(memcmp)(const void *lhs, const void *rhs,
 }
 
 OT_WEAK
-int OT_PREFIX_IF_NOT_RV32(memrcmp)(const void *lhs, const void *rhs,
-                                   size_t len) {
+int memrcmp(const void *lhs, const void *rhs, size_t len) {
   const uint8_t *lhs8 = (uint8_t *)lhs;
   const uint8_t *rhs8 = (uint8_t *)rhs;
   size_t j;

--- a/sw/device/lib/base/memory_unittest.cc
+++ b/sw/device/lib/base/memory_unittest.cc
@@ -73,8 +73,8 @@ class MemChrTest : public ::testing::TestWithParam<decltype(&ot_memchr)> {};
 INSTANTIATE_TEST_SUITE_P(MemCpy, MemCpyTest,
                          ::testing::Values(ot_memcpy, __builtin_memcpy));
 INSTANTIATE_TEST_SUITE_P(MemCmp, MemCmpTest,
-                         ::testing::Values(ot_memcmp, __builtin_memcmp,
-                                           ot_memrcmp, ref_memrcmp));
+                         ::testing::Values(ot_memcmp, __builtin_memcmp, memrcmp,
+                                           ref_memrcmp));
 INSTANTIATE_TEST_SUITE_P(MemSet, MemSetTest,
                          ::testing::Values(ot_memset, __builtin_memset));
 INSTANTIATE_TEST_SUITE_P(MemChr, MemChrTest,
@@ -233,8 +233,7 @@ TEST_P(MemCmpTest, Properties) {
 TEST_P(MemCmpTest, DoesNotUseSystemEndianness) {
   auto memcmp_func = GetParam();
 
-  const bool reverse =
-      memcmp_func == &ot_memrcmp || memcmp_func == &ref_memrcmp;
+  const bool reverse = memcmp_func == &memrcmp || memcmp_func == &ref_memrcmp;
 
   constexpr uint8_t kBuf1[] = {0, 0, 0, 1};
   constexpr uint8_t kBuf2[] = {0, 0, 1, 0};


### PR DESCRIPTION


This fixes the warnings about implicit declarations of `memcpy()` that
we encountered when building //sw/device/lib/base:mmio_unittest.

This commit also unmangles `memrcmp()` because there is no libc
definition for host builds to use. Apparently, none of its callers were
compiled for the host or there would have been a linker error!

Fixes #14525