### PR TITLE
[e2e] Regularize invocation of rust-based tests

### DIFF
--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -8,3 +8,33 @@ pub mod init;
 pub mod load_bitstream;
 pub mod rpc;
 pub mod status;
+
+/// The `execute_test` macro should be used in end-to-end tests to
+/// invoke each test from the `main` function.
+/// ```
+/// fn main() -> Result<()> {
+///     // Set up the test environment.
+///
+///     execute_test!(test_foo, &opts, &stransport);
+///     execute_test!(test_bar, &opts, &stransport);
+///     execute_test!(test_baz, &opts, &stransport);
+///     Ok(())
+/// }
+/// ```
+///
+/// The `main` function and each test function should return an `anyhow::Result<()>`.
+///
+/// The `execute_test` macro will print the standard test header and
+/// result footer.  A failed test will abort the program and subsequent tests will
+/// not be executed.
+#[macro_export]
+macro_rules! execute_test {
+    ($test:path, $($args:tt)*) => {
+        println!("Starting test {}...", stringify!($test));
+        let result = $test($($args)*);
+        println!("Finished test {}: {:?}", stringify!($test), result);
+        if result.is_err() {
+            return result;
+        }
+    };
+}

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use structopt::StructOpt;
 
 use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
 use opentitanlib::spiflash::{BlockEraseSize, SpiFlash, SupportedAddressModes, WriteGranularity};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::{ExitStatus, UartConsole};
@@ -198,10 +199,20 @@ fn main() -> Result<()> {
     opts.init.init_logging();
 
     let transport = opts.init.init_target()?;
-    test_bootstrap_entry(&opts, &transport, BootstrapRequest::No)?;
-    test_bootstrap_entry(&opts, &transport, BootstrapRequest::Yes)?;
-    test_jedec_id(&opts, &transport)?;
-    test_sfdp(&opts, &transport)?;
-    test_write_enable_disable(&transport)?;
+    execute_test!(
+        test_bootstrap_entry,
+        &opts,
+        &transport,
+        BootstrapRequest::No
+    );
+    execute_test!(
+        test_bootstrap_entry,
+        &opts,
+        &transport,
+        BootstrapRequest::Yes
+    );
+    execute_test!(test_jedec_id, &opts, &transport);
+    execute_test!(test_sfdp, &opts, &transport);
+    execute_test!(test_write_enable_disable, &transport);
     Ok(())
 }

--- a/sw/host/tests/rom/e2e_bootup_bad_rom_ext_signature/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootup_bad_rom_ext_signature/src/main.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{bail, Result};
 use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::{ExitStatus, UartConsole};
 use regex::Regex;
@@ -85,6 +86,6 @@ fn main() -> Result<()> {
     opts.init.init_logging();
 
     let transport = opts.init.init_target()?;
-    test_corrupted_rom_ext(&opts, &transport)?;
+    execute_test!(test_corrupted_rom_ext, &opts, &transport);
     Ok(())
 }

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
 use opentitanlib::test_utils::e2e_command::TestCommand;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
@@ -50,6 +51,6 @@ fn main() -> Result<()> {
     opts.init.init_logging();
 
     let transport = opts.init.init_target()?;
-    test_chip_specific_startup(&opts, &transport)?;
+    execute_test!(test_chip_specific_startup, &opts, &transport);
     Ok(())
 }


### PR DESCRIPTION
1. Add an `execute_test!` macro that will print regular headers and
   footers for every test.

Signed-off-by: Chris Frantz <cfrantz@google.com>

Note to reviewer: this PR builds on top of #13998.  You need only review the last commit.