### PR TITLE
[sw/silicon_creator] Extend sec_mmio_ctx_t to accommodate 1000 entries

### DIFF
--- a/sw/device/silicon_creator/lib/base/sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.h
@@ -50,11 +50,8 @@ extern "C" {
 enum {
   /**
    * Number of registers stored in the sec_mmio context.
-   *
-   * This value must be less than the `kSecMmioRndStep` in sec_mmio.c.
    */
-  // TODO(#6609): Update size of expectations table.
-  kSecMmioRegFileSize = 200,
+  kSecMmioRegFileSize = 1000,
 };
 
 /**
@@ -102,12 +99,12 @@ typedef struct sec_mmio_ctx {
  * to both boot stages.
  */
 OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, values, 0);
-OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, addrs, 800);
-OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, last_index, 1600);
-OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, write_count, 1604);
-OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, expected_write_count, 1608);
-OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, check_count, 1612);
-OT_ASSERT_SIZE(sec_mmio_ctx_t, 1616);  // Checked by linker script.
+OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, addrs, 4000);
+OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, last_index, 8000);
+OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, write_count, 8004);
+OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, expected_write_count, 8008);
+OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, check_count, 8012);
+OT_ASSERT_SIZE(sec_mmio_ctx_t, 8016);  // Checked by linker script.
 
 // The sec_mmio_ctx is referenced here to be able to use it inside the
 // `SEC_MMIO_WRITE_INCREMENT()` macro.

--- a/sw/device/silicon_creator/lib/base/static_critical.ld
+++ b/sw/device/silicon_creator/lib/base/static_critical.ld
@@ -19,6 +19,6 @@
   KEEP(*(.static_critical.sec_mmio_ctx))
 
   ASSERT(
-    . - ADDR(.static_critical) == 1648,
+    . - ADDR(.static_critical) == 8048,
     "Error: .static_critical section size has changed");
 } > ram_main


### PR DESCRIPTION
At 1616 bytes (~1.6 kiB), `sec_mmio_ctx_t` can currently hold up to 200 entries and its utilization is at ~75% (see [this doc](https://docs.google.com/document/d/1WcXW0r7ffFPQnN-p0mka5512tzWIXYETkc1m9jXuLRc/edit#heading=h.olu7pjrm8gi)). The size of OpenTitan's main SRAM is 128 kiB. In order to be able accommodate additional `sec_mmio` accesses in ROM_EXT without copying older entries to a new table, this commit increases `kSecMmioRegFileSize` from 200 to 1000, increasing the size of `sec_mmio_ctx_t` to 8016 bytes (~8 kiB).

Fixes #6609

Signed-off-by: Alphan Ulusoy <alphan@google.com>