### PR TITLE
[spi_device/dv] Update spi agent for CSB

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -26,14 +26,16 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   // spi_host regs
   //-------------------------
   // csid reg
-  bit [MAX_CS-1:0] csid;
+  bit [CSB_WIDTH-1:0] csid;
+  // indicate csb is selected in cfg or spi_item
+  bit                     csb_sel_in_cfg = 1;
   // configopts register fields
-  bit              sck_polarity[MAX_CS];       // aka CPOL
-  bit              sck_phase[MAX_CS];          // aka CPHA
-  bit              full_cyc[MAX_CS];
-  bit [3:0]        csn_lead[MAX_CS];
-  bit [3:0]        csn_trail[MAX_CS];
-  bit [3:0]        csn_idle[MAX_CS];
+  bit              sck_polarity[NUM_CSB];       // aka CPOL
+  bit              sck_phase[NUM_CSB];          // aka CPHA
+  bit              full_cyc[NUM_CSB];
+  bit [3:0]        csn_lead[NUM_CSB];
+  bit [3:0]        csn_trail[NUM_CSB];
+  bit [3:0]        csn_idle[NUM_CSB];
   // command register fields
   spi_mode_e       spi_mode;
   // Cmd info configs

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -13,7 +13,8 @@ package spi_agent_pkg;
   `include "dv_macros.svh"
 
   // parameter
-  parameter uint MAX_CS = 4;      // set to the maximum valid value
+  parameter uint CSB_WIDTH = 2;
+  parameter uint NUM_CSB = CSB_WIDTH ** 2;
 
   // transaction type
   typedef enum {

--- a/hw/dv/sv/spi_agent/spi_if.sv
+++ b/hw/dv/sv/spi_agent/spi_if.sv
@@ -4,13 +4,14 @@
 
 interface spi_if
   import spi_agent_pkg::*;
+  import uvm_pkg::*;
 (
   input rst_n
 );
 
   // standard spi interface pins
   logic       sck;
-  logic [3:0] csb;
+  logic [CSB_WIDTH-1:0] csb;
   logic [3:0] sio;
 
   // debug signals
@@ -22,6 +23,7 @@ interface spi_if
   bit         sck_polarity;
   bit         sck_phase;
 
+  string      msg_id = "spi_if";
   //---------------------------------
   // common tasks
   //---------------------------------
@@ -38,4 +40,18 @@ interface spi_if
     endcase
   endtask : get_data_from_sio
 
+  function automatic bit [CSB_WIDTH-1:0] get_active_csb();
+    foreach (csb[i]) begin
+      if (csb[i] === 0) begin
+        return i;
+      end
+    end
+    `uvm_fatal(msg_id, "Don't call this function - get_active_csb when there is no active CSB")
+  endfunction : get_active_csb
+
+  // check only 1 csb can be active
+  initial forever begin
+    @(csb);
+    `DV_CHECK_LE($countones(CSB_WIDTH'(~csb)), 1, , , msg_id)
+  end
 endinterface : spi_if

--- a/hw/dv/sv/spi_agent/spi_item.sv
+++ b/hw/dv/sv/spi_agent/spi_item.sv
@@ -24,6 +24,9 @@ class spi_item extends uvm_sequence_item;
   rand uint dummy_clk_cnt;
   rand uint dummy_sck_length_ns;
 
+  // indicate the active csb
+  bit [CSB_WIDTH-1:0] csb_sel;
+
   // transaction status. only use in monitor on flash mode
   // allow scb to process payload when one byte data is received, instead
   // of wait until the entire item is collected. This indicates item has collected all data.
@@ -52,6 +55,7 @@ class spi_item extends uvm_sequence_item;
     `uvm_field_int(opcode,                       UVM_DEFAULT)
     `uvm_field_int(num_lanes,                    UVM_DEFAULT)
     `uvm_field_int(dummy_cycles,                 UVM_DEFAULT)
+    `uvm_field_int(csb_sel,                      UVM_DEFAULT)
     `uvm_field_queue_int(payload_q,              UVM_DEFAULT)
     `uvm_field_queue_int(address_q,              UVM_DEFAULT)
   `uvm_object_utils_end


### PR DESCRIPTION
Update agent to be able to control CSB via an item, rather than just via
agent_cfg, so that we could start TPM seq across with flash seq, as they use
different CSB.

Signed-off-by: Weicai Yang <weicai@google.com>