### PR TITLE
[otbn] Fix DMEM/IMEM rdata bus enabled assertions

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -450,8 +450,7 @@ module otbn
      imem_rdata_bus_raw[31:0]};
 
   `ASSERT(ImemRDataBusDisabledWhenCoreAccess_A, imem_access_core |-> !imem_rdata_bus_en_q)
-  `ASSERT(ImemRDataBusEnabledWhenNoCoreAccess_A,
-    !imem_access_core && ~locking && !imem_dummy_response_q |-> imem_rdata_bus_en_q)
+  `ASSERT(ImemRDataBusEnabledWhenIdle_A, status_q == StatusIdle |-> imem_rdata_bus_en_q)
   `ASSERT(ImemRDataBusDisabledWhenLocked_A, locking |=> !imem_rdata_bus_en_q)
   `ASSERT(ImemRDataBusReadAsZeroWhenLocked_A,
     imem_rvalid_bus & locking |-> imem_rdata_bus_raw == '0)
@@ -683,8 +682,7 @@ module otbn
   end
 
   `ASSERT(DmemRDataBusDisabledWhenCoreAccess_A, dmem_access_core |-> !dmem_rdata_bus_en_q)
-  `ASSERT(DmemRDataBusEnabledWhenNoCoreAccess_A,
-    !dmem_access_core && ~locking && !dmem_dummy_response_q |-> dmem_rdata_bus_en_q)
+  `ASSERT(DmemRDataBusEnabledWhenIdle_A, status_q == StatusIdle |-> dmem_rdata_bus_en_q)
   `ASSERT(DmemRDataBusDisabledWhenLocked_A, locking |=> !dmem_rdata_bus_en_q)
   `ASSERT(DmemRDataBusReadAsZeroWhenLocked_A,
     dmem_rvalid_bus & locking |-> dmem_rdata_bus_raw == '0)


### PR DESCRIPTION
These assertions tried to capture all conditions when a core would not
access DMEM or IMEM to assert that DMEM or IMEM would then be accessible
via the bus.  However, the conditions were not sufficiently specific,
and when DMEM or IMEM were not accessible while the conditions held, the
assertion would fail.  One option would be to make the conditions more
specific, but that would approach the definition of the enable signal,
which is not the point of an assertion.

Instead, an assertion should check if an implementation behaves as
specified.  OTBN's specification states that DMEM/IMEM can be read via
the bus when OTBN is *Idle*.

This PR changes those assertions to match the specification. It therefore resolves #14602.