### PR TITLE
[dv] Update bootstrap implementation for SPI flash mode

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_device_cmd_rsp_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_device_cmd_rsp_seq.sv
@@ -82,7 +82,7 @@ class spi_device_cmd_rsp_seq extends spi_device_seq;
 
         SpiData: begin
           case (cmd)
-            ReadStd, ReadDual, ReadQuad, ReadSts1, ReadSts2, ReadSts3, ReadJedec: begin
+            ReadStd, ReadDual, ReadQuad: begin
               // read_until CSB low
               data = $urandom();
               addr_cnt += 4;

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -49,18 +49,13 @@ package spi_agent_pkg;
   } spi_func_mode_e;
 
   typedef enum bit [7:0] {
-    ReadStd    = 8'b11001100,
-    WriteStd   = 8'b11111100,
-    ReadDual   = 8'b00000011,
-    WriteDual  = 8'b00001100,
-    ReadQuad   = 8'b00001111,
-    WriteQuad  = 8'b11110000,
-    CmdOnly    = 8'b10000001,
-    ReadSts1   = 8'b00000101,
-    ReadSts2   = 8'b00110101,
-    ReadSts3   = 8'b00010101,
-    ReadJedec  = 8'b10011111,
-    ReadSfdp   = 8'b01011010
+    ReadStd      = 8'b11001100,
+    WriteStd     = 8'b11111100,
+    ReadDual     = 8'b00000011,
+    WriteDual    = 8'b00001100,
+    ReadQuad     = 8'b00001111,
+    WriteQuad    = 8'b11110000,
+    CmdOnly      = 8'b10000001
   } spi_cmd_e;
 
   typedef enum bit [1:0] {

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -141,7 +141,7 @@
             - Ensure the image is executed correctly
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_uart_tx_rx_bootstrap"]
     }
     {
       name: chip_sw_spi_device_pass_through

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -381,6 +381,7 @@
       sw_images: ["//sw/device/tests/sim_dv:uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_spi_load_bootstrap=1", "+calibrate_usb_clk=1"]
+      run_timeout_mins: 180
     }
     {
       name: chip_sw_uart_rand_baudrate

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -56,7 +56,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // - .elf:          embedded executable
   // - .32.vmem:      mem image with 32-bit word size (for boot ROM)
   // - .64.vmem:      mem image with 64-bit word size (for sw_test / flash load)
-  // - .frames.vmem:  mem image converted with spiflash frames (for tests with boostrap enabled)
   // - .rodata.txt:   dump of RO sections of the SW
   // - .logs.txt:     dump of SW logs
   //

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -98,6 +98,26 @@ package chip_env_pkg;
     LcOtpError
   } lc_ctrl_status_e;
 
+  // Typical SPI flash opcodes.
+  typedef enum bit [7:0] {
+    SpiFlashReadJedec    = 8'h9F,
+    SpiFlashReadSfdp     = 8'h5A,
+    SpiFlashReadNormal   = 8'h03,
+    SpiFlashReadFast     = 8'h0B,
+    SpiFlashReadDual     = 8'h3B,
+    SpiFlashReadQuad     = 8'h6B,
+    SpiFlashReadSts1     = 8'h05,
+    SpiFlashReadSts2     = 8'h35,
+    SpiFlashReadSts3     = 8'h15,
+    SpiFlashWriteDisable = 8'h04,
+    SpiFlashWriteEnable  = 8'h06,
+    SpiFlashChipErase    = 8'hC7,
+    SpiFlashSectorErase  = 8'h20,
+    SpiFlashPageProgram  = 8'h02,
+    SpiFlashEn4B         = 8'hB7,
+    SpiFlashEx4B         = 8'hE9
+  } spi_flash_cmd_e;
+
   // Extracts the address and size of a const symbol in a SW test (supplied as an ELF file).
   //
   // Used by a testbench to modify the given symbol in an executable (elf) generated for an embedded

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -85,9 +85,10 @@ class chip_base_vseq #(
 
     // Initialize the SW strap pins - these are sort of dedicated.
     // TODO: add logic to drive / undrive this only when the ROM / test ROM code is active.
-    if (cfg.use_spi_load_bootstrap) begin
-      cfg.chip_vif.sw_straps_if.drive({2'b00, cfg.use_spi_load_bootstrap});
-    end
+    cfg.chip_vif.sw_straps_if.drive({3{cfg.use_spi_load_bootstrap}});
+
+    // Connect DIOs
+    cfg.chip_vif.enable_spi_host = 1;
 
     // Initialize all memories via backdoor.
     cfg.mem_bkdr_util_h[FlashBank0Info].set_mem();


### PR DESCRIPTION
Clean up enums for spi_host DV-specific commands vs. SPI flash commands.

Sync up the bootstrap method to use SPI flash mode.