### PR TITLE
Fix common typos of "partition"

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_partition_walk_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_partition_walk_vseq.sv
@@ -21,7 +21,7 @@ class otp_ctrl_partition_walk_vseq extends otp_ctrl_base_vseq;
       // granularity of 64 bits
       if (is_secret(dai_addr) || is_digest(dai_addr)) begin
         if (addr % 2) continue;
-        // DAI access hw parition will throw an access error, thus it is not a valid operation.
+        // DAI access hw partition will throw an access error, thus it is not a valid operation.
         if (is_digest(dai_addr) && !is_sw_digest(dai_addr)) is_valid_dai_op = 0;
         dai_wr(dai_addr, dai_addr, dai_addr + 1);
         if (!is_digest(dai_addr)) dai_rd_check(dai_addr, dai_addr, dai_addr + 1);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -359,7 +359,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
   // LC state transition tasks
   // This function takes the token value from the four LC_CTRL token CSRs, then runs through
   // cshake128 to get a 768-bit XORed token output.
-  // The first 128 bits of the decoded token should match the OTP paritition's descrambled tokens
+  // The first 128 bits of the decoded token should match the OTP partition's descrambled tokens
   // value.
   virtual function bit [TokenWidthBit-1:0] dec_otp_token_from_lc_csrs(
       bit [7:0] token_in[TokenWidthByte]);

--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -57,7 +57,7 @@ typedef enum dif_otp_ctrl_partition {
   /**
    * Scrambled partition 0.
    *
-   * This paritition contains TEST lifecycle state unlock tokens.
+   * This partition contains TEST lifecycle state unlock tokens.
    */
   kDifOtpCtrlPartitionSecret0,
   /**
@@ -409,7 +409,7 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
  * access.
  *
  * Furthermore, `address` must be well-aligned: it must be four-byte aligned for
- * normal paritions and eight-byte-aligned for secret partitions. An error is
+ * normal partitions and eight-byte-aligned for secret partitions. An error is
  * returned for unaligned access.
  *
  * @param otp An OTP handle.

--- a/sw/device/tests/sim_dv/lc_ctrl_kmac_reset_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_kmac_reset_test.c
@@ -32,7 +32,7 @@ OTTF_DEFINE_TEST_CONFIG();
  * Tests the kmac reset won't affect LC state transition.
  *
  * 1) OTP pre-load image with lc_count = `8`.
- * 2) Backdoor write OTP's LC parition to `TestUnlocked1` state, and backdoor
+ * 2) Backdoor write OTP's LC partition to `TestUnlocked1` state, and backdoor
  * write OTP's `test_exit` token and `test_unlock` token to match the rand
  * patterns.
  * 3) Write a wrong KMAC exit token and trigger a LC state transition request

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
@@ -43,7 +43,7 @@ static volatile const uint8_t kLcExitToken[LC_TOKEN_SIZE] = {
  * Tests the state transition request handshake between LC_CTRL and OTP_CTRL.
  *
  * 1). OTP pre-load image with lc_count = `8`.
- * 2). Backdoor write OTP's LC parition to `TestLocked1` state, and backdoor
+ * 2). Backdoor write OTP's LC partition to `TestLocked1` state, and backdoor
  * write OTP's `test_exit` token and `test_unlock` token to match the rand
  * patterns.
  * 3). `TestLocked1` state disabled CPU, so external testbench will drive JTAG

--- a/sw/host/opentitanlib/src/otp/otp_mmap.rs
+++ b/sw/host/opentitanlib/src/otp/otp_mmap.rs
@@ -153,7 +153,7 @@ impl OtpMap {
             );
 
             // Fetch the img definition for partition, this contains the associated values for
-            // paritition items.
+            // partition items.
             let mut img_partition = img.get_partition(&partition.name);
 
             let mut offset = 0usize;

--- a/sw/host/opentitanlib/src/otp/vmem_serialize.rs
+++ b/sw/host/opentitanlib/src/otp/vmem_serialize.rs
@@ -75,8 +75,8 @@ pub struct VmemPartition {
     digest_type: DigestType,
     /// Partition size.
     size: usize,
-    /// The key name for this parition.
-    /// If specified, the serializer will attempt to scramble this parition using the key named in
+    /// The key name for this partition.
+    /// If specified, the serializer will attempt to scramble this partition using the key named in
     /// this field.
     key_name: Option<String>,
 }

--- a/util/design/lib/OtpMemMap.py
+++ b/util/design/lib/OtpMemMap.py
@@ -295,7 +295,7 @@ def _validate_mmap(config):
                                 check_int(part["size"]) - DIGEST_SIZE)
             if offset > canonical_offset:
                 raise RuntimeError(
-                    "Not enough space in partitition "
+                    "Not enough space in partition "
                     "{} to accommodate a digest. Bytes available "
                     "= {}, bytes allocated to items = {}".format(
                         part["name"], part["size"], offset - part["offset"]))
@@ -307,7 +307,7 @@ def _validate_mmap(config):
 
         # check offsets and size
         if offset > check_int(part["offset"]) + check_int(part["size"]):
-            raise RuntimeError("Not enough space in partitition "
+            raise RuntimeError("Not enough space in partition "
                                "{} to accommodate all items. Bytes available "
                                "= {}, bytes allocated to items = {}".format(
                                    part["name"], part["size"],


### PR DESCRIPTION
I ran the following commands to make these changes:

    git sed paritition partition
    git sed Paritition Partition
    git sed parition partition
    git sed partitition partition
