### PR TITLE
[kmac] Not advance the ErrChk FSM in error cases

### DIFF
--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -322,7 +322,17 @@ module kmac_errchk
   ///////////////////
   // State Machine //
   ///////////////////
-  `PRIM_FLOP_SPARSE_FSM(u_state_regs, st_d, st, st_e, StIdle)
+  st_e st_gated_d;
+
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, st_gated_d, st, st_e, StIdle)
+
+  // ICEBOX(#14631): Move block_swcmd to PRIM_FLOP_SPARSE_FSM()
+  //
+  // It would be better to place this condition (block_swcmd) in `always_ff`
+  // block to clearly indicate the clock gating condition. However, the
+  // statemachine uses the sparse encoding scheme and macro. It prevents any
+  // latch enable signals.
+  assign st_gated_d = (block_swcmd) ? st : st_d ;
 
   always_comb begin : next_state
     st_d = st;


### PR DESCRIPTION
_Related Issue: https://github.com/lowRISC/opentitan/issues/14470 _

The `kmac_errchk` module reports errors in case of SW's mis-config/
mis-control. When the module detects any errors, `kmac_errchk` blocks
the SW command and report via **ERR_CODE**.

However, the module has advanced to the next state internally. The
internal FSM inside the `kmac_errchk` is to track the external and check
the correctness.

In this commit, the `kmac_errchk` stops moving to the next state in case
of `block_swcmd` occurs.

It is best to add the block condition in the `always_ff` of the `st`.
However, the sparse FSM coding style prevents it from adding the latch
enable condition. The issue
https://github.com/lowRISC/opentitan/issues/14631 has been created to
enhance the macro and the flop module.
