### PR TITLE
[dv] Fix timeout log

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -374,10 +374,20 @@
   end
 `endif
 
+// macro that waits for a given delay and then reports an error
+`ifndef DV_WAIT_TIMEOUT
+`define DV_WAIT_TIMEOUT(TIMEOUT_NS_, ID_  = `gfn, ERROR_MSG_ = "timeout occurred!", REPORT_FATAL_ = 1) \
+  begin \
+    #(TIMEOUT_NS_ * 1ns); \
+    if (REPORT_FATAL_) `dv_fatal(ERROR_MSG_, ID_) \
+    else               `dv_error(ERROR_MSG_, ID_) \
+  end
+`endif
+
 // wait a task or statement with timer watchdog
 `ifndef DV_SPINWAIT
 `define DV_SPINWAIT(WAIT_, MSG_ = "timeout occurred!", TIMEOUT_NS_ = default_spinwait_timeout_ns, ID_ =`gfn) \
-  `DV_SPINWAIT_EXIT(WAIT_, wait_timeout(TIMEOUT_NS_, ID_, MSG_);, "", ID_)
+  `DV_SPINWAIT_EXIT(WAIT_, `DV_WAIT_TIMEOUT(TIMEOUT_NS_, ID_, MSG_);, "", ID_)
 `endif
 
 // a shorthand of `DV_SPINWAIT(wait(...))


### PR DESCRIPTION
Changed the wait_timeout to a macro.

Without this fix, the timeout error can't really tell which line causes the timeout.
It points to `dv_utils_pkg.sv:147` which is the function of `wait_timeout`, not the place that
`wait_timeout` is invoked.

> UVM_FATAL @ * ps: (**dv_utils_pkg.sv:147**)
[uvm_test_top.env.virtual_sequencer.spi_device_flash_all_vseq] timeout occurred!

After this fix, now it tells which line causes it. This is quite useful when the sequence
contains multiple waits with timeout timer

> UVM_FATAL @ * ps: (**spi_device_base_vseq.sv:228**) uvm_test_top.env.virtual_sequencer
[uvm_test_top.env.virtual_sequencer.spi_device_flash_all_vseq] timeout occurred!

Once this is in, will make another PR to replace all `wait_timeout` with this macro and remove
`wait_timeout`

Signed-off-by: Weicai Yang <weicai@google.com>