### PR TITLE
[bazel] fix airgapped directory generation script

### DIFF
--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -140,6 +140,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   ${BAZELISK} fetch \
     --repository_cache=${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR} \
     //... \
+    @bindgen_clang_linux//... \
     @lowrisc_rv32imcb_files//... \
     @local_config_cc_toolchains//... \
     @local_config_platform//... \


### PR DESCRIPTION
Turns out #14860 requires an update to this script. It's blocking the Bazel airgapped image gen until it is merged.

Signed-off-by: Timothy Trippel <ttrippel@google.com>