### PR TITLE
[test] Add rom_e2e_shutdown_exception_c test

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -666,7 +666,7 @@ def opentitan_rom_binary(
         dev_targets.extend(opentitan_binary(
             name = devname,
             deps = deps + dev_deps,
-            extract_sw_logs_db = device in ["sim_dv", "sim_verilator"],
+            extract_sw_logs_db = device == "sim_dv",
             **kwargs
         ))
         elf_name = "{}.{}".format(devname, "elf")
@@ -783,7 +783,7 @@ def opentitan_flash_binary(
         dev_targets.extend(opentitan_binary(
             name = devname,
             deps = [depname],
-            extract_sw_logs_db = device in ["sim_dv", "sim_verilator"],
+            extract_sw_logs_db = device == "sim_dv",
             **kwargs
         ))
         bin_name = "{}_{}".format(devname, "bin")

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -63,6 +63,7 @@ _manifest_entry_point = _ottf_start - _ottf_start_address;
 SECTIONS {
   .manifest _ottf_start_address : {
     KEEP(*(.manifest))
+    . = ALIGN(256);
   } > ottf_flash
 
   /**

--- a/sw/device/silicon_creator/rom/data/rom_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_testplan.hjson
@@ -478,7 +478,6 @@
               - Apply bootstrap pin strapping and reset the chip.
               - Send `command` with invalid 3-byte address, e.g. `0xffffff`.
               - Verify that the chip outputs the expected `BFV` over UART.
-                - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2
@@ -767,7 +766,7 @@
 
     {
       name: rom_e2e_address_translation
-      desc: '''Verify that all address translation configurations work
+      desc: '''Verify that all address translation configurations work.
 
             - Bootstrap the chip with a valid second stage image. See the table below.
             - Verify that the chip behaves as expected.
@@ -922,9 +921,12 @@
 
     {
       name: rom_e2e_asm_c_interrupt_handler
-      desc: '''Verify that `rom_start.S` configures the ROM C interrupt handler and it triggers
-            shutdown.
+      desc: '''Verify that `rom_start.S` configures the ROM C interrupt handler and it triggers shutdown.
 
+            #### Using a ROM_EXT image (preferred)
+            See #14274.
+
+            #### Using a debugger
             `CREATOR_SW_CFG_ROM_EXEC_EN` should be set to `0` and the chip should in a life cycle
              state where debugging is enabled, i.e. TEST, DEV, or RMA.
 
@@ -1096,8 +1098,7 @@
 
     {
       name: rom_e2e_static_critical
-      desc: '''Verify that ROM initializes the data structures in the `.static_critical` section
-            properly.
+      desc: '''Verify that ROM initializes the data structures in the `.static_critical` section properly.
 
             - Verify that `boot_measurements` holds the digest of the next stage.
               - Don't specify any usage constraints to be able to compute the actual hash in the second stage.

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -15,6 +15,37 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 opentitan_functest(
+    name = "rom_e2e_shutdown_exception_c",
+    srcs = ["rom_e2e_shutdown_exception_c_test.c"],
+    cw310 = cw310_params(
+        bitstream = "//hw/bitstream:rom",
+        # Note: This test never prints a failure message so it will fail only
+        # when it times out.
+        exit_failure = "NO_FAILURE_MESSAGE",
+        exit_success = "BFV:01495202(?s:.*)BFV:01495202",
+    ),
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    signed = True,
+    targets = [
+        "cw310",
+        "verilator",
+    ],
+    verilator = verilator_params(
+        timeout = "eternal",
+        exit_failure = "NO_FAILURE_MESSAGE",
+        exit_success = "BFV:01495202(?s:.*)BFV:01495202",
+        rom = "//sw/device/silicon_creator/rom",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/lib/base:static_critical_boot_measurements",
+        "//sw/device/silicon_creator/lib/base:static_critical_sec_mmio",
+        "//sw/device/silicon_creator/rom_ext:ld_slot_a",
+    ],
+)
+
+opentitan_functest(
     name = "e2e_bootup_success",
     srcs = ["empty_test.c"],
     cw310 = cw310_params(

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -26,12 +26,8 @@ opentitan_functest(
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
     verilator = verilator_params(
+        timeout = "eternal",
         rom = "//sw/device/silicon_creator/rom",
-        # Note: Leaving as broken since this test takes a long time and
-        # we don't really need it as long as the CI runs the FPGA version.
-        tags = [
-            "broken",
-        ],
     ),
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_shutdown_exception_c_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_shutdown_exception_c_test.c
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/manifest_def.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Note: Since this test program is written to verify the behavior of the ROM C
+// exception handlers,
+// - it does not have a `.crt` section,
+// - its entrypoint `_rom_ext_start_boot()` is defined here and it doesn't have
+// a `rom_ext_main()` function, and
+// - it has has only the following sections:
+//   - `.manifest`, to be able to boot this program from ROM,
+//   - `.text`, only 2 instructions to trigger an instruction access fault, and
+//   - `.static_critical`, required by the linker script.
+
+void _rom_ext_start_boot(void) {
+  ((void (*)(void))TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR)();
+}

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -61,6 +61,7 @@ _manifest_entry_point = _rom_ext_start_boot - _rom_ext_start_address;
 SECTIONS {
   .manifest _rom_ext_start_address : {
     KEEP(*(.manifest))
+    . = ALIGN(256);
   } > rom_ext_flash
 
   /**

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -118,6 +118,9 @@ SECTIONS {
     *(.srodata.*)
     *(.rodata)
     *(.rodata.*)
+    /* TODO(#14636): extract_sw_logs_db requires .rodata section. */
+    . = ALIGN(4);
+    _rodata_end = .;
   } > rom_ext_flash
 
   /**

--- a/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
@@ -54,6 +54,7 @@ _manifest_entry_point = _start_boot - _slot_start_address;
 SECTIONS {
   .manifest _slot_start_address : {
     KEEP(*(.manifest))
+    . = ALIGN(256);
   } > owner_flash
 
   /**


### PR DESCRIPTION
This PR
* makes some minor changes and fixes in bazel files and linker scripts (first 3 commits), and
* adds the `rom_e2e_shutdown_exception_c` test (#14274).

Since this test point tests the ROM C handlers, I wanted to keep the test program minimal: 
* no sections other than `.manifest`, `.text`, and `.static_critical`, e.g. no CRT or `.vectors`, and 
* 2 instructions in total ([disassembly](https://gist.github.com/83bbd8cc73e62592fb070b21e9063e3f))