### PR TITLE
[entropy_src/rtl] remove AsyncOn enables

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -523,7 +523,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   prim_mubi4_sync #(
     .NumCopies(EsEnableCopies),
-    .AsyncOn(1)
+    .AsyncOn(0)
   ) u_prim_mubi4_sync_es_enable (
     .clk_i,
     .rst_ni,
@@ -639,7 +639,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   prim_mubi8_sync #(
     .NumCopies(1),
-    .AsyncOn(1)
+    .AsyncOn(0)
   ) u_prim_mubi8_sync_es_fw_over (
     .clk_i,
     .rst_ni,
@@ -2609,7 +2609,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   prim_mubi8_sync #(
     .NumCopies(1),
-    .AsyncOn(1)
+    .AsyncOn(0)
   ) u_prim_mubi8_sync_es_fw_read (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
The AsyncOn option was set for some of the prim_mubi4/8_sync blocks.
There are no async clock crossing in this module, so all set to zero.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>