### PR TITLE
[opentitantool] Fix typo in CW310 backend

### DIFF
--- a/sw/host/opentitanlib/src/backend/cw310.rs
+++ b/sw/host/opentitanlib/src/backend/cw310.rs
@@ -27,7 +27,7 @@ pub fn create(args: &BackendOpts) -> Result<Box<dyn Transport>> {
         .unwrap_or(Vec::new());
     Ok(Box::new(CW310::new(
         args.usb_vid,
-        args.usb_vid,
+        args.usb_pid,
         args.usb_serial.as_deref(),
         &uarts,
     )?))


### PR DESCRIPTION
There's a small typo in opentitantool's backend for the CW310 where the USB device vendor-id is being passed as it's product.id.
In most cases this has no effect since both value are usually a `None` variant of a `Option<u16>`, which means "use the default".