### PR TITLE
[sw/silicon_creator] Error cleanup

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/retention_sram.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.c
@@ -18,21 +18,6 @@ enum {
   kBase = TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR,
 };
 
-/**
- * Check that control register writes are enabled.
- *
- * @return Result of the operation.
- */
-static rom_error_t is_locked(void) {
-  if (!bitfield_bit32_read(
-          abs_mmio_read32(kBase + SRAM_CTRL_CTRL_REGWEN_REG_OFFSET),
-          SRAM_CTRL_CTRL_REGWEN_CTRL_REGWEN_BIT)) {
-    return kErrorRetSramLocked;
-  }
-
-  return kErrorOk;
-}
-
 volatile retention_sram_t *retention_sram_get(void) {
   static_assert(sizeof(retention_sram_t) == TOP_EARLGREY_RAM_RET_AON_SIZE_BYTES,
                 "Unexpected retention SRAM size.");
@@ -43,24 +28,16 @@ void retention_sram_clear(void) {
   *retention_sram_get() = (retention_sram_t){0};
 }
 
-rom_error_t retention_sram_init(void) {
-  RETURN_IF_ERROR(is_locked());
-
+void retention_sram_init(void) {
   uint32_t reg = bitfield_bit32_write(0, SRAM_CTRL_CTRL_INIT_BIT, true);
   abs_mmio_write32(kBase + SRAM_CTRL_CTRL_REG_OFFSET, reg);
-
-  return kErrorOk;
 }
 
-rom_error_t retention_sram_scramble(void) {
-  RETURN_IF_ERROR(is_locked());
-
+void retention_sram_scramble(void) {
   // Request the renewal of the scrambling key and initialization to random
   // values.
   uint32_t ctrl = 0;
   ctrl = bitfield_bit32_write(ctrl, SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT, true);
   ctrl = bitfield_bit32_write(ctrl, SRAM_CTRL_CTRL_INIT_BIT, true);
   abs_mmio_write32(kBase + SRAM_CTRL_CTRL_REG_OFFSET, ctrl);
-
-  return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.h
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.h
@@ -66,7 +66,7 @@ void retention_sram_clear(void);
  *
  * @return Result of the operation.
  */
-rom_error_t retention_sram_init(void);
+void retention_sram_init(void);
 
 /**
  * Start scrambling the retention SRAM.
@@ -80,7 +80,7 @@ rom_error_t retention_sram_init(void);
  *
  * @return An error if a new key cannot be requested.
  */
-rom_error_t retention_sram_scramble(void);
+void retention_sram_scramble(void);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/retention_sram_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram_functest.c
@@ -45,10 +45,7 @@ rom_error_t retention_sram_scramble_test(void) {
 
   // Scramble the retention SRAM.
   LOG_INFO("Scrambling retention SRAM.");
-  if (retention_sram_scramble() != kErrorOk) {
-    LOG_ERROR("Scrambling failed.");
-    return kErrorUnknown;
-  }
+  retention_sram_scramble();
 
   // Copy the contents of the retention SRAM into an array of 64-bit integers.
   // We use 64-bit integers rather than 32-bit integers to reduce the

--- a/sw/device/silicon_creator/lib/drivers/retention_sram_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram_unittest.cc
@@ -23,44 +23,24 @@ class RetentionSramTest : public rom_test::RomTest {
 class ScrambleTest : public RetentionSramTest {};
 
 TEST_F(ScrambleTest, Ok) {
-  EXPECT_ABS_READ32(base_ + SRAM_CTRL_CTRL_REGWEN_REG_OFFSET,
-                    {
-                        {SRAM_CTRL_CTRL_REGWEN_CTRL_REGWEN_BIT, 1},
-                    });
   EXPECT_ABS_WRITE32(base_ + SRAM_CTRL_CTRL_REG_OFFSET,
                      {
                          {SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT, 1},
                          {SRAM_CTRL_CTRL_INIT_BIT, 1},
                      });
 
-  EXPECT_EQ(retention_sram_scramble(), kErrorOk);
-}
-
-TEST_F(ScrambleTest, Locked) {
-  EXPECT_ABS_READ32(base_ + SRAM_CTRL_CTRL_REGWEN_REG_OFFSET, 0);
-
-  EXPECT_EQ(retention_sram_scramble(), kErrorRetSramLocked);
+  retention_sram_scramble();
 }
 
 class InitTest : public RetentionSramTest {};
 
 TEST_F(InitTest, Ok) {
-  EXPECT_ABS_READ32(base_ + SRAM_CTRL_CTRL_REGWEN_REG_OFFSET,
-                    {
-                        {SRAM_CTRL_CTRL_REGWEN_CTRL_REGWEN_BIT, 1},
-                    });
   EXPECT_ABS_WRITE32(base_ + SRAM_CTRL_CTRL_REG_OFFSET,
                      {
                          {SRAM_CTRL_CTRL_INIT_BIT, 1},
                      });
 
-  EXPECT_EQ(retention_sram_init(), kErrorOk);
-}
-
-TEST_F(InitTest, Locked) {
-  EXPECT_ABS_READ32(base_ + SRAM_CTRL_CTRL_REGWEN_REG_OFFSET, 0);
-
-  EXPECT_EQ(retention_sram_init(), kErrorRetSramLocked);
+  retention_sram_init();
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/lib/drivers/uart.c
+++ b/sw/device/silicon_creator/lib/drivers/uart.c
@@ -35,10 +35,6 @@ static void uart_reset(void) {
 }
 
 rom_error_t uart_init(uint32_t precalculated_nco) {
-  if (precalculated_nco == 0 || precalculated_nco & ~UART_CTRL_NCO_MASK) {
-    return kErrorUartInvalidArgument;
-  }
-
   // Must be called before the first write to any of the UART registers.
   uart_reset();
 

--- a/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
@@ -56,11 +56,6 @@ TEST_F(InitTest, Initialize) {
   EXPECT_EQ(uart_init(1), kErrorOk);
 }
 
-TEST_F(InitTest, InvalidInit) {
-  EXPECT_EQ(uart_init(0), kErrorUartInvalidArgument);
-  EXPECT_EQ(uart_init(65536), kErrorUartInvalidArgument);
-}
-
 class BytesSendTest : public UartTest {
  protected:
   /**

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -68,28 +68,38 @@ enum module_ {
 //       have been created.  This is required for error-space stability
 //       after the ROM is frozen.
 #define DEFINE_ERRORS(X) \
-  X(kErrorOk, 0x739), \
+  X(kErrorOk,                         0x739), \
+  X(kErrorUnknown,                    0xffffffff), \
+  \
   X(kErrorSigverifyBadEncodedMessage, ERROR_(1, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadKey,            ERROR_(2, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadSignature,      ERROR_(3, kModuleSigverify, kInvalidArgument)), \
+  \
   X(kErrorKeymgrInternal,             ERROR_(1, kModuleKeymgr, kInternal)), \
+  \
   X(kErrorManifestBadEntryPoint,      ERROR_(1, kModuleManifest, kInternal)), \
   X(kErrorManifestBadCodeRegion,      ERROR_(2, kModuleManifest, kInternal)), \
+  \
   X(kErrorAlertBadIndex,              ERROR_(1, kModuleAlertHandler, kInvalidArgument)), \
   X(kErrorAlertBadClass,              ERROR_(2, kModuleAlertHandler, kInvalidArgument)), \
   X(kErrorAlertBadEnable,             ERROR_(3, kModuleAlertHandler, kInvalidArgument)), \
   X(kErrorAlertBadEscalation,         ERROR_(4, kModuleAlertHandler, kInvalidArgument)), \
   X(kErrorAlertBadCrc32,              ERROR_(5, kModuleAlertHandler, kInvalidArgument)), \
+  \
   X(kErrorRomBootFailed,              ERROR_(1, kModuleRom, kFailedPrecondition)), \
+  \
   /* The high-byte of kErrorInterrupt is modified with the interrupt cause */ \
   X(kErrorInterrupt,                  ERROR_(0, kModuleInterrupt, kUnknown)), \
+  \
   X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
+  \
   X(kErrorOtbnInvalidArgument,        ERROR_(1, kModuleOtbn, kInvalidArgument)), \
   X(kErrorOtbnBadOffsetLen,           ERROR_(2, kModuleOtbn, kInvalidArgument)), \
   X(kErrorOtbnExecutionFailed,        ERROR_(3, kModuleOtbn, kInternal)), \
   X(kErrorOtbnSecWipeImemFailed,      ERROR_(4, kModuleOtbn, kInternal)), \
   X(kErrorOtbnSecWipeDmemFailed,      ERROR_(5, kModuleOtbn, kInternal)), \
   X(kErrorOtbnBadInsnCount,           ERROR_(6, kModuleOtbn, kInternal)), \
+  \
   X(kErrorFlashCtrlDataRead,          ERROR_(1, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlInfoRead,          ERROR_(2, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlDataWrite,         ERROR_(3, kModuleFlashCtrl, kInternal)), \
@@ -97,20 +107,25 @@ enum module_ {
   X(kErrorFlashCtrlDataErase,         ERROR_(5, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlInfoErase,         ERROR_(6, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlDataEraseVerify,   ERROR_(7, kModuleFlashCtrl, kInternal)), \
+  \
   X(kErrorBootPolicyBadIdentifier,    ERROR_(1, kModuleBootPolicy, kInternal)), \
   X(kErrorBootPolicyBadLength,        ERROR_(2, kModuleBootPolicy, kInternal)), \
   X(kErrorBootPolicyRollback,         ERROR_(3, kModuleBootPolicy, kInternal)), \
+  \
   X(kErrorBootstrapEraseAddress,      ERROR_(1, kModuleBootstrap, kInvalidArgument)), \
   X(kErrorBootstrapProgramAddress,    ERROR_(2, kModuleBootstrap, kInvalidArgument)), \
   X(kErrorBootstrapInvalidState,      ERROR_(3, kModuleBootstrap, kInvalidArgument)), \
   X(kErrorBootstrapNotRequested,      ERROR_(4, kModuleBootstrap, kInternal)), \
+  \
   X(kErrorLogBadFormatSpecifier,      ERROR_(1, kModuleLog, kInternal)), \
+  \
   X(kErrorBootDataNotFound,           ERROR_(1, kModuleBootData, kInternal)), \
   X(kErrorBootDataWriteCheck,         ERROR_(2, kModuleBootData, kInternal)), \
   X(kErrorBootDataInvalid,            ERROR_(3, kModuleBootData, kInternal)), \
+  \
   X(kErrorSpiDevicePayloadOverflow,   ERROR_(1, kModuleSpiDevice, kInternal)), \
-  X(kErrorAstInitNotDone,             ERROR_(1, kModuleAst, kInternal)), \
-  X(kErrorUnknown, 0xFFFFFFFF)
+  \
+  X(kErrorAstInitNotDone,             ERROR_(1, kModuleAst, kInternal))
 // clang-format on
 
 #define ERROR_ENUM_INIT(name_, value_) name_ = value_

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -36,7 +36,6 @@ enum module_ {
   kModuleOtbn =         MODULE_CODE('B', 'N'),
   kModuleFlashCtrl =    MODULE_CODE('F', 'C'),
   kModuleBootPolicy =   MODULE_CODE('B', 'P'),
-  kModuleRetSram =      MODULE_CODE('R', 'S'),
   kModuleBootstrap =    MODULE_CODE('B', 'S'),
   kModuleLog =          MODULE_CODE('L', 'G'),
   kModuleBootData =     MODULE_CODE('B', 'D'),
@@ -101,7 +100,6 @@ enum module_ {
   X(kErrorBootPolicyBadIdentifier,    ERROR_(1, kModuleBootPolicy, kInternal)), \
   X(kErrorBootPolicyBadLength,        ERROR_(2, kModuleBootPolicy, kInternal)), \
   X(kErrorBootPolicyRollback,         ERROR_(3, kModuleBootPolicy, kInternal)), \
-  X(kErrorRetSramLocked,              ERROR_(1, kModuleRetSram, kInternal)), \
   X(kErrorBootstrapEraseAddress,      ERROR_(1, kModuleBootstrap, kInvalidArgument)), \
   X(kErrorBootstrapProgramAddress,    ERROR_(2, kModuleBootstrap, kInvalidArgument)), \
   X(kErrorBootstrapInvalidState,      ERROR_(3, kModuleBootstrap, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -27,7 +27,6 @@ enum module_ {
   // clang-format off
   kModuleUnknown = 0,
   kModuleAlertHandler = MODULE_CODE('A', 'H'),
-  kModuleUart =         MODULE_CODE('U', 'A'),
   kModuleSigverify =    MODULE_CODE('S', 'V'),
   kModuleKeymgr =       MODULE_CODE('K', 'M'),
   kModuleManifest =     MODULE_CODE('M', 'A'),
@@ -71,8 +70,6 @@ enum module_ {
 //       after the ROM is frozen.
 #define DEFINE_ERRORS(X) \
   X(kErrorOk, 0x739), \
-  X(kErrorUartInvalidArgument,        ERROR_(1, kModuleUart, kInvalidArgument)), \
-  X(kErrorUartBadBaudRate,            ERROR_(2, kModuleUart, kInvalidArgument)), \
   X(kErrorSigverifyBadEncodedMessage, ERROR_(1, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadKey,            ERROR_(2, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadSignature,      ERROR_(3, kModuleSigverify, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -34,16 +34,13 @@ enum module_ {
   kModuleRom =          MODULE_CODE('M', 'R'),
   kModuleInterrupt =    MODULE_CODE('I', 'R'),
   kModuleEpmp =         MODULE_CODE('E', 'P'),
-  kModuleOtp =          MODULE_CODE('O', 'P'),
   kModuleOtbn =         MODULE_CODE('B', 'N'),
   kModuleFlashCtrl =    MODULE_CODE('F', 'C'),
-  kModuleSecMmio =      MODULE_CODE('I', 'O'),
   kModuleBootPolicy =   MODULE_CODE('B', 'P'),
   kModuleRetSram =      MODULE_CODE('R', 'S'),
   kModuleBootstrap =    MODULE_CODE('B', 'S'),
   kModuleLog =          MODULE_CODE('L', 'G'),
   kModuleBootData =     MODULE_CODE('B', 'D'),
-  kModuleShutdown =     MODULE_CODE('S', 'D'),
   kModuleSpiDevice =    MODULE_CODE('S', 'P'),
   kModuleAst =          MODULE_CODE('A', 'S'),
   // clang-format on
@@ -78,8 +75,7 @@ enum module_ {
   X(kErrorUartBadBaudRate,            ERROR_(2, kModuleUart, kInvalidArgument)), \
   X(kErrorSigverifyBadEncodedMessage, ERROR_(1, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadKey,            ERROR_(2, kModuleSigverify, kInvalidArgument)), \
-  X(kErrorSigverifyBadOtpValue,       ERROR_(3, kModuleSigverify, kInternal)), \
-  X(kErrorSigverifyBadSignature,      ERROR_(4, kModuleSigverify, kInvalidArgument)), \
+  X(kErrorSigverifyBadSignature,      ERROR_(3, kModuleSigverify, kInvalidArgument)), \
   X(kErrorKeymgrInternal,             ERROR_(1, kModuleKeymgr, kInternal)), \
   X(kErrorManifestBadEntryPoint,      ERROR_(1, kModuleManifest, kInternal)), \
   X(kErrorManifestBadCodeRegion,      ERROR_(2, kModuleManifest, kInternal)), \
@@ -92,14 +88,12 @@ enum module_ {
   /* The high-byte of kErrorInterrupt is modified with the interrupt cause */ \
   X(kErrorInterrupt,                  ERROR_(0, kModuleInterrupt, kUnknown)), \
   X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
-  X(kErrorOtpBadAlignment,            ERROR_(1, kModuleOtp, kInvalidArgument)), \
   X(kErrorOtbnInvalidArgument,        ERROR_(1, kModuleOtbn, kInvalidArgument)), \
   X(kErrorOtbnBadOffsetLen,           ERROR_(2, kModuleOtbn, kInvalidArgument)), \
   X(kErrorOtbnExecutionFailed,        ERROR_(3, kModuleOtbn, kInternal)), \
   X(kErrorOtbnSecWipeImemFailed,      ERROR_(4, kModuleOtbn, kInternal)), \
   X(kErrorOtbnSecWipeDmemFailed,      ERROR_(5, kModuleOtbn, kInternal)), \
-  X(kErrorOtbnUnavailable,            ERROR_(6, kModuleOtbn, kInternal)), \
-  X(kErrorOtbnBadInsnCount,           ERROR_(7, kModuleOtbn, kInternal)), \
+  X(kErrorOtbnBadInsnCount,           ERROR_(6, kModuleOtbn, kInternal)), \
   X(kErrorFlashCtrlDataRead,          ERROR_(1, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlInfoRead,          ERROR_(2, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlDataWrite,         ERROR_(3, kModuleFlashCtrl, kInternal)), \
@@ -107,29 +101,14 @@ enum module_ {
   X(kErrorFlashCtrlDataErase,         ERROR_(5, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlInfoErase,         ERROR_(6, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlDataEraseVerify,   ERROR_(7, kModuleFlashCtrl, kInternal)), \
-  X(kErrorSecMmioRegFileSize,         ERROR_(0, kModuleSecMmio, kResourceExhausted)), \
-  X(kErrorSecMmioReadFault,           ERROR_(1, kModuleSecMmio, kInternal)), \
-  X(kErrorSecMmioWriteFault,          ERROR_(2, kModuleSecMmio, kInternal)), \
-  X(kErrorSecMmioCheckValueFault,     ERROR_(3, kModuleSecMmio, kInternal)), \
-  X(kErrorSecMmioCheckIndexFault,     ERROR_(4, kModuleSecMmio, kInternal)), \
-  X(kErrorSecMmioWriteCountFault,     ERROR_(5, kModuleSecMmio, kInternal)), \
-  X(kErrorSecMmioCheckCountFault,     ERROR_(6, kModuleSecMmio, kInternal)), \
   X(kErrorBootPolicyBadIdentifier,    ERROR_(1, kModuleBootPolicy, kInternal)), \
   X(kErrorBootPolicyBadLength,        ERROR_(2, kModuleBootPolicy, kInternal)), \
   X(kErrorBootPolicyRollback,         ERROR_(3, kModuleBootPolicy, kInternal)), \
   X(kErrorRetSramLocked,              ERROR_(1, kModuleRetSram, kInternal)), \
-  X(kErrorBootstrapSpiDevice,         ERROR_(1, kModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapErase,             ERROR_(2, kModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapEraseCheck,        ERROR_(3, kModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapEraseExit,         ERROR_(4, kModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapWrite,             ERROR_(5, kModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapGpio,              ERROR_(6, kModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapUnknown,           ERROR_(7, kModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapEraseAddress,      ERROR_(8, kModuleBootstrap, kInvalidArgument)), \
-  X(kErrorBootstrapProgramAddress,    ERROR_(9, kModuleBootstrap, kInvalidArgument)), \
-  X(kErrorBootstrapInvalidOpcode,     ERROR_(10, kModuleBootstrap, kInvalidArgument)), \
-  X(kErrorBootstrapInvalidState,      ERROR_(11, kModuleBootstrap, kInvalidArgument)), \
-  X(kErrorBootstrapNotRequested,      ERROR_(12, kModuleBootstrap, kInternal)), \
+  X(kErrorBootstrapEraseAddress,      ERROR_(1, kModuleBootstrap, kInvalidArgument)), \
+  X(kErrorBootstrapProgramAddress,    ERROR_(2, kModuleBootstrap, kInvalidArgument)), \
+  X(kErrorBootstrapInvalidState,      ERROR_(3, kModuleBootstrap, kInvalidArgument)), \
+  X(kErrorBootstrapNotRequested,      ERROR_(4, kModuleBootstrap, kInternal)), \
   X(kErrorLogBadFormatSpecifier,      ERROR_(1, kModuleLog, kInternal)), \
   X(kErrorBootDataNotFound,           ERROR_(1, kModuleBootData, kInternal)), \
   X(kErrorBootDataWriteCheck,         ERROR_(2, kModuleBootData, kInternal)), \

--- a/sw/device/silicon_creator/lib/error_unittest.cc
+++ b/sw/device/silicon_creator/lib/error_unittest.cc
@@ -58,7 +58,7 @@ TEST(ErrorsTest, NoDuplicateValues) {
 
 // Checks that the RETURN_IF_ERROR macro works as expected.
 TEST(ErrorsTest, CheckReturnIfError) {
-  EXPECT_EQ(kErrorUartBadBaudRate, ReturnIfError(kErrorUartBadBaudRate));
+  EXPECT_EQ(kErrorUnknown, ReturnIfError(kErrorUnknown));
 
   rom_error_t ok = ReturnIfError(kErrorOk);
   EXPECT_EQ(0, static_cast<int>(ok));

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -577,14 +577,11 @@ TEST(ShutdownModule, RedactErrors) {
   EXPECT_EQ(shutdown_redact(kErrorOk, kShutdownErrorRedactModule), 0);
   EXPECT_EQ(shutdown_redact(kErrorOk, kShutdownErrorRedactAll), 0);
 
-  EXPECT_EQ(shutdown_redact(kErrorUartBadBaudRate, kShutdownErrorRedactNone),
-            0x02554103);
-  EXPECT_EQ(shutdown_redact(kErrorUartBadBaudRate, kShutdownErrorRedactError),
-            0x00554103);
-  EXPECT_EQ(shutdown_redact(kErrorUartBadBaudRate, kShutdownErrorRedactModule),
-            0x00000003);
-  EXPECT_EQ(shutdown_redact(kErrorUartBadBaudRate, kShutdownErrorRedactAll),
-            0xFFFFFFFF);
+  rom_error_t error = static_cast<rom_error_t>(0xaabbccdd);
+  EXPECT_EQ(shutdown_redact(error, kShutdownErrorRedactNone), 0xaabbccdd);
+  EXPECT_EQ(shutdown_redact(error, kShutdownErrorRedactError), 0x00bbccdd);
+  EXPECT_EQ(shutdown_redact(error, kShutdownErrorRedactModule), 0x000000dd);
+  EXPECT_EQ(shutdown_redact(error, kShutdownErrorRedactAll), 0xffffffff);
 }
 
 TEST_F(ShutdownTest, ShutdownFinalize) {


### PR DESCRIPTION
This PR,
* Removes some unused error codes and module definitions,
* Removes errors of `uart` and `retention_sram` drivers, and
* Reorganizes the error table for clarity.

Signed-off-by: Alphan Ulusoy <alphan@google.com>

**Must be rebased if merged after #14770**