### PR TITLE
[chip,dv] add local alert event to  rstmgr_alert_info test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1338,7 +1338,7 @@
             reset cause to verify the alert crashdump.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_rstmgr_alert_info"]
     }
     {
       name: chip_sw_alert_handler_ping_timeout

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -554,7 +554,9 @@
       uvm_test_seq: chip_sw_rstmgr_alert_info_vseq
       sw_images: ["//sw/device/tests:rstmgr_alert_info_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18_000_000", "+en_scb_tl_err_chk=0"]
+      run_opts: ["+sw_test_timeout_ns=15_000_000", "+en_scb_tl_err_chk=0",
+                 "+en_scb_ping_chk=0"]
+      run_timeout_mins: 40
     }
     {
       name: chip_sw_rstmgr_cpu_info

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1459,6 +1459,7 @@ opentitan_functest(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:alert_handler_testutils",
         "//sw/device/lib/testing:aon_timer_testutils",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",


### PR DESCRIPTION
This PR updates 'rstmgr_alert_info_test' to address (#14140)
by adding loc_alert_cause field in aleart handler crash dump. 
The loc_alert_cause field is set by alert ping timeout event.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>