### PR TITLE
[entropy_src/rtl] check cs_ack before new cs_req

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -256,7 +256,9 @@ module entropy_src_main_sm #(
         end
       end
       Sha3MsgDone: begin
-        state_d = Sha3Prep;
+        if (!cs_aes_halt_ack_i) begin
+          state_d = Sha3Prep;
+        end
       end
       Sha3Prep: begin
         // for normal or halt cases, always prevent a power spike


### PR DESCRIPTION
The entropy_src to csrng req/ack bus follows the 4 phase req/ack protocol very closely.
By checking that the ack is deassert before a new request is made will complete the
protocol behavior.
This also allows for verification to use the proper req/ack vip model.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>