### PR TITLE
[AST] Suppress VCS Lint warnings in rng.sv

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/rng.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/rng.sv
@@ -70,7 +70,7 @@ logic [12-1:0] dv_srate_value;
 logic [12-1:0] rng_srate_value_min = 12'd32;
 logic [12-1:0] rng_srate_value_max = 12'd128;
 
-initial begin
+initial begin : rng_plusargs
   void'($value$plusargs("rng_srate_value_min=%0d", rng_srate_value_min));
   void'($value$plusargs("rng_srate_value_max=%0d", rng_srate_value_max));
   `ASSERT_I(DvRngSrateMinCheck, rng_srate_value_min inside {[5:500]})


### PR DESCRIPTION
Suppress VCS Lint warnings in rng.sv
```
Lint-[SVA-UB] Unnamed block
../rtl/rng.sv, 73
"vcs_0"
  Assertion found in unnamed block.
  \assert((rng_srate_value_max >= rng_srate_value_min)) else begin
  $error("%0t: (%0s:%0d) [%m] [ASSERT FAILED] %0s", $time, "../rtl/rng.sv", 
  78, "DvRngSrateBoundsCheck");
  end

Lint-[SVA-UB] Unnamed block
../rtl/rng.sv, 73
"vcs_0"
  Assertion found in unnamed block.
  \assert((rng_srate_value_max inside {[5:500]})) else begin
  $error("%0t: (%0s:%0d) [%m] [ASSERT FAILED] %0s", $time, "../rtl/rng.sv", 
  77, "DvRngSrateMaxCheck");
  end

Lint-[SVA-UB] Unnamed block
../rtl/rng.sv, 73
"vcs_0"
  Assertion found in unnamed block.
  \assert((rng_srate_value_min inside {[5:500]})) else begin
  $error("%0t: (%0s:%0d) [%m] [ASSERT FAILED] %0s", $time, "../rtl/rng.sv", 
  76, "DvRngSrateMinCheck");
  End
```
Signed-off-by: Jacob Levy <jacob.levy@nuvoton.com>