### PR TITLE
[otbn,dv] Fix OTBN tests for xlm

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -386,7 +386,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
         OtbnModelStatus: begin
           bit was_executing = model_status inside {otbn_pkg::StatusBusyExecute,
                                                    otbn_pkg::StatusBusySecWipeInt};
-          bit is_busy = otbn_pkg::is_busy_status(item.status);
+          bit is_busy = otbn_pkg::is_busy_status(status_e'(item.status));
 
           // Did the status change happen due to a reset? If so, reset the model status as well.
           if (item.rst_n !== 1'b1) model_status = item.status;

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -63,8 +63,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       end
       // injecting error on opcode
       2: begin
-        otbn_pkg::alu_op_bignum_e  good_op;
-        otbn_pkg::alu_op_bignum_e  bad_op;
+        logic [3:0] good_op, bad_op;
         bit op_valid;
         err_path = "tb.dut.u_otbn_core.u_otbn_alu_bignum.operation_i.op";
         `DV_SPINWAIT(


### PR DESCRIPTION
Since default is VCS, these went unnoticed. This commit fixes build errors in xcelium tool.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>