### PR TITLE
[crypto] Create templates for cryptolib API files.

### DIFF
--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_AES_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_AES_H_
+
+/**
+ * @file
+ * @brief AES operations for the OpenTitan cryptography library.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_AES_H_

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DATATYPES_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DATATYPES_H_
+
+/**
+ * @file
+ * @brief Shared datatypes for the OpenTitan cryptography library.
+ *
+ * This header defines status codes, byte buffer representations, and key
+ * representations that are shared between different algorithms within the
+ * library.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DATATYPES_H_

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DRBG_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DRBG_H_
+
+/**
+ * @file
+ * @brief DRBG for the OpenTitan cryptography library.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DRBG_H_

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_ECC_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_ECC_H_
+
+/**
+ * @file
+ * @brief Elliptic curve operations for OpenTitan cryptography library.
+ *
+ * Includes ECDSA, ECDH, Ed25519, and X25519.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_ECC_H_

--- a/sw/device/lib/crypto/include/hash.h
+++ b/sw/device/lib/crypto/include/hash.h
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_HASH_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_HASH_H_
+
+/**
+ * @file
+ * @brief Hash functions for the OpenTitan cryptography library.
+ *
+ * Supports both SHA2 and SHA3 hash functions, plus the additional Keccak-based
+ * hash functions SHAKE and cSHAKE.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_HASH_H_

--- a/sw/device/lib/crypto/include/kdf.h
+++ b/sw/device/lib/crypto/include/kdf.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KDF_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KDF_H_
+
+/**
+ * @file
+ * @brief Key derivation functions for the OpenTitan cryptography library.
+ *
+ * Includes HMAC- and KMAC-based KDFs.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KDF_H_

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KEY_TRANSPORT_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KEY_TRANSPORT_H_
+
+/**
+ * @file
+ * @brief Key import/export for the OpenTitan cryptography library.
+ *
+ * These functions allow library users to translate to and from the crypto
+ * library's key representations.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KEY_TRANSPORT_H_

--- a/sw/device/lib/crypto/include/mac.h
+++ b/sw/device/lib/crypto/include/mac.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_MAC_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_MAC_H_
+
+/**
+ * @file
+ * @brief Message authentication codes for the OpenTitan cryptography library.
+ *
+ * Supports message authentication based on either HMAC or KMAC.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_MAC_H_

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_RSA_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_RSA_H_
+
+/**
+ * @file
+ * @brief RSA signature operations for the OpenTitan cryptography library.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_RSA_H_


### PR DESCRIPTION
The current, monolithic cryptolib API header will be replaced by the following files:
- `aes.h`: All AES block cipher modes, plus the higher-level AES-based schemes AES-GCM and AES-KWP
- `datatypes.h`: Shared crypto library datatypes, such as the status enum and key representations
- `drbg.h`: Random bit generator interface
- `ecc.h`: All elliptic-curve operations: ECDSA, ECDH, Ed25519, and X25519
- `hash.h`: All hash functions: SHA2-{256,384, 512}, SHA3-{224,256,384,512}, [c]SHAKE-{128,256}-XOF.
- `kdf.h`: HMAC- and KMAC-based key derivation functions.
- `key_transport.h`: Key import and export functions
- `mac.h`: HMAC and KMAC message authentication
- `rsa.h`: RSA signatures

**I have not put any code in these headers yet.** For now, they are empty stubs. In a follow-up PR, I will move all the code without modification from `api.h` to these files. It will be a huge diff, although no code will change. By adding these stubs I'm just trying to make that diff as easy to read as possible :slightly_smiling_face: 

Splitting the API will allow users to import only what they need, make changes easier to parallelize, and avoid enormous `.h` and especially `.c` files that are difficult to navigate. Happy to hear opinions about alternative ways of splitting these up!