### PR TITLE
[dv/clkmgr] Add calib_rdy_i input

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -50,6 +50,9 @@ interface clkmgr_if (
   prim_mubi_pkg::mubi4_t jitter_en_o;
   clkmgr_pkg::clkmgr_out_t clocks_o;
 
+  prim_mubi_pkg::mubi4_t calib_rdy;
+  prim_mubi_pkg::mubi4_t hi_speed_sel;
+
   // Internal DUT signals.
   // TODO: This is a core env component (i.e. reusable entity) that makes hierarchical references
   // into the DUT. A better strategy would be to bind this interface to the DUT in tb.sv and use
@@ -167,6 +170,10 @@ interface clkmgr_if (
   end
   always_comb usb_timeout_err = `CLKMGR_HIER.u_usb_meas.timeout_err_o;
 
+  function automatic void update_calib_rdy(prim_mubi_pkg::mubi4_t value);
+    calib_rdy = value;
+  endfunction
+
   function automatic void update_idle(mubi_hintables_t value);
     idle_i = value;
   endfunction
@@ -230,8 +237,10 @@ interface clkmgr_if (
 
   task automatic init(mubi_hintables_t idle, prim_mubi_pkg::mubi4_t scanmode,
                       lc_ctrl_pkg::lc_tx_t lc_debug_en = lc_ctrl_pkg::Off,
-                      lc_ctrl_pkg::lc_tx_t lc_clk_byp_req = lc_ctrl_pkg::Off);
+                      lc_ctrl_pkg::lc_tx_t lc_clk_byp_req = lc_ctrl_pkg::Off,
+                      prim_mubi_pkg::mubi4_t calib_rdy = prim_mubi_pkg::MuBi4True);
     `uvm_info("clkmgr_if", "In clkmgr_if init", UVM_MEDIUM)
+    update_calib_rdy(calib_rdy);
     update_idle(idle);
     update_lc_clk_byp_req(lc_clk_byp_req);
     update_lc_debug_en(lc_debug_en);

--- a/hw/ip/clkmgr/dv/tb.sv
+++ b/hw/ip/clkmgr/dv/tb.sv
@@ -149,11 +149,10 @@ module tb;
     .jitter_en_o(clkmgr_if.jitter_en_o),
     .clocks_o   (clkmgr_if.clocks_o),
 
-    // assumes calibration is always ready
-    .calib_rdy_i(prim_mubi_pkg::MuBi4True),
+    .calib_rdy_i(clkmgr_if.calib_rdy),
 
     // TODO: connect and use this interface.
-    .hi_speed_sel_o()
+    .hi_speed_sel_o(clkmgr_if.hi_speed_sel)
   );
 
   initial begin


### PR DESCRIPTION
Randomize this input for clkmgr_frequency test sequence. When the input
is low clock frequency measurements won't run and measure_ctrl_regwen is
set to 1.

Signed-off-by: Guillermo Maturana <maturana@google.com>