### PR TITLE
[dv/top] Regression triage

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -481,7 +481,8 @@
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStDev",
+      run_opts: ["+flash_program_latency=5",
+                 "+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStDev",
                  // The test takes long time because it will transit to RMA state
                  "+sw_test_timeout_ns=200_000_000"]
       run_timeout_mins: 240
@@ -491,7 +492,8 @@
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProd",
+      run_opts: ["+flash_program_latency=5",
+                 "+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProd",
                  // The test takes long time because it will transit to RMA state
                  "+sw_test_timeout_ns=200_000_000"]
       run_timeout_mins: 240
@@ -501,7 +503,8 @@
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProdEnd"]
+      run_opts: ["+flash_program_latency=5",
+                 "+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProdEnd"]
     }
     {
       name: chip_sw_lc_walkthrough_rma


### PR DESCRIPTION
- fixes #14389
- Shorten the amount of time it takes to do rma flash erase through
  run time options
- Qualify assertions with busy_sec_wipe, which appeared to be missing

Signed-off-by: Timothy Chen <timothytim@google.com>