### PR TITLE
[util] Fix extract_sw_logs.py

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -489,8 +489,6 @@ def _gen_sim_dv_logs_db_impl(ctx):
             arguments = [
                 "--elf-file",
                 src.path,
-                "--rodata-sections",
-                ".rodata",
                 "--logs-fields-section",
                 ".logs.fields",
                 "--name",

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -152,10 +152,6 @@ SECTIONS {
     KEEP(*(__llvm_covfun))
     KEEP(*(__llvm_covmap))
     KEEP(*(__llvm_prf_names))
-
-    /* TODO(#14636): extract_sw_logs_db requires .rodata section. */
-    . = ALIGN(4);
-    _rodata_end = .;
   } > ottf_flash
 
   /**


### PR DESCRIPTION
Fixes #14636.
Fixes issue encountered in #14858.

Rather than being told which ELF sections to parse and generate a database from, the script now reads ALL valid sections from the ELF and creates a database of address and string found at that address. This eliminates the need to pass sections using the `--rodata-sections` arg in the bazel rules. This takes care of string constants that reside in other sections (for example, the `chip_info` which resides in its own `.chip_info` section).

The other bug was in the `get_str_at_addr()` method, which returns a string (or substring) starting at a particular address. This computation requires the original length of the string to be known. Since the strings go through sanitization, the orignal length may change, leading to errors thrown when printing single whitespace characters, such as `LOG_INFO("\n")`. The change records the original length of the string along with the string (as a tuple) at each address.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>