### PR TITLE
[otbn,dv] Update testplan for countermeasures

### DIFF
--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -105,7 +105,7 @@
       name: sec_cm_data_reg_sw_sca
       desc: "Verify the countermeasure(s) DATA_REG_SW.SCA."
       stage: V2S
-      tests: []
+      tests: ["otbn_single"]
     }
     {
       name: sec_cm_ctrl_redun
@@ -199,19 +199,19 @@
       name: sec_cm_data_mem_sec_wipe
       desc: "Verify the countermeasure(s) DATA.MEM.SEC_WIPE."
       stage: V2S
-      tests: []
+      tests: ["otbn_single"]
     }
     {
       name: sec_cm_instruction_mem_sec_wipe
       desc: "Verify the countermeasure(s) INSTRUCTION.MEM.SEC_WIPE."
       stage: V2S
-      tests: []
+      tests: ["otbn_single"]
     }
     {
       name: sec_cm_data_reg_sw_sec_wipe
       desc: "Verify the countermeasure(s) DATA_REG_SW.SEC_WIPE."
       stage: V2S
-      tests: []
+      tests: ["otbn_single"]
     }
     {
       name: sec_cm_write_mem_integrity
@@ -229,7 +229,7 @@
       name: sec_cm_ctrl_flow_sca
       desc: "Verify the countermeasure(s) CTRL_FLOW.SCA."
       stage: V2S
-      tests: []
+      tests: ["otbn_single"]
     }
     {
       name: sec_cm_data_mem_sw_noaccess


### PR DESCRIPTION
With PR #14322 *.SCA and *.SEC_WIPE countermeasures can be considered verified with the assertions.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>

Resolves https://github.com/lowRISC/opentitan/issues/13964
Resolves https://github.com/lowRISC/opentitan/issues/13329