### PR TITLE
[sw] Use macro to define HW top header files

### DIFF
--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
@@ -14,7 +14,7 @@
 #include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/vendor/eembc_coremark/coremark.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #if VALIDATION_RUN
 volatile ee_s32 seed1_volatile = 0x3415;

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -21,7 +21,7 @@
 #include "sw/device/lib/testing/usb_testutils_controlep.h"
 #include "sw/device/lib/testing/usb_testutils_simpleserial.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 // These just for the '/' printout
 #define USBDEV_BASE_ADDR TOP_EARLGREY_USBDEV_BASE_ADDR

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/examples/sram_program/sram_program.c
+++ b/sw/device/examples/sram_program/sram_program.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_uart_t uart0;
 

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -418,4 +418,17 @@
   if (expr_) {            \
   }
 
+/**
+ * Stub for the HW top header file.
+ * The definition can point to a different path with a compile flag.
+ */
+#ifndef OPENTITAN_HW_TOP_HDR_PATH
+#define OPENTITAN_HW_TOP_HDR_PATH "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#endif
+
+#ifndef OPENTITAN_HW_TOP_MEMORY_HDR_PATH
+#define OPENTITAN_HW_TOP_MEMORY_HDR_PATH \
+  "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#endif
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MACROS_H_

--- a/sw/device/lib/crypto/drivers/aes.c
+++ b/sw/device/lib/crypto/drivers/aes.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/base/memory.h"
 
 #include "aes_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 // Static assertions for enum values.
 OT_ASSERT_ENUM_VALUE(kAesCipherModeEcb, AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB);

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -9,7 +9,7 @@
 #include "sw/device/lib/base/memory.h"
 
 #include "csrng_regs.h"  // Generated
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 enum {
   kBaseCsrng = TOP_EARLGREY_CSRNG_BASE_ADDR,

--- a/sw/device/lib/crypto/drivers/entropy_kat.c
+++ b/sw/device/lib/crypto/drivers/entropy_kat.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/runtime/log.h"
 
 #include "csrng_regs.h"  // Generated
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 enum {
   kBaseCsrng = TOP_EARLGREY_CSRNG_BASE_ADDR,

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -9,7 +9,7 @@
 #include "sw/device/lib/base/memory.h"
 
 #include "hmac_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 void hmac_sha256_init(void) {
   // Clear the config, stopping the SHA engine.

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -8,7 +8,7 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/memory.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "kmac_regs.h"  // Generated.
 
 // For each x (denoting security strength) in {128, 224, 256, 384, 512}

--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otbn_regs.h"  // Generated.
 
 #define ASSERT_ERR_BIT_MATCH(enum_val, autogen_val) \

--- a/sw/device/lib/crypto/ecdsa_p256/ecdsa_p256.c
+++ b/sw/device/lib/crypto/ecdsa_p256/ecdsa_p256.c
@@ -8,7 +8,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/otbn_util.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTBN_DECLARE_APP_SYMBOLS(p256_ecdsa);        // The OTBN ECDSA/P-256 app.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, mode);  // ECDSA mode (sign or verify).

--- a/sw/device/lib/crypto/rsa_3072/rsa_3072_verify.c
+++ b/sw/device/lib/crypto/rsa_3072/rsa_3072_verify.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/otbn_util.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTBN_DECLARE_APP_SYMBOLS(run_rsa_verify_3072);  // The OTBN RSA-3072 app.
 OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072,

--- a/sw/device/lib/dif/dif_rv_core_ibex.c
+++ b/sw/device/lib/dif/dif_rv_core_ibex.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
 
-// #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+// #include OPENTITAN_HW_TOP_HDR_PATH
 #include "rv_core_ibex_regs.h"
 
 /**

--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/dif/dif_aon_timer.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 uint32_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds) {
   uint64_t cycles = udiv64_slow(microseconds * kClockFreqAonHz, 1000000,

--- a/sw/device/lib/testing/autogen/isr_testutils.c
+++ b/sw/device/lib/testing/autogen/isr_testutils.c
@@ -33,7 +33,7 @@
 #include "sw/device/lib/dif/dif_usbdev.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 void isr_testutils_adc_ctrl_isr(
     plic_isr_ctx_t plic_ctx, adc_ctrl_isr_ctx_t adc_ctrl_ctx,

--- a/sw/device/lib/testing/autogen/isr_testutils.h
+++ b/sw/device/lib/testing/autogen/isr_testutils.h
@@ -38,7 +38,7 @@
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/dif/dif_usbdev.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 /**
  * A handle to a PLIC ISR context struct.

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -8,7 +8,7 @@
 #include "sw/device/lib/dif/dif_entropy_src.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static void setup_entropy_src(const dif_entropy_src_t *entropy_src) {
   const dif_entropy_src_config_t config = {

--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -17,7 +17,7 @@
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 enum {
   /** Flash Secret partition ID. */

--- a/sw/device/lib/testing/pinmux_testutils.c
+++ b/sw/device/lib/testing/pinmux_testutils.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 void pinmux_testutils_init(dif_pinmux_t *pinmux) {
   // Set up SW straps on IOC0-IOC2, for GPIOs 22-24

--- a/sw/device/lib/testing/rand_testutils.c
+++ b/sw/device/lib/testing/rand_testutils.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/rv_core_ibex_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /**
  * The polynomial co-efficients used in the 32-bit LFSR implementation.

--- a/sw/device/lib/testing/test_framework/freertos_port.c
+++ b/sw/device/lib/testing/test_framework/freertos_port.c
@@ -13,7 +13,7 @@
 #include "external/freertos/include/task.h"
 #include "external/freertos/portable/GCC/RISC-V/portmacro.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 // NOTE: some of the function names below do NOT, and cannot, conform to the
 // style guide, since they are specific implementations of FreeRTOS defined

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -26,7 +26,7 @@
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 
 // TODO: make this toplevel agnostic.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 // Check layout of test configuration struct since OTTF ISR asm code requires a
 // specific layout.

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -24,7 +24,7 @@
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/rom/bootstrap.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 /**
  * This symbol is defined in `sw/device/lib/testing/test_rom/test_rom.ld`,

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
 #include "sw/device/lib/base/macros.h"
+#include OPENTITAN_HW_TOP_MEMORY_HDR_PATH
 #include "sw/device/lib/base/multibits_asm.h"
 #include "ast_regs.h"
 #include "csrng_regs.h"

--- a/sw/device/lib/testing/usb_testutils.c
+++ b/sw/device/lib/testing/usb_testutils.c
@@ -7,7 +7,7 @@
 #include "sw/device/lib/dif/dif_usbdev.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define USBDEV_BASE_ADDR TOP_EARLGREY_USBDEV_BASE_ADDR
 

--- a/sw/device/riscv_compliance_support/support.c
+++ b/sw/device/riscv_compliance_support/support.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 // These symbopls are provided by the riscv-compliance libraries.
 extern void run_rvc_test(void);

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -11,7 +11,7 @@
 #include "sw/device/sca/lib/sca.h"
 #include "sw/device/sca/lib/simple_serial.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /**
  * OpenTitan program for AES side-channel analysis.

--- a/sw/device/sca/ecc384_serial.c
+++ b/sw/device/sca/ecc384_serial.c
@@ -14,7 +14,7 @@
 #include "sw/device/sca/lib/sca.h"
 #include "sw/device/sca/lib/simple_serial.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /**
  * OpenTitan program for OTBN ECDSA-P384 side-channel analysis.

--- a/sw/device/sca/ecc_serial.c
+++ b/sw/device/sca/ecc_serial.c
@@ -14,7 +14,7 @@
 #include "sw/device/sca/lib/sca.h"
 #include "sw/device/sca/lib/simple_serial.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /**
  * OpenTitan program for OTBN ECDSA-P384 side-channel analysis.

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -22,7 +22,7 @@
 #include "clkmgr_regs.h"  // Generated
 #include "csrng_regs.h"   // Generated
 #include "edn_regs.h"     // Generated
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #if !OT_IS_ENGLISH_BREAKFAST
 #include "sw/device/lib/dif/dif_csrng.h"

--- a/sw/device/sca/lib/simple_serial.c
+++ b/sw/device/sca/lib/simple_serial.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/sca/lib/prng.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /**
  * Macro for ignoring return values.

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -12,7 +12,7 @@
 #include "sw/device/sca/lib/sca.h"
 #include "sw/device/sca/lib/simple_serial.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "kmac_regs.h"
 
 /**

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -141,6 +141,7 @@ cc_library(
         "//hw/top_earlgrey/ip/pwrmgr/data/autogen:pwrmgr_regs",
         "//hw/top_earlgrey/ip/rstmgr/data/autogen:rstmgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:macros",
         "//sw/device/lib/base:multibits",
     ],
 )

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -16,7 +16,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 
 #include "flash_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 static_assert(kBootDataEntriesPerPage ==

--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -12,7 +12,7 @@
 #include "sw/device/silicon_creator/lib/test_main.h"
 
 #include "flash_ctrl_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/silicon_creator/lib/drivers/alert.c
+++ b/sw/device/silicon_creator/lib/drivers/alert.c
@@ -11,7 +11,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 
 #include "alert_handler_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 enum {

--- a/sw/device/silicon_creator/lib/drivers/alert_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/alert_functest.c
@@ -21,7 +21,7 @@
 
 #include "alert_handler_regs.h"
 #include "flash_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 #include "rstmgr_regs.h"
 

--- a/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
@@ -13,7 +13,7 @@
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "alert_handler_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 namespace alert_unittest {

--- a/sw/device/silicon_creator/lib/drivers/ast.c
+++ b/sw/device/silicon_creator/lib/drivers/ast.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 #include "sensor_ctrl_regs.h"
 

--- a/sw/device/silicon_creator/lib/drivers/ast_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/ast_unittest.cc
@@ -14,7 +14,7 @@
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 #include "sensor_ctrl_regs.h"
 

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -16,7 +16,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 
 #include "flash_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 // Values of `flash_ctrl_partition_t` constants must be distinct from each

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -16,7 +16,7 @@
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "flash_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 namespace flash_ctrl_unittest {

--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -11,7 +11,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 
 #include "hmac_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 void hmac_sha256_init(void) {
   // Clear the config, stopping the SHA engine.

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -14,7 +14,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 // From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
 static const char kGettysburgPrelude[] =

--- a/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
@@ -14,7 +14,7 @@
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "hmac_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 namespace hmac_unittest {
 namespace {

--- a/sw/device/silicon_creator/lib/drivers/ibex.c
+++ b/sw/device/silicon_creator/lib/drivers/ibex.c
@@ -7,7 +7,7 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "rv_core_ibex_regs.h"
 
 enum {

--- a/sw/device/silicon_creator/lib/drivers/ibex_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/ibex_unittest.cc
@@ -11,7 +11,7 @@
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "rv_core_ibex_regs.h"
 
 namespace ibex_unittest {

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "keymgr_regs.h"  // Generated.
 
 #define KEYMGR_ASSERT(a, b) static_assert(a == b, "Bad value for " #a)

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -26,7 +26,7 @@
 #include "sw/device/silicon_creator/lib/keymgr_binding_value.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "keymgr_regs.h"
 #include "kmac_regs.h"
 

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -12,7 +12,7 @@
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "keymgr_regs.h"  // Generated.
 
 namespace keymgr_unittest {

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "lc_ctrl_regs.h"
 
 enum {

--- a/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
@@ -11,7 +11,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "lc_ctrl_regs.h"
 
 namespace lifecycle_unittest {

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -14,7 +14,7 @@
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otbn_regs.h"  // Generated.
 
 #define ASSERT_ERR_BIT_MATCH(enum_val, autogen_val) \

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -12,7 +12,7 @@
 #include "sw/device/silicon_creator/lib/drivers/mock_rnd.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otbn_regs.h"  // Generated.
 
 namespace otbn_unittest {

--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -10,7 +10,7 @@
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"  // Generated.
 
 enum { kBase = TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR };

--- a/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
@@ -12,7 +12,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"  // Generated.
 
 namespace otp_unittest {

--- a/sw/device/silicon_creator/lib/drivers/pinmux.c
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.c
@@ -9,7 +9,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 #include "pinmux_regs.h"
 

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -10,7 +10,7 @@
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 #include "pinmux_regs.h"
 

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.c
@@ -8,7 +8,7 @@
 
 #include "sw/device/lib/base/abs_mmio.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sram_ctrl_regs.h"  // Generated.
 
 enum {

--- a/sw/device/silicon_creator/lib/drivers/retention_sram_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram_functest.c
@@ -12,7 +12,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static rom_error_t retention_sram_clear_test(void) {
   // Set every bit in the retention SRAM to one.

--- a/sw/device/silicon_creator/lib/drivers/retention_sram_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram_unittest.cc
@@ -9,7 +9,7 @@
 #include "sw/device/lib/base/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sram_ctrl_regs.h"  // Generated.
 
 namespace retention_sram_unittest {

--- a/sw/device/silicon_creator/lib/drivers/rnd.c
+++ b/sw/device/silicon_creator/lib/drivers/rnd.c
@@ -9,7 +9,7 @@
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 #include "rv_core_ibex_regs.h"
 

--- a/sw/device/silicon_creator/lib/drivers/rnd_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/rnd_unittest.cc
@@ -12,7 +12,7 @@
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 #include "rv_core_ibex_regs.h"
 

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.c
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.c
@@ -16,7 +16,7 @@
 
 #include "sw/device/lib/base/abs_mmio.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "rstmgr_regs.h"
 
 enum {

--- a/sw/device/silicon_creator/lib/drivers/rstmgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr_unittest.cc
@@ -10,7 +10,7 @@
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "rstmgr_regs.h"  // Generated.
 
 namespace rstmgr_unittest {

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -11,7 +11,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 
 #include "flash_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "spi_device_regs.h"
 
 enum {

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -15,7 +15,7 @@
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "flash_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "spi_device_regs.h"
 
 namespace spi_device_unittest {

--- a/sw/device/silicon_creator/lib/drivers/uart.c
+++ b/sw/device/silicon_creator/lib/drivers/uart.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "uart_regs.h"  // Generated.
 
 static void uart_reset(void) {

--- a/sw/device/silicon_creator/lib/drivers/uart_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/uart_functest.c
@@ -11,7 +11,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG(.can_clobber_uart = true, );
 

--- a/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
@@ -9,7 +9,7 @@
 #include "sw/device/lib/base/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "uart_regs.h"  // Generated.
 
 namespace uart_unittest {

--- a/sw/device/silicon_creator/lib/drivers/watchdog.c
+++ b/sw/device/silicon_creator/lib/drivers/watchdog.c
@@ -10,7 +10,7 @@
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 
 #include "aon_timer_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 #include "pwrmgr_regs.h"
 

--- a/sw/device/silicon_creator/lib/drivers/watchdog_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/watchdog_functest.c
@@ -20,7 +20,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "rstmgr_regs.h"
 
 // Tests that we can pet the watchdog and avoid a reset.

--- a/sw/device/silicon_creator/lib/drivers/watchdog_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/watchdog_unittest.cc
@@ -14,7 +14,7 @@
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "aon_timer_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 #include "pwrmgr_regs.h"
 

--- a/sw/device/silicon_creator/lib/irq_asm.S
+++ b/sw/device/silicon_creator/lib/irq_asm.S
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits_asm.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include OPENTITAN_HW_TOP_MEMORY_HDR_PATH
 #include "flash_ctrl_regs.h"
 #include "rstmgr_regs.h"
 

--- a/sw/device/silicon_creator/lib/irq_asm_functest.c
+++ b/sw/device/silicon_creator/lib/irq_asm_functest.c
@@ -19,7 +19,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /**
  * Exception handler written in assembly.

--- a/sw/device/silicon_creator/lib/manifest.c
+++ b/sw/device/silicon_creator/lib/manifest.c
@@ -6,7 +6,7 @@
 
 #include "sw/device/silicon_creator/lib/base/chip.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static_assert(CHIP_ROM_EXT_SIZE_MIN >= CHIP_MANIFEST_SIZE,
               "`CHIP_ROM_EXT_SIZE_MIN` is too small");

--- a/sw/device/silicon_creator/lib/otbn_util.c
+++ b/sw/device/silicon_creator/lib/otbn_util.c
@@ -11,7 +11,7 @@
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/otbn.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 void otbn_init(otbn_t *ctx) {
   *ctx = (otbn_t){

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -22,7 +22,7 @@
 
 #include "alert_handler_regs.h"
 #include "flash_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "keymgr_regs.h"
 #include "lc_ctrl_regs.h"
 #include "otp_ctrl_regs.h"

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -19,7 +19,7 @@
 
 #include "alert_handler_regs.h"
 #include "flash_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "lc_ctrl_regs.h"
 #include "otp_ctrl_regs.h"
 #include "rv_core_ibex_regs.h"

--- a/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.c
+++ b/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.c
@@ -11,7 +11,7 @@
 #include "sw/device/silicon_creator/lib/otbn_util.h"
 #include "sw/device/silicon_creator/lib/sigverify/rsa_key.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTBN_DECLARE_APP_SYMBOLS(
     run_rsa_verify_3072_rr_modexp);  // The OTBN RSA-3072 app.

--- a/sw/device/silicon_creator/lib/sigverify/sigverify.c
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify.c
@@ -12,7 +12,7 @@
 #include "sw/device/silicon_creator/lib/sigverify/mod_exp_ibex.h"
 #include "sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 /*

--- a/sw/device/silicon_creator/lib/sigverify/sigverify_unittest.cc
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify_unittest.cc
@@ -18,7 +18,7 @@
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "flash_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 static_assert(kSigverifyFlashExec == FLASH_CTRL_PARAM_EXEC_EN,

--- a/sw/device/silicon_creator/rom/boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom/boot_policy_ptrs.h
@@ -7,7 +7,7 @@
 
 #include "sw/device/silicon_creator/lib/manifest.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #ifdef __cplusplus
 extern "C" {

--- a/sw/device/silicon_creator/rom/bootstrap.c
+++ b/sw/device/silicon_creator/rom/bootstrap.c
@@ -17,7 +17,7 @@
 
 #include "flash_ctrl_regs.h"
 #include "gpio_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 enum {

--- a/sw/device/silicon_creator/rom/bootstrap_unittest.cc
+++ b/sw/device/silicon_creator/rom/bootstrap_unittest.cc
@@ -17,7 +17,7 @@
 
 #include "flash_ctrl_regs.h"
 #include "gpio_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 bool operator==(flash_ctrl_perms_t lhs, flash_ctrl_perms_t rhs) {

--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup.c
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/ujson/ujson.h"
 #include "sw/device/silicon_creator/rom/e2e/json/command.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_shutdown_exception_c_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_shutdown_exception_c_test.c
@@ -4,7 +4,7 @@
 
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 // Note: Since this test program is written to verify the behavior of the ROM C
 // exception handlers,

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_static_critical_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_static_critical_test.c
@@ -15,7 +15,7 @@
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -38,7 +38,7 @@
 #include "sw/device/silicon_creator/rom/rom_epmp.h"
 #include "sw/device/silicon_creator/rom/sigverify_keys.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"
 
 /**

--- a/sw/device/silicon_creator/rom/rom_epmp.c
+++ b/sw/device/silicon_creator/rom/rom_epmp.c
@@ -7,7 +7,7 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/csr.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 // Symbols defined in linker script.
 extern char _stack_start[];  // Lowest stack address.

--- a/sw/device/silicon_creator/rom/rom_epmp_init.S
+++ b/sw/device/silicon_creator/rom/rom_epmp_init.S
@@ -2,9 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/epmp_defs.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include OPENTITAN_HW_TOP_MEMORY_HDR_PATH
 
 /**
  * Helper macro to move v into the correct position to set the pmp{N*4+i}cfg

--- a/sw/device/silicon_creator/rom/rom_epmp_test.c
+++ b/sw/device/silicon_creator/rom/rom_epmp_test.c
@@ -27,7 +27,7 @@
 #include "sw/device/silicon_creator/rom/rom_epmp.h"
 
 #include "flash_ctrl_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /**
  * ROM ePMP test.

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits_asm.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include OPENTITAN_HW_TOP_MEMORY_HDR_PATH
 #include "aon_timer_regs.h"
 #include "ast_regs.h"
 #include "clkmgr_regs.h"

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -27,7 +27,7 @@
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_epmp.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 // In-memory copy of the ePMP register configuration.
 epmp_state_t epmp;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
@@ -9,7 +9,7 @@
 #include "sw/device/silicon_creator/lib/base/chip.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #ifdef __cplusplus
 extern "C" {

--- a/sw/device/silicon_creator/rom_ext/rom_ext_epmp.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_epmp.c
@@ -7,7 +7,7 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/csr.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 void rom_ext_epmp_unlock_owner_stage_rx(epmp_state_t *state,
                                         epmp_region_t region) {

--- a/sw/device/silicon_creator/rom_ext/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_start.S
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "sw/device/lib/base/macros.h"
+#include OPENTITAN_HW_TOP_MEMORY_HDR_PATH
 
 /**
  * ROM_EXT Interrupt Vector

--- a/sw/device/silicon_owner/bare_metal/bare_metal.c
+++ b/sw/device/silicon_owner/bare_metal/bare_metal.c
@@ -5,7 +5,7 @@
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 #include "sw/device/silicon_creator/lib/rom_print.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 void bare_metal_main(void) {
   rom_printf("Bare metal PASS!\r\n");

--- a/sw/device/silicon_owner/bare_metal/bare_metal_start.S
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_start.S
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "sw/device/lib/base/macros.h"
+#include OPENTITAN_HW_TOP_MEMORY_HDR_PATH
 
 /**
  * ROM_EXT Interrupt Vector

--- a/sw/device/tests/aes_entropy_test.c
+++ b/sw/device/tests/aes_entropy_test.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define TIMEOUT (1000 * 1000)
 

--- a/sw/device/tests/aes_idle_test.c
+++ b/sw/device/tests/aes_idle_test.c
@@ -14,7 +14,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define TIMEOUT (1000 * 1000)
 

--- a/sw/device/tests/aes_sideload_test.c
+++ b/sw/device/tests/aes_sideload_test.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "kmac_regs.h"  // Generated.
 
 #define TIMEOUT (1000 * 1000)

--- a/sw/device/tests/aes_smoketest.c
+++ b/sw/device/tests/aes_smoketest.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define TIMEOUT (1000 * 1000)
 

--- a/sw/device/tests/alert_handler_ping_timeout_test.c
+++ b/sw/device/tests/alert_handler_ping_timeout_test.c
@@ -20,7 +20,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "alert_handler_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -21,7 +21,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
+++ b/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
@@ -17,7 +17,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define IDLE_TIME_US 10
 #define WKUP_TIME_US 2000

--- a/sw/device/tests/aon_timer_smoketest.c
+++ b/sw/device/tests/aon_timer_smoketest.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -18,7 +18,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -25,7 +25,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/ast_clk_outs_test.c
+++ b/sw/device/tests/ast_clk_outs_test.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/autogen/alert_test.c
+++ b/sw/device/tests/autogen/alert_test.c
@@ -48,7 +48,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 
 #include "alert_handler_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/autogen/plic_all_irqs_test.c
+++ b/sw/device/tests/autogen/plic_all_irqs_test.c
@@ -40,7 +40,7 @@
 #include "sw/device/lib/testing/rv_plic_testutils.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_adc_ctrl_t adc_ctrl_aon;
 static dif_alert_handler_t alert_handler;

--- a/sw/device/tests/clkmgr_external_clk_src_for_sw_impl.c
+++ b/sw/device/tests/clkmgr_external_clk_src_for_sw_impl.c
@@ -16,7 +16,7 @@
 #include "sw/device/lib/testing/clkmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 // Switching to external clocks causes the clocks to be unstable for some time.
 // This is used to delay further action when the switch happens.

--- a/sw/device/tests/clkmgr_jitter_test.c
+++ b/sw/device/tests/clkmgr_jitter_test.c
@@ -8,7 +8,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/clkmgr_off_aes_trans_test.c
+++ b/sw/device/tests/clkmgr_off_aes_trans_test.c
@@ -6,7 +6,7 @@
 
 #include "sw/device/tests/clkmgr_off_trans_impl.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 bool test_main(void) {
   return execute_off_trans_test(kTopEarlgreyHintableClocksMainAes);

--- a/sw/device/tests/clkmgr_off_hmac_trans_test.c
+++ b/sw/device/tests/clkmgr_off_hmac_trans_test.c
@@ -6,7 +6,7 @@
 
 #include "sw/device/tests/clkmgr_off_trans_impl.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 bool test_main(void) {
   return execute_off_trans_test(kTopEarlgreyHintableClocksMainHmac);

--- a/sw/device/tests/clkmgr_off_kmac_trans_test.c
+++ b/sw/device/tests/clkmgr_off_kmac_trans_test.c
@@ -6,7 +6,7 @@
 
 #include "sw/device/tests/clkmgr_off_trans_impl.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 bool test_main() {
   return execute_off_trans_test(kTopEarlgreyHintableClocksMainKmac);

--- a/sw/device/tests/clkmgr_off_otbn_trans_test.c
+++ b/sw/device/tests/clkmgr_off_otbn_trans_test.c
@@ -6,7 +6,7 @@
 
 #include "sw/device/tests/clkmgr_off_trans_impl.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 bool test_main(void) {
   return execute_off_trans_test(kTopEarlgreyHintableClocksMainOtbn);

--- a/sw/device/tests/clkmgr_off_peri_test.c
+++ b/sw/device/tests/clkmgr_off_peri_test.c
@@ -20,7 +20,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "spi_host_regs.h"
 #include "uart_regs.h"
 #include "usbdev_regs.h"

--- a/sw/device/tests/clkmgr_off_trans_impl.c
+++ b/sw/device/tests/clkmgr_off_trans_impl.c
@@ -20,7 +20,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /**
  * The hints bit order is

--- a/sw/device/tests/clkmgr_reset_frequency_test.c
+++ b/sw/device/tests/clkmgr_reset_frequency_test.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/clkmgr_sleep_frequency_test.c
+++ b/sw/device/tests/clkmgr_sleep_frequency_test.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/clkmgr_smoketest.c
+++ b/sw/device/tests/clkmgr_smoketest.c
@@ -8,7 +8,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/crt_test.c
+++ b/sw/device/tests/crt_test.c
@@ -17,7 +17,7 @@
 #include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/csrng_kat_test.c
+++ b/sw/device/tests/csrng_kat_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/csrng_smoketest.c
+++ b/sw/device/tests/csrng_smoketest.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/entropy_src_ast_rng_req_test.c
+++ b/sw/device/tests/entropy_src_ast_rng_req_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -25,7 +25,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "alert_handler_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTBN_DECLARE_APP_SYMBOLS(randomness);
 OTBN_DECLARE_SYMBOL_ADDR(randomness, rv);

--- a/sw/device/tests/entropy_src_fw_ovr_test.c
+++ b/sw/device/tests/entropy_src_fw_ovr_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/entropy_src_kat_test.c
+++ b/sw/device/tests/entropy_src_kat_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/entropy_src_smoketest.c
+++ b/sw/device/tests/entropy_src_smoketest.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/example_test_from_rom.c
+++ b/sw/device/tests/example_test_from_rom.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 static dif_pinmux_t pinmux;
 static dif_uart_t uart0;

--- a/sw/device/tests/flash_ctrl_clock_freqs_test.c
+++ b/sw/device/tests/flash_ctrl_clock_freqs_test.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/flash_ctrl_idle_low_power_test.c
+++ b/sw/device/tests/flash_ctrl_idle_low_power_test.c
@@ -18,7 +18,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/flash_ctrl_ops_test.c
+++ b/sw/device/tests/flash_ctrl_ops_test.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 
 #define FLASH_CTRL_NUM_IRQS 5

--- a/sw/device/tests/flash_ctrl_test.c
+++ b/sw/device/tests/flash_ctrl_test.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define CHECK_EQZ(x) CHECK((x) == 0)
 #define CHECK_NEZ(x) CHECK((x) != 0)

--- a/sw/device/tests/gpio_smoketest.c
+++ b/sw/device/tests/gpio_smoketest.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_gpio_t gpio;
 static dif_pinmux_t pinmux;

--- a/sw/device/tests/hmac_enc_idle_test.c
+++ b/sw/device/tests/hmac_enc_idle_test.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define TIMEOUT (1000 * 1000)
 

--- a/sw/device/tests/hmac_enc_test.c
+++ b/sw/device/tests/hmac_enc_test.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 
 static plic_isr_ctx_t plic_ctx = {

--- a/sw/device/tests/hmac_smoketest.c
+++ b/sw/device/tests/hmac_smoketest.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/kmac_app_rom_test.c
+++ b/sw/device/tests/kmac_app_rom_test.c
@@ -8,7 +8,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_rom_ctrl_t rom_ctrl;
 

--- a/sw/device/tests/kmac_idle_test.c
+++ b/sw/device/tests/kmac_idle_test.c
@@ -9,7 +9,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_clkmgr_t clkmgr;
 static dif_kmac_t kmac;

--- a/sw/device/tests/kmac_mode_cshake_test.c
+++ b/sw/device/tests/kmac_mode_cshake_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/kmac_mode_kmac_test.c
+++ b/sw/device/tests/kmac_mode_kmac_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/kmac_smoketest.c
+++ b/sw/device/tests/kmac_smoketest.c
@@ -9,7 +9,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
+++ b/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_otp_ctrl_t otp;
 static dif_lc_ctrl_t lc;

--- a/sw/device/tests/otbn_ecdsa_op_irq_test.c
+++ b/sw/device/tests/otbn_ecdsa_op_irq_test.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /**
  * ECDSA sign and verify test with the NIST P-256 curve using OTBN.

--- a/sw/device/tests/otbn_irq_test.c
+++ b/sw/device/tests/otbn_irq_test.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTBN_DECLARE_APP_SYMBOLS(err_test);
 

--- a/sw/device/tests/otbn_mem_scramble_test.c
+++ b/sw/device/tests/otbn_mem_scramble_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTBN_DECLARE_APP_SYMBOLS(randomness);
 OTBN_DECLARE_SYMBOL_ADDR(randomness, rv);

--- a/sw/device/tests/otbn_rsa_test.c
+++ b/sw/device/tests/otbn_rsa_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /**
  * End-to-end RSA encryption and decryption test using OTBN.

--- a/sw/device/tests/otbn_smoketest.c
+++ b/sw/device/tests/otbn_smoketest.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTBN_DECLARE_APP_SYMBOLS(barrett384);
 OTBN_DECLARE_SYMBOL_ADDR(barrett384, inp_a);

--- a/sw/device/tests/otp_ctrl_smoketest.c
+++ b/sw/device/tests/otp_ctrl_smoketest.c
@@ -14,7 +14,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_otp_ctrl_t otp;
 

--- a/sw/device/tests/plic_sw_irq_test.c
+++ b/sw/device/tests/plic_sw_irq_test.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "rv_plic_regs.h"  // Generated.
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/pwrmgr_sleep_disabled_test.c
+++ b/sw/device/tests/pwrmgr_sleep_disabled_test.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/pwrmgr_smoketest.c
+++ b/sw/device/tests/pwrmgr_smoketest.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/pwrmgr_wdog_reset_reqs_test.c
+++ b/sw/device/tests/pwrmgr_wdog_reset_reqs_test.c
@@ -18,7 +18,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -26,7 +26,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "alert_handler_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 /*
   RSTMGR ALERT_INFO Test
 

--- a/sw/device/tests/rstmgr_cpu_info_test.c
+++ b/sw/device/tests/rstmgr_cpu_info_test.c
@@ -16,7 +16,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_macros.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/rstmgr_smoketest.c
+++ b/sw/device/tests/rstmgr_smoketest.c
@@ -8,7 +8,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/rstmgr_sw_req_test.c
+++ b/sw/device/tests/rstmgr_sw_req_test.c
@@ -9,7 +9,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_rstmgr_t rstmgr;
 

--- a/sw/device/tests/rstmgr_sw_rst_ctrl_test.c
+++ b/sw/device/tests/rstmgr_sw_rst_ctrl_test.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "i2c_regs.h"
 #include "spi_device_regs.h"
 #include "spi_host_regs.h"

--- a/sw/device/tests/rv_core_ibex_address_translation_test.c
+++ b/sw/device/tests/rv_core_ibex_address_translation_test.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_macros.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define TEST_STR "Hello there, WHaT 1S Y0Ur N@ME?"
 #define EXPECTED_RESULT_MAKE_LOWER_CASE "hello there, what 1s y0ur n@me?"

--- a/sw/device/tests/rv_core_ibex_nmi_irq_test.c
+++ b/sw/device/tests/rv_core_ibex_nmi_irq_test.c
@@ -24,7 +24,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_isrs.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/rv_core_ibex_rnd_test.S
+++ b/sw/device/tests/rv_core_ibex_rnd_test.S
@@ -12,7 +12,8 @@
  * extent by using the assembly versions.
  */
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "sw/device/lib/base/macros.h"
+#include OPENTITAN_HW_TOP_MEMORY_HDR_PATH
 #include "rv_core_ibex_regs.h"
 
 /**

--- a/sw/device/tests/rv_core_ibex_rnd_test.c
+++ b/sw/device/tests/rv_core_ibex_rnd_test.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "rv_core_ibex_regs.h"
 
 // Initialize OTTF.

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
 

--- a/sw/device/tests/rv_timer_smoketest.c
+++ b/sw/device/tests/rv_timer_smoketest.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_rv_timer_t timer;
 

--- a/sw/device/tests/sensor_ctrl_alerts.c
+++ b/sw/device/tests/sensor_ctrl_alerts.c
@@ -17,7 +17,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sensor_ctrl_regs.h"  // Generated.
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/sensor_ctrl_wakeup.c
+++ b/sw/device/tests/sensor_ctrl_wakeup.c
@@ -14,7 +14,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sensor_ctrl_regs.h"  // Generated.
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 

--- a/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
+++ b/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/alert_handler_entropy_test.c
+++ b/sw/device/tests/sim_dv/alert_handler_entropy_test.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "alert_handler_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /*
   In SV test, force the alert_handler's wait_cyc_mask_i input to shorten the

--- a/sw/device/tests/sim_dv/alert_handler_escalation.c
+++ b/sw/device/tests/sim_dv/alert_handler_escalation.c
@@ -20,7 +20,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "alert_handler_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "rv_core_ibex_regs.h"  // Generated.
 
 /*

--- a/sw/device/tests/sim_dv/ast_usb_clk_calib.c
+++ b/sw/device/tests/sim_dv/ast_usb_clk_calib.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/clkmgr_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/clkmgr_escalation_reset_test.c
@@ -24,7 +24,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/csrng_fuse_en_sw_app_read.c
+++ b/sw/device/tests/sim_dv/csrng_fuse_en_sw_app_read.c
@@ -14,8 +14,8 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
-#include "otp_ctrl_regs.h"                            // Generated
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
+#include "otp_ctrl_regs.h"          // Generated
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/entropy_src_fuse_en_fw_read_test.c
+++ b/sw/device/tests/sim_dv/entropy_src_fuse_en_fw_read_test.c
@@ -13,8 +13,8 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
-#include "otp_ctrl_regs.h"                            // Generated
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
+#include "otp_ctrl_regs.h"          // Generated
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test.c
+++ b/sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test.c
@@ -14,7 +14,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_flash_ctrl_state_t flash;
 

--- a/sw/device/tests/sim_dv/flash_init_test.c
+++ b/sw/device/tests/sim_dv/flash_init_test.c
@@ -14,7 +14,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 static dif_uart_t uart0;
 static dif_flash_ctrl_state_t flash_state;

--- a/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
+++ b/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
@@ -16,7 +16,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 #define LC_TOKEN_SIZE 16
 

--- a/sw/device/tests/sim_dv/gpio_test.c
+++ b/sw/device/tests/sim_dv/gpio_test.c
@@ -14,7 +14,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_gpio_t gpio;
 static dif_pinmux_t pinmux;

--- a/sw/device/tests/sim_dv/keymgr_key_derivation_test.c
+++ b/sw/device/tests/sim_dv/keymgr_key_derivation_test.c
@@ -21,7 +21,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "keymgr_regs.h"  // Generated.
 #include "kmac_regs.h"    // Generated.
 

--- a/sw/device/tests/sim_dv/keymgr_sideload_kmac_test.c
+++ b/sw/device/tests/sim_dv/keymgr_sideload_kmac_test.c
@@ -17,7 +17,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "keymgr_regs.h"  // Generated.
 #include "kmac_regs.h"    // Generated.
 

--- a/sw/device/tests/sim_dv/lc_ctrl_kmac_reset_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_kmac_reset_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define LC_TOKEN_SIZE 16
 

--- a/sw/device/tests/sim_dv/lc_ctrl_program_error.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_program_error.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 /*
  TO BE FILLED IN

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/lc_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define LC_TOKEN_SIZE 16
 

--- a/sw/device/tests/sim_dv/lc_walkthrough_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_test.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define LC_TOKEN_SIZE 16
 

--- a/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define LC_TOKEN_SIZE 16
 

--- a/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
@@ -19,7 +19,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "aon_timer_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 /*
    PWRMGR BACK TO BACK DEEP SLEEP, RESET / WAKEUP TEST
 

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
@@ -31,7 +31,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 // In dvsim, one run
 // with --waves can take

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_wake_ups.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_wake_ups.c
@@ -18,7 +18,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "pwrmgr_regs.h"
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_power_glitch_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_power_glitch_test.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/pwrmgr_main_power_glitch_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_main_power_glitch_test.c
@@ -9,7 +9,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -31,7 +31,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 static volatile const uint8_t RST_IDX[7] = {0, 1, 2, 3, 4, 5, 6};

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_wake_ups.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_wake_ups.c
@@ -19,7 +19,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "pwrmgr_regs.h"
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
@@ -31,7 +31,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 static volatile const uint8_t RST_IDX[12] = {0, 1, 2, 3, 4,  5,

--- a/sw/device/tests/sim_dv/pwrmgr_sleep_power_glitch_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sleep_power_glitch_test.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
@@ -23,7 +23,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 static volatile const uint8_t RST_IDX[5] = {3, 30, 130, 5, 50};

--- a/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
+++ b/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
@@ -21,7 +21,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_pwrmgr_t pwrmgr;
 static dif_usbdev_t usbdev;

--- a/sw/device/tests/sim_dv/rom_ctrl_integrity_check_test.c
+++ b/sw/device/tests/sim_dv/rom_ctrl_integrity_check_test.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static dif_lc_ctrl_t lc;
 static dif_rom_ctrl_t rom_ctrl;

--- a/sw/device/tests/sim_dv/rv_dm_ndm_reset_req.c
+++ b/sw/device/tests/sim_dv/rv_dm_ndm_reset_req.c
@@ -16,7 +16,7 @@
 
 #include "adc_ctrl_regs.h"
 #include "flash_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "keymgr_regs.h"
 #include "otp_ctrl_regs.h"
 #include "pinmux_regs.h"

--- a/sw/device/tests/sim_dv/sensor_ctrl_status.c
+++ b/sw/device/tests/sim_dv/sensor_ctrl_status.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "sensor_ctrl_regs.h"  // Generated.
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 

--- a/sw/device/tests/sim_dv/spi_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_tx_rx_test.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define SPI_DEVICE_DATASET_SIZE 128
 #define SPI_DEVICE_NUM_IRQS 6

--- a/sw/device/tests/sim_dv/sram_ctrl_execution_test_main.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_execution_test_main.c
@@ -20,7 +20,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "otp_ctrl_regs.h"  // Generated
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/sim_dv/sram_ctrl_main_scrambled_access_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_main_scrambled_access_test.c
@@ -16,7 +16,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "rstmgr_regs.h"     // Generated.
 #include "sram_ctrl_regs.h"  // Generated.
 

--- a/sw/device/tests/sim_dv/sram_ctrl_ret_scrambled_access_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_ret_scrambled_access_test.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define SRAM_CTRL_BACKDOOR_TEST_WORDS 16
 #define SRAM_CTRL_BACKDOOR_TEST_BYTES \

--- a/sw/device/tests/sim_dv/sysrst_ctrl_inputs_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_inputs_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/sysrst_ctrl_outputs_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_outputs_test.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/sysrst_ctrl_reset_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_reset_test.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -17,7 +17,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 // TODO, remove it once pinout configuration is provided
 #include "pinmux_regs.h"

--- a/sw/device/tests/sleep_pwm_pulses_test.c
+++ b/sw/device/tests/sleep_pwm_pulses_test.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 #include "pwm_regs.h"
 
 /**

--- a/sw/device/tests/spi_host_smoketest.c
+++ b/sw/device/tests/spi_host_smoketest.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
               "This test assumes the target platform is little endian.");

--- a/sw/device/tests/sram_ctrl_execution_test.c
+++ b/sw/device/tests/sram_ctrl_execution_test.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_macros.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
@@ -14,7 +14,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 #define NUM_TEST_WORDS 16
 

--- a/sw/device/tests/sram_ctrl_smoketest.c
+++ b/sw/device/tests/sram_ctrl_smoketest.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 // define a number of reads and writes to perform,
 // for our purposes a small number will be sufficient.

--- a/sw/device/tests/uart_smoketest.c
+++ b/sw/device/tests/uart_smoketest.c
@@ -9,7 +9,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 static const uint8_t kSendData[] = "Smoke test!";
 

--- a/sw/device/tests/usbdev_test.c
+++ b/sw/device/tests/usbdev_test.c
@@ -27,7 +27,7 @@
 #include "sw/device/lib/testing/usb_testutils_controlep.h"
 #include "sw/device/lib/testing/usb_testutils_simpleserial.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH  // Generated.
 
 /**
  * Configuration values for USB.

--- a/util/autogen_testutils/templates/isr_testutils.c.tpl
+++ b/util/autogen_testutils/templates/isr_testutils.c.tpl
@@ -14,7 +14,7 @@ ${autogen_banner}
 % endfor
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h" // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH // Generated.
 
 % for ip in ips_with_difs:
   % if ip.irqs:

--- a/util/autogen_testutils/templates/isr_testutils.h.tpl
+++ b/util/autogen_testutils/templates/isr_testutils.h.tpl
@@ -19,7 +19,7 @@ ${autogen_banner}
   % endif
 % endfor
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h" // Generated.
+#include OPENTITAN_HW_TOP_HDR_PATH // Generated.
 
 /**
  * A handle to a PLIC ISR context struct.

--- a/util/topgen/templates/alert_test.c.tpl
+++ b/util/topgen/templates/alert_test.c.tpl
@@ -17,7 +17,7 @@ alert_peripheral_names = sorted({p.name for p in helper.alert_peripherals})
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 
 #include "alert_handler_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/util/topgen/templates/plic_all_irqs_test.c.tpl
+++ b/util/topgen/templates/plic_all_irqs_test.c.tpl
@@ -23,7 +23,7 @@ def args(p):
 #include "sw/device/lib/testing/rv_plic_testutils.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
-#include "hw/top_${top["name"]}/sw/autogen/top_${top["name"]}.h"
+#include OPENTITAN_HW_TOP_HDR_PATH
 
 % for p in helper.irq_peripherals:
 static dif_${p.name}_t ${p.inst_name};


### PR DESCRIPTION
Set the default to top_earlgrey; however, this allows the user to
switch to a different top design during compilation without forking
out the source code.

Signed-off-by: Cindy Liu <hcindyl@google.com>