### PR TITLE
[doc] Replace `find` with `bazelisk.sh outquery`

### DIFF
--- a/doc/getting_started/build_sw.md
+++ b/doc/getting_started/build_sw.md
@@ -223,12 +223,20 @@ Note, the file will **not** have an extension.
 A disassembly of all executable sections is produced by the build system by default.
 It can be found by looking for files with the `.dis` extension next to the corresponding ELF file.
 
+```console
+./bazelisk.sh build //sw/device/tests:uart_smoketest_prog_sim_verilator_dis
+
+less "$(./bazelisk.sh outquery //sw/device/tests:uart_smoketest_prog_sim_verilator_dis)"
+```
+
 To get a different type of disassembly, e.g. one which includes data sections in addition to executable sections, objdump can be called manually.
 For example the following command shows how to disassemble all sections of the UART DIF smoke test interleaved with the actual source code:
 
 ```console
+./bazelisk.sh build --config=riscv32 //sw/device/tests:uart_smoketest_prog_sim_verilator.elf
+
 riscv32-unknown-elf-objdump --disassemble-all --headers --line-numbers --source \
-  $(find -L bazel-out/ -type f -name "uart_smoketest_prog_sim_verilator")
+  "$(./bazelisk.sh outquery --config=riscv32 //sw/device/tests:uart_smoketest_prog_sim_verilator.elf)"
 ```
 
 Refer to the output of `riscv32-unknown-elf-objdump --help` for a full list of options.

--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -357,7 +357,7 @@ Then a connection between OpenOCD and GDB may be established with:
 ```console
 cd $REPO_TOP
 riscv32-unknown-elf-gdb -ex "target extended-remote :3333" -ex "info reg" \
-  $(find -L bazel-out/ -type f -name "uart_smoketest_prog_fpga_cw310.elf" | head -n 1)
+  "$(./bazelisk.sh outquery --config=riscv32 //sw/device/tests:uart_smoketest_prog_fpga_cw310.elf)"
 ```
 
 Note, the above will print out the contents of the registers upon successs.

--- a/doc/getting_started/setup_verilator.md
+++ b/doc/getting_started/setup_verilator.md
@@ -187,7 +187,7 @@ Lastly, connect GDB using the following command (noting it needs to be altered t
 ```console
 cd $REPO_TOP
 riscv32-unknown-elf-gdb -ex "target extended-remote :3333" -ex "info reg" \
-  $(find -L bazel-out/ -type f -name "uart_smoketest_prog_sim_verilator.elf" | head -n 1)
+  "$(./bazelisk.sh outquery --config=riscv32 //sw/device/tests:uart_smoketest_prog_sim_verilator.elf)"
 ```
 
 ## SPI device test interface (optional)


### PR DESCRIPTION
This commit updates example commands that rely on `find` with invocations of `bazelisk.sh outquery`.

Issue #14806

Signed-off-by: Dan McArdle <dmcardle@google.com>