### PR TITLE
[spi_device/dv] Update scb to check read buffer interrupts

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_mode_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_mode_vseq.sv
@@ -16,6 +16,10 @@ class spi_device_flash_mode_vseq extends spi_device_intercept_vseq;
     target_ops = {READ_CMD_LIST};
   endfunction
 
+  constraint num_trans_c {
+    num_trans inside {[20:30]};
+  }
+
   task body();
     // increase the chance (15%->50%) to send large payload,
     // in order to exercise watermark and flip events

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -481,6 +481,63 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     csr_update(.csr(ral.cmd_info[idx]));
   endtask : add_cmd_info
 
+  // transfer in command including opcode, address and payload
+  // if byte_addr_q is empty, the host_seq will use a random addr
+  virtual task spi_host_xfer_flash_item(bit [7:0] op, uint payload_size,
+                                        bit [31:0] addr, bit wait_on_busy = 1);
+    spi_host_flash_seq m_spi_host_seq;
+    bit [7:0] byte_addr_q[$];
+    `uvm_create_on(m_spi_host_seq, p_sequencer.spi_sequencer_h)
+
+    if (op inside {READ_CMD_LIST} && cfg.spi_host_agent_cfg.is_opcode_supported(op)) begin
+      int num_addr_bytes = cfg.spi_host_agent_cfg.get_num_addr_byte(op);
+      if (num_addr_bytes > 0) begin
+        if (num_addr_bytes == 4) begin
+          byte_addr_q.push_back(addr[31:24]);
+        end
+        // push the lower 3 bytes address
+        byte_addr_q = {byte_addr_q, addr[23:16], addr[15:8], addr[7:0]};
+      end
+    end
+
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(m_spi_host_seq,
+                                   opcode == op;
+                                   address_q.size() == byte_addr_q.size();
+                                   foreach (byte_addr_q[i]) address_q[i] == byte_addr_q[i];
+                                   payload_q.size() == payload_size;
+                                   read_size == payload_size;)
+    `uvm_send(m_spi_host_seq)
+
+    if (op == `gmv(ral.cmd_info_en4b.opcode) && `gmv(ral.cmd_info_en4b.valid)) begin
+      cfg.spi_device_agent_cfg.flash_addr_4b_en = 1;
+      cfg.spi_host_agent_cfg.flash_addr_4b_en   = 1;
+    end else if (op == `gmv(ral.cmd_info_ex4b.opcode) && `gmv(ral.cmd_info_ex4b.valid)) begin
+      cfg.spi_device_agent_cfg.flash_addr_4b_en = 0;
+      cfg.spi_host_agent_cfg.flash_addr_4b_en   = 0;
+    end
+
+    if (cfg.is_read_buffer_cmd(m_spi_host_seq.rsp)) begin
+      cfg.read_buffer_addr = convert_addr_from_byte_queue(m_spi_host_seq.rsp.address_q) +
+                             m_spi_host_seq.rsp.payload_q.size();
+      cfg.clk_rst_vif.wait_clks(10);
+
+      `uvm_info(`gfn, $sformatf("Updated read_buffer_addr to 0x%0x", cfg.read_buffer_addr),
+                UVM_MEDIUM)
+    end
+
+    // TODO, only read last_read_addr in this mode due to #14586
+    if (device_mode == FlashMode && $urandom_range(0, 1)) begin
+      csr_rd_check(.ptr(ral.last_read_addr), .compare_value(cfg.read_buffer_addr));
+    end
+
+    if (wait_on_busy) begin
+      spi_device_reg_cmd_info cmd_info = cfg.get_cmd_info_reg_by_opcode(op);
+      if (cmd_info != null && `gmv(cmd_info.upload) && `gmv(cmd_info.busy)) begin
+        spi_host_wait_on_busy();
+      end
+    end
+  endtask
+
   virtual task random_access_flash_status(bit write = $urandom_range(0, 1),
                                           bit busy  = $urandom_range(0, 1),
                                           bit wel   = $urandom_range(0, 1),
@@ -510,20 +567,21 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     int cmdfifo_depth_val, addrfifo_depth_val, payload_depth_val;
     int payload_base_offset;
     bit busy_val;
+    bit intr_cmdfifo, intr_payload;
 
     csr_rd(ral.intr_state, intr_state_val);
     csr_rd(ral.upload_status, status_val);
     csr_rd(ral.upload_status2, status2_val);
 
+    intr_cmdfifo = get_field_val(ral.intr_state.upload_cmdfifo_not_empty, intr_state_val);
+    intr_payload = get_field_val(ral.intr_state.upload_payload_not_empty, intr_state_val);
     cmdfifo_depth_val = get_field_val(ral.upload_status.cmdfifo_depth, status_val);
     addrfifo_depth_val = get_field_val(ral.upload_status.addrfifo_depth, status_val);
     payload_depth_val = get_field_val(ral.upload_status2.payload_depth, status2_val);
 
-    if (`gmv(ral.intr_state.upload_cmdfifo_not_empty) == 0 &&
-        `gmv(ral.intr_state.upload_payload_not_empty) == 0) begin
-      return;
-    end
+    if (intr_cmdfifo == 0 && intr_payload == 0) return;
 
+    if (intr_cmdfifo) `DV_CHECK_GT(cmdfifo_depth_val, 0)
     for (int i = 0; i < cmdfifo_depth_val; i++) begin
       bit [TL_DW-1:0] val;
       csr_rd(ral.upload_cmdfifo, val);
@@ -536,7 +594,9 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
       `uvm_info(`gfn, $sformatf("read upload_addrfifo: idx: %0d, data: 0x%0x", i, val), UVM_MEDIUM)
     end
 
+    if (intr_payload) `DV_CHECK_GT(payload_depth_val, 0)
     if (payload_depth_val > PAYLOAD_FIFO_SIZE) payload_depth_val = PAYLOAD_FIFO_SIZE;
+
     // need to shift by 2 for the offset used at mem_rd
     payload_base_offset = (READ_BUFFER_SIZE + MAILBOX_BUFFER_SIZE + SFDP_SIZE) / 4;
     payload_depth_val = payload_depth_val / 4;
@@ -549,6 +609,9 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     end
 
     // clear interrupt
+    intr_state_val = 0;
+    if (intr_cmdfifo) intr_state_val[CmdFifoNotEmpty] = 1;
+    if (intr_payload) intr_state_val[PayloadNotEmpty] = 1;
     csr_wr(ral.intr_state, intr_state_val);
 
     // clear busy bit


### PR DESCRIPTION
Model read buffer interupts and last_read_addr in scb
Since it crosses clock domain and don't want to do cycle accurate check,
create an interrupt pending scheme, which skips the 1st interrupt read when
interrupt is just triggered.

Small update on the sequence to make sequence only clean the interrupt it proccessed

Signed-off-by: Weicai Yang <weicai@google.com>