### PR TITLE
[dv,top] Fix chip_sw_aon_timer_irq

### DIFF
--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -95,8 +95,8 @@ static void execute_test(dif_aon_timer_t *aon_timer, uint64_t irq_time_us,
   uint64_t sleep_range_h = irq_time_us + variation;
   uint64_t sleep_range_l = irq_time_us - variation;
 
-  // Add 500 cpu cycles of overhead to cover irq handling.
-  sleep_range_h += udiv64_slow(500 * 1000000, kClockFreqCpuHz, NULL);
+  // Add 600 cpu cycles of overhead to cover irq handling.
+  sleep_range_h += udiv64_slow(600 * 1000000, kClockFreqCpuHz, NULL);
 
   uint32_t count_cycles =
       aon_timer_testutils_get_aon_cycles_from_us(irq_time_us);


### PR DESCRIPTION
The test requires an ISR to happen within a certain number of cycles of the programmed timeout. It provides some slack to account for the time it takes to service the ISR, but that slack is too tight. This increases the slack from 500 to 600 CPU cycles.

Fixes #14838

Signed-off-by: Guillermo Maturana <maturana@google.com>