### PR TITLE
[test] Add a testplan file for manual ROM tests

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -10,7 +10,7 @@
                      // "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "hw/ip/tlul/data/tlul_testplan.hjson",
-                     "sw/device/silicon_creator/rom/data/rom_testplan.hjson",
+                     "sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson",
                      "hw/top_earlgrey/data/chip_conn_testplan.hjson"]
 
   testpoints: [

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -6,12 +6,15 @@
 hjson
 libcst
 mako
+pluralizer
 pycryptodome >= 3.11.0
 pyelftools
 pytest
 pytest-timeout
 pyyaml
+rich
 tabulate
+typer
 
 # Dependencies: dv_sim
 enlighten

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -7,6 +7,7 @@ load("//rules:exclude_files.bzl", "exclude_files")
 load("//rules:linker.bzl", "ld_library")
 load(
     "//rules:opentitan_test.bzl",
+    "manual_test",
     "opentitan_functest",
 )
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
@@ -317,4 +318,13 @@ pkg_files(
     name = "package",
     srcs = [":pre_package"],
     prefix = "earlgrey/rom",
+)
+
+manual_test(
+    name = "manual_test",
+    tags = [
+        "manual",
+        "no-cache",
+    ],
+    testplan = "//sw/device/silicon_creator/rom/data:rom_manual_testplan.hjson",
 )

--- a/sw/device/silicon_creator/rom/data/BUILD
+++ b/sw/device/silicon_creator/rom/data/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "rom_e2e_testplan.hjson",
+    "rom_manual_testplan.hjson",
+])

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 {
-  name: "rom"
+  name: "rom_e2e"
 
   testpoints: [
     {

--- a/sw/device/silicon_creator/rom/data/rom_manual_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_manual_testplan.hjson
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  name: "rom_manual"
+
+  testpoints: [
+    {
+      name: rom_manual_spi_device_constants
+      desc: '''Verify that spi_device constants in `spi_device.h` are up to date.
+
+            Certain spi_device hardware constants are currently hard-coded in `spi_device.h` since
+            they are not auto-generated yet. See #11740 for details.
+
+            - Verify that the following constants defined in `spi_device.h` are up to date:
+              - `kSpiDeviceSfdpAreaNumBytes`
+              - `kSpiDeviceSfdpAreaOffset`
+              - `kSpiDevicePayloadAreaOffset`
+              - `kSpiDevicePayloadAreaNumBytes`
+              - `kSpiDevicePayloadAreaNumWords`
+              - `kSpiDeviceWelBit`
+            '''
+      tags: ["manual"]
+      stage: V2
+      tests: []
+    }
+  ]
+}

--- a/util/BUILD
+++ b/util/BUILD
@@ -65,3 +65,16 @@ py_test(
         "generate_compilation_db_test.py",
     ],
 )
+
+py_binary(
+    name = "run_manual_tests",
+    srcs = [
+        "run_manual_tests.py",
+    ],
+    deps = [
+        requirement("typer"),
+        requirement("hjson"),
+        requirement("rich"),
+        requirement("pluralizer"),
+    ],
+)

--- a/util/run_manual_tests.py
+++ b/util/run_manual_tests.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Runs, i.e. walks through, the test points of a manual test plan.
+
+This script prints the descriptions of each test point in a manual test plan
+one by one and prompts whether they pass or fail. A manual test plan passes if
+all test points are interactively verified.
+
+  Typical usage:
+
+  # This script can be run either directly, or
+  util/run_manual_tests.py sw/device/silicon_creator/rom/data/rom_manual_testplan.hjson
+  # via the `manual_test()` bazel rule.
+  bazel test -t- //sw/device/silicon_creator/rom:manual
+"""
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import hjson
+import typer
+from pluralizer import Pluralizer
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.prompt import Confirm
+from rich.text import Text
+
+pluralize = Pluralizer().pluralize
+
+
+def _get_tty():
+    """Returns the terminal that we should use.
+
+    When this script is run directly, the terminal should be the terminal of the process.
+    When this script is run by bazel, the terminal should be the terminal of the bazel
+    client. Note that we cannot simply traverse the process tree, since this script is
+    run by the bazel server, which could be started from a different terminal.
+    """
+    term = subprocess.check_output(
+        ["/bin/ps", "-p", f"{os.getpid()}", "-o", "tty="]).decode().strip()
+    if term == "?":
+        res = subprocess.check_output(["/bin/ps", "-axo",
+                                       "tty=,cmd="]).decode()
+        m = re.search(r"^(?P<term>[\w/]*) *bazel.*test.*$", res, re.MULTILINE)
+        if not m:
+            raise RuntimeError("Could not find the terminal")
+        term = m["term"]
+    return f"/dev/{term}"
+
+
+# Set the terminal manually since this test is interactive.
+# This is really a hack since bazel does not support interactive commands.
+stdin = open(_get_tty(), "r")
+stdout = open(_get_tty(), "w")
+console = Console(force_interactive=True, force_terminal=True, file=stdout)
+
+
+def _run_manual_testpoint(testplan_name: str,
+                          testpoint: Dict[str, Any]) -> Tuple[str, bool]:
+    """Runs a testpoint in a manual testplan."""
+    name = f"{testplan_name}/{testpoint['name']}"
+    md = f"**{name}**: {testpoint['desc']}"
+    console.print(Markdown(md))
+    console.print("")
+    prompt = Text.styled("\n> Was the test successful? [y/n]", style="bold")
+    return (name,
+            Confirm.ask(prompt,
+                        show_choices=False,
+                        console=console,
+                        stream=stdin))
+
+
+def _print_results(testplan_name: str, results: List[Tuple[str,
+                                                           bool]]) -> None:
+    """Prints the results for a testplan."""
+    title = Text.assemble(
+        ("Results of testplan ", "bold"),
+        (f"{testplan_name}", "bold reverse"),
+        (":", "bold"),
+    )
+    console.print("")
+    console.print(title)
+    console.print("")
+
+    for testpoint, passed in results:
+        line = Text.assemble(f"  {testpoint}: ",
+                             ("PASSED", "bold green") if passed else
+                             ("FAILED", "bold red"))
+        console.print(line)
+    console.print("")
+
+    num_tests = len(results)
+    num_pass = len([res[1] for res in results if res[1]])
+    num_fail = num_tests - num_pass
+    summary = Text.assemble(f"{num_pass} of {num_tests} tests passed. ",
+                            ("All tests PASSED",
+                             "bold green") if not num_fail else
+                            (f"{pluralize('test', num_fail, True)} FAILED",
+                             "bold white on red"))
+    console.print(summary)
+    raise typer.Exit(code=num_fail)
+
+
+def main(testplan_path: Path):
+    """Run manual tests listed in a testplan hjson file."""
+    testplan = hjson.load(testplan_path.open())
+    results = [
+        _run_manual_testpoint(testplan['name'], t)
+        for t in testplan['testpoints']
+    ]
+    _print_results(testplan["name"], results)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
@moidx this is what I put together for the manual tests that we discussed offline.

@timothytrippel Do we have an example for this in HW tests? I added a new file and made up a tag (`manual`) for these tests. Does this conflict with the testplan guidelines?

If we are happy with this approach, we can consider adding a simple utility that walks through each test point and asks y/n so that this can be added to a test suite in bazel, e.g. `rom-release` which runs `rom-e2e`, `rom-manual`, and maybe even `rom-functests` (these are TBD).



![manual_tests](https://user-images.githubusercontent.com/57949550/188865969-a416c5c7-3b0e-47b9-8a6a-13025dee3f22.gif)

