### PR TITLE
[top-test] Increase reverse ping test timeout

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -803,7 +803,7 @@
       // processing alerts accurately from both ends.
       // This test takes long due to the compile time configured reverse timeout. See test plan for
       // more details.
-      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=240_000_000"]
+      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=300_000_000"]
       run_timeout_mins: 240
     }
     {


### PR DESCRIPTION
Increase chip_sw_alert_handler_reverse_ping_in_deep_sleep test timeout to 0.300s. The previous calculations didn't take into account the time needed to increase the counters before going into deep sleep.

