### PR TITLE
[flash_ctrl/doc] Change integrity ECC to ICV

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -895,7 +895,7 @@
                 name: "ECC_EN",
                 mubi: true,
                 desc: '''
-                  Region is ECC enabled (both integrity and reliability ECC).
+                  Region is integrity checked and reliability ECC enabled.
                 ''',
                 resval: false
               }

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -896,7 +896,7 @@
                 name: "ECC_EN",
                 mubi: true,
                 desc: '''
-                  Region is ECC enabled (both integrity and reliability ECC).
+                  Region is integrity checked and reliability ECC enabled.
                 ''',
                 resval: false
               }

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -901,7 +901,7 @@
                 name: "ECC_EN",
                 mubi: true,
                 desc: '''
-                  Region is ECC enabled (both integrity and reliability ECC).
+                  Region is integrity checked and reliability ECC enabled.
                 ''',
                 resval: false
               }


### PR DESCRIPTION
This hopefully makes the documentation clearer and better reflects which of the two ECC implementations we are referring to.

Signed-off-by: Timothy Chen <timothytim@google.com>