### PR TITLE
[test] Fix rom_e2e_bootstrap_enabled_not_requested

### DIFF
--- a/sw/device/silicon_creator/rom/data/rom_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_testplan.hjson
@@ -147,8 +147,7 @@
             - Reset the chip.
             - Verify that the chip outputs the expected `BFV`: `0142500d` over UART.
               - ROM will continously reset the chip and output the same `BFV`.
-            - Verify that the chip does not respond to `READ_STATUS` (`0x05`).
-              - The data on the CIPO line must be `0xff`.
+            - Verify that the chip does not respond to `READ_SFDP` (`0x5a`).
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2


### PR DESCRIPTION
This PR updates `rom_e2e_bootstrap_enabled_not_requested` (#14451) to use `READ_SFDP` instead of `READ_STATUS` to verify that the target is not in bootstrap mode.

CIPO line is in high-Z mode when CMD_INFO registers are not configured. Thus, we use `READ_STATUS` to avoid false negatives when bootstrap is not requested.

Signed-off-by: Alphan Ulusoy <alphan@google.com>