### PR TITLE
[top/dv] Add i2c_host_tx_rx test

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -6,6 +6,11 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
 
   bit en_monitor = 1'b1; // enable monitor
 
+  // Valid only when agent is in DEVICE role.
+  // When loopback is enabled, whatever is written by the host
+  // is stored and then fed back to the host
+  bit en_loopback = 1'b0;
+
   // this parameters can be set by test to slow down the agent's responses
   int host_latency_cycles = 0;
   int device_latency_cycles = 0;

--- a/hw/dv/sv/i2c_agent/i2c_item.sv
+++ b/hw/dv/sv/i2c_agent/i2c_item.sv
@@ -6,7 +6,6 @@ class i2c_item extends uvm_sequence_item;
 
   // transaction data part
   bit [7:0]                data_q[$];
-  bit [7:0]                rdata_q[$];
   bit [9:0]                addr;      // enough to support both 7 & 10-bit target address
   int                      tran_id;
   int                      num_data;  // valid data

--- a/hw/dv/sv/i2c_agent/i2c_item.sv
+++ b/hw/dv/sv/i2c_agent/i2c_item.sv
@@ -6,6 +6,7 @@ class i2c_item extends uvm_sequence_item;
 
   // transaction data part
   bit [7:0]                data_q[$];
+  bit [7:0]                rdata_q[$];
   bit [9:0]                addr;      // enough to support both 7 & 10-bit target address
   int                      tran_id;
   int                      num_data;  // valid data

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
@@ -20,17 +20,20 @@ class i2c_base_seq extends dv_base_seq #(
     data_q.size() inside {[cfg.i2c_host_min_data_rw : cfg.i2c_host_max_data_rw]};
   }
 
+  // return the data in this queue if it's provided, otherwise, random data will be used
+  bit[7:0] byte_data_q[$];
+
   virtual task body();
     if (cfg.if_mode == Device) begin
       // get seq for agent running in Device mode
       fork
         forever begin
-          i2c_item  req;
+          i2c_item req;
           p_sequencer.req_analysis_fifo.get(req);
           req_q.push_back(req);
         end
         forever begin
-          i2c_item  rsp;
+          i2c_item rsp;
           wait(req_q.size > 0);
           rsp = req_q.pop_front();
           start_item(rsp);

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
@@ -20,9 +20,6 @@ class i2c_base_seq extends dv_base_seq #(
     data_q.size() inside {[cfg.i2c_host_min_data_rw : cfg.i2c_host_max_data_rw]};
   }
 
-  // return the data in this queue if it's provided, otherwise, random data will be used
-  bit[7:0] byte_data_q[$];
-
   virtual task body();
     if (cfg.if_mode == Device) begin
       // get seq for agent running in Device mode

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -239,14 +239,17 @@
 
             - Program the I2C to be in host mode.
             - The SW test writes a known payload over the chip's I2C host interface, which is
-              received and verified by the testbench for correctness.
+              received by the testbench.
+            - The testbench then loops this data back to the chip's I2C host and exercises the
+              read interface.
             - SW validates the reception of FMT watermark and trans complete interrupts.
+            - SW validates that the read data matches the original write data.
             - Verify the virtual / true open drain capability.
 
             Verify all instances of I2C in the chip.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_i2c_host_tx_rx"]
     }
     {
       name: chip_sw_i2c_device_tx_rx

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -390,6 +390,14 @@
       reseed: 5
     }
     {
+      name: chip_sw_i2c_tx_rx
+      uvm_test_seq: chip_sw_i2c_tx_rx_vseq
+      sw_images: ["//sw/device/tests/sim_dv:i2c_tx_rx_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: []
+      reseed: 1
+    }
+    {
       name: chip_sw_spi_device_tx_rx
       uvm_test_seq: chip_sw_spi_tx_rx_vseq
       sw_images: ["//sw/device/tests/sim_dv:spi_tx_rx_test:1"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -390,7 +390,7 @@
       reseed: 5
     }
     {
-      name: chip_sw_i2c_tx_rx
+      name: chip_sw_i2c_host_tx_rx
       uvm_test_seq: chip_sw_i2c_tx_rx_vseq
       sw_images: ["//sw/device/tests/sim_dv:i2c_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -25,6 +25,7 @@ filesets:
       - lowrisc:dv:sw_logger_if
       - lowrisc:dv:uart_agent
       - lowrisc:dv:pwm_monitor
+      - lowrisc:dv:i2c_agent
       - lowrisc:ip:otp_ctrl_pkg
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
       - "fileset_partner ? (partner:systems:ast_pkg)"
@@ -86,6 +87,7 @@ filesets:
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_entropy_src_fuse_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_usb_ast_clk_calib_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_i2c_tx_rx_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - ast_ext_clk_if.sv
       - ast_supply_if.sv

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -11,6 +11,7 @@ class chip_env extends cip_base_env #(
   `uvm_component_utils(chip_env)
 
   uart_agent             m_uart_agents[NUM_UARTS];
+  i2c_agent              m_i2c_agents[NUM_I2CS];
   jtag_riscv_agent       m_jtag_riscv_agent;
   jtag_riscv_reg_adapter m_jtag_riscv_reg_adapter;
   spi_agent              m_spi_agent;
@@ -145,6 +146,12 @@ class chip_env extends cip_base_env #(
                                           cfg.m_uart_agent_cfgs[i]);
     end
 
+    foreach (m_i2c_agents[i]) begin
+      m_i2c_agents[i] = i2c_agent::type_id::create($sformatf("m_i2c_agent%0d", i), this);
+      uvm_config_db#(i2c_agent_cfg)::set(this, $sformatf("m_i2c_agent%0d*", i), "cfg",
+                                          cfg.m_i2c_agent_cfgs[i]);
+    end
+
     m_jtag_riscv_agent = jtag_riscv_agent::type_id::create("m_jtag_riscv_agent", this);
     uvm_config_db#(jtag_riscv_agent_cfg)::set(this, "m_jtag_riscv_agent*", "cfg",
                                               cfg.m_jtag_riscv_agent_cfg);
@@ -186,6 +193,11 @@ class chip_env extends cip_base_env #(
         virtual_sequencer.uart_sequencer_hs[i] = m_uart_agents[i].sequencer;
       end
     end
+
+    foreach (m_i2c_agents[i]) begin
+      virtual_sequencer.i2c_sequencer_hs[i] = m_i2c_agents[i].sequencer;
+    end
+
     if (cfg.is_active && cfg.m_jtag_riscv_agent_cfg.is_active) begin
       virtual_sequencer.jtag_sequencer_h = m_jtag_riscv_agent.sequencer;
     end

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -99,6 +99,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   rand jtag_agent_cfg       m_jtag_agent_cfg;
   rand spi_agent_cfg        m_spi_agent_cfg;
   pwm_monitor_cfg           m_pwm_monitor_cfg[NUM_PWM_CHANNELS];
+  rand i2c_agent_cfg        m_i2c_agent_cfgs[NUM_I2CS];
 
   // JTAG DMI register model
   rand jtag_dmi_reg_block jtag_dmi_ral;
@@ -142,6 +143,11 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     // create uart agent config obj
     foreach (m_uart_agent_cfgs[i]) begin
       m_uart_agent_cfgs[i] = uart_agent_cfg::type_id::create($sformatf("m_uart_agent_cfg%0d", i));
+    end
+
+    // create i2c agent config obj
+    foreach (m_i2c_agent_cfgs[i]) begin
+      m_i2c_agent_cfgs[i] = i2c_agent_cfg::type_id::create($sformatf("m_i2c_agent_cfg%0d", i));
     end
 
     // create jtag agent config obj

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -42,6 +42,7 @@ package chip_env_pkg;
   import pwm_reg_pkg::NOutputs;
   import tl_main_pkg::ADDR_SPACE_RV_CORE_IBEX__CFG;
   import rv_core_ibex_reg_pkg::RV_CORE_IBEX_DV_SIM_WINDOW_OFFSET;
+  import i2c_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -55,6 +56,9 @@ package chip_env_pkg;
   parameter uint NUM_GPIOS = 16;
   parameter uint NUM_UARTS = 4;
   parameter uint NUM_PWM_CHANNELS = pwm_reg_pkg::NOutputs;
+
+  // only handle one for the time being
+  parameter uint NUM_I2CS = 1;
 
   // Buffer is half of SPI_DEVICE Dual Port SRAM
   parameter uint SPI_FRAME_BYTE_SIZE = spi_device_reg_pkg::SPI_DEVICE_BUFFER_SIZE/2;

--- a/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
+++ b/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
@@ -9,6 +9,7 @@ class chip_virtual_sequencer extends cip_base_virtual_sequencer #(
   `uvm_component_utils(chip_virtual_sequencer)
 
   uart_sequencer       uart_sequencer_hs[NUM_UARTS];
+  i2c_sequencer        i2c_sequencer_hs[NUM_I2CS];
   jtag_riscv_sequencer jtag_sequencer_h;
   spi_sequencer        spi_sequencer_h;
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_i2c_tx_rx_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_i2c_tx_rx_vseq)
+
+  `uvm_object_new
+
+  // need to figure out is there a way to get this from the tb
+  int clock_period_nanos = 41;
+  int i2c_clock_period_nanos = 1000;
+  int rise_fall_nanos = 10;
+  int rise_cycles = ((rise_fall_nanos - 1) / clock_period_nanos) + 1;
+  int fall_cycles = ((rise_fall_nanos - 1) / clock_period_nanos) + 1;
+  int clock_period_cycles = ((i2c_clock_period_nanos - 1) / clock_period_nanos) + 1;
+  int half_period_cycles = ((i2c_clock_period_nanos/2 - 1) / clock_period_nanos) + 1;
+
+  virtual task cpu_init();
+    bit[7:0] clock_period_nanos_data[1] = {clock_period_nanos};
+    bit[7:0] rise_fall_nanos_data[1] = {rise_fall_nanos};
+    bit[7:0] i2c_clock_period_nanos_data[4] = {<<byte{i2c_clock_period_nanos}};
+
+    super.cpu_init();
+    // need to figure out a better way to calculate this based on tb clock frequency
+    sw_symbol_backdoor_overwrite("kClockPeriodNanos", clock_period_nanos_data);
+    sw_symbol_backdoor_overwrite("kI2cRiseFallNanos", rise_fall_nanos_data);
+    sw_symbol_backdoor_overwrite("kI2cClockPeriodNanos", i2c_clock_period_nanos_data);
+  endtask
+
+  virtual task body();
+    i2c_base_seq m_base_seq;
+    super.body();
+
+    // enable the monitor
+    cfg.m_i2c_agent_cfgs[0].en_monitor = 1'b1;
+    cfg.m_i2c_agent_cfgs[0].if_mode = Device;
+    cfg.m_i2c_agent_cfgs[0].en_loopback = 1'b1;
+
+    `uvm_info(`gfn, $sformatf("Full period cycle: %d", clock_period_cycles), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("Half period cycle: %d", half_period_cycles), UVM_MEDIUM)
+
+    // tClockLow needs to be "slightly" shorter than the actual clock low period
+    cfg.m_i2c_agent_cfgs[0].timing_cfg.tClockLow = half_period_cycles - 1;
+
+    // tClockPulse needs to be "slightly" longer than the clock period.
+    cfg.m_i2c_agent_cfgs[0].timing_cfg.tClockPulse = half_period_cycles + 1;
+
+    m_base_seq = i2c_base_seq::type_id::create("m_base_seq");
+    fork
+      m_base_seq.start(p_sequencer.i2c_sequencer_hs[0]);
+    join_none
+
+  endtask
+
+endclass : chip_sw_i2c_tx_rx_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -52,3 +52,4 @@
 `include "chip_sw_lc_ctrl_program_error_vseq.sv"
 `include "chip_sw_entropy_src_fuse_vseq.sv"
 `include "chip_sw_usb_ast_clk_calib_vseq.sv"
+`include "chip_sw_i2c_tx_rx_vseq.sv"

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -26,6 +26,7 @@
 `define USBDEV_HIER           `CHIP_HIER.u_usbdev
 `define PWRMGR_HIER           `CHIP_HIER.u_pwrmgr_aon
 `define OTBN_HIER             `CHIP_HIER.u_otbn
+`define I2C0_HIER             `CHIP_HIER.u_i2c0
 
 // The path to the actual memory array in rom_ctrl. This is a bit of a hack to allow a long path
 // without overflowing 100 characters or including any whitespace (which breaks a DV_STRINGIFY call

--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -19,7 +19,7 @@
  */
 static uint16_t round_up_divide(uint32_t a, uint32_t b) {
   if (a == 0) {
-    return 0;
+    return 1;
   }
 
   return ((a - 1) / b) + 1;
@@ -45,7 +45,7 @@ static dif_i2c_config_t default_timing_for_speed(dif_i2c_speed_t speed,
               round_up_divide(4700, clock_period_nanos),
           .start_signal_hold_cycles = round_up_divide(4000, clock_period_nanos),
           .data_signal_setup_cycles = round_up_divide(250, clock_period_nanos),
-          .data_signal_hold_cycles = 0,
+          .data_signal_hold_cycles = round_up_divide(0, clock_period_nanos),
           .stop_signal_setup_cycles = round_up_divide(4000, clock_period_nanos),
           .stop_signal_hold_cycles = round_up_divide(4700, clock_period_nanos),
       };
@@ -56,7 +56,7 @@ static dif_i2c_config_t default_timing_for_speed(dif_i2c_speed_t speed,
           .start_signal_setup_cycles = round_up_divide(600, clock_period_nanos),
           .start_signal_hold_cycles = round_up_divide(600, clock_period_nanos),
           .data_signal_setup_cycles = round_up_divide(100, clock_period_nanos),
-          .data_signal_hold_cycles = 0,
+          .data_signal_hold_cycles = round_up_divide(0, clock_period_nanos),
           .stop_signal_setup_cycles = round_up_divide(600, clock_period_nanos),
           .stop_signal_hold_cycles = round_up_divide(1300, clock_period_nanos),
       };
@@ -67,7 +67,7 @@ static dif_i2c_config_t default_timing_for_speed(dif_i2c_speed_t speed,
           .start_signal_setup_cycles = round_up_divide(260, clock_period_nanos),
           .start_signal_hold_cycles = round_up_divide(260, clock_period_nanos),
           .data_signal_setup_cycles = round_up_divide(50, clock_period_nanos),
-          .data_signal_hold_cycles = 0,
+          .data_signal_hold_cycles = round_up_divide(0, clock_period_nanos),
           .stop_signal_setup_cycles = round_up_divide(260, clock_period_nanos),
           .stop_signal_hold_cycles = round_up_divide(500, clock_period_nanos),
       };
@@ -377,7 +377,8 @@ dif_result_t dif_i2c_write_byte_raw(const dif_i2c_t *i2c, uint8_t byte,
   }
   // Validate that "write only" flags and "read only" flags are not set
   // simultaneously.
-  bool has_write_flags = flags.start || flags.stop || flags.suppress_nak_irq;
+  // bool has_write_flags = flags.start || flags.stop || flags.suppress_nak_irq;
+  bool has_write_flags = flags.start || flags.suppress_nak_irq;
   bool has_read_flags = flags.read || flags.read_cont;
   if (has_write_flags && has_read_flags) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_i2c_unittest.cc
+++ b/sw/device/lib/dif/dif_i2c_unittest.cc
@@ -88,7 +88,7 @@ TEST(ComputeTimingTest, StandardSpeed) {
       .start_signal_setup_cycles = 53,
       .start_signal_hold_cycles = 45,
       .data_signal_setup_cycles = 3,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 45,
       .stop_signal_hold_cycles = 53,
   };
@@ -105,7 +105,7 @@ TEST(ComputeTimingTest, StandardSpeed) {
       .start_signal_setup_cycles = 235,
       .start_signal_hold_cycles = 200,
       .data_signal_setup_cycles = 13,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 200,
       .stop_signal_hold_cycles = 235,
   };
@@ -123,7 +123,7 @@ TEST(ComputeTimingTest, StandardSpeed) {
       .start_signal_setup_cycles = 53,
       .start_signal_hold_cycles = 45,
       .data_signal_setup_cycles = 3,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 45,
       .stop_signal_hold_cycles = 53,
   };
@@ -145,7 +145,7 @@ TEST(ComputeTimingTest, FastSpeed) {
       .start_signal_setup_cycles = 7,
       .start_signal_hold_cycles = 7,
       .data_signal_setup_cycles = 2,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 7,
       .stop_signal_hold_cycles = 15,
   };
@@ -162,7 +162,7 @@ TEST(ComputeTimingTest, FastSpeed) {
       .start_signal_setup_cycles = 30,
       .start_signal_hold_cycles = 30,
       .data_signal_setup_cycles = 5,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 30,
       .stop_signal_hold_cycles = 65,
   };
@@ -180,7 +180,7 @@ TEST(ComputeTimingTest, FastSpeed) {
       .start_signal_setup_cycles = 7,
       .start_signal_hold_cycles = 7,
       .data_signal_setup_cycles = 2,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 7,
       .stop_signal_hold_cycles = 15,
   };
@@ -202,7 +202,7 @@ TEST(ComputeTimingTest, FastPlusSpeed) {
       .start_signal_setup_cycles = 13,
       .start_signal_hold_cycles = 13,
       .data_signal_setup_cycles = 3,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 13,
       .stop_signal_hold_cycles = 25,
   };
@@ -220,7 +220,7 @@ TEST(ComputeTimingTest, FastPlusSpeed) {
       .start_signal_setup_cycles = 13,
       .start_signal_hold_cycles = 13,
       .data_signal_setup_cycles = 3,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 13,
       .stop_signal_hold_cycles = 25,
   };
@@ -243,7 +243,7 @@ TEST_F(ConfigTest, NormalInit) {
       .start_signal_setup_cycles = 235,
       .start_signal_hold_cycles = 200,
       .data_signal_setup_cycles = 13,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 200,
       .stop_signal_hold_cycles = 235,
   };
@@ -550,8 +550,8 @@ TEST_F(FifoTest, WriteRawBadArgs) {
   EXPECT_DIF_BADARG(dif_i2c_write_byte_raw(nullptr, 0xff, {}));
   EXPECT_DIF_BADARG(dif_i2c_write_byte_raw(&i2c_, 0xff,
                                            {
-                                               .start = false,
-                                               .stop = true,
+                                               .start = true,
+                                               .stop = false,
                                                .read = true,
                                            }));
   EXPECT_DIF_BADARG(dif_i2c_write_byte_raw(&i2c_, 0xff,

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -148,6 +148,21 @@ cc_library(
 )
 
 cc_library(
+    name = "i2c_testutils",
+    srcs = ["i2c_testutils.c"],
+    hdrs = ["i2c_testutils.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/ip/i2c/data:i2c_regs",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/testing/test_framework:check",
+    ],
+)
+
+cc_library(
     name = "keymgr_testutils",
     srcs = ["keymgr_testutils.c"],
     hdrs = ["keymgr_testutils.h"],

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -12,6 +12,7 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_i2c.h"
 #include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
 #include "i2c_regs.h"  // Generated.
@@ -35,7 +36,8 @@ void i2c_testutils_wr(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count,
 
   // first write the address
   flags.start = true;
-  data_frame = (addr < 1) | kI2cWrite;
+  LOG_INFO("testutils: address %d address %d", addr, addr < 1);
+  data_frame = (addr << 1) | kI2cWrite;
   CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, data_frame, flags));
 
   // once address phase is through, blast the rest as generic data
@@ -49,7 +51,7 @@ void i2c_testutils_wr(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count,
     data++;
   }
 
-  // check for errors / status?
+  // TODO check for errors / status?
 }
 
 void i2c_testutils_rd(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count) {
@@ -62,7 +64,7 @@ void i2c_testutils_rd(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count) {
 
   // first write the address
   flags.start = true;
-  data_frame = (addr < 1) | kI2cRead;
+  data_frame = (addr << 1) | kI2cRead;
   CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, data_frame, flags));
 
   // once address phase is through, issue the read transaction
@@ -73,5 +75,5 @@ void i2c_testutils_rd(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count) {
   // inform the controller how many bytes to read overall
   CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, byte_count, flags));
 
-  // check for errors / status?
+  // TODO check for errors / status?
 }

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -1,0 +1,77 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/i2c_testutils.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_i2c.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+
+#include "i2c_regs.h"  // Generated.
+
+static const uint8_t kI2cWrite = 0;
+static const uint8_t kI2cRead = 1;
+
+// default flags
+static const dif_i2c_fmt_flags_t default_flags = {.start = false,
+                                                  .stop = false,
+                                                  .read = false,
+                                                  .read_cont = false,
+                                                  .suppress_nak_irq = false};
+
+void i2c_testutils_wr(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count,
+                      uint8_t *data, bool skip_stop) {
+  dif_i2c_fmt_flags_t flags = default_flags;
+  uint8_t data_frame;
+
+  // need a max check for byte_count right now
+
+  // first write the address
+  flags.start = true;
+  data_frame = (addr < 1) | kI2cWrite;
+  CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, data_frame, flags));
+
+  // once address phase is through, blast the rest as generic data
+  flags = default_flags;
+  for (uint8_t i = 0; i < byte_count; i++) {
+    // issue a stop for the last byte
+    if ((i == byte_count - 1) & !skip_stop) {
+      flags.stop = true;
+    }
+    CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, *data, flags));
+    data++;
+  }
+
+  // check for errors / status?
+}
+
+void i2c_testutils_rd(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count) {
+  dif_i2c_fmt_flags_t flags = default_flags;
+  uint8_t data_frame;
+  uint8_t fifo_level;
+
+  // need a max check based on FIFO depth
+  // for simplicity, don't handle more than FIFO depth right now
+
+  // first write the address
+  flags.start = true;
+  data_frame = (addr < 1) | kI2cRead;
+  CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, data_frame, flags));
+
+  // once address phase is through, issue the read transaction
+  flags = default_flags;
+  flags.read = true;
+  flags.stop = true;
+
+  // inform the controller how many bytes to read overall
+  CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, byte_count, flags));
+
+  // check for errors / status?
+}

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_I2C_TESTUTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_I2C_TESTUTILS_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/dif/dif_i2c.h"
+
+/**
+ * Construct an i2c write.
+ *
+ * @param i2c A i2c dif handle.
+ * @param addr The deivce address for the transaction.
+ * @param byte_count The number of bytes to be written.
+ * @param data Stream of data bytes to be written.
+ * @param skip_stop Skip the stop bit as this may be chained with a read.
+ */
+void i2c_testutils_wr(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count,
+                      uint8_t *data, bool skip_stop);
+
+/**
+ * Construct an i2c read
+ *
+ * @param i2c A i2c dif handle.
+ * @param addr The deivce address for the transaction.
+ * @param byte_count The number of bytes to be read.
+ */
+void i2c_testutils_rd(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_I2C_TESTUTILS_H_

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -28,6 +28,27 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "i2c_tx_rx_test",
+    srcs = ["i2c_tx_rx_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
+        "//hw/top_earlgrey/ip/clkmgr/data/autogen:clkmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:i2c_testutils",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "flash_ctrl_lc_rw_en_test",
     srcs = ["flash_ctrl_lc_rw_en_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/i2c_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_tx_rx_test.c
@@ -1,0 +1,123 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_i2c.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/i2c_testutils.h"
+#include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// TODO, remove it once pinout configuration is provided
+#include "pinmux_regs.h"
+
+static dif_i2c_t i2c;
+static dif_pinmux_t pinmux;
+static dif_rv_plic_t plic;
+
+static const dif_i2c_fmt_flags_t default_flags = {.start = false,
+                                                  .stop = false,
+                                                  .read = false,
+                                                  .read_cont = false,
+                                                  .suppress_nak_irq = false};
+
+OTTF_DEFINE_TEST_CONFIG();
+
+/**
+ * This symbol is meant to be backdoor loaded by the testbench.
+ * The testbench will inform the test the rough speed of the clock
+ * used by the I2C modules
+ */
+static volatile const uint8_t kClockPeriodNanos = 0;
+static volatile const uint8_t kI2cRiseFallNanos = 0;
+static volatile const uint32_t kI2cClockPeriodNanos = 0;
+
+/**
+ * This symbol is meant to be backdoor loaded by the testbench.
+ * to indicate which I2c is actually under test. It is not used
+ * at the moment, will connect it later.
+ */
+static volatile const uint8_t kI2cIdx = 0;
+
+bool test_main(void) {
+  CHECK_DIF_OK(
+      dif_i2c_init(mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR), &i2c));
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+
+  // Temporary hack that connects i2c to a couple of open drain pins
+  CHECK_DIF_OK(dif_pinmux_input_select(&pinmux,
+                                       kTopEarlgreyPinmuxPeripheralInI2c0Scl,
+                                       kTopEarlgreyPinmuxInselIob11));
+  CHECK_DIF_OK(dif_pinmux_input_select(&pinmux,
+                                       kTopEarlgreyPinmuxPeripheralInI2c0Sda,
+                                       kTopEarlgreyPinmuxInselIob12));
+  CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIob11,
+                                        kTopEarlgreyPinmuxOutselI2c0Scl));
+  CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIob12,
+                                        kTopEarlgreyPinmuxOutselI2c0Sda));
+
+  // I2C speed parameters
+  dif_i2c_timing_config_t timing_config = {
+      .lowest_target_device_speed = kDifI2cSpeedFastPlus,
+      .clock_period_nanos = kClockPeriodNanos,
+      .sda_rise_nanos = kI2cRiseFallNanos,
+      .sda_fall_nanos = kI2cRiseFallNanos,
+      .scl_period_nanos = kI2cClockPeriodNanos};
+
+  dif_i2c_config_t config;
+  CHECK_DIF_OK(dif_i2c_compute_timing(timing_config, &config));
+  CHECK_DIF_OK(dif_i2c_configure(&i2c, config));
+  CHECK_DIF_OK(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
+
+  // randomize variables
+  uint8_t byte_count = rand_testutils_gen32_range(1, 64);
+  uint8_t device_addr = rand_testutils_gen32_range(0, 16);
+  uint8_t expected_data[byte_count];
+
+  // controlling the randomization from C side is a bit slow, but might be
+  // easier for portability to a different setup later
+  for (uint32_t i = 0; i < byte_count; ++i) {
+    expected_data[i] = rand_testutils_gen32_range(0, 0xff);
+  };
+
+  // write expected data to i2c device
+  i2c_testutils_wr(&i2c, device_addr, byte_count, expected_data, false);
+
+  uint8_t tx_fifo_lvl, rx_fifo_lvl;
+
+  // make sure all fifo entries have been drained
+  do {
+    CHECK_DIF_OK(dif_i2c_get_fifo_levels(&i2c, &tx_fifo_lvl, &rx_fifo_lvl));
+  } while (tx_fifo_lvl > 0);
+
+  // read data from i2c device
+  i2c_testutils_rd(&i2c, device_addr, byte_count);
+
+  // make sure all data has been read back
+  do {
+    CHECK_DIF_OK(dif_i2c_get_fifo_levels(&i2c, &tx_fifo_lvl, &rx_fifo_lvl));
+  } while (rx_fifo_lvl < byte_count);
+
+  uint8_t byte;
+
+  // make sure every read is the same
+  for (uint32_t i = 0; i < byte_count; ++i) {
+    CHECK_DIF_OK(dif_i2c_read_byte(&i2c, &byte));
+    // LOG_INFO("Expected data 0x%x, read data 0x%x", expected_data[i], byte);
+    CHECK(expected_data[i] == byte);
+  };
+
+  return true;
+}


### PR DESCRIPTION

- The test sends a random number of bytes to the tb i2c agent,
  which then loops the data back to the host for comparison.
- The host (DUT C test) then is responsible for making sure what
  was sent out was read back correctly.

- To support this, a loopback mode was added to the i2c agent.
  The driver maintains a per device queue that it just writes into
  upon a valid transmission from the DUT.  When read, the appropriate
  entries are popped out and sent back to the device.