### PR TITLE
[test] Add rom_e2e_bootstrap_shutdown

### DIFF
--- a/sw/device/silicon_creator/rom/data/rom_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_testplan.hjson
@@ -474,10 +474,13 @@
 
             `OWNER_SW_CFG_ROM_BOOTSTRAP_EN` OTP item must be `kHardenedBoolTrue` (`0x739`).
 
-            - For `command` in {`SECTOR_ERASE` (`0xc7`) and `PAGE_PROGRAM (`0x02`)}
+            - For `command` in {`SECTOR_ERASE` (`0xc7`) and `PAGE_PROGRAM` (`0x02`)}
               - Apply bootstrap pin strapping and reset the chip.
-              - Send `command` with invalid 3-byte address, e.g. `0xffffff`.
+              - Send `CHIP_ERASE` command to transition to bootstrap phase 2.
+              - Send `command` with an invalid 3-byte address, e.g. `0xffffff`.
               - Verify that the chip outputs the expected `BFV` over UART.
+                - For `SECTOR_ERASE`: `BFV:01425303` (`kErrorBootstrapEraseAddress`) followed by `BFV:0142500d` (`kErrorBootPolicyBadIdentifier`)
+                - For `PAGE_PROGRAM`: `BFV:02425303` (`kErrorBootstrapProgramAddress`) followed by `BFV:0142500d` (`kErrorBootPolicyBadIdentifier`)
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2

--- a/sw/host/opentitanlib/src/bootstrap/mod.rs
+++ b/sw/host/opentitanlib/src/bootstrap/mod.rs
@@ -96,8 +96,8 @@ pub struct BootstrapOptions {
         help = "Whether to reset target and clear UART RX buffer after bootstrap. For CW310 only."
     )]
     pub clear_uart: Option<bool>,
-    #[structopt(long, parse(try_from_str=parse_duration), help = "Duration of the reset delay")]
-    pub reset_delay: Option<Duration>,
+    #[structopt(long, parse(try_from_str=parse_duration), default_value = "100ms", help = "Duration of the reset delay")]
+    pub reset_delay: Duration,
     #[structopt(long, parse(try_from_str=parse_duration), help = "Duration of the inter-frame delay")]
     pub inter_frame_delay: Option<Duration>,
     #[structopt(long, parse(try_from_str=parse_duration), help = "Duration of the flash-erase delay")]
@@ -115,8 +115,6 @@ pub struct Bootstrap<'a> {
 }
 
 impl<'a> Bootstrap<'a> {
-    const RESET_DELAY: Duration = Duration::from_millis(200);
-
     /// Perform the update, sending the firmware `payload` to a SPI or UART target depending on
     /// given `options`, which specifies protocol and port to use.
     pub fn update(
@@ -164,7 +162,7 @@ impl<'a> Bootstrap<'a> {
             uart_params: &options.uart_params,
             spi_params: &options.spi_params,
             reset_pin: transport.gpio_pin("RESET")?,
-            reset_delay: options.reset_delay.unwrap_or(Self::RESET_DELAY),
+            reset_delay: options.reset_delay,
         }
         .do_update(updater, transport, payload, &progress)
     }

--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -24,7 +24,7 @@ pub struct UartConsole {
     pub newline: bool,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ExitStatus {
     None,
     CtrlC,

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -118,11 +118,8 @@ fn test_bootstrap_enabled_requested(opts: &Opts, transport: &TransportWrapper) -
 
     // Now watch the console for the exit conditions.
     let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
-    match result {
-        ExitStatus::ExitSuccess => {}
-        _ => {
-            bail!("FAIL: {:?}", result);
-        }
+    if result != ExitStatus::ExitSuccess {
+        bail!("FAIL: {:?}", result);
     };
     // Now check whether the SPI device is responding to status messages
     let spi = transport.spi("0")?;
@@ -147,11 +144,8 @@ fn test_bootstrap_enabled_not_requested(opts: &Opts, transport: &TransportWrappe
 
     // Now watch the console for the exit conditions.
     let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
-    match result {
-        ExitStatus::ExitSuccess => {}
-        _ => {
-            bail!("FAIL: {:?}", result);
-        }
+    if result != ExitStatus::ExitSuccess {
+        bail!("FAIL: {:?}", result);
     };
 
     // Now check whether the SPI device is responding to commands.

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -111,13 +111,7 @@ fn test_bootstrap_enabled_requested(opts: &Opts, transport: &TransportWrapper) -
     };
 
     transport.apply_pin_strapping("ROM_BOOTSTRAP")?;
-    let reset_delay = opts
-        .init
-        .bootstrap
-        .options
-        .reset_delay
-        .unwrap_or(Duration::from_millis(50));
-    transport.reset_target(reset_delay, true)?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
 
     // Now watch the console for the exit conditions.
     let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
@@ -147,13 +141,7 @@ fn test_bootstrap_enabled_not_requested(opts: &Opts, transport: &TransportWrappe
     };
 
     transport.remove_pin_strapping("ROM_BOOTSTRAP")?;
-    let reset_delay = opts
-        .init
-        .bootstrap
-        .options
-        .reset_delay
-        .unwrap_or(Duration::from_millis(50));
-    transport.reset_target(reset_delay, true)?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
 
     // Now watch the console for the exit conditions.
     let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -99,6 +99,8 @@ impl<'a> Drop for BootstrapTest<'a> {
 }
 
 fn test_bootstrap_enabled_requested(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
+
     // TODO: Should really `opts.init.uart_params.create()` here, but we need to refactor
     // BootstrapOptions first.
     //let uart = opts.init.uart_params.create(&transport)?;
@@ -140,7 +142,6 @@ fn test_bootstrap_enabled_not_requested(opts: &Opts, transport: &TransportWrappe
         ..Default::default()
     };
 
-    transport.remove_pin_strapping("ROM_BOOTSTRAP")?;
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
 
     // Now watch the console for the exit conditions.
@@ -168,6 +169,8 @@ fn test_bootstrap_enabled_not_requested(opts: &Opts, transport: &TransportWrappe
 }
 
 fn test_jedec_id(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
+
     let spi = transport.spi("0")?;
     let id = SpiFlash::read_jedec_id(&*spi, 16)?;
     log::info!("Read jedec id: {:x?}", id);
@@ -187,7 +190,9 @@ fn test_jedec_id(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     Ok(())
 }
 
-fn test_write_enable_disable(transport: &TransportWrapper) -> Result<()> {
+fn test_write_enable_disable(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
+
     let spi = transport.spi("0")?;
 
     assert_eq!(SpiFlash::read_status(&*spi)?, 0x0);
@@ -202,6 +207,8 @@ fn test_write_enable_disable(transport: &TransportWrapper) -> Result<()> {
 }
 
 fn test_sfdp(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
+
     let spi = transport.spi("0")?;
     let sfdp = SpiFlash::read_sfdp(&*spi)?;
     log::info!("SFDP: {:#x?}", sfdp);
@@ -253,6 +260,6 @@ fn main() -> Result<()> {
     execute_test!(test_bootstrap_enabled_requested, &opts, &transport);
     execute_test!(test_jedec_id, &opts, &transport);
     execute_test!(test_sfdp, &opts, &transport);
-    execute_test!(test_write_enable_disable, &transport);
+    execute_test!(test_write_enable_disable, &opts, &transport);
     Ok(())
 }


### PR DESCRIPTION
This PR adds
* `BootstrapEntry` which is an implementation of the RAII technique to isolate bootstrap test points from each other,
* `rom_e2e_bootstrap_shutdown` test, and
* some cleanups.

~**Must be rebased if merged after #14774**~ Rebased and updated expected BFVs.