### PR TITLE
[docs] Fix OpenOCD/GDB instructions

### DIFF
--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -357,7 +357,7 @@ Then a connection between OpenOCD and GDB may be established with:
 ```console
 cd $REPO_TOP
 riscv32-unknown-elf-gdb -ex "target extended-remote :3333" -ex "info reg" \
-  $(find -L bazel-out/ -type f -name "uart_smoketest_sim_verilator | head -n 1")
+  $(find -L bazel-out/ -type f -name "uart_smoketest_prog_fpga_cw310.elf" | head -n 1)
 ```
 
 Note, the above will print out the contents of the registers upon successs.

--- a/doc/getting_started/setup_verilator.md
+++ b/doc/getting_started/setup_verilator.md
@@ -187,7 +187,7 @@ Lastly, connect GDB using the following command (noting it needs to be altered t
 ```console
 cd $REPO_TOP
 riscv32-unknown-elf-gdb -ex "target extended-remote :3333" -ex "info reg" \
-  $(find -L bazel-out/ -type f -name "uart_smoketest_sim_verilator | head -n 1")
+  $(find -L bazel-out/ -type f -name "uart_smoketest_prog_sim_verilator.elf" | head -n 1)
 ```
 
 ## SPI device test interface (optional)


### PR DESCRIPTION
The setup guide for GDB uses a broken `find` command, fix it.
