### PR TITLE
[opentitantool] Set programming speed before loading bitstream

### DIFF
--- a/sw/host/opentitanlib/src/transport/cw310/usb.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/usb.rs
@@ -347,7 +347,8 @@ impl Backend {
         bitstream: &[u8],
         progress: Option<&dyn Fn(u32, u32)>,
     ) -> Result<()> {
-        self.fpga_prepare(20_000_000)?;
+        const PROG_SPEED: u32 = 20_000_000;
+        self.fpga_prepare(PROG_SPEED)?;
         let result = self.fpga_download(bitstream, progress);
 
         let mut status = false;


### PR DESCRIPTION
On firmwares that support variable programming speed (`1.0.0`+), make sure that it is configured program at 20MHz as the default has changed to 1MHz.

Tested manually by doing a `load-bitstream` on a CW310 running firmware versions `0.40.1` and `1.2.0`, taking the same time in both cases.