### PR TITLE
[crypto] Update cryptolib OTBN driver based on silicon_creator version.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -146,5 +146,6 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
     ],
 )

--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -4,12 +4,9 @@
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
 
-#include <assert.h>
-#include <stddef.h>
-#include <stdint.h>
-
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otbn_regs.h"  // Generated.
@@ -41,6 +38,8 @@ ASSERT_ERR_BIT_MATCH(kOtbnErrBitsFatalSoftware,
 const size_t kOtbnDMemSizeBytes = OTBN_DMEM_SIZE_BYTES;
 const size_t kOtbnIMemSizeBytes = OTBN_IMEM_SIZE_BYTES;
 
+enum { kBase = TOP_EARLGREY_OTBN_BASE_ADDR };
+
 /**
  * Ensures that `offset_bytes` and `len` are valid for a given `mem_size`.
  */
@@ -54,33 +53,104 @@ static otbn_error_t check_offset_len(uint32_t offset_bytes, size_t num_words,
   return kOtbnErrorOk;
 }
 
-void otbn_execute(void) {
-  abs_mmio_write32(TOP_EARLGREY_OTBN_BASE_ADDR + OTBN_CMD_REG_OFFSET,
-                   kOtbnCmdExecute);
+otbn_error_t otbn_assert_idle(void) {
+  uint32_t status = launder32(~kOtbnStatusIdle);
+  otbn_error_t res = launder32(kOtbnErrorOk ^ status);
+  status = abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET);
+  res ^= ~status;
+  if (launder32(res) == kOtbnErrorOk) {
+    HARDENED_CHECK_EQ(res, kOtbnErrorOk);
+    HARDENED_CHECK_EQ(abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET),
+                      kOtbnStatusIdle);
+    return res;
+  }
+  return kOtbnErrorUnavailable;
 }
 
-bool otbn_is_busy(void) {
-  uint32_t status =
-      abs_mmio_read32(TOP_EARLGREY_OTBN_BASE_ADDR + OTBN_STATUS_REG_OFFSET);
-  return status != kOtbnStatusIdle && status != kOtbnStatusLocked;
+otbn_error_t otbn_busy_wait_for_done(void) {
+  uint32_t status = launder32(UINT32_MAX);
+  otbn_error_t res = launder32(kOtbnErrorOk ^ status);
+  do {
+    status = abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET);
+  } while (launder32(status) != kOtbnStatusIdle &&
+           launder32(status) != kOtbnStatusLocked);
+  res ^= ~status;
+
+  otbn_err_bits_t err_bits;
+  otbn_err_bits_get(&err_bits);
+
+  if (launder32(res) == kOtbnErrorOk &&
+      launder32(err_bits) == kOtbnErrBitsNoError) {
+    HARDENED_CHECK_EQ(res, kOtbnErrorOk);
+    otbn_err_bits_get(&err_bits);
+    HARDENED_CHECK_EQ(err_bits, kOtbnErrBitsNoError);
+    HARDENED_CHECK_EQ(abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET),
+                      kOtbnStatusIdle);
+    return res;
+  }
+  return kOtbnErrorExecutionFailed;
 }
 
-void otbn_get_err_bits(otbn_err_bits_t *err_bits) {
-  *err_bits =
-      abs_mmio_read32(TOP_EARLGREY_OTBN_BASE_ADDR + OTBN_ERR_BITS_REG_OFFSET);
+/**
+ * Helper function for writing to OTBN's DMEM or IMEM.
+ *
+ * @param dest_addr Destination address.
+ * @param src Source buffer.
+ * @param num_words Number of words to copy.
+ */
+static void otbn_write(uint32_t dest_addr, const uint32_t *src,
+                       size_t num_words) {
+  // TODO: replace 0 with a random index like the silicon_creator driver
+  // (requires an interface to Ibex's RND valid bit and data register).
+  size_t i = ((uint64_t)0 * (uint64_t)num_words) >> 32;
+  enum { kStep = 1 };
+  size_t iter_cnt = 0;
+  for (; launder32(iter_cnt) < num_words; ++iter_cnt) {
+    abs_mmio_write32(dest_addr + i * sizeof(uint32_t), src[i]);
+    i += kStep;
+    if (launder32(i) >= num_words) {
+      i -= num_words;
+    }
+    HARDENED_CHECK_LT(i, num_words);
+  }
+  HARDENED_CHECK_EQ(iter_cnt, num_words);
+}
+
+otbn_error_t otbn_execute(void) {
+  // Ensure OTBN is idle before attempting to run a command.
+  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+
+  abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdExecute);
+  return kOtbnErrorOk;
+}
+
+void otbn_err_bits_get(otbn_err_bits_t *err_bits) {
+  *err_bits = abs_mmio_read32(kBase + OTBN_ERR_BITS_REG_OFFSET);
+}
+
+uint32_t otbn_instruction_count_get(void) {
+  return abs_mmio_read32(kBase + OTBN_INSN_CNT_REG_OFFSET);
+}
+
+otbn_error_t otbn_imem_sec_wipe(void) {
+  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+  abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdSecWipeImem);
+  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done());
+  return kOtbnErrorOk;
 }
 
 otbn_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
                              size_t num_words) {
   OTBN_RETURN_IF_ERROR(
       check_offset_len(offset_bytes, num_words, kOtbnIMemSizeBytes));
+  otbn_write(kBase + OTBN_IMEM_REG_OFFSET + offset_bytes, src, num_words);
+  return kOtbnErrorOk;
+}
 
-  for (size_t i = 0; i < num_words; ++i) {
-    abs_mmio_write32(TOP_EARLGREY_OTBN_BASE_ADDR + OTBN_IMEM_REG_OFFSET +
-                         offset_bytes + i * sizeof(uint32_t),
-                     src[i]);
-  }
-
+otbn_error_t otbn_dmem_sec_wipe(void) {
+  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+  abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdSecWipeDmem);
+  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done());
   return kOtbnErrorOk;
 }
 
@@ -88,13 +158,7 @@ otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
                              size_t num_words) {
   OTBN_RETURN_IF_ERROR(
       check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
-
-  for (size_t i = 0; i < num_words; ++i) {
-    abs_mmio_write32(TOP_EARLGREY_OTBN_BASE_ADDR + OTBN_DMEM_REG_OFFSET +
-                         offset_bytes + i * sizeof(uint32_t),
-                     src[i]);
-  }
-
+  otbn_write(kBase + OTBN_DMEM_REG_OFFSET + offset_bytes, src, num_words);
   return kOtbnErrorOk;
 }
 
@@ -103,23 +167,20 @@ otbn_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest,
   OTBN_RETURN_IF_ERROR(
       check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
 
-  for (size_t i = 0; i < num_words; ++i) {
-    dest[i] =
-        abs_mmio_read32(TOP_EARLGREY_OTBN_BASE_ADDR + OTBN_DMEM_REG_OFFSET +
-                        offset_bytes + i * sizeof(uint32_t));
+  size_t i = 0;
+  for (; launder32(i) < num_words; ++i) {
+    dest[i] = abs_mmio_read32(kBase + OTBN_DMEM_REG_OFFSET + offset_bytes +
+                              i * sizeof(uint32_t));
   }
+  HARDENED_CHECK_EQ(i, num_words);
 
   return kOtbnErrorOk;
 }
 
-void otbn_zero_dmem(void) {
-  for (size_t i = 0; i < kOtbnDMemSizeBytes; i += sizeof(uint32_t)) {
-    abs_mmio_write32(TOP_EARLGREY_OTBN_BASE_ADDR + OTBN_DMEM_REG_OFFSET + i,
-                     0u);
-  }
-}
-
 otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
+  // Ensure OTBN is idle (otherwise CTRL writes will be ignored).
+  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+
   // Only one bit in the CTRL register so no need to read current value.
   uint32_t new_ctrl;
 
@@ -129,12 +190,7 @@ otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
     new_ctrl = 0;
   }
 
-  abs_mmio_write32(TOP_EARLGREY_OTBN_BASE_ADDR + OTBN_CTRL_REG_OFFSET,
-                   new_ctrl);
-  if (abs_mmio_read32(TOP_EARLGREY_OTBN_BASE_ADDR + OTBN_CTRL_REG_OFFSET) !=
-      new_ctrl) {
-    return kOtbnErrorUnavailable;
-  }
+  abs_mmio_write32(kBase + OTBN_CTRL_REG_OFFSET, new_ctrl);
 
   return kOtbnErrorOk;
 }

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -9,6 +9,7 @@ cc_library(
     srcs = ["otbn_util.c"],
     hdrs = ["otbn_util.h"],
     deps = [
+        "//sw/device/lib/base:hardened",
         "//sw/device/lib/crypto/drivers:otbn",
     ],
 )

--- a/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.c
+++ b/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.c
@@ -103,6 +103,9 @@ static otbn_error_t setup_data_pointers(otbn_t *otbn) {
 otbn_error_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
                              const ecdsa_p256_private_key_t *private_key,
                              ecdsa_p256_signature_t *result) {
+  // If OTBN is non-idle, return an error.
+  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+
   otbn_t otbn;
   otbn_init(&otbn);
 
@@ -126,7 +129,7 @@ otbn_error_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
   OTBN_RETURN_IF_ERROR(otbn_execute_app(&otbn));
 
   // Spin here waiting for OTBN to complete.
-  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done(&otbn));
+  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done());
 
   // Read signature R out of OTBN dmem.
   OTBN_RETURN_IF_ERROR(otbn_copy_data_from_otbn(&otbn, kP256ScalarNumWords,
@@ -148,6 +151,9 @@ otbn_error_t ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
                                const ecdsa_p256_message_digest_t *digest,
                                const ecdsa_p256_public_key_t *public_key,
                                hardened_bool_t *result) {
+  // If OTBN is non-idle, return an error.
+  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+
   otbn_t otbn;
   otbn_init(&otbn);
 
@@ -183,7 +189,7 @@ otbn_error_t ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
   OTBN_RETURN_IF_ERROR(otbn_execute_app(&otbn));
 
   // Spin here waiting for OTBN to complete.
-  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done(&otbn));
+  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done());
 
   // Read x_r (recovered R) out of OTBN dmem.
   uint32_t x_r[kP256ScalarNumWords];

--- a/sw/device/lib/crypto/impl/otbn_util.h
+++ b/sw/device/lib/crypto/impl/otbn_util.h
@@ -5,10 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_OTBN_UTIL_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_OTBN_UTIL_H_
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 
 #ifdef __cplusplus
@@ -77,14 +74,14 @@ typedef struct otbn {
   /**
    * The application loaded or to be loaded into OTBN.
    *
-   * Only valid if @p app_is_loaded is true.
+   * Only valid if @p app_is_loaded is kHardenedBoolTrue.
    */
   otbn_app_t app;
 
   /**
    * Is the application loaded into OTBN?
    */
-  bool app_is_loaded;
+  hardened_bool_t app_is_loaded;
 
   /**
    * The error bits from the last execution of OTBN.
@@ -187,9 +184,12 @@ typedef struct otbn {
 void otbn_init(otbn_t *ctx);
 
 /**
- * (Re-)loads the RSA application into OTBN.
+ * (Re-)loads the provided application into OTBN.
  *
- * Load the application image with both instruction and data segments into OTBN.
+ * Load the application image with both instruction and data segments into
+ * OTBN.
+ *
+ * This function will return an error if called when OTBN is not idle.
  *
  * @param ctx The context object.
  * @param app The application to load into OTBN.
@@ -200,20 +200,12 @@ otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app);
 /**
  * Start the OTBN application.
  *
- * Use `otbn_busy_wait_for_done()` to wait for the function call to complete.
+ * This function will return an error if called when OTBN is not idle.
  *
  * @param ctx The context object.
  * @return The result of the operation.
  */
 otbn_error_t otbn_execute_app(otbn_t *ctx);
-
-/**
- * Busy waits for OTBN to be done with its operation.
- *
- * @param ctx The context object.
- * @return The result of the operation.
- */
-otbn_error_t otbn_busy_wait_for_done(otbn_t *ctx);
 
 /**
  * Copies data from the CPU memory to OTBN data memory.

--- a/sw/device/lib/crypto/impl/rsa_3072/rsa_3072_verify.c
+++ b/sw/device/lib/crypto/impl/rsa_3072/rsa_3072_verify.c
@@ -148,7 +148,7 @@ otbn_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
   OTBN_RETURN_IF_ERROR(otbn_execute_app(&otbn));
 
   // Spin here waiting for OTBN to complete.
-  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done(&otbn));
+  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done());
 
   // Read constant rr out of DMEM.
   OTBN_RETURN_IF_ERROR(
@@ -212,7 +212,7 @@ otbn_error_t rsa_3072_verify(const rsa_3072_int_t *signature,
   OTBN_RETURN_IF_ERROR(otbn_execute_app(&otbn));
 
   // Spin here waiting for OTBN to complete.
-  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done(&otbn));
+  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done());
 
   // Read recovered message out of OTBN dmem.
   rsa_3072_int_t recoveredMessage;

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -114,6 +114,9 @@ autogen_cryptotest_header(
 opentitan_functest(
     name = "rsa_3072_verify_functest_wycheproof",
     srcs = ["rsa_3072_verify_functest.c"],
+    cw310 = cw310_params(
+        timeout = "long",
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -55,16 +55,18 @@ bool sign_then_verify_test(void) {
   ecdsa_p256_signature_t signature;
   hardened_bool_t verificationResult;
 
+  // Spin until OTBN is idle.
+  if (otbn_busy_wait_for_done() != kOtbnErrorOk) {
+    return false;
+  }
+
   // Generate a signature for the message
   LOG_INFO("Signing...");
   otbn_error_t err = ecdsa_p256_sign(&digest, &kPrivateKey, &signature);
-  for (size_t i = 0; i < kP256ScalarNumWords; i++) {
-    LOG_INFO("h[%d] = 0x%08x", i, digest.h[i]);
-  }
   if (err != kOtbnErrorOk) {
     LOG_ERROR("Error from OTBN while signing: 0x%08x.", err);
     otbn_err_bits_t err_bits;
-    otbn_get_err_bits(&err_bits);
+    otbn_err_bits_get(&err_bits);
     LOG_INFO("OTBN error bits: 0x%08x", err_bits);
     return false;
   }
@@ -76,7 +78,7 @@ bool sign_then_verify_test(void) {
   if (err != kOtbnErrorOk) {
     LOG_ERROR("Error from OTBN while verifying signature: 0x%08x.", err);
     otbn_err_bits_t err_bits;
-    otbn_get_err_bits(&err_bits);
+    otbn_err_bits_get(&err_bits);
     LOG_INFO("OTBN error bits: 0x%08x", err_bits);
     return false;
   }

--- a/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
@@ -48,7 +48,7 @@ bool ecdsa_p256_verify_test(const ecdsa_p256_verify_test_vector_t *testvec) {
   otbn_error_t err = ecdsa_p256_verify(&testvec->signature, &digest,
                                        &testvec->public_key, &result);
   otbn_err_bits_t err_bits;
-  otbn_get_err_bits(&err_bits);
+  otbn_err_bits_get(&err_bits);
   CHECK(
       err == kOtbnErrorOk,
       "Error from OTBN while verifying signature: 0x%08x. Error bits: 0b%032b",


### PR DESCRIPTION
Since the cryptolib's OTBN driver was originally copied over from `silicon_creator`, there has been extensive effort applied to hardening the silicon_creator version. This commit essentially replaces the cryptolib OTBN driver with the silicon_creator version in order to take advantage of the existing hardening effort.

The main difference between this version and the one in `silicon_creator` is that everything in ROM is blocking, this is fine for `silicon_creator`, but the cryptolib needs to also support asynchronous OTBN execution. So, while the `silicon_creator` version has a static `otbn_cmd_run` function that issues a command (execute or secure wipe) and awaits a "done" interrupt, this driver instead separates the execute/secure wipe IMEM/secure wipe DMEM functions and only blocks for the secure wipes. For `execute`, the function returns immediately without waiting. Also, it polls the status register rather than the interrupt state.

Also to support asynchronous execution, this version has more defensive checks and explicit requirements that ensure OTBN is idle.