### PR TITLE
[fpv/otp] Update assertion ports

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -1463,7 +1463,7 @@ module otp_ctrl
       u_otp_ctrl_lfsr_timer.u_prim_double_lfsr, alert_tx_o[1])
 
   // Alert assertions for reg_we onehot check
-  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg_core, alert_tx_o[1])
+  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg_core, alert_tx_o[2])
 
   // Assertions for countermeasures inside prim_otp
   `ifndef PRIM_DEFAULT_IMPL


### PR DESCRIPTION
This PR updates assertion ports for OnehotRegen check from port 1 to
port2.
Fix issue #14614. thanks @matutem .

Signed-off-by: Cindy Chen <chencindy@opentitan.org>