### PR TITLE
[spi_device/dv] Align last_read_addr behavior with design

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_read_buffer_direct_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_read_buffer_direct_vseq.sv
@@ -62,6 +62,7 @@ class spi_device_read_buffer_direct_vseq extends spi_device_flash_mode_vseq;
     `uvm_info(`gfn, "reading 1 more byte at read_threshold_val - 1", UVM_MEDIUM)
     send_read_cmd(.start_addr(start_addr), .payload_size(1));
     check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(1));
+    check_interrupts(.interrupts((1 << ReadbufFlip)), .check_set(0));
     start_addr += 1;
 
     payload_size = READ_BUFFER_SIZE / 2 - 1;
@@ -72,10 +73,10 @@ class spi_device_read_buffer_direct_vseq extends spi_device_flash_mode_vseq;
     check_interrupts(.interrupts((1 << ReadbufFlip)), .check_set(1));
     start_addr += payload_size;
 
-    start_addr += 1;
     `uvm_info(`gfn, "reading 1 more byte at read_threshold_val - 1 in 2nd half", UVM_MEDIUM)
     send_read_cmd(.start_addr(start_addr), .payload_size(1));
     check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(1));
+    check_interrupts(.interrupts((1 << ReadbufFlip)), .check_set(0));
   endtask
 
   task send_read_cmd(bit[31:0] start_addr, int payload_size);
@@ -87,6 +88,6 @@ class spi_device_read_buffer_direct_vseq extends spi_device_flash_mode_vseq;
     spi_host_xfer_flash_item(opcode, payload_size, start_addr);
     cfg.clk_rst_vif.wait_clks(10);
 
-    csr_rd_check(.ptr(ral.last_read_addr), .compare_value(start_addr + payload_size));
+    csr_rd_check(.ptr(ral.last_read_addr), .compare_value(start_addr + payload_size - 1));
   endtask
 endclass : spi_device_read_buffer_direct_vseq

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -9,7 +9,8 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
   bit [TL_AW-1:0]     sram_end_addr;
 
   // read buffer needs to be read with incremental address, otherwise, watermark/fip won't work
-  bit [TL_AW-1:0]     read_buffer_addr;
+  // this needs to be kept across sequences and cleared when reset occurs. Only seq uses it.
+  bit [TL_AW-1:0]     next_read_buffer_addr;
   // read_buffer_addr is updated after a transaction is done
   // this ptr is updated when a flip event occurs, so that we could know which part is
   // read by the SPI host, in order to update the other part


### PR DESCRIPTION
Updated scb to align the behavior #14620. Now last_read_addr shows last address,
rather than the next address

Moved interrupt clear before updating mem, to avoid a new interrupt comes before
it's cleared

Signed-off-by: Weicai Yang <weicai@google.com>