### PR TITLE
[chip, dv] Test chip_sw_lc_ctrl_key_div

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -852,6 +852,13 @@
       run_opts: ["+sw_test_timeout_ns=20_000_000"]
     }
     {
+      name: chip_sw_keymgr_key_derivation_prod
+      uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
+      sw_images: ["//sw/device/tests/sim_dv:keymgr_key_derivation_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+lc_at_prod=1", "+sw_test_timeout_ns=20_000_000"]
+    }
+    {
       name: chip_sw_keymgr_key_derivation_jitter_en
       uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
       sw_images: ["//sw/device/tests/sim_dv:keymgr_key_derivation_test:1"]


### PR DESCRIPTION
Enabled `chip_sw_keymgr_key_derivation_vseq` to run in PROD state
and checked another key_div is used in the advance operation

Signed-off-by: Weicai Yang <weicai@google.com>