### PR TITLE
[sw] Allow for the optional inclusion of a .bazelrc-site file

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -62,3 +62,6 @@ build:ubsan --copt -g
 build:ubsan --strip=never
 build:ubsan --copt -fno-omit-frame-pointer
 build:ubsan --linkopt -fsanitize=undefined
+
+# Import site-specific configuration.
+try-import .bazelrc-site

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ rust-project.json
 # Bazel-related cache and output directories
 bazel-*
 
+# Site-specific bazel configuration
+.bazelrc-site
+
 # Compilation database generated from build system
 compile_commands.json
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,6 +136,9 @@ jobs:
     displayName: Type of change
     # Check what kinds of changes the PR contains
     name: DetermineBuildType
+  - bash: ci/scripts/check-no-bazelrc-site.sh
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    displayName: Confirm no .bazelrc-site files
 
 - job: download_bazel_dependencies
   displayName: Prefetch Bazel deps

--- a/ci/scripts/check-no-bazelrc-site.sh
+++ b/ci/scripts/check-no-bazelrc-site.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks that .bazelrc-site file has not been accidentally committed to git
+# where it could potentially impact the local configuration of other users.
+#
+# To be run in a CI environment (with a repo), and thus we simply check for
+# the non-existence of the file, to confirm that it is not in the repo.
+
+set -e
+
+if [ -f .bazelrc-site ]; then
+    echo -n "##vso[task.logissue type=error]"
+    echo "The .bazelrc-site file should not appear in a clean checkout"
+    exit 1
+fi

--- a/doc/ug/bazel_notes.md
+++ b/doc/ug/bazel_notes.md
@@ -272,6 +272,25 @@ test --test_tag_filters=-cw310
 See the [`.bazelrc`](https://github.com/lowRISC/opentitan/blob/master/.bazelrc) file in the OpenTitan repository for more examples.
 Additionally, for more information see the Bazel [documentation](https://bazel.build/run/bazelrc).
 
+### Site-specific `.bazelrc-site` options
+
+We use the term "compute site" to refer to a particular development host, or more broadly a _collection_ of compute nodes, that is operated by an organization with its own unique compute requirements or IT policies.
+The experience of working in such an environment may be different than using an off-the-shelf Linux distribution, and so team members working on some compute sites may require the use of slightly different Bazel options.
+
+In addition to each user's `$HOME/.bazelrc` file and the project-level configurations in [`$REPO_TOP/.bazelrc`](https://github.com/lowRISC/opentitan/blob/master/.bazelrc), there is the option to add site-specific configuration options, by adding them to the file `$REPO_TOP/.bazelrc-site`.
+
+The `.bazelrc-site` file can be useful for enforcing site-specific policies such as:
+- Default locations for build artifacts (e.g., new defaults for `--output_user_root` or perhaps `--output_base` options, outside the `$HOME` filesystem).
+- Site-specific, non-standard paths for build-tools, libraries, or package configuration data.
+
+Putting Bazel options in this file adds another layer of configuration to help groups of individuals working on a common compute site share the same site-specific default options.
+
+At a more fine-grained level, individual users can still place options in `$HOME/.bazelrc`, potentially overriding the options used in `.bazelrc-site` and `$REPO_TOP/.bazelrc`.
+However the "$HOME/.bazelrc" file is not specific to OpenTitan, which could create confusion for users working on a number of projects.
+
+The policies and paths for each contributing site could vary greatly.
+So in order to avoid accidental conflicts between sites, the `.bazelrc-site` file is explicitly _not_ included in the git repository and OpenTitan CI scripts will reject any commit that includes a `.bazelrc-site` file.
+
 ## Disk Cache
 
 Bazel can use a directory on the file system as a remote cache.


### PR DESCRIPTION
The .bazelrc-site file allows for site-specific compile options
(output_base, library paths etc).   This file is an optional
addition to each working repository, however this file should
not be added to the upstrem repository. Therefore this file
is also added to .gitignore, and a CI check is added to
ensure that this file is not forcibly added to an
upstream commit.

Fixes #14767
Fixes #14768

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>