### PR TITLE
[test] Non-volatile scratch and counter fixes

### DIFF
--- a/hw/top_earlgrey/sw/autogen/BUILD
+++ b/hw/top_earlgrey/sw/autogen/BUILD
@@ -19,7 +19,7 @@ cc_library(
 
 ld_library(
     name = "top_earlgrey_memory",
-    fragments = ["top_earlgrey_memory.ld"],
+    includes = ["top_earlgrey_memory.ld"],
 )
 
 filegroup(

--- a/rules/linker.bzl
+++ b/rules/linker.bzl
@@ -7,6 +7,15 @@
 def _ld_library_impl(ctx):
     files = [] + ctx.files.includes
     user_link_flags = []
+
+    # Disable non-volatile scratch region and counters if building for english
+    # breakfast. This should appear before the linker script.
+    if "-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_" in ctx.fragments.cpp.copts:
+        user_link_flags += [
+            "-Wl,--defsym=no_ottf_nv_scratch=1",
+            "-Wl,--defsym=no_ottf_nv_counter=1",
+        ]
+
     if ctx.file.script:
         files += ctx.files.script
         user_link_flags += [
@@ -30,6 +39,7 @@ def _ld_library_impl(ctx):
 
 ld_library = rule(
     implementation = _ld_library_impl,
+    fragments = ["cpp"],
     doc = """
     A linker script library. Linker script libraries consist of a collection of
     "includes" (the linker equivalent of a header) and an optional script. Linker

--- a/rules/linker.bzl
+++ b/rules/linker.bzl
@@ -5,7 +5,7 @@
 """Rules for declaring linker scripts and linker script fragments."""
 
 def _ld_library_impl(ctx):
-    files = [] + ctx.files.fragments
+    files = [] + ctx.files.includes
     user_link_flags = []
     if ctx.file.script:
         files += ctx.files.script
@@ -32,16 +32,16 @@ ld_library = rule(
     implementation = _ld_library_impl,
     doc = """
     A linker script library. Linker script libraries consist of a collection of
-    "fragments" (the linker equivalent of a header) and an optional script. Linker
-    script libraries can depend on other libraries to access the fragments they
-    public; cc_binaries can depend on an ld_library with a script to specify it
+    "includes" (the linker equivalent of a header) and an optional script. Linker
+    script libraries can depend on other libraries to access the includes they
+    publish; cc_binaries can depend on an ld_library with a script to specify it
     as the linker script for that binary.
 
     At most one ld_library in a cc_binary's dependencies may have a script.
     """,
     attrs = {
         "script": attr.label(allow_single_file = True),
-        "fragments": attr.label_list(
+        "includes": attr.label_list(
             default = [],
             allow_files = True,
         ),

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -309,7 +309,7 @@ def _elf_to_disassembly_impl(ctx):
             execution_requirements = {
                 "no-sandbox": "1",
             },
-            command = "$1 --disassemble --headers --line-numbers --disassemble-zeroes --source --visualize-jumps $2 | $3 > $4",
+            command = "$1 -wx --disassemble --headers --line-numbers --disassemble-zeroes --source --visualize-jumps $2 | $3 > $4",
         )
         return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
 

--- a/sw/device/BUILD
+++ b/sw/device/BUILD
@@ -8,7 +8,7 @@ package(default_visibility = ["//visibility:public"])
 
 ld_library(
     name = "info_sections",
-    fragments = ["info_sections.ld"],
+    includes = ["info_sections.ld"],
 )
 
 # FIXME(lowRISC/opentitan#12065) This is a hack to work around currently

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -125,6 +125,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:flash_ctrl",

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -216,35 +216,41 @@ OT_WARN_UNUSED_RESULT
 bool flash_ctrl_testutils_bank_erase(dif_flash_ctrl_state_t *flash_state,
                                      uint32_t bank, bool data_only);
 
-/**
- * Determines a count value as the index of the first bit set to 1 in a word.
- *
- * This uses an incrementing counter implemented as a uint32_t initialized to
- * all 1 (meaning a count of zero), and on each increment operation the lowest
- * bit set is cleared. This is consistent with the capability of flash.
- *
- * @param strike_counter The address of the counter.
- * @return The bit position of the first bit set to 1.
- */
-uint32_t flash_ctrl_testutils_get_count(uint32_t *strike_counter);
+enum {
+  kFlashCtrlTestUtilsCounterMaxCount = 256,
+};
 
 /**
- * Increments a strike counter by clearing a bit.
+ * Returns the value of a non-volatile counter in flash.
  *
- * Uses a strike counter as described for flash_ctrl_testutils_get_count.
- * It is give a bit to be cleared, typically the value returned by the most
- * recent call to flash_ctrl_testutils_get_count.
- *
- * Notice if the right-most bit set to 1 is not cleared the counter will not
- * advance.
+ * @param counter Counter ID, [0, 2].
+ * @return Value of the non-volatile counter
+ */
+uint32_t flash_ctrl_testutils_counter_get(size_t counter);
+
+/**
+ * Increments a non-volatile counter in flash.
  *
  * @param flash_state A flash_ctrl state handle.
- * @param strike_counter The address of the counter.
- * @param index The bit to clear.
+ * @param counter Counter ID, [0, 2].
  */
-void flash_ctrl_testutils_increment_counter(dif_flash_ctrl_state_t *flash_state,
-                                            uint32_t *strike_counter,
-                                            uint32_t index);
+void flash_ctrl_testutils_counter_increment(dif_flash_ctrl_state_t *flash_state,
+                                            size_t counter);
+
+/**
+ * Sets a non-volatile counter to at least `val`.
+ *
+ * This function simply writes zeros to the corresponding flash word without any
+ * checks and is intended for contexts where performance is critical, e.g. ISRs.
+ * The value of the counter will not change if it is already greater than or
+ * equal to `val`.
+ *
+ * @param flash_state A flash_ctrl state handle.
+ * @param counter Counter ID, [0, 2].
+ * @param val Counter value.
+ */
+void flash_ctrl_testutils_counter_set_at_least(
+    dif_flash_ctrl_state_t *flash_state, size_t counter, uint32_t val);
 
 /**
  * Sets a strike counter to an arbitrary value.

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -57,7 +57,7 @@ cc_library(
 
 ld_library(
     name = "ottf_ld_common",
-    fragments = ["ottf_common.ld"],
+    includes = ["ottf_common.ld"],
     deps = [
         "//sw/device:info_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -60,17 +60,6 @@ SECTIONS {
   } > ottf_flash
 
   /**
-   * Non-volatile Scratch area in flash.
-   *
-   * This is a separate section for tests to read/write data to/from to persist
-   * across resets.
-   */
-  .non_volatile_scratch : ALIGN(2048){
-    _non_volatile_scratch_start = .;
-    KEEP(*(.non_volatile_scratch))
-  } > ottf_flash
-
-  /**
    * Ibex interrupt vector. See 'ottf_start.S' for more information.
    *
    * This has to be set up at a 256-byte offset, so that we can use it with
@@ -238,6 +227,67 @@ SECTIONS {
     _freertos_heap_start = .;
     *(.freertos.heap)
   } > ram_main
+
+  /**
+   * Non-volatile scratch and counter areas for tests.
+   *
+   * These sections are meant to be used by tests to store data that should
+   * persist across resets. Since `opentitantool` assumes that the signed
+   * region of an image extends until the end, these sections are placed after
+   * all other sections and are NOLOAD so that they don't appear in the binary
+   * and therefore don't end up being covered by the signature.
+   */
+   _non_volatile_scratch_size = 20480;
+   _non_volatile_scratch_end = ORIGIN(ottf_flash) + _ottf_size;
+   _non_volatile_scratch_start = _non_volatile_scratch_end - _non_volatile_scratch_size;
+
+   _non_volatile_counter_size = 2048;
+   _non_volatile_counter_flash_words = _non_volatile_counter_size / 8;
+
+   _non_volatile_counter_0_end = _non_volatile_scratch_start;
+   _non_volatile_counter_0_start = _non_volatile_counter_0_end - _non_volatile_counter_size;
+
+   _non_volatile_counter_1_end = _non_volatile_counter_0_start;
+   _non_volatile_counter_1_start = _non_volatile_counter_1_end - _non_volatile_counter_size;
+
+   _non_volatile_counter_2_end = _non_volatile_counter_1_start;
+   _non_volatile_counter_2_start = _non_volatile_counter_2_end - _non_volatile_counter_size;
+
+  /**
+   * Non-volatile scratch area in flash.
+   */
+  .non_volatile_scratch _non_volatile_scratch_start (NOLOAD) : ALIGN(2048) {
+    KEEP(*(.non_volatile_scratch))
+    KEEP(*(.non_volatile_scratch.*))
+    . = _non_volatile_scratch_size;
+  } > ottf_flash
+
+
+  /**
+   * Non-volatile counter area in flash.
+   *
+   * Similar to the `.non_volatile_scratch` section, this section is meant to
+   * be used by tests. Because we don't want to write to the same flash word
+   * twice, tests that require non-volatile counters can use this section by
+   * striking flash words to count up to `_non_volatile_counter_max_count`.
+   */
+  .non_volatile_counter_0 _non_volatile_counter_0_start (NOLOAD) : ALIGN(2048) {
+    KEEP(*(.non_volatile_counter_0))
+    KEEP(*(.non_volatile_counter_0.*))
+    . = _non_volatile_counter_size;
+  } > ottf_flash
+
+  .non_volatile_counter_1 _non_volatile_counter_1_start (NOLOAD) : ALIGN(2048) {
+    KEEP(*(.non_volatile_counter_1))
+    KEEP(*(.non_volatile_counter_1.*))
+    . = _non_volatile_counter_size;
+  } > ottf_flash
+
+  .non_volatile_counter_2 _non_volatile_counter_2_start (NOLOAD) : ALIGN(2048) {
+    KEEP(*(.non_volatile_counter_2))
+    KEEP(*(.non_volatile_counter_2.*))
+    . = _non_volatile_counter_size;
+  } > ottf_flash
 
   INCLUDE sw/device/info_sections.ld
 }

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -237,11 +237,11 @@ SECTIONS {
    * all other sections and are NOLOAD so that they don't appear in the binary
    * and therefore don't end up being covered by the signature.
    */
-   _non_volatile_scratch_size = 20480;
+   _non_volatile_scratch_size = DEFINED(no_ottf_nv_scratch) ? 0 : 20480;
    _non_volatile_scratch_end = ORIGIN(ottf_flash) + _ottf_size;
    _non_volatile_scratch_start = _non_volatile_scratch_end - _non_volatile_scratch_size;
 
-   _non_volatile_counter_size = 2048;
+   _non_volatile_counter_size = DEFINED(no_ottf_nv_counter) ? 0 : 2048;
    _non_volatile_counter_flash_words = _non_volatile_counter_size / 8;
 
    _non_volatile_counter_0_end = _non_volatile_scratch_start;

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -79,7 +79,7 @@ cc_library(
 
 ld_library(
     name = "static_critical_sections",
-    fragments = [
+    includes = [
         "static_critical.ld",
     ],
 )

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -72,7 +72,7 @@ cc_test(
 
 ld_library(
     name = "ld_common",
-    fragments = ["rom_ext_common.ld"],
+    includes = ["rom_ext_common.ld"],
     deps = [
         "//sw/device:info_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -13,7 +13,7 @@ load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest")
 
 ld_library(
     name = "ld_common",
-    fragments = ["bare_metal_common.ld"],
+    includes = ["bare_metal_common.ld"],
     deps = [
         "//sw/device:info_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",

--- a/sw/device/tests/example_test_from_flash.c
+++ b/sw/device/tests/example_test_from_flash.c
@@ -73,17 +73,17 @@ OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
 // void ottf_external_isr(void) {}
 
 /**
- * Place data in flash that will need to persist across resets by marking with
- * with the section ".non_volatile_scratch"). Write to this region with the
- * flash controller DIFs. Read from it with `abs_mmio_read32(...)`.
- * Additionally, be sure to initialize the bits in this array to all 1s,
- * otherwise this region may not be programmed properly, depending on the
- * programming transactions issued. According to the hardware specification:
- *  - a bit cannot be programmed back to 1 once it has been programmed to 0, and
- *  - only erase can restore a bit to 1 under normal circumstances.
+ * Place data that will need to persist across resets by placing it in the
+ * ".non_volatile_scratch" section. OpenTitan's flash is mapped to its address
+ * space for reads. Thus, these variables can be read as usual. Write to this
+ * region with the flash controller DIFs, obeying flash constraints. Since the
+ * non-volatile scratch region is NOLOAD and bootstrap erases all flash, initial
+ * values of variables in this section are always `0xff`, regardless of any
+ * initialization in the source code. In order to avoid confusion, don't
+ * initialize or assign to these values. If needed, they can be initialized at
+ * runtime during flash controller DIFs.
  */
-// __attribute__((section(".non_volatile_scratch")))
-// const volatile uint32_t non_volatile_data[2] = {UINT32_MAX, UINT32_MAX};
+// OT_SECTION(".non_volatile_scratch") uint32_t non_volatile_data[2];
 
 bool test_main(void) {
   /**

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -99,12 +99,6 @@ static dif_aon_timer_t aon_timer;
 static dif_pwrmgr_t pwrmgr;
 static dif_i2c_t i2c0, i2c1, i2c2;
 
-/**
- * event vector/index for randomization
- */
-__attribute__((section(".non_volatile_scratch")))
-const volatile uint32_t events_vector = UINT32_MAX;
-
 typedef struct node {
   const char *name;
   dif_alert_handler_alert_t alert;
@@ -797,8 +791,7 @@ bool test_main(void) {
       kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark);
 
   // First check the flash stored value.
-  uint32_t event_idx =
-      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
+  uint32_t event_idx = flash_ctrl_testutils_counter_get(0);
 
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
@@ -810,8 +803,7 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are.
-  flash_ctrl_testutils_increment_counter(&flash_ctrl,
-                                         (uint32_t *)&events_vector, event_idx);
+  flash_ctrl_testutils_counter_increment(&flash_ctrl, 0);
 
   LOG_INFO("Test round %d", event_idx);
 

--- a/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
@@ -41,10 +41,6 @@ static dif_flash_ctrl_state_t flash_ctrl;
 static dif_sysrst_ctrl_t sysrst_ctrl;
 static dif_pinmux_t pinmux;
 
-// This is a strike counter to keep track of progress.
-__attribute__((section(".non_volatile_scratch")))
-const volatile uint32_t events_vector = UINT32_MAX;
-
 /**
  * sysrst_ctrl config for test #1
  * . set sysrst_ctrl.KEY_INTR_CTL.pwrb_in_H2L to 1
@@ -95,8 +91,7 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
 
   // First check the flash stored value
-  uint32_t event_idx =
-      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
+  uint32_t event_idx = flash_ctrl_testutils_counter_get(0);
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
                                              /*rd_en*/ true,
@@ -107,8 +102,7 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are
-  flash_ctrl_testutils_increment_counter(&flash_ctrl,
-                                         (uint32_t *)&events_vector, event_idx);
+  flash_ctrl_testutils_counter_increment(&flash_ctrl, 0);
 
   // Read wakeup reason before check
   dif_pwrmgr_wakeup_reason_t wakeup_reason;

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
@@ -55,12 +55,6 @@ static dif_sysrst_ctrl_t sysrst_ctrl_aon;
 static dif_rstmgr_t rstmgr;
 
 /**
- * event vector/index for randomization
- */
-__attribute__((section(".non_volatile_scratch")))
-const volatile uint32_t events_vector = UINT32_MAX;
-
-/**
  * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
  * the phase 1 (i.e. wipe secrets) should occur and last during the time the
  * wdog is programed to bark.
@@ -434,8 +428,7 @@ bool test_main(void) {
   alert_handler_config();
 
   // First check the flash stored value.
-  uint32_t event_idx =
-      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
+  uint32_t event_idx = flash_ctrl_testutils_counter_get(0);
 
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
@@ -447,8 +440,7 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are.
-  flash_ctrl_testutils_increment_counter(&flash_ctrl,
-                                         (uint32_t *)&events_vector, event_idx);
+  flash_ctrl_testutils_counter_increment(&flash_ctrl, 0);
 
   LOG_INFO("Test round %d", event_idx);
   LOG_INFO("RST_IDX[%d] = %d", event_idx, RST_IDX[event_idx]);

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -49,12 +49,6 @@ static dif_sysrst_ctrl_t sysrst_ctrl_aon;
 static dif_rstmgr_t rstmgr;
 
 /**
- * event vector/index for randomization
- */
-__attribute__((section(".non_volatile_scratch")))
-const volatile uint32_t events_vector = UINT32_MAX;
-
-/**
  * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
  * the phase 1 (i.e. wipe secrets) should occur and last during the time the
  * wdog is programed to bark.
@@ -442,8 +436,7 @@ bool test_main(void) {
   alert_handler_config();
 
   // First check the flash stored value
-  uint32_t event_idx =
-      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
+  uint32_t event_idx = flash_ctrl_testutils_counter_get(0);
 
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
@@ -455,8 +448,7 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are
-  flash_ctrl_testutils_increment_counter(&flash_ctrl,
-                                         (uint32_t *)&events_vector, event_idx);
+  flash_ctrl_testutils_counter_increment(&flash_ctrl, 0);
 
   LOG_INFO("Test round %d", event_idx);
   LOG_INFO("RST_IDX[%d] = %d", event_idx, RST_IDX[event_idx]);

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
@@ -50,12 +50,6 @@ static dif_sysrst_ctrl_t sysrst_ctrl_aon;
 static dif_rstmgr_t rstmgr;
 
 /**
- * event vector/index for randomization
- */
-__attribute__((section(".non_volatile_scratch")))
-const volatile uint32_t events_vector = UINT32_MAX;
-
-/**
  * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
  * the phase 1 (i.e. wipe secrets) should occur and last during the time the
  * wdog is programed to bark.
@@ -479,8 +473,7 @@ bool test_main(void) {
   alert_handler_config();
 
   // First check the flash stored value
-  uint32_t event_idx =
-      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
+  uint32_t event_idx = flash_ctrl_testutils_counter_get(0);
 
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
@@ -492,8 +485,7 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are
-  flash_ctrl_testutils_increment_counter(&flash_ctrl,
-                                         (uint32_t *)&events_vector, event_idx);
+  flash_ctrl_testutils_counter_increment(&flash_ctrl, 0);
 
   LOG_INFO("Test round %d", event_idx);
   LOG_INFO("RST_IDX[%d] = %d", event_idx, RST_IDX[event_idx]);

--- a/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
@@ -29,9 +29,6 @@ OTTF_DEFINE_TEST_CONFIG();
 static volatile const uint8_t RST_IDX[5] = {3, 30, 130, 5, 50};
 static dif_flash_ctrl_state_t flash_ctrl;
 
-__attribute__((section(".non_volatile_scratch")))
-const volatile uint32_t events_vector = UINT32_MAX;
-
 /**
  * Configure the sysrst.
  */
@@ -160,8 +157,7 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
 
   // First check the flash stored value
-  uint32_t event_idx =
-      flash_ctrl_testutils_get_count((uint32_t *)&events_vector);
+  uint32_t event_idx = flash_ctrl_testutils_counter_get(0);
 
   // Enable flash access
   flash_ctrl_testutils_default_region_access(&flash_ctrl,
@@ -173,8 +169,7 @@ bool test_main(void) {
                                              /*he_en*/ false);
 
   // Increment flash counter to know where we are
-  flash_ctrl_testutils_increment_counter(&flash_ctrl,
-                                         (uint32_t *)&events_vector, event_idx);
+  flash_ctrl_testutils_counter_increment(&flash_ctrl, 0);
 
   LOG_INFO("Test round %d", event_idx);
   LOG_INFO("RST_IDX[%d] = %d", event_idx, RST_IDX[event_idx]);


### PR DESCRIPTION
This PR:
* Makes `.non_volatile_scratch` `NOLOAD` so that it doesn't end up in the binary and therefore in the signed region,
* Introduces 3 additional `NOLOAD` sections in flash `.non_volatile_counter{0,1,2}` to be used as non-volatile counters in tests
* Replaces the bit-striking approach with flash-word striking so that we adhere to the flash rules, i.e. don't write to the same word multiple times, updates the implementation in `flash_ctrl_testutils`, removes redundant implementations, and
* Updates tests.

Fixes #14828.

Note that bit-striking would not work if we enable ECC and/or scrambling even if it seems to work at our current usage level, i.e. the number of additional writes to the same flash word.