### PR TITLE
[bazel,ottf,dv] fix `extract_sw_logs.py` script

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -152,10 +152,6 @@ SECTIONS {
     KEEP(*(__llvm_covfun))
     KEEP(*(__llvm_covmap))
     KEEP(*(__llvm_prf_names))
-
-    /* TODO(#14636): extract_sw_logs_db requires .rodata section. */
-    . = ALIGN(4);
-    _rodata_end = .;
   } > ottf_flash
 
   /**

--- a/util/device_sw_utils/extract_sw_logs.py
+++ b/util/device_sw_utils/extract_sw_logs.py
@@ -157,7 +157,9 @@ def get_str_at_addr(str_addr, addr_strings):
     for addr in addr_strings.keys():
         if addr <= str_addr < addr + len(addr_strings[addr]):
             return addr_strings[addr][str_addr - addr:].strip()
-    raise KeyError("string at addr {} not found".format(str_addr))
+    raise KeyError(f"string at addr {str_addr} not found"
+                   "Are you trying to print (unsupported) whitespace? "
+                   "i.e., LOG_INFO(\"\\n\"")
 
 
 def extract_sw_logs(elf_file, logs_fields_section, ro_sections):
@@ -177,10 +179,8 @@ def extract_sw_logs(elf_file, logs_fields_section, ro_sections):
                 size = int(section.header['sh_size'])
                 data = section.data()
                 ro_contents.append((base_addr, size, data))
-            else:
-                print("Error: {} section not found in {}".format(
-                    ro_section, elf_file))
-                sys.exit(1)
+            # If there is no ro section then we will end up generating empty
+            # database files which is OK, and keeps the SW build from failing.
         addr_strings = get_addr_strings(ro_contents)
 
         # Dump the {addr: string} data.


### PR DESCRIPTION
This fixes two issues with the `extract_sw_logs.py` script that were noticed in #14636 and #14858:

1. if the is no `.rodata` section the script was failing, when in reality it could just generate empty logs database files to pass to the DV testbench,
2. Logging a string of whitespace, e.g., with `LOG_INFO("\n")` caused the script to error out silently. Now, a more detailed error message is printed to inform developers this is un-supported behavior.

This fixes #14636.

Signed-off-by: Timothy Trippel <ttrippel@google.com>