### PR TITLE
[top/dv] Update dv / test to work with ast usb calibration

### DIFF
--- a/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
@@ -271,15 +271,6 @@ module clkmgr_bind;
     .cg_en(cg_en_o.main_secure == prim_mubi_pkg::MuBi4True)
   );
 
-  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_usb_secure (
-    .clk(clk_usb_i),
-    .rst_n(rst_usb_ni),
-    .ip_clk_en(clk_usb_en),
-    .sw_clk_en(1'b1),
-    .scanmode(prim_mubi_pkg::MuBi4False),
-    .cg_en(cg_en_o.usb_secure == prim_mubi_pkg::MuBi4True)
-  );
-
   bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_div4_timers (
     .clk(clk_io_div4_i),
     .rst_n(rst_io_div4_ni),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -145,7 +145,6 @@
           clk_io_div4_secure: io_div4
           clk_main_secure: main
           clk_aon_secure: aon
-          clk_usb_secure: usb
         }
       }
       {
@@ -4058,7 +4057,11 @@
         clk_ast_alert_i: io_div4
         clk_ast_es_i: main
         clk_ast_rng_i: main
-        clk_ast_usb_i: usb
+        clk_ast_usb_i:
+        {
+          clock: usb
+          group: peri
+        }
       }
       clock_group: secure
       reset_connections:
@@ -4107,7 +4110,7 @@
         clk_ast_alert_i: clkmgr_aon_clocks.clk_io_div4_secure
         clk_ast_es_i: clkmgr_aon_clocks.clk_main_secure
         clk_ast_rng_i: clkmgr_aon_clocks.clk_main_secure
-        clk_ast_usb_i: clkmgr_aon_clocks.clk_usb_secure
+        clk_ast_usb_i: clkmgr_aon_clocks.clk_usb_peri
       }
       param_decl: {}
       param_list: []

--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -21,6 +21,7 @@ create_generated_clock -name clk_io_div2 -source [get_pin ${u_pll}/CLKOUT0] -div
 set u_div4 top_*/u_clkmgr_aon/u_no_scan_io_div4_div
 create_generated_clock -name clk_io_div4 -source [get_pin ${u_pll}/CLKOUT0] -divide_by 4 [get_pin ${u_div4}/u_clk_div_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufg.bufg_i/O]
 
+
 # the step-down mux is implemented with a LUT right now and the mux switches on the falling edge.
 # therefore, Vivado propagates both clock edges down the clock network.
 # this implementation is not ideal - but we can at least tell Vivado to only honour the rising edge for
@@ -68,4 +69,9 @@ set_output_delay -clock clk_spi 5 [get_ports SPI_DEV_D1] -add_delay
 create_generated_clock -name clk_spi_in  -divide_by 1 -source [get_ports SPI_DEV_CLK] [get_pins top_*/u_spi_device/u_clk_spi_in_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufr.bufr_i/O]
 create_generated_clock -name clk_spi_out -divide_by 1 -source [get_ports SPI_DEV_CLK] [get_pins top_*/u_spi_device/u_clk_spi_out_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufr.bufr_i/O] -invert
 
+## Set asynchronous clock groups
 set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group ${clks_aon_unbuf} -group clk_io_div2 -group clk_io_div4 -group lc_jtag_tck -group rv_jtag_tck -group {clk_spi clk_spi_in clk_spi_out} -group sys_clk_pin -asynchronous
+
+## The usb calibration handling inside ast is assumed to be async to the outside world
+## even though its interface is also a usb clock.
+set_false_path -from [get_clocks clk_usb_48mhz] -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/gen_*/q_o_reg[0]/D]

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -478,7 +478,10 @@
         clk_ast_alert_i: "io_div4",
         clk_ast_es_i: "main",
         clk_ast_rng_i: "main",
-        clk_ast_usb_i: "usb"
+        clk_ast_usb_i: {
+	  clock: "usb",
+	  group: "peri"
+	}
       },
       clock_group: "secure",
       reset_connections: {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1185,7 +1185,7 @@
       uvm_test_seq: "chip_sw_usb_ast_clk_calib_vseq"
       sw_images: ["//sw/device/tests/sim_dv:ast_usb_clk_calib:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+usb_large_drift=1"]
+      run_opts: ["+usb_max_drift=1", "+usb_fast_sof=1"]
       reseed: 1
     }
   ]

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -743,17 +743,6 @@
     .mubi_i(((clk_main_en) ? MuBi4False : MuBi4True)),
     .mubi_o(cg_en_o.main_secure)
   );
-  assign clocks_o.clk_usb_secure = clk_usb_root;
-
-  // clock gated indication for alert handler
-  prim_mubi4_sender #(
-    .ResetValue(MuBi4True)
-  ) u_prim_mubi4_sender_clk_usb_secure (
-    .clk_i(clk_usb_i),
-    .rst_ni(rst_usb_ni),
-    .mubi_i(((clk_usb_en) ? MuBi4False : MuBi4True)),
-    .mubi_o(cg_en_o.usb_secure)
-  );
   assign clocks_o.clk_io_div4_timers = clk_io_div4_root;
 
   // clock gated indication for alert handler

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -42,7 +42,6 @@ package clkmgr_pkg;
     logic clk_io_div2_infra;
     logic clk_io_div4_secure;
     logic clk_main_secure;
-    logic clk_usb_secure;
     logic clk_io_div4_timers;
     logic clk_io_div4_peri;
     logic clk_io_div2_peri;
@@ -73,7 +72,6 @@ package clkmgr_pkg;
     prim_mubi_pkg::mubi4_t io_div2_infra;
     prim_mubi_pkg::mubi4_t io_div4_secure;
     prim_mubi_pkg::mubi4_t main_secure;
-    prim_mubi_pkg::mubi4_t usb_secure;
     prim_mubi_pkg::mubi4_t io_div4_timers;
     prim_mubi_pkg::mubi4_t io_div4_peri;
     prim_mubi_pkg::mubi4_t io_div2_peri;
@@ -81,7 +79,7 @@ package clkmgr_pkg;
     prim_mubi_pkg::mubi4_t usb_peri;
   } clkmgr_cg_en_t;
 
-  parameter int NumOutputClk = 27;
+  parameter int NumOutputClk = 26;
 
 
   typedef struct packed {

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -889,7 +889,7 @@ module chip_earlgrey_asic #(
     .clk_ast_alert_i (clkmgr_aon_clocks.clk_io_div4_secure),
     .clk_ast_es_i (clkmgr_aon_clocks.clk_main_secure),
     .clk_ast_rng_i (clkmgr_aon_clocks.clk_main_secure),
-    .clk_ast_usb_i (clkmgr_aon_clocks.clk_usb_secure),
+    .clk_ast_usb_i (clkmgr_aon_clocks.clk_usb_peri),
     .rst_ast_tlul_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]),
     .rst_ast_adc_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]),
     .rst_ast_alert_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -858,7 +858,7 @@ module chip_earlgrey_cw310 #(
     .clk_ast_alert_i (clkmgr_aon_clocks.clk_io_div4_secure),
     .clk_ast_es_i (clkmgr_aon_clocks.clk_main_secure),
     .clk_ast_rng_i (clkmgr_aon_clocks.clk_main_secure),
-    .clk_ast_usb_i (clkmgr_aon_clocks.clk_usb_secure),
+    .clk_ast_usb_i (clkmgr_aon_clocks.clk_usb_peri),
     .rst_ast_tlul_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]),
     .rst_ast_adc_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]),
     .rst_ast_alert_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -919,8 +919,6 @@ module top_earlgrey #(
     assign unused_cg_en_13 = clkmgr_aon_cg_en.io_infra;
     prim_mubi_pkg::mubi4_t unused_cg_en_14;
     assign unused_cg_en_14 = clkmgr_aon_cg_en.io_div2_infra;
-    prim_mubi_pkg::mubi4_t unused_cg_en_15;
-    assign unused_cg_en_15 = clkmgr_aon_cg_en.usb_secure;
     prim_mubi_pkg::mubi4_t unused_rst_en_0;
     assign unused_rst_en_0 = rstmgr_aon_rst_en.por_aon[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_1;

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -297,7 +297,7 @@ module chip_earlgrey_verilator (
     .clk_ast_alert_i (clkmgr_aon_clocks.clk_io_div4_secure),
     .clk_ast_es_i (clkmgr_aon_clocks.clk_main_secure),
     .clk_ast_rng_i (clkmgr_aon_clocks.clk_main_secure),
-    .clk_ast_usb_i (clkmgr_aon_clocks.clk_usb_secure),
+    .clk_ast_usb_i (clkmgr_aon_clocks.clk_usb_peri),
     .rst_ast_tlul_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
     .rst_ast_adc_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::Domain0Sel]),
     .rst_ast_alert_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -325,7 +325,10 @@
         clk_ast_alert_i: "io_div4",
         clk_ast_es_i: "main",
         clk_ast_rng_i: "main",
-        clk_ast_usb_i: "usb"
+        clk_ast_usb_i: {
+	  clock: "usb",
+	  group: "peri"
+	}
       },
       clock_group: "secure",
       reset_connections: {

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -841,6 +841,7 @@ opentitan_functest(
     srcs = ["ast_usb_clk_calib.c"],
     targets = ["dv"],
     deps = [
+        "//hw/top_earlgrey/ip/ast/data:ast_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",


### PR DESCRIPTION
- companion commmit to #14618
- we now have the option to do a "fast" sof calibration,
  since otherwise the system would just sit around for 20ms.

Signed-off-by: Timothy Chen <timothytim@google.com>