### PR TITLE
[sw/silicon_creator, test] Move shared constants to toplevel_memory.ld.tpl

### DIFF
--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -15,3 +15,32 @@ MEMORY {
   rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = 0x80000
   owner_virtual(rx): ORIGIN = 0xa0000000, LENGTH = 0x80000
 }
+
+/**
+ * Stack at the top of the main SRAM.
+ */
+_stack_size = 4096;
+_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_stack_start = _stack_end - _stack_size;
+
+/**
+ * Size of the `.static_critical` section at the bottom of the main SRAM (in
+ * bytes).
+ */
+_static_critical_size = 8048;
+
+/**
+ * `.chip_info` at the top of ROM.
+ */
+_chip_info_size = 128;
+_chip_info_end   = ORIGIN(rom) + LENGTH(rom);
+_chip_info_start = _chip_info_end - _chip_info_size;
+
+/**
+ * Size of the initial ePMP RX region at reset (in bytes). This region must be
+ * large enough to cover the .crt section.
+ *
+ * NOTE: This value must match the size of the RX region in
+ * hw/ip/rv_core_ibex/rtl/ibex_pmp_reset.svh.
+ */
+_epmp_reset_rx_size = 1024;

--- a/sw/device/examples/sram_program/sram_program.ld
+++ b/sw/device/examples/sram_program/sram_program.ld
@@ -16,7 +16,6 @@ OUTPUT_ARCH(riscv);
 __DYNAMIC = 0;
 
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
-INCLUDE sw/device/silicon_creator/lib/base/static_critical_size.ld
 
 _stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
 

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -17,13 +17,6 @@ OUTPUT_ARCH(riscv)
 __DYNAMIC = 0;
 
 /**
- * Reserving space at the top of the RAM for the stack.
- */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
-/**
  * Marking the entry point correctly for the ELF file. The signer tool will
  * transfer this value to the `entry_point` field of the manifest, which will
  * then be used by `rom_boot` or `rom_ext_boot` to handover execution to

--- a/sw/device/lib/testing/test_rom/test_rom.ld
+++ b/sw/device/lib/testing/test_rom/test_rom.ld
@@ -43,7 +43,6 @@ _flash_start = ORIGIN(eflash);
 _manifest = _flash_start;
 
 _rom_digest_size = 32;
-_chip_info_size = 128;
 _chip_info_start = ORIGIN(rom) + LENGTH(rom) - _rom_digest_size - _chip_info_size;
 
 /* DV Log offset (has to be different to other boot stages). */

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -80,7 +80,6 @@ cc_library(
 ld_library(
     name = "static_critical_sections",
     fragments = [
-        "static_critical_size.ld",
         "static_critical.ld",
     ],
 )

--- a/sw/device/silicon_creator/lib/base/static_critical.ld
+++ b/sw/device/silicon_creator/lib/base/static_critical.ld
@@ -10,8 +10,6 @@
  * memory sections.
  */
 
-INCLUDE sw/device/silicon_creator/lib/base/static_critical_size.ld
-
 .static_critical ORIGIN(ram_main) (NOLOAD) : ALIGN(4) {
   ASSERT(
     . == ORIGIN(ram_main),

--- a/sw/device/silicon_creator/lib/base/static_critical_size.ld
+++ b/sw/device/silicon_creator/lib/base/static_critical_size.ld
@@ -1,8 +1,0 @@
-/* Copyright lowRISC contributors. */
-/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
-/* SPDX-License-Identifier: Apache-2.0 */
-
-/**
- * Size of the `.static_critical` section (in bytes).
- */
-_static_critical_size = 8048;

--- a/sw/device/silicon_creator/rom/rom.ld
+++ b/sw/device/silicon_creator/rom/rom.ld
@@ -24,30 +24,11 @@ INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 _rom_boot_address = ORIGIN(rom);
 
 /**
- * Size of the initial ePMP RX region at reset. This region must be large
- * enough to cover the .crt section.
- *
- * NOTE: This value must match the size of the RX region in
- * hw/ip/rv_core_ibex/rtl/ibex_pmp_reset.svh.
- */
-_epmp_reset_rx_size = 0x400;
-
-/**
  * Symbols to be used in the setup of the address translation for ROM_EXT.
  */
 _rom_ext_virtual_start_address = ORIGIN(rom_ext_virtual);
 _rom_ext_virtual_size = LENGTH(rom_ext_virtual);
 ASSERT((_rom_ext_virtual_size <= (LENGTH(eflash) / 2)), "Error: rom ext flash is bigger than slot");
-
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
-/* Reserving 128 bytes at the top of ROM for chip info */
-_chip_info_size  = 0x80;
-_chip_info_end   = ORIGIN(rom) + LENGTH(rom);
-_chip_info_start = _chip_info_end - _chip_info_size;
 
 /* DV Log offset (has to be different to other boot stages). */
 _dv_log_offset = 0x0;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -16,11 +16,6 @@ OUTPUT_ARCH(riscv)
  */
 __DYNAMIC = 0;
 
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
 /**
  * Symbols to be used in the setup of the address translation for ROM_EXT.
  */

--- a/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
@@ -16,11 +16,6 @@ OUTPUT_ARCH(riscv)
  */
 __DYNAMIC = 0;
 
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
 /**
  * Marking the entry point correctly for the ELF file. The signer tool will
  * transfer this value to the `entry_point` field of the manifest, which will

--- a/util/topgen/templates/toplevel_memory.ld.tpl
+++ b/util/topgen/templates/toplevel_memory.ld.tpl
@@ -54,3 +54,32 @@ MEMORY {
   rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = 0x80000
   owner_virtual(rx): ORIGIN = 0xa0000000, LENGTH = 0x80000
 }
+
+/**
+ * Stack at the top of the main SRAM.
+ */
+_stack_size = 4096;
+_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_stack_start = _stack_end - _stack_size;
+
+/**
+ * Size of the `.static_critical` section at the bottom of the main SRAM (in
+ * bytes).
+ */
+_static_critical_size = 8048;
+
+/**
+ * `.chip_info` at the top of ROM.
+ */
+_chip_info_size = 128;
+_chip_info_end   = ORIGIN(rom) + LENGTH(rom);
+_chip_info_start = _chip_info_end - _chip_info_size;
+
+/**
+ * Size of the initial ePMP RX region at reset (in bytes). This region must be
+ * large enough to cover the .crt section.
+ *
+ * NOTE: This value must match the size of the RX region in
+ * hw/ip/rv_core_ibex/rtl/ibex_pmp_reset.svh.
+ */
+_epmp_reset_rx_size = 1024;


### PR DESCRIPTION
This commit moves linker constants such as stack size, chip info size, etc. to `toplevel_memory.ld.tpl`. Since the linker script generated from this template is included by rom, rom_ext, bare_metal, and ottf linker scripts, this change makes it easier to keep all these settings in sync.

Please note that this PR increases the size of the stack from 1 KiB to 4 KiB (after running into a stack overflow when trying to run `//sw/device/silicon_creator/lib/drivers:retention_sram_functest_fpga_cw310` with `rom` as part of #14503).

Signed-off-by: Alphan Ulusoy <alphan@google.com>