### PR TITLE
[dv,chip] Create build mode for test development

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -145,6 +145,12 @@
       ]
       is_sim_mode: 1
     }
+    // Sim mode that enables faster simulation for test development.
+    // DO NOT USE FOR NIGHTLY
+    {
+      name: fast_sim
+      build_opts: ["+define+DISABLE_ROM_INTEGRITY_CHECK"]
+    }
   ]
 
   // Add options needed to compile against otbn_memutil, otbn_tracer, and


### PR DESCRIPTION
Add "fast_sim" build mode that disables hardware ROM integrity check.
This causes the rather slow rom integrity check to be bypassed, making
each reset much faster.

Signed-off-by: Guillermo Maturana <maturana@google.com>