### PR TITLE
[ci] do not fail on Docker build failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -647,6 +647,7 @@ jobs:
   - template: ci/checkout-template.yml
   - task: Docker@2
     displayName: Build Developer Utility Container
+    continueOnError: True
     inputs:
       command: build
       Dockerfile: ./util/container/Dockerfile


### PR DESCRIPTION
Since the docker image is only experimentally supported and causing
build errors, we only attempt to build it but don't fail when it fails.

Signed-off-by: Timothy Trippel <ttrippel@google.com>