### PR TITLE
[dv/top] Regression triage

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -680,7 +680,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:otbn_randomness_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18_000_000"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000","+rng_srate_value=30"]
     }
     {
       name: chip_sw_otbn_ecdsa_op_irq

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -153,7 +153,8 @@ void initialize_clkmgr(void) {
 }
 
 bool test_main(void) {
-  entropy_testutils_boot_mode_init();
+  // Initialize EDN in auto mode.
+  entropy_testutils_auto_mode_init();
 
   initialize_clkmgr();
 
@@ -177,9 +178,6 @@ bool test_main(void) {
   // verify that the OTBN clk hint status within clkmgr reads 1 (OTBN is not
   // idle).
   CHECK(otbn_load_app(&otbn_ctx, kOtbnAppCfiTest) == kOtbnOk);
-
-  // Re-initialize EDN in auto mode.
-  entropy_testutils_auto_mode_init();
 
   CHECK(otbn_execute(&otbn_ctx) == kOtbnOk);
 


### PR DESCRIPTION
- fixes #14595
- change test to invoke auto_mode only, instead of boot and auto mode.
- shorten the rng raw bits generation time to speed up the test.

Signed-off-by: Timothy Chen <timothytim@google.com>