### PR TITLE
[dif/entropy_src] FW_OV_WR_FIFO Management

### DIFF
--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -643,11 +643,13 @@ dif_result_t dif_entropy_src_observe_fifo_blocking_read(
  * @param entropy_src An entropy source handle.
  * @param buf A buffer to push words from into the pipeline.
  * @param len The number of words to write from `buf`.
+ * @param[out] written The number of words successfully written.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_entropy_src_observe_fifo_write(
-    const dif_entropy_src_t *entropy_src, const uint32_t *buf, size_t len);
+    const dif_entropy_src_t *entropy_src, const uint32_t *buf, size_t len,
+    size_t *written);
 
 /**
  * Starts conditioner operation.

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -561,10 +561,12 @@ class ObserveFifoWriteTest : public EntropySrcTest {};
 
 TEST_F(ObserveFifoWriteTest, NullArgs) {
   uint32_t buf[8] = {0};
-  EXPECT_DIF_BADARG(dif_entropy_src_observe_fifo_write(nullptr, buf, 8));
   EXPECT_DIF_BADARG(
-      dif_entropy_src_observe_fifo_write(&entropy_src_, nullptr, 8));
-  EXPECT_DIF_BADARG(dif_entropy_src_observe_fifo_write(nullptr, nullptr, 8));
+      dif_entropy_src_observe_fifo_write(nullptr, buf, 8, nullptr));
+  EXPECT_DIF_BADARG(
+      dif_entropy_src_observe_fifo_write(&entropy_src_, nullptr, 8, nullptr));
+  EXPECT_DIF_BADARG(
+      dif_entropy_src_observe_fifo_write(nullptr, nullptr, 8, nullptr));
 }
 
 TEST_F(ObserveFifoWriteTest, BadConfig) {
@@ -576,7 +578,7 @@ TEST_F(ObserveFifoWriteTest, BadConfig) {
       {{ENTROPY_SRC_FW_OV_CONTROL_FW_OV_ENTROPY_INSERT_OFFSET,
         kMultiBitBool4False},
        {ENTROPY_SRC_FW_OV_CONTROL_FW_OV_MODE_OFFSET, kMultiBitBool4False}});
-  EXPECT_EQ(dif_entropy_src_observe_fifo_write(&entropy_src_, buf, 8),
+  EXPECT_EQ(dif_entropy_src_observe_fifo_write(&entropy_src_, buf, 8, nullptr),
             kDifError);
 
   // Entropy insert mode not set.
@@ -585,34 +587,39 @@ TEST_F(ObserveFifoWriteTest, BadConfig) {
       {{ENTROPY_SRC_FW_OV_CONTROL_FW_OV_ENTROPY_INSERT_OFFSET,
         kMultiBitBool4False},
        {ENTROPY_SRC_FW_OV_CONTROL_FW_OV_MODE_OFFSET, kMultiBitBool4True}});
-  EXPECT_EQ(dif_entropy_src_observe_fifo_write(&entropy_src_, buf, 8),
+  EXPECT_EQ(dif_entropy_src_observe_fifo_write(&entropy_src_, buf, 8, nullptr),
             kDifError);
 }
 
 TEST_F(ObserveFifoWriteTest, FifoFull) {
   uint32_t buf[4];
+  size_t written = -1;
   EXPECT_READ32(
       ENTROPY_SRC_FW_OV_CONTROL_REG_OFFSET,
       {{ENTROPY_SRC_FW_OV_CONTROL_FW_OV_ENTROPY_INSERT_OFFSET,
         kMultiBitBool4True},
        {ENTROPY_SRC_FW_OV_CONTROL_FW_OV_MODE_OFFSET, kMultiBitBool4True}});
   EXPECT_READ32(ENTROPY_SRC_FW_OV_WR_FIFO_FULL_REG_OFFSET, 1);
-  EXPECT_EQ(dif_entropy_src_observe_fifo_write(&entropy_src_, buf, 4),
+  EXPECT_EQ(dif_entropy_src_observe_fifo_write(&entropy_src_, buf, 4, &written),
             kDifIpFifoFull);
+  EXPECT_EQ(written, 0);
 }
 
 TEST_F(ObserveFifoWriteTest, Success) {
   uint32_t buf[4] = {1, 2, 3, 4};
+  size_t written = -1;
   EXPECT_READ32(
       ENTROPY_SRC_FW_OV_CONTROL_REG_OFFSET,
       {{ENTROPY_SRC_FW_OV_CONTROL_FW_OV_ENTROPY_INSERT_OFFSET,
         kMultiBitBool4True},
        {ENTROPY_SRC_FW_OV_CONTROL_FW_OV_MODE_OFFSET, kMultiBitBool4True}});
-  EXPECT_READ32(ENTROPY_SRC_FW_OV_WR_FIFO_FULL_REG_OFFSET, 0);
   for (size_t i = 0; i < 4; ++i) {
+    EXPECT_READ32(ENTROPY_SRC_FW_OV_WR_FIFO_FULL_REG_OFFSET, 0);
     EXPECT_WRITE32(ENTROPY_SRC_FW_OV_WR_DATA_REG_OFFSET, i + 1);
   }
-  EXPECT_DIF_OK(dif_entropy_src_observe_fifo_write(&entropy_src_, buf, 4));
+  EXPECT_DIF_OK(
+      dif_entropy_src_observe_fifo_write(&entropy_src_, buf, 4, &written));
+  EXPECT_EQ(written, 4);
 }
 
 class ConditionerStartTest : public EntropySrcTest {};
@@ -639,6 +646,7 @@ TEST_F(ConditionerStopTest, NullHandle) {
 }
 
 TEST_F(ConditionerStopTest, Success) {
+  EXPECT_READ32(ENTROPY_SRC_FW_OV_WR_FIFO_FULL_REG_OFFSET, 0);
   EXPECT_WRITE32(ENTROPY_SRC_FW_OV_SHA3_START_REG_OFFSET, kMultiBitBool4False);
   EXPECT_DIF_OK(dif_entropy_src_conditioner_stop(&entropy_src_));
 }

--- a/sw/device/tests/entropy_src_fw_ovr_test.c
+++ b/sw/device/tests/entropy_src_fw_ovr_test.c
@@ -101,8 +101,8 @@ void test_firmware_override(dif_entropy_src_t *entropy) {
     for (size_t i = 0; i < kEntropyFifoBufferSize; ++i) {
       CHECK(buf[i] != 0);
     }
-    CHECK_DIF_OK(dif_entropy_src_observe_fifo_write(entropy, buf,
-                                                    kEntropyFifoBufferSize));
+    CHECK_DIF_OK(dif_entropy_src_observe_fifo_write(
+        entropy, buf, kEntropyFifoBufferSize, NULL));
     word_count += kEntropyFifoBufferSize;
   } while (dif_entropy_src_is_entropy_available(entropy) == kDifUnavailable);
   LOG_INFO("Processed %d words via FIFO_OVR buffer.", word_count);

--- a/sw/device/tests/entropy_src_kat_test.c
+++ b/sw/device/tests/entropy_src_kat_test.c
@@ -12,6 +12,8 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
 
+#define KAT_TEST_TIMEOUT_ATTEMPTS 256
+
 OTTF_DEFINE_TEST_CONFIG();
 
 enum {
@@ -51,6 +53,49 @@ static void entropy_with_fw_override_enable(dif_entropy_src_t *entropy_src) {
 }
 
 /**
+ * Cleanly disables the SHA3 conditioner while in SHA3 mode, prompting
+ * the release of a conditioned seed.
+ *
+ * If stopping the conditioner fails, due to pending data keep trying for
+ * at most KAT_TEST_TIMEOUT_ATTEMPTS.
+ *
+ * @param entropy An entropy source instance.
+ */
+
+static void stop_sha3_conditioner(dif_entropy_src_t *entropy_src) {
+  uint32_t fail_count = 0;
+  dif_result_t op_result;
+
+  do {
+    op_result = dif_entropy_src_conditioner_stop(entropy_src);
+    if (op_result == kDifIpFifoFull) {
+      fail_count++;
+      CHECK(fail_count < KAT_TEST_TIMEOUT_ATTEMPTS);
+    } else {
+      CHECK_DIF_OK(op_result);
+    }
+  } while (op_result == kDifIpFifoFull);
+}
+
+/**
+ * Flushes any previously absorbed entropy from the SHA3 conditioning block.
+ *
+ * @param entropy An entropy source instance.
+ */
+
+static void flush_sha3_conditioner(dif_entropy_src_t *entropy_src) {
+  // Start and stop the conditioner, without adding any new entropy.
+  CHECK_DIF_OK(dif_entropy_src_conditioner_start(entropy_src));
+  stop_sha3_conditioner(entropy_src);
+
+  // Read (and discard) the resulting seed.
+  uint32_t got[kEntropyFifoBufferSize];
+  for (size_t i = 0; i < ARRAYSIZE(got); ++i) {
+    CHECK_DIF_OK(dif_entropy_src_non_blocking_read(entropy_src, &got[i]));
+  }
+}
+
+/**
  * Runs known answer test for the entropy_src SHA-3 conditioner.
  *
  * This test uses the following SHA3 CAVP test vector:
@@ -61,29 +106,55 @@ static void entropy_with_fw_override_enable(dif_entropy_src_t *entropy_src) {
  * See:
  * https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/secure-hashing
  */
-void test_sha384_kat(dif_entropy_src_t *entropy) {
-  CHECK_DIF_OK(dif_entropy_src_set_enabled(entropy, kDifToggleDisabled));
-  entropy_with_fw_override_enable(entropy);
-  CHECK_DIF_OK(dif_entropy_src_conditioner_start(entropy));
+
+void test_sha384_kat(dif_entropy_src_t *entropy_src) {
+  CHECK_DIF_OK(dif_entropy_src_set_enabled(entropy_src, kDifToggleDisabled));
+  entropy_with_fw_override_enable(entropy_src);
+
+  // Though most of the entropy_src state is cleared on disable, the
+  // SHA3 conditioner accumulates entropy even from aborted seeds. For
+  // the KAT though, we must clear any previously absorbed entropy.
+  flush_sha3_conditioner(entropy_src);
 
   const uint32_t kInputMsg[kEntropyFifoBufferSize] = {
       0xa52a0da9, 0xcae141b2, 0x6d5bab9d, 0x2c3e5cc0, 0x225afc93, 0x5d31a610,
       0x91b7f960, 0x0d566bb3, 0xef35e170, 0x94ba7d8e, 0x534eb741, 0x6b60b0da,
   };
-  CHECK_DIF_OK(dif_entropy_src_observe_fifo_write(entropy, kInputMsg,
-                                                  ARRAYSIZE(kInputMsg)));
 
-  CHECK_DIF_OK(dif_entropy_src_conditioner_stop(entropy));
+  CHECK_DIF_OK(dif_entropy_src_conditioner_start(entropy_src));
+
+  dif_result_t op_result;
+  uint32_t fail_count = 0;
+  uint32_t count;
+  uint32_t total = 0;
+
+  // Load the input data.
+  do {
+    op_result = dif_entropy_src_observe_fifo_write(
+        entropy_src, kInputMsg + total, ARRAYSIZE(kInputMsg) - total, &count);
+    total += count;
+    if (op_result == kDifIpFifoFull) {
+      fail_count++;
+      CHECK(fail_count < KAT_TEST_TIMEOUT_ATTEMPTS);
+    } else {
+      fail_count = 0;
+      CHECK_DIF_OK(op_result);
+    }
+  } while (total < ARRAYSIZE(kInputMsg));
+
+  // Cleanly disable the conditioner.
+  stop_sha3_conditioner(entropy_src);
 
   uint32_t got[kEntropyFifoBufferSize];
   for (size_t i = 0; i < ARRAYSIZE(got); ++i) {
-    CHECK_DIF_OK(dif_entropy_src_non_blocking_read(entropy, &got[i]));
+    CHECK_DIF_OK(dif_entropy_src_non_blocking_read(entropy_src, &got[i]));
   }
 
   const uint32_t kExpectedDigest[kEntropyFifoBufferSize] = {
       0x1c88164a, 0x5ff456e1, 0x0845dbdf, 0xbe233f8e, 0x7a5a4c1b, 0x5d31356a,
       0x751cc536, 0x337375f2, 0x85a1ac19, 0x1333abd4, 0xf745fe0f, 0xc5bbf151,
   };
+
   CHECK_ARRAYS_EQ(got, kExpectedDigest, kEntropyFifoBufferSize,
                   "Unexpected digest value.");
 }

--- a/sw/device/tests/sim_dv/entropy_src_fuse_en_fw_read_test.c
+++ b/sw/device/tests/sim_dv/entropy_src_fuse_en_fw_read_test.c
@@ -87,7 +87,7 @@ static void test_fuse_init(dif_entropy_src_t *entropy) {
       0x91b7f960, 0x0d566bb3, 0xef35e170, 0x94ba7d8e, 0x534eb741, 0x6b60b0da,
   };
   CHECK_DIF_OK(dif_entropy_src_observe_fifo_write(entropy, kInputMsg,
-                                                  ARRAYSIZE(kInputMsg)));
+                                                  ARRAYSIZE(kInputMsg), NULL));
 
   CHECK_DIF_OK(dif_entropy_src_conditioner_stop(entropy));
 }


### PR DESCRIPTION
The entropy_src FW_OV_WR_FIFO can become full after even a single write. It can also retain entropy that is still wainting at the input of the SHA3 conditioner.  Thus the FW_OV_WR_FIFO_FULL register should be checked before writing each word, and before disabling the conditioner.

This commit updates the DIF to make perform these checks more frequently.

The dif_entropy_src_observe_fifo_write function can now encounter a FIFO
full failure part-way through a write operation.   So an output
paramater has been added to return the number of words successfully
written before the FIFO was detected to be full.

Such FIFO full events are usually transient, but it is important to check for them, otherwise FW_OV data may be dropped.

All of the dependent tests have also been updated.

The KAT in particular has been updated to keep trying even if the test has failed, with an arbitrary 256 attempt timeout if the FW_OV FIFO is frequently full.

Finally, this commit also changes the entropy_src KAT to flush the SHA3 conditioner before loading the test data.  This accounts for the fact that the conditioner may have absorbed entropy in a previous test, which is especially likely to happen in the FPGA environment where many tests are run back to back without a reset.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>