### PR TITLE
[flash_ctrl dv] Reorg flash_ctrl_mem__if bind

### DIFF
--- a/hw/ip/flash_ctrl/dv/sva/flash_ctrl_bind.sv
+++ b/hw/ip/flash_ctrl/dv/sva/flash_ctrl_bind.sv
@@ -20,22 +20,4 @@ module flash_ctrl_bind;
     .d2h    (core_tl_o)
   );
 
-  if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_mif_bind
-    for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_per_bank
-      bind tb.dut.u_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[i].
-                    u_prim_flash_bank flash_ctrl_mem_if flash_ctrl_mem_if (
-        .clk_i,
-        .rst_ni,
-        .data_mem_req,
-        .mem_wr,
-        .mem_addr,
-        .mem_wdata,
-        .mem_part,
-        .mem_info_sel,
-        .info0_mem_req (gen_info_types[0].info_mem_req),
-        .info1_mem_req (gen_info_types[1].info_mem_req),
-        .info2_mem_req (gen_info_types[2].info_mem_req)
-      );
-    end
-  end
 endmodule


### PR DESCRIPTION
This commit moves the `flash_ctrl_mem_if` bind to the
testbench under the prim_impl generate block, becuase
its a core testbench component and not an SVA component.

The closed repo will then have a similar change, except
the bind point will be at the "real" flash bank hierarchy.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>