### PR TITLE
[otbn,rtl] Ignore bignum `rd` indirect error on call stack error

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -1135,6 +1135,7 @@ module otbn_controller
 
   assign rf_d_indirect_err = insn_dec_bignum_i.rf_d_indirect    &
                              (|rf_base_rd_data_b_no_intg[31:5]) &
+                             ~rf_base_call_stack_sw_err_i       &
                              rf_base_rd_en_b_o;
 
   assign rf_indirect_err =


### PR DESCRIPTION
Prior to this PR, a `BN.LID` where the index of `rd` comes from an
empty call stack would raise an illegal instruction error (through the
internal bignum `rd` indirect error) if the index of `rd` exceeds 31.
Whether an illegal instruction error was raised or not would depend on
the residual value in the empty call stack.  Because call stack values
are not reset, this could be physically random or residual charge from
an earlier run (in silicon) or unknown (in RTL simulation).  Therefore,
the illegal instruction error could be uncorrelated with the current
program, which should be avoided.  This scenario already raises a call
stack error, so the instruction is not committed.

This problem can be reproduced by running the `bnlid-2.s` test program,
which is run as part of the `otbn_multi_err` test.

This PR fixes the described problem by ignoring bits [31:5] of the
index of `rd` when a call stack error occurs.