### PR TITLE
[flash_ctrl,dv] mem bus integrity tests

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -80,6 +80,8 @@ filesets:
       - seq_lib/flash_ctrl_oversize_error_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_connect_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_disable_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_rd_path_intg_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_wr_path_intg_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -596,9 +596,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         if (overrd > 0) begin
           overread(flash_op, bank, num, overrd);
         end
-        wait_flash_op_done();
 
-       if (!in_err) wait_flash_op_done();
+        if (!in_err) wait_flash_op_done();
 
       end
       if (derr_is_set | cfg.ierr_created[0]) begin

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence sends read and write traffic with or without tlul memory
+// bus read path error injection.
+// Error response will be sent to tl_agent(flash_ctrl_eflash_reg_block)
+// with d_error=1.
+class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_rw_vseq;
+  `uvm_object_utils(flash_ctrl_rd_path_intg_vseq)
+  `uvm_object_new
+
+  task body();
+    string path1 = {"tb.dut.u_eflash.gen_flash_cores[0].u_core",
+                    ".u_rd.u_bus_intg.data_intg_o[38]"};
+    string path2 = {"tb.dut.u_eflash.gen_flash_cores[1].u_core",
+                    ".u_rd.u_bus_intg.data_intg_o[38]"};
+
+    `uvm_info(`gfn, "Assert read path err", UVM_LOW)
+    `DV_CHECK(uvm_hdl_force(path1, 1'b1))
+    `DV_CHECK(uvm_hdl_force(path2, 1'b1))
+    cfg.scb_h.exp_tl_rsp_intg_err = 1;
+
+    super.body();
+    `uvm_info(`gfn, "Wait until all drain", UVM_LOW)
+    cfg.clk_rst_vif.wait_clks(100);
+    `DV_CHECK(uvm_hdl_release(path1))
+    `DV_CHECK(uvm_hdl_release(path2))
+    `uvm_info(`gfn, "Normal traffic START", UVM_LOW)
+    cfg.scb_h.exp_tl_rsp_intg_err = 0;
+
+    super.body();
+  endtask
+
+endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -48,4 +48,6 @@
 `include "flash_ctrl_oversize_error_vseq.sv"
 `include "flash_ctrl_connect_vseq.sv"
 `include "flash_ctrl_disable_vseq.sv"
+`include "flash_ctrl_rd_path_intg_vseq.sv"
+`include "flash_ctrl_wr_path_intg_vseq.sv"
 `include "flash_ctrl_stress_all_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence sends write traffic with or without tlul memory
+// bus write path error injection.
+// This test will trigger fatal_std_err so clear fatal alert at the end of the test by reset.
+class flash_ctrl_wr_path_intg_vseq extends flash_ctrl_rw_vseq;
+  `uvm_object_utils(flash_ctrl_wr_path_intg_vseq)
+  `uvm_object_new
+
+  task body();
+    string path = "tb.dut.u_prog_fifo.wdata_i[38]";
+    `uvm_info(`gfn, "Assert write path err", UVM_LOW)
+    `DV_CHECK(uvm_hdl_force(path, 1'b1))
+     $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
+
+    // disable tl_rsp error check
+    cfg.m_tl_agent_cfg.check_tl_errs = 0;
+    fork
+      begin
+        repeat(cfg.otf_num_rw) begin
+          `DV_CHECK_RANDOMIZE_FATAL(this)
+          ctrl = rand_op;
+          bank = rand_op.addr[OTFBankId];
+          if (ctrl.partition == FlashPartData) begin
+            num = ctrl_num;
+          end else begin
+            num = ctrl_info_num;
+          end
+          randcase
+            cfg.otf_wr_pct: begin
+              uvm_reg_data_t ldata;
+              cfg.scb_h.exp_alert["fatal_std_err"] = 1;
+              cfg.scb_h.alert_chk_max_delay["fatal_std_err"] = 2000;
+              cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
+
+              prog_flash(ctrl, bank, 1, fractions, 1);
+              // Check std_fault.prog_intg_err,  err_code.prog_err
+              csr_rd_check(.ptr(ral.std_fault_status.prog_intg_err), .compare_value(1));
+              csr_rd_check(.ptr(ral.err_code.prog_err), .compare_value(1));
+              csr_rd_check(.ptr(ral.op_status.err), .compare_value(1));
+
+              ldata = get_csr_val_with_updated_field(ral.err_code.prog_err, ldata, 1);
+              csr_wr(.ptr(ral.err_code), .value(ldata));
+
+              ldata = get_csr_val_with_updated_field(ral.op_status.err, ldata, 0);
+              csr_wr(.ptr(ral.op_status), .value(ldata));
+            end
+            cfg.otf_rd_pct:read_flash(ctrl, bank, num, fractions);
+          endcase
+        end
+      end
+      begin
+        for (int i = 0; i < cfg.otf_num_hr; ++i) begin
+          fork
+            send_rand_host_rd();
+          join_none
+          #0;
+        end
+        csr_utils_pkg::wait_no_outstanding_access();
+      end
+    join
+
+    `uvm_info(`gfn, "Wait until all drain", UVM_LOW)
+    cfg.clk_rst_vif.wait_clks(100);
+    `DV_CHECK(uvm_hdl_release(path))
+    // disable tlul_err_cnt check
+    cfg.tlul_core_obs_cnt = cfg.tlul_core_exp_cnt;
+    flash_init_c.constraint_mode(0);
+    flash_init = FlashMemInitRandomize;
+    apply_reset();
+  endtask
+
+endclass

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -346,6 +346,18 @@
       uvm_test_seq: flash_ctrl_connect_vseq
       reseed: 5
     }
+    {
+      name: flash_ctrl_rd_intg
+      uvm_test_seq: flash_ctrl_rd_path_intg_vseq
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=50"]
+      reseed: 1
+    }
+    {
+      name: flash_ctrl_wr_intg
+      uvm_test_seq: flash_ctrl_wr_path_intg_vseq
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=0", "+otf_rd_pct=0"]
+      reseed: 1
+    }
   ]
 
   // List of regressions.

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -25,21 +25,35 @@
   testpoints: [
     {
       name: sec_cm_reg_bus_integrity
-      desc: "Verify the countermeasure(s) REG.BUS.INTEGRITY."
+      desc: '''Verify the countermeasure(s) REG.BUS.INTEGRITY.
+            This entry is covered by tl_access_test
+            (hw/dv/tools/dvsim/tests/tl_access_tests.hjson)
+            '''
       stage: V2S
-      tests: []
+      tests: ["flash_ctrl_tl_intg_err"]
     }
     {
       name: sec_cm_host_bus_integrity
-      desc: "Verify the countermeasure(s) HOST.BUS.INTEGRITY."
+      desc: '''Verify the countermeasure(s) HOST.BUS.INTEGRITY.
+            This entry is covered by tl_access_test
+            (hw/dv/tools/dvsim/tests/tl_access_tests.hjson)
+            '''
       stage: V2S
-      tests: []
+      tests: ["flash_ctrl_tl_intg_err"]
     }
     {
       name: sec_cm_mem_bus_integrity
-      desc: "Verify the countermeasure(s) MEM.BUS.INTEGRITY."
+      desc: '''Verify the countermeasure(s) MEM.BUS.INTEGRITY.
+            For read path, inject error to
+            tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd.u_bus_intg
+            tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd.u_bus_intg
+	    read data error will be detected by tl_agent in tb.
+            For write path, inject error to tb.dut.u_prog_fifo.wdata_i
+            This will trigger fatal_std_err (prog_intg_err) and
+            err_code.prog_err
+            '''
       stage: V2S
-      tests: []
+      tests: ["flash_ctrl_rd_intg", "flash_ctrl_wr_intg"]
     }
     {
       name: sec_cm_scramble_key_sideload


### PR DESCRIPTION
This PR adds two memory bus integrity error tests.
- flash_ctrl_rd_intg : Inject error on the read path (tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd)
- flash_ctrl_wr_intg : Inject error on the write path (tb.dut.u_prog_fifo)

Signed-off-by: Jaedon Kim <jdonjdon@google.com>