### PR TITLE
[chip,dv,i2c] Add a sequence to copy write data to read data

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent.core
+++ b/hw/dv/sv/i2c_agent/i2c_agent.core
@@ -21,6 +21,7 @@ filesets:
       - i2c_agent.sv: {is_include_file: true}
       - seq_lib/i2c_seq_list.sv: {is_include_file: true}
       - seq_lib/i2c_base_seq.sv: {is_include_file: true}
+      - seq_lib/i2c_device_response_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -56,12 +56,11 @@ class i2c_monitor extends dv_base_monitor #(
   // collect transactions forever
   virtual protected task collect_thread(uvm_phase phase);
     i2c_item full_item;
-
     wait(cfg.en_monitor);
     if (mon_dut_item.stop ||
        (!mon_dut_item.stop && !mon_dut_item.start && !mon_dut_item.rstart)) begin
       cfg.vif.wait_for_host_start(cfg.timing_cfg);
-      `uvm_info(`gfn, "\nmonitor, detect HOST START", UVM_DEBUG)
+      `uvm_info(`gfn, "\nmonitor, detect HOST START", UVM_HIGH)
     end else begin
       mon_dut_item.rstart = 1'b1;
     end
@@ -92,17 +91,19 @@ class i2c_monitor extends dv_base_monitor #(
     mon_dut_item.tran_id = num_dut_tran;
     for (int i = cfg.target_addr_mode - 1; i >= 0; i--) begin
       cfg.vif.get_bit_data("host", cfg.timing_cfg, mon_dut_item.addr[i]);
-      `uvm_info(`gfn, $sformatf("\nmonitor, address[%0d] %b", i, mon_dut_item.addr[i]), UVM_DEBUG)
+      `uvm_info(`gfn, $sformatf("\nmonitor, address[%0d] %b", i, mon_dut_item.addr[i]), UVM_HIGH)
     end
-    `uvm_info(`gfn, $sformatf("\nmonitor, address 0x%0x", mon_dut_item.addr), UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf("\nmonitor, address %0x", mon_dut_item.addr), UVM_HIGH)
     cfg.vif.get_bit_data("host", cfg.timing_cfg, rw_req);
+    `uvm_info(`gfn, $sformatf("\nmonitor, rw %d", rw_req), UVM_HIGH)
     mon_dut_item.bus_op = (rw_req) ? BusOpRead : BusOpWrite;
     // get ack after transmitting address
     mon_dut_item.drv_type = DevAck;
     `downcast(clone_item, mon_dut_item.clone());
+    `uvm_info(`gfn, $sformatf("Req analysis port: address thread"), UVM_HIGH)
     req_analysis_port.write(clone_item);
     cfg.vif.wait_for_device_ack(cfg.timing_cfg);
-    `uvm_info(`gfn, $sformatf("\nmonitor, address, detect TARGET ACK"), UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf("\nmonitor, address, detect TARGET ACK"), UVM_HIGH)
   endtask : address_thread
 
   virtual protected task read_thread();
@@ -116,22 +117,23 @@ class i2c_monitor extends dv_base_monitor #(
       // ask driver response read data
       mon_dut_item.drv_type = RdData;
       `downcast(clone_item, mon_dut_item.clone());
+      `uvm_info(`gfn, $sformatf("Req analysis port: read thread"), UVM_HIGH)
       req_analysis_port.write(clone_item);
       // sample read data
       for (int i = 7; i >= 0; i--) begin
         cfg.vif.get_bit_data("device", cfg.timing_cfg, mon_data[i]);
         `uvm_info(`gfn, $sformatf("\nmonitor, rd_data, trans %0d, byte %0d, bit[%0d] %0b",
-            mon_dut_item.tran_id, mon_dut_item.num_data+1, i, mon_data[i]), UVM_DEBUG)
+            mon_dut_item.tran_id, mon_dut_item.num_data+1, i, mon_data[i]), UVM_HIGH)
       end
       mon_dut_item.data_q.push_back(mon_data);
       mon_dut_item.num_data++;
       `uvm_info(`gfn, $sformatf("\nmonitor, rd_data, trans %0d, byte %0d 0x%0x",
-          mon_dut_item.tran_id, mon_dut_item.num_data, mon_data), UVM_DEBUG)
+          mon_dut_item.tran_id, mon_dut_item.num_data, mon_data), UVM_HIGH)
       // sample host ack/nack (in the last byte, nack can be issue if rcont is set)
       cfg.vif.wait_for_host_ack_or_nack(cfg.timing_cfg, mon_dut_item.ack, mon_dut_item.nack);
       `DV_CHECK_NE_FATAL({mon_dut_item.ack, mon_dut_item.nack}, 2'b11)
       `uvm_info(`gfn, $sformatf("\nmonitor, detect HOST %s",
-          (mon_dut_item.ack) ? "ACK" : "NO_ACK"), UVM_DEBUG)
+          (mon_dut_item.ack) ? "ACK" : "NO_ACK"), UVM_HIGH)
       // if nack is issued, next bit must be stop or rstart
       if (mon_dut_item.nack) begin
         cfg.vif.wait_for_host_stop_or_rstart(cfg.timing_cfg,
@@ -139,7 +141,7 @@ class i2c_monitor extends dv_base_monitor #(
                                              mon_dut_item.stop);
         `DV_CHECK_NE_FATAL({mon_dut_item.rstart, mon_dut_item.stop}, 2'b11)
         `uvm_info(`gfn, $sformatf("\nmonitor, rd_data, detect HOST %s",
-            (mon_dut_item.stop) ? "STOP" : "RSTART"), UVM_DEBUG)
+            (mon_dut_item.stop) ? "STOP" : "RSTART"), UVM_HIGH)
       end
     end
   endtask : read_thread
@@ -154,6 +156,7 @@ class i2c_monitor extends dv_base_monitor #(
         begin : iso_fork_write
           fork
             begin
+               `uvm_info(`gfn, $sformatf("Req analysis port: write thread data"), UVM_HIGH)
               // ask driver's response a write request
               mon_dut_item.drv_type = WrData;
               `downcast(clone_item, mon_dut_item.clone());
@@ -161,10 +164,15 @@ class i2c_monitor extends dv_base_monitor #(
               for (int i = 7; i >= 0; i--) begin
                 cfg.vif.get_bit_data("host", cfg.timing_cfg, mon_data[i]);
               end
+              `uvm_info(`gfn, $sformatf("Monitor collected data %0x", mon_data), UVM_HIGH)
               mon_dut_item.num_data++;
               mon_dut_item.data_q.push_back(mon_data);
+
+              // send device ack to host write
+              mon_dut_item.wdata = mon_data;
               mon_dut_item.drv_type = DevAck;
               `downcast(clone_item, mon_dut_item.clone());
+              `uvm_info(`gfn, $sformatf("Req analysis port: write thread ack"), UVM_HIGH)
               req_analysis_port.write(clone_item);
               cfg.vif.wait_for_device_ack(cfg.timing_cfg);
             end
@@ -174,7 +182,7 @@ class i2c_monitor extends dv_base_monitor #(
                                                    mon_dut_item.stop);
               `DV_CHECK_NE_FATAL({mon_dut_item.rstart, mon_dut_item.stop}, 2'b11)
               `uvm_info(`gfn, $sformatf("\nmonitor, wr_data, detect HOST %s %0b",
-                  (mon_dut_item.stop) ? "STOP" : "RSTART", mon_dut_item.stop), UVM_DEBUG)
+                  (mon_dut_item.stop) ? "STOP" : "RSTART", mon_dut_item.stop), UVM_HIGH)
             end
           join_any
           disable fork;
@@ -193,4 +201,3 @@ class i2c_monitor extends dv_base_monitor #(
   endtask : monitor_ready_to_end
 
 endclass : i2c_monitor
-

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_device_response_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_device_response_seq.sv
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class i2c_device_response_seq extends i2c_base_seq;
+  `uvm_object_utils(i2c_device_response_seq)
+  `uvm_object_new
+
+  REQ w_q[256][$];
+
+  protected virtual task get_dev_req(output REQ req);
+    fork
+      begin: isolation_thread
+        fork
+          begin
+            REQ item;
+            p_sequencer.req_analysis_fifo.get(item);
+            `downcast(req, item)
+          end
+          wait (stop);
+        join_any
+        #0;
+        disable fork;
+      end
+    join
+  endtask
+
+  task send_device_mode_txn();
+    // get seq for agent running in Device mode
+    fork
+      forever begin
+        REQ req;
+        get_dev_req(req);
+        if (req != null) begin
+          `uvm_info(`gfn, $sformatf("bus_op:%s drv_type:%s data_q:%p",req.bus_op.name,
+                                    req.drv_type.name, req.data_q), UVM_HIGH)
+          if (req.bus_op == BusOpWrite && req.drv_type == DevAck && req.data_q.size() > 0) begin
+            w_q[req.addr].push_back(req);
+          end else if (req.bus_op == BusOpRead && req.drv_type == RdData) begin
+            if (w_q[req.addr].size() == 0) begin
+              `uvm_fatal(`gfn, $sformatf("Read requested on empty Write queue"))
+            end else begin
+              rsp = w_q[req.addr].pop_front();
+              req.rdata = rsp.wdata;
+              req.cp_wdata = 1;
+            end
+          end
+          start_item(req);
+          finish_item(req);
+        end
+        if (stop) break;
+      end // forever begin
+      forever begin
+        @(negedge cfg.vif.rst_ni);
+        foreach (w_q[i]) begin
+          w_q[i].delete();
+        end
+      end
+    join
+  endtask // send_device_mode
+
+endclass // i2c_device_response_seq

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_seq_list.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_seq_list.sv
@@ -3,3 +3,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `include "i2c_base_seq.sv"
+`include "i2c_device_response_seq.sv"

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_i2c_tx_rx_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_i2c_tx_rx_vseq)
+
+  `uvm_object_new
+
+  // need to figure out is there a way to get this from the tb
+  int clock_period_nanos = 41;
+  int i2c_clock_period_nanos = 1000;
+  int rise_fall_nanos = 10;
+  int rise_cycles = ((rise_fall_nanos - 1) / clock_period_nanos) + 1;
+  int fall_cycles = ((rise_fall_nanos - 1) / clock_period_nanos) + 1;
+  int clock_period_cycles = ((i2c_clock_period_nanos - 1) / clock_period_nanos) + 1;
+  int half_period_cycles = ((i2c_clock_period_nanos/2 - 1) / clock_period_nanos) + 1;
+
+  virtual task cpu_init();
+    bit[7:0] clock_period_nanos_data[1] = {clock_period_nanos};
+    bit[7:0] rise_fall_nanos_data[1] = {rise_fall_nanos};
+    bit[7:0] i2c_clock_period_nanos_data[4] = {<<byte{i2c_clock_period_nanos}};
+
+    super.cpu_init();
+    // need to figure out a better way to calculate this based on tb clock frequency
+    sw_symbol_backdoor_overwrite("kClockPeriodNanos", clock_period_nanos_data);
+    sw_symbol_backdoor_overwrite("kI2cRiseFallNanos", rise_fall_nanos_data);
+    sw_symbol_backdoor_overwrite("kI2cClockPeriodNanos", i2c_clock_period_nanos_data);
+  endtask
+
+  virtual task body();
+    i2c_device_response_seq m_base_seq;
+    super.body();
+
+    // enable the monitor
+    cfg.m_i2c_agent_cfgs[0].en_monitor = 1'b1;
+    cfg.m_i2c_agent_cfgs[0].if_mode = Device;
+
+    `uvm_info(`gfn, $sformatf("Full period cycle: %d", clock_period_cycles), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("Half period cycle: %d", half_period_cycles), UVM_MEDIUM)
+
+    // tClockLow needs to be "slightly" shorter than the actual clock low period
+    cfg.m_i2c_agent_cfgs[0].timing_cfg.tClockLow = half_period_cycles - 1;
+
+    // tClockPulse needs to be "slightly" longer than the clock period.
+    cfg.m_i2c_agent_cfgs[0].timing_cfg.tClockPulse = half_period_cycles + 1;
+
+    i2c_device_autoresponder(m_base_seq);
+
+  endtask
+
+  virtual task i2c_device_autoresponder(i2c_device_response_seq seq = null);
+    if (seq == null) seq = i2c_device_response_seq::type_id::create("seq");
+    fork seq.start(p_sequencer.i2c_sequencer_hs[0]) join_none
+    #0;  // Ensure seq actually starts before subsequent code executes.
+  endtask
+
+endclass : chip_sw_i2c_tx_rx_vseq


### PR DESCRIPTION
This PR has following change.
1. Add a new sequence for #14714 
   When write transaction comes in to the agent, the agent store each write data per address fifo (lb_fifo) under sequencer.
   When read request comes in, this sequence creates a read data based on pre captured write data from lb_fifo.
2. Refactoring i2c_base_seq to reuse subset of code in a child sequence.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>