### PR TITLE
[bazel,ottf] enable running OTTF tests at BL0

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -91,6 +91,33 @@ ld_library(
     ],
 )
 
+ld_library(
+    name = "ottf_ld_silicon_owner_slot_a",
+    script = "ottf_silicon_owner_a.ld",
+    deps = [
+        ":ottf_ld_common",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+    ],
+)
+
+ld_library(
+    name = "ottf_ld_silicon_owner_slot_b",
+    script = "ottf_silicon_owner_b.ld",
+    deps = [
+        ":ottf_ld_common",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+    ],
+)
+
+ld_library(
+    name = "ottf_ld_silicon_owner_slot_virtual",
+    script = "ottf_silicon_owner_virtual.ld",
+    deps = [
+        ":ottf_ld_common",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+    ],
+)
+
 # TODO(#12905): Use a slightly hollowed out version of the silicon_creator
 # manifest_def implementation when building the test_framework for the english
 # breakfast top level.

--- a/sw/device/lib/testing/test_framework/ottf_silicon_owner_a.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_owner_a.ld
@@ -1,0 +1,25 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for OpenTitan OTTF-launched test binaries.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * This linker script generates a binary to run BL0 tests.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/**
+ * Symbols to be used in the setup of the address translation for the OTTF run
+ * at the BL0 boot stage in slot A.
+ */
+/* TODO(#9045): Move ROM_EXT size to a common location. */
+_ottf_size = (LENGTH(eflash) / 2) - 0x10000;
+_ottf_start_address = ORIGIN(eflash) + 0x10000;
+
+REGION_ALIAS("ottf_flash", eflash);
+
+INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/lib/testing/test_framework/ottf_silicon_owner_b.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_owner_b.ld
@@ -1,0 +1,25 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for OpenTitan OTTF-launched test binaries.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * This linker script generates a binary to run BL0 tests.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/**
+ * Symbols to be used in the setup of the address translation for the OTTF run
+ * at the BL0 boot stage in slot B.
+ */
+/* TODO(#9045): Move ROM_EXT size to a common location. */
+_ottf_size = (LENGTH(eflash) / 2) - 0x10000;
+_ottf_start_address = ORIGIN(eflash) + (LENGTH(eflash) / 2) + 0x10000;
+
+REGION_ALIAS("ottf_flash", eflash);
+
+INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/lib/testing/test_framework/ottf_silicon_owner_virtual.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_owner_virtual.ld
@@ -1,0 +1,26 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for OpenTitan OTTF-launched test binaries.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * This linker script generates a binary to run BL0 tests.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/**
+ * Symbols to be used in the setup of the address translation for ROM_EXT.
+ */
+/* TODO(#9045): Move BL0 size to a common location. */
+_ottf_size = LENGTH(owner_virtual) - 64K;
+_ottf_start_address = ORIGIN(owner_virtual) + 64K;
+ASSERT((_ottf_size <= (LENGTH(eflash) / 2)),
+  "Error: BL0 flash is bigger than slot.");
+
+REGION_ALIAS("ottf_flash", owner_virtual);
+
+INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -11,6 +11,8 @@ load(
 )
 load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest")
 
+package(default_visibility = ["//visibility:public"])
+
 ld_library(
     name = "ld_common",
     fragments = ["bare_metal_common.ld"],
@@ -110,6 +112,9 @@ opentitan_flash_binary(
     ],
 )
 
+################################################################################
+# Bare metal ROM_EXT + BL0 test that DOES NOT use OTTF.
+################################################################################
 opentitan_multislot_flash_binary(
     name = "rom_ext_virtual_bare_metal_virtual",
     srcs = {
@@ -135,6 +140,46 @@ opentitan_functest(
     ),
     key = "multislot",
     ot_flash_binary = ":rom_ext_virtual_bare_metal_virtual",
+    signed = True,
+    targets = ["cw310"],
+)
+
+################################################################################
+# Bare metal ROM_EXT + BL0 test that DOES use OTTF.
+################################################################################
+opentitan_flash_binary(
+    name = "ottf_test_bl0_slot_virtual",
+    srcs = ["empty_test.c"],
+    manifest = "//sw/device/silicon_owner/bare_metal:manifest_virtual",
+    signed = True,
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_multislot_flash_binary(
+    name = "rom_ext_virtual_ottf_bl0_virtual",
+    srcs = {
+        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": {
+            "key": "test_key_0",
+            "offset": "0x0",
+        },
+        ":ottf_test_bl0_slot_virtual": {
+            "key": "test_key_0",
+            "offset": "0x10000",
+        },
+    },
+    image_size = "0x13000",
+)
+
+opentitan_functest(
+    name = "rom_ext_virtual_ottf_bl0_virtual_test",
+    cw310 = cw310_params(
+        bitstream = "//hw/bitstream:rom",
+    ),
+    key = "multislot",
+    ot_flash_binary = ":rom_ext_virtual_ottf_bl0_virtual",
     signed = True,
     targets = ["cw310"],
 )

--- a/sw/device/silicon_owner/bare_metal/empty_test.c
+++ b/sw/device/silicon_owner/bare_metal/empty_test.c
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) { return true; }


### PR DESCRIPTION
This fixes #10712 by enabling OTTF-launched tests to run at BL0.

Signed-off-by: Timothy Trippel <ttrippel@google.com>