### PR TITLE
[test_rom] enable address translation

### DIFF
--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -13,7 +13,7 @@ MEMORY {
   ram_main(rwx) : ORIGIN = 0x10000000, LENGTH = 0x20000
   rom(rx) : ORIGIN = 0x00008000, LENGTH = 0x8000
   rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = 0x80000
-  owner_virtual(rx): ORIGIN = 0xa0000000, LENGTH = 0x80000
+  owner_virtual(rx) : ORIGIN = 0xa0000000, LENGTH = 0x80000
 }
 
 /**

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -2,15 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-package(default_visibility = ["//visibility:public"])
-
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 load(
     "//rules:opentitan_test.bzl",
     "cw310_params",
     "opentitan_functest",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "global_mock",
@@ -94,7 +93,6 @@ opentitan_functest(
     name = "memory_perftest",
     srcs = ["memory_perftest.c"],
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:test_rom",
         tags = [
             "flaky",
             "manual",

--- a/sw/device/lib/testing/test_rom/test_rom.ld
+++ b/sw/device/lib/testing/test_rom/test_rom.ld
@@ -23,24 +23,13 @@ INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
  */
 _boot_address = ORIGIN(rom);
 
-_heap_size = 0xe000;
-_stack_size = LENGTH(ram_main) - _heap_size - _static_critical_size;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-_flash_start = ORIGIN(eflash);
-
 /**
- * TODO(lowrisc/opentitan:#10712): setup Ibex address translation
+ * Symbols to be used in the setup of the address translation for ROM_EXT.
  */
-
-/**
- * This symbol points at the manifest of the OTTF + test binary, which contains
- * loading and signing information.
- *
- * See `sw/device/lib/testing/test_framework/ottf.ld`, under the
- * .manifest section, which populates it.
- */
-_manifest = _flash_start;
+_rom_ext_virtual_start_address = ORIGIN(rom_ext_virtual);
+_rom_ext_virtual_size = LENGTH(rom_ext_virtual);
+ASSERT((_rom_ext_virtual_size <= (LENGTH(eflash) / 2)),
+  "Error: rom ext flash is bigger than slot.");
 
 _rom_digest_size = 32;
 _chip_info_start = ORIGIN(rom) + LENGTH(rom) - _rom_digest_size - _chip_info_size;
@@ -145,7 +134,7 @@ SECTIONS {
    * Immutable chip_info data, containing build-time-recorded information.
    */
   .chip_info _chip_info_start : ALIGN(4) {
-    *(.chip_info)
+    KEEP(*(.chip_info))
   } > rom
 
   /**

--- a/sw/device/silicon_creator/rom/rom.ld
+++ b/sw/device/silicon_creator/rom/rom.ld
@@ -28,7 +28,8 @@ _rom_boot_address = ORIGIN(rom);
  */
 _rom_ext_virtual_start_address = ORIGIN(rom_ext_virtual);
 _rom_ext_virtual_size = LENGTH(rom_ext_virtual);
-ASSERT((_rom_ext_virtual_size <= (LENGTH(eflash) / 2)), "Error: rom ext flash is bigger than slot");
+ASSERT((_rom_ext_virtual_size <= (LENGTH(eflash) / 2)),
+  "Error: rom ext flash is bigger than slot.");
 
 /* DV Log offset (has to be different to other boot stages). */
 _dv_log_offset = 0x0;

--- a/util/topgen/templates/toplevel_memory.ld.tpl
+++ b/util/topgen/templates/toplevel_memory.ld.tpl
@@ -33,6 +33,14 @@ def flags(mem):
         flags_str += "x"
 
     return flags_str
+
+def get_virtual_memory_size(top):
+    for mod in top["module"]:
+        if "memory" in mod:
+            for _, mem in mod["memory"].items():
+                if mem["label"] == "eflash":
+                    return hex(int(mem["size"], 0) // 2)
+    return None
 %>\
 
 /**
@@ -51,8 +59,8 @@ MEMORY {
 % for m in top["memory"]:
   ${m["name"]}(${memory_to_flags(m)}) : ORIGIN = ${m["base_addr"]}, LENGTH = ${m["size"]}
 % endfor
-  rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = 0x80000
-  owner_virtual(rx): ORIGIN = 0xa0000000, LENGTH = 0x80000
+  rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = ${get_virtual_memory_size(top)}
+  owner_virtual(rx) : ORIGIN = 0xa0000000, LENGTH = ${get_virtual_memory_size(top)}
 }
 
 /**


### PR DESCRIPTION
This commit:
1. enables address translation in the test ROM, and
2. aligns test ROM manifest symbols with ROM's.

Note, it does not yet make the virtual slot the default OTTF slot used, as this will require further enhancements to the `opentitan_flash_binary` Bazel macro to update the manifest field for unsigned flash images, which may not be worth it in the short term.

This partially addresses #10712.

Signed-off-by: Timothy Trippel <ttrippel@google.com>