### PR TITLE
[spi_device/dv] Fix spi_device_tx_async_fifo_reset

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tx_async_fifo_reset_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tx_async_fifo_reset_vseq.sv
@@ -23,10 +23,6 @@ class spi_device_tx_async_fifo_reset_vseq extends spi_device_base_vseq;
     wait_for_tx_avail_bytes(SRAM_WORD_SIZE, SramSpaceAvail, avail_bytes);
     write_device_words_to_send({device_data}); //TODO random amount of data
     cfg.clk_rst_vif.wait_clks(16);
-    // Write 0 into read and write point of TX SRAM FIFO
-    ral.txf_ptr.wptr.set(sram_device_base_addr);
-    ral.txf_ptr.rptr.set(sram_device_base_addr);
-    csr_update(.csr(ral.txf_ptr));
     csr_rd(.ptr(ral.async_fifo_level.txlvl), .value(tx_level));
     `DV_CHECK_CASE_NE(tx_level, 0)
     // Program `rst_txfifo` to reset the async FIFO

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -736,6 +736,11 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
           end
         end
       end
+      "control": begin
+        if (write && channel == AddrChannel) begin
+          if (!`gmv(ral.control.rst_txfifo)) tx_word_q.delete();
+        end
+      end
       "upload_cmdfifo": begin
         if (!write && channel == DataChannel) begin
           `DV_CHECK_GT(upload_cmd_q.size, 0)


### PR DESCRIPTION
Updated scb to reset tx_word_q when receiving `rst_txfifo`
Fixed seq that sets pointers to 0.

Signed-off-by: Weicai Yang <weicai@google.com>