### PR TITLE
[spi_device/dv] Fix regression failures

### DIFF
--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -738,7 +738,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
       end
       "control": begin
         if (write && channel == AddrChannel) begin
-          if (!`gmv(ral.control.rst_txfifo)) tx_word_q.delete();
+          if (!`gmv(ral.control.rst_txfifo) || `gmv(ral.control.abort)) tx_word_q.delete();
         end
       end
       "upload_cmdfifo": begin


### PR DESCRIPTION
1st PR is just to fix spaces/indents

2nd PR:
1. fix spi_device_abort - clear fifo when abort occurs
2. fix spi_device_bit_transfer - simplify it to send less than 7 bit for partial byte
and check the RX part data

Signed-off-by: Weicai Yang <weicai@google.com>