### PR TITLE
[opentitantool, bazel] USR_ACCESS updates

### DIFF
--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -109,6 +109,7 @@ bitstream_splice(
     data = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem",
     meminfo = ":rom_mmi",
     tags = ["manual"],
+    update_usr_access = True,
     visibility = ["//visibility:private"],
 )
 
@@ -119,6 +120,7 @@ bitstream_splice(
     data = "//sw/device/silicon_creator/rom:rom_fpga_cw310_scr_vmem",
     meminfo = ":rom_mmi",
     tags = ["manual"],
+    update_usr_access = True,
     visibility = ["//visibility:private"],
 )
 
@@ -129,5 +131,6 @@ bitstream_splice(
     data = "//hw/ip/otp_ctrl/data:img_dev",
     meminfo = ":otp_mmi",
     tags = ["manual"],
+    update_usr_access = True,
     visibility = ["//visibility:private"],
 )

--- a/rules/splice.bzl
+++ b/rules/splice.bzl
@@ -61,19 +61,26 @@ def _bitstream_splice_impl(ctx):
         env = ENV,
     )
 
-    ctx.actions.run(
-        mnemonic = "UpdateUsrAccessValue",
-        outputs = [output],
-        inputs = [spliced],
-        arguments = [
-            "--logging",
-            "info",
-            "update-usr-access",
-            spliced.path,
-            output.path,
-        ],
-        executable = ctx.executable._opentitantool,
-    )
+    if ctx.attr.update_usr_access:
+        ctx.actions.run(
+            mnemonic = "UpdateUsrAccessValue",
+            outputs = [output],
+            inputs = [spliced],
+            arguments = [
+                "--rcfile=",
+                "--logging",
+                "info",
+                "update-usr-access",
+                spliced.path,
+                output.path,
+            ],
+            executable = ctx.executable._opentitantool,
+        )
+    else:
+        ctx.actions.symlink(
+            output = output,
+            target_file = spliced,
+        )
 
     return [
         DefaultInfo(
@@ -94,6 +101,7 @@ bitstream_splice = rule(
         "data": attr.label(allow_single_file = True, doc = "The memory image to splice into the bitstream"),
         "swap_nybbles": attr.bool(default = True, doc = "Swap nybbles while preparing the memory image"),
         "debug": attr.bool(default = True, doc = "Emit debug info while updating"),
+        "update_usr_access": attr.bool(default = False, doc = "Update the USR_ACCESS value of the bitstream, breaks hermeticity"),
         "_gen_mem_img": attr.label(
             default = "//hw/ip/rom_ctrl/util:gen_vivado_mem_image",
             executable = True,


### PR DESCRIPTION
This PR
* adds an optional parameter (default = Vivado style timestamp) to the `update-usr-access` command for specifying the new USR_ACCESS value and 
* adds the `update_usr_access` parameter to the `bitstream_splice` rule (default = False).

@cfrantz, do you think we need to expose the USR_ACCESS value in the `bitstream_splice` rule? I can't think of a reason to do that for local workflows but PLMK if you have any thoughts.