### PR TITLE
[chip, dv] Increase default reseed to 3

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -102,7 +102,7 @@
   vcs_cov_excl_files: ["{proj_root}/hw/top_earlgrey/dv/cov/conn_ast_mem_cfg.el"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 1
+  reseed: 3
 
   // Uncomment if using manufacturer tests / test hooks that live somewhere else
   // on your system, outside of $REPO_TOP. See


### PR DESCRIPTION
Make SW test failure more persistent in nightly, which helps test
failure triage

Signed-off-by: Weicai Yang <weicai@google.com>