### PR TITLE
[test] Add OTBN sideloading test.

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2141,7 +2141,7 @@
                sideloading to otbn.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_keymgr_sideload_otbn"]
     }
 
     // OTBN (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -879,6 +879,13 @@
       run_opts: ["+sw_test_timeout_ns=20_000_000"]
     }
     {
+      name: chip_sw_keymgr_sideload_otbn
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests/sim_dv:keymgr_sideload_otbn_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000"]
+    }
+    {
       name: chip_sw_kmac_mode_cshake
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:kmac_mode_cshake_test:1"]

--- a/sw/device/lib/testing/keymgr_testutils.h
+++ b/sw/device/lib/testing/keymgr_testutils.h
@@ -26,7 +26,7 @@ static const dif_keymgr_versioned_key_params_t kKeyVersionedParams = {
             0x322288d8,
             0xde919d54,
         },
-    .version = 0xaa,
+    .version = 0x1,
 };
 
 /**
@@ -70,7 +70,8 @@ static const dif_keymgr_state_params_t kOwnerIntParams = {
  * procedure is so that the key manager will not use KMAC with the default
  * entropy settings.
  *
- * @param keymgr A key manager handle.
+ * @param keymgr A key manager handle, may be uninitialized.
+ * @param kmac A KMAC handle, may be uninitialized.
  */
 void keymgr_testutils_startup(dif_keymgr_t *keymgr, dif_kmac_t *kmac);
 

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -209,6 +209,26 @@ opentitan_functest(
     ],
 )
 
+opentitan_functest(
+    name = "keymgr_sideload_otbn_test",
+    srcs = ["keymgr_sideload_otbn_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/ip/otbn/data:otbn_regs",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:otbn",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:keymgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/otbn/crypto:x25519_sideload",
+    ],
+)
+
 cc_library(
     name = "lc_ctrl_transition_impl",
     srcs = ["lc_ctrl_transition_impl.c"],

--- a/sw/device/tests/sim_dv/keymgr_sideload_otbn_test.c
+++ b/sw/device/tests/sim_dv/keymgr_sideload_otbn_test.c
@@ -1,0 +1,148 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/dif/dif_keymgr.h"
+#include "sw/device/lib/dif/dif_otbn.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/otbn.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/keymgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otbn_regs.h"  // Generated.
+
+/* Set up pointers to symbols in the OTBN application. */
+OTBN_DECLARE_APP_SYMBOLS(x25519_sideload);
+OTBN_DECLARE_SYMBOL_ADDR(x25519_sideload, enc_u);
+OTBN_DECLARE_SYMBOL_ADDR(x25519_sideload, enc_result);
+static const otbn_app_t kOtbnAppX25519 = OTBN_APP_T_INIT(x25519_sideload);
+static const otbn_addr_t kOtbnVarEncU =
+    OTBN_ADDR_T_INIT(x25519_sideload, enc_u);
+static const otbn_addr_t kOtbnVarEncResult =
+    OTBN_ADDR_T_INIT(x25519_sideload, enc_result);
+
+OTTF_DEFINE_TEST_CONFIG();
+
+/**
+ * Encoded Montgomery u-coordinate for testing.
+ *
+ * This value (9) is actually the u-coordinate of the Curve25519 base point, so
+ * the X25519 function will effectively compute the public key. This is the
+ * first step in key exchange (see RFC 7748, section 6.1).
+ */
+static const uint32_t encoded_u[8] = {
+    0x9, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+};
+
+/**
+ * Runs the OTBN X25519 application.
+ *
+ * The X25519 app and sideloaded key should already be loaded into OTBN before
+ * this routine is called.
+ *
+ * @param otbn_ctx OTBN context object
+ * @param[out] result Resulting Montgomery u-coordinate.
+ * @return true if the execution completed successfully, otherwise false
+ */
+static bool run_x25519_app(otbn_t *otbn_ctx, uint32_t *result) {
+  // Copy the input argument (Montgomery u-coordinate).
+  CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(encoded_u), &encoded_u,
+                               kOtbnVarEncU) == kOtbnOk);
+
+  // Run the OTBN program and wait for it to complete.
+  LOG_INFO("Starting OTBN program...");
+  CHECK(otbn_execute(otbn_ctx) == kOtbnOk);
+  if (otbn_busy_wait_for_done(otbn_ctx) != kOtbnOk) {
+    // Error during execution; retrieve error bits and instruction count to
+    // help with debugging and then exit early.
+    dif_otbn_err_bits_t err_bits;
+    CHECK(dif_otbn_get_err_bits(&otbn_ctx->dif, &err_bits) == kDifOk);
+    uint32_t insn_count;
+    CHECK(dif_otbn_get_insn_cnt(&otbn_ctx->dif, &insn_count) == kDifOk);
+    LOG_ERROR(
+        "OTBN encountered an error.\n  Error bits: 0x%08x\n  Instruction "
+        "count: 0x%08x",
+        err_bits, insn_count);
+
+    return false;
+  }
+
+  // Copy the result (also a 256-bit Montgomery u-coordinate).
+  CHECK(otbn_copy_data_from_otbn(otbn_ctx, 32, kOtbnVarEncResult, result) ==
+        kOtbnOk);
+
+  return true;
+}
+
+/**
+ * Run an OTBN program using a sideloaded key.
+ *
+ * This routine does not check the correctness of results, merely sideloads the
+ * key from keymgr to OTBN and then runs the X25519 program.
+ */
+static void test_otbn_with_sideloaded_key(dif_keymgr_t *keymgr,
+                                          otbn_t *otbn_ctx) {
+  // Generate the sideloaded key.
+  // TODO(weicai): also check in SV sequence that the key is correct.
+  dif_keymgr_versioned_key_params_t sideload_params = kKeyVersionedParams;
+  sideload_params.dest = kDifKeymgrVersionedKeyDestOtbn;
+  keymgr_testutils_generate_versioned_key(keymgr, sideload_params);
+  LOG_INFO("Keymgr generated HW output for OTBN.");
+
+  // Load the X25519 application.
+  CHECK(otbn_load_app(otbn_ctx, kOtbnAppX25519) == kOtbnOk);
+
+  // Run the OTBN app and retrieve the result.
+  uint32_t result[8];
+  CHECK(run_x25519_app(otbn_ctx, result) == true);
+
+  // Change the salt to generate a different key.
+  sideload_params.salt[0] = ~sideload_params.salt[0];
+  keymgr_testutils_generate_versioned_key(keymgr, sideload_params);
+  LOG_INFO("Keymgr generated HW output for OTBN.");
+
+  uint32_t modified_salt_result[8];
+  CHECK(run_x25519_app(otbn_ctx, modified_salt_result) == true);
+
+  // Check that the result with the new key is different from the original
+  // result.
+  CHECK_ARRAYS_NE(result, modified_salt_result, ARRAYSIZE(result));
+
+  // Change the salt back to generate the first key again.
+  sideload_params.salt[0] = ~sideload_params.salt[0];
+  keymgr_testutils_generate_versioned_key(keymgr, sideload_params);
+  LOG_INFO("Keymgr generated HW output for OTBN.");
+
+  uint32_t same_key_result[8];
+  CHECK(run_x25519_app(otbn_ctx, same_key_result) == true);
+
+  // Check that the result generated using the same key matches the original
+  // result.
+  CHECK_ARRAYS_EQ(result, same_key_result, ARRAYSIZE(result));
+}
+
+bool test_main(void) {
+  // Initialize keymgr and advance to CreatorRootKey state.
+  dif_keymgr_t keymgr;
+  dif_kmac_t kmac;
+  keymgr_testutils_startup(&keymgr, &kmac);
+
+  // Initialize OTBN.
+  otbn_t otbn_ctx;
+  CHECK(otbn_init(&otbn_ctx, mmio_region_from_addr(
+                                 TOP_EARLGREY_OTBN_BASE_ADDR)) == kOtbnOk);
+
+  // Test OTBN sideloading.
+  test_otbn_with_sideloaded_key(&keymgr, &otbn_ctx);
+
+  return true;
+}

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -379,6 +379,17 @@ otbn_library(
     ],
 )
 
+otbn_binary(
+    name = "x25519_sideload",
+    srcs = [
+        "x25519_sideload.s",
+    ],
+    deps = [
+        ":field25519",
+        ":x25519",
+    ],
+)
+
 otbn_sim_test(
     name = "x25519_test",
     srcs = [

--- a/sw/otbn/crypto/x25519.s
+++ b/sw/otbn/crypto/x25519.s
@@ -20,7 +20,7 @@
  *
  * @param[in]  w8: enc(k), encoded scalar (256-bit random number)
  * @param[in]  w9: enc(u), encoded Montgomery u-coordinate (256 bits)
- * @param[out] w22: result, X25519(k, u) as a u-coordinate
+ * @param[out] w22: result, X25519(k, u) as an encoded u-coordinate
  *
  * clobbered registers: w2 to w24
  * clobbered flag groups: FG0
@@ -364,4 +364,4 @@ modulus25519:
 .balign 32
 a24:
 .word 0x0001db41
-.zero 24
+.zero 28

--- a/sw/otbn/crypto/x25519_sideload.s
+++ b/sw/otbn/crypto/x25519_sideload.s
@@ -1,0 +1,58 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * This application runs X25519 with a sideloaded secret key.
+ *
+ * Computes X25519(k, u) according to RFC 7748, where:
+ *   - k is the 256-bit value derived from the sideloaded key
+ *   - u is the caller-provided Montgomery u-coordinate.
+ *
+ * The key manager provides 384 bits of sideloaded data, expressed in 2 shares
+ * across the special registers KEY_S0_L, KEY_S0_H, KEY_S1_L, and KEY_S1_H.
+ * Since we only need 256 bits, the extra bits in KEY_S0_H and KEY_S1_H are
+ * ignored and the encoded value of k, enc(k), is equal to KEY_S0_L ^ KEY_S1_L.
+ *
+ * The caller must check that the key manager has finished generating the key
+ * before attempting to run this application.
+ */
+
+.section .text.start
+
+main:
+  /* w7 <= KEY_S0_L */
+  bn.wsrr w7, 4
+  /* w8 <= KEY_S1_L */
+  bn.wsrr w8, 6
+  /* w8 <= KEY_S0_L ^ KEY_S1_L = enc(k) */
+  bn.xor  w8, w7, w8
+
+  /* w9 <= dmem[enc_u] = enc(u) */
+  li      x2, 9
+  la      x3, enc_u
+  bn.lid  x2, 0(x3)
+
+  /* w22 <= enc(X25519(k, u)) */
+  jal     x1, X25519
+
+  /* dmem[enc_result] <= w22 = enc(X25519(k, u)) */
+  li      x2, 22
+  la      x3, enc_result
+  bn.sid  x2, 0(x3)
+
+  ecall
+
+.data
+
+/* Input Montgomery u-coordinate (encoded, 256 bits). */
+.globl enc_u
+.balign 32
+enc_u:
+.zero 32
+
+/* Output Montgomery u-coordinate (encoded, 256 bits). */
+.globl enc_result
+.balign 32
+enc_result:
+.zero 32


### PR DESCRIPTION
For https://github.com/lowRISC/opentitan/issues/14159

Create the software side of the `chip_sw_keymgr_sideload_otbn` chip-level test. This test requires running an OTBN program with a sideloaded key. None of the existing OTBN programs have sideloading options, so I added a new entrypoint for X25519. I chose X25519 because it's the fastest existing OTBN crypto program we have that can use sideloaded keys.

We probably should use some checks on the SV side to check the value of the sideloaded key, so I've left a TODO for @weicaiyang . In the meantime, I call X25519 three times:
1. Generate a key, call X25519.
2.  Change the key (by adjusting the salt) and call X25519 again. Check that the results is _different_ from (1).
3. Re-generate the original key and call X25519 again. Check that the result is the _same_ as (1).

A few notes about this setup:
- Only 256 bits of the sideloaded key are used by X25519, so this implementation could theoretically miss some issue that affects only the upper bits of the key.
- It's probably overkill to call X25519 three times, and the test takes about 5m in Verilator; we can remove this once there are SV-side checks.
- Because the test is pretty heayweight, I didn't advance keymgr to `OwnerIntKey` and test it again like the KMAC sideload test (this is optional in the test plan).