### PR TITLE
[docgen] Add description column to autogen'd inter-signal table

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -925,6 +925,7 @@
       act:     "req"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Power sequencing signals to AST (VDD domain)."
     }
     // Power sequencing signals from AST
     { struct:  "otp_ast_rsp"
@@ -933,6 +934,7 @@
       act:     "rcv"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Power sequencing signals coming from AST (VCC domain)."
     }
     // EDN interface
     { struct:  "edn"
@@ -940,6 +942,7 @@
       name:    "edn"
       act:     "req"
       package: "edn_pkg"
+      desc:    "Entropy request to the entropy distribution network for LFSR reseeding and ephemeral key derivation."
     }
     // Power manager init command
     { struct:  "pwr_otp"
@@ -948,6 +951,7 @@
       act:     "rsp"
       default: "'0"
       package: "pwrmgr_pkg"
+      desc:    "Initialization request/acknowledge from/to power manager."
     }
     // Macro-specific test signals to/from LC TAP
     { struct:  "lc_otp_vendor_test"
@@ -956,6 +960,7 @@
       act:     "rsp"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Vendor test control signals from/to the life cycle TAP."
     }
     // LC transition command
     { struct:  "lc_otp_program"
@@ -964,6 +969,7 @@
       act:     "rsp"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Life cycle state transition interface."
     }
     // Broadcast to LC
     { struct:  "otp_lc_data"
@@ -972,6 +978,10 @@
       act:     "req"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    '''
+               Life cycle state output holding the current life cycle state,
+               the value of the transition counter and the tokens needed for life cycle transitions.
+               '''
     }
     // Broadcast from LC
     { struct:  "lc_tx"
@@ -980,6 +990,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Life cycle escalation enable coming from life cycle controller.
+               This signal moves all FSMs within OTP into the error state.
+               '''
     }
     { struct:  "lc_tx"
       type:    "uni"
@@ -987,6 +1001,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Provision enable qualifier coming from life cycle controller.
+               This signal enables SW read / write access to the RMA_TOKEN and CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
+               '''
     }
     { struct:  "lc_tx"
       type:    "uni"
@@ -994,6 +1012,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Seed read enable coming from life cycle controller.
+               This signal enables HW read access to the CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
+               '''
     }
     { struct:  "lc_tx"
       type:    "uni"
@@ -1001,6 +1023,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Test enable qualifier coming from from life cycle controller.
+               This signals enables the TL-UL access port to the proprietary OTP IP.
+               '''
     }
     { struct:  "lc_tx"
       type:    "uni"
@@ -1008,6 +1034,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Life cycle partition check bypass signal.
+               This signal causes the life cycle partition to bypass consistency checks during life cycle state transitions in order to prevent spurious consistency check failures.
+               '''
     }
     // Broadcast to Key Manager
     { struct:  "otp_keymgr_key"
@@ -1016,6 +1046,7 @@
       act:     "req"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Key output to the key manager holding CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1."
     }
     // Broadcast to Flash Controller
     { struct:  "flash_otp_key"
@@ -1024,6 +1055,7 @@
       act:     "rsp"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Key derivation interface for FLASH scrambling."
     }
     // Key request from SRAM scramblers
     { struct:  "sram_otp_key"
@@ -1035,6 +1067,7 @@
       act:     "rsp"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Array with key derivation interfaces for SRAM scrambling devices."
     }
     // Key request from OTBN RAM Scrambler
     { struct:  "otbn_otp_key"
@@ -1043,6 +1076,7 @@
       act:     "rsp"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Key derivation interface for OTBN scrambling devices."
     }
     // Hardware config partition
     { struct:  "otp_hw_cfg"
@@ -1051,6 +1085,7 @@
       act:     "req"
       default: "'0"
       package: "otp_ctrl_part_pkg"
+      desc:    "Output of the HW_CFG partition."
     }
     // AST observability control
     { struct: "ast_obs_ctrl",
@@ -1058,6 +1093,7 @@
       name: "obs_ctrl",
       act: "rcv",
       package: "ast_pkg"
+      desc:    "AST observability control signals."
     }
     // prim otp observe bus
     { struct: "logic",
@@ -1066,6 +1102,7 @@
       act: "req",
       width: "8",
       package: ""
+      desc:    "AST observability bus."
     }
   ] // inter_signal_list
 

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -198,6 +198,7 @@
       act:     "req"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Power sequencing signals to AST (VDD domain)."
     }
     // Power sequencing signals from AST
     { struct:  "otp_ast_rsp"
@@ -206,6 +207,7 @@
       act:     "rcv"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Power sequencing signals coming from AST (VCC domain)."
     }
     // EDN interface
     { struct:  "edn"
@@ -213,6 +215,7 @@
       name:    "edn"
       act:     "req"
       package: "edn_pkg"
+      desc:    "Entropy request to the entropy distribution network for LFSR reseeding and ephemeral key derivation."
     }
     // Power manager init command
     { struct:  "pwr_otp"
@@ -221,6 +224,7 @@
       act:     "rsp"
       default: "'0"
       package: "pwrmgr_pkg"
+      desc:    "Initialization request/acknowledge from/to power manager."
     }
     // Macro-specific test signals to/from LC TAP
     { struct:  "lc_otp_vendor_test"
@@ -229,6 +233,7 @@
       act:     "rsp"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Vendor test control signals from/to the life cycle TAP."
     }
     // LC transition command
     { struct:  "lc_otp_program"
@@ -237,6 +242,7 @@
       act:     "rsp"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Life cycle state transition interface."
     }
     // Broadcast to LC
     { struct:  "otp_lc_data"
@@ -245,6 +251,10 @@
       act:     "req"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    '''
+               Life cycle state output holding the current life cycle state,
+               the value of the transition counter and the tokens needed for life cycle transitions.
+               '''
     }
     // Broadcast from LC
     { struct:  "lc_tx"
@@ -253,6 +263,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Life cycle escalation enable coming from life cycle controller.
+               This signal moves all FSMs within OTP into the error state.
+               '''
     }
     { struct:  "lc_tx"
       type:    "uni"
@@ -260,6 +274,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Provision enable qualifier coming from life cycle controller.
+               This signal enables SW read / write access to the RMA_TOKEN and CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
+               '''
     }
     { struct:  "lc_tx"
       type:    "uni"
@@ -267,6 +285,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Seed read enable coming from life cycle controller.
+               This signal enables HW read access to the CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
+               '''
     }
     { struct:  "lc_tx"
       type:    "uni"
@@ -274,6 +296,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Test enable qualifier coming from from life cycle controller.
+               This signals enables the TL-UL access port to the proprietary OTP IP.
+               '''
     }
     { struct:  "lc_tx"
       type:    "uni"
@@ -281,6 +307,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Life cycle partition check bypass signal.
+               This signal causes the life cycle partition to bypass consistency checks during life cycle state transitions in order to prevent spurious consistency check failures.
+               '''
     }
     // Broadcast to Key Manager
     { struct:  "otp_keymgr_key"
@@ -289,6 +319,7 @@
       act:     "req"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Key output to the key manager holding CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1."
     }
     // Broadcast to Flash Controller
     { struct:  "flash_otp_key"
@@ -297,6 +328,7 @@
       act:     "rsp"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Key derivation interface for FLASH scrambling."
     }
     // Key request from SRAM scramblers
     { struct:  "sram_otp_key"
@@ -308,6 +340,7 @@
       act:     "rsp"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Array with key derivation interfaces for SRAM scrambling devices."
     }
     // Key request from OTBN RAM Scrambler
     { struct:  "otbn_otp_key"
@@ -316,6 +349,7 @@
       act:     "rsp"
       default: "'0"
       package: "otp_ctrl_pkg"
+      desc:    "Key derivation interface for OTBN scrambling devices."
     }
     // Hardware config partition
     { struct:  "otp_hw_cfg"
@@ -324,6 +358,7 @@
       act:     "req"
       default: "'0"
       package: "otp_ctrl_part_pkg"
+      desc:    "Output of the HW_CFG partition."
     }
     // AST observability control
     { struct: "ast_obs_ctrl",
@@ -331,6 +366,7 @@
       name: "obs_ctrl",
       act: "rcv",
       package: "ast_pkg"
+      desc:    "AST observability control signals."
     }
     // prim otp observe bus
     { struct: "logic",
@@ -339,6 +375,7 @@
       act: "req",
       width: "8",
       package: ""
+      desc:    "AST observability bus."
     }
   ] // inter_signal_list
 

--- a/hw/ip/otp_ctrl/doc/_index.md
+++ b/hw/ip/otp_ctrl/doc/_index.md
@@ -314,35 +314,6 @@ Parameter                   | Default (Max) | Top Earlgrey | Description
 
 {{< incGenFromIpDesc "../data/otp_ctrl.hjson" "hwcfg" >}}
 
-The table below lists other OTP controller signals.
-
-Signal                       | Direction        | Type                        | Description
------------------------------|------------------|-----------------------------|---------------
-`otp_ast_pwr_seq_o`          | `output`         | `otp_ast_req_t `            | Power sequencing signals going to AST (VDD domain).
-`otp_ast_pwr_seq_h_i`        | `input`          | `otp_ast_rsp_t `            | Power sequencing signals coming from AST (VCC domain).
-`otp_edn_o`                  | `output`         | `otp_edn_req_t`             | Entropy request to the entropy distribution network for LFSR reseeding and ephemeral key derivation.
-`otp_edn_i`                  | `input`          | `otp_edn_rsp_t`             | Entropy acknowledgment to the entropy distribution network for LFSR reseeding and ephemeral key derivation.
-`pwr_otp_i`                  | `input`          | `pwrmgr::pwr_otp_req_t`     | Initialization request coming from power manager.
-`pwr_otp_o`                  | `output`         | `pwrmgr::pwr_otp_rsp_t`     | Initialization response and programming idle state going to power manager.
-`lc_otp_vendor_test_i`       | `input`          | `lc_otp_vendor_test_req_t`  | Vendor test control signals coming from the life cycle TAP.
-`lc_otp_vendor_test_o`       | `output`         | `lc_otp_vendor_test_rsp_t`  | Vendor test status signals going to the life cycle TAP.
-`lc_otp_program_i`           | `input`          | `lc_otp_program_req_t`      | Life cycle state transition request.
-`lc_otp_program_o`           | `output`         | `lc_otp_program_rsp_t`      | Life cycle state transition response.
-`lc_escalate_en_i`           | `input`          | `lc_ctrl_pkg::lc_tx_t`      | Life cycle escalation enable coming from life cycle controller. This signal moves all FSMs within OTP into the error state.
-`lc_check_byp_en_i`          | `input`          | `lc_ctrl_pkg::lc_tx_t`      | Life cycle partition check bypass signal. This signal causes the life cycle partition to bypass consistency checks during life cycle state transitions in order to prevent spurious consistency check failures.
-`lc_creator_seed_sw_rw_en_i` | `input`          | `lc_ctrl_pkg::lc_tx_t`      | Provision enable qualifier coming from life cycle controller. This signal enables SW read / write access to the RMA_TOKEN and CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
-`lc_seed_hw_rd_en_i`         | `input`          | `lc_ctrl_pkg::lc_tx_t`      | Seed read enable coming from life cycle controller. This signal enables HW read access to the CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
-`lc_dft_en_i`                | `input`          | `lc_ctrl_pkg::lc_tx_t`      | Test enable qualifier coming from from life cycle controller. This signals enables the TL-UL access port to the proprietary OTP IP.
-`otp_lc_data_o`              | `output`         | `otp_lc_data_t`             | Life cycle state output holding the current life cycle state, the value of the transition counter and the tokens needed for life cycle transitions.
-`otp_keymgr_key_o`           | `output`         | `keymgr_key_t`              | Key output to the key manager holding CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
-`flash_otp_key_i`            | `input`          | `flash_otp_key_req_t`       | Key derivation request for FLASH scrambling.
-`flash_otp_key_o`            | `output`         | `flash_otp_key_rsp_t`       | Key output holding static scrambling keys derived from FLASH_DATA_KEY_SEED and FLASH_ADDR_KEY_SEED.
-`sram_otp_key_i`             | `input`          | `sram_otp_key_req_t[NumSramKeyReqSlots-1:0]` | Array with key derivation requests from SRAM scrambling devices.
-`sram_otp_key_o`             | `output`         | `sram_otp_key_rsp_t[NumSramKeyReqSlots-1:0]` | Array with key outputs holding ephemeral scrambling keys derived from SRAM_DATA_KEY_SEED.
-`otbn_otp_key_i`             | `input`          | `otbn_otp_key_req_t`                         | Key derivation requests from OTBN DMEM scrambling device.
-`otbn_otp_key_o`             | `output`         | `otbn_otp_key_rsp_t`                         | Key output holding ephemeral scrambling key derived from SRAM_DATA_KEY_SEED.
-`otp_hw_cfg_o`               | `output`         | `otp_hw_cfg_t`                               | Output of the HW_CFG partition.
-
 The OTP controller contains various interfaces that connect to other comportable IPs within OpenTitan, and these are briefly explained further below.
 
 #### EDN Interface

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1255,6 +1255,7 @@
         }
         {
           name: otp_ast_pwr_seq
+          desc: Power sequencing signals to AST (VDD domain).
           struct: otp_ast_req
           package: otp_ctrl_pkg
           type: uni
@@ -1269,6 +1270,7 @@
         }
         {
           name: otp_ast_pwr_seq_h
+          desc: Power sequencing signals coming from AST (VCC domain).
           struct: otp_ast_rsp
           package: otp_ctrl_pkg
           type: uni
@@ -1283,6 +1285,7 @@
         }
         {
           name: edn
+          desc: Entropy request to the entropy distribution network for LFSR reseeding and ephemeral key derivation.
           struct: edn
           package: edn_pkg
           type: req_rsp
@@ -1295,6 +1298,7 @@
         }
         {
           name: pwr_otp
+          desc: Initialization request/acknowledge from/to power manager.
           struct: pwr_otp
           package: pwrmgr_pkg
           type: req_rsp
@@ -1307,6 +1311,7 @@
         }
         {
           name: lc_otp_vendor_test
+          desc: Vendor test control signals from/to the life cycle TAP.
           struct: lc_otp_vendor_test
           package: otp_ctrl_pkg
           type: req_rsp
@@ -1319,6 +1324,7 @@
         }
         {
           name: lc_otp_program
+          desc: Life cycle state transition interface.
           struct: lc_otp_program
           package: otp_ctrl_pkg
           type: req_rsp
@@ -1331,6 +1337,11 @@
         }
         {
           name: otp_lc_data
+          desc:
+            '''
+            Life cycle state output holding the current life cycle state,
+            the value of the transition counter and the tokens needed for life cycle transitions.
+            '''
           struct: otp_lc_data
           package: otp_ctrl_pkg
           type: uni
@@ -1345,6 +1356,11 @@
         }
         {
           name: lc_escalate_en
+          desc:
+            '''
+            Life cycle escalation enable coming from life cycle controller.
+            This signal moves all FSMs within OTP into the error state.
+            '''
           struct: lc_tx
           package: lc_ctrl_pkg
           type: uni
@@ -1357,6 +1373,11 @@
         }
         {
           name: lc_creator_seed_sw_rw_en
+          desc:
+            '''
+            Provision enable qualifier coming from life cycle controller.
+            This signal enables SW read / write access to the RMA_TOKEN and CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
+            '''
           struct: lc_tx
           package: lc_ctrl_pkg
           type: uni
@@ -1369,6 +1390,11 @@
         }
         {
           name: lc_seed_hw_rd_en
+          desc:
+            '''
+            Seed read enable coming from life cycle controller.
+            This signal enables HW read access to the CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
+            '''
           struct: lc_tx
           package: lc_ctrl_pkg
           type: uni
@@ -1381,6 +1407,11 @@
         }
         {
           name: lc_dft_en
+          desc:
+            '''
+            Test enable qualifier coming from from life cycle controller.
+            This signals enables the TL-UL access port to the proprietary OTP IP.
+            '''
           struct: lc_tx
           package: lc_ctrl_pkg
           type: uni
@@ -1393,6 +1424,11 @@
         }
         {
           name: lc_check_byp_en
+          desc:
+            '''
+            Life cycle partition check bypass signal.
+            This signal causes the life cycle partition to bypass consistency checks during life cycle state transitions in order to prevent spurious consistency check failures.
+            '''
           struct: lc_tx
           package: lc_ctrl_pkg
           type: uni
@@ -1405,6 +1441,7 @@
         }
         {
           name: otp_keymgr_key
+          desc: Key output to the key manager holding CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
           struct: otp_keymgr_key
           package: otp_ctrl_pkg
           type: uni
@@ -1419,6 +1456,7 @@
         }
         {
           name: flash_otp_key
+          desc: Key derivation interface for FLASH scrambling.
           struct: flash_otp_key
           package: otp_ctrl_pkg
           type: req_rsp
@@ -1431,6 +1469,7 @@
         }
         {
           name: sram_otp_key
+          desc: Array with key derivation interfaces for SRAM scrambling devices.
           struct: sram_otp_key
           package: otp_ctrl_pkg
           type: req_rsp
@@ -1445,6 +1484,7 @@
         }
         {
           name: otbn_otp_key
+          desc: Key derivation interface for OTBN scrambling devices.
           struct: otbn_otp_key
           package: otp_ctrl_pkg
           type: req_rsp
@@ -1458,6 +1498,7 @@
         }
         {
           name: otp_hw_cfg
+          desc: Output of the HW_CFG partition.
           struct: otp_hw_cfg
           package: otp_ctrl_part_pkg
           type: uni
@@ -1470,6 +1511,7 @@
         }
         {
           name: obs_ctrl
+          desc: AST observability control signals.
           struct: ast_obs_ctrl
           package: ast_pkg
           type: uni
@@ -1482,6 +1524,7 @@
         }
         {
           name: otp_obs
+          desc: AST observability bus.
           struct: logic
           type: uni
           act: req
@@ -14646,6 +14689,7 @@
       }
       {
         name: otp_ast_pwr_seq
+        desc: Power sequencing signals to AST (VDD domain).
         struct: otp_ast_req
         package: otp_ctrl_pkg
         type: uni
@@ -14660,6 +14704,7 @@
       }
       {
         name: otp_ast_pwr_seq_h
+        desc: Power sequencing signals coming from AST (VCC domain).
         struct: otp_ast_rsp
         package: otp_ctrl_pkg
         type: uni
@@ -14674,6 +14719,7 @@
       }
       {
         name: edn
+        desc: Entropy request to the entropy distribution network for LFSR reseeding and ephemeral key derivation.
         struct: edn
         package: edn_pkg
         type: req_rsp
@@ -14686,6 +14732,7 @@
       }
       {
         name: pwr_otp
+        desc: Initialization request/acknowledge from/to power manager.
         struct: pwr_otp
         package: pwrmgr_pkg
         type: req_rsp
@@ -14698,6 +14745,7 @@
       }
       {
         name: lc_otp_vendor_test
+        desc: Vendor test control signals from/to the life cycle TAP.
         struct: lc_otp_vendor_test
         package: otp_ctrl_pkg
         type: req_rsp
@@ -14710,6 +14758,7 @@
       }
       {
         name: lc_otp_program
+        desc: Life cycle state transition interface.
         struct: lc_otp_program
         package: otp_ctrl_pkg
         type: req_rsp
@@ -14722,6 +14771,11 @@
       }
       {
         name: otp_lc_data
+        desc:
+          '''
+          Life cycle state output holding the current life cycle state,
+          the value of the transition counter and the tokens needed for life cycle transitions.
+          '''
         struct: otp_lc_data
         package: otp_ctrl_pkg
         type: uni
@@ -14736,6 +14790,11 @@
       }
       {
         name: lc_escalate_en
+        desc:
+          '''
+          Life cycle escalation enable coming from life cycle controller.
+          This signal moves all FSMs within OTP into the error state.
+          '''
         struct: lc_tx
         package: lc_ctrl_pkg
         type: uni
@@ -14748,6 +14807,11 @@
       }
       {
         name: lc_creator_seed_sw_rw_en
+        desc:
+          '''
+          Provision enable qualifier coming from life cycle controller.
+          This signal enables SW read / write access to the RMA_TOKEN and CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
+          '''
         struct: lc_tx
         package: lc_ctrl_pkg
         type: uni
@@ -14760,6 +14824,11 @@
       }
       {
         name: lc_seed_hw_rd_en
+        desc:
+          '''
+          Seed read enable coming from life cycle controller.
+          This signal enables HW read access to the CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
+          '''
         struct: lc_tx
         package: lc_ctrl_pkg
         type: uni
@@ -14772,6 +14841,11 @@
       }
       {
         name: lc_dft_en
+        desc:
+          '''
+          Test enable qualifier coming from from life cycle controller.
+          This signals enables the TL-UL access port to the proprietary OTP IP.
+          '''
         struct: lc_tx
         package: lc_ctrl_pkg
         type: uni
@@ -14784,6 +14858,11 @@
       }
       {
         name: lc_check_byp_en
+        desc:
+          '''
+          Life cycle partition check bypass signal.
+          This signal causes the life cycle partition to bypass consistency checks during life cycle state transitions in order to prevent spurious consistency check failures.
+          '''
         struct: lc_tx
         package: lc_ctrl_pkg
         type: uni
@@ -14796,6 +14875,7 @@
       }
       {
         name: otp_keymgr_key
+        desc: Key output to the key manager holding CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
         struct: otp_keymgr_key
         package: otp_ctrl_pkg
         type: uni
@@ -14810,6 +14890,7 @@
       }
       {
         name: flash_otp_key
+        desc: Key derivation interface for FLASH scrambling.
         struct: flash_otp_key
         package: otp_ctrl_pkg
         type: req_rsp
@@ -14822,6 +14903,7 @@
       }
       {
         name: sram_otp_key
+        desc: Array with key derivation interfaces for SRAM scrambling devices.
         struct: sram_otp_key
         package: otp_ctrl_pkg
         type: req_rsp
@@ -14836,6 +14918,7 @@
       }
       {
         name: otbn_otp_key
+        desc: Key derivation interface for OTBN scrambling devices.
         struct: otbn_otp_key
         package: otp_ctrl_pkg
         type: req_rsp
@@ -14849,6 +14932,7 @@
       }
       {
         name: otp_hw_cfg
+        desc: Output of the HW_CFG partition.
         struct: otp_hw_cfg
         package: otp_ctrl_part_pkg
         type: uni
@@ -14861,6 +14945,7 @@
       }
       {
         name: obs_ctrl
+        desc: AST observability control signals.
         struct: ast_obs_ctrl
         package: ast_pkg
         type: uni
@@ -14873,6 +14958,7 @@
       }
       {
         name: otp_obs
+        desc: AST observability bus.
         struct: logic
         type: uni
         act: req

--- a/util/reggen/gen_cfg_html.py
+++ b/util/reggen/gen_cfg_html.py
@@ -101,6 +101,7 @@ def gen_cfg_html(cfgs: IpBlock, outfile: TextIO) -> None:
                "      <th>Type</th>\n" +
                "      <th>Act</th>\n" +
                "      <th>Width</th>\n" +
+               "      <th>Description</th>\n" +
                "    </tr>\n" +
                "  </thead>\n" +
                "  <tbody>\n")
@@ -111,6 +112,7 @@ def gen_cfg_html(cfgs: IpBlock, outfile: TextIO) -> None:
             sig_type = ims.signal_type
             act = ims.act
             width = str(ims.width) if ims.width is not None else "1"
+            desc = ims.desc if ims.desc is not None else ""
             genout(outfile,
                    "    <tr>\n" +
                    "      <td>" + name + "</td>\n" +
@@ -118,6 +120,7 @@ def gen_cfg_html(cfgs: IpBlock, outfile: TextIO) -> None:
                    "      <td>" + sig_type+ "</td>\n" +
                    "      <td>" + act + "</td>\n" +
                    "      <td>" + width + "</td>\n" +
+                   "      <td>" + desc + "</td>\n" +
                    "    </tr>\n")
             continue
 


### PR DESCRIPTION
The `docgen` update prints out the description field into the autogen'd documentation table.
This allows us to remove hardcoded intersignal description tables in the markdown files and migrate them to Hjson.

`otp_ctrl` is then updated accordingly, but we should also clean up other IP documentation (filed an issue for this #14718).

It's probably worth thinking about doing the same for parameters declared in the Hjson file.