### PR TITLE
Fix chip sw sram ctrl main scrambled access test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -951,7 +951,7 @@
       sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_main_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+mem_sel=main",
-                 "+sw_test_timeout_ns=12_000_000"]
+                 "+sw_test_timeout_ns=12_000_000", "+en_scb_tl_err_chk=0"]
     }
     {
       name: chip_sw_sram_ctrl_main_scrambled_access_jitter_en
@@ -960,7 +960,7 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+mem_sel=main",
                  "+sw_test_timeout_ns=12_000_000",
-                 "+en_jitter=1"]
+                 "+en_jitter=1", "+en_scb_tl_err_chk=0"]
     }
     {
       name: chip_sw_sram_ctrl_execution_main


### PR DESCRIPTION
This PR:

-  Disable the integrity errors via testbench for scramble test, relying only in the data to be incorrect after the scrambling.
-  Change the test to tolerate a minimum of ECC errors in the scrambling test.

Fixes #14551