### PR TITLE
[dif] Fix dif_keymgr

### DIFF
--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -340,8 +340,6 @@ dif_result_t dif_keymgr_get_status_codes(
   // Read and clear OP_STATUS register (rw1c).
   uint32_t reg_op_status =
       mmio_region_read32(keymgr->base_addr, KEYMGR_OP_STATUS_REG_OFFSET);
-  mmio_region_write32(keymgr->base_addr, KEYMGR_OP_STATUS_REG_OFFSET,
-                      reg_op_status);
 
   bool is_idle = false;
   bool has_error = false;
@@ -351,10 +349,14 @@ dif_result_t dif_keymgr_get_status_codes(
       break;
     case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS:
       is_idle = true;
+      mmio_region_write32(keymgr->base_addr, KEYMGR_OP_STATUS_REG_OFFSET,
+                          reg_op_status);
       break;
     case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR:
       is_idle = true;
       has_error = true;
+      mmio_region_write32(keymgr->base_addr, KEYMGR_OP_STATUS_REG_OFFSET,
+                          reg_op_status);
       break;
     case KEYMGR_OP_STATUS_STATUS_VALUE_WIP:
       break;

--- a/sw/device/lib/testing/keymgr_testutils.h
+++ b/sw/device/lib/testing/keymgr_testutils.h
@@ -26,7 +26,7 @@ static const dif_keymgr_versioned_key_params_t kKeyVersionedParams = {
             0x322288d8,
             0xde919d54,
         },
-    .version = 0x1,
+    .version = 0x11,
 };
 
 /**


### PR DESCRIPTION
keymgr status is W1C and coded like this

> idle: 0
> WIP: 1
> Success: 2
> Error: 3

Before this change,  we always read status and write the read-back value.
So, when it reads WIP, then write 1 to it. Between this read and write, HW may updates
status to Error (0x3). In this case, SW accidentally clears the 1st bit and the status
becomes Success (0x2).

Now changed to only clear status when it's either success or error.

Signed-off-by: Weicai Yang <weicai@google.com>