### PR TITLE
[test] Add rom_e2e_bootstrap_phase1 tests

### DIFF
--- a/sw/device/silicon_creator/rom/bootstrap.c
+++ b/sw/device/silicon_creator/rom/bootstrap.c
@@ -231,14 +231,16 @@ static rom_error_t bootstrap_handle_erase(bootstrap_state_t *state) {
       error = bootstrap_chip_erase();
       HARDENED_RETURN_IF_ERROR(error);
       *state = kBootstrapStateEraseVerify;
+      // Note: We clear WIP and WEN bits in `bootstrap_handle_erase_verify()`
+      // after checking that both data banks have been erased.
       break;
     default:
-      // Ignore any other command, e.g. PAGE_PROGRAM, RESET.
+      // Ignore any other command, e.g. PAGE_PROGRAM, RESET, and clear WIP and
+      // WEN bits right away.
+      spi_device_flash_status_clear();
       error = kErrorOk;
   }
 
-  // Note: We clear WIP and WEN bits in `bootstrap_handle_erase_verify()` after
-  // checking that both data banks have been erased.
   return error;
 }
 

--- a/sw/device/silicon_creator/rom/bootstrap_unittest.cc
+++ b/sw/device/silicon_creator/rom/bootstrap_unittest.cc
@@ -471,20 +471,21 @@ TEST_F(BootstrapTest, MisalignedEraseAddress) {
 }
 
 TEST_F(BootstrapTest, IgnoredCommands) {
-  // Erase
+  // Phase 1: Erase
   ExpectBootstrapRequestCheck(true);
   EXPECT_CALL(spi_device_, Init());
   ExpectSpiCmd(ChipEraseCmd());  // Ignored, missing WREN.
   ExpectSpiFlashStatusGet(false);
   ExpectSpiCmd(ResetCmd());  // Ignored, not supported.
   ExpectSpiFlashStatusGet(true);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
-  // Verify
+  // Phase 1: Verify
   ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
   EXPECT_CALL(spi_device_, FlashStatusClear());
-  // Erase/Program
+  // Phase 2: Erase/Program
   ExpectSpiCmd(SectorEraseCmd(0));
   ExpectSpiFlashStatusGet(false);
   ExpectSpiCmd(ChipEraseCmd());

--- a/sw/device/silicon_creator/rom/bootstrap_unittest.cc
+++ b/sw/device/silicon_creator/rom/bootstrap_unittest.cc
@@ -327,7 +327,7 @@ TEST_F(BootstrapTest, BootstrapOddPayload) {
   EXPECT_EQ(bootstrap(), kErrorUnknown);
 }
 
-TEST_F(BootstrapTest, BootstrapMisalignedAddr) {
+TEST_F(BootstrapTest, BootstrapMisalignedAddrLongPayload) {
   // Erase
   ExpectBootstrapRequestCheck(true);
   EXPECT_CALL(spi_device_, Init());
@@ -350,6 +350,37 @@ TEST_F(BootstrapTest, BootstrapMisalignedAddr) {
   EXPECT_CALL(flash_ctrl_, DataWrite(0xfff0, 4, HasBytes(flash_bytes_0)))
       .WillOnce(Return(kErrorOk));
   EXPECT_CALL(flash_ctrl_, DataWrite(0xff00, 60, HasBytes(flash_bytes_1)))
+      .WillOnce(Return(kErrorOk));
+  ExpectFlashCtrlAllDisable();
+
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Reset
+  ExpectSpiCmd(ResetCmd());
+  EXPECT_CALL(rstmgr_, Reset());
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, BootstrapMisalignedAddrShortPayload) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Program
+  auto cmd = PageProgramCmd(816, 8);
+  ExpectSpiCmd(cmd);
+  ExpectSpiFlashStatusGet(true);
+
+  std::vector<uint8_t> flash_bytes(cmd.payload,
+                                   cmd.payload + cmd.payload_byte_count);
+
+  ExpectFlashCtrlWriteEnable();
+  EXPECT_CALL(flash_ctrl_, DataWrite(816, 2, HasBytes(flash_bytes)))
       .WillOnce(Return(kErrorOk));
   ExpectFlashCtrlAllDisable();
 

--- a/sw/device/silicon_creator/rom/data/rom_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_testplan.hjson
@@ -288,18 +288,14 @@
 
     {
       name: rom_e2e_bootstrap_phase1_reset
-      desc: '''Verify that bootstrap phase 1 handles `RESET` (`0x99`) correctly.
+      desc: '''Verify that bootstrap phase 1 ignores `RESET` (`0x99`).
 
             `OWNER_SW_CFG_ROM_BOOTSTRAP_EN` OTP item must be `kHardenedBoolTrue` (`0x739`).
 
             - Apply bootstrap pin strapping.
             - Reset the chip.
-            - Verify that the chip responds to `READ_STATUS` (`0x05`) with `0x00`.
             - Send `RESET` (`0x99`).
-            - Verify that the chip outputs the expected `BFV`: `0142500d` over UART.
-              - ROM will continously reset the chip and output the same `BFV` and `LCV`.
-            - Verify that the chip does not respond to `READ_STATUS` (`0x05`).
-              - The data on the CIPO line must be `0xff`.
+            - Verify that the chip does not output anything over UART for at least 1 s.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2

--- a/sw/device/silicon_creator/rom/data/rom_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_testplan.hjson
@@ -334,19 +334,19 @@
             - For `erase` in {`SECTOR_ERASE` (`0x20`), `CHIP_ERASE` (`0xc7`)}:
               - Apply bootstrap pin strapping and reset the chip.
               - Send `erase`.
-              - Write `0x4552544f` (ASCII "OTRE") at byte offset `0x334`.
-              - Write `0x1` at byte offset `0x374`.
+              - Write `0x4552544f_00000000` (ASCII "\0\0\0\0OTRE") at byte offset `0x80330`.
+                - Note: Writes must start at a flash-word-aligned address and we
+                  must write to the second slot since ROM returns the last error.
               - Release pins and reset.
-              - Verify that the chip outputs the expected `BFV`: `024d410d` over UART.
+              - Verify that the chip outputs the expected `BFV`: `0242500d`
+                over UART (`kErrorBootPolicyBadLength`).
                 - ROM will continously reset the chip and output the same `BFV` and `LCV`.
               - Apply bootstrap pin strapping and reset the chip.
               - Send `erase`.
               - Release pins and reset.
-              - Verify that the chip outputs the expected `BFV`: `0142500d` over UART.
+              - Verify that the chip outputs the expected `BFV`: `0142500d`
+                over UART (`kErrorBootPolicyBadIdentifier`).
                 - ROM will continously reset the chip and output the same `BFV` and `LCV`.
-
-            Note: For additional coverage we can also add another test point that uses a test
-            program on flash.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2

--- a/sw/device/silicon_creator/rom/data/rom_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_testplan.hjson
@@ -310,12 +310,14 @@
 
             - Apply bootstrap pin strapping.
             - Reset the chip.
-            - Write `0x4552544f` (ASCII "OTRE") at byte offset `0x334`.
-            - Write `0x1` at byte offset `0x374`.
+            - Write `0x4552544f_00000000` (ASCII "\0\0\0\0OTRE") at byte offset `0x80330`.
+              - Note: Writes must start at a flash-word-aligned address and we
+                must write to the second slot since ROM returns the last error.
             - Reset the chip.
-            - Verify that the chip outputs the expected `BFV`: `0142500d` over UART.
-              - If the write succeeds, which shouldn't happen, ROM outputs `024d410d`
-                (`kErrorManifestBadCodeRegion`).
+            - Verify that the chip outputs the expected `BFV`: `0142500d` over
+              UART (`kErrorBootPolicyBadIdentifier').
+              - If the write succeeds, which shouldn't happen, ROM outputs `0242500d`
+                (`kErrorBootPolicyBadLength`).
               - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]

--- a/sw/device/silicon_creator/rom/data/rom_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_testplan.hjson
@@ -361,15 +361,18 @@
 
             - Apply bootstrap pin strapping and reset the chip.
             - Send `CHIP_ERASE` (`0xc7`).
-            - Write `0x4552544f` (ASCII "OTRE") at byte offset `0x334`.
+            - Write `0x4552544f_00000000` (ASCII "\0\0\0\0OTRE") at byte offset `0x80330`.
+              - Note: Writes must start at a flash-word-aligned address and we
+                must write to the second slot since ROM returns the last error.
             - Reset the chip.
-            - Verify that the chip outputs the expected `BFV`: `024d410d` over UART.
+            - Verify that the chip outputs the expected `BFV`: `0242500d` over
+              UART (`kErrorBootPolicyBadLength`).
               - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             - Apply bootstrap pin strapping and reset the chip.
-            - Send `READ` (`0x03`) followed by the 3-byte address 0x000334.
-              - This is the address of the identifier that was written earlier.
-            - Verify that the chip does not respond for the next 4 bytes.
-              - The data on the CIPO line must be `0xff`.
+            - Verify that the chip responds to `READ_STATUS` (`0x05`) with `0x00`.
+            - Send `READ` (`0x03`) followed by the 3-byte address 0x80330.
+              - This is the start address of the write operation performed above.
+            - Verify that the data on the CIPO line does not match `0x4552544f_00000000`.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -85,6 +85,13 @@ impl<'a> BootstrapTest<'a> {
 
 impl<'a> Drop for BootstrapTest<'a> {
     fn drop(&mut self) {
+        self.transport.apply_pin_strapping("ROM_BOOTSTRAP").unwrap();
+        self.transport.reset_target(self.reset_delay, true).unwrap();
+        let spi = self.transport.spi("0").unwrap();
+        SpiFlash::from_spi(&*spi)
+            .unwrap()
+            .chip_erase(&*spi)
+            .unwrap();
         self.transport
             .remove_pin_strapping("ROM_BOOTSTRAP")
             .unwrap();

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -6,7 +6,6 @@ use anyhow::{bail, Result};
 use regex::Regex;
 use std::matches;
 use std::ops::Drop;
-use std::thread;
 use std::time::Duration;
 use structopt::StructOpt;
 
@@ -80,12 +79,6 @@ impl<'a> BootstrapTest<'a> {
         };
         transport.apply_pin_strapping("ROM_BOOTSTRAP")?;
         transport.reset_target(b.reset_delay, true)?;
-
-        let spi = transport.spi("0")?;
-        while SpiFlash::read_status(&*spi)? != 0 {
-            thread::sleep(Duration::from_millis(10));
-        }
-
         Ok(b)
     }
 }

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -292,28 +292,21 @@ fn test_bootstrap_shutdown(
 fn main() -> Result<()> {
     let opts = Opts::from_args();
     opts.init.init_logging();
-
     let transport = opts.init.init_target()?;
+
     execute_test!(test_bootstrap_enabled_not_requested, &opts, &transport);
     execute_test!(test_bootstrap_enabled_requested, &opts, &transport);
     execute_test!(test_jedec_id, &opts, &transport);
     execute_test!(test_sfdp, &opts, &transport);
     execute_test!(test_write_enable_disable, &opts, &transport);
-    // `kErrorBootstrapEraseAddress` (01425303) is defined in `error.h`.
-    execute_test!(
-        test_bootstrap_shutdown,
-        &opts,
-        &transport,
-        SpiFlash::SECTOR_ERASE,
-        "01425303"
-    );
-    // `kErrorBootstrapProgramAddress` (02425303) is defined in `error.h`.
-    execute_test!(
-        test_bootstrap_shutdown,
-        &opts,
-        &transport,
-        SpiFlash::PAGE_PROGRAM,
-        "02425303"
-    );
+    for (cmd, bfv) in [
+        // `kErrorBootstrapEraseAddress` (01425303) is defined in `error.h`.
+        (SpiFlash::SECTOR_ERASE, "01425303"),
+        // `kErrorBootstrapProgramAddress` (02425303) is defined in `error.h`.
+        (SpiFlash::PAGE_PROGRAM, "02425303"),
+    ] {
+        execute_test!(test_bootstrap_shutdown, &opts, &transport, cmd, bfv);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
This PR adds e2e tests for the first phase of bootstrap:
* #14459
* #14460
* #14461 
* #14462 

This PR also fixes 2 issues that I ran into while adding these e2e tests:
* #14871
* #14873 