### PR TITLE
[top/dv] spi_host_tx_rx_test

### DIFF
--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -13,6 +13,7 @@ class spi_device_driver extends spi_driver;
       @(negedge cfg.vif.rst_n);
       `uvm_info(`gfn, "\n  dev_drv: in reset progress", UVM_DEBUG)
       under_reset = 1'b1;
+      cfg.vif.sio = 'hz;
       @(posedge cfg.vif.rst_n);
       under_reset = 1'b0;
       `uvm_info(`gfn, "\n  dev_drv: out of reset", UVM_DEBUG)

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -219,11 +219,8 @@
       desc: '''Verify the transmission of data on the chip's SPI host port.
 
             - Program the SPI host to send a known payload out of the chip on the SPI host ports.
-            - At the same time, the testbench transfers a known payload from device to host on the
-              SPI host interface.
-            - The SPI device monitor in the testbench grabs the host payload and verifies its
-              integrity.
-            - The SW verifies the device payload for integrity and services the SPI event interrupt.
+            - The testbench receives the payload and plays it back to the SPI host interface.
+	    - The SW verifies the sent payload matches the read response and services SPI event interrupts.
             - Run with min and max SPI clk frequencies and with single, dual and quad SPI modes.
 
             Verify all SPI host instances in the chip.

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -409,6 +409,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_spi_host_tx_rx
+      uvm_test_seq: chip_sw_spi_host_tx_rx_vseq
+      sw_images: ["//sw/device/tests/sim_dv:spi_host_tx_rx_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_gpio
       uvm_test_seq: chip_sw_gpio_vseq
       sw_images: ["//sw/device/tests/sim_dv:gpio_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_common_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_common_pkg.sv
@@ -10,7 +10,7 @@ package chip_common_pkg;
   // Chip composition (number of hardware resources).
   parameter dv_utils_pkg::uint NUM_GPIOS = 16;
   parameter dv_utils_pkg::uint NUM_UARTS = 4;
-  parameter dv_utils_pkg::uint NUM_SPI_HOSTS = 1;
+  parameter dv_utils_pkg::uint NUM_SPI_HOSTS = 2;
   parameter dv_utils_pkg::uint NUM_I2CS = 3;
   parameter dv_utils_pkg::uint NUM_PWM_CHANNELS = pwm_reg_pkg::NOutputs;
 

--- a/hw/top_earlgrey/dv/env/chip_common_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_common_pkg.sv
@@ -10,6 +10,7 @@ package chip_common_pkg;
   // Chip composition (number of hardware resources).
   parameter dv_utils_pkg::uint NUM_GPIOS = 16;
   parameter dv_utils_pkg::uint NUM_UARTS = 4;
+  parameter dv_utils_pkg::uint NUM_SPI_HOSTS = 1;
   parameter dv_utils_pkg::uint NUM_I2CS = 3;
   parameter dv_utils_pkg::uint NUM_PWM_CHANNELS = pwm_reg_pkg::NOutputs;
 

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -78,6 +78,7 @@ filesets:
       - seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_spi_host_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -84,8 +84,9 @@ class chip_env extends cip_base_env #(
 
     // dut spi host, tb spi device
     foreach (m_spi_device_agents[i]) begin
-      m_spi_device_agents[i] = spi_agent::type_id::create($sformatf("m_spi_device_agent%0d", i), this);
-      uvm_config_db#(spi_agent_cfg)::set(this, $sformatf("m_spi_device_agent%0d*", i), "cfg",
+      m_spi_device_agents[i] =
+        spi_agent::type_id::create($sformatf("m_spi_device_agents%0d", i), this);
+      uvm_config_db#(spi_agent_cfg)::set(this, $sformatf("m_spi_device_agents%0d*", i), "cfg",
                                          cfg.m_spi_device_agent_cfgs[i]);
     end
 
@@ -148,11 +149,6 @@ class chip_env extends cip_base_env #(
     foreach (m_uart_agents[i]) begin
       m_uart_agents[i].monitor.tx_analysis_port.connect(
           virtual_sequencer.uart_tx_fifos[i].analysis_export);
-    end
-
-    foreach (m_spi_device_agents[i]) begin
-      m_spi_device_agents[i].monitor.device_analysis_port.connect(
-          virtual_sequencer.spi_device_fifos[i].analysis_export);
     end
 
     foreach (m_pwm_monitor[i]) begin

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -139,7 +139,8 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
     // create spi device agent config obj
     foreach (m_spi_device_agent_cfgs[i]) begin
-      m_spi_device_agent_cfgs[i] = spi_agent_cfg::type_id::create($sformatf("m_spi_device_agent_cfg%0d", i));
+      m_spi_device_agent_cfgs[i] =
+        spi_agent_cfg::type_id::create($sformatf("m_spi_device_agent_cfg%0d", i));
     end
 
     // create jtag agent config obj

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -82,6 +82,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
   // ext component cfgs
   rand uart_agent_cfg       m_uart_agent_cfgs[NUM_UARTS];
+  rand spi_agent_cfg        m_spi_device_agent_cfgs[NUM_SPI_HOSTS];
   rand jtag_riscv_agent_cfg m_jtag_riscv_agent_cfg;
   rand jtag_agent_cfg       m_jtag_agent_cfg;
   rand spi_agent_cfg        m_spi_agent_cfg;
@@ -134,6 +135,11 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     // create uart agent config obj
     foreach (m_uart_agent_cfgs[i]) begin
       m_uart_agent_cfgs[i] = uart_agent_cfg::type_id::create($sformatf("m_uart_agent_cfg%0d", i));
+    end
+
+    // create spi device agent config obj
+    foreach (m_spi_device_agent_cfgs[i]) begin
+      m_spi_device_agent_cfgs[i] = spi_agent_cfg::type_id::create($sformatf("m_spi_device_agent_cfg%0d", i));
     end
 
     // create jtag agent config obj

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -37,6 +37,7 @@ package chip_env_pkg;
   import sw_test_status_pkg::*;
   import tl_agent_pkg::*;
   import uart_agent_pkg::*;
+  import spi_agent_pkg::*;
   import xbar_env_pkg::*;
   import top_earlgrey_pkg::*;
   import top_earlgrey_rnd_cnst_pkg::*;

--- a/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
+++ b/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
@@ -16,9 +16,6 @@ class chip_virtual_sequencer extends cip_base_virtual_sequencer #(
   // Grab packets from UART TX port for in-sequence checking.
   uvm_tlm_analysis_fifo #(uart_item) uart_tx_fifos[NUM_UARTS];
 
-
-  uvm_tlm_analysis_fifo #(spi_item) spi_device_fifos[NUM_SPI_HOSTS];
-
   // Collect pkts from pwm monitor
   uvm_tlm_analysis_fifo #(pwm_item) pwm_rx_fifo[NUM_PWM_CHANNELS];
 
@@ -27,7 +24,6 @@ class chip_virtual_sequencer extends cip_base_virtual_sequencer #(
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     foreach (uart_tx_fifos[i]) uart_tx_fifos[i] = new($sformatf("uart_tx_fifo%0d", i), this);
-    foreach (spi_device_fifos[i]) spi_device_fifos[i] = new($sformatf("spi_device_fifo%0d", i), this);
     foreach (pwm_rx_fifo[i]) pwm_rx_fifo[i] = new($sformatf("pwm_rx_fifo%0d", i), this);
   endfunction
 

--- a/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
+++ b/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
@@ -9,11 +9,15 @@ class chip_virtual_sequencer extends cip_base_virtual_sequencer #(
   `uvm_component_utils(chip_virtual_sequencer)
 
   uart_sequencer       uart_sequencer_hs[NUM_UARTS];
+  spi_sequencer        spi_device_sequencer_hs[NUM_SPI_HOSTS];
   jtag_riscv_sequencer jtag_sequencer_h;
   spi_sequencer        spi_sequencer_h;
 
   // Grab packets from UART TX port for in-sequence checking.
   uvm_tlm_analysis_fifo #(uart_item) uart_tx_fifos[NUM_UARTS];
+
+
+  uvm_tlm_analysis_fifo #(spi_item) spi_device_fifos[NUM_SPI_HOSTS];
 
   // Collect pkts from pwm monitor
   uvm_tlm_analysis_fifo #(pwm_item) pwm_rx_fifo[NUM_PWM_CHANNELS];
@@ -23,6 +27,7 @@ class chip_virtual_sequencer extends cip_base_virtual_sequencer #(
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     foreach (uart_tx_fifos[i]) uart_tx_fifos[i] = new($sformatf("uart_tx_fifo%0d", i), this);
+    foreach (spi_device_fifos[i]) spi_device_fifos[i] = new($sformatf("spi_device_fifo%0d", i), this);
     foreach (pwm_rx_fifo[i]) pwm_rx_fifo[i] = new($sformatf("pwm_rx_fifo%0d", i), this);
   endfunction
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_host_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_host_tx_rx_vseq.sv
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_spi_host_tx_rx_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_spi_host_tx_rx_vseq)
+
+  `uvm_object_new
+
+  rand int spi_host_idx;
+
+  constraint spi_host_idx_c {
+    spi_host_idx inside {[0 : 0]};
+  }
+
+  task pre_start();
+    // Select the first Csb for communication.
+    cfg.m_spi_device_agent_cfgs[spi_host_idx].csid = '0;
+
+    // While the selection of this value seems arbitrary, it is not.
+    // The spi agent has a concept of "transaction size" that is used by the
+    // monitor / driver to determine how it should view the number of collected
+    // bytes.
+    // The value 4 is chosen because the corresponding C test case does the following:
+    // Transmit 4 bytes
+    // Transmit and receive N bytes
+    // Receive 4 bytes
+    // This sequence, when paired with the agent's 4 byte granularity playback,
+    // works well as a smoke test case for spi host activity.
+    cfg.m_spi_device_agent_cfgs[spi_host_idx].num_bytes_per_trans_in_mon = 4;
+
+    // Setting the byte order to 0 ensures that the 4 byte transaction sent to
+    // the agent from the DUT is played back in exactly the same order, thus
+    // making things easy to compare.
+    cfg.m_spi_device_agent_cfgs[spi_host_idx].byte_order = '0;
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    spi_device_seq m_device_seq;
+    super.body();
+    `uvm_info(`gfn, $sformatf("Testing with spi host %d", spi_host_idx), UVM_LOW)
+
+    // enable interface
+    cfg.chip_vif.enable_spi_device(spi_host_idx, 1);
+
+    // create and start the spi_device sequence
+    m_device_seq = spi_device_seq::type_id::create("m_device_seq");
+
+    fork begin
+       m_device_seq.start(p_sequencer.spi_device_sequencer_hs[spi_host_idx]);
+    end
+    join_none
+  endtask
+
+
+endclass : chip_sw_spi_host_tx_rx_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -36,6 +36,7 @@
 `include "chip_sw_lc_walkthrough_vseq.sv"
 `include "chip_sw_lc_walkthrough_testunlocks_vseq.sv"
 `include "chip_sw_spi_tx_rx_vseq.sv"
+`include "chip_sw_spi_host_tx_rx_vseq.sv"
 `include "chip_sw_rom_ctrl_integrity_check_vseq.sv"
 `include "chip_sw_sram_ctrl_execution_main_vseq.sv"
 `include "chip_sw_sram_ctrl_scrambled_access_vseq.sv"

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -45,6 +45,12 @@ class chip_base_test extends cip_base_test #(
     cfg.m_uart_agent_cfgs[0].en_logger = cfg.en_uart_logger;
     cfg.m_uart_agent_cfgs[0].write_logs_to_file = cfg.write_sw_logs_to_file;
 
+    // all the spi_agents talking to the host interface should be configured into
+    // device mode
+    foreach (cfg.m_spi_device_agent_cfgs[i]) begin
+       cfg.m_spi_device_agent_cfgs[i].if_mode = dv_utils_pkg::Device;
+    end
+
     // Knob to set the sw_test_timeout_ns (set to 12ms by default).
     void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1630,6 +1630,83 @@ typedef enum top_earlgrey_pinmux_outsel {
 } top_earlgrey_pinmux_outsel_t;
 
 /**
+ * Dedicated Pad Selects
+ */
+typedef enum top_earlgrey_direct_pads {
+  kTopEarlgreyDirectPadsUsbdevUsbDp = 0, /**<  */
+  kTopEarlgreyDirectPadsUsbdevUsbDn = 1, /**<  */
+  kTopEarlgreyDirectPadsSpiHost0Sd0 = 2, /**<  */
+  kTopEarlgreyDirectPadsSpiHost0Sd1 = 3, /**<  */
+  kTopEarlgreyDirectPadsSpiHost0Sd2 = 4, /**<  */
+  kTopEarlgreyDirectPadsSpiHost0Sd3 = 5, /**<  */
+  kTopEarlgreyDirectPadsSpiDeviceSd0 = 6, /**<  */
+  kTopEarlgreyDirectPadsSpiDeviceSd1 = 7, /**<  */
+  kTopEarlgreyDirectPadsSpiDeviceSd2 = 8, /**<  */
+  kTopEarlgreyDirectPadsSpiDeviceSd3 = 9, /**<  */
+  kTopEarlgreyDirectPadsSysrstCtrlAonEcRstL = 10, /**<  */
+  kTopEarlgreyDirectPadsSysrstCtrlAonFlashWpL = 11, /**<  */
+  kTopEarlgreyDirectPadsSpiDeviceSck = 12, /**<  */
+  kTopEarlgreyDirectPadsSpiDeviceCsb = 13, /**<  */
+  kTopEarlgreyDirectPadsSpiHost0Sck = 14, /**<  */
+  kTopEarlgreyDirectPadsSpiHost0Csb = 15, /**<  */
+  kTopEarlgreyDirectPadsLast = 15, /**< \internal Last valid direct pad */
+} top_earlgrey_direct_pads_t;
+
+/**
+ * Muxed Pad Selects
+ */
+typedef enum top_earlgrey_muxed_pads {
+  kTopEarlgreyMuxedPadsIoa0 = 0, /**<  */
+  kTopEarlgreyMuxedPadsIoa1 = 1, /**<  */
+  kTopEarlgreyMuxedPadsIoa2 = 2, /**<  */
+  kTopEarlgreyMuxedPadsIoa3 = 3, /**<  */
+  kTopEarlgreyMuxedPadsIoa4 = 4, /**<  */
+  kTopEarlgreyMuxedPadsIoa5 = 5, /**<  */
+  kTopEarlgreyMuxedPadsIoa6 = 6, /**<  */
+  kTopEarlgreyMuxedPadsIoa7 = 7, /**<  */
+  kTopEarlgreyMuxedPadsIoa8 = 8, /**<  */
+  kTopEarlgreyMuxedPadsIob0 = 9, /**<  */
+  kTopEarlgreyMuxedPadsIob1 = 10, /**<  */
+  kTopEarlgreyMuxedPadsIob2 = 11, /**<  */
+  kTopEarlgreyMuxedPadsIob3 = 12, /**<  */
+  kTopEarlgreyMuxedPadsIob4 = 13, /**<  */
+  kTopEarlgreyMuxedPadsIob5 = 14, /**<  */
+  kTopEarlgreyMuxedPadsIob6 = 15, /**<  */
+  kTopEarlgreyMuxedPadsIob7 = 16, /**<  */
+  kTopEarlgreyMuxedPadsIob8 = 17, /**<  */
+  kTopEarlgreyMuxedPadsIob9 = 18, /**<  */
+  kTopEarlgreyMuxedPadsIob10 = 19, /**<  */
+  kTopEarlgreyMuxedPadsIob11 = 20, /**<  */
+  kTopEarlgreyMuxedPadsIob12 = 21, /**<  */
+  kTopEarlgreyMuxedPadsIoc0 = 22, /**<  */
+  kTopEarlgreyMuxedPadsIoc1 = 23, /**<  */
+  kTopEarlgreyMuxedPadsIoc2 = 24, /**<  */
+  kTopEarlgreyMuxedPadsIoc3 = 25, /**<  */
+  kTopEarlgreyMuxedPadsIoc4 = 26, /**<  */
+  kTopEarlgreyMuxedPadsIoc5 = 27, /**<  */
+  kTopEarlgreyMuxedPadsIoc6 = 28, /**<  */
+  kTopEarlgreyMuxedPadsIoc7 = 29, /**<  */
+  kTopEarlgreyMuxedPadsIoc8 = 30, /**<  */
+  kTopEarlgreyMuxedPadsIoc9 = 31, /**<  */
+  kTopEarlgreyMuxedPadsIoc10 = 32, /**<  */
+  kTopEarlgreyMuxedPadsIoc11 = 33, /**<  */
+  kTopEarlgreyMuxedPadsIoc12 = 34, /**<  */
+  kTopEarlgreyMuxedPadsIor0 = 35, /**<  */
+  kTopEarlgreyMuxedPadsIor1 = 36, /**<  */
+  kTopEarlgreyMuxedPadsIor2 = 37, /**<  */
+  kTopEarlgreyMuxedPadsIor3 = 38, /**<  */
+  kTopEarlgreyMuxedPadsIor4 = 39, /**<  */
+  kTopEarlgreyMuxedPadsIor5 = 40, /**<  */
+  kTopEarlgreyMuxedPadsIor6 = 41, /**<  */
+  kTopEarlgreyMuxedPadsIor7 = 42, /**<  */
+  kTopEarlgreyMuxedPadsIor10 = 43, /**<  */
+  kTopEarlgreyMuxedPadsIor11 = 44, /**<  */
+  kTopEarlgreyMuxedPadsIor12 = 45, /**<  */
+  kTopEarlgreyMuxedPadsIor13 = 46, /**<  */
+  kTopEarlgreyMuxedPadsLast = 46, /**< \internal Last valid muxed pad */
+} top_earlgrey_muxed_pads_t;
+
+/**
  * Power Manager Wakeup Signals
  */
 typedef enum top_earlgrey_power_manager_wake_ups {

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -75,6 +75,12 @@ extern const uint64_t kClockFreqCpuHz;
 extern const uint64_t kClockFreqPeripheralHz;
 
 /**
+ * The high-speed peripheral clock frequency of the device, in hertz.
+ * This is the operating clock used by the spi host
+ */
+extern const uint64_t kClockFreqHiSpeedPeripheralHz;
+
+/**
  * The USB clock frequency of the device, in hertz.
  * This is the operating clock used by the USB phy interface.
  */

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -21,6 +21,8 @@ const uint64_t kClockFreqCpuHz = kClockFreqCpuMhz * 1000 * 1000;
 
 uint64_t to_cpu_cycles(uint64_t usec) { return usec * kClockFreqCpuMhz; }
 
+const uint64_t kClockFreqHiSpeedPeripheralHz = 10 * 1000 * 1000;  // 10MHz
+
 const uint64_t kClockFreqPeripheralHz = 25 * 100 * 1000;  // 2.5MHz
 
 const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -21,6 +21,8 @@ const uint64_t kClockFreqCpuHz = kClockFreqCpuMhz * 1000 * 1000;
 
 uint64_t to_cpu_cycles(uint64_t usec) { return usec * kClockFreqCpuMhz; }
 
+const uint64_t kClockFreqHiSpeedPeripheralHz = 96 * 1000 * 1000;  // 96MHz
+
 const uint64_t kClockFreqPeripheralHz = 24 * 1000 * 1000;  // 24MHz
 
 const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -28,6 +28,8 @@ uint64_t to_cpu_cycles(uint64_t usec) {
   return (usec + 1) / 2;
 }
 
+const uint64_t kClockFreqHiSpeedPeripheralHz = 500 * 1000;  // 500kHz
+
 const uint64_t kClockFreqPeripheralHz = 125 * 1000;  // 125kHz
 
 const uint64_t kClockFreqUsbHz = 500 * 1000;  // 500kHz

--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -71,7 +71,8 @@ dif_result_t dif_spi_host_configure(const dif_spi_host_t *spi_host,
     return kDifBadArg;
   }
 
-  uint32_t divider = (config.peripheral_clock_freq_hz / config.spi_clock) - 1;
+  uint32_t divider =
+      ((config.peripheral_clock_freq_hz / config.spi_clock) / 2) - 1;
   if (divider & ~SPI_HOST_CONFIGOPTS_CLKDIV_0_MASK) {
     return kDifBadArg;
   }

--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -89,7 +89,7 @@ class SpiHostTest : public Test, public MmioTest {
   };
 
   dif_spi_host_config config_ = {
-      .spi_clock = 1000000,
+      .spi_clock = 500000,
       .peripheral_clock_freq_hz = 1000000,
       .chip_select =
           {
@@ -162,7 +162,7 @@ TEST_F(ConfigTest, ClockRate) {
   ExpectDeviceReset();
   EXPECT_WRITE32(SPI_HOST_CONFIGOPTS_REG_OFFSET,
                  {
-                     {SPI_HOST_CONFIGOPTS_CLKDIV_0_OFFSET, 1},
+                     {SPI_HOST_CONFIGOPTS_CLKDIV_0_OFFSET, 0},
                      {SPI_HOST_CONFIGOPTS_CSNIDLE_0_OFFSET, 0},
                      {SPI_HOST_CONFIGOPTS_CSNTRAIL_0_OFFSET, 0},
                      {SPI_HOST_CONFIGOPTS_CSNLEAD_0_OFFSET, 0},

--- a/sw/device/tests/rstmgr_sw_rst_ctrl_test.c
+++ b/sw/device/tests/rstmgr_sw_rst_ctrl_test.c
@@ -82,7 +82,7 @@ static void spi_device_config(void *dif) {
 
 static void spi_host0_config(void *dif) {
   dif_spi_host_config_t cfg = {
-      .spi_clock = 1000000,
+      .spi_clock = 500000,
       .peripheral_clock_freq_hz = 1000000,
       .chip_select =
           {
@@ -99,7 +99,7 @@ static void spi_host0_config(void *dif) {
 
 static void spi_host1_config(void *dif) {
   dif_spi_host_config_t cfg = {
-      .spi_clock = 5000000,
+      .spi_clock = 2500000,
       .peripheral_clock_freq_hz = 5000000,
       .chip_select =
           {

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -631,6 +631,23 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "spi_host_tx_rx_test",
+    srcs = ["spi_host_tx_rx_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:spi_host",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "rv_dm_ndm_reset_req",
     srcs = ["rv_dm_ndm_reset_req.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/spi_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_host_tx_rx_test.c
@@ -1,0 +1,113 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_spi_host.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define DATA_SET_SIZE 16
+
+static dif_spi_host_t spi_host;
+static dif_pinmux_t pinmux;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+void enable_pull_up(void) {
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+
+  dif_pinmux_pad_attr_t out_attr;
+  dif_pinmux_pad_attr_t in_attr = {
+      .slew_rate = 0,
+      .drive_strength = 0,
+      .flags = kDifPinmuxPadAttrPullResistorEnable |
+               kDifPinmuxPadAttrPullResistorUp};
+
+  // set weak pull-ups for all the pins
+  top_earlgrey_direct_pads_t spi_direct_pads[6] = {
+      kTopEarlgreyDirectPadsSpiHost0Sd0, kTopEarlgreyDirectPadsSpiHost0Sd1,
+      kTopEarlgreyDirectPadsSpiHost0Sd2, kTopEarlgreyDirectPadsSpiHost0Sd3,
+      kTopEarlgreyDirectPadsSpiHost0Sck, kTopEarlgreyDirectPadsSpiHost0Csb};
+
+  for (uint32_t i = 0; i <= ARRAYSIZE(spi_direct_pads); ++i) {
+    CHECK_DIF_OK(dif_pinmux_pad_write_attrs(
+        &pinmux, spi_direct_pads[i], kDifPinmuxPadKindDio, in_attr, &out_attr));
+  }
+}
+
+bool test_main(void) {
+  // enable pull-up on relevant pads
+  enable_pull_up();
+
+  CHECK_DIF_OK(dif_spi_host_init(
+      mmio_region_from_addr(TOP_EARLGREY_SPI_HOST0_BASE_ADDR), &spi_host));
+
+  dif_spi_host_config_t config = {
+      .spi_clock = (uint32_t)(kClockFreqHiSpeedPeripheralHz / 2),
+      .peripheral_clock_freq_hz = (uint32_t)(kClockFreqHiSpeedPeripheralHz),
+      .chip_select = {.idle = 2, .trail = 2, .lead = 2},
+      .full_cycle = true,
+      .cpha = true,
+      .cpol = true};
+
+  // Setup spi host configuration
+  CHECK_DIF_OK(dif_spi_host_configure(&spi_host, config));
+
+  uint32_t expected_data[DATA_SET_SIZE];
+  uint32_t received_data[DATA_SET_SIZE];
+  for (uint32_t i = 0; i < ARRAYSIZE(expected_data); ++i) {
+    expected_data[i] = rand_testutils_gen32();
+  }
+
+  // Define the segments:
+  // 1st segment, TX only, host sends out the first word.
+  // 2nd segment, Bidirectional.  The external device begins sending back data
+  // that it received. So it always lags the TX by 1 word.
+  // 3rd segment, RX only, final word readback.
+  dif_spi_host_segment_t host_operations[3] = {
+      {.type = kDifSpiHostSegmentTypeTx,
+       .tx = {.width = kDifSpiHostWidthStandard,
+              .buf = &expected_data[0],
+              .length = 4}},
+
+      {.type = kDifSpiHostSegmentTypeBidirectional,
+       .bidir = {.width = kDifSpiHostWidthStandard,
+                 .txbuf = &expected_data[1],
+                 .rxbuf = received_data,
+                 .length = (DATA_SET_SIZE - 1) * sizeof(uint32_t)}},
+
+      {.type = kDifSpiHostSegmentTypeRx,
+       .tx = {.width = kDifSpiHostWidthStandard,
+              .buf = &received_data[DATA_SET_SIZE - 1],
+              .length = 4}},
+  };
+
+  // Enable spi host to actually talk to the outside world
+  CHECK_DIF_OK(dif_spi_host_output_set_enabled(&spi_host, true));
+
+  // Issue host transactions
+  CHECK_DIF_OK(dif_spi_host_transaction(&spi_host, /*csid=*/0, host_operations,
+                                        ARRAYSIZE(host_operations)));
+
+  uint32_t err = 0;
+  for (int32_t i = 0; i < ARRAYSIZE(expected_data); ++i) {
+    if (received_data[i] != expected_data[i]) {
+      err++;
+      LOG_INFO("Received 0x%x, Expected 0x%x", received_data[i],
+               expected_data[i]);
+    }
+  }
+
+  return (err == 0);
+}

--- a/util/topgen/templates/toplevel.h.tpl
+++ b/util/topgen/templates/toplevel.h.tpl
@@ -164,6 +164,16 @@ ${helper.pinmux_mio_out.render()}
 ${helper.pinmux_outsel.render()}
 
 /**
+ * Dedicated Pad Selects
+ */
+${helper.direct_pads.render()}
+
+/**
+ * Muxed Pad Selects
+ */
+${helper.muxed_pads.render()}
+
+/**
  * Power Manager Wakeup Signals
  */
 ${helper.pwrmgr_wakeups.render()}


### PR DESCRIPTION
Add a basic spi host tx rx test.
This test uses the spi_agent's native "loopback" behavior.
The spi agent, when in device mode, by default just plays
back whatever data is sent to it by the host.

The test prepares a random payload, sends it to the device agent,
and just reads back to make sure the data is matched.

This test DOES NOT do any kind of flash protocol checking.

- Add a device value for high speed peripehral clock
- Add a minor fix for dif_spi_host clock divider setting