### PR TITLE
[bazel/otp] Add Bazel rule to generate JSON file for OTP image

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:autogen.bzl", "autogen_hjson_header", "otp_image")
+load("//rules:otp.bzl", "otp_json")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
@@ -14,14 +15,26 @@ autogen_hjson_header(
     ],
 )
 
+otp_json(
+    name = "otp_ctrl_rma_json",
+    lc_count = 8,
+    lc_state = "RMA",
+)
+
 otp_image(
     name = "img_rma",
-    src = ":otp_ctrl_img_rma.hjson",
+    src = ":otp_ctrl_rma_json",
+)
+
+otp_json(
+    name = "otp_ctrl_dev_json",
+    lc_count = 5,
+    lc_state = "DEV",
 )
 
 otp_image(
     name = "img_dev",
-    src = ":otp_ctrl_img_dev.hjson",
+    src = ":otp_ctrl_dev_json",
 )
 
 filegroup(

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:autogen.bzl", "autogen_hjson_header", "otp_image")
-load("//rules:otp.bzl", "otp_json")
+load("//rules:autogen.bzl", "autogen_hjson_header")
+load("//rules:otp.bzl", "otp_image", "otp_json")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -108,25 +108,20 @@ def _otp_image(ctx):
     # TODO(dmcardle) I don't like hardcoding the width in the filename. Maybe we
     # can write it into some metadata in the file instead.
     output = ctx.actions.declare_file(ctx.attr.name + ".24.vmem")
+    args = ctx.actions.args()
+    args.add("--quiet")
+    args.add("--lc-state-def", ctx.file.lc_state_def)
+    args.add("--mmap-def", ctx.file.mmap_def)
+    args.add("--img-cfg", ctx.file.src)
+    args.add("--out", "{}/{}.BITWIDTH.vmem".format(output.dirname, ctx.attr.name))
     ctx.actions.run(
         outputs = [output],
         inputs = [
             ctx.file.src,
             ctx.file.lc_state_def,
             ctx.file.mmap_def,
-            ctx.executable._tool,
         ],
-        arguments = [
-            "--quiet",
-            "--lc-state-def",
-            ctx.file.lc_state_def.path,
-            "--mmap-def",
-            ctx.file.mmap_def.path,
-            "--img-cfg",
-            ctx.file.src.path,
-            "--out",
-            "{}/{}.BITWIDTH.vmem".format(output.dirname, ctx.attr.name),
-        ],
+        arguments = [args],
         executable = ctx.executable._tool,
     )
     return [DefaultInfo(files = depset([output]), data_runfiles = ctx.runfiles(files = [output]))]

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -104,50 +104,6 @@ autogen_chip_info = rule(
     },
 )
 
-def _otp_image(ctx):
-    # TODO(dmcardle) I don't like hardcoding the width in the filename. Maybe we
-    # can write it into some metadata in the file instead.
-    output = ctx.actions.declare_file(ctx.attr.name + ".24.vmem")
-    args = ctx.actions.args()
-    args.add("--quiet")
-    args.add("--lc-state-def", ctx.file.lc_state_def)
-    args.add("--mmap-def", ctx.file.mmap_def)
-    args.add("--img-cfg", ctx.file.src)
-    args.add("--out", "{}/{}.BITWIDTH.vmem".format(output.dirname, ctx.attr.name))
-    ctx.actions.run(
-        outputs = [output],
-        inputs = [
-            ctx.file.src,
-            ctx.file.lc_state_def,
-            ctx.file.mmap_def,
-        ],
-        arguments = [args],
-        executable = ctx.executable._tool,
-    )
-    return [DefaultInfo(files = depset([output]), data_runfiles = ctx.runfiles(files = [output]))]
-
-otp_image = rule(
-    implementation = _otp_image,
-    attrs = {
-        "src": attr.label(allow_single_file = True),
-        "lc_state_def": attr.label(
-            allow_single_file = True,
-            default = "//hw/ip/lc_ctrl/data:lc_ctrl_state.hjson",
-            doc = "Life-cycle state definition file in Hjson format.",
-        ),
-        "mmap_def": attr.label(
-            allow_single_file = True,
-            default = "//hw/ip/otp_ctrl/data:otp_ctrl_mmap.hjson",
-            doc = "OTP Controller memory map file in Hjson format.",
-        ),
-        "_tool": attr.label(
-            default = "//util/design:gen-otp-img",
-            executable = True,
-            cfg = "exec",
-        ),
-    },
-)
-
 def _cryptotest_hjson_external(ctx):
     """
     Implementation of the Bazel rule for parsing externally-sourced test vectors.

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -1,0 +1,189 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rules for generating OTP images.
+
+The rules in this file are used to generate a JSON file that describe the OTP
+configuration which is then consumed to produce the OTP VMEM image file for
+preloading the OTP in FPGA synthesis or simulation.
+"""
+
+def _otp_json_impl(ctx):
+    """Bazel rule for generating JSON specifications for OTP configurations."""
+
+    otp = {}
+
+    # Seed to be used for generation of partition randomized values.
+    # Can be overridden by the OTP image generation tool.
+    otp["seed"] = "01931961561863975174"
+
+    # Assemble all OTP paritions
+    # The partition and item names must correspond with the OTP memory map.
+    otp["partitions"] = [
+        {
+            "name": "CREATOR_SW_CFG",
+            "items": {
+                "CREATOR_SW_CFG_DIGEST": "0x0",
+                # Use software mod_exp implementation for signature
+                # verification. See the definition of `hardened_bool_t` in
+                # sw/device/lib/base/hardened.h.
+                "CREATOR_SW_CFG_USE_SW_RSA_VERIFY": "0x739",
+                # Mark the first two keys as valid and remaining as invalid
+                # since we have currently only two keys. See the definition of
+                # `hardened_byte_bool_t` in sw/device/lib/base/hardened.h.
+                "CREATOR_SW_CFG_KEY_IS_VALID": "0x4b4b4b4b4b4ba5a5",
+                # Enable use of entropy for countermeasures. See the definition
+                # of `hardened_bool_t` in sw/device/lib/base/hardened.h.
+                "CREATOR_SW_CFG_RNG_EN": "0x739",
+                # ROM execution is enabled if this item is set to a non-zero
+                # value.
+                "CREATOR_SW_CFG_ROM_EXEC_EN": "0xffffffff",
+                # Value to write to the cpuctrl CSR in `rom_init()`.
+                # See:
+                # https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html#cpu-control-register-cpuctrl
+                "CREATOR_SW_CFG_CPUCTRL": "0x1",
+                "CREATOR_SW_CFG_JITTER_EN": "0x9",
+                # Value of the min_security_version_rom_ext field of the
+                # default boot data.
+                "CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT": "0x0",
+                # Value of the min_security_version_bl0 field of the default
+                # boot data.
+                "CREATOR_SW_CFG_MIN_SEC_VER_BL0": "0x0",
+                # Enable the default boot data in PROD and PROD_END life cycle
+                # states. See the definition of `hardened_bool_t` in
+                # sw/device/lib/base/hardened.h.
+                "CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN": "0x739",
+            },
+        },
+        {
+            "name": "OWNER_SW_CFG",
+            "items": {
+                "OWNER_SW_CFG_DIGEST": "0x0",
+                # Enable bootstrap. See `hardened_bool_t` in
+                # sw/device/lib/base/hardened.h.
+                "OWNER_SW_CFG_ROM_BOOTSTRAP_EN": "0x739",
+                # Set to 0x739 to use the ROM_EXT hash measurement as the key
+                # manager attestation binding value.
+                "OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN": "0x0",
+                # Set the enables to kAlertEnableNone.
+                # See `alert_enable_t` in
+                # sw/device/silicon_creator/lib/drivers/alert.h
+                "OWNER_SW_CFG_ROM_ALERT_CLASS_EN": "0xa9a9a9a9",
+                # Set the esclation policies to kAlertEscalateNone.
+                # See `alert_escalate_t`
+                # in sw/device/silicon_creator/lib/drivers/alert.h
+                "OWNER_SW_CFG_ROM_ALERT_ESCALATION": "0xd1d1d1d1",
+                # Set the classifiactions to kAlertClassX.
+                # See `alert_class_t` in
+                # sw/device/silicon_creator/lib/drivers/alert.h
+                "OWNER_SW_CFG_ROM_ALERT_CLASSIFICATION": ["0x94949494"] * 80,
+                # Set the classifiactions to kAlertClassX.
+                # See `alert_class_t` in
+                # sw/device/silicon_creator/lib/drivers/alert.h
+                "OWNER_SW_CFG_ROM_LOCAL_ALERT_CLASSIFICATION": ["0x94949494"] * 16,
+                # Set the alert accumulation thresholds to 0 per class.
+                "OWNER_SW_CFG_ROM_ALERT_ACCUM_THRESH": ["0x00000000"] * 4,
+                # Set the alert timeout cycles to 0 per class.
+                "OWNER_SW_CFG_ROM_ALERT_TIMEOUT_CYCLES": ["0x00000000"] * 4,
+                # Set the alert phase cycles to 0,10,10,0xFFFFFFFF for classes
+                # A and B, and to all zeros for classes C and D.
+                "OWNER_SW_CFG_ROM_ALERT_PHASE_CYCLES": [
+                    "0x0",
+                    "0xa",
+                    "0xa",
+                    "0xFFFFFFFF",
+                    "0x0",
+                    "0xa",
+                    "0xa",
+                    "0xFFFFFFFF",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                ],
+                "OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA": "0x36ed9cb0",
+            },
+        },
+        {
+            "name": "HW_CFG",
+            # If set to true, this computes the HW digest value and locks the
+            # partition.
+            "lock": True,
+            "items": {
+                "DEVICE_ID": "<random>",
+                # Cryptolib and chip-level tests require access to the CSRNG
+                # software interfaces.
+                "EN_CSRNG_SW_APP_READ": True,
+                # Cryptolib and chip-level tests require access to the
+                # entropy_src FW data interface.
+                "EN_ENTROPY_SRC_FW_READ": True,
+                # Cryptolib and chip-level tests require access to the
+                # entropy_src FW override interface.
+                "EN_ENTROPY_SRC_FW_OVER": True,
+            },
+        },
+        {
+            "name": "SECRET0",
+            "lock": True,
+            "items": {
+                "TEST_UNLOCK_TOKEN": "<random>",
+                "TEST_EXIT_TOKEN": "<random>",
+            },
+        },
+        {
+            "name": "SECRET1",
+            "lock": True,
+            "items": {
+                "FLASH_ADDR_KEY_SEED": "<random>",
+                "FLASH_DATA_KEY_SEED": "<random>",
+                "SRAM_DATA_KEY_SEED": "<random>",
+            },
+        },
+        {
+            "name": "SECRET2",
+            "lock": False,
+            "items": {
+                "RMA_TOKEN": "<random>",
+                "CREATOR_ROOT_KEY_SHARE0": "<random>",
+                "CREATOR_ROOT_KEY_SHARE1": "<random>",
+            },
+        },
+        {
+            "name": "LIFE_CYCLE",
+            "state": ctx.attr.lc_state,
+            # Can range from 0 to 16.
+            # Note that a value of 0 is only permissible in RAW state.
+            "count": ctx.attr.lc_count,
+        },
+    ]
+
+    # For every partition with an "items" dictionary, expand the dictionary of
+    # key:value pairs into a list of dicts, each of the form
+    # {
+    #   "name": key,
+    #   "value": value
+    # }
+    # This format is expected by the OTP image generation tool
+    for partition in otp["partitions"]:
+        if "items" in partition.keys():
+            items = partition["items"]
+            partition["items"] = [{"name": k, "value": items[k]} for k in items.keys()]
+
+    file = ctx.actions.declare_file("{}.json".format(ctx.attr.name))
+    ctx.actions.write(file, json.encode_indent(otp))
+    return DefaultInfo(files = depset([file]))
+
+otp_json = rule(
+    implementation = _otp_json_impl,
+    attrs = {
+        # Valid life cycle states can be found in the life cycle state
+        # definition file (default: hw/ip/lc_ctrl/data/lc_ctrl_state.hjson)
+        "lc_state": attr.string(doc = "Life cycle state", default = "RMA"),
+        "lc_count": attr.int(doc = "Life cycle count", default = 8),
+    },
+)


### PR DESCRIPTION
This PR adds a rule to generate JSON files that define OTP images. While the rule only allows configuring the LC state at the moment, the intention is that as we add additional configurability as needed when writing tests.

Closes #14546