### PR TITLE
[test] Add rom_e2e_static_critical test

### DIFF
--- a/sw/device/examples/sram_program/BUILD
+++ b/sw/device/examples/sram_program/BUILD
@@ -13,6 +13,7 @@ ld_library(
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
         "//sw/device:info_sections",
+        "//sw/device/silicon_creator/lib/base:static_critical_sections",
     ],
 )
 
@@ -29,7 +30,6 @@ opentitan_ram_binary(
         ":sram_program_linker_script",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:macros",
-        "//sw/device/lib/dif:sram_ctrl",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:check",
     ],

--- a/sw/device/examples/sram_program/sram_program.ld
+++ b/sw/device/examples/sram_program/sram_program.ld
@@ -16,6 +16,7 @@ OUTPUT_ARCH(riscv);
 __DYNAMIC = 0;
 
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE sw/device/silicon_creator/lib/base/static_critical_size.ld
 
 _stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
 
@@ -33,7 +34,7 @@ SECTIONS {
    * SRAM programs consist only of a `.data` section that contains all input
    * `.rodata`, `.data`, `.text`, and `.bss` sections.
    */
-  .data : ALIGN(4){
+  .data ORIGIN(ram_main) + _static_critical_size : ALIGN(4){
     /* This will get loaded into `gp`, and the linker will use that register for
      * accessing data within [-2048,2047] of `__global_pointer$`.
      *

--- a/sw/device/lib/dif/dif_hmac_unittest.cc
+++ b/sw/device/lib/dif/dif_hmac_unittest.cc
@@ -53,7 +53,7 @@ class HmacTest : public testing::Test, public mock_mmio::MmioTest {
     for (size_t i = 0; i < size; i += sizeof(uint32_t)) {
       uint32_t word = 0;
       memcpy(&word, &key[i], sizeof(uint32_t));
-      EXPECT_WRITE32(i + HMAC_KEY_0_REG_OFFSET, word);
+      EXPECT_WRITE32(HMAC_KEY_7_REG_OFFSET - i, word);
     }
   }
 };

--- a/sw/device/lib/testing/hmac_testutils.c
+++ b/sw/device/lib/testing/hmac_testutils.c
@@ -28,14 +28,14 @@ const uint8_t kRefHmacLongKey[100] = {
 const dif_hmac_digest_t kRefExpectedShaDigest = {
     .digest =
         {
-            0xBCE0AFF1,
-            0x9CF5AA6A,
-            0x7469A30D,
-            0x61D04E43,
-            0x76E4BBF6,
-            0x381052EE,
-            0x9E7F3392,
             0x5C954D52,
+            0x9E7F3392,
+            0x381052EE,
+            0x76E4BBF6,
+            0x61D04E43,
+            0x7469A30D,
+            0x9CF5AA6A,
+            0xBCE0AFF1,
         },
 };
 
@@ -45,14 +45,14 @@ const dif_hmac_digest_t kRefExpectedShaDigest = {
 const dif_hmac_digest_t kRefExpectedHmacDigest = {
     .digest =
         {
-            0xBDCCB6C7,
-            0x2DDEADB5,
-            0x00AE7683,
-            0x86CB38CC,
-            0x41C63DBB,
-            0x0878DDB9,
-            0xC7A38A43,
             0x1B78378D,
+            0xC7A38A43,
+            0x0878DDB9,
+            0x41C63DBB,
+            0x86CB38CC,
+            0x00AE7683,
+            0x2DDEADB5,
+            0xBDCCB6C7,
         },
 };
 

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -58,7 +58,10 @@ cc_library(
 ld_library(
     name = "ottf_ld_common",
     fragments = ["ottf_common.ld"],
-    deps = ["//sw/device:info_sections"],
+    deps = [
+        "//sw/device:info_sections",
+        "//sw/device/silicon_creator/lib/base:static_critical_sections",
+    ],
 )
 
 ld_library(
@@ -117,7 +120,9 @@ alias(
 # This target provides start files without providing the full OTTF, and can be
 # used to bootstrap post-ROM execution without pulling in the full OTTF. This is
 # useful for programs in `sw/device/examples/` and `sw/device/sca/` that do not
-# make us of the full OTTF.
+# make use of the full OTTF. This target is also suitable for preparing ROM_EXT
+# and BLO images since it reserves space at the start of main SRAM for the
+# `.static_critical` section that holds boot measurements and sec_mmio context.
 #
 # The binary target must provide a `noreturn void _ottf_main(void)` function
 # that this library will call.
@@ -140,6 +145,8 @@ cc_library(
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
+        "//sw/device/silicon_creator/lib/base:static_critical_boot_measurements",
+        "//sw/device/silicon_creator/lib/base:static_critical_sec_mmio",
     ],
 )
 

--- a/sw/device/lib/testing/test_framework/check.h
+++ b/sw/device/lib/testing/test_framework/check.h
@@ -56,25 +56,25 @@
 // See: https://en.cppreference.com/w/c/language/generic
 // clang-format off
 #define SHOW_MISMATCH_FMT_STR_(a) _Generic((a),                 \
-          bool: "CHECK-fail: [%d] got: 0x02%x; want: 0x02%x",   \
-        int8_t: "CHECK-fail: [%d] got: 0x02%x; want: 0x02%x",   \
-       uint8_t: "CHECK-fail: [%d] got: 0x02%x; want: 0x02%x",   \
-       int16_t: "CHECK-fail: [%d] got: 0x04%x; want: 0x04%x",   \
-      uint16_t: "CHECK-fail: [%d] got: 0x04%x; want: 0x04%x",   \
-       int32_t: "CHECK-fail: [%d] got: 0x08%x; want: 0x08%x",   \
-      uint32_t: "CHECK-fail: [%d] got: 0x08%x; want: 0x08%x",   \
-       int64_t: "CHECK-fail: [%d] got: 0x016%x; want: 0x016%x", \
-      uint64_t: "CHECK-fail: [%d] got: 0x016%x; want: 0x016%x")
+          bool: "CHECK-fail: [%d] got: 0x%02x; want: 0x%02x",   \
+        int8_t: "CHECK-fail: [%d] got: 0x%02x; want: 0x%02x",   \
+       uint8_t: "CHECK-fail: [%d] got: 0x%02x; want: 0x%02x",   \
+       int16_t: "CHECK-fail: [%d] got: 0x%04x; want: 0x%04x",   \
+      uint16_t: "CHECK-fail: [%d] got: 0x%04x; want: 0x%04x",   \
+       int32_t: "CHECK-fail: [%d] got: 0x%08x; want: 0x%08x",   \
+      uint32_t: "CHECK-fail: [%d] got: 0x%08x; want: 0x%08x",   \
+       int64_t: "CHECK-fail: [%d] got: 0x%016x; want: 0x%016x", \
+      uint64_t: "CHECK-fail: [%d] got: 0x%016x; want: 0x%016x")
 #define SHOW_MATCH_FMT_STR_(a) _Generic((a),            \
-          bool: "CHECK-fail: [%d] both equal: 0x02%x",  \
-        int8_t: "CHECK-fail: [%d] both equal: 0x02%x",  \
-       uint8_t: "CHECK-fail: [%d] both equal: 0x02%x",  \
-       int16_t: "CHECK-fail: [%d] both equal: 0x04%x",  \
-      uint16_t: "CHECK-fail: [%d] both equal: 0x04%x",  \
-       int32_t: "CHECK-fail: [%d] both equal: 0x08%x",  \
-      uint32_t: "CHECK-fail: [%d] both equal: 0x08%x",  \
-       int64_t: "CHECK-fail: [%d] both equal: 0x016%x", \
-      uint64_t: "CHECK-fail: [%d] both equal: 0x016%x")
+          bool: "CHECK-fail: [%d] both equal: 0x%02x",  \
+        int8_t: "CHECK-fail: [%d] both equal: 0x%02x",  \
+       uint8_t: "CHECK-fail: [%d] both equal: 0x%02x",  \
+       int16_t: "CHECK-fail: [%d] both equal: 0x%04x",  \
+      uint16_t: "CHECK-fail: [%d] both equal: 0x%04x",  \
+       int32_t: "CHECK-fail: [%d] both equal: 0x%08x",  \
+      uint32_t: "CHECK-fail: [%d] both equal: 0x%08x",  \
+       int64_t: "CHECK-fail: [%d] both equal: 0x%016x", \
+      uint64_t: "CHECK-fail: [%d] both equal: 0x%016x")
 // clang-format on
 
 /**

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -155,6 +155,12 @@ SECTIONS {
   } > ottf_flash
 
   /**
+   * Critical static data that is accessible by both the ROM and the ROM
+   * extension.
+   */
+  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
+
+  /**
    * Standard mutable data section, at the bottom of RAM. This will be
    * initialized from the .idata section at runtime by the CRT.
    */

--- a/sw/device/lib/testing/test_framework/ottf_start.S
+++ b/sw/device/lib/testing/test_framework/ottf_start.S
@@ -111,6 +111,18 @@ _ottf_interrupt_vector:
   .type _ottf_start, @function
 _ottf_start:
   /**
+   * Set up the global pointer `gp`.
+   *
+   * Linker relaxations are disabled until the global pointer is setup below,
+   * because otherwise some sequences may be turned into `gp`-relative
+   * sequences, which is incorrect when `gp` is not initialized.
+   */
+  .option push
+  .option norelax
+  la gp, __global_pointer$
+  .option pop
+
+  /**
    * Set up the stack pointer.
    *
    * In RISC-V, the stack grows downwards, so we load the address of the highest
@@ -152,17 +164,6 @@ _ottf_start:
   la   a0, _bss_start
   la   a1, _bss_end
   call crt_section_clear
-
-  /**
-   * Setup global pointer.
-   *
-   * This requires that we temporarily disable linker relaxations, or it will be
-   * relaxed to `mv gp, gp`.
-   */
-  .option push
-  .option norelax
-  la gp, __global_pointer$
-  .option pop
 
  /**
   * Call the functions in the `.init_array` section.

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -79,7 +79,10 @@ cc_library(
 
 ld_library(
     name = "static_critical_sections",
-    fragments = ["static_critical.ld"],
+    fragments = [
+        "static_critical_size.ld",
+        "static_critical.ld",
+    ],
 )
 
 cc_library(

--- a/sw/device/silicon_creator/lib/base/static_critical.ld
+++ b/sw/device/silicon_creator/lib/base/static_critical.ld
@@ -10,6 +10,8 @@
  * memory sections.
  */
 
+INCLUDE sw/device/silicon_creator/lib/base/static_critical_size.ld
+
 .static_critical ORIGIN(ram_main) (NOLOAD) : ALIGN(4) {
   ASSERT(
     . == ORIGIN(ram_main),
@@ -19,6 +21,6 @@
   KEEP(*(.static_critical.sec_mmio_ctx))
 
   ASSERT(
-    . - ADDR(.static_critical) == 8048,
+    SIZEOF(.static_critical) == _static_critical_size,
     "Error: .static_critical section size has changed");
 } > ram_main

--- a/sw/device/silicon_creator/lib/base/static_critical_size.ld
+++ b/sw/device/silicon_creator/lib/base/static_critical_size.ld
@@ -1,0 +1,8 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Size of the `.static_critical` section (in bytes).
+ */
+_static_critical_size = 8048;

--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -25,7 +25,6 @@ void hmac_sha256_init(void) {
 
   uint32_t reg = 0;
   reg = bitfield_bit32_write(reg, HMAC_CFG_DIGEST_SWAP_BIT, false);
-  // Enable endian swap since our inputs are little-endian.
   reg = bitfield_bit32_write(reg, HMAC_CFG_ENDIAN_SWAP_BIT, false);
   reg = bitfield_bit32_write(reg, HMAC_CFG_SHA_EN_BIT, true);
   reg = bitfield_bit32_write(reg, HMAC_CFG_HMAC_EN_BIT, false);

--- a/sw/device/silicon_creator/lib/manifest_def.c
+++ b/sw/device/silicon_creator/lib/manifest_def.c
@@ -16,7 +16,7 @@ extern const uint32_t _manifest_entry_point[];
 static_assert(sizeof(uint32_t) == sizeof(uintptr_t), "Pointer is not 32-bits.");
 
 const volatile manifest_t kManifest = {
-    .code_start = (uintptr_t)&_manifest_code_start,
-    .code_end = (uintptr_t)&_manifest_code_end,
-    .entry_point = (uintptr_t)&_manifest_entry_point,
+    .code_start = (uint32_t)_manifest_code_start,
+    .code_end = (uint32_t)_manifest_code_end,
+    .entry_point = (uint32_t)_manifest_entry_point,
 };

--- a/sw/device/silicon_creator/rom/data/rom_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_testplan.hjson
@@ -1104,6 +1104,7 @@
               - Don't specify any usage constraints to be able to compute the actual hash in the second stage.
             - Verify that `sec_mmio_ctx` is valid using `sec_mmio_check_values()` and
               `sec_mmio_check_counters()`.
+            - Verify that a failed sec_mmio check triggers an illegal instruction exception.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -65,6 +65,30 @@ opentitan_functest(
     ],
 )
 
+opentitan_functest(
+    name = "rom_e2e_static_critical",
+    srcs = ["rom_e2e_static_critical_test.c"],
+    cw310 = cw310_params(
+        bitstream = "//hw/bitstream:rom",
+    ),
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    signed = True,
+    targets = [
+        "cw310",
+        "verilator",
+    ],
+    verilator = verilator_params(
+        timeout = "eternal",
+        rom = "//sw/device/silicon_creator/rom",
+    ),
+    deps = [
+        "//sw/device/lib/dif:hmac",
+        "//sw/device/lib/testing:hmac_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
 # Same as `:e2e_bootup_success`, but the Dev OTP image is spliced into the
 # bitstream before it's sent to the CW310 FPGA.
 opentitan_functest(

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_static_critical_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_static_critical_test.c
@@ -1,0 +1,136 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_hmac.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/hmac_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/base/boot_measurements.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+#define RUN_TEST(test_)                    \
+  LOG_INFO("Starting test " #test_ "..."); \
+  test_();                                 \
+  LOG_INFO("Finished test " #test_ ": ok.");
+
+#define CHECK_WORD_ALIGNED(addr_)                 \
+  CHECK((uintptr_t)addr_ % sizeof(uint32_t) == 0, \
+        #addr_ " must be word aligned");
+
+void boot_measurements_test(void) {
+  CHECK(kManifest.usage_constraints.selector_bits == 0,
+        "Selector bits must be 0");
+  const volatile char *manifest_start = (const volatile char *)&kManifest;
+  const char *manifest_end = (const char *)manifest_start + sizeof(manifest_t);
+  const volatile char *signed_region_start =
+      manifest_start + sizeof(sigverify_rsa_buffer_t);
+  const char *signed_region_end =
+      (const char *)manifest_start + kManifest.length;
+  size_t manifest_signed_region_size = manifest_end - signed_region_start;
+  size_t signed_region_size = signed_region_end - signed_region_start;
+  dif_hmac_t hmac;
+
+  CHECK_WORD_ALIGNED(manifest_start);
+  CHECK_WORD_ALIGNED(manifest_end);
+  CHECK_WORD_ALIGNED(signed_region_start);
+  CHECK_WORD_ALIGNED(signed_region_end);
+  CHECK_WORD_ALIGNED(manifest_signed_region_size);
+  CHECK_WORD_ALIGNED(signed_region_size);
+
+  CHECK_DIF_OK(
+      dif_hmac_init(mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR), &hmac));
+  CHECK_DIF_OK(dif_hmac_mode_sha256_start(
+      &hmac, (dif_hmac_transaction_t){
+                 .digest_endianness = kDifHmacEndiannessLittle,
+                 .message_endianness = kDifHmacEndiannessLittle,
+             }));
+
+  // Copy the part of the manifest that's in the signed region to
+  // memory before pushing to hmac since it's volatile.
+  // Note: this array is larger than `manifest_signed_region_size` since VLAs
+  // are optional in C11.
+  char manifest_signed_region[sizeof(manifest_t)];
+  for (size_t i = 0; i < manifest_signed_region_size; ++i) {
+    manifest_signed_region[i] =
+        *((const volatile char *)signed_region_start + i);
+  }
+  hmac_testutils_push_message(&hmac, manifest_signed_region,
+                              manifest_signed_region_size);
+  // Rest of the image
+  hmac_testutils_push_message(&hmac, manifest_end,
+                              signed_region_size - manifest_signed_region_size);
+
+  CHECK_DIF_OK(dif_hmac_process(&hmac));
+  dif_hmac_digest_t act_digest;
+  hmac_testutils_finish_polled(&hmac, &act_digest);
+
+  CHECK_ARRAYS_EQ(boot_measurements.rom_ext.data, act_digest.digest,
+                  ARRAYSIZE(act_digest.digest));
+}
+
+void sec_mmio_pos_test(void) {
+  enum {
+    kRndOffset = 13,
+    kRomCheckValue = 6,
+  };
+
+  sec_mmio_check_values(kRndOffset);
+  sec_mmio_check_counters(kRomCheckValue + 1);
+}
+
+static volatile bool exception_expected = false;
+static volatile bool exception_observed = false;
+
+// Redeclaration of the addressable symbol in `sec_mmio_neg_test()` to be used
+// in `ottf_exception_handler()`.
+extern const char kSecMmioNegTestReturn[];
+
+void ottf_exception_handler(void) {
+  CHECK(exception_expected == true);
+  CHECK(exception_observed == false);
+  exception_expected = false;
+  // The frame address is the address of the stack location that holds the
+  // `mepc`, since the OTTF exception handler entry code saves the `mepc` to
+  // the top of the stack before transferring control flow to the exception
+  // handler function (which is overridden here). See the `handler_exception`
+  // subroutine in `sw/device/lib/testing/testing/ottf_isrs.S` for more details.
+  uintptr_t *mepc_stack_addr = (uintptr_t *)OT_FRAME_ADDR();
+  ibex_exc_t exception = ibex_mcause_read();
+  switch (exception) {
+    case kIbexExcIllegalInstrFault:
+      LOG_INFO("Observed illegal instruction fault");
+      exception_observed = true;
+      *mepc_stack_addr = (uintptr_t)kSecMmioNegTestReturn;
+      break;
+    default:
+      LOG_FATAL("Unexpected exception id = 0x%x", exception);
+      abort();
+  }
+}
+
+void sec_mmio_neg_test(void) {
+  exception_expected = true;
+  sec_mmio_check_counters(0);
+  CHECK(false, "Should not be here");
+
+  OT_ADDRESSABLE_LABEL(kSecMmioNegTestReturn);
+  CHECK(exception_observed == true);
+}
+
+bool test_main(void) {
+  RUN_TEST(boot_measurements_test);
+  RUN_TEST(sec_mmio_pos_test);
+  RUN_TEST(sec_mmio_neg_test);
+  return true;
+}

--- a/sw/device/tests/hmac_smoketest.c
+++ b/sw/device/tests/hmac_smoketest.c
@@ -25,34 +25,36 @@ static const char kData[142] =
     "one of the few honest people that I have ever "
     "known";
 
-static uint32_t kHmacKey[8] = {0x243f6a88, 0x85a308d3, 0x13198a2e, 0x03707344,
-                               0xa4093822, 0x299f31d0, 0x082efa98, 0xec4e6c89};
+static uint32_t kHmacKey[8] = {
+    0xec4e6c89, 0x082efa98, 0x299f31d0, 0xa4093822,
+    0x03707344, 0x13198a2e, 0x85a308d3, 0x243f6a88,
+};
 
 static const dif_hmac_digest_t kExpectedShaDigest = {
     .digest =
         {
-            0x3dc296dc,
-            0x68e236af,
-            0x71ff68cb,
-            0xe2762fe9,
-            0x9d37a8b8,
-            0x45c76d42,
-            0xf7cff519,
             0xd6c6c94e,
+            0xf7cff519,
+            0x45c76d42,
+            0x9d37a8b8,
+            0xe2762fe9,
+            0x71ff68cb,
+            0x68e236af,
+            0x3dc296dc,
         },
 };
 
 static const dif_hmac_digest_t kExpectedHmacDigest = {
     .digest =
         {
-            0x397b98e4,
-            0x90d3833f,
-            0xafbbf3c2,
-            0xfadb9531,
-            0x0c48fb23,
-            0x5eae12b0,
-            0x284d39f1,
             0xebce4019,
+            0x284d39f1,
+            0x5eae12b0,
+            0x0c48fb23,
+            0xfadb9531,
+            0xafbbf3c2,
+            0x90d3833f,
+            0x397b98e4,
         },
 };
 


### PR DESCRIPTION
This PR
* Adds the `rom_e2e_static_critical` test,
* Updates the `rom_e2e_static_critical` test in the test plan to include a negative sec_mmio test.
* Adds the `.static_critical` section to OTTF, 
* Updates `dif_hmac` to read the digest in reverse to preserve its numerical value and also to match output of commands like `sha256sum`,
* Updates `dif_hmac` key word order,
* Fixes global pointer initialization in `ottf_start.S`, and
* Fixes log format strings for array check failures.

Fixes #14502

Signed-off-by: Alphan Ulusoy <alphan@google.com>