### PR TITLE
[entropy_src/dv] Support complete backpressure

### DIFF
--- a/hw/ip/entropy_src/dv/sva/entropy_src_assert_if.sv
+++ b/hw/ip/entropy_src/dv/sva/entropy_src_assert_if.sv
@@ -23,6 +23,8 @@
     tb.dut.u_entropy_src_core.u_prim_mubi4_sync_es_type
 `define PATH9 \
     tb.dut.u_entropy_src_core.u_prim_mubi4_sync_es_enable
+`define PATH10 \
+    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_es_prebitsel_enable
 `define CORE \
     tb.dut.u_entropy_src_core
 `define SHA3 \
@@ -73,6 +75,10 @@ interface entropy_src_assert_if
     $assertoff(0, `PATH9.PrimMubi4SyncCheckTransients_A);
     $assertoff(0, `PATH9.PrimMubi4SyncCheckTransients0_A);
     $assertoff(0, `PATH9.PrimMubi4SyncCheckTransients1_A);
+
+    $assertoff(0, `PATH10.PrimMubi4SyncCheckTransients_A);
+    $assertoff(0, `PATH10.PrimMubi4SyncCheckTransients0_A);
+    $assertoff(0, `PATH10.PrimMubi4SyncCheckTransients1_A);
   endtask // assert_off_alert
 
   task automatic assert_on_alert ();
@@ -111,6 +117,10 @@ interface entropy_src_assert_if
     $asserton(0, `PATH9.PrimMubi4SyncCheckTransients_A);
     $asserton(0, `PATH9.PrimMubi4SyncCheckTransients0_A);
     $asserton(0, `PATH9.PrimMubi4SyncCheckTransients1_A);
+
+    $asserton(0, `PATH10.PrimMubi4SyncCheckTransients_A);
+    $asserton(0, `PATH10.PrimMubi4SyncCheckTransients0_A);
+    $asserton(0, `PATH10.PrimMubi4SyncCheckTransients1_A);
   endtask // assert_on_alert
 
   task automatic assert_off_err ();


### PR DESCRIPTION
Testing the cs_aes_halt_req/ack port calls for improving backpressure
support in the entire entropy_src pipeline, as submitted in PR #14644.
These changes in turn actually simplify some of the timing subtleties
that have to be done in the DV scoreboard.  Some of the DV timing
hacks done prior to this commit no longer accurately predict
the timing of the entropy source.  Most notably, data samples
no longer linger in the RNG bit-select FIFO until another RNG
sample is recieved.

This commit also updates the assertion tweaks that need to be
done to support the backpressure changes.  This is because
there is another instance of prim_mubi4_sync that needs to be
relaxed when bad Mubi values are injected into the pipeline.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>