### PR TITLE
[prim_lfsr] Enable randomization of initial seed

### DIFF
--- a/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
@@ -41,6 +41,13 @@
   // main build mode. See commit lowrisc/opentitan#51000a8 for more details.
   primary_build_mode: prim_lfsr_dw_24
 
+  // Always randomize the initial seed of the LFSR.
+  //
+  // For this block level, the DefaultSeed is ignored and a random value is picked instead. This is
+  // facilitated by the plusarg below. At the chip level, this plusarg is not set, so prim_lfsr
+  // randomly picks between the DefaultSeed value and a random value.
+  run_opts: ["+prim_lfsr_use_default_seed=0"]
+
   // dw_8 is only used for "smoke" sims, so coverage collection is not needed.
   prim_lfsr_dw_8_vcs_cov_cfg_file: ""
   prim_lfsr_dw_24_vcs_cov_cfg_file: "-cm_hier {proj_root}/hw/ip/prim/dv/prim_lfsr/data/prim_lfsr_cover.cfg"
@@ -58,6 +65,7 @@
     {
       name: prim_lfsr_test
       build_mode: prim_lfsr_dw_24
+      run_timeout_mins: 120
     }
   ]
 

--- a/hw/ip/prim/rtl/prim_double_lfsr.sv
+++ b/hw/ip/prim/rtl/prim_double_lfsr.sv
@@ -84,6 +84,20 @@ module prim_double_lfsr #(
     );
   end
 
+`ifndef SYNTHESIS
+`ifndef VERILATOR
+  // Ensure both LFSRs start off with the same default seed. if randomized in simulations.
+  initial begin
+    wait (!$isunknown(gen_double_lfsr[0].u_prim_lfsr.DefaultSeedLocal));
+    wait (!$isunknown(gen_double_lfsr[1].u_prim_lfsr.DefaultSeedLocal));
+    gen_double_lfsr[1].u_prim_lfsr.DefaultSeedLocal =
+        gen_double_lfsr[0].u_prim_lfsr.DefaultSeedLocal;
+    $display("%m: Updated gen_double_lfsr[1].u_prim_lfsr.DefaultSeedLocal = 0x%0h",
+        gen_double_lfsr[1].u_prim_lfsr.DefaultSeedLocal);
+  end
+`endif
+`endif
+
   // Output the state from the first LFSR
   assign state_o = lfsr_state[0][StateOutDw-1:0];
   assign err_o = lfsr_state[0] != lfsr_state[1];


### PR DESCRIPTION
This commit enables the randomization of the initial seed in the
RTL itself, within an ifdef SYNTHESIS block.

The prim_lfsr testbench required some associated fixes to get it
working again.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>