### PR TITLE
[spi_device/doc] Update doc for last_read_addr

### DIFF
--- a/hw/ip/spi_device/doc/_index.md
+++ b/hw/ip/spi_device/doc/_index.md
@@ -498,9 +498,9 @@ The IP only uses lower 11 bits of the received read command address (`addr[10:0]
 
 SW is responsible for updating the read buffer contents.
 The HW notifies the SW to update the buffer contents when needed.
-The HW provides a SW configurable read watermark CSR and read-only {{<regref "LAST_READ_ADDRESS">}} CSR.
-The **LAST_READ_ADDRESS** shows the last read address from the buffer.
-For instance, if the host system issues `0xABCD_E000` and reads 128 (or 0x80) bytes, the **LAST_READ_ADDRESS** after the transaction will show `0xABCD_E080`.
+The HW provides a SW configurable read watermark CSR and read-only {{<regref "LAST_READ_ADDR">}} CSR.
+The **LAST_READ_ADDR** shows the last read address of the recent read command.
+For instance, if the host system issues `0xABCD_E000` and reads 128 (or 0x80) bytes, the **LAST_READ_ADDR** after the transaction will show `0xABCD_E07F`.
 It does not show the commands falling into the mailbox region or Read SFDP command's address.
 
 The read watermark address width is 1 bit smaller than the read buffer address.


### PR DESCRIPTION
1. fixed the CSR name
2. Updated description since last_read_addr can reflect read address in
   passthrough mode too
3. Fixed the address value in an example

Discussed at #14590
Signed-off-by: Weicai Yang <weicai@google.com>