### PR TITLE
[test_rom, rom_ext, bare_metal] .static_critical and global pointer fixes

### DIFF
--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -21,6 +21,7 @@ ld_library(
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
         "//sw/device:info_sections",
+        "//sw/device/silicon_creator/lib/base:static_critical_sections",
     ],
 )
 
@@ -145,6 +146,9 @@ cc_library(
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+        "//sw/device/silicon_creator/lib/base:static_critical_boot_measurements",
+        "//sw/device/silicon_creator/lib/base:static_critical_sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
 )

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -20,6 +20,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/device/lib/testing/test_rom/chip_info.h"  // Generated.
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/rom/bootstrap.h"
@@ -55,6 +56,9 @@ static dif_rv_core_ibex_t ibex;
 // rom tests. By default, it simply jumps into the OTTF's flash.
 OT_WEAK
 bool rom_test_main(void) {
+  // Initial sec_mmio, required by bootstrap and its dependencies.
+  sec_mmio_init();
+
   // Configure the pinmux.
   CHECK_DIF_OK(dif_pinmux_init(
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));

--- a/sw/device/lib/testing/test_rom/test_rom.ld
+++ b/sw/device/lib/testing/test_rom/test_rom.ld
@@ -24,7 +24,7 @@ INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 _boot_address = ORIGIN(rom);
 
 _heap_size = 0xe000;
-_stack_size = LENGTH(ram_main) - _heap_size;
+_stack_size = LENGTH(ram_main) - _heap_size - _static_critical_size;
 _stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
 _stack_start = _stack_end - _stack_size;
 _flash_start = ORIGIN(eflash);
@@ -100,19 +100,24 @@ SECTIONS {
   } > rom
 
   /**
-   * "Intitial data" section, the initial values of the mutable data section
-   * initialized at runtime.
+   * Critical static data that is accessible by both the ROM and the ROM
+   * extension.
    */
-  .idata : ALIGN(4) {
-    _data_init_start = .;
-  } > rom
+  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
 
   /**
    * Standard mutable data section, at the bottom of RAM. This will be
    * initialized from the .idata section at runtime by the CRT.
    */
-  .data ORIGIN(ram_main): AT(_data_init_start) ALIGN(4) {
+  .data : ALIGN(4) {
     _data_start = .;
+    _data_init_start = LOADADDR(.data);
+
+    /* This will get loaded into `gp`, and the linker will use that register for
+     * accessing data within [-2048,2047] of `__global_pointer$`.
+     *
+     * This is much cheaper (for small data) than materializing the
+     * address and loading from that (which will take one extra instruction). */
     __global_pointer$ = . + 2048;
 
     /* Small data should come before larger data. This helps to ensure small
@@ -126,9 +131,16 @@ SECTIONS {
      */
     *(.data)
     *(.data.*)
+
+    /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _data_end = .;
-  } > ram_main
+    _data_init_end = LOADADDR(.data) + SIZEOF(.data);
+
+    /* This puts it in ram_main at runtime (for the VMA), but puts the section
+     * into rom for load time (for the LMA). This is why `_data_init_*` uses
+     * `LOADADDR`. */
+  } > ram_main AT> rom
 
   /**
    * Immutable chip_info data, containing build-time-recorded information.

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -86,10 +86,17 @@ _test_rom_interrupt_vector:
   .global _reset_start
   .type _reset_start, @function
 _reset_start:
+
+  // Set up the global pointer. This requires that we disable linker relaxations
+  // (or it will be relaxed to `mv gp, gp`).
+  .option push
+  .option norelax
+  la  gp, __global_pointer$
+  .option pop
+
   // Clobber all writeable registers.
   li  x1, 0x0
   li  x2, 0x0
-  li  x3, 0x0
   li  x4, 0x0
   li  x5, 0x0
   li  x6, 0x0
@@ -122,12 +129,6 @@ _reset_start:
   // Set up the stack.
   la  sp, _stack_end
 
-  // Set up the global pointer. This requires that we disable linker relaxations
-  // (or it will be relaxed to `mv gp, gp`).
-  .option push
-  .option norelax
-  la  gp, __global_pointer$
-  .option pop
 
   // Explicit fall-through to `_start`.
   .size _reset_start, .-_reset_start

--- a/sw/device/silicon_creator/rom_ext/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_start.S
@@ -101,14 +101,6 @@ _rom_ext_interrupt_vector:
   .section .crt, "ax"
 
   /**
-   * Linker Relaxation is disabled until `__global_pointer$` is setup, below,
-   * because otherwise some sequences may be turned into gp-relative sequences,
-   * which is incorrect when `gp` is not initialized.
-   */
-  .option push
-  .option norelax
-
-  /**
    * Entry point.
    *
    * This symbol is jumped to from `rom_boot` using the `entry_point` field
@@ -118,6 +110,18 @@ _rom_ext_interrupt_vector:
   .global _rom_ext_start_boot
   .type _rom_ext_start_boot, @function
 _rom_ext_start_boot:
+  /**
+   * Set up the global pointer `gp`.
+   *
+   * Linker relaxations are disabled until the global pointer is setup below,
+   * because otherwise some sequences may be turned into `gp`-relative
+   * sequences, which is incorrect when `gp` is not initialized.
+   */
+  .option push
+  .option norelax
+  la gp, __global_pointer$
+  .option pop
+
   /**
    * Disable Interrupts.
    *
@@ -196,17 +200,6 @@ _rom_ext_start_boot:
   li a5, 0x0
   li a6, 0x0
   li a7, 0x0
-
-  /**
-   * Setup global pointer.
-   *
-   * This requires that we disable linker relaxations, or it will be relaxed to
-   * `mv gp, gp`, so we disabled relaxations for all of `_rom_start_boot`.
-   */
-  la gp, __global_pointer$
-
-  // Re-enable linker relaxation.
-  .option pop
 
   /**
    * Jump to C Code

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -50,6 +50,8 @@ cc_library(
     deps = [
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/lib:rom_print",
+        "//sw/device/silicon_creator/lib/base:static_critical_boot_measurements",
+        "//sw/device/silicon_creator/lib/base:static_critical_sec_mmio",
     ],
 )
 

--- a/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
@@ -101,6 +101,12 @@ SECTIONS {
   } > owner_flash
 
   /**
+   * Critical static data that is accessible by both the ROM and the ROM
+   * extension.
+   */
+  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
+
+  /**
    * Mutable data section, at the bottom of ram_main. This will be initialized
    * from flash at runtime by the CRT.
    *

--- a/sw/device/silicon_owner/bare_metal/bare_metal_start.S
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_start.S
@@ -101,20 +101,24 @@ _interrupt_vector:
   .section .crt, "ax"
 
   /**
-   * Linker Relaxation is disabled until `__global_pointer$` is setup, below,
-   * because otherwise some sequences may be turned into gp-relative sequences,
-   * which is incorrect when `gp` is not initialized.
-   */
-  .option push
-  .option norelax
-
-  /**
    * Entry point.
    */
   .balign 4
   .global _start_boot
   .type _start_boot, @function
 _start_boot:
+  /**
+   * Set up the global pointer `gp`.
+   *
+   * Linker relaxations are disabled until the global pointer is setup below,
+   * because otherwise some sequences may be turned into `gp`-relative
+   * sequences, which is incorrect when `gp` is not initialized.
+   */
+  .option push
+  .option norelax
+  la gp, __global_pointer$
+  .option pop
+
   /**
    * Disable Interrupts.
    *
@@ -193,17 +197,6 @@ _start_boot:
   li a5, 0x0
   li a6, 0x0
   li a7, 0x0
-
-  /**
-   * Setup global pointer.
-   *
-   * This requires that we disable linker relaxations, or it will be relaxed to
-   * `mv gp, gp`, so we disabled relaxations for all of `_rom_start_boot`.
-   */
-  la gp, __global_pointer$
-
-  // Re-enable linker relaxation.
-  .option pop
 
   /**
    * Jump to C Code


### PR DESCRIPTION
This PR,
- Fixes global pointer initialization in `test_rom`,
- Adds the `.static_critical` section to `test_rom` and `bare_metal` for consistency with `silicon_creator` code, and
- Moves global pointer initialization in `rom_ext` and `bare_metal` to start for simplicity. 