### PR TITLE
[dv/kmac] Entropy_refresh sequence

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -124,6 +124,29 @@
       tests: ["{variant}_app_with_partial_data"]
    }
    {
+      name: entropy_refresh
+      desc: ''' Test entropy interface for KMAC.
+
+            This test randomly chooses to execute either a SW-controlled hash or a hash from the
+            App interface.
+            All configuration fields are left as is, but now we will request EDN entropy by setting
+            the following registers with random value:
+            - "cmd.entropy_req": Request an EDN entropy
+            - "cmd.hash_cnt_clear": Clear the entropy_refresh_hash_cnt
+            - "entropy_refresh_threshold_shadowed": The threshold when KMAC should request an EDN
+              entropy
+
+            In masked mode, scoreboard will check:
+            - Register `entropy_refresh_hash_cnt` value
+            - KMAC requests EDN at the correct time
+
+            In unmasked mode, scoreboard will check:
+            - Register `entropy_refresh_hash_cnt` always returns 0
+            '''
+      stage: V2
+      tests: ["{variant}_entropy_refresh"]
+   }
+   {
       name: error
       desc: '''
             Try several error sequences:
@@ -168,8 +191,8 @@
     {
       name: edn_timeout_error
       desc: ''' Test kmac responses correctly when EDN response timeout.
-            Based on kmac app sequence, this sequence write `ral.entropy_period.wait_timer` with
-            the minimal value (timeout after 1 cycle) to ensure a EDN timeout request.
+            Based on kmac app sequence, this sequence configures kmac to ensure an EDN timeout
+            error by writing `entropy_period.wait_timer` and `entropy_period.prescaler` registers.
             **Check**:
             - Check error related registers including `err_code`, `status`, and `interrupt`.
             - Check keymgr interface responses with error bit sets to 1.
@@ -180,7 +203,7 @@
       stage: V2
       tests: ["{variant}_edn_timeout_error"]
     }
-     {
+    {
       name: entropy_mode_error
       desc: ''' Test kmac responses correctly when entropy mode is configured incorrectly.
             Based on kmac edn_timeout sequence, this sequence write incorrect
@@ -193,7 +216,7 @@
             '''
       stage: V2
       tests: ["{variant}_entropy_mode_error"]
-    }
+   }
    {
       name: lc_escalation
       desc: '''
@@ -216,23 +239,6 @@
             - Randomly add reset between each sequence'''
       stage: V2
       tests: ["kmac_stress_all"]
-    }
-    {
-      name: entropy_timers
-      desc: ''' Test entropy interface for KMAC.
-
-            This test randomly chooses to execute either a SW-controlled hash or a hash
-            from the App interface.
-            All configuration fields are left as is, but now we set both of the internal timer CSRs:
-            - the entropy_timer value is the number of cycles that KMAC will wait before
-              sending a new request to EDN for more entropy
-            - the wait_timer value is the number of cycles that KMAC will wait for an EDN response
-              before raising an error
-
-            This will be checked in the scoreboard using the cycle acurate model.
-            '''
-      stage: V3
-      tests: ["{variant}_entropy"]
     }
     {
       name: throughput

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -38,6 +38,7 @@ filesets:
       - seq_lib/kmac_burst_write_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_app_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_app_with_partial_data_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_entropy_refresh_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_key_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_edn_timeout_error_vseq.sv: {is_include_file: true}

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -128,10 +128,6 @@ class kmac_base_vseq extends cip_base_vseq #(
 
   bit do_kmac_init = 1'b1;
 
-  constraint hash_cnt_clr_c{
-    hash_cnt_clr dist {0 :/ 9, 1 :/ 1};
-  }
-
   // constrain xof_en to 0 if not in kmac mode
   constraint xof_en_c {
     (!kmac_en) -> (xof_en == 1'b0);

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_entropy_refresh_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_entropy_refresh_vseq.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This sequence enables entropy refresh by changing the `entropy_refresh_c` constraint:
+// 1). Allow `hash_threshold` to be any random value.
+// 2). Allow `hash_cnt_clr` to clear the current hash_cnt.
+class kmac_entropy_refresh_vseq extends kmac_app_with_partial_data_vseq;
+
+  `uvm_object_utils(kmac_entropy_refresh_vseq)
+  `uvm_object_new
+
+  constraint entropy_refresh_c {
+    hash_cnt_clr dist {0 :/ 19, 1 :/ 1};
+  }
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -67,6 +67,11 @@ class kmac_smoke_vseq extends kmac_base_vseq;
     entropy_ready == 1;
   }
 
+  constraint entropy_refresh_c {
+    hash_threshold == 0;
+    hash_cnt_clr   == 0;
+  }
+
   // Constraint output byte length to be at most the keccak block size (168/136).
   // This way we can read the entire digest without having to manually squeeze data.
   constraint output_len_c {

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -15,6 +15,7 @@
 `include "kmac_burst_write_vseq.sv"
 `include "kmac_app_vseq.sv"
 `include "kmac_app_with_partial_data_vseq.sv"
+`include "kmac_entropy_refresh_vseq.sv"
 `include "kmac_error_vseq.sv"
 `include "kmac_key_error_vseq.sv"
 `include "kmac_edn_timeout_error_vseq.sv"

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -150,6 +150,10 @@
       reseed: 10
     }
     {
+      name: "{variant}_entropy_refresh"
+      uvm_test_seq: kmac_entropy_refresh_vseq
+   }
+   {
       name: "{variant}_error"
       uvm_test_seq: kmac_error_vseq
     }


### PR DESCRIPTION
This PR moves the entropy_refresh sequence from V3 to V2 stage, and implement the logic to clear the hash_cnt and add threshold to the hash_cnt.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>