### PR TITLE
[spi_device/dv] Update scb to check upload related CSRs

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_all_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_all_vseq.sv
@@ -39,18 +39,6 @@ class spi_device_flash_all_vseq extends spi_device_pass_base_vseq;
     join
   endtask : body
 
-  virtual task upload_fifo_read_seq();
-    int upload_read_dly;
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(upload_read_dly,
-        upload_read_dly dist {
-            [0:10]      :/ 1,
-            [11:100]    :/ 2,
-            [101:1000]  :/ 2,
-            [1000:5000] :/ 1};)
-    cfg.clk_rst_vif.wait_clks(upload_read_dly);
-    read_upload_fifos();
-  endtask : upload_fifo_read_seq
-
   virtual task main_seq();
     for (int i = 0; i < num_trans; ++i) begin
       `uvm_info(`gfn, $sformatf("running iteration %0d/%0d", i, num_trans), UVM_LOW)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_upload_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_upload_vseq.sv
@@ -9,19 +9,23 @@ class spi_device_upload_vseq extends spi_device_pass_cmd_filtering_vseq;
 
   virtual task pre_start();
     allow_upload = 1;
+    // addr 3b/4b mode affects upload, as it determines how many bytes the address are.
+    allow_addr_cfg_cmd = 1;
     super.pre_start();
   endtask
 
-  virtual task spi_host_wait_on_busy();
-    // read fifo and clear busy
-    read_upload_fifos();
-
-    // issue read status to actually clear the busy bit
-    super.spi_host_wait_on_busy();
-  endtask
-
   virtual task body();
-    super.body();
-    read_upload_fifos();
+    bit main_seq_done;
+    fork
+      // this thread runs until the main_seq completes
+      while (!main_seq_done) upload_fifo_read_seq();
+      // main seq that sends spi items
+      begin
+        super.body();
+        // add some delay to allow interrupt to be sent and captured in another thread.
+        cfg.clk_rst_vif.wait_clks(100);
+        main_seq_done = 1;
+      end
+    join
   endtask : body
 endclass : spi_device_upload_vseq


### PR DESCRIPTION
Scb updates:
1. Added checker for upload interrupt and upload status CSRs
2. Consolidated 2 types of queue for upload cmd/addr
3. Aligned with design change #14640 that last_read_addr is only updated in
flash mode

Minor sequence updates
1. Use a separate thread to read upload data and clear busy bit. Another
thread to drive SPI command and wait for busy to clear
2. Skip reading upload status unless there is an upload interrupt, so that scb
doesn't need to model upload status cycle accurately

Signed-off-by: Weicai Yang <weicai@google.com>