### PR TITLE
[chip dv] Cleanup of nightly regression fallout due to #14776

### DIFF
--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -68,6 +68,13 @@ package dv_utils_pkg;
     BusOpRead  = 1'b1
   } bus_op_e;
 
+ // Enum representing a probe operation on an internal signal.
+  typedef enum {
+    SignalProbeSample,  // Sample the signal.
+    SignalProbeForce,   // Force the signal with some value.
+    SignalProbeRelease  // Release the previous force.
+  } signal_probe_e;
+
   // Enum representing a type of host requests - read only, write only or random read & write
   typedef enum int {
     HostReqNone      = 0,

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -19,7 +19,7 @@
     // Signed chip-level tests to be run with ROM, instead of test ROM.
     {
       name: chip_sw_uart_smoketest_signed
-      uvm_test_seq: chip_sw_base_vseq
+      uvm_test_seq: chip_sw_uart_smoke_vseq
       sw_images: ["//sw/device/tests:uart_smoketest_signed:1:signed"]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -247,9 +247,7 @@
       // The tests using this mode only require the ROM init check to succeed.
       // The example_test_from_rom test is sufficient.
       sw_images: ["//sw/device/tests:example_test_from_rom:0:test_in_rom"]
-      run_opts: ["+create_jtag_riscv_map=1",
-                 // select DFT tap
-                 "+uart0_sel=0"]
+      run_opts: ["+create_jtag_riscv_map=1"]
       reseed: 5
     }
     {

--- a/hw/top_earlgrey/dv/chip_smoketests.hjson
+++ b/hw/top_earlgrey/dv/chip_smoketests.hjson
@@ -108,7 +108,7 @@
     }
     {
       name: chip_sw_uart_smoketest
-      uvm_test_seq: chip_sw_base_vseq
+      uvm_test_seq: chip_sw_uart_smoke_vseq
       sw_images: ["//sw/device/tests:uart_smoketest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }

--- a/hw/top_earlgrey/dv/env/chip_common_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_common_pkg.sv
@@ -99,4 +99,11 @@ package chip_common_pkg;
     UsbDev
   } chip_peripheral_e;
 
+  typedef enum bit [1:0] {
+    JtagTapNone = 2'b00,
+    JtagTapLc = 2'b01,
+    JtagTapRvDm = 2'b10,
+    JtagTapDft = 2'b11
+  } chip_jtag_tap_e;
+
 endpackage

--- a/hw/top_earlgrey/dv/env/chip_common_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_common_pkg.sv
@@ -28,6 +28,26 @@ package chip_common_pkg;
 
   // TODO: Eventually, move everything from chip_env_pkg to here.
 
+  // Represents the various chip-wide control signals broadcast by the LC controller.
+  //
+  // The design emits these as a redundantly encoded signal of type lc_ctrl_pkg::lc_tx_t, which can
+  // be compared against the {On, Off} values.
+  typedef enum {
+    LcCtrlSignalDftEn,
+    LcCtrlSignalNvmDebugEn,
+    LcCtrlSignalHwDebugEn,
+    LcCtrlSignalCpuEn,
+    LcCtrlSignalCreatorSeedEn,
+    LcCtrlSignalOwnerSeedEn,
+    LcCtrlSignalIsoRdEn,
+    LcCtrlSignalIsoWrEn,
+    LcCtrlSignalSeedRdEn,
+    LcCtrlSignalKeyMgrEn,
+    LcCtrlSignalEscEn,
+    LcCtrlSignalCheckBypEn,
+    LcCtrlSignalNumTotal
+  } lc_ctrl_signal_e;
+
   // Chip IOs.
   //
   // This aggregates all chip IOs as seen at the pads.

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -26,6 +26,7 @@ filesets:
       - lowrisc:dv:uart_agent
       - lowrisc:dv:pwm_monitor
       - lowrisc:ip:otp_ctrl_pkg
+      - lowrisc:ip:pwrmgr_pkg
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
       - "fileset_partner ? (partner:systems:ast_pkg)"
     files:

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -47,6 +47,7 @@ filesets:
       - seq_lib/chip_prim_tl_access_vseq.sv: {is_include_file: true}
       - seq_lib/chip_tap_straps_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_uart_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_jtag_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_alert_handler_entropy_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_alert_handler_escalation_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -105,40 +105,6 @@ package chip_env_pkg;
     LcOtpError
   } lc_ctrl_status_e;
 
-  // enumeration for lc_ctrl broadcasts
-  typedef enum int {
-    DftEn = 0,
-    NvmDebugEn,
-    HwDebugEn,
-    CpuEn,
-    CreatorSeedEn,
-    OwnerSeedEn,
-    IsoRdEn,
-    IsoWrEn,
-    SeedRdEn,
-    KeyMgrEn,
-    EscEn,
-    CheckBypEn,
-    LcBroadcastLast
-  } lc_broadcast_e;
-
-  // hierarchy paths for lc_ctrl broadcast signals
-  string lc_broadcast_paths[LcBroadcastLast] = '{
-    0  : "lc_dft_en_o",
-    1  : "lc_nvm_debug_en_o",
-    2  : "lc_hw_debug_en_o",
-    3  : "lc_cpu_en_o",
-    4  : "lc_creator_seed_sw_rw_en_o",
-    5  : "lc_owner_seed_sw_rw_en_o",
-    6  : "lc_iso_part_sw_rd_en_o",
-    7  : "lc_iso_part_sw_wr_en_o",
-    8  : "lc_seed_hw_rd_en_o",
-    9  : "lc_keymgr_en_o",
-    10 : "lc_escalate_en_o",
-    11 : "lc_check_byp_en_o"
-  };
-
-
   // Extracts the address and size of a const symbol in a SW test (supplied as an ELF file).
   //
   // Used by a testbench to modify the given symbol in an executable (elf) generated for an embedded

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -94,13 +94,6 @@ package chip_env_pkg;
     SwTypeOtbn  // Otbn SW.
   } sw_type_e;
 
-  typedef enum bit [1:0] {
-    DeselectJtagTap = 2'b00,
-    SelectLCJtagTap = 2'b01,
-    SelectRVJtagTap = 2'b10,
-    SelectDftJtagTap = 2'b11
-  } chip_tap_type_e;
-
   // Two status for LC JTAG to identify if LC state transition is successful.
   typedef enum int {
     LcReady,

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -213,8 +213,8 @@ interface chip_if;
   // Functional (muxed) interface: sysrst_ctrl.
   // TODO: Replace with sysrst_ctrl IP level interface.
   // TODO; combine all into 1 single sysrst_ctrl_if.
-  pins_if #(8) sysrst_ctrl_if(.pins({ios[IoB3], ios[IoB6], ios[IoB8], ios[IoB9],
-                                     ios[IoC7], ios[IoC9], ios[IoR5], ios[IoR6]}));
+  pins_if #(8) sysrst_ctrl_if(.pins({ios[IoR6], ios[IoR5], ios[IoC9], ios[IoC7],
+                                     ios[IoB9], ios[IoB8], ios[IoB6], ios[IoB3]}));
 
   // Functional (dedicated) interface (input): AST misc.
   pins_if #(1) ast_misc_if(.pins(ios[AstMisc]));

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -174,7 +174,7 @@ interface chip_if;
 
   // Functional (dedicated) interface: SPI host interface (drives traffic into the chip).
   // TODO: Update spi_if to emit all signals as inout ports.
-  // spi_if spi_host_if(.rst_n(top_earlgrey.u_spi_device.rst_ni),
+  // spi_if spi_host_if(.rst_n(`SPI_DEVICE_HIER.rst_ni),
   //                    .sck(ios[SpiDevClk]),
   //                    .csb(ios[SpiDevCsL]),
   //                    .sio(ios[SpiDevD3:SpiDevD0]));
@@ -186,6 +186,12 @@ interface chip_if;
   assign spi_host_if.sio[1] = ios[SpiDevD1];
 
   // Functional (dedicated) interface: SPI AP device interface (receives traffic from the chip).
+  // TODO: Update spi_if to emit all signals as inout ports.
+  // spi_if spi_device_ap_if(.rst_n(`SPI_HOST_HIER(0).rst_ni),
+  //                         .sck(ios[SpiHostClk]),
+  //                         .csb(ios[SpiHostCsL]),
+  //                         .sio(ios[SpiHostD3:SpiHostD0]));
+
   spi_if spi_device_ap_if(.rst_n(`SPI_HOST_HIER(0).rst_ni));
   assign spi_device_ap_if.sck = ios[SpiHostClk];
   assign spi_device_ap_if.csb = ios[SpiHostCsL];
@@ -292,9 +298,10 @@ interface chip_if;
   assign ios[IoR4] = __enable_jtag ? jtag_if.trst_n : 1'bz;
 
   // Functional (muxed) interface: Flash controller JTAG.
-  logic enable_flash_ctrl_jtag, flash_ctrl_jtag_enabled;
+  bit enable_flash_ctrl_jtag, flash_ctrl_jtag_enabled;
   jtag_if flash_ctrl_jtag_if();
 
+  // TODO: Revisit this logic.
   assign flash_ctrl_jtag_enabled = enable_flash_ctrl_jtag && lc_hw_debug_en;
   assign ios[IoB0] = flash_ctrl_jtag_enabled ? flash_ctrl_jtag_if.tms : 1'bz;
   assign flash_ctrl_jtag_if.tdo = flash_ctrl_jtag_enabled ? ios[IoB1] : 1'bz;
@@ -344,11 +351,11 @@ interface chip_if;
   endfunction
 
   // Functional (muxed) interface: SPI EC device interface (receives traffic from the chip).
-  // spi_if spi_device_ec_if(.rst_n(top_earlgrey.u_spi_host1.rst_ni));
-  // assign spi_device_ec_if.csk = ios[IoB3];
-  // assign spi_device_ec_if.csb = ios[IoB0];
-  // assign spi_device_ec_if.sio[0] = ios[IoB1];
-  // assign ios[IoB2] = assign spi_device_ec_if.sio[1] : 1'bz;
+  // TODO: Update spi_if to emit all signals as inout ports.
+  // spi_if spi_device_ec_if(.rst_n(`SPI_HOST_HIER(1).rst_ni),
+  //                         .sck(ios[IoB3]),
+  //                         .csb(ios[IoB0]),
+  //                         .sio(ios[IoB1:IoB2]));
 
   // Functional (muxed) interface: I2Cs.
   bit [NUM_I2CS-1:0] enable_i2c;

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -175,11 +175,12 @@ interface chip_if;
   //                    .csb(ios[SpiDevCsL]),
   //                    .sio(ios[SpiDevD3:SpiDevD0]));
 
+  bit enable_spi_host = 1;  // Since these are DIOs.
   spi_if spi_host_if(.rst_n(`SPI_DEVICE_HIER.rst_ni));
-  assign ios[SpiDevClk] = spi_host_if.sck;
-  assign ios[SpiDevCsL] = spi_host_if.csb;
-  assign ios[SpiDevD0] = spi_host_if.sio[0];
-  assign spi_host_if.sio[1] = ios[SpiDevD1];
+  assign ios[SpiDevClk] = enable_spi_host ? spi_host_if.sck : 1'bz;
+  assign ios[SpiDevCsL] = enable_spi_host ? spi_host_if.csb : 1'bz;
+  assign ios[SpiDevD0] = enable_spi_host ? spi_host_if.sio[0] : 1'bz;
+  assign spi_host_if.sio[1] = enable_spi_host ? ios[SpiDevD1] : 1'bz;
 
   // Functional (dedicated) interface: SPI AP device interface (receives traffic from the chip).
   // TODO: Update spi_if to emit all signals as inout ports.
@@ -188,9 +189,10 @@ interface chip_if;
   //                         .csb(ios[SpiHostCsL]),
   //                         .sio(ios[SpiHostD3:SpiHostD0]));
 
+  bit enable_spi_device_ap = 1;  // Since these are DIOs.
   spi_if spi_device_ap_if(.rst_n(`SPI_HOST_HIER(0).rst_ni));
-  assign spi_device_ap_if.sck = ios[SpiHostClk];
-  assign spi_device_ap_if.csb = ios[SpiHostCsL];
+  assign spi_device_ap_if.sck = enable_spi_device_ap ? ios[SpiHostClk] : 1'bz;
+  assign spi_device_ap_if.csb = enable_spi_device_ap ? ios[SpiHostCsL] : 1'bz;
   // for (genvar i = 0; i < 4; i++) begin : gen_spi_device_ap_if_sio_conn
   //   // TODO: This logic needs to be firmed up.
   //   assign ios[SpiHostD0 + i] = spi_device_ap_if.sio_oe[i] ? spi_device_ap_if.sio[i] : 1'bz;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -144,35 +144,21 @@ class chip_base_vseq #(
     end
   endtask
 
-  // shorten alert ping timer enable wait time
+  // Shorten the alert handler ping timer wait cycles.
+  //
+  // This is done to speed up the simulation while achieving coverage on alert pings to various
+  // blocks.
+  // TODO; plusargs should be sought in a singla place (we do it in the base test class).
+  // TODO: Nothing may happen after calling this function, becuase it internally fetches a plusarg
+  // which can result in a nop. Refactor this later.
   task alert_ping_en_shorten();
-    string mask_path = {`DV_STRINGIFY(tb.dut.`ALERT_HANDLER_HIER),
-                        ".u_ping_timer.wait_cyc_mask_i"};
     bit shorten_ping_en;
-    `uvm_info(`gfn, $sformatf("ping enable path: %s", mask_path), UVM_HIGH)
     void'($value$plusargs("shorten_ping_en=%0d", shorten_ping_en));
     if (shorten_ping_en) begin
-       `DV_CHECK_FATAL(uvm_hdl_force(mask_path, 16'h3F))
+      void'(cfg.chip_vif.signal_probe_alert_handler_ping_timer_wait_cyc_mask_i(
+          SignalProbeForce, 16'h3F));
     end
   endtask : alert_ping_en_shorten
-
-  // shorten alert ping timer enable wait time
-  virtual task check_lc_ctrl_broadcast(bit [LcBroadcastLast-1:0] bool_vector);
-    foreach (lc_broadcast_paths[i]) begin
-      logic [lc_ctrl_pkg::TxWidth-1:0] curr_val;
-      string path = {`DV_STRINGIFY(tb.dut.`LC_CTRL_HIER), ".", lc_broadcast_paths[i]};
-      `DV_CHECK_FATAL(uvm_hdl_read(path, curr_val))
-      // if bool vector bit is 1, the probed value should be ON
-      // if bool vector bit is 0, the probed value should be OFF
-      if (bool_vector[i] ~^ (curr_val == lc_ctrl_pkg::On)) begin
-        `uvm_info(`gfn, $sformatf("%s: %d matched", lc_broadcast_paths[i],
-                                  curr_val), UVM_HIGH)
-      end else begin
-        `uvm_error(`gfn, $sformatf("%s: %d mismatched", lc_broadcast_paths[i],
-                                   curr_val))
-      end
-    end
-  endtask : check_lc_ctrl_broadcast
 
   // Initialize the OTP creator SW cfg region to use otbn for signature verification.
   virtual function void initialize_otp_sig_verify();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -54,6 +54,16 @@ class chip_base_vseq #(
     super.apply_reset(kind);
   endtask
 
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
+    cfg.chip_vif.por_n_if.drive(0);
+    // At least 6 AON clock cycles.
+    // TODO: Tentatively this is set to 100us. Fetch the individual clock freqs from AST via
+    // chip_vif.
+    reset_duration_ps = max2(reset_duration_ps, 100_000_000 /* 100us */);
+    super.apply_resets_concurrently(reset_duration_ps);
+    cfg.chip_vif.por_n_if.drive(1);
+  endtask
+
   chip_callback_vseq callback_vseq;
 
   // Iniitializes the DUT.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -49,6 +49,7 @@ class chip_base_vseq #(
     // TODO: Cannot assert different types of resets in parallel; due to randomization
     // resets de-assert at different times. If the main rst_n de-asserts before others,
     // the CPU starts executing right away which can cause breakages.
+    // TODO; Invoke only if JTAG is used.
     cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.do_trst_n();
     super.apply_reset(kind);
   endtask
@@ -58,7 +59,7 @@ class chip_base_vseq #(
   // Iniitializes the DUT.
   //
   // Initializes DUT inputs, internal memories, etc., brings the DUT out of reset (performs a reset
-  // cycle) and  performs immediate post-reset steps to prime the design for stimilus. The
+  // cycle) and  performs immediate post-reset steps to prime the design for stimulus. The
   // base class method invoked by super.dut_init() applies the reset.
   virtual task dut_init(string reset_kind = "HARD");
     // Initialize these spare IOs (chip inputs) to 0.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_base_vseq.sv
@@ -21,9 +21,9 @@ class chip_jtag_base_vseq extends chip_sw_base_vseq;
   endfunction // set_handles
 
   virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
     super.pre_start();
     max_outstanding_accesses = 1;
-    cfg.chip_vif.tap_straps_if.drive(SelectRVJtagTap);
   endtask
 
   task debug_mode_en();
@@ -47,4 +47,5 @@ class chip_jtag_base_vseq extends chip_sw_base_vseq;
       super.apply_reset(kind);
     join
   endtask
+
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_csr_rw_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_csr_rw_vseq.sv
@@ -9,9 +9,9 @@ class chip_jtag_csr_rw_vseq extends chip_common_vseq;
   `uvm_object_new
 
   virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
     cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
     super.pre_start();
-    cfg.chip_vif.tap_straps_if.drive(SelectRVJtagTap);
   endtask
 
   virtual task body();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_mem_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_mem_vseq.sv
@@ -13,9 +13,9 @@ class chip_jtag_mem_vseq extends chip_common_vseq;
   `uvm_object_new
 
   virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
     cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
     super.pre_start();
-    cfg.chip_vif.tap_straps_if.drive(SelectRVJtagTap);
   endtask
 
   virtual task body();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -19,14 +19,14 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     // monitor in block-level
     foreach (cfg.m_uart_agent_cfgs[i]) cfg.m_uart_agent_cfgs[i].en_tx_monitor = 0;
 
-    super.pre_start();
     // Deselect JTAG interface.
     if (cfg.jtag_riscv_map != null || cfg.use_jtag_dmi == 1) begin
-      cfg.chip_vif.tap_straps_if.drive(SelectRVJtagTap);
+      cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
     end else begin
-      cfg.chip_vif.tap_straps_if.drive(DeselectJtagTap);
+      cfg.chip_vif.tap_straps_if.drive(JtagTapNone);
     end
     enable_asserts_in_hw_reset_rand_wr = 0;
+    super.pre_start();
   endtask
 
   task post_start();
@@ -46,10 +46,10 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
 
   virtual task dut_init(string reset_kind = "HARD");
     // make sure jtag rst triggers
-    cfg.chip_vif.tap_straps_if.drive(SelectRVJtagTap);
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
     super.dut_init(reset_kind);
     if (cfg.jtag_riscv_map == null && cfg.use_jtag_dmi == 0) begin
-      cfg.chip_vif.tap_straps_if.drive(DeselectJtagTap);
+      cfg.chip_vif.tap_straps_if.drive(JtagTapNone);
     end
     // Program the AST with the configuration data loaded in OTP creator SW config region.
     if (cfg.use_jtag_dmi == 0) do_ast_cfg();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_entropy_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_entropy_vseq.sv
@@ -12,9 +12,7 @@ class chip_sw_alert_handler_entropy_vseq extends chip_sw_base_vseq;
   `uvm_object_new
 
   virtual task pre_start();
-    string wait_cyc_mask_path = {`DV_STRINGIFY(tb.dut.`ALERT_HANDLER_HIER),
-                                 ".u_ping_timer.wait_cyc_mask_i"};
-    `DV_CHECK(uvm_hdl_force(wait_cyc_mask_path, 'h7))
+    void'(cfg.chip_vif.signal_probe_alert_handler_ping_timer_wait_cyc_mask_i(SignalProbeForce, 7));
     super.pre_start();
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_escalation_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_escalation_vseq.sv
@@ -8,7 +8,7 @@ class chip_sw_alert_handler_escalation_vseq extends chip_sw_base_vseq;
   `uvm_object_new
 
   virtual task pre_start();
-    cfg.chip_vif.tap_straps_if.drive(SelectLCJtagTap);
+    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
     super.pre_start();
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -25,19 +25,14 @@ class chip_sw_base_vseq extends chip_base_vseq;
     super.dut_init(reset_kind);
   endtask
 
-  // Backdoor load the sw test image, setup UART, logger and test status interfaces.
+  // Backdoor load the sw test image, initialize memories, sw logger and test status interfaces.
   virtual task cpu_init();
      int size_bytes;
      int total_bytes;
 
-    `uvm_info(`gfn, "Started cpu_init", UVM_MEDIUM)
-    // TODO: Fixing this for now - need to find a way to pass this on to the SW test.
-    foreach (cfg.m_uart_agent_cfgs[i]) begin
-      cfg.m_uart_agent_cfgs[i].set_parity(1'b0, 1'b0);
-      cfg.m_uart_agent_cfgs[i].set_baud_rate(cfg.uart_baud_rate);
-    end
+    `uvm_info(`gfn, "Starting cpu_init", UVM_MEDIUM)
 
-    // initialize the sw logger interface
+    // Initialize the sw logger interface.
     foreach (cfg.sw_images[i]) begin
       cfg.sw_logger_vif.add_sw_log_db(cfg.sw_images[i]);
     end
@@ -45,12 +40,12 @@ class chip_sw_base_vseq extends chip_base_vseq;
     cfg.sw_logger_vif.write_sw_logs_to_file = cfg.write_sw_logs_to_file;
     cfg.sw_logger_vif.ready();
 
-    // initialize the sw test status
+    // Initialize the sw test status.
     cfg.sw_test_status_vif.sw_test_status_addr = SW_DV_TEST_STATUS_ADDR;
 
-    `uvm_info(`gfn, "Initializing RAM", UVM_MEDIUM)
+    `uvm_info(`gfn, "Initializing SRAMs", UVM_MEDIUM)
 
-    // Assume each tile contains the same number of bytes
+    // Assume each tile contains the same number of bytes.
     size_bytes = cfg.mem_bkdr_util_h[chip_mem_e'(RamMain0)].get_size_bytes();
     total_bytes = size_bytes * cfg.num_ram_main_tiles;
 
@@ -81,6 +76,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
 `else
     cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".39.scr.vmem"});
 `endif
+
     // TODO: the location of the main execution image should be randomized to either bank in future.
     if (cfg.sw_images.exists(SwTypeTest)) begin
       if (cfg.use_spi_load_bootstrap) begin
@@ -95,7 +91,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     config_jitter();
 
-    `uvm_info(`gfn, "CPU_init done", UVM_MEDIUM)
+    `uvm_info(`gfn, "cpu_init completed", UVM_MEDIUM)
   endtask
 
   // The jitter enable mechanism is different from test_rom and rom right now.
@@ -186,7 +182,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
   virtual task body();
     cfg.sw_test_status_vif.set_num_iterations(num_trans);
-    // Initialize the CPU to kick off the sw test.
+    // Initialize the CPU to kick off the sw test. TODO: Should be called in pre_start() instead.
     cpu_init();
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
@@ -29,7 +29,6 @@ class chip_sw_i2c_tx_rx_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual task body();
-    i2c_device_response_seq m_base_seq;
     super.body();
 
     // enable the monitor
@@ -45,8 +44,7 @@ class chip_sw_i2c_tx_rx_vseq extends chip_sw_base_vseq;
     // tClockPulse needs to be "slightly" longer than the clock period.
     cfg.m_i2c_agent_cfgs[0].timing_cfg.tClockPulse = half_period_cycles + 1;
 
-    i2c_device_autoresponder(m_base_seq);
-
+    i2c_device_autoresponder();
   endtask
 
   virtual task i2c_device_autoresponder(i2c_device_response_seq seq = null);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv
@@ -8,7 +8,7 @@ class chip_sw_lc_ctrl_program_error_vseq extends chip_sw_base_vseq;
   `uvm_object_new
 
   virtual task pre_start();
-    cfg.chip_vif.tap_straps_if.drive(SelectLCJtagTap);
+    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
     super.pre_start();
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv
@@ -14,8 +14,6 @@ class chip_sw_lc_ctrl_program_error_vseq extends chip_sw_base_vseq;
 
   virtual task body();
     bit [TL_DW-1:0] status_val;
-    string otp_path = {`DV_STRINGIFY(tb.dut.`OTP_CTRL_HIER),
-                       ".u_otp_ctrl_lci.lc_err_o"};
 
     super.body();
 
@@ -25,7 +23,7 @@ class chip_sw_lc_ctrl_program_error_vseq extends chip_sw_base_vseq;
              cfg.sw_test_timeout_ns)
 
     // force lc_ctrl program path to error
-    `DV_CHECK_FATAL(uvm_hdl_force(otp_path, 1'b1));
+    void'(cfg.chip_vif.signal_probe_otp_ctrl_lc_err_o(SignalProbeForce, 1));
 
     // poll for state to transition to post transition state
     jtag_csr_spinwait(ral.lc_ctrl.lc_state.get_offset(),

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -13,7 +13,7 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
   constraint num_trans_c {num_trans inside {[1 : 2]};}
 
   virtual task pre_start();
-    cfg.chip_vif.tap_straps_if.drive(SelectLCJtagTap);
+    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
     super.pre_start();
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
@@ -19,7 +19,7 @@ class chip_sw_lc_walkthrough_testunlocks_vseq extends chip_sw_base_vseq;
   bit [7:0] otp_unlock_token[TokenWidthByte];
 
   virtual task pre_start();
-    cfg.chip_vif.tap_straps_if.drive(SelectLCJtagTap);
+    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
     otp_raw_img_mubi_assertion_ctrl(.enable(0));
     super.pre_start();
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
@@ -23,9 +23,8 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
   virtual task pre_start();
     `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, dest_dec_state, dest_dec_state)
     `uvm_info(`gfn, $sformatf("Destination state is %0s", dest_dec_state.name), UVM_MEDIUM)
-
-    cfg.chip_vif.tap_straps_if.drive(SelectLCJtagTap);
     otp_raw_img_mubi_assertion_ctrl(.enable(0));
+    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
     super.pre_start();
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_repeat_reset_wkup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_repeat_reset_wkup_vseq.sv
@@ -25,7 +25,6 @@ class chip_sw_repeat_reset_wkup_vseq extends chip_sw_base_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    cfg.chip_vif.por_n_if.drive(0);
     cfg.chip_vif.pwrb_in_if.drive(1);
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_smoke_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_smoke_vseq.sv
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_uart_smoke_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_uart_smoke_vseq)
+
+  `uvm_object_new
+
+  rand int uart_idx;
+
+  constraint uart_idx_c {
+    uart_idx inside {[0:NUM_UARTS-1]};
+  }
+
+  // The smoke test only uses UART0, but it may change in future. Disable this constraint in
+  // extended classes.
+  constraint uart_idx_smoke_c {
+    uart_idx == 0;
+  }
+
+  virtual task body();
+    super.body();
+    configure_and_connect_uart(uart_idx);
+  endtask
+
+  // Configures the UART agent and connects uart_if to the chip IOs for the given instance.
+  virtual function void configure_and_connect_uart(int instance_num);
+    `DV_CHECK_FATAL(instance_num inside {[0:NUM_UARTS-1]})
+    `uvm_info(`gfn, $sformatf("Configuring and connecting UART%0d", instance_num), UVM_LOW)
+    cfg.m_uart_agent_cfgs[instance_num].set_parity(1'b0, 1'b0);
+    cfg.m_uart_agent_cfgs[instance_num].set_baud_rate(cfg.uart_baud_rate);
+    cfg.chip_vif.enable_uart(instance_num, 1);
+  endfunction
+
+  virtual task post_start();
+    super.post_start();
+    // Disconnect the UART interface.
+    cfg.chip_vif.enable_uart(uart_idx, 0);
+  endtask
+
+endclass : chip_sw_uart_smoke_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
+class chip_sw_uart_tx_rx_vseq extends chip_sw_uart_smoke_vseq;
   `uvm_object_utils(chip_sw_uart_tx_rx_vseq)
 
   `uvm_object_new
@@ -22,15 +22,14 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
     uart_rx_data.size() == UART_DATASET_SIZE;
   }
 
-  rand int uart_idx;
-
-  constraint uart_idx_c {
-    uart_idx inside {[0 : NUM_UARTS-1]};
-  }
+  function void pre_randomize();
+    uart_idx_smoke_c.constraint_mode(0);
+    super.pre_randomize();
+  endfunction
 
   task pre_start();
     void'($value$plusargs("uart_idx=%0d", uart_idx));
-    `DV_CHECK_LT(uart_idx, NUM_UARTS)
+    `DV_CHECK_FATAL(uart_idx inside {[0:NUM_UARTS-1]})
     super.pre_start();
   endtask
 
@@ -47,9 +46,6 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
 
-    // Connect the UART RX pin to the chip IOs.
-    cfg.chip_vif.enable_uart(uart_idx, 1);
-
     // Spawn off a thread to retrieve UART TX items.
     fork get_uart_tx_items(uart_idx); join_none
 
@@ -57,7 +53,7 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
     `DV_WAIT(uart_tx_data_q.size() > 0)
 
     // Start sending uart_rx_data over RX.
-    send_uart_rx_data();
+    send_uart_rx_data(.instance_num(uart_idx));
 
     // Wait until we receive all bytes over TX.
     `DV_WAIT(uart_tx_data_q.size() == exp_uart_tx_data.size())
@@ -69,24 +65,20 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
     end
 
     // Send UART_RX_FIFO_SIZE+1 random bytes over RX to create an overflow condition.
-    send_uart_rx_data(.size(UART_RX_FIFO_SIZE + 1), .random(1'b1));
+    send_uart_rx_data(.instance_num(uart_idx), .size(UART_RX_FIFO_SIZE + 1), .random(1'b1));
   endtask
 
   // Send data over RX.
-  virtual task send_uart_rx_data(int size = -1, bit random = 0);
+  virtual task send_uart_rx_data(int instance_num, int size = -1, bit random = 0);
     uart_default_seq send_rx_seq;
-    `uvm_create_on(send_rx_seq, p_sequencer.uart_sequencer_hs[uart_idx]);
+    `DV_CHECK_FATAL(instance_num inside {[0:NUM_UARTS-1]})
+    `uvm_create_on(send_rx_seq, p_sequencer.uart_sequencer_hs[instance_num]);
     if (size == -1) size = uart_rx_data.size();
     for (int i = 0; i < size; i++) begin
       byte rx_data = random ? $urandom : uart_rx_data[i];
       `DV_CHECK_RANDOMIZE_WITH_FATAL(send_rx_seq, data == rx_data;)
       `uvm_send(send_rx_seq)
     end
-  endtask
-
-  virtual task dut_shutdown();
-    super.dut_shutdown();
-    if (uart_idx > 0) cfg.chip_vif.enable_uart(uart_idx, 0);
   endtask
 
 endclass : chip_sw_uart_tx_rx_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -10,6 +10,7 @@
 `include "chip_jtag_mem_vseq.sv"
 // This needs to be listed prior to all sequences that derive from it.
 `include "chip_sw_base_vseq.sv"
+`include "chip_sw_uart_smoke_vseq.sv"
 `include "chip_jtag_base_vseq.sv"
 `include "chip_prim_tl_access_vseq.sv"
 `include "chip_sw_all_escalation_resets_vseq.sv"

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -112,7 +112,7 @@ module tb;
     .IOC9(dut.chip_if.ios[IoC9]), // MIO Pad 31
     .IOC10(dut.chip_if.ios[IoC10]), // MIO Pad 32
     .IOC11(dut.chip_if.ios[IoC11]), // MIO Pad 33
-    .IOC12(dut.chip_if.ios[IoC11]), // MIO Pad 34
+    .IOC12(dut.chip_if.ios[IoC12]), // MIO Pad 34
     .IOR0(dut.chip_if.ios[IoR0]), // MIO Pad 35
     .IOR1(dut.chip_if.ios[IoR1]), // MIO Pad 36
     .IOR2(dut.chip_if.ios[IoR2]), // MIO Pad 37

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -539,11 +539,11 @@ bool test_main(void) {
       kTopEarlgreyPinmuxMioOutIob5, kTopEarlgreyPinmuxOutselUart1Tx);
   // TODO: the UARTs below still need to be mapped to the correct location.
   pinmux_connect_uart_to_pads(
-      kTopEarlgreyPinmuxInselIor7, kTopEarlgreyPinmuxPeripheralInUart2Rx,
-      kTopEarlgreyPinmuxMioOutIor10, kTopEarlgreyPinmuxOutselUart2Tx);
+      kTopEarlgreyPinmuxInselIoa4, kTopEarlgreyPinmuxPeripheralInUart2Rx,
+      kTopEarlgreyPinmuxMioOutIoa5, kTopEarlgreyPinmuxOutselUart2Tx);
   pinmux_connect_uart_to_pads(
-      kTopEarlgreyPinmuxInselIor11, kTopEarlgreyPinmuxPeripheralInUart3Rx,
-      kTopEarlgreyPinmuxMioOutIor12, kTopEarlgreyPinmuxOutselUart3Tx);
+      kTopEarlgreyPinmuxInselIoa0, kTopEarlgreyPinmuxPeripheralInUart3Rx,
+      kTopEarlgreyPinmuxMioOutIoa1, kTopEarlgreyPinmuxOutselUart3Tx);
 
   if (kUseExtClk) {
     config_external_clock(&clkmgr);


### PR DESCRIPTION
See associated issue #14872 for reference. 

There are several commits in this PR which fix several tests that failed due to the introduction of #14776. Each individual commit describes what was fixed. 

This PR also introduces a new way to probe internal signals (sample / force / release) such that signals are not directly referenced in test sequences, but indirectly using an SV interface. 

Only 3 failure signatures now remain for debug. 