### PR TITLE
[bazel] Silence outquery's info + progress output

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -117,7 +117,9 @@ function main() {
             #   outquery.x: return output files ending with the substring ".x".
             QEXPR="$(outquery_starlark_expr "$1")"
             shift
-            exec "$file" cquery "$@" --output=starlark --starlark:expr="$QEXPR"
+            exec "$file" cquery "$@" \
+                --output=starlark --starlark:expr="$QEXPR" \
+                --ui_event_filters=-info --noshow_progress
             ;;
         *)
             exec "$file" "$@"


### PR DESCRIPTION
Prior to this commit, users would see unnecessary output when using `./bazelisk.sh outquery` as a subcommand.

Note that we are not suppressing error messages. For example, if outquery gets a nonexistent target, it will still print an error message.

Issue #14806

Signed-off-by: Dan McArdle <dmcardle@google.com>