### PR TITLE
[testutils] Move the strike counter to flash_ctrl testutils

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -124,6 +124,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
+        "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/runtime:hart",

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -216,4 +216,34 @@ OT_WARN_UNUSED_RESULT
 bool flash_ctrl_testutils_bank_erase(dif_flash_ctrl_state_t *flash_state,
                                      uint32_t bank, bool data_only);
 
+/**
+ * Determines a count value as the index of the first bit set to 1 in a word.
+ *
+ * This uses an incrementing counter implemented as a uint32_t initialized to
+ * all 1 (meaning a count of zero), and on each increment operation the lowest
+ * bit set is cleared. This is consistent with the capability of flash.
+ *
+ * @param strike_counter The address of the counter.
+ * @return The bit position of the first bit set to 1.
+ */
+uint32_t flash_ctrl_testutils_get_count(uint32_t *strike_counter);
+
+/**
+ * Increments a strike counter by clearing a bit.
+ *
+ * Uses a strike counter as described for flash_ctrl_testutils_get_count.
+ * It is give a bit to be cleared, typically the value returned by the most
+ * recent call to flash_ctrl_testutils_get_count.
+ *
+ * Notice if the right-most bit set to 1 is not cleared the counter will not
+ * advance.
+ *
+ * @param flash_state A flash_ctrl state handle.
+ * @param strike_counter The address of the counter.
+ * @param index The bit to clear.
+ */
+void flash_ctrl_testutils_increment_counter(dif_flash_ctrl_state_t *flash_state,
+                                            uint32_t *strike_counter,
+                                            uint32_t index);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_FLASH_CTRL_TESTUTILS_H_

--- a/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
@@ -41,37 +41,9 @@ static dif_flash_ctrl_state_t flash_ctrl;
 static dif_sysrst_ctrl_t sysrst_ctrl;
 static dif_pinmux_t pinmux;
 
+// This is a strike counter to keep track of progress.
 __attribute__((section(".non_volatile_scratch")))
 const volatile uint32_t events_vector = UINT32_MAX;
-
-/**
- *  Extracts current event id from the bit-strike counter.
- */
-static uint32_t event_to_test(void) {
-  uint32_t addr = (uint32_t)(&events_vector);
-  uint32_t val = abs_mmio_read32(addr);
-
-  for (size_t i = 0; i < 32; ++i) {
-    if (val >> i & 0x1) {
-      return i;
-    }
-  }
-  return -1;
-};
-
-/**
- *  Increment flash bit-strike counter.
- */
-static bool incr_flash_cnt(uint32_t tested_idx) {
-  uint32_t addr = (uint32_t)(&events_vector);
-
-  // set the tested bit to 0
-  uint32_t val = abs_mmio_read32(addr) & ~(1 << tested_idx);
-
-  // program the word into flash
-  return flash_ctrl_testutils_write(&flash_ctrl, addr, 0, &val,
-                                    kDifFlashCtrlPartitionTypeData, 1);
-};
 
 /**
  * sysrst_ctrl config for test #1
@@ -123,8 +95,8 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
 
   // First check the flash stored value
-  uint32_t event_idx = event_to_test();
-
+  uint32_t event_idx =
+      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
                                              /*rd_en*/ true,
@@ -135,9 +107,8 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are
-  if (!incr_flash_cnt(event_idx)) {
-    LOG_ERROR("Error when incrementing flash counter");
-  }
+  flash_ctrl_testutils_increment_counter(&flash_ctrl,
+                                         (uint32_t *)&events_vector, event_idx);
 
   // Read wakeup reason before check
   dif_pwrmgr_wakeup_reason_t wakeup_reason;

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
@@ -61,35 +61,6 @@ __attribute__((section(".non_volatile_scratch")))
 const volatile uint32_t events_vector = UINT32_MAX;
 
 /**
- *  Extracts current event id from the bit-strike counter.
- */
-static uint32_t event_to_test(void) {
-  uint32_t addr = (uint32_t)(&events_vector);
-  uint32_t val = abs_mmio_read32(addr);
-
-  for (size_t i = 0; i < 32; ++i) {
-    if (val >> i & 0x1) {
-      return i;
-    }
-  }
-  return -1;
-};
-
-/**
- *  Increment flash bit-strike counter.
- */
-static bool incr_flash_cnt(uint32_t tested_idx) {
-  uint32_t addr = (uint32_t)(&events_vector);
-
-  // set the tested bit to 0
-  uint32_t val = abs_mmio_read32(addr) & ~(1 << tested_idx);
-
-  // program the word into flash
-  return flash_ctrl_testutils_write(&flash_ctrl, addr, 0, &val,
-                                    kDifFlashCtrlPartitionTypeData, 1);
-};
-
-/**
  * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
  * the phase 1 (i.e. wipe secrets) should occur and last during the time the
  * wdog is programed to bark.
@@ -463,7 +434,8 @@ bool test_main(void) {
   alert_handler_config();
 
   // First check the flash stored value.
-  uint32_t event_idx = event_to_test();
+  uint32_t event_idx =
+      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
 
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
@@ -475,9 +447,8 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are.
-  if (!incr_flash_cnt(event_idx)) {
-    LOG_ERROR("Error when incrementing flash counter");
-  }
+  flash_ctrl_testutils_increment_counter(&flash_ctrl,
+                                         (uint32_t *)&events_vector, event_idx);
 
   LOG_INFO("Test round %d", event_idx);
   LOG_INFO("RST_IDX[%d] = %d", event_idx, RST_IDX[event_idx]);

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -55,35 +55,6 @@ __attribute__((section(".non_volatile_scratch")))
 const volatile uint32_t events_vector = UINT32_MAX;
 
 /**
- *  Extracts current event id from the bit-strike counter.
- */
-static uint32_t event_to_test(void) {
-  uint32_t addr = (uint32_t)(&events_vector);
-  uint32_t val = abs_mmio_read32(addr);
-
-  for (size_t i = 0; i < 32; ++i) {
-    if (val >> i & 0x1) {
-      return i;
-    }
-  }
-  return -1;
-};
-
-/**
- *  Increment flash bit-strike counter.
- */
-static bool incr_flash_cnt(uint32_t tested_idx) {
-  uint32_t addr = (uint32_t)(&events_vector);
-
-  // set the tested bit to 0
-  uint32_t val = abs_mmio_read32(addr) & ~(1 << tested_idx);
-
-  // program the word into flash
-  return flash_ctrl_testutils_write(&flash_ctrl, addr, 0, &val,
-                                    kDifFlashCtrlPartitionTypeData, 1);
-};
-
-/**
  * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
  * the phase 1 (i.e. wipe secrets) should occur and last during the time the
  * wdog is programed to bark.
@@ -471,7 +442,8 @@ bool test_main(void) {
   alert_handler_config();
 
   // First check the flash stored value
-  uint32_t event_idx = event_to_test();
+  uint32_t event_idx =
+      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
 
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
@@ -483,9 +455,8 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are
-  if (!incr_flash_cnt(event_idx)) {
-    LOG_ERROR("Error when incrementing flash counter");
-  }
+  flash_ctrl_testutils_increment_counter(&flash_ctrl,
+                                         (uint32_t *)&events_vector, event_idx);
 
   LOG_INFO("Test round %d", event_idx);
   LOG_INFO("RST_IDX[%d] = %d", event_idx, RST_IDX[event_idx]);

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
@@ -56,35 +56,6 @@ __attribute__((section(".non_volatile_scratch")))
 const volatile uint32_t events_vector = UINT32_MAX;
 
 /**
- *  Extracts current event id from the bit-strike counter.
- */
-static uint32_t event_to_test(void) {
-  uint32_t addr = (uint32_t)(&events_vector);
-  uint32_t val = abs_mmio_read32(addr);
-
-  for (size_t i = 0; i < 32; ++i) {
-    if (val >> i & 0x1) {
-      return i;
-    }
-  }
-  return -1;
-};
-
-/**
- *  Increment flash bit-strike counter.
- */
-static bool incr_flash_cnt(uint32_t tested_idx) {
-  uint32_t addr = (uint32_t)(&events_vector);
-
-  // set the tested bit to 0
-  uint32_t val = abs_mmio_read32(addr) & ~(1 << tested_idx);
-
-  // program the word into flash
-  return flash_ctrl_testutils_write(&flash_ctrl, addr, 0, &val,
-                                    kDifFlashCtrlPartitionTypeData, 1);
-};
-
-/**
  * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
  * the phase 1 (i.e. wipe secrets) should occur and last during the time the
  * wdog is programed to bark.
@@ -495,7 +466,8 @@ bool test_main(void) {
   alert_handler_config();
 
   // First check the flash stored value
-  uint32_t event_idx = event_to_test();
+  uint32_t event_idx =
+      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
 
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
@@ -507,9 +479,8 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are
-  if (!incr_flash_cnt(event_idx)) {
-    LOG_ERROR("Error when incrementing flash counter");
-  }
+  flash_ctrl_testutils_increment_counter(&flash_ctrl,
+                                         (uint32_t *)&events_vector, event_idx);
 
   LOG_INFO("Test round %d", event_idx);
   LOG_INFO("RST_IDX[%d] = %d", event_idx, RST_IDX[event_idx]);

--- a/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
@@ -33,35 +33,6 @@ __attribute__((section(".non_volatile_scratch")))
 const volatile uint32_t events_vector = UINT32_MAX;
 
 /**
- *  Extracts current event id from the bit-strike counter.
- */
-static uint32_t event_to_test(void) {
-  uint32_t addr = (uint32_t)(&events_vector);
-  uint32_t val = abs_mmio_read32(addr);
-
-  for (size_t i = 0; i < 32; ++i) {
-    if (val >> i & 0x1) {
-      return i;
-    }
-  }
-  return -1;
-};
-
-/**
- *  Increment flash bit-strike counter.
- */
-static bool incr_flash_cnt(uint32_t tested_idx) {
-  uint32_t addr = (uint32_t)(&events_vector);
-
-  // set the tested bit to 0
-  uint32_t val = abs_mmio_read32(addr) & ~(1 << tested_idx);
-
-  // program the word into flash
-  return flash_ctrl_testutils_write(&flash_ctrl, addr, 0, &val,
-                                    kDifFlashCtrlPartitionTypeData, 1);
-};
-
-/**
  * Configure the sysrst.
  */
 static void config_sysrst(const dif_pwrmgr_t *pwrmgr,
@@ -189,7 +160,8 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
 
   // First check the flash stored value
-  uint32_t event_idx = event_to_test();
+  uint32_t event_idx =
+      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
 
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
@@ -201,9 +173,8 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are
-  if (!incr_flash_cnt(event_idx)) {
-    LOG_ERROR("Error when incrementing flash counter");
-  }
+  flash_ctrl_testutils_increment_counter(&flash_ctrl,
+                                         (uint32_t *)&events_vector, event_idx);
 
   LOG_INFO("Test round %d", event_idx);
   LOG_INFO("RST_IDX[%d] = %d", event_idx, RST_IDX[event_idx]);


### PR DESCRIPTION
The strike counter utility is pretty handy for preserving state
across resets. It should not be replicated in individual tests.

Signed-off-by: Guillermo Maturana <maturana@google.com>