### PR TITLE
[dv/kmac] Change how scb fetches sideload key

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -169,6 +169,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
           `uvm_info(`gfn, "starting kmac_app requests", UVM_HIGH)
           begin : send_kmac_req
             send_kmac_app_req(app_mode);
+            wait_no_outstanding_access();
             disable invalid_msgfifo_wr;
             disable sw_cmd_in_app;
             disable check_invalid_key_err;


### PR DESCRIPTION
The current scoreboard only fetches sideload key when the valid bit
dropped and reset to 1, but does not count the scenario where we change
the key value on the fly.
Changing the key value on the fly is not a valid operation, but we want
to test it to make sure it won't create any unexpected errors.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>