### PR TITLE
[otbn,util] Add initial constants to constant-time checker.

### DIFF
--- a/hw/ip/otbn/util/shared/information_flow_analysis.py
+++ b/hw/ip/otbn/util/shared/information_flow_analysis.py
@@ -528,7 +528,7 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
 
 
 def get_subroutine_iflow(program: OTBNProgram, graph: ControlGraph,
-                         subroutine_name: str) -> SubroutineIFlow:
+        subroutine_name: str, start_constants: Dict[str,int]) -> SubroutineIFlow:
     '''Gets the information-flow graphs for the subroutine.
 
     Returns three items:
@@ -540,9 +540,14 @@ def get_subroutine_iflow(program: OTBNProgram, graph: ControlGraph,
     3. The information-flow nodes whose values at the start of the subroutine
        influence its control flow.
     '''
+    if 'x0' in start_constants and start_constants['x0'] != 0:
+        raise ValueError('The x0 register is always 0; cannot require '
+                f'x0={start_constants["x0"]}')
+    start_constants['x0'] = 0
+    constants = ConstantContext(start_constants)
     start_pc = program.get_pc_at_symbol(subroutine_name)
     _, ret_iflow, end_iflow, _, cycles, control_deps = _get_iflow(
-        program, graph, start_pc, ConstantContext.empty(), None, IFlowCache())
+        program, graph, start_pc, constants, None, IFlowCache())
     if cycles:
         for pc in cycles:
             print(cycles[pc].pretty())

--- a/rules/otbn.bzl
+++ b/rules/otbn.bzl
@@ -216,6 +216,8 @@ def _otbn_consttime_test_impl(ctx):
         script_content += " --subroutine {}".format(ctx.attr.subroutine)
     if ctx.attr.secrets:
         script_content += " --secrets {}".format(" ".join(ctx.attr.secrets))
+    if ctx.attr.initial_constants:
+        script_content += " --constants {}".format(" ".join(ctx.attr.initial_constants))
     ctx.actions.write(
         output = ctx.outputs.executable,
         content = script_content,
@@ -310,6 +312,7 @@ otbn_consttime_test = rule(
         "deps": attr.label_list(providers = [OutputGroupInfo]),
         "subroutine": attr.string(),
         "secrets": attr.string_list(),
+        "initial_constants": attr.string_list(),
         "_checker": attr.label(
             default = "//hw/ip/otbn/util:check_const_time",
             executable = True,

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -344,19 +344,19 @@ otbn_consttime_test(
 #   subroutine = "p384_sign",
 # )
 
-# TODO: Add an argument to the constant-time checker script that accepts
-# "required constant registers". This test fails because the subroutine
-# requires some registers (indirect references) to be constant at the start,
-# and without this information the constant-time checker cannot construct the
-# information-flow graph.
-#
-# otbn_consttime_test(
-#   name = "p384_proj_add_consttime",
-#   deps = [
-#       ":p384_ecdsa_sign_test"
-#   ],
-#   subroutine = "proj_add_p384",
-# )
+otbn_consttime_test(
+    name = "proj_add_p384_consttime",
+    initial_constants = [
+        "x22:10",
+        "x23:11",
+        "x24:16",
+        "x25:17",
+    ],
+    subroutine = "proj_add_p384",
+    deps = [
+        ":p384_ecdsa_sign_test",
+    ],
+)
 
 otbn_consttime_test(
     name = "scalar_mult_p384_consttime",


### PR DESCRIPTION
Allows the constant-time checker to require certain constant values at the start of subroutines. This resolves a TODO and allows us to check `that proj_add_p384` is constant-time where we couldn't before, since that subroutine requires certain GPRs to have specific values.

For context, the constant-time checker cares about constants because of indirect references to WDRs; some instructions reference particular wide registers based on constant values stored in GPRs. This is the case with `proj_add_p384`, as you can see from its docstring: https://github.com/lowRISC/opentitan/blob/adfa87b52aed06a4f28537bd7cf6542a63db6b2b/sw/otbn/crypto/p384_base.s#L365-L368

Without these constants, the constant-time checker can't construct an information-flow graph for the program, since it doesn't know which wide registers are being read from/written to, and therefore can't tell if we're potentially branching on secret values.