### PR TITLE
[otbn,dv] Coverage extension for ECC and MuBi Errors and RND spurious ack checking

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -368,6 +368,7 @@ interface otbn_trace_if
   controller_bad_int_t controller_bad_int_i, controller_bad_int_d, controller_bad_int_q;
   missed_gnt_t missed_gnt_i, missed_gnt_d, missed_gnt_q;
   logic scramble_state_err_i, scramble_state_err_d, scramble_state_err_q;
+  logic ext_mubi_err_i, ext_mubi_err_d, ext_mubi_err_q;
   logic urnd_all_zero_d, urnd_all_zero_q;
   logic insn_addr_err_d, insn_addr_err_q;
   logic rf_base_spurious_we_err_d, rf_base_spurious_we_err_q;
@@ -380,6 +381,7 @@ interface otbn_trace_if
   assign start_stop_bad_int_d = (locking_o) ? '0 : (start_stop_bad_int_q | start_stop_bad_int_i);
   assign controller_bad_int_d = (locking_o) ? '0 : (controller_bad_int_q | controller_bad_int_i);
   assign scramble_state_err_d = (locking_o) ? '0 : (scramble_state_err_q | scramble_state_err_i);
+  assign ext_mubi_err_d = (locking_o) ? '0 : (ext_mubi_err_q| ext_mubi_err_i);
   assign rf_base_spurious_we_err_d = (locking_o) ? '0 :
    (rf_base_spurious_we_err_q | rf_base_spurious_we_err);
   assign rf_bignum_spurious_we_err_d = (locking_o) ? '0 :
@@ -387,6 +389,7 @@ interface otbn_trace_if
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
+      ext_mubi_err_q <= '0;
       missed_gnt_q <= '0;
       predec_err_q <= '0;
       urnd_all_zero_q <= '0;
@@ -397,6 +400,7 @@ interface otbn_trace_if
       rf_bignum_spurious_we_err_q <= '0;
       rf_base_spurious_we_err_q <= '0;
     end else begin
+      ext_mubi_err_q <= ext_mubi_err_d;
       missed_gnt_q <= missed_gnt_d;
       predec_err_q <= predec_err_d;
       urnd_all_zero_q <= urnd_all_zero_d;
@@ -439,6 +443,7 @@ interface otbn_trace_if
     u_otbn_controller.rf_base_call_stack_hw_err_i;
   assign controller_bad_int_i.spr_secwipe_acks = u_otbn_controller.spurious_secure_wipe_ack_q;
   assign controller_bad_int_i.state_err = u_otbn_controller.state_error;
+  assign controller_bad_int_i.controller_mubi_err = u_otbn_controller.mubi_err_q;
 
 endinterface
 

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -421,7 +421,10 @@ interface otbn_trace_if
   assign predec_err_i.rd_err = rd_predec_error;
 
   assign start_stop_bad_int_i.state_err = u_otbn_start_stop_control.state_error_d;
-  assign start_stop_bad_int_i.spr_urnd_acks = u_otbn_start_stop_control.spurious_urnd_ack_error;
+  assign start_stop_bad_int_i.spr_urnd_acks = u_otbn_rnd.edn_urnd_ack_i &&
+    (!u_otbn_rnd.edn_urnd_req_o);
+  assign start_stop_bad_int_i.spr_rnd_acks = u_otbn_rnd.edn_rnd_ack_i &&
+    (!u_otbn_rnd.edn_rnd_req_o);
   assign start_stop_bad_int_i.spr_secwipe_reqs = u_otbn_start_stop_control.secure_wipe_error_q;
 
   assign start_stop_bad_int_i.mubi_rma_err = u_otbn_start_stop_control.mubi_err_d &&

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -666,6 +666,18 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
 
   endgroup
 
+  // This covergroup tracks each possible "Internal Integrity Errors" with probes from RTL.
+  covergroup internal_intg_err_cg with function sample(otbn_pkg::internal_intg_err_t intg_err);
+
+    `DEF_SEEN_CP(rf_base_intg_err_cp, intg_err.rf_base_intg_err)
+    `DEF_SEEN_CP(rf_bignum_intg_err_cp, intg_err.rf_bignum_intg_err)
+    `DEF_SEEN_CP(mod_ispr_intg_err_cp, intg_err.mod_ispr_intg_err)
+    `DEF_SEEN_CP(acc_ispr_intg_err_cp, intg_err.acc_ispr_intg_err)
+    `DEF_SEEN_CP(loop_stack_addr_intg_err_cp, intg_err.loop_stack_addr_intg_err)
+    `DEF_SEEN_CP(insn_fetch_intg_err_cp, intg_err.insn_fetch_intg_err)
+
+  endgroup
+
   // This covergroup tracks straight-line instructions (i.e., instructions that do not
   // branch or jump) at the top of instruction memory (i.e., at the highest possible
   // address).
@@ -2235,6 +2247,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
                                  cfg.trace_vif.start_stop_bad_int_q,
                                  cfg.trace_vif.rf_base_spurious_we_err_q,
                                  cfg.trace_vif.rf_bignum_spurious_we_err_q);
+
+    internal_intg_err_cg.sample(cfg.trace_vif.internal_intg_err_q);
   endfunction
 
   function void on_write_to_wr_csr(uvm_reg csr, logic [31:0] data, operational_state_e state);

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -644,6 +644,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     `DEF_SEEN_CP(rd_predec_err, predec_err.rd_err)
 
     `DEF_SEEN_CP(spr_urnd_acks_cp, start_stop_bad_int.spr_urnd_acks)
+    `DEF_SEEN_CP(spr_rnd_acks_cp, start_stop_bad_int.spr_rnd_acks)
     `DEF_SEEN_CP(spr_secwipe_reqs_cp, start_stop_bad_int.spr_secwipe_reqs)
     `DEF_SEEN_CP(mubi_rma_err_cp, start_stop_bad_int.mubi_rma_err)
     `DEF_SEEN_CP(mubi_urnd_err_cp, start_stop_bad_int.mubi_urnd_err)

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -633,7 +633,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
                          otbn_pkg::controller_bad_int_t controller_bad_int,
                          otbn_pkg::start_stop_bad_int_t start_stop_bad_int,
                          logic rf_base_spurious_we_err,
-                         logic rf_bignum_spurious_we_err);
+                         logic rf_bignum_spurious_we_err,
+                         logic ext_mubi_err);
 
     `DEF_SEEN_CP(alu_bignum_predec_err, predec_err.alu_bignum_err)
     `DEF_SEEN_CP(mac_bignum_predec_err, predec_err.mac_bignum_err)
@@ -654,6 +655,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     `DEF_SEEN_CP(rf_base_call_stack_err_cp, controller_bad_int.rf_base_call_stack_err)
     `DEF_SEEN_CP(spr_secwipe_acks_cp, controller_bad_int.spr_secwipe_acks)
     `DEF_SEEN_CP(controller_state_err_cp, controller_bad_int.state_err)
+    `DEF_SEEN_CP(controller_mubi_err_cp, controller_bad_int.controller_mubi_err)
 
     `DEF_SEEN_CP(imem_gnt_missed_err_cp, missed_gnt.imem_gnt_missed_err)
     `DEF_SEEN_CP(dmem_gnt_missed_err_cp, missed_gnt.dmem_gnt_missed_err)
@@ -663,6 +665,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     `DEF_SEEN_CP(scramble_state_err_cp, scramble_state_err)
     `DEF_SEEN_CP(rf_base_spurious_we_err_cp, rf_base_spurious_we_err)
     `DEF_SEEN_CP(rf_bignum_spurious_we_err_cp, rf_bignum_spurious_we_err)
+    `DEF_SEEN_CP(ext_mubi_err_cp, ext_mubi_err)
 
   endgroup
 
@@ -2246,7 +2249,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
                                  cfg.trace_vif.controller_bad_int_q,
                                  cfg.trace_vif.start_stop_bad_int_q,
                                  cfg.trace_vif.rf_base_spurious_we_err_q,
-                                 cfg.trace_vif.rf_bignum_spurious_we_err_q);
+                                 cfg.trace_vif.rf_bignum_spurious_we_err_q,
+                                 cfg.trace_vif.ext_mubi_err_q);
 
     internal_intg_err_cg.sample(cfg.trace_vif.internal_intg_err_q);
   endfunction

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -158,6 +158,7 @@ module tb;
   ) i_otbn_trace_if (.*);
 
   assign dut.u_otbn_core.i_otbn_trace_if.scramble_state_err_i = dut.otbn_scramble_state_error;
+  assign dut.u_otbn_core.i_otbn_trace_if.ext_mubi_err_i = dut.mubi_err;
   assign dut.u_otbn_core.i_otbn_trace_if.missed_gnt_i.imem_gnt_missed_err = dut.imem_missed_gnt;
   assign dut.u_otbn_core.i_otbn_trace_if.missed_gnt_i.dmem_gnt_missed_err = dut.dmem_missed_gnt;
 

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -174,6 +174,7 @@ module otbn_top_sim (
   bind otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
 
   assign u_otbn_core.i_otbn_trace_if.scramble_state_err_i = '0;
+  assign u_otbn_core.i_otbn_trace_if.ext_mubi_err_i = '0;
   assign u_otbn_core.i_otbn_trace_if.missed_gnt_i = '0;
 
   // Convert from core_err_bits_t to err_bits_t

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -122,6 +122,7 @@ package otbn_pkg;
 
   typedef struct packed {
     logic spr_urnd_acks;
+    logic spr_rnd_acks;
     logic spr_secwipe_reqs;
     logic mubi_rma_err;
     logic mubi_urnd_err;

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -135,6 +135,7 @@ package otbn_pkg;
     logic rf_base_call_stack_err;
     logic spr_secwipe_acks;
     logic state_err;
+    logic controller_mubi_err;
   } controller_bad_int_t;
 
   typedef struct packed {

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -142,6 +142,15 @@ package otbn_pkg;
     logic dmem_gnt_missed_err;
   } missed_gnt_t;
 
+  typedef struct packed {
+    logic rf_base_intg_err;
+    logic rf_bignum_intg_err;
+    logic mod_ispr_intg_err;
+    logic acc_ispr_intg_err;
+    logic loop_stack_addr_intg_err;
+    logic insn_fetch_intg_err;
+  } internal_intg_err_t;
+
   // All the error signals that can be generated directly from the controller. Note that this is
   // organised to include every software error (including 'call_stack', which actually gets fed in
   // from the base register file)


### PR DESCRIPTION
This PR includes work towards completing functional coverage for issues: [#14541](https://github.com/lowRISC/opentitan/issues/14541), [#11539](https://github.com/lowRISC/opentitan/issues/11539) and https://github.com/lowRISC/opentitan/issues/11546