### PR TITLE
[top/dv] Patch up CI failures

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -905,16 +905,16 @@ module flash_ctrl
   assign local_esc = lc_ctrl_pkg::lc_tx_bool_to_lc_tx(fatal_std_err);
 
   assign alert_srcs = {
-    fatal_prim_flash_alert,
     recov_prim_flash_alert,
+    fatal_prim_flash_alert,
     fatal_err,
     fatal_std_err,
     recov_err
   };
 
   assign alert_tests = {
-    reg2hw.alert_test.fatal_prim_flash_alert.q & reg2hw.alert_test.fatal_prim_flash_alert.qe,
     reg2hw.alert_test.recov_prim_flash_alert.q & reg2hw.alert_test.recov_prim_flash_alert.qe,
+    reg2hw.alert_test.fatal_prim_flash_alert.q & reg2hw.alert_test.fatal_prim_flash_alert.qe,
     reg2hw.alert_test.fatal_err.q & reg2hw.alert_test.fatal_err.qe,
     reg2hw.alert_test.fatal_std_err.q & reg2hw.alert_test.fatal_std_err.qe,
     reg2hw.alert_test.recov_err.q & reg2hw.alert_test.recov_err.qe

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -906,16 +906,16 @@ module flash_ctrl
   assign local_esc = lc_ctrl_pkg::lc_tx_bool_to_lc_tx(fatal_std_err);
 
   assign alert_srcs = {
-    fatal_prim_flash_alert,
     recov_prim_flash_alert,
+    fatal_prim_flash_alert,
     fatal_err,
     fatal_std_err,
     recov_err
   };
 
   assign alert_tests = {
-    reg2hw.alert_test.fatal_prim_flash_alert.q & reg2hw.alert_test.fatal_prim_flash_alert.qe,
     reg2hw.alert_test.recov_prim_flash_alert.q & reg2hw.alert_test.recov_prim_flash_alert.qe,
+    reg2hw.alert_test.fatal_prim_flash_alert.q & reg2hw.alert_test.fatal_prim_flash_alert.qe,
     reg2hw.alert_test.fatal_err.q & reg2hw.alert_test.fatal_err.qe,
     reg2hw.alert_test.fatal_std_err.q & reg2hw.alert_test.fatal_std_err.qe,
     reg2hw.alert_test.recov_err.q & reg2hw.alert_test.recov_err.qe

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -912,16 +912,16 @@ module flash_ctrl
   assign local_esc = lc_ctrl_pkg::lc_tx_bool_to_lc_tx(fatal_std_err);
 
   assign alert_srcs = {
-    fatal_prim_flash_alert,
     recov_prim_flash_alert,
+    fatal_prim_flash_alert,
     fatal_err,
     fatal_std_err,
     recov_err
   };
 
   assign alert_tests = {
-    reg2hw.alert_test.fatal_prim_flash_alert.q & reg2hw.alert_test.fatal_prim_flash_alert.qe,
     reg2hw.alert_test.recov_prim_flash_alert.q & reg2hw.alert_test.recov_prim_flash_alert.qe,
+    reg2hw.alert_test.fatal_prim_flash_alert.q & reg2hw.alert_test.fatal_prim_flash_alert.qe,
     reg2hw.alert_test.fatal_err.q & reg2hw.alert_test.fatal_err.qe,
     reg2hw.alert_test.fatal_std_err.q & reg2hw.alert_test.fatal_std_err.qe,
     reg2hw.alert_test.recov_err.q & reg2hw.alert_test.recov_err.qe


### PR DESCRIPTION
- The number of alerts now exceed 64, so the previous structure
  for alert dumps is no longer sufficient.  This should be
  further improved in the future.

- Swap the order of prim_fatal and prim_recov alerts to match what
  was defined in the hjson for flash.

Signed-off-by: Timothy Chen <timothytim@google.com>