### PR TITLE
[kmac] Add `valid` RW1C field in `ERR_CODE`

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -399,7 +399,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   prim_mubi_pkg::mubi4_t    sha3_absorbed;
   logic                     sha3_squeezing;
   logic [2:0]               sha3_fsm;
-  logic [32:0]              sha3_err;
+  logic [31:0]              sha3_err;
   logic                     cs_aes_halt_req;
   logic                     sha3_msg_rdy;
   logic [HalfRegWidth-1:0]  window_cntr;

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -867,15 +867,20 @@
       swaccess: "ro",
       hwaccess: "hwo",
       fields: [
-        { bits: "31:0",
+        { bits: "31"
+          name: "valid"
+          desc: '''If 1, err_code field represents the captured error.'''
+          swaccess: "rw1c"
+        } // f: valid
+        { bits: "30:0",
           name: "err_code",
           desc: '''If error interrupt occurs, this register has information of error cause.
                 Please take a look at `hw/ip/kmac/rtl/kmac_pkg.sv:err_code_e enum type.
                 '''
-          tags: [// Randomly write mem will cause this reg updated by design
-                 "excl:CsrNonInitTests:CsrExclWriteCheck"]
         }
       ]
+      tags: [// Randomly write mem will cause this reg updated by design
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     } // R: ERR_CODE
     { skipto: "0x400"}
     { window: {

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -608,37 +608,45 @@ module kmac
                      ;
 
   // Assing error code to the register
-  assign hw2reg.err_code.de = event_error;
+  assign hw2reg.err_code.err_code.de = event_error;
+  assign hw2reg.err_code.valid.de    = event_error;
 
   always_comb begin
-    hw2reg.err_code.d = '0;
+    hw2reg.err_code.err_code.d = '0;
+    hw2reg.err_code.valid.d = 1'b 0;
 
     priority case (1'b 1)
       // app_err has the highest priority. If SW issues an incorrect command
       // while app is in active state, the error from AppIntf is passed
       // through.
       app_err.valid: begin
-        hw2reg.err_code.d = {app_err.code, app_err.info};
+        hw2reg.err_code.valid.d    = 1'b 1;
+        hw2reg.err_code.err_code.d = {app_err.code, app_err.info};
       end
 
       errchecker_err.valid: begin
-        hw2reg.err_code.d = {errchecker_err.code , errchecker_err.info};
+        hw2reg.err_code.valid.d    = 1'b 1;
+        hw2reg.err_code.err_code.d = {errchecker_err.code , errchecker_err.info};
       end
 
       sha3_err.valid: begin
-        hw2reg.err_code.d = {sha3_err.code , sha3_err.info};
+        hw2reg.err_code.valid.d    = 1'b 1;
+        hw2reg.err_code.err_code.d = {sha3_err.code , sha3_err.info};
       end
 
       entropy_err.valid: begin
-        hw2reg.err_code.d = {entropy_err.code, entropy_err.info};
+        hw2reg.err_code.valid.d    = 1'b 1;
+        hw2reg.err_code.err_code.d = {entropy_err.code, entropy_err.info};
       end
 
       msgfifo_err.valid: begin
-        hw2reg.err_code.d = {msgfifo_err.code, msgfifo_err.info};
+        hw2reg.err_code.valid.d    = 1'b 1;
+        hw2reg.err_code.err_code.d = {msgfifo_err.code, msgfifo_err.info};
       end
 
       default: begin
-        hw2reg.err_code.d = '0;
+        hw2reg.err_code.valid.d    = 1'b 0;
+        hw2reg.err_code.err_code.d = '0;
       end
     endcase
   end

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -340,57 +340,57 @@ package kmac_pkg;
   ////////////////////
 
   // Error structure is same to the SHA3 one. The codes do not overlap.
-  typedef enum logic [7:0] {
-    ErrNone = 8'h 00,
+  typedef enum logic [6:0] {
+    ErrNone = 7'h 00,
 
     // ErrSha3SwControl occurs when software sent wrong flow signal.
     // e.g) Sw set `process_i` without `start_i`. The state machine ignores
     //      the signal and report through the error FIFO.
-    //ErrSha3SwControl = 8'h 80
+    //ErrSha3SwControl = 7'h 80
 
     // ErrKeyNotValid: KeyMgr interface raises an error if the secret key is
     // not valid when KeyMgr initiates KDF.
-    ErrKeyNotValid = 8'h 01,
+    ErrKeyNotValid = 7'h 01,
 
     // ErrSwPushMsgFifo: Sw writes data into Msg FIFO abruptly.
     // This error occurs in below scenario:
     //   - Sw does not send "Start" command to KMAC then writes data into
     //     Msg FIFO
     //   - Sw writes data into Msg FIFO when KeyMgr is in operation
-    ErrSwPushedMsgFifo = 8'h 02,
+    ErrSwPushedMsgFifo = 7'h 02,
 
     // ErrSwIssuedCmdInAppActive
     //  - Sw writes any command while AppIntf is in active.
-    ErrSwIssuedCmdInAppActive = 8'h 03,
+    ErrSwIssuedCmdInAppActive = 7'h 03,
 
     // ErrWaitTimerExpired
     // Entropy Wait timer expired. Something wrong on EDN i/f
-    ErrWaitTimerExpired = 8'h 04,
+    ErrWaitTimerExpired = 7'h 04,
 
     // ErrIncorrectEntropyMode
     // Incorrect Entropy mode when entropy is ready
-    ErrIncorrectEntropyMode = 8'h 05,
+    ErrIncorrectEntropyMode = 7'h 05,
 
     // ErrUnexpectedModeStrength
-    ErrUnexpectedModeStrength = 8'h 06,
+    ErrUnexpectedModeStrength = 7'h 06,
 
     // ErrIncorrectFunctionName "KMAC"
-    ErrIncorrectFunctionName = 8'h 07,
+    ErrIncorrectFunctionName = 7'h 07,
 
     // ErrSwCmdSequence
-    ErrSwCmdSequence = 8'h 08,
+    ErrSwCmdSequence = 7'h 08,
 
     // Error Shadow register update
-    ErrShadowRegUpdate = 8'h C0,
+    ErrShadowRegUpdate = 7'h 60,
 
     // Error due to lc_escalation_en_i or fatal fault
-    ErrFatalError = 8'h C1,
+    ErrFatalError = 7'h 61,
 
     // Error due to the counter integrity check failure inside MsgFifo.Packer
-    ErrPackerIntegrity = 8'h C2,
+    ErrPackerIntegrity = 7'h 62,
 
     // Error due to the counter integrity check failure inside MsgFifo.Fifo
-    ErrMsgFifoIntegrity = 8'h C3
+    ErrMsgFifoIntegrity = 7'h 63
   } err_code_e;
 
   typedef struct packed {

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -224,8 +224,14 @@ package kmac_reg_pkg;
   } kmac_hw2reg_entropy_refresh_hash_cnt_reg_t;
 
   typedef struct packed {
-    logic [31:0] d;
-    logic        de;
+    struct packed {
+      logic [30:0] d;
+      logic        de;
+    } err_code;
+    struct packed {
+      logic        d;
+      logic        de;
+    } valid;
   } kmac_hw2reg_err_code_reg_t;
 
   // Register -> HW type
@@ -248,11 +254,11 @@ package kmac_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    kmac_hw2reg_intr_state_reg_t intr_state; // [62:57]
-    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [56:56]
-    kmac_hw2reg_status_reg_t status; // [55:44]
-    kmac_hw2reg_entropy_refresh_hash_cnt_reg_t entropy_refresh_hash_cnt; // [43:33]
-    kmac_hw2reg_err_code_reg_t err_code; // [32:0]
+    kmac_hw2reg_intr_state_reg_t intr_state; // [63:58]
+    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [57:57]
+    kmac_hw2reg_status_reg_t status; // [56:45]
+    kmac_hw2reg_entropy_refresh_hash_cnt_reg_t entropy_refresh_hash_cnt; // [44:34]
+    kmac_hw2reg_err_code_reg_t err_code; // [33:0]
   } kmac_hw2reg_t;
 
   // Register offsets

--- a/hw/ip/kmac/rtl/sha3_pkg.sv
+++ b/hw/ip/kmac/rtl/sha3_pkg.sv
@@ -183,13 +183,13 @@ package sha3_pkg;
   //////////////////
   // Error Report //
   //////////////////
-  typedef enum logic [7:0] {
-    ErrNone = 8'h 00,
+  typedef enum logic [6:0] {
+    ErrNone = 7'h 00,
 
     // ErrSha3SwControl occurs when software sent wrong flow signal.
     // e.g) Sw set `process_i` without `start_i`. The state machine ignores
     //      the signal and report through the error FIFO.
-    ErrSha3SwControl = 8'h 80
+    ErrSha3SwControl = 7'h 40
   } err_code_e;
 
   typedef struct packed {


### PR DESCRIPTION
This commit adds `valid` field to `ERR_CODE` CSR. It is RW1C for SW to clear when it acks.

It is useful for SW to check if ERR_CODE is current event or previous.

This change breaks the API as the error code field is shrinked to 7bit from 8bit.

Related Issue: https://github.com/lowRISC/opentitan/issues/14713