### PR TITLE
[crypto] Refactor how the cryptolib AES driver represents configuration parameters.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
     ],
 )

--- a/sw/device/lib/crypto/drivers/aes_test.c
+++ b/sw/device/lib/crypto/drivers/aes_test.c
@@ -18,12 +18,15 @@ static const uint32_t kSecretKey[] = {
     0x3c4fcf09,
 };
 
-static const uint32_t kIv[] = {
-    // Init Counter: f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
-    0xf3f2f1f0,
-    0xf7f6f5f4,
-    0xfbfaf9f8,
-    0xfffefdfc,
+static const aes_block_t kIv = {
+    .data =
+        {
+            // Init Counter: f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
+            0xf3f2f1f0,
+            0xf7f6f5f4,
+            0xfbfaf9f8,
+            0xfffefdfc,
+        },
 };
 
 static const aes_block_t kPlaintext[] = {
@@ -66,17 +69,13 @@ bool test_main(void) {
                               0,          0,          0,          0};
 
   LOG_INFO("Configuring the AES hardware.");
-  aes_params_t params = {
-      .encrypt = true,
+  aes_key_t key = {
       .mode = kAesCipherModeCtr,
+      .sideload = kHardenedBoolFalse,
       .key_len = kAesKeyLen128,
-      .key = {share0, share1},
-      .iv = {0},
+      .key_shares = {share0, share1},
   };
-  for (size_t i = 0; i < ARRAYSIZE(kIv); ++i) {
-    params.iv[i] = kIv[i];
-  }
-  CHECK(aes_begin(params) == kAesOk);
+  CHECK(aes_encrypt_begin(key, &kIv) == kAesOk);
 
   aes_block_t ciphertext[ARRAYSIZE(kCiphertext)] = {0};
   for (size_t i = 0; i < ARRAYSIZE(kPlaintext); ++i) {

--- a/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h
+++ b/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h
@@ -26,8 +26,7 @@ extern "C" {
  *
  * This implementation does not support short tags.
  *
- * @param key_len length of key
- * @param key_shares key, expressed in two shares
+ * @param key AES key
  * @param iv_len length of IV in bytes
  * @param iv IV value (may be NULL if iv_len is 0)
  * @param plaintext_len length of plaintext in bytes
@@ -38,8 +37,7 @@ extern "C" {
  * @param[out] tag Output buffer for tag (128 bits)
  */
 OT_WARN_UNUSED_RESULT
-aes_error_t aes_gcm_encrypt(const aes_key_len_t key_len,
-                            const uint32_t *key_shares[2], const size_t iv_len,
+aes_error_t aes_gcm_encrypt(const aes_key_t key, const size_t iv_len,
                             const uint8_t *iv, const size_t plaintext_len,
                             const uint8_t *plaintext, const size_t aad_len,
                             const uint8_t *aad, uint8_t *ciphertext,


### PR DESCRIPTION
Previously, the cryptolib's AES driver took an `aes_params_t` struct for all configuration/key/IV information in order to program the hardware. In practice, particularly for AES-GCM, this was a little awkward to work with; if you need to run multiple AES operations with the same key but a different IV, or need to first encrypt and then decrypt, you need to either manipulate the parameters struct or pass around multiple arguments for separate elements such as the key.

Now, I have changed the API to mostly replace `aes_params_t` with `aes_key_t`. The IV is now a separate parameter (since it may well change with the same key; this also allows us to mark it `const` because we don't have to manipulate it within the struct) and the encrypt/decrypt boolean is hidden and replaced with two separate wrappers. This is for readability; now it's easy to see in the code which operation is being performed without having to find `.encrypt = true` wherever the parameters struct was created.

**TL;DR rather than calling `aes_begin(params)` you now call `aes_encrypt_begin(key, iv)`.**

This PR also adds an option to the key struct that configures the block to read a sideloaded key.