### PR TITLE
[flash_ctrl,dv]Add covergroups for newly added features

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -419,5 +419,36 @@
             - update_err: A shadow register encountered an update error.
             '''
     }
+    {
+      name: eviction_cg
+      desc: '''
+            Covers eviction with mp_region_cfgs for data and info regions.
+            Sample all 4 rd_buf status.
+            When each buffer hazard is set, capture the address stored in the buffer.
+            Then search from tb data base to see which region the address belong to.
+            After that record the config value (scrambe_en and ecc_en) of the region.
+            Use cross over buffer index, the operation to cause the eviction and
+            the region config values.
+            '''
+    }
+    {
+      name: fetch_code_cg
+      desc: '''
+            Covers whether dut received valid or invalid key value from ral.exec register.
+            Cross with tlul.instr_types.
+            '''
+    }
+    {
+      name: rma_init_cg
+      desc: '''
+            Cover rma operation is executed regardless of when flash_init started.
+            flash_ctrl_hw_rma runs rma operation and flash init in parallel thread.
+            In this test, sample rma state when flash init starts.
+            If rma state is StRmaIdle, which means rma is not started. So it confirms
+            rma start after flash init start.
+            If rma state is [StRmaPageSel:StRmaInvalid], which mean rma is on going.
+            So it confirms rma start before flash init start.
+            '''
+    }
   ]
 }

--- a/hw/ip/flash_ctrl/dv/cov/flash_ctrl_cov_if.sv
+++ b/hw/ip/flash_ctrl/dv/cov/flash_ctrl_cov_if.sv
@@ -11,13 +11,15 @@ interface flash_ctrl_cov_if (
 
   import uvm_pkg::*;
   import flash_ctrl_pkg::*;
+  import lc_ctrl_pkg::*;
   import dv_utils_pkg::*;
   `include "dv_fcov_macros.svh"
 
-  ///////////////////////////////////
-  // Control register cover points //
-  ///////////////////////////////////
-
-  // TODO add covergroups and coverpoints
-
+  logic       rd_buf_en;
+  lc_tx_t rma_req;
+  rma_state_e rma_state;
+  logic [10:0] prog_state0;
+  logic [10:0] prog_state1;
+  logic [10:0] lcmgr_state;
+  logic        init;
 endinterface

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -19,7 +19,6 @@ filesets:
       - flash_ctrl_eflash_ral_pkg.sv
       - flash_ctrl_env_pkg.sv
       - flash_ctrl_if.sv
-      - flash_ctrl_dv_if.sv
       - flash_ctrl_mem_if.sv
       - flash_mem_bkdr_util.sv: {is_include_file: true}
       - flash_mem_addr_attrs.sv: {is_include_file: true}

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -30,9 +30,9 @@ class flash_ctrl_env #(
         )) begin
       `uvm_fatal(`gfn, "failed to get flash_ctrl_vif from uvm_config_db")
     end
-    if (!uvm_config_db#(virtual flash_ctrl_dv_if)::get(
-            this, "", "flash_ctrl_dv_vif", cfg.flash_ctrl_dv_vif)) begin
-      `uvm_fatal(`gfn, "failed to get flash_ctrl_dv_vif from uvm_config_db")
+    if (!uvm_config_db#(virtual flash_ctrl_cov_if)::get(
+            this, "", "flash_ctrl_cov_vif", cfg.flash_ctrl_cov_vif)) begin
+      `uvm_fatal(`gfn, "failed to get flash_ctrl_cov_vif from uvm_config_db")
     end
     for (int i = 0; i < NumBanks; i++) begin
       if (!uvm_config_db#(virtual flash_ctrl_mem_if)::get(

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -73,6 +73,21 @@ class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
     evic_all_cross : cross evic_idx_cp, evic_op_cp, evic_cfg_cp;
   endgroup // eviction_cg
 
+  covergroup fetch_code_cg with function sample(bit is_exec_key, logic [MuBi4Width-1:0] instr);
+    key_cp: coverpoint is_exec_key;
+    instr_type_cp: coverpoint instr {
+      bins instr_types[2] = {MuBi4True, MuBi4False};
+      bins others = {[0:15]} with (!(item inside {MuBi4True, MuBi4False}));
+    }
+    key_instr_cross : cross key_cp, instr_type_cp;
+  endgroup // fetch_code_cg
+
+  covergroup rma_init_cg with function sample(flash_ctrl_pkg::rma_state_e st);
+    rma_start_cp: coverpoint st {
+      bins rma_st[2] = {StRmaIdle, [StRmaPageSel:StRmaInvalid]};
+    }
+  endgroup // rma_init_cg
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
     control_cg = new();
@@ -80,6 +95,8 @@ class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
     error_cg = new();
     fifo_lvl_cg = new();
     eviction_cg = new();
+    fetch_code_cg = new();
+    rma_init_cg = new();
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -258,7 +258,6 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
       end
 
     end
-
   endtask : body
 
   // Task to initialize the Flash Access (Enable All Regions)

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
@@ -56,7 +56,7 @@ class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
           reset_state_index_e reset_state_index = $urandom_range(DVStRmaPageSel, DVStRmaRdVerify);
           // Assert reset during RMA state transition
           `uvm_info("Test", $sformatf("Reset index: %s", reset_state_index.name), UVM_LOW)
-          `DV_SPINWAIT(wait(cfg.flash_ctrl_dv_vif.rma_state == dv2rma_st(reset_state_index));,
+          `DV_SPINWAIT(wait(cfg.flash_ctrl_cov_vif.rma_state == dv2rma_st(reset_state_index));,
                        $sformatf("Timed out waiting for rma_state: %s", reset_state_index.name),
                        state_wait_timeout_ns)
           // Give more cycles for long stages

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
@@ -46,7 +46,7 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
             csr_wr(.ptr(ral.init), .value(1));
             `uvm_info("Test","OTP",UVM_LOW)
             otp_model();
-            `DV_SPINWAIT(wait(cfg.flash_ctrl_dv_vif.rd_buf_en == 1);,
+            `DV_SPINWAIT(wait(cfg.flash_ctrl_cov_vif.rd_buf_en == 1);,
                          "Timed out waiting for rd_buf_en",
                          state_wait_timeout_ns)
             `uvm_info("Test", "RMA REQUEST START", UVM_LOW)
@@ -70,7 +70,7 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
             if (reset_index == DVWaitRmaRsp) wait_time = long_wait_timeout_ns;
             else wait_time = state_wait_timeout_ns;
 
-            `DV_SPINWAIT(wait(cfg.flash_ctrl_dv_vif.lcmgr_state == dv2rtl_st(reset_index));,
+            `DV_SPINWAIT(wait(cfg.flash_ctrl_cov_vif.lcmgr_state == dv2rtl_st(reset_index));,
                          $sformatf("Timed out waiting for %s", reset_index.name),
                          wait_time)
             // Since these are single cycle state,
@@ -138,7 +138,7 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
       cfg.clk_rst_vif.wait_clks(2);
       `uvm_info("Test","OTP after loop",UVM_LOW)
       otp_model();
-      `DV_SPINWAIT(wait(cfg.flash_ctrl_dv_vif.rd_buf_en == 1);,
+      `DV_SPINWAIT(wait(cfg.flash_ctrl_cov_vif.rd_buf_en == 1);,
                    "Timed out waiting for rd_buf_en",
                    state_wait_timeout_ns)
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_prog_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_prog_reset_vseq.sv
@@ -69,8 +69,8 @@ class flash_ctrl_prog_reset_vseq extends flash_ctrl_otf_base_vseq;
           string path1, path2;
           reset_index_e reset_index = $urandom_range(DVStPrePack, DVStCalcEcc);
           `uvm_info("Test", $sformatf("reset_idx: %s", reset_index.name), UVM_MEDIUM)
-          `DV_SPINWAIT(wait(cfg.flash_ctrl_dv_vif.prog_state0 == dv2rtl_st(reset_index) ||
-                            cfg.flash_ctrl_dv_vif.prog_state1 == dv2rtl_st(reset_index));,
+          `DV_SPINWAIT(wait(cfg.flash_ctrl_cov_vif.prog_state0 == dv2rtl_st(reset_index) ||
+                            cfg.flash_ctrl_cov_vif.prog_state1 == dv2rtl_st(reset_index));,
                        $sformatf("Timed out waiting for %s", reset_index.name),
                        // Use long time out.
                        // Some unique state does not always guarantee to reach.
@@ -87,7 +87,7 @@ class flash_ctrl_prog_reset_vseq extends flash_ctrl_otf_base_vseq;
     csr_wr(.ptr(ral.init), .value(1));
     `uvm_info("Test","OTP",UVM_LOW)
     otp_model();
-    `DV_SPINWAIT(wait(cfg.flash_ctrl_dv_vif.rd_buf_en == 1);,
+    `DV_SPINWAIT(wait(cfg.flash_ctrl_cov_vif.rd_buf_en == 1);,
                  "Timed out waiting for rd_buf_en",
                  state_timeout_ns)
 

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -65,10 +65,6 @@ module tb;
     .rst_n(rst_n)
   );
   flash_ctrl_if flash_ctrl_if ();
-  flash_ctrl_dv_if flash_ctrl_dv_if (
-    .clk_i  (clk),
-    .rst_ni (rst_n)
-  );
   flash_phy_prim_if fpp_if (
     .clk  (clk),
     .rst_n(rst_n)
@@ -111,14 +107,15 @@ module tb;
   assign otp_rsp.rand_key   = flash_ctrl_if.otp_rsp.rand_key;
   assign otp_rsp.seed_valid = flash_ctrl_if.otp_rsp.seed_valid;
 
-  assign flash_ctrl_dv_if.rd_buf_en   = tb.dut.u_flash_hw_if.rd_buf_en_o;
-  assign flash_ctrl_dv_if.rma_req     = tb.dut.u_flash_hw_if.rma_req_i;
-  assign flash_ctrl_dv_if.rma_state   = tb.dut.u_flash_hw_if.rma_state_q;
-  assign flash_ctrl_dv_if.prog_state0 =
+  assign dut.u_flash_ctrl_cov_if.rd_buf_en   = tb.dut.u_flash_hw_if.rd_buf_en_o;
+  assign dut.u_flash_ctrl_cov_if.rma_req     = tb.dut.u_flash_hw_if.rma_req_i;
+  assign dut.u_flash_ctrl_cov_if.rma_state   = tb.dut.u_flash_hw_if.rma_state_q;
+  assign dut.u_flash_ctrl_cov_if.prog_state0 =
                tb.dut.u_eflash.gen_flash_cores[0].u_core.gen_prog_data.u_prog.state_q;
-  assign flash_ctrl_dv_if.prog_state1 =
+  assign dut.u_flash_ctrl_cov_if.prog_state1 =
                tb.dut.u_eflash.gen_flash_cores[1].u_core.gen_prog_data.u_prog.state_q;
-  assign flash_ctrl_dv_if.lcmgr_state = tb.dut.u_flash_hw_if.state_q;
+  assign dut.u_flash_ctrl_cov_if.lcmgr_state = tb.dut.u_flash_hw_if.state_q;
+  assign dut.u_flash_ctrl_cov_if.init = tb.dut.u_flash_hw_if.init_i;
 
   wire flash_test_v;
   assign (pull1, pull0) flash_test_v = 1'b1;
@@ -339,8 +336,15 @@ module tb;
                                        prim_tl_if);
     uvm_config_db#(virtual flash_ctrl_if)::set(null, "*.env", "flash_ctrl_vif", flash_ctrl_if);
     uvm_config_db#(virtual flash_phy_prim_if)::set(null, "*.env.m_fpp_agent*", "vif", fpp_if);
-    uvm_config_db#(virtual flash_ctrl_dv_if)::set(null, "*.env", "flash_ctrl_dv_vif",
-                                                  flash_ctrl_dv_if);
+    uvm_config_db#(virtual flash_ctrl_cov_if)::set(null, "*.env", "flash_ctrl_cov_vif",
+                                                  dut.u_flash_ctrl_cov_if);
+    uvm_config_db#(virtual flash_ctrl_mem_if)::set(null, "*.env", "flash_ctrl_mem_vif[0]",
+        dut.u_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[0].
+                                                   u_prim_flash_bank.flash_ctrl_mem_if);
+    uvm_config_db#(virtual flash_ctrl_mem_if)::set(null, "*.env", "flash_ctrl_mem_vif[1]",
+        dut.u_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[1].
+                                                   u_prim_flash_bank.flash_ctrl_mem_if);
+
     $timeformat(-9, 1, " ns", 9);
     run_test();
   end


### PR DESCRIPTION
This PR added covergroups for following features as part of
addressing issue #14527

- Flash instruction execution enable
- RMA entry without flash initialization

Other features can be checked by code coverage.

Also moved flash_ctrl_dv_if to flash_ctrl_cov_if
as part of coverage code clean up.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>