### PR TITLE
[dv,chip,rom_integ] Add mechanism to disable rom integrity check

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -539,9 +539,12 @@ module rom_ctrl
 
   // Check that whenever there is an alert triggered and FSM state is Invalid, there is no response
   // to read requests.
-  `ASSERT(BusLocalEscChk_A,
-          (gen_fsm_scramble_enabled.u_checker_fsm.state_d == rom_ctrl_pkg::Invalid)
-          |-> always(!bus_rom_rvalid))
+  if (!SecDisableScrambling) begin : gen_fsm_scramble_enabled_asserts
+
+    `ASSERT(BusLocalEscChk_A,
+            (gen_fsm_scramble_enabled.u_checker_fsm.state_d == rom_ctrl_pkg::Invalid)
+            |-> always(!bus_rom_rvalid))
+  end
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A,

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -76,8 +76,11 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     `uvm_info(`gfn, "Initializing ROM", UVM_MEDIUM)
     // Backdoor load memories with sw images.
+`ifdef DISABLE_ROM_INTEGRITY_CHECK
+    cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".32.vmem"});
+`else
     cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".39.scr.vmem"});
-
+`endif
     // TODO: the location of the main execution image should be randomized to either bank in future.
     if (cfg.sw_images.exists(SwTypeTest)) begin
       if (cfg.use_spi_load_bootstrap) begin

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -30,7 +30,11 @@
 // The path to the actual memory array in rom_ctrl. This is a bit of a hack to allow a long path
 // without overflowing 100 characters or including any whitespace (which breaks a DV_STRINGIFY call
 // in the system-level testbench).
+`ifdef DISABLE_ROM_INTEGRITY_CHECK
+`define ROM_CTRL_INT_PATH     gen_rom_scramble_disabled.u_rom.u_prim_rom.`MEM_ARRAY_SUB
+`else
 `define ROM_CTRL_INT_PATH     gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom.`MEM_ARRAY_SUB
+`endif
 
 // Memory hierarchies.
 // TODO: Temporarily only reference info type0 of the info partitions in flash. In the future, this

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -9,7 +9,9 @@
 //                -o hw/top_earlgrey/ \
 //                --rnd_cnst_seed 4881560218908238235
 
-module chip_earlgrey_asic (
+module chip_earlgrey_asic #(
+  parameter bit SecRomCtrlDisableScrambling = 1'b0
+) (
   // Dedicated Pads
   inout POR_N, // Manual Pad
   inout USB_P, // Manual Pad
@@ -1071,7 +1073,8 @@ module chip_earlgrey_asic (
   // Top-level design //
   //////////////////////
   top_earlgrey #(
-    .PinmuxAonTargetCfg(PinmuxTargetCfg)
+    .PinmuxAonTargetCfg(PinmuxTargetCfg),
+    .SecRomCtrlDisableScrambling(SecRomCtrlDisableScrambling)
   ) top_earlgrey (
     // ast connections
     .por_n_i                      ( por_n                      ),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -77,7 +77,9 @@ module chip_${top["name"]}_${target["name"]} #(
   parameter OtpCtrlMemInitFile = "otp_img_fpga_${target["name"]}.vmem"
 ) (
 % else:
-module chip_${top["name"]}_${target["name"]} (
+module chip_${top["name"]}_${target["name"]} #(
+  parameter bit SecRomCtrlDisableScrambling = 1'b0
+) (
 % endif
 <%
   removed_port_names = []
@@ -908,7 +910,12 @@ module chip_${top["name"]}_${target["name"]} (
   // Top-level design //
   //////////////////////
   top_${top["name"]} #(
+% if target["name"] != "asic":
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
+% else:
+    .PinmuxAonTargetCfg(PinmuxTargetCfg),
+    .SecRomCtrlDisableScrambling(SecRomCtrlDisableScrambling)
+% endif
   ) top_${top["name"]} (
     // ast connections
     .por_n_i                      ( por_n                      ),


### PR DESCRIPTION
During DV development there is no need to perform rom integrity
checks on each chip reset. This provides a build time mechanism
to configure the hardware to remove the scrambling and integrity
checks.

To use it, pass the following flag to dvsim:
  --build-opts +define+DISABLE_ROM_INTEGRITY_CHECK

Signed-off-by: Guillermo Maturana <maturana@google.com>