### PR TITLE
[chip tests] Shutdown AON timer before exit

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -689,6 +689,7 @@
       sw_images: ["//sw/device/tests:aon_timer_sleep_wdog_sleep_pause_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=18_000_000"]
+      reseed: 5
     }
     {
       name: chip_sw_aon_timer_wdog_bite_reset

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -696,6 +696,7 @@ opentitan_functest(
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aon_timer_testutils",
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -237,5 +237,7 @@ bool test_main(void) {
   execute_test(&aon_timer, irq_time,
                /*expected_irq=*/kDifAonTimerIrqWdogTimerBark);
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
+++ b/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
@@ -91,5 +91,7 @@ bool test_main(void) {
     LOG_ERROR("Got unexpected reset_info=0x%x", rst_info);
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/aon_timer_smoketest.c
+++ b/sw/device/tests/aon_timer_smoketest.c
@@ -67,5 +67,7 @@ bool test_main(void) {
   aon_timer_test_wakeup_timer(&aon);
   aon_timer_test_watchdog_timer(&aon);
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon);
   return true;
 }

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -132,5 +132,7 @@ bool test_main(void) {
     LOG_INFO("Booting for the third time due to wdog bite reset during sleep");
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -252,5 +252,7 @@ bool test_main(void) {
     return false;
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/ast_clk_outs_test.c
+++ b/sw/device/tests/ast_clk_outs_test.c
@@ -136,5 +136,7 @@ bool test_main(void) {
     return false;
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return false;
 }

--- a/sw/device/tests/clkmgr_off_peri_test.c
+++ b/sw/device/tests/clkmgr_off_peri_test.c
@@ -243,6 +243,8 @@ bool test_main(void) {
       LOG_ERROR("This is unreachable since a reset should have been triggered");
       return false;
     } else {
+      // Turn off the AON timer hardware completely before exiting.
+      aon_timer_testutils_shutdown(&aon_timer);
       return true;
     }
   } else {

--- a/sw/device/tests/clkmgr_off_trans_impl.c
+++ b/sw/device/tests/clkmgr_off_trans_impl.c
@@ -185,6 +185,9 @@ bool execute_off_trans_test(dif_clkmgr_hintable_clock_t clock) {
     LOG_INFO("DATA ADDRESS = 0x%x", cpu_dump[2]);
     LOG_INFO("EXC ADDRESS  = 0x%x", cpu_dump[3]);
     */
+
+    // Turn off the AON timer hardware completely before exiting.
+    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   } else {
     dif_rstmgr_reset_info_bitfield_t reset_info;

--- a/sw/device/tests/clkmgr_sleep_frequency_test.c
+++ b/sw/device/tests/clkmgr_sleep_frequency_test.c
@@ -143,5 +143,7 @@ bool test_main(void) {
   CHECK(clkmgr_testutils_check_measurement_counts(&clkmgr));
   CHECK(clkmgr_testutils_check_measurement_enables(&clkmgr, kDifToggleEnabled));
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/flash_ctrl_idle_low_power_test.c
+++ b/sw/device/tests/flash_ctrl_idle_low_power_test.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/irq.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/pwrmgr_testutils.h"
 #include "sw/device/lib/testing/rand_testutils.h"
@@ -165,5 +166,7 @@ bool test_main(void) {
     return false;
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon);
   return true;
 }

--- a/sw/device/tests/pwrmgr_sleep_disabled_test.c
+++ b/sw/device/tests/pwrmgr_sleep_disabled_test.c
@@ -143,6 +143,9 @@ bool test_main(void) {
     LOG_INFO("The interrupt was processed");
     // And to be extra safe, check there is no pwrmgr interrupt pending.
     CHECK(!is_pwrmgr_irq_pending());
+
+    // Turn off the AON timer hardware completely before exiting.
+    aon_timer_testutils_shutdown(&aon_timer);
     return true;
 
   } else if (pwrmgr_testutils_is_wakeup_reason(

--- a/sw/device/tests/pwrmgr_wdog_reset_reqs_test.c
+++ b/sw/device/tests/pwrmgr_wdog_reset_reqs_test.c
@@ -105,6 +105,9 @@ bool test_main(void) {
     wdog_bite_test(&aon_timer, &pwrmgr, /*bark_time_us=*/200);
   } else if (rst_info == kDifRstmgrResetInfoWatchdog) {
     LOG_INFO("Booting for the second time due to wdog bite reset");
+
+    // Turn off the AON timer hardware completely before exiting.
+    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   }
   LOG_ERROR("Got unexpected reset info 0x%x", rst_info);

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -879,6 +879,9 @@ bool test_main(void) {
     CHECK(false, "Should have reset before this line");
   } else if (rst_info == kDifRstmgrResetInfoEscalation && event_idx == 4) {
     collect_alert_dump_and_compare(kRound4);
+
+    // Turn off the AON timer hardware completely before exiting.
+    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   } else {
     LOG_FATAL("unexpected reset info %d", rst_info);

--- a/sw/device/tests/rstmgr_cpu_info_test.c
+++ b/sw/device/tests/rstmgr_cpu_info_test.c
@@ -195,5 +195,8 @@ bool test_main(void) {
       }
     }
   }
+
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/rv_core_ibex_nmi_irq_test.c
+++ b/sw/device/tests/rv_core_ibex_nmi_irq_test.c
@@ -294,5 +294,7 @@ bool test_main(void) {
   // the reset reason is still POR.
   pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0);
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/sim_dv/clkmgr_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/clkmgr_escalation_reset_test.c
@@ -269,5 +269,7 @@ bool test_main(void) {
     return false;
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
@@ -152,6 +152,8 @@ bool test_main(void) {
     LOG_INFO("Test round %d", event_idx);
   } else {
     LOG_INFO("Test finish");
+    // Turn off the AON timer hardware completely before exiting.
+    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   }
 

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
@@ -523,5 +523,7 @@ bool test_main(void) {
       LOG_INFO("Booting for undefined case");
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_wake_ups.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_wake_ups.c
@@ -330,5 +330,7 @@ bool test_main(void) {
     return false;
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return false;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -535,5 +535,7 @@ bool test_main(void) {
       LOG_INFO("Booting for undefined case");
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_wake_ups.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_wake_ups.c
@@ -351,6 +351,9 @@ bool test_main(void) {
       cleanup(i);
       LOG_INFO("clean up done source %d", i);
     }
+
+    // Turn off the AON timer hardware completely before exiting.
+    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   }
 

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
@@ -618,5 +618,7 @@ bool test_main(void) {
       LOG_INFO("Booting for undefined case");
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
@@ -195,7 +195,9 @@ bool test_main(void) {
     LOG_INFO("Booting for the third time due to wdog bite reset");
     LOG_INFO("Last Booting");
   }
-  LOG_INFO("Test finish");
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
+  LOG_INFO("Test finish");
   return true;
 }

--- a/sw/device/tests/sleep_pwm_pulses_test.c
+++ b/sw/device/tests/sleep_pwm_pulses_test.c
@@ -127,6 +127,10 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_rstmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
 
+  dif_aon_timer_t aon_timer;
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+
   // Assuming the chip hasn't slept yet, wakeup reason should be empty.
 
   // Notice we are clearing rstmgr's RESET_INFO, so after the aon wakeup there
@@ -170,10 +174,6 @@ bool test_main(void) {
     // Prepare rstmgr for a reset.
     rstmgr_testutils_pre_reset(&rstmgr);
 
-    dif_aon_timer_t aon_timer;
-    CHECK_DIF_OK(dif_aon_timer_init(
-        mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR),
-        &aon_timer));
     aon_timer_testutils_wakeup_config(&aon_timer, wakeup_threshold);
     // Deep sleep.
     pwrmgr_testutils_enable_low_power(&pwrmgr,
@@ -205,5 +205,7 @@ bool test_main(void) {
     return false;
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return false;
 }

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
@@ -115,5 +115,7 @@ bool test_main(void) {
     LOG_FATAL("Unexepected reset type detected.");
   }
 
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }


### PR DESCRIPTION
This commit shuts down to AON timer completely before exitting the
simulation to avoid the counters from counting up and thereby, causing
end-of-sim assertion failures due to simulation exitting at a time
when the counts were not fully synchronized from the AON to core
clock domain.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>