### PR TITLE
[dv/flash_ctrl] fix `flash_ctrl_cov_if` reference

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:dv:flash_phy_prim_agent
+      - lowrisc:dv:flash_ctrl_cov
       - lowrisc:ip:flash_ctrl_pkg
       - lowrisc:constants:top_pkg
     files:


### PR DESCRIPTION
This fixes a broken `flash_ctrl_cov_if` reference that was introduced in #14641 and was breaking the Kokoro presubmit on foundry.

Signed-off-by: Timothy Trippel <ttrippel@google.com>