### PR TITLE
[e2e] Fix up bootstrap_entry target

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -128,13 +128,13 @@ opentitan_functest(
     name = "e2e_bootstrap_entry",
     srcs = ["empty_test.c"],
     cw310 = cw310_params(
-        args = [
+        data = [
+            "//hw/bitstream:rom",
+        ],
+        test_cmds = [
             "--rom-kind=rom",
             "--bitstream=\"$(location //hw/bitstream:rom)\"",
             "--bootstrap=\"$(location {flash})\"",
-        ],
-        data = [
-            "//hw/bitstream:rom",
         ],
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -128,9 +128,7 @@ opentitan_functest(
     name = "e2e_bootstrap_entry",
     srcs = ["empty_test.c"],
     cw310 = cw310_params(
-        data = [
-            "//hw/bitstream:rom",
-        ],
+        bitstream = "//hw/bitstream:rom",
         test_cmds = [
             "--rom-kind=rom",
             "--bitstream=\"$(location //hw/bitstream:rom)\"",


### PR DESCRIPTION
Use test_cmds for the permanent args portion, and kick over the bitstream dependency to the explicit parameter.