### PR TITLE
[sw] Use default environment for srec_cat

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -413,6 +413,7 @@ def _bin_to_vmem_impl(ctx):
         # This this executable is expected to be installed (as required by the
         # srecord package in apt-requirements.txt).
         executable = "srec_cat",
+        use_default_shell_env = True,
     )
     return [DefaultInfo(
         files = depset(outputs),


### PR DESCRIPTION
This commit pulls in the default shell environment when invoking srec_cat allowing for systems where srec_cat is not installed in the usual path.

Fixes #14769

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>