### PR TITLE
[ast/sensor_ctrl] Turn ast_init_done_o to Mubi and remove flash/otp alerts from AST

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4210,7 +4210,6 @@
       [
         {
           name: ast_alert
-          desc: alert requests/acknowledgements from/to `analog sensor top`
           struct: ast_alert
           package: ast_pkg
           type: req_rsp
@@ -4225,7 +4224,6 @@
         }
         {
           name: ast_status
-          desc: " Incoming `analog sensor top` status."
           struct: ast_status
           package: ast_pkg
           type: uni
@@ -4240,7 +4238,6 @@
         }
         {
           name: ast_init_done
-          desc: Initialization done indication coming from `analog sensor top`
           struct: logic
           type: uni
           act: rcv
@@ -4255,7 +4252,6 @@
         }
         {
           name: ast2pinmux
-          desc: Outgoing `analog sensor top` DFT signals that are being forwarded to the pinmux via ast_debug_out.
           struct: logic
           type: uni
           act: rcv
@@ -4270,7 +4266,6 @@
         }
         {
           name: wkup_req
-          desc: Raised if an alert event is seen during low power
           struct: logic
           type: uni
           act: req
@@ -16774,7 +16769,6 @@
       }
       {
         name: ast_alert
-        desc: alert requests/acknowledgements from/to `analog sensor top`
         struct: ast_alert
         package: ast_pkg
         type: req_rsp
@@ -16789,7 +16783,6 @@
       }
       {
         name: ast_status
-        desc: " Incoming `analog sensor top` status."
         struct: ast_status
         package: ast_pkg
         type: uni
@@ -16804,7 +16797,6 @@
       }
       {
         name: ast_init_done
-        desc: Initialization done indication coming from `analog sensor top`
         struct: logic
         type: uni
         act: rcv
@@ -16819,7 +16811,6 @@
       }
       {
         name: ast2pinmux
-        desc: Outgoing `analog sensor top` DFT signals that are being forwarded to the pinmux via ast_debug_out.
         struct: logic
         type: uni
         act: rcv
@@ -16834,7 +16825,6 @@
       }
       {
         name: wkup_req
-        desc: Raised if an alert event is seen during low power
         struct: logic
         type: uni
         act: req

--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -19,7 +19,7 @@ module ast #(
   // tlul if
   input tlul_pkg::tl_h2d_t tl_i,              // TLUL H2D
   output tlul_pkg::tl_d2h_t tl_o,             // TLUL D2H
-  output logic ast_init_done_o,               // AST (registers) Init Done
+  output prim_mubi_pkg::mubi4_t ast_init_done_o,  // AST (registers) Init Done
 
   // clocks / resets
   input clk_ast_adc_i,                        // Buffered AST ADC Clock
@@ -112,8 +112,6 @@ module ast #(
   output edn_pkg::edn_req_t entropy_req_o,    // Entropy Request
 
   // alerts
-  input ast_pkg::ast_dif_t fla_alert_src_i,    // Flash Alert Input
-  input ast_pkg::ast_dif_t otp_alert_src_i,    // OTP Alert Input
   input ast_pkg::ast_alert_rsp_t alert_rsp_i,  // Alerts Trigger & Acknowledge Inputs
   output ast_pkg::ast_alert_req_t alert_req_o, // Alerts Output
 
@@ -736,28 +734,6 @@ ast_alert u_alert_ts_lo (
   .alert_req_o ( alert_req_o.alerts[ast_pkg::TsLoSel] )
 );  // of u_alert_ts_lo
 
-// Flash Alert (FLA)
-///////////////////////////////////////
-ast_alert u_alert_fla (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( fla_alert_src_i ),  //TODO: Add enable
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::FlaSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::FlaSel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::FlaSel] )
-);  // of u_alert_fla
-
-// OTP Alert (OTP)
-///////////////////////////////////////
-ast_alert u_alert_otp (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( otp_alert_src_i ),  //TODO: Add enable
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::OtpSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::OtpSel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::OtpSel] )
-);  // of u_alert_otp
-
 // Other-0 Alert (OT0)
 ///////////////////////////////////////
 ast_alert u_alert_ot0 (
@@ -874,10 +850,10 @@ assign hw2reg.regal.d = regal;
 always_ff @( posedge clk_ast_tlul_i, negedge regal_rst_n ) begin
   if ( !regal_rst_n ) begin
     regal           <= ast_reg_pkg::AST_REGAL_RESVAL;
-    ast_init_done_o <= 1'b0;
+    ast_init_done_o <= prim_mubi_pkg::MuBi4False;
   end else if ( regal_we ) begin
     regal           <= regal_di;
-    ast_init_done_o <= 1'b1;
+    ast_init_done_o <= prim_mubi_pkg::MuBi4True;
   end
 end
 

--- a/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
@@ -11,22 +11,20 @@
 
 package ast_pkg;
 
-// Alerts
-parameter int unsigned NumAlerts  = 13;
 parameter int unsigned NumIoRails = 2;
+// Alerts
+parameter int unsigned NumAlerts  = 11;
 parameter int unsigned AsSel      = 0;
 parameter int unsigned CgSel      = 1;
 parameter int unsigned GdSel      = 2;
 parameter int unsigned TsHiSel    = 3;
 parameter int unsigned TsLoSel    = 4;
-parameter int unsigned FlaSel     = 5;
-parameter int unsigned OtpSel     = 6;
-parameter int unsigned Ot0Sel     = 7;
-parameter int unsigned Ot1Sel     = 8;
-parameter int unsigned Ot2Sel     = 9;
-parameter int unsigned Ot3Sel     = 10;
-parameter int unsigned Ot4Sel     = 11;
-parameter int unsigned Ot5Sel     = 12;
+parameter int unsigned Ot0Sel     = 5;
+parameter int unsigned Ot1Sel     = 6;
+parameter int unsigned Ot2Sel     = 7;
+parameter int unsigned Ot3Sel     = 8;
+parameter int unsigned Ot4Sel     = 9;
+parameter int unsigned Ot5Sel     = 10;
 //
 parameter int unsigned Lc2HcTrCyc = 102;  // ((99+1)+(3+1))x5 = 520 us
 parameter int unsigned Hc2LcTrCyc = 38;   // ((35+1)+(3+1))x5 = 200 us

--- a/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
+++ b/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
@@ -16,7 +16,7 @@
   ],
   available_output_list: [
     { name: "ast_debug_out",
-      desc: "Outgoing `analog sensor top` debug output signals to `pinmux`.",
+      desc: "ast debug outputs to pinmux",
       width: "9"
     }
   ],
@@ -32,7 +32,7 @@
   param_list: [
     { name:    "NumAlertEvents",
       type:    "int",
-      default: "13",
+      default: "11",
       desc:    "Number of alert events from ast",
       local:   "true"
     },
@@ -79,7 +79,6 @@
       name:    "ast_alert",
       act:     "rsp",
       package: "ast_pkg",
-      desc:    "alert requests/acknowledgements from/to `analog sensor top`"
     },
 
     { struct:  "ast_status",
@@ -87,7 +86,6 @@
       name:    "ast_status",
       act:     "rcv",
       package: "ast_pkg",
-      desc:    " Incoming `analog sensor top` status."
     },
 
     { struct:  "logic",
@@ -95,7 +93,6 @@
       name:    "ast_init_done",
       act:     "rcv",
       package: "",
-      desc:    "Initialization done indication coming from `analog sensor top`"
     },
 
     { struct:  "logic",
@@ -103,16 +100,14 @@
       name:    "ast2pinmux",
       act:     "rcv",
       width:   9,
-      package: "",
-      desc:    "Outgoing `analog sensor top` DFT signals that are being forwarded to the pinmux via ast_debug_out."
+      package: ""
     },
 
     { struct:  "logic",
       type:    "uni",
       name:    "wkup_req",
       act:     "req",
-      package: "",
-      desc:    "Raised if an alert event is seen during low power"
+      package: ""
     },
   ],
 

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
@@ -7,7 +7,7 @@
 package sensor_ctrl_reg_pkg;
 
   // Param list
-  parameter int NumAlertEvents = 13;
+  parameter int NumAlertEvents = 11;
   parameter int NumLocalEvents = 1;
   parameter int NumAlerts = 2;
   parameter int NumIoRails = 2;
@@ -109,21 +109,21 @@ package sensor_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    sensor_ctrl_reg2hw_intr_state_reg_t intr_state; // [64:63]
-    sensor_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [62:61]
-    sensor_ctrl_reg2hw_intr_test_reg_t intr_test; // [60:57]
-    sensor_ctrl_reg2hw_alert_test_reg_t alert_test; // [56:53]
-    sensor_ctrl_reg2hw_alert_trig_mreg_t [12:0] alert_trig; // [52:40]
-    sensor_ctrl_reg2hw_fatal_alert_en_mreg_t [12:0] fatal_alert_en; // [39:27]
-    sensor_ctrl_reg2hw_recov_alert_mreg_t [12:0] recov_alert; // [26:14]
-    sensor_ctrl_reg2hw_fatal_alert_mreg_t [13:0] fatal_alert; // [13:0]
+    sensor_ctrl_reg2hw_intr_state_reg_t intr_state; // [56:55]
+    sensor_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [54:53]
+    sensor_ctrl_reg2hw_intr_test_reg_t intr_test; // [52:49]
+    sensor_ctrl_reg2hw_alert_test_reg_t alert_test; // [48:45]
+    sensor_ctrl_reg2hw_alert_trig_mreg_t [10:0] alert_trig; // [44:34]
+    sensor_ctrl_reg2hw_fatal_alert_en_mreg_t [10:0] fatal_alert_en; // [33:23]
+    sensor_ctrl_reg2hw_recov_alert_mreg_t [10:0] recov_alert; // [22:12]
+    sensor_ctrl_reg2hw_fatal_alert_mreg_t [11:0] fatal_alert; // [11:0]
   } sensor_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    sensor_ctrl_hw2reg_intr_state_reg_t intr_state; // [62:59]
-    sensor_ctrl_hw2reg_recov_alert_mreg_t [12:0] recov_alert; // [58:33]
-    sensor_ctrl_hw2reg_fatal_alert_mreg_t [13:0] fatal_alert; // [32:5]
+    sensor_ctrl_hw2reg_intr_state_reg_t intr_state; // [54:51]
+    sensor_ctrl_hw2reg_recov_alert_mreg_t [10:0] recov_alert; // [50:29]
+    sensor_ctrl_hw2reg_fatal_alert_mreg_t [11:0] fatal_alert; // [28:5]
     sensor_ctrl_hw2reg_status_reg_t status; // [4:0]
   } sensor_ctrl_hw2reg_t;
 

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -163,10 +163,6 @@ module sensor_ctrl_reg_top (
   logic alert_trig_val_9_wd;
   logic alert_trig_val_10_qs;
   logic alert_trig_val_10_wd;
-  logic alert_trig_val_11_qs;
-  logic alert_trig_val_11_wd;
-  logic alert_trig_val_12_qs;
-  logic alert_trig_val_12_wd;
   logic fatal_alert_en_we;
   logic fatal_alert_en_val_0_qs;
   logic fatal_alert_en_val_0_wd;
@@ -190,10 +186,6 @@ module sensor_ctrl_reg_top (
   logic fatal_alert_en_val_9_wd;
   logic fatal_alert_en_val_10_qs;
   logic fatal_alert_en_val_10_wd;
-  logic fatal_alert_en_val_11_qs;
-  logic fatal_alert_en_val_11_wd;
-  logic fatal_alert_en_val_12_qs;
-  logic fatal_alert_en_val_12_wd;
   logic recov_alert_we;
   logic recov_alert_val_0_qs;
   logic recov_alert_val_0_wd;
@@ -217,10 +209,6 @@ module sensor_ctrl_reg_top (
   logic recov_alert_val_9_wd;
   logic recov_alert_val_10_qs;
   logic recov_alert_val_10_wd;
-  logic recov_alert_val_11_qs;
-  logic recov_alert_val_11_wd;
-  logic recov_alert_val_12_qs;
-  logic recov_alert_val_12_wd;
   logic fatal_alert_val_0_qs;
   logic fatal_alert_val_1_qs;
   logic fatal_alert_val_2_qs;
@@ -233,8 +221,6 @@ module sensor_ctrl_reg_top (
   logic fatal_alert_val_9_qs;
   logic fatal_alert_val_10_qs;
   logic fatal_alert_val_11_qs;
-  logic fatal_alert_val_12_qs;
-  logic fatal_alert_val_13_qs;
   logic status_ast_init_done_qs;
   logic [1:0] status_io_pok_qs;
 
@@ -736,58 +722,6 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_10_qs)
   );
 
-  //   F[val_11]: 11:11
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_alert_trig_val_11 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (alert_trig_we),
-    .wd     (alert_trig_val_11_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.alert_trig[11].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (alert_trig_val_11_qs)
-  );
-
-  //   F[val_12]: 12:12
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_alert_trig_val_12 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (alert_trig_we),
-    .wd     (alert_trig_val_12_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.alert_trig[12].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (alert_trig_val_12_qs)
-  );
-
 
   // Subregister 0 of Multireg fatal_alert_en
   // R[fatal_alert_en]: V(False)
@@ -1080,58 +1014,6 @@ module sensor_ctrl_reg_top (
     .qs     (fatal_alert_en_val_10_qs)
   );
 
-  //   F[val_11]: 11:11
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_fatal_alert_en_val_11 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (fatal_alert_en_gated_we),
-    .wd     (fatal_alert_en_val_11_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.fatal_alert_en[11].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (fatal_alert_en_val_11_qs)
-  );
-
-  //   F[val_12]: 12:12
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_fatal_alert_en_val_12 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (fatal_alert_en_gated_we),
-    .wd     (fatal_alert_en_val_12_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.fatal_alert_en[12].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (fatal_alert_en_val_12_qs)
-  );
-
 
   // Subregister 0 of Multireg recov_alert
   // R[recov_alert]: V(False)
@@ -1419,58 +1301,6 @@ module sensor_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (recov_alert_val_10_qs)
-  );
-
-  //   F[val_11]: 11:11
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_recov_alert_val_11 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (recov_alert_we),
-    .wd     (recov_alert_val_11_wd),
-
-    // from internal hardware
-    .de     (hw2reg.recov_alert[11].de),
-    .d      (hw2reg.recov_alert[11].d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.recov_alert[11].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (recov_alert_val_11_qs)
-  );
-
-  //   F[val_12]: 12:12
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_recov_alert_val_12 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (recov_alert_we),
-    .wd     (recov_alert_val_12_wd),
-
-    // from internal hardware
-    .de     (hw2reg.recov_alert[12].de),
-    .d      (hw2reg.recov_alert[12].d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.recov_alert[12].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (recov_alert_val_12_qs)
   );
 
 
@@ -1788,58 +1618,6 @@ module sensor_ctrl_reg_top (
     .qs     (fatal_alert_val_11_qs)
   );
 
-  //   F[val_12]: 12:12
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
-  ) u_fatal_alert_val_12 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.fatal_alert[12].de),
-    .d      (hw2reg.fatal_alert[12].d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.fatal_alert[12].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (fatal_alert_val_12_qs)
-  );
-
-  //   F[val_13]: 13:13
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
-  ) u_fatal_alert_val_13 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.fatal_alert[13].de),
-    .d      (hw2reg.fatal_alert[13].d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.fatal_alert[13].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (fatal_alert_val_13_qs)
-  );
-
 
   // R[status]: V(False)
   //   F[ast_init_done]: 0:0
@@ -1975,10 +1753,6 @@ module sensor_ctrl_reg_top (
   assign alert_trig_val_9_wd = reg_wdata[9];
 
   assign alert_trig_val_10_wd = reg_wdata[10];
-
-  assign alert_trig_val_11_wd = reg_wdata[11];
-
-  assign alert_trig_val_12_wd = reg_wdata[12];
   assign fatal_alert_en_we = addr_hit[6] & reg_we & !reg_error;
 
   assign fatal_alert_en_val_0_wd = reg_wdata[0];
@@ -2002,10 +1776,6 @@ module sensor_ctrl_reg_top (
   assign fatal_alert_en_val_9_wd = reg_wdata[9];
 
   assign fatal_alert_en_val_10_wd = reg_wdata[10];
-
-  assign fatal_alert_en_val_11_wd = reg_wdata[11];
-
-  assign fatal_alert_en_val_12_wd = reg_wdata[12];
   assign recov_alert_we = addr_hit[7] & reg_we & !reg_error;
 
   assign recov_alert_val_0_wd = reg_wdata[0];
@@ -2029,10 +1799,6 @@ module sensor_ctrl_reg_top (
   assign recov_alert_val_9_wd = reg_wdata[9];
 
   assign recov_alert_val_10_wd = reg_wdata[10];
-
-  assign recov_alert_val_11_wd = reg_wdata[11];
-
-  assign recov_alert_val_12_wd = reg_wdata[12];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -2089,8 +1855,6 @@ module sensor_ctrl_reg_top (
         reg_rdata_next[8] = alert_trig_val_8_qs;
         reg_rdata_next[9] = alert_trig_val_9_qs;
         reg_rdata_next[10] = alert_trig_val_10_qs;
-        reg_rdata_next[11] = alert_trig_val_11_qs;
-        reg_rdata_next[12] = alert_trig_val_12_qs;
       end
 
       addr_hit[6]: begin
@@ -2105,8 +1869,6 @@ module sensor_ctrl_reg_top (
         reg_rdata_next[8] = fatal_alert_en_val_8_qs;
         reg_rdata_next[9] = fatal_alert_en_val_9_qs;
         reg_rdata_next[10] = fatal_alert_en_val_10_qs;
-        reg_rdata_next[11] = fatal_alert_en_val_11_qs;
-        reg_rdata_next[12] = fatal_alert_en_val_12_qs;
       end
 
       addr_hit[7]: begin
@@ -2121,8 +1883,6 @@ module sensor_ctrl_reg_top (
         reg_rdata_next[8] = recov_alert_val_8_qs;
         reg_rdata_next[9] = recov_alert_val_9_qs;
         reg_rdata_next[10] = recov_alert_val_10_qs;
-        reg_rdata_next[11] = recov_alert_val_11_qs;
-        reg_rdata_next[12] = recov_alert_val_12_qs;
       end
 
       addr_hit[8]: begin
@@ -2138,8 +1898,6 @@ module sensor_ctrl_reg_top (
         reg_rdata_next[9] = fatal_alert_val_9_qs;
         reg_rdata_next[10] = fatal_alert_val_10_qs;
         reg_rdata_next[11] = fatal_alert_val_11_qs;
-        reg_rdata_next[12] = fatal_alert_val_12_qs;
-        reg_rdata_next[13] = fatal_alert_val_13_qs;
       end
 
       addr_hit[9]: begin

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -709,11 +709,6 @@ module chip_earlgrey_asic #(
   otp_ctrl_pkg::otp_ast_req_t otp_ctrl_otp_ast_pwr_seq;
   otp_ctrl_pkg::otp_ast_rsp_t otp_ctrl_otp_ast_pwr_seq_h;
 
-  // otp alert
-  ast_pkg::ast_dif_t otp_alert;
-  assign otp_alert.p = 1'b0;
-  assign otp_alert.n = 1'b1;
-
   logic usb_ref_pulse;
   logic usb_ref_val;
 
@@ -739,9 +734,6 @@ module chip_earlgrey_asic #(
   prim_mubi_pkg::mubi4_t flash_bist_enable;
   logic flash_power_down_h;
   logic flash_power_ready_h;
-  ast_pkg::ast_dif_t flash_alert;
-  assign flash_alert.p = 1'b0;
-  assign flash_alert.n = 1'b1;
 
   // clock bypass req/ack
   prim_mubi_pkg::mubi4_t io_clk_byp_req;
@@ -849,9 +841,13 @@ module chip_earlgrey_asic #(
 
   logic unused_pwr_clamp;
   assign unused_pwr_clamp = base_ast_pwr.pwr_clamp;
-  logic ast_init_done;
+
   logic usb_diff_rx_obs;
 
+
+  prim_mubi_pkg::mubi4_t ast_init_done_o;  // TODO: Tim to rename to ast_init_done
+  logic ast_init_done;                     // TODO: Tim to remove 2 lines
+  assign ast_init_done = prim_mubi_pkg::mubi4_test_true_strict(ast_init_done_o);
 
   ast #(
     .EntropyStreams(ast_pkg::EntropyStreams),
@@ -882,7 +878,7 @@ module chip_earlgrey_asic #(
     .tl_i                  ( base_ast_bus ),
     .tl_o                  ( ast_base_bus ),
     // init done indication
-    .ast_init_done_o       ( ast_init_done ),
+    .ast_init_done_o       ( ast_init_done_o ),   // TODO: Tim to rename to ast_init_done
     // buffered clocks & resets
     .clk_ast_tlul_i (clkmgr_aon_clocks.clk_io_div4_secure),
     .clk_ast_adc_i (clkmgr_aon_clocks.clk_aon_secure),
@@ -949,8 +945,6 @@ module chip_earlgrey_asic #(
     .entropy_rsp_i         ( ast_edn_edn_rsp ),
     .entropy_req_o         ( ast_edn_edn_req ),
     // alerts
-    .fla_alert_src_i       ( flash_alert    ),
-    .otp_alert_src_i       ( otp_alert      ),
     .alert_rsp_i           ( ast_alert_rsp  ),
     .alert_req_o           ( ast_alert_req  ),
     // dft

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -670,11 +670,6 @@ module chip_earlgrey_cw310 #(
   otp_ctrl_pkg::otp_ast_req_t otp_ctrl_otp_ast_pwr_seq;
   otp_ctrl_pkg::otp_ast_rsp_t otp_ctrl_otp_ast_pwr_seq_h;
 
-  // otp alert
-  ast_pkg::ast_dif_t otp_alert;
-  assign otp_alert.p = 1'b0;
-  assign otp_alert.n = 1'b1;
-
   logic usb_ref_pulse;
   logic usb_ref_val;
 
@@ -700,9 +695,6 @@ module chip_earlgrey_cw310 #(
   prim_mubi_pkg::mubi4_t flash_bist_enable;
   logic flash_power_down_h;
   logic flash_power_ready_h;
-  ast_pkg::ast_dif_t flash_alert;
-  assign flash_alert.p = 1'b0;
-  assign flash_alert.n = 1'b1;
 
   // clock bypass req/ack
   prim_mubi_pkg::mubi4_t io_clk_byp_req;
@@ -818,6 +810,10 @@ module chip_earlgrey_cw310 #(
   };
 
 
+  prim_mubi_pkg::mubi4_t ast_init_done_o;  // TODO: Tim to rename to ast_init_done
+  logic ast_init_done;                     // TODO: Tim to remove 2 lines
+  assign ast_init_done = prim_mubi_pkg::mubi4_test_true_strict(ast_init_done_o);
+
   ast #(
     .EntropyStreams(ast_pkg::EntropyStreams),
     .AdcChannels(ast_pkg::AdcChannels),
@@ -851,7 +847,7 @@ module chip_earlgrey_cw310 #(
     .tl_i                  ( base_ast_bus ),
     .tl_o                  ( ast_base_bus ),
     // init done indication
-    .ast_init_done_o       ( ast_init_done ),
+    .ast_init_done_o       ( ast_init_done_o ),   // TODO: Tim to rename to ast_init_done
     // buffered clocks & resets
     .clk_ast_tlul_i (clkmgr_aon_clocks.clk_io_div4_secure),
     .clk_ast_adc_i (clkmgr_aon_clocks.clk_aon_secure),
@@ -918,8 +914,6 @@ module chip_earlgrey_cw310 #(
     .entropy_rsp_i         ( ast_edn_edn_rsp ),
     .entropy_req_o         ( ast_edn_edn_req ),
     // alerts
-    .fla_alert_src_i       ( flash_alert    ),
-    .otp_alert_src_i       ( otp_alert      ),
     .alert_rsp_i           ( ast_alert_rsp  ),
     .alert_req_o           ( ast_alert_req  ),
     // dft

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -243,15 +243,9 @@ module chip_earlgrey_verilator (
   logic unused_pwr_clamp;
   assign unused_pwr_clamp = base_ast_pwr.pwr_clamp;
 
-  ast_pkg::ast_dif_t flash_alert;
-  ast_pkg::ast_dif_t otp_alert;
-
-  assign otp_alert.p = 1'b0;
-  assign otp_alert.n = 1'b1;
-
-  logic ast_init_done;
-  assign flash_alert.p = 1'b0;
-  assign flash_alert.n = 1'b1;
+  prim_mubi_pkg::mubi4_t ast_init_done_o;  // TODO: Tim to rename to ast_init_done
+  logic ast_init_done;                     // TODO: Tim to remove 2 lines
+  assign ast_init_done = prim_mubi_pkg::mubi4_test_true_strict(ast_init_done_o);
 
   ast #(
     .EntropyStreams(ast_pkg::EntropyStreams),
@@ -290,7 +284,7 @@ module chip_earlgrey_verilator (
     .tl_i                  ( base_ast_bus ),
     .tl_o                  ( ast_base_bus ),
     // init done indication
-    .ast_init_done_o       ( ast_init_done ),
+    .ast_init_done_o       ( ast_init_done_o ),   // TODO: Tim to rename to ast_init_done
     // buffered clocks & resets
     .clk_ast_tlul_i (clkmgr_aon_clocks.clk_io_div4_secure),
     .clk_ast_adc_i (clkmgr_aon_clocks.clk_aon_secure),
@@ -356,8 +350,6 @@ module chip_earlgrey_verilator (
     .entropy_rsp_i         ( ast_edn_edn_rsp ),
     .entropy_req_o         ( ast_edn_edn_req ),
     // alerts
-    .fla_alert_src_i       ( flash_alert    ),
-    .otp_alert_src_i       ( otp_alert      ),
     .alert_rsp_i           ( ast_alert_rsp  ),
     .alert_req_o           ( ast_alert_req  ),
     // dft

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -490,11 +490,6 @@ module chip_${top["name"]}_${target["name"]} #(
   otp_ctrl_pkg::otp_ast_req_t otp_ctrl_otp_ast_pwr_seq;
   otp_ctrl_pkg::otp_ast_rsp_t otp_ctrl_otp_ast_pwr_seq_h;
 
-  // otp alert
-  ast_pkg::ast_dif_t otp_alert;
-  assign otp_alert.p = 1'b0;
-  assign otp_alert.n = 1'b1;
-
   logic usb_ref_pulse;
   logic usb_ref_val;
 
@@ -520,9 +515,6 @@ module chip_${top["name"]}_${target["name"]} #(
   prim_mubi_pkg::mubi4_t flash_bist_enable;
   logic flash_power_down_h;
   logic flash_power_ready_h;
-  ast_pkg::ast_dif_t flash_alert;
-  assign flash_alert.p = 1'b0;
-  assign flash_alert.n = 1'b1;
 
   // clock bypass req/ack
   prim_mubi_pkg::mubi4_t io_clk_byp_req;
@@ -636,7 +628,7 @@ module chip_${top["name"]}_${target["name"]} #(
 
   logic unused_pwr_clamp;
   assign unused_pwr_clamp = base_ast_pwr.pwr_clamp;
-  logic ast_init_done;
+
   logic usb_diff_rx_obs;
 
 % else:
@@ -671,6 +663,10 @@ module chip_${top["name"]}_${target["name"]} #(
   };
 
 % endif
+
+  prim_mubi_pkg::mubi4_t ast_init_done_o;  // TODO: Tim to rename to ast_init_done
+  logic ast_init_done;                     // TODO: Tim to remove 2 lines
+  assign ast_init_done = prim_mubi_pkg::mubi4_test_true_strict(ast_init_done_o);
 
   ast #(
     .EntropyStreams(ast_pkg::EntropyStreams),
@@ -721,7 +717,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .tl_i                  ( base_ast_bus ),
     .tl_o                  ( ast_base_bus ),
     // init done indication
-    .ast_init_done_o       ( ast_init_done ),
+    .ast_init_done_o       ( ast_init_done_o ),   // TODO: Tim to rename to ast_init_done
     // buffered clocks & resets
     % for port, clk in ast["clock_connections"].items():
     .${port} (${clk}),
@@ -782,8 +778,6 @@ module chip_${top["name"]}_${target["name"]} #(
     .entropy_rsp_i         ( ast_edn_edn_rsp ),
     .entropy_req_o         ( ast_edn_edn_req ),
     // alerts
-    .fla_alert_src_i       ( flash_alert    ),
-    .otp_alert_src_i       ( otp_alert      ),
     .alert_rsp_i           ( ast_alert_rsp  ),
     .alert_req_o           ( ast_alert_req  ),
     // dft


### PR DESCRIPTION
This PR replaces PR "[ast/sensor_ctrl] Remove unused OTP/Flash alert signals https://github.com/lowRISC/opentitan/pull/14721"

* Turn ast_init_done_o to Mubi, and 
* Remove flash/otp alerts from AST

@tjaychen @msfschaffner  @arnonsha @zi-v 

Signed-off-by: Jacob Levy <jacob.levy@nuvoton.com>