### PR TITLE
[chip dv] Quiesce AON timer completely in chip simulations (only pwrmgr_smoketest in this PR)

### DIFF
--- a/sw/device/lib/dif/dif_aon_timer.c
+++ b/sw/device/lib/dif/dif_aon_timer.c
@@ -100,6 +100,20 @@ dif_result_t dif_aon_timer_wakeup_restart(const dif_aon_timer_t *aon) {
   return kDifOk;
 }
 
+dif_result_t dif_aon_timer_wakeup_is_enabled(const dif_aon_timer_t *aon,
+                                             bool *is_enabled) {
+  if (aon == NULL || is_enabled == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg =
+      mmio_region_read32(aon->base_addr, AON_TIMER_WKUP_CTRL_REG_OFFSET);
+
+  *is_enabled = bitfield_bit32_read(reg, AON_TIMER_WKUP_CTRL_ENABLE_BIT);
+
+  return kDifOk;
+}
+
 dif_result_t dif_aon_timer_clear_wakeup_cause(const dif_aon_timer_t *aon) {
   if (aon == NULL) {
     return kDifBadArg;
@@ -181,6 +195,20 @@ dif_result_t dif_aon_timer_watchdog_restart(const dif_aon_timer_t *aon) {
 
   aon_timer_watchdog_clear_counter(aon);
   aon_timer_watchdog_toggle(aon, true);
+
+  return kDifOk;
+}
+
+dif_result_t dif_aon_timer_watchdog_is_enabled(const dif_aon_timer_t *aon,
+                                               bool *is_enabled) {
+  if (aon == NULL || is_enabled == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg =
+      mmio_region_read32(aon->base_addr, AON_TIMER_WDOG_CTRL_REG_OFFSET);
+
+  *is_enabled = bitfield_bit32_read(reg, AON_TIMER_WDOG_CTRL_ENABLE_BIT);
 
   return kDifOk;
 }

--- a/sw/device/lib/dif/dif_aon_timer.h
+++ b/sw/device/lib/dif/dif_aon_timer.h
@@ -62,6 +62,17 @@ dif_result_t dif_aon_timer_wakeup_stop(const dif_aon_timer_t *aon);
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_aon_timer_wakeup_restart(const dif_aon_timer_t *aon);
 
+/**
+ * Checks whether this Always-On Timer (wake-up timer) is enabled.
+ *
+ * @param aon An Always-On Timer handle.
+ * @param[out] is_enabled Out-param for the enabled state.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aon_timer_wakeup_is_enabled(const dif_aon_timer_t *aon,
+                                             bool *is_enabled);
+
 /** Clear Always-On Timer wakeup cause
  *
  * Clears WKUP_CAUSE register
@@ -122,6 +133,17 @@ dif_result_t dif_aon_timer_watchdog_stop(const dif_aon_timer_t *aon);
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_aon_timer_watchdog_restart(const dif_aon_timer_t *aon);
+
+/**
+ * Checks whether this Always-On Timer (watchdog timer) is enabled.
+ *
+ * @param aon An Always-On Timer handle.
+ * @param[out] is_enabled Out-param for the enabled state.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aon_timer_watchdog_is_enabled(const dif_aon_timer_t *aon,
+                                               bool *is_enabled);
 
 /** Retrieves Always-On Timer (watchdog timer) tick count.
  *

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -72,6 +72,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
         "//sw/device/lib/base:math",
         "//sw/device/lib/dif:aon_timer",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/lib/testing/aon_timer_testutils.h
+++ b/sw/device/lib/testing/aon_timer_testutils.h
@@ -40,4 +40,14 @@ void aon_timer_testutils_watchdog_config(const dif_aon_timer_t *aon_timer,
                                          uint32_t bite_cycles,
                                          bool pause_in_sleep);
 
+/**
+ * Turn off the AON timer peripheral.
+ *
+ * At the end of the simulation, stop the wakeup and watchdog timers so that
+ * the design stops generating events that may affect the simulation from
+ * terminating cleanly. The wakeup and watchdog timer controls are read back
+ * to ensure the written value successfully crossed the AON clock domain.
+ */
+void aon_timer_testutils_shutdown(const dif_aon_timer_t *aon_timer);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_AON_TIMER_TESTUTILS_H_


### PR DESCRIPTION
Fixes #14581. 
See relevant issues #14585, #14599.

The first commit adds 2 methods to AON timer DIFs, to read out the current status of the timers respectively. The read helps ensure the previous write completes (the write needs to synchronize to the slow AON clock domain which takes a long time). 

The second commit adds a method to AON timer testutil to shutdown the peripheral. 

Finally, the third commit invokes the testutil to shut down the AON timer before exiting the simulation. 