### PR TITLE
[sw/silicon_creator] Update retention SRAM layout

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/retention_sram.h
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.h
@@ -15,20 +15,9 @@ extern "C" {
 /**
  * The retention SRAM is memory that is used to retain information, such as a
  * boot service request, across a device reset. If the reset reason is 'power
- * on' (POR) all fields will be initialized to zero by the ROM.
- *
- * TODO(lowRISC/opentitan#5760): the memory map for the retention SRAM is not
- * yet finalized. When it is the layout and content of this structure should
- * be frozen.
+ * on' (POR) all fields will be initialized using the LFSR by the ROM.
  */
 typedef struct retention_sram {
-  /**
-   * A boot services request.
-   *
-   * TODO(lowRISC/opentitan#5760): enumerate boot service identifiers.
-   */
-  uint32_t boot_info;
-
   /**
    * Reset reasons reported by the reset manager before they were reset in mask
    * ROM.
@@ -37,20 +26,8 @@ typedef struct retention_sram {
 
   /**
    * Space reserved for future allocation by the silicon creator.
-   *
-   * TODO(lowRISC/opentitan#5760): the size / offset of this allocation should
-   * be reviewed.
    */
-  uint32_t reserved_creator[446];
-
-  /**
-   * Panic record.
-   *
-   * TODO(lowRISC/opentitan#5760): placeholder, this is for saving a detailed
-   * crashdump record when the CPU is able to respond to a fault or alert
-   * escalation. The size / offset of this allocation should be reviewed.
-   */
-  uint32_t panic_record[256 / sizeof(uint32_t)];
+  uint32_t reserved_creator[2048 / sizeof(uint32_t) - 1];
 
   /**
    * Space reserved for allocation by the silicon owner.
@@ -60,15 +37,12 @@ typedef struct retention_sram {
    *
    * Tests that need to trigger (or detect) a device reset may use this field to
    * preserve state information across resets.
-   *
-   * TODO(lowRISC/opentitan#5760): the size / offset of this allocation should
-   * be reviewed.
    */
   uint32_t reserved_owner[2048 / sizeof(uint32_t)];
 } retention_sram_t;
 
-OT_ASSERT_MEMBER_OFFSET(retention_sram_t, boot_info, 0);
-OT_ASSERT_MEMBER_OFFSET(retention_sram_t, panic_record, 1792);
+OT_ASSERT_MEMBER_OFFSET(retention_sram_t, reset_reasons, 0);
+OT_ASSERT_MEMBER_OFFSET(retention_sram_t, reserved_creator, 4);
 OT_ASSERT_MEMBER_OFFSET(retention_sram_t, reserved_owner, 2048);
 OT_ASSERT_SIZE(retention_sram_t, 4096);
 


### PR DESCRIPTION
We won't be able to finalize the layout of the retention SRAM until we design and implement the boot services and possibly the entire ROM_EXT. This commit finalizes the layout of the retention SRAM by removing the `boot_info` and `panic_record` fields, splitting the available space evenly between the silicon creator and the silicon owner, and updating some comments.

Fixes #5760

Signed-off-by: Alphan Ulusoy <alphan@google.com>