### PR TITLE
[spi_device] Update last_read_addr only in FlashMode

### DIFF
--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -330,6 +330,10 @@ module spi_readcmd
   // Events: watermark, flip
   logic read_watermark, read_flip;
 
+  // SPI Mode
+  logic  spid_in_flashmode;
+  assign spid_in_flashmode = (spi_mode_i == FlashMode);
+
   //////////////
   // Datapath //
   //////////////
@@ -360,10 +364,12 @@ module spi_readcmd
     if (!sys_rst_ni) begin
       readbuf_addr <= '0;
     end else if ((main_st == MainOutput) && (sel_dp_i == DpReadCmd)
-      && addr_latch_en && !(mailbox_en_i && addr_q_in_mailbox)) begin
+      && addr_latch_en && !(mailbox_en_i && addr_q_in_mailbox)
+      && spid_in_flashmode) begin
       readbuf_addr <= addr_q;
     end
   end
+
   assign readbuf_address_o = readbuf_addr;
 
   always_comb begin


### PR DESCRIPTION
This commit limits the update of `last_read_addr` CSR only when the
SPI_DEVICE is set to flash mode.

Related Issue: https://github.com/lowRISC/opentitan/issues/14612

In previous design, SPI_DEVICE updated the last_read_addr if mailbox is
enabled but the intercept.mailbox is off in passthrough mode. As SW
won't use `last_read_addr` in passthrough mode, it would be easier just
limiting the update in Flash mode.