### PR TITLE
[prim_lfsr] Initial block label

### DIFF
--- a/hw/ip/prim/rtl/prim_double_lfsr.sv
+++ b/hw/ip/prim/rtl/prim_double_lfsr.sv
@@ -87,7 +87,7 @@ module prim_double_lfsr #(
 `ifndef SYNTHESIS
 `ifndef VERILATOR
   // Ensure both LFSRs start off with the same default seed. if randomized in simulations.
-  initial begin
+  initial begin : p_sync_lfsr_default_seed
     wait (!$isunknown(gen_double_lfsr[0].u_prim_lfsr.DefaultSeedLocal));
     wait (!$isunknown(gen_double_lfsr[1].u_prim_lfsr.DefaultSeedLocal));
     gen_double_lfsr[1].u_prim_lfsr.DefaultSeedLocal =

--- a/hw/ip/prim/rtl/prim_lfsr.sv
+++ b/hw/ip/prim/rtl/prim_lfsr.sv
@@ -322,7 +322,7 @@ module prim_lfsr #(
     logic [LfsrDw-1:0] DefaultSeedLocal;
     logic prim_lfsr_use_default_seed;
 
-    initial begin
+    initial begin : p_randomize_default_seed
       if (!$value$plusargs("prim_lfsr_use_default_seed=%0d", prim_lfsr_use_default_seed)) begin
         // 30% of the time, use the DefaultSeed parameter; 70% of the time, randomize it.
         `ASSERT_I(UseDefaultSeedRandomizeCheck_A, std::randomize(prim_lfsr_use_default_seed) with {


### PR DESCRIPTION
Add label to initial block to fix lint error.
Fixes #14628.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>