### PR TITLE
[sw/silicon_creator] Update OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -257,7 +257,7 @@
                 },
                 {
                     name: "OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA",
-                    value: "0xc20dd3a6",
+                    value: "0x36ed9cb0",
                 }
             ],
         }


### PR DESCRIPTION
This PR updates the alert handler config digest in RMA. This should have been handled in #14639 but was masked because of a CI issue.

We are still working on the tooling to generate these values automatically but for now we can use this [workaround](https://gist.github.com/alphan/58d3e3dcba9f10837925389ff91b8d49).

Signed-off-by: Alphan Ulusoy <alphan@google.com>