### PR TITLE
[dv,flash_ctrl] lc_ctrl mubi input test

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -228,6 +228,25 @@
       tests: ["flash_ctrl_oversize_error"]
     }
     {
+      name: flash_ctrl_disable
+      desc: '''
+            Set flash ctrl disable by hw (lc_escalate_en = On) or
+            sw (flash_ctrl.dis = MuBi4True). And try to access flash ctrl
+            and check the access attempt to be failed.
+            '''
+      stage: V2
+      tests: ["flash_ctrl_disable"]
+    }
+    {
+      name: flash_ctrl_connect
+      desc: '''
+            Check jtag input / output ports connectivity with lc_nvm_debug_en.
+            Connections are set only when lc_nvm_debug_en = On.
+            '''
+      stage: V2
+      tests: ["flash_ctrl_connect"]
+    }
+    {
       name: stress_all
       desc: '''
             - combine above sequences in one test to run sequentially, except csr sequence
@@ -241,15 +260,6 @@
       desc: '''
             Perform accesses in order to provoke native flash error. Test both, Software interface
             and Hardware interface. Related covergroup is error_cg.
-            '''
-      stage: V2S
-      tests: []
-    }
-    {
-      name: error_lc
-      desc: '''
-            Perform accesses in order to provoke life cycle management interface error. Related
-            covergroup is error_cg.
             '''
       stage: V2S
       tests: []

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -56,7 +56,6 @@ filesets:
       - seq_lib/flash_ctrl_error_mp_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_invalid_op_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_mid_op_rst_vseq.sv: {is_include_file: true}
-      - seq_lib/flash_ctrl_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_otf_base_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_wo_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_ro_vseq.sv: {is_include_file: true}
@@ -82,6 +81,8 @@ filesets:
       - seq_lib/flash_ctrl_disable_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_rd_path_intg_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_wr_path_intg_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_info_part_access_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
@@ -34,7 +34,8 @@ class flash_ctrl_connect_vseq extends flash_ctrl_base_vseq;
     // tdo_oe : dut.eflash
 
     lc_nvm_debug_en = $urandom_range(0, 1);
-    cfg.flash_ctrl_vif.lc_nvm_debug_en = (lc_nvm_debug_en)? lc_ctrl_pkg::On : lc_ctrl_pkg::Off;
+    cfg.flash_ctrl_vif.lc_nvm_debug_en = (lc_nvm_debug_en)?
+      lc_ctrl_pkg::On : get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
 
     // takes dealy to propagate lc_nvm_debug_en
     cfg.clk_rst_vif.wait_clks(5);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
@@ -14,15 +14,15 @@ class flash_ctrl_disable_vseq extends flash_ctrl_otf_base_vseq;
     bit exp_err;
 
     send_rand_ops();
-    exp_err = set_flash_disable();
+    set_flash_disable(exp_err);
 
     if (exp_err) begin
-       `uvm_info("SEQ", $sformatf("assa disable is set"), UVM_MEDIUM)
+       `uvm_info("SEQ", $sformatf("disable is set"), UVM_MEDIUM)
        csr_utils_pkg::wait_no_outstanding_access();
        cfg.m_tl_agent_cfg.check_tl_errs = 0;
 
     end
-    `uvm_info("SEQ", $sformatf("assa disable txn start"), UVM_MEDIUM)
+    `uvm_info("SEQ", $sformatf("disable txn start"), UVM_MEDIUM)
     // mp error or tlul error expected
 
     send_rand_ops(1, exp_err);
@@ -30,11 +30,21 @@ class flash_ctrl_disable_vseq extends flash_ctrl_otf_base_vseq;
     `DV_CHECK_EQ(cfg.tlul_core_obs_cnt, cfg.tlul_core_exp_cnt)
   endtask // body
 
-  // Assign static value for now.
-  // Will be randomzie for V2S.
-  function bit set_flash_disable();
-    cfg.flash_ctrl_vif.lc_escalate_en = lc_ctrl_pkg::On;
-
-    return (cfg.flash_ctrl_vif.lc_escalate_en == lc_ctrl_pkg::On);
-  endfunction
+  task set_flash_disable(ref bit exp_err);
+    bit is_disable = 0;
+    randcase
+      1: begin
+        cfg.flash_ctrl_vif.lc_escalate_en =
+          get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(4));
+        is_disable = (cfg.flash_ctrl_vif.lc_escalate_en == lc_ctrl_pkg::On);
+      end
+      1: begin
+        mubi4_t dis_val;
+        dis_val = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(4));
+        csr_wr(.ptr(ral.dis), .value(dis_val));
+        is_disable = (dis_val == MuBi4True);
+      end
+    endcase // randcase
+    exp_err = is_disable;
+  endtask
 endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
@@ -47,7 +47,7 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
 
   endfunction : configure_vseq
 
-  task body();
+  virtual task body();
 
     // Local Variables
     data_q_t flash_op_data;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
@@ -1,0 +1,143 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The sequence accesses secret info regions after randomize lc_ctrl inputs.
+// lc_ctrl_inputs:
+
+//   .lc_creator_seed_sw_rw_en_i
+//   .lc_owner_seed_sw_rw_en_i
+//   .lc_seed_hw_rd_en_i
+//   .lc_iso_part_sw_rd_en_i
+//   .lc_iso_part_sw_wr_en_i
+
+class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
+  `uvm_object_utils(flash_ctrl_info_part_access_vseq)
+  `uvm_object_new
+
+  typedef enum {
+    AccessTest,
+    ReadOnlyTest,
+    WriteOnlyTest
+  } test_type_e;
+
+  virtual task body();
+    int round = 0;
+    flash_init = FlashMemInitRandomize;
+    reset_flash();
+
+    // INITIALIZE FLASH REGIONS
+    init_sec_info_part();
+    $assertoff(0, "prim_lc_sync");
+    cfg.seq_cfg.check_mem_post_tran = 1;
+
+    repeat (10) begin
+      `uvm_info(`gfn, $sformatf("iter:%0d", round++), UVM_LOW)
+
+      check_lc_ctrl(cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en, FlashCreatorPart);
+      check_lc_ctrl(cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en, FlashOwnerPart);
+      randcase
+        1: check_lc_ctrl(cfg.flash_ctrl_vif.lc_seed_hw_rd_en, FlashCreatorPart, ReadOnlyTest);
+        1: check_lc_ctrl(cfg.flash_ctrl_vif.lc_seed_hw_rd_en, FlashOwnerPart, ReadOnlyTest);
+      endcase
+      randcase
+        1: check_lc_ctrl(cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en, FlashIsolPart, WriteOnlyTest);
+        1: check_lc_ctrl(cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en, FlashIsolPart, ReadOnlyTest);
+      endcase
+    end
+  endtask // body
+
+  task check_lc_ctrl(lc_ctrl_pkg::lc_tx_t sig, flash_sec_part_e part,
+                     test_type_e test = AccessTest);
+    flash_op_e flash_op;
+    bit is_valid;
+
+    if (test == AccessTest) begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flash_op,
+                                         flash_op != FlashOpInvalid;)
+    end else if (test  == ReadOnlyTest) begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flash_op,
+                                         flash_op == FlashOpRead;)
+    end else begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flash_op,
+                                         flash_op inside {FlashOpProgram, FlashOpErase};)
+    end
+
+    sig = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(4));
+    is_valid = is_lc_ctrl_valid(sig);
+
+    `uvm_info(`gfn, $sformatf("Check sig:0x%x(is_valid:%0d) part:%s op:%s testype:%s",
+                              sig, is_valid, part.name, flash_op.name, test.name), UVM_LOW)
+
+    do_flash_op_info_part(part, flash_op, is_valid);
+  endtask // check_lc_ctrl
+
+  // Task to access secret info partition.
+  // lc control should be set from the exernal task.
+  task do_flash_op_info_part(flash_sec_part_e part, flash_op_e op, bit is_valid);
+    data_q_t flash_op_data;
+    flash_op_t flash_op;
+    flash_op.op = op;
+    flash_op.erase_type = FlashErasePage;
+
+    case (part)
+      FlashCreatorPart: begin
+        flash_op.addr      = FlashCreatorPartStartAddr;  // Fixed Val
+        flash_op.num_words = FullPageNumWords;  // Fixed Val
+        flash_op.partition = FlashPartInfo;
+      end
+      FlashOwnerPart: begin
+        flash_op.addr      = FlashOwnerPartStartAddr;  // Fixed Val
+        flash_op.num_words = FullPageNumWords;  // Fixed Val
+        flash_op.partition = FlashPartInfo;
+      end
+      FlashIsolPart: begin
+        flash_op.addr      = FlashIsolPartStartAddr;  // Fixed Val
+        flash_op.num_words = FullPageNumWords;  // Fixed Val
+        flash_op.partition = FlashPartInfo;
+      end
+      default: `uvm_error(`gfn, $sformatf("%s partition is not supported in this task",
+                                          part.name))
+    endcase
+
+
+    flash_op_data = '{};
+    case (op)
+      FlashOpErase: begin
+        if (!is_valid) set_otf_exp_alert("recov_err");
+        flash_ctrl_start_op(flash_op);
+        wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
+        cfg.flash_mem_bkdr_erase_check(.flash_op(flash_op), .check_match(is_valid));
+      end
+      FlashOpProgram: begin
+        for (int i = 0; i < flash_op.num_words; i++) begin
+          flash_op_data[i] = $urandom_range(0, 2 ** (TL_DW) - 1);
+        end
+        if (!is_valid) begin
+          repeat(32) set_otf_exp_alert("recov_err");
+        end
+        // This task issues flash_ctrl.control write 32 times
+        flash_ctrl_write_extra(flash_op, flash_op_data, is_valid);
+
+      end
+      FlashOpRead: begin
+        if (!is_valid) set_otf_exp_alert("recov_err");
+        flash_ctrl_start_op(flash_op);
+        flash_ctrl_read(flash_op.num_words, flash_op_data, 1);
+        wait_flash_op_done();
+        cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data, is_valid);
+      end
+      default: `uvm_error(`gfn, $sformatf("%s op is not supported in this task",
+                                          op.name))
+    endcase
+  endtask
+
+  task init_sec_info_part();
+    flash_bank_mp_info_page_cfg_t info_regions = '{default: MuBi4True};
+
+    for (int i = 1; i < 4; i++) begin
+      flash_ctrl_mp_info_page_cfg(0, 0, i, info_regions);
+    end
+  endtask // init_info_part
+
+endclass // flash_ctrl_info_part_access_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -596,7 +596,6 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         if (overrd > 0) begin
           overread(flash_op, bank, num, overrd);
         end
-
         if (!in_err) wait_flash_op_done();
 
       end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -50,4 +50,5 @@
 `include "flash_ctrl_disable_vseq.sv"
 `include "flash_ctrl_rd_path_intg_vseq.sv"
 `include "flash_ctrl_wr_path_intg_vseq.sv"
+`include "flash_ctrl_info_part_access_vseq.sv"
 `include "flash_ctrl_stress_all_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -331,11 +331,16 @@
       uvm_test_seq: flash_ctrl_disable_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+en_always_all=1",
                  "+bypass_alert_ready_to_end_check=1"]
-      reseed: 1
+      reseed: 20
     }
     {
       name: flash_ctrl_sec_cm
       run_timeout_mins: 120
+    }
+    {
+      name: flash_ctrl_sec_info_access
+      uvm_test_seq: flash_ctrl_info_part_access_vseq
+      reseed: 5
     }
     {
       name: flash_ctrl_stress_all

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -57,15 +57,31 @@
     }
     {
       name: sec_cm_scramble_key_sideload
-      desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
+      desc: '''Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD.
+
+      '''
       stage: V2S
       tests: []
     }
     {
       name: sec_cm_lc_ctrl_intersig_mubi
-      desc: "Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI."
+      desc: '''Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI.
+        - Creator info partition can be read, written, erased when lc_creator_seed_sw_rw_en is true.
+          Owner info partition can be read, written, erased when lc_owner_seed_sw_rw_en is true.
+          Both partition can be read when lc_seed_hw_rd_en is true.
+          Isolated info partition can be written whwen lc_iso_part_sw_wr_en is true,
+          and can be read when lc_iso_part_sw_rd_en is true.
+          Run test for each partition and check whether each partition can be accessed
+          only when each lc_ctrl input is valid.
+          If lc_ctrl inputs are invalid, the access to the secret info region will trigger
+          recoverable fatal alert.
+        - lc_escalate_en_i is covered by flash_ctrl_disable test. See 'flash_ctrl_disable`
+          from the flash_ctrl_testpan.hjson
+        - lc_nvm_debug_en_i is covered by flash_ctrl_connect. See 'flash_ctrl_connect'
+          from the flash_ctrl_testplan.hjson
+      '''
       stage: V2S
-      tests: []
+      tests: ["flash_ctrl_sec_info_access", "flash_ctrl_disable", "flash_ctrl_connect"]
     }
     {
       name: sec_cm_ctrl_config_regwen


### PR DESCRIPTION
 - Add not equal match to mem_bkdr_read_check
 - Add a new test to drive lc_ctrl inputs with invalid value
 - Add sw disable mode to flash_ctrl_disable test
 - Add mubi rand to flash_ctrl_disable test and flash_ctrl_connect test
 - Update testplans

Signed-off-by: Jaedon Kim <jdonjdon@google.com>