### PR TITLE
[dv] Enable CDC random delay in DV simulations

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -75,9 +75,7 @@
                "+define+DUT_HIER={dut_instance}"]
 
   run_opts: ["+UVM_NO_RELNOTES",
-             "+UVM_VERBOSITY={expand_uvm_verbosity_{verbosity}}",
-             // TODO: remove once smoke regr passes:
-             "+prim_cdc_rand_delay_mode=disable"]
+             "+UVM_VERBOSITY={expand_uvm_verbosity_{verbosity}}"]
 
   // Default list of things to export to shell
   exports: [

--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -20,7 +20,7 @@
 // csr_assert_fpv is an auto-generated csr read assertion module. So only assertion coverage is
 // meaningful to collect.
 -moduletree *csr_assert_fpv
--module prim_cdc_rand_delay // DV CDC module
+-moduletree prim_cdc_rand_delay  // DV construct.
 
 begin tgl
   -tree tb
@@ -37,7 +37,6 @@ end
 
 begin assert
   +moduletree *csr_assert_fpv
-  -moduletree prim_cdc_rand_delay // TODO: CDC not enabled yet
   // These three assertions in prim_lc_sync and prim_mubi* check when `lc_ctrl_pkg::lc_tx_t` or
   // `mubi*_t` input are neither `On` or `Off`, it is interrupted to the correct `On` or `Off`
   // after one clock cycle. This behavior is implemented outside of IP level design thus these

--- a/hw/ip/prim/rtl/prim_diff_decode.sv
+++ b/hw/ip/prim/rtl/prim_diff_decode.sv
@@ -51,9 +51,13 @@ module prim_diff_decode #(
     // 2 sync regs, one reg for edge detection
     logic diff_pq, diff_nq, diff_pd, diff_nd;
 
+    // TODO: Disable prim CDC randomization since the addition of delays violates the tolerance of
+    // differential signaling being out of sync.
+
     prim_flop_2sync #(
       .Width(1),
-      .ResetValue('0)
+      .ResetValue('0),
+      .EnablePrimCdcRandDelay(0)
     ) i_sync_p (
       .clk_i,
       .rst_ni,
@@ -63,7 +67,8 @@ module prim_diff_decode #(
 
     prim_flop_2sync #(
       .Width(1),
-      .ResetValue(1'b1)
+      .ResetValue(1'b1),
+      .EnablePrimCdcRandDelay(0)
     ) i_sync_n (
       .clk_i,
       .rst_ni,

--- a/hw/ip/prim/rtl/prim_flop_2sync.sv
+++ b/hw/ip/prim/rtl/prim_flop_2sync.sv
@@ -10,7 +10,8 @@ module prim_flop_2sync #(
   parameter int               Width      = 16,
   parameter logic [Width-1:0] ResetValue = '0,
   parameter int               CdcLatencyPs = 1000,
-  parameter int               CdcJitterPs = 1000
+  parameter int               CdcJitterPs = 1000,
+  parameter bit               EnablePrimCdcRandDelay = 1
 ) (
   input                    clk_i,
   input                    rst_ni,
@@ -21,6 +22,7 @@ module prim_flop_2sync #(
   logic [Width-1:0] d_o;
 
   prim_cdc_rand_delay #(
+    .EnablePrimCdcRandDelay(EnablePrimCdcRandDelay),
     .DataWidth(Width),
     .UseSourceClock(0),
     .LatencyPs(CdcLatencyPs),

--- a/hw/top_earlgrey/dv/cov/chip_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover.cfg
@@ -28,6 +28,7 @@ begin line+cond+fsm+branch+assert
   -tree tb.dut.top_earlgrey.u_rv_core_ibex.u_core
   +moduletree rv_plic
   +moduletree sensor_ctrl
+  -moduletree prim_cdc_rand_delay  // DV construct.
 
   // Prim_alert/esc pairs are verified in FPV and DV testbenches.
   -moduletree prim_alert_sender


### PR DESCRIPTION
This PR enables CDC randomization delay to all DV simulations, except for one module - the differential signaling module, which has in-build timing assumptions.