### PR TITLE
[entropy_src/dv] Test cs_aes_halt_req/ack port

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -12,6 +12,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
        m_rng_agent_cfg;
   rand push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))
        m_csrng_agent_cfg;
+  rand push_pull_agent_cfg#(.HostDataWidth(0))
+       m_aes_halt_agent_cfg;
 
   // Additional reset interface for the csrng.
   virtual clk_rst_if    csrng_rst_vif;
@@ -147,6 +149,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
                             type_id::create("m_rng_agent_cfg");
     m_csrng_agent_cfg     = push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))::
                             type_id::create("m_csrng_agent_cfg");
+    m_aes_halt_agent_cfg  = push_pull_agent_cfg#(.HostDataWidth(0))::
+                            type_id::create("m_aes_halt_agent_cfg");
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/entropy_src/dv/env/entropy_src_virtual_sequencer.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_virtual_sequencer.sv
@@ -10,6 +10,7 @@ class entropy_src_virtual_sequencer extends cip_base_virtual_sequencer #(
 
   push_pull_sequencer#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))         rng_sequencer_h;
   push_pull_sequencer#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))  csrng_sequencer_h;
+  push_pull_sequencer#(.HostDataWidth(0))                                      aes_halt_sequencer_h;
 
   `uvm_component_new
 

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -39,6 +39,9 @@ module tb;
       rng_if(.clk(clk), .rst_n(csrng_rst_n));
   push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
       csrng_if(.clk(clk), .rst_n(csrng_rst_n));
+  // Use a push_pull interface to
+  push_pull_if#(.HostDataWidth(0))
+      aes_halt_if(.clk(clk), .rst_n(csrng_rst_n));
   entropy_src_path_if entropy_src_path_if (.entropy_src_hw_if_i(entropy_src_hw_if_i));
   entropy_src_assert_if entropy_src_assert_if (.entropy_src_hw_if_i(entropy_src_hw_if_i));
 
@@ -60,8 +63,8 @@ module tb;
                                     csrng_if.d_data[entropy_src_pkg::CSRNG_BUS_WIDTH]}),
     .entropy_src_hw_if_i          (csrng_if.req),
 
-    .cs_aes_halt_o                (),
-    .cs_aes_halt_i                (1'b1),
+    .cs_aes_halt_o                (aes_halt_if.req),
+    .cs_aes_halt_i                (aes_halt_if.ack),
 
     .entropy_src_xht_o            (),
     .entropy_src_xht_i            ('0),
@@ -108,6 +111,8 @@ module tb;
         (null, "*.env.m_rng_agent*", "vif", rng_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)))::
         set(null, "*.env.m_csrng_agent*", "vif", csrng_if);
+    uvm_config_db#(virtual push_pull_if#(.HostDataWidth(0)))::
+        set(null, "*.env.m_aes_halt_agent*", "vif", aes_halt_if);
     uvm_config_db#(virtual entropy_src_assert_if)::set(null, "*.env", "entropy_src_assert_vif",
         entropy_src_assert_if);
     uvm_config_db#(virtual entropy_src_path_if)::set(null, "*.env", "entropy_src_path_vif",


### PR DESCRIPTION
The `cs_aes_halt_req`/`ack` ports allow the top level design the ability
to stall the `entropy_src` SHA engine to prevent power spikes.  This
commit adds a push_pull agent to the environment exercise this port
properly.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>