### PR TITLE
C patches to DMI DPI

### DIFF
--- a/hw/dv/dpi/common/tcp_server/tcp_server.c
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.c
@@ -21,11 +21,7 @@
 /**
  * Simple buffer for passing data between TCP sockets and DPI modules
  */
-#ifdef __cplusplus
-const int BUFSIZE_BYTE = 256;
-#else
 #define BUFSIZE_BYTE 256
-#endif
 
 struct tcp_buf {
   unsigned int rptr;
@@ -382,7 +378,8 @@ err_cleanup_return:
 }
 
 // Abstract interface functions
-struct tcp_server_ctx *tcp_server_create(const char *display_name, int listen_port) {
+struct tcp_server_ctx *tcp_server_create(const char *display_name,
+                                         int listen_port) {
   struct tcp_server_ctx *ctx =
       (struct tcp_server_ctx *)calloc(1, sizeof(struct tcp_server_ctx));
   assert(ctx);

--- a/hw/dv/dpi/common/tcp_server/tcp_server.c
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.c
@@ -21,7 +21,11 @@
 /**
  * Simple buffer for passing data between TCP sockets and DPI modules
  */
+#ifdef __cplusplus
 const int BUFSIZE_BYTE = 256;
+#else
+#define BUFSIZE_BYTE 256
+#endif
 
 struct tcp_buf {
   unsigned int rptr;
@@ -38,8 +42,8 @@ struct tcp_server_ctx {
   uint16_t listen_port;
   volatile bool socket_run;
   // Writeable by the server thread
-  tcp_buf *buf_in;
-  tcp_buf *buf_out;
+  struct tcp_buf *buf_in;
+  struct tcp_buf *buf_out;
   int sfd;  // socket fd
   int cfd;  // client fd
   pthread_t sock_thread;
@@ -378,7 +382,7 @@ err_cleanup_return:
 }
 
 // Abstract interface functions
-tcp_server_ctx *tcp_server_create(const char *display_name, int listen_port) {
+struct tcp_server_ctx *tcp_server_create(const char *display_name, int listen_port) {
   struct tcp_server_ctx *ctx =
       (struct tcp_server_ctx *)calloc(1, sizeof(struct tcp_server_ctx));
   assert(ctx);

--- a/hw/dv/dpi/common/tcp_server/tcp_server.h
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.h
@@ -16,8 +16,8 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 struct tcp_server_ctx;
 
@@ -48,7 +48,8 @@ void tcp_server_write(struct tcp_server_ctx *ctx, char dat);
  * @param listen_port On which port the server should listen
  * @return A pointer to the created context struct
  */
-struct tcp_server_ctx *tcp_server_create(const char *display_name, int listen_port);
+struct tcp_server_ctx *tcp_server_create(const char *display_name,
+                                         int listen_port);
 
 /**
  * Shut down the server and free all reserved memory

--- a/hw/dv/dpi/common/tcp_server/tcp_server.h
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.h
@@ -17,6 +17,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 
 struct tcp_server_ctx;
 
@@ -47,7 +48,7 @@ void tcp_server_write(struct tcp_server_ctx *ctx, char dat);
  * @param listen_port On which port the server should listen
  * @return A pointer to the created context struct
  */
-tcp_server_ctx *tcp_server_create(const char *display_name, int listen_port);
+struct tcp_server_ctx *tcp_server_create(const char *display_name, int listen_port);
 
 /**
  * Shut down the server and free all reserved memory

--- a/hw/dv/dpi/dmidpi/dmidpi.c
+++ b/hw/dv/dpi/dmidpi/dmidpi.c
@@ -31,11 +31,7 @@ const int IDCODEVAL = 0x04F5484D;
 // [3:0]    0x1  - Protocol version (0.13)
 const int DTMCSRVAL = 0x00000071;
 
-#ifndef __cplusplus
 enum jtag_state_t {
-#else
-enum jtag_state_t : uint8_t {
-#endif
   TestLogicReset,
   RunTestIdle,
   SelectDrScan,
@@ -54,11 +50,7 @@ enum jtag_state_t : uint8_t {
   UpdateIr
 };
 
-#ifndef __cplusplus
 enum jtag_reg_t {
-#else
-enum jtag_reg_t : uint8_t {
-#endif
   Bypass0 = 0x0,
   IdCode = 0x1,
   DTMCSR = 0x10,

--- a/hw/dv/dpi/dmidpi/dmidpi.c
+++ b/hw/dv/dpi/dmidpi/dmidpi.c
@@ -31,7 +31,11 @@ const int IDCODEVAL = 0x04F5484D;
 // [3:0]    0x1  - Protocol version (0.13)
 const int DTMCSRVAL = 0x00000071;
 
+#ifndef __cplusplus
+enum jtag_state_t {
+#else
 enum jtag_state_t : uint8_t {
+#endif
   TestLogicReset,
   RunTestIdle,
   SelectDrScan,
@@ -50,7 +54,11 @@ enum jtag_state_t : uint8_t {
   UpdateIr
 };
 
+#ifndef __cplusplus
+enum jtag_reg_t {
+#else
 enum jtag_reg_t : uint8_t {
+#endif
   Bypass0 = 0x0,
   IdCode = 0x1,
   DTMCSR = 0x10,
@@ -65,7 +73,7 @@ struct jtag_ctx {
   uint64_t dr_captured;
   uint8_t dr_length;
   uint8_t jtag_tdo;
-  jtag_state_t jtag_state;
+  enum jtag_state_t jtag_state;
   uint8_t dmi_outstanding;
 };
 


### PR DESCRIPTION
Hi, I'm experimenting with some elements of the DMI DPI debugger system. When I was compiling with VCS, I encountered some errors that seem to be related to C/C++ differences. This patches fixes them as non-invasively as possible

Signed-off-by: Dan Petrisko <petrisko@cs.washington.edu>