### PR TITLE
[top/sw] Add i2c_host_tx_rx test

### DIFF
--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -18,10 +18,6 @@
  * As usual, a divisor of 0 is still Undefined Behavior.
  */
 static uint16_t round_up_divide(uint32_t a, uint32_t b) {
-  if (a == 0) {
-    return 0;
-  }
-
   return ((a - 1) / b) + 1;
 }
 
@@ -45,7 +41,7 @@ static dif_i2c_config_t default_timing_for_speed(dif_i2c_speed_t speed,
               round_up_divide(4700, clock_period_nanos),
           .start_signal_hold_cycles = round_up_divide(4000, clock_period_nanos),
           .data_signal_setup_cycles = round_up_divide(250, clock_period_nanos),
-          .data_signal_hold_cycles = 0,
+          .data_signal_hold_cycles = 1,
           .stop_signal_setup_cycles = round_up_divide(4000, clock_period_nanos),
           .stop_signal_hold_cycles = round_up_divide(4700, clock_period_nanos),
       };
@@ -56,7 +52,7 @@ static dif_i2c_config_t default_timing_for_speed(dif_i2c_speed_t speed,
           .start_signal_setup_cycles = round_up_divide(600, clock_period_nanos),
           .start_signal_hold_cycles = round_up_divide(600, clock_period_nanos),
           .data_signal_setup_cycles = round_up_divide(100, clock_period_nanos),
-          .data_signal_hold_cycles = 0,
+          .data_signal_hold_cycles = 1,
           .stop_signal_setup_cycles = round_up_divide(600, clock_period_nanos),
           .stop_signal_hold_cycles = round_up_divide(1300, clock_period_nanos),
       };
@@ -67,7 +63,7 @@ static dif_i2c_config_t default_timing_for_speed(dif_i2c_speed_t speed,
           .start_signal_setup_cycles = round_up_divide(260, clock_period_nanos),
           .start_signal_hold_cycles = round_up_divide(260, clock_period_nanos),
           .data_signal_setup_cycles = round_up_divide(50, clock_period_nanos),
-          .data_signal_hold_cycles = 0,
+          .data_signal_hold_cycles = 1,
           .stop_signal_setup_cycles = round_up_divide(260, clock_period_nanos),
           .stop_signal_hold_cycles = round_up_divide(500, clock_period_nanos),
       };
@@ -377,7 +373,7 @@ dif_result_t dif_i2c_write_byte_raw(const dif_i2c_t *i2c, uint8_t byte,
   }
   // Validate that "write only" flags and "read only" flags are not set
   // simultaneously.
-  bool has_write_flags = flags.start || flags.stop || flags.suppress_nak_irq;
+  bool has_write_flags = flags.start || flags.suppress_nak_irq;
   bool has_read_flags = flags.read || flags.read_cont;
   if (has_write_flags && has_read_flags) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_i2c_unittest.cc
+++ b/sw/device/lib/dif/dif_i2c_unittest.cc
@@ -88,7 +88,7 @@ TEST(ComputeTimingTest, StandardSpeed) {
       .start_signal_setup_cycles = 53,
       .start_signal_hold_cycles = 45,
       .data_signal_setup_cycles = 3,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 45,
       .stop_signal_hold_cycles = 53,
   };
@@ -105,7 +105,7 @@ TEST(ComputeTimingTest, StandardSpeed) {
       .start_signal_setup_cycles = 235,
       .start_signal_hold_cycles = 200,
       .data_signal_setup_cycles = 13,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 200,
       .stop_signal_hold_cycles = 235,
   };
@@ -123,7 +123,7 @@ TEST(ComputeTimingTest, StandardSpeed) {
       .start_signal_setup_cycles = 53,
       .start_signal_hold_cycles = 45,
       .data_signal_setup_cycles = 3,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 45,
       .stop_signal_hold_cycles = 53,
   };
@@ -145,7 +145,7 @@ TEST(ComputeTimingTest, FastSpeed) {
       .start_signal_setup_cycles = 7,
       .start_signal_hold_cycles = 7,
       .data_signal_setup_cycles = 2,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 7,
       .stop_signal_hold_cycles = 15,
   };
@@ -162,7 +162,7 @@ TEST(ComputeTimingTest, FastSpeed) {
       .start_signal_setup_cycles = 30,
       .start_signal_hold_cycles = 30,
       .data_signal_setup_cycles = 5,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 30,
       .stop_signal_hold_cycles = 65,
   };
@@ -180,7 +180,7 @@ TEST(ComputeTimingTest, FastSpeed) {
       .start_signal_setup_cycles = 7,
       .start_signal_hold_cycles = 7,
       .data_signal_setup_cycles = 2,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 7,
       .stop_signal_hold_cycles = 15,
   };
@@ -202,7 +202,7 @@ TEST(ComputeTimingTest, FastPlusSpeed) {
       .start_signal_setup_cycles = 13,
       .start_signal_hold_cycles = 13,
       .data_signal_setup_cycles = 3,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 13,
       .stop_signal_hold_cycles = 25,
   };
@@ -220,7 +220,7 @@ TEST(ComputeTimingTest, FastPlusSpeed) {
       .start_signal_setup_cycles = 13,
       .start_signal_hold_cycles = 13,
       .data_signal_setup_cycles = 3,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 13,
       .stop_signal_hold_cycles = 25,
   };
@@ -243,7 +243,7 @@ TEST_F(ConfigTest, NormalInit) {
       .start_signal_setup_cycles = 235,
       .start_signal_hold_cycles = 200,
       .data_signal_setup_cycles = 13,
-      .data_signal_hold_cycles = 0,
+      .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 200,
       .stop_signal_hold_cycles = 235,
   };
@@ -550,8 +550,8 @@ TEST_F(FifoTest, WriteRawBadArgs) {
   EXPECT_DIF_BADARG(dif_i2c_write_byte_raw(nullptr, 0xff, {}));
   EXPECT_DIF_BADARG(dif_i2c_write_byte_raw(&i2c_, 0xff,
                                            {
-                                               .start = false,
-                                               .stop = true,
+                                               .start = true,
+                                               .stop = false,
                                                .read = true,
                                            }));
   EXPECT_DIF_BADARG(dif_i2c_write_byte_raw(&i2c_, 0xff,

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -148,6 +148,19 @@ cc_library(
 )
 
 cc_library(
+    name = "i2c_testutils",
+    srcs = ["i2c_testutils.c"],
+    hdrs = ["i2c_testutils.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/ip/i2c/data:i2c_regs",
+        "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/testing/test_framework:check",
+    ],
+)
+
+cc_library(
     name = "keymgr_testutils",
     srcs = ["keymgr_testutils.c"],
     hdrs = ["keymgr_testutils.h"],

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -1,0 +1,73 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/i2c_testutils.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_i2c.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+
+#include "i2c_regs.h"  // Generated.
+
+static const uint8_t kI2cWrite = 0;
+static const uint8_t kI2cRead = 1;
+
+// Default flags for i2c operations.
+static const dif_i2c_fmt_flags_t kDefaultFlags = {.start = false,
+                                                  .stop = false,
+                                                  .read = false,
+                                                  .read_cont = false,
+                                                  .suppress_nak_irq = false};
+
+void i2c_testutils_wr(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count,
+                      uint8_t *data, bool skip_stop) {
+  dif_i2c_fmt_flags_t flags = kDefaultFlags;
+  uint8_t data_frame;
+
+  // TODO: The current function does not support write payloads
+  // larger than the fifo depth.
+  CHECK(byte_count < I2C_PARAM_FIFO_DEPTH);
+
+  // First write the address.
+  flags.start = true;
+  data_frame = (addr << 1) | kI2cWrite;
+  CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, data_frame, flags));
+
+  // Once address phase is through, blast the rest as generic data.
+  flags = kDefaultFlags;
+  for (uint8_t i = 0; i < byte_count; ++i) {
+    // Issue a stop for the last byte.
+    flags.stop = ((i == byte_count - 1) && !skip_stop);
+    CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, data[i], flags));
+  }
+
+  // TODO: Check for errors / status.
+}
+
+void i2c_testutils_rd(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count) {
+  dif_i2c_fmt_flags_t flags = kDefaultFlags;
+  uint8_t data_frame;
+  uint8_t fifo_level;
+
+  // First write the address.
+  flags.start = true;
+  data_frame = (addr << 1) | kI2cRead;
+  CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, data_frame, flags));
+
+  // Once address phase is through, issue the read transaction.
+  flags = kDefaultFlags;
+  flags.read = true;
+  flags.stop = true;
+
+  // Inform the controller how many bytes to read overall.
+  CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, byte_count, flags));
+
+  // TODO: Check for errors / status.
+}

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_I2C_TESTUTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_I2C_TESTUTILS_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/dif/dif_i2c.h"
+
+/**
+ * Construct an i2c write.
+ *
+ * @param i2c A i2c dif handle.
+ * @param addr The device address for the transaction.
+ * @param byte_count The number of bytes to be written.
+ * @param data Stream of data bytes to be written.
+ * @param skip_stop Skip the stop bit as this may be chained with a read.
+ */
+void i2c_testutils_wr(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count,
+                      uint8_t *data, bool skip_stop);
+
+/**
+ * Construct an i2c read
+ *
+ * @param i2c A i2c dif handle.
+ * @param addr The device address for the transaction.
+ * @param byte_count The number of bytes to be read.
+ */
+void i2c_testutils_rd(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_I2C_TESTUTILS_H_

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -28,6 +28,28 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "i2c_host_tx_rx_test",
+    srcs = ["i2c_host_tx_rx_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
+        "//hw/top_earlgrey/ip/clkmgr/data/autogen:clkmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:i2c_testutils",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "flash_ctrl_lc_rw_en_test",
     srcs = ["flash_ctrl_lc_rw_en_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
@@ -1,0 +1,204 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_i2c.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/i2c_testutils.h"
+#include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
+
+// TODO, remove it once pinout configuration is provided
+#include "pinmux_regs.h"
+
+static dif_i2c_t i2c;
+static dif_pinmux_t pinmux;
+static dif_rv_plic_t plic;
+
+static const dif_i2c_fmt_flags_t default_flags = {.start = false,
+                                                  .stop = false,
+                                                  .read = false,
+                                                  .read_cont = false,
+                                                  .suppress_nak_irq = false};
+
+OTTF_DEFINE_TEST_CONFIG();
+
+/**
+ * This symbol is meant to be backdoor loaded by the testbench.
+ * The testbench will inform the test the rough speed of the clock
+ * used by the I2C modules.
+ */
+static volatile const uint8_t kClockPeriodNanos = 0;
+static volatile const uint8_t kI2cRiseFallNanos = 0;
+static volatile const uint32_t kI2cClockPeriodNanos = 0;
+
+/**
+ * This symbol is meant to be backdoor loaded by the testbench.
+ * to indicate which I2c is actually under test. It is not used
+ * at the moment, will connect it later.
+ */
+static volatile const uint8_t kI2cIdx = 0;
+
+/**
+ * Provides external irq handling for this test.
+ *
+ * This function overrides the default OTTF external ISR.
+ */
+static volatile bool fmt_irq_seen = false;
+static volatile bool rx_irq_seen = false;
+static volatile bool done_irq_seen = false;
+
+void ottf_external_isr(void) {
+  plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
+                             .hart_id = kTopEarlgreyPlicTargetIbex0};
+
+  i2c_isr_ctx_t i2c_ctx = {
+      .i2c = &i2c,
+      .plic_i2c_start_irq_id = kTopEarlgreyPlicIrqIdI2c0FmtWatermark,
+      .expected_irq = 0,
+      .is_only_irq = false};
+
+  top_earlgrey_plic_peripheral_t peripheral;
+  dif_i2c_irq_t i2c_irq;
+  isr_testutils_i2c_isr(plic_ctx, i2c_ctx, &peripheral, &i2c_irq);
+
+  switch (i2c_irq) {
+    case kDifI2cIrqFmtWatermark:
+      fmt_irq_seen = true;
+      i2c_irq = kDifI2cIrqFmtWatermark;
+      break;
+    case kDifI2cIrqRxWatermark:
+      rx_irq_seen = true;
+      i2c_irq = kDifI2cIrqRxWatermark;
+      break;
+    case kDifI2cIrqTransComplete:
+      done_irq_seen = true;
+      i2c_irq = kDifI2cIrqTransComplete;
+      break;
+    default:
+      LOG_ERROR("Unexpected interrupt (at I2C): %d", i2c_irq);
+      break;
+  }
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(
+      dif_i2c_init(mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR), &i2c));
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
+
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      &plic, kTopEarlgreyPlicIrqIdI2c0FmtWatermark, kTopEarlgreyPlicTargetIbex0,
+      kDifToggleEnabled));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      &plic, kTopEarlgreyPlicIrqIdI2c0RxWatermark, kTopEarlgreyPlicTargetIbex0,
+      kDifToggleEnabled));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      &plic, kTopEarlgreyPlicIrqIdI2c0TransComplete,
+      kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      &plic, kTopEarlgreyPlicIrqIdI2c0FmtWatermark, 0x1));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      &plic, kTopEarlgreyPlicIrqIdI2c0RxWatermark, 0x1));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      &plic, kTopEarlgreyPlicIrqIdI2c0TransComplete, 0x1));
+
+  // Enable the external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  // Temporary hack that connects i2c to a couple of open drain pins.
+  CHECK_DIF_OK(dif_pinmux_input_select(&pinmux,
+                                       kTopEarlgreyPinmuxPeripheralInI2c0Scl,
+                                       kTopEarlgreyPinmuxInselIob11));
+  CHECK_DIF_OK(dif_pinmux_input_select(&pinmux,
+                                       kTopEarlgreyPinmuxPeripheralInI2c0Sda,
+                                       kTopEarlgreyPinmuxInselIob12));
+  CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIob11,
+                                        kTopEarlgreyPinmuxOutselI2c0Scl));
+  CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIob12,
+                                        kTopEarlgreyPinmuxOutselI2c0Sda));
+
+  // I2C speed parameters.
+  dif_i2c_timing_config_t timing_config = {
+      .lowest_target_device_speed = kDifI2cSpeedFastPlus,
+      .clock_period_nanos = kClockPeriodNanos,
+      .sda_rise_nanos = kI2cRiseFallNanos,
+      .sda_fall_nanos = kI2cRiseFallNanos,
+      .scl_period_nanos = kI2cClockPeriodNanos};
+
+  dif_i2c_config_t config;
+  CHECK_DIF_OK(dif_i2c_compute_timing(timing_config, &config));
+  CHECK_DIF_OK(dif_i2c_configure(&i2c, config));
+  CHECK_DIF_OK(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_i2c_set_watermarks(&i2c, kDifI2cLevel30Byte, kDifI2cLevel4Byte));
+  CHECK_DIF_OK(
+      dif_i2c_irq_set_enabled(&i2c, kDifI2cIrqFmtWatermark, kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_i2c_irq_set_enabled(&i2c, kDifI2cIrqRxWatermark, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_i2c_irq_set_enabled(&i2c, kDifI2cIrqTransComplete,
+                                       kDifToggleEnabled));
+
+  // Randomize variables.
+  uint8_t byte_count = rand_testutils_gen32_range(1, 64);
+  uint8_t device_addr = rand_testutils_gen32_range(0, 16);
+  uint8_t expected_data[byte_count];
+  LOG_INFO("Loopback %d bytes with device %d", byte_count, device_addr);
+
+  // Controlling the randomization from C side is a bit slow, but might be
+  // easier for portability to a different setup later.
+  for (uint32_t i = 0; i < byte_count; ++i) {
+    expected_data[i] = rand_testutils_gen32_range(0, 0xff);
+  };
+
+  // Write expected data to i2c device.
+  CHECK(!fmt_irq_seen);
+  i2c_testutils_wr(&i2c, device_addr, byte_count, expected_data, false);
+
+  uint8_t tx_fifo_lvl, rx_fifo_lvl;
+
+  // Make sure all fifo entries have been drained.
+  do {
+    CHECK_DIF_OK(dif_i2c_get_fifo_levels(&i2c, &tx_fifo_lvl, &rx_fifo_lvl));
+  } while (tx_fifo_lvl > 0);
+  CHECK(fmt_irq_seen);
+  fmt_irq_seen = false;
+
+  // Read data from i2c device.
+  CHECK(!rx_irq_seen);
+  i2c_testutils_rd(&i2c, device_addr, byte_count);
+
+  // Make sure all data has been read back.
+  do {
+    CHECK_DIF_OK(dif_i2c_get_fifo_levels(&i2c, &tx_fifo_lvl, &rx_fifo_lvl));
+  } while (rx_fifo_lvl < byte_count);
+  CHECK(rx_irq_seen);
+
+  // Make sure every read is the same.
+  for (uint32_t i = 0; i < byte_count; ++i) {
+    uint8_t byte;
+    CHECK_DIF_OK(dif_i2c_read_byte(&i2c, &byte));
+    if (expected_data[i] != byte) {
+      LOG_ERROR("Byte %d, Expected data 0x%x, read data 0x%x", i,
+                expected_data[i], byte);
+    }
+  };
+  CHECK(done_irq_seen);
+
+  return true;
+}


### PR DESCRIPTION
- The test sends a random number of bytes to the tb i2c agent, which then loops the data back to the host for comparison.
- The host (DUT C test) then is responsible for making sure what was sent out was read back correctly.

- This test contains only the C side changes, the tb/uvm changes that were done previously are deprecated due to bad uvm style.

Signed-off-by: Timothy Chen <timothytim@google.com>

address some comments

Signed-off-by: Timothy Chen <timothytim@google.com>