### PR TITLE
[otbn,dv] Fix `OTBNState.stop()` before initial secure wipe is done

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -389,7 +389,7 @@ class OTBNState:
             elif self._fsm_state in [FsmState.WIPING_BAD, FsmState.WIPING_GOOD]:
                 assert should_lock
                 self._next_fsm_state = FsmState.WIPING_BAD
-            else:
+            elif self._init_sec_wipe_state == InitSecWipeState.DONE:
                 assert should_lock
                 self._next_fsm_state = FsmState.LOCKED
                 next_status = Status.LOCKED


### PR DESCRIPTION
Prior to this commit, calling `OTBNState.stop()` before the initial
secure wipe has started (the model remains in `FsmState.IDLE` while it
waits for the initial URND acknowledge) caused the model to become
locked immediately.  This is different from the RTL, which in this case
correctly completes the secure wipe before becoming locked.

This can be reproduced with test `otbn_escalate` and seed `3491964481`.

This commit fixes `OTBNState.stop()` to match the correct RTL behavior.