### PR TITLE
[bazel] fix airgapped prep script

### DIFF
--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -156,7 +156,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @rust_windows_x86_64_toolchains//...
   cp -R "$(${BAZELISK} info output_base)"/external/${BAZEL_PYTHON_WHEEL_REPO} \
     ${BAZEL_AIRGAPPED_DIR}/
-  cp -R "$(dirname "$(readlink -f "$(bazel info output_base)"/external/${BAZEL_BITSTREAMS_REPO}/cache)")" \
+  cp -R "$(dirname "$(readlink -f "$(${BAZELISK} info output_base)"/external/${BAZEL_BITSTREAMS_REPO}/cache)")" \
     ${BAZEL_AIRGAPPED_DIR}/${BAZEL_BITSTREAMS_CACHEDIR}
   echo "Done."
 fi


### PR DESCRIPTION
The airgapped preparation script did not use `bazelisk.sh` for one of
the commands. This is an issue for systems that do not have Bazel
natively installed.

Signed-off-by: Timothy Trippel <ttrippel@google.com>