### PR TITLE
[dv/otp_ctrl] Sec_cm test update

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
@@ -57,7 +57,7 @@ virtual task test_sec_cm_fi();
     // when a fault occurs at the reg_we_check, it's treated as a TL intg error
     if (if_proxy.sec_cm_type == SecCmPrimOnehot &&
         !uvm_re_match("*u_prim_reg_we_check*", if_proxy.path)) begin
-      check_tl_intg_error_response();
+      check_sec_tl_intg_error_resp(if_proxy.path);
     end else begin
       check_sec_cm_fi_resp(if_proxy);
     end
@@ -67,6 +67,10 @@ virtual task test_sec_cm_fi();
     dut_init("HARD");
   end
 endtask : test_sec_cm_fi
+
+virtual task check_sec_tl_intg_error_resp(string proxy_path);
+  check_tl_intg_error_response();
+endtask
 
 virtual task sec_cm_inject_fault(sec_cm_base_if_proxy if_proxy);
   if_proxy.inject_fault();

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -30,11 +30,11 @@ package otp_ctrl_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
-  parameter string LIST_OF_ALERTS[]      = {"fatal_macro_error",
-                                            "fatal_check_error",
-                                            "fatal_bus_integ_error",
-                                            "fatal_prim_otp_alert",
-                                            "recov_prim_otp_alert"};
+  parameter string LIST_OF_ALERTS[] = {"fatal_macro_error",
+                                       "fatal_check_error",
+                                       "fatal_bus_integ_error",
+                                       "fatal_prim_otp_alert",
+                                       "recov_prim_otp_alert"};
   parameter uint NUM_ALERTS              = 5;
   parameter uint NUM_EDN                 = 1;
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -8,6 +8,9 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
   rand bit [TL_DW-1:0] dai_addr, wdata0, wdata1;
   rand port_drive_condition_e reset_drive_cond;
 
+  string prim_otp_alert_name = "fatal_prim_otp_alert";
+  string integ_err_alert_name = "fatal_bus_integ_error";
+
   constraint dai_addr_c {
     dai_addr dist {
         [0 : (PartInfo[LifeCycleIdx].offset - 1)]    :/ 1,
@@ -93,49 +96,94 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     endcase
   endtask : wait_to_issue_reset
 
+  // This task overrides the check for `prim_onehot_check`.
+  // Alerts coming from the `u_otp` module will only bypass OTP_CTRL, it won't affect the OTP_CTRL
+  // and will fire its own alerts.
+  virtual task check_sec_tl_intg_error_resp(string proxy_path);
+    if (!uvm_re_match("*.u_otp.*", proxy_path)) begin
+      repeat ($urandom_range(5, 20)) begin
+        wait_alert_trigger(prim_otp_alert_name, .wait_complete(1));
+      end
+    end else begin
+      super.check_sec_tl_intg_error_resp(proxy_path);
+    end
+  endtask
+
+  virtual task check_sec_cm_alert(string sec_type_name, string alert_name);
+    `uvm_info(`gfn, $sformatf("expected fatal alert is triggered for %s",
+              sec_type_name), UVM_LOW)
+
+    // This is a fatal alert and design keeps sending it until reset is issued.
+    // Check alerts are triggered for a few times
+    repeat (5) begin
+      wait_alert_trigger(alert_name, .wait_complete(1));
+    end
+  endtask
+
   virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
-    bit[TL_DW-1:0] exp_status_val, rdata0, rdata1;
-    super.check_sec_cm_fi_resp(if_proxy);
+    bit [TL_DW-1:0] exp_status_val, rdata0, rdata1;
+    string prim_otp_alert_name = "fatal_prim_otp_alert";
+    string integ_err_alert_name = "fatal_bus_integ_error";
 
-    // Set expected status error val.
-    for (int i = 0; i <= OtpLciErrIdx; i++) exp_status_val[i] = 1;
-    if (!uvm_re_match("*.u_otp_ctrl_lfsr_timer*", if_proxy.path)) begin
-      exp_status_val[OtpLfsrFsmErrIdx] = 1;
-    end else if (!uvm_re_match("*u_otp_ctrl_kdi*", if_proxy.path)) begin
-      exp_status_val[OtpDerivKeyFsmErrIdx] = 1;
-    end else if (!uvm_re_match("*u_otp_ctrl_scrmbl*", if_proxy.path)) begin
-      exp_status_val[OtpScramblingFsmErrIdx] = 1;
+    // Alerts coming from the `u_otp` module will only bypass OTP_CTRL, it won't affect the
+    // OTP_CTRL and will fire its own alerts.
+    if (!uvm_re_match("*.u_otp.*", if_proxy.path)) begin
+      check_sec_cm_alert(if_proxy.sec_cm_type.name, prim_otp_alert_name);
+
+    // Alerts coming from the `u_tlul_lc_gate` module will only trigger bus_integrity alerts, and
+    // bus_integrity related status.
+    // This error won't local escalate to OTP partitions.
+    end else if (!uvm_re_match("*.u_tlul_lc_gate*", if_proxy.path)) begin
+      check_sec_cm_alert(if_proxy.sec_cm_type.name, integ_err_alert_name);
+
+      exp_status_val[OtpBusIntegErrorIdx] = 1;
+      exp_status_val[OtpDaiIdleIdx] = 1;
+
+    // All other errors triggers normal fatal alerts, and will locally escalate to other
+    // partitions.
+    end else begin
+      super.check_sec_cm_fi_resp(if_proxy);
+
+      // Set expected status error val.
+      for (int i = 0; i <= OtpLciErrIdx; i++) exp_status_val[i] = 1;
+      if (!uvm_re_match("*.u_otp_ctrl_lfsr_timer*", if_proxy.path)) begin
+        exp_status_val[OtpLfsrFsmErrIdx] = 1;
+      end else if (!uvm_re_match("*u_otp_ctrl_kdi*", if_proxy.path)) begin
+        exp_status_val[OtpDerivKeyFsmErrIdx] = 1;
+      end else if (!uvm_re_match("*u_otp_ctrl_scrmbl*", if_proxy.path)) begin
+        exp_status_val[OtpScramblingFsmErrIdx] = 1;
+      end
+
+      csr_rd_check(.ptr(ral.status), .compare_value(exp_status_val), .err_msg(
+                  $sformatf("cm_fi status failed at injection %0s", if_proxy.sec_cm_type.name)));
+
+      // Check OTP is locked after fault error.
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      is_valid_dai_op = 0;
+
+      // Access OTP via DAI interface.
+      dai_wr(dai_addr, wdata0, wdata1);
+      dai_rd(dai_addr, rdata0, rdata1);
+      `DV_CHECK_EQ(rdata0, 0)
+      `DV_CHECK_EQ(rdata1, 0)
+      if (is_sw_part(dai_addr)) begin
+        uvm_reg_addr_t tlul_addr = cfg.ral.get_addr_from_offset(get_sw_window_offset(dai_addr));
+        tl_access(.addr(tlul_addr), .write(0), .data(rdata0), .blocking(1), .check_rsp(1),
+                  .exp_err_rsp(1), .exp_data('1));
+      end
+      cal_hw_digests();
+      write_sw_digests();
+
+      // Access OTP via app interface.
+      if ($urandom_range(0, 1)) req_otbn_key(0);
+      if ($urandom_range(0, 1)) req_flash_addr_key(0);
+      if ($urandom_range(0, 1)) req_flash_data_key(0);
+      if ($urandom_range(0, 1)) req_all_sram_keys(0);
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 20));
+
+      csr_rd_check(.ptr(ral.status), .compare_value(exp_status_val),
+                   .err_msg("status failure after OTP fatal fault error"));
     end
-
-    csr_rd_check(.ptr(ral.status), .compare_value(exp_status_val), .err_msg(
-                 $sformatf("cm_fi status failed at injection %0s", if_proxy.sec_cm_type.name)));
-
-    // Check OTP is locked after fault error.
-    `DV_CHECK_RANDOMIZE_FATAL(this)
-    is_valid_dai_op = 0;
-
-    // Access OTP via DAI interface.
-    dai_wr(dai_addr, wdata0, wdata1);
-    dai_rd(dai_addr, rdata0, rdata1);
-    `DV_CHECK_EQ(rdata0, 0)
-    `DV_CHECK_EQ(rdata1, 0)
-    if (is_sw_part(dai_addr)) begin
-      uvm_reg_addr_t tlul_addr = cfg.ral.get_addr_from_offset(get_sw_window_offset(dai_addr));
-      tl_access(.addr(tlul_addr), .write(0), .data(rdata0), .blocking(1), .check_rsp(1),
-                .exp_err_rsp(1), .exp_data('1));
-    end
-    cal_hw_digests();
-    write_sw_digests();
-
-    // Access OTP via app interface.
-    if ($urandom_range(0, 1)) req_otbn_key(0);
-    if ($urandom_range(0, 1)) req_flash_addr_key(0);
-    if ($urandom_range(0, 1)) req_flash_data_key(0);
-    if ($urandom_range(0, 1)) req_all_sram_keys(0);
-    cfg.clk_rst_vif.wait_clks($urandom_range(10, 20));
-
-    csr_rd_check(.ptr(ral.status), .compare_value(exp_status_val),
-                 .err_msg("status failure after OTP fatal fault error"));
   endtask : check_sec_cm_fi_resp
 
    virtual function void sec_cm_fi_ctrl_svas(sec_cm_base_if_proxy if_proxy, bit enable);

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -1456,7 +1456,7 @@ module otp_ctrl
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntScrmblCheck_A,
       u_otp_ctrl_scrmbl.u_prim_count, alert_tx_o[1])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(TlLcGateFsm_A,
-      u_tlul_lc_gate.u_state_regs, alert_tx_o[1])
+      u_tlul_lc_gate.u_state_regs, alert_tx_o[2])
 
   // Alert assertions for double LFSR.
   `ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ALERT(DoubleLfsrCheck_A,


### PR DESCRIPTION
This PR update otp_ctrl_sec_cm test after design moves prim_otp alerts to the OTP_CTRL standard wrappers.
With this movement, we need to slightly change the testbench because: 1). prim_otp module output to a separate alerts.
2). prim_otp module's alert only bypass OTP_CTRL, it does not create any
  actual error.
3). tl_integrity error coming from prim_otp module will only bypass
  OTP_CTRL as well.
4). LC_gate module will output to a different alert output.

This fixes issue #14790

Signed-off-by: Cindy Chen <chencindy@opentitan.org>