### PR TITLE
[dv,top,jtag_mem] Fix chip_jtag_mem_access test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_mem_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_mem_vseq.sv
@@ -42,7 +42,7 @@ class chip_jtag_mem_vseq extends chip_common_vseq;
     test_mems.shuffle();
 
     for (int i = 0;i < test_mems.size(); ++i) begin
-      test_mem_rw(test_mems[i]);
+      test_mem_rw(.mem(test_mems[i]), .max_access(128));
     end
   endtask : body
 


### PR DESCRIPTION
This test occasionally times-out. Make it take a more predictable amount of time by explicitly setting the number of accesses, and randomizing the addresses.

Signed-off-by: Guillermo Maturana <maturana@google.com>