### PR TITLE
[otbn] Raise bad_internal_state error on invalid MuBi values

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -380,7 +380,7 @@ interface otbn_trace_if
   assign predec_err_i.rf_err = rf_bignum_predec_error;
   assign predec_err_i.rd_err = rd_predec_error;
 
-  assign start_stop_bad_int_i.state_err = u_otbn_start_stop_control.state_error;
+  assign start_stop_bad_int_i.state_err = u_otbn_start_stop_control.state_error_d;
   assign start_stop_bad_int_i.spr_urnd_acks = u_otbn_start_stop_control.spurious_urnd_ack_error;
   assign start_stop_bad_int_i.spr_secwipe_reqs = u_otbn_start_stop_control.secure_wipe_error_q;
 

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -259,6 +259,7 @@ module otbn_core
   logic                 prefetch_ignore_errs;
 
   core_err_bits_t err_bits_q, err_bits_d;
+  logic           mubi_err;
 
   logic start_stop_fatal_error;
   logic rf_bignum_predec_error, alu_bignum_predec_error, ispr_predec_error, mac_bignum_predec_error;
@@ -564,7 +565,8 @@ module otbn_core
                            urnd_all_zero,
                            predec_error,
                            insn_addr_err,
-                           rf_base_spurious_we_err},
+                           rf_base_spurious_we_err,
+                           mubi_err},
     reg_intg_violation:  |{controller_err_bits.reg_intg_violation,
                            non_controller_reg_intg_violation},
     dmem_intg_violation: lsu_rdata_err,
@@ -611,6 +613,11 @@ module otbn_core
                   mubi4_bool_to_mubi(|{urnd_all_zero, rf_base_intg_err, rf_base_spurious_we_err,
                                        predec_error, lsu_rdata_err, insn_fetch_err,
                                        controller_fatal_err, insn_addr_err}));
+
+  // Signal error if MuBi input signals take on invalid values as this means something bad is
+  // happening. The explicit error detection is required as the mubi4_or_hi operations above
+  // might mask invalid values depending on other input operands.
+  assign mubi_err = mubi4_test_invalid(escalate_en_i);
 
   assign insn_cnt_o = insn_cnt;
 

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -295,7 +295,15 @@ module otbn_start_stop_control
     end
 
     // If the MuBi signals take on invalid values, something bad is happening. Put them back to
-    // a safe value and signal an error.
+    // a safe value (if possible) and signal an error.
+    if (mubi4_test_invalid(escalate_en_i)) begin
+      mubi_err_d = 1'b1;
+      state_d = OtbnStartStopStateLocked;
+    end
+    if (mubi4_test_invalid(rma_req_i)) begin
+      mubi_err_d = 1'b1;
+      state_d = OtbnStartStopStateLocked;
+    end
     if (mubi4_test_invalid(wipe_after_urnd_refresh_q)) begin
       wipe_after_urnd_refresh_d = MuBi4False;
       mubi_err_d = 1'b1;


### PR DESCRIPTION
Previously, invalid MuBi values were not handled in a consistent way. In some cases, invalid values weren't detected. Sometimes, signals were checked but invalid values didn't set an error cause, whereas in some cases a bad_internal_state error was raised.

This PR aligns things to 1) check all MuBi signals for invalid values and 2) to raise a bad internal state error in case of invalid
values.