### PR TITLE
Fix format specifier widths

### DIFF
--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -106,7 +106,7 @@ void keymgr_testutils_startup(dif_keymgr_t *keymgr, dif_kmac_t *kmac) {
     wait_for_interrupt();
 
   } else {
-    CHECK(info == kDifRstmgrResetInfoSw, "Unexpected reset reason: %0x", info);
+    CHECK(info == kDifRstmgrResetInfoSw, "Unexpected reset reason: %08x", info);
     LOG_INFO(
         "Powered up for the second time, actuate keymgr and perform test.");
 

--- a/sw/device/lib/testing/lc_ctrl_testutils.c
+++ b/sw/device/lib/testing/lc_ctrl_testutils.c
@@ -33,20 +33,20 @@ bool lc_ctrl_testutils_debug_func_enabled(const dif_lc_ctrl_t *lc_ctrl) {
 
 void lc_ctrl_testutils_check_transition_count(const dif_lc_ctrl_t *lc_ctrl,
                                               uint8_t exp_lc_count) {
-  LOG_INFO("Read LC count and check with expect_val=%0d", exp_lc_count);
+  LOG_INFO("Read LC count and check with expect_val=%d", exp_lc_count);
   uint8_t lc_count;
   CHECK_DIF_OK(dif_lc_ctrl_get_attempts(lc_ctrl, &lc_count));
   CHECK(lc_count == exp_lc_count,
-        "LC_count error, expected %0d but actual count is %0d", exp_lc_count,
+        "LC_count error, expected %d but actual count is %d", exp_lc_count,
         lc_count);
 }
 
 void lc_ctrl_testutils_check_lc_state(const dif_lc_ctrl_t *lc_ctrl,
                                       dif_lc_ctrl_state_t exp_lc_state) {
-  LOG_INFO("Read LC state and check with expect_state=%0d", exp_lc_state);
+  LOG_INFO("Read LC state and check with expect_state=%d", exp_lc_state);
   dif_lc_ctrl_state_t lc_state;
   CHECK_DIF_OK(dif_lc_ctrl_get_state(lc_ctrl, &lc_state));
   CHECK(lc_state == exp_lc_state,
-        "LC_state error, expected %0d but actual state is %0d", exp_lc_state,
+        "LC_state error, expected %d but actual state is %d", exp_lc_state,
         lc_state);
 }

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -257,7 +257,7 @@ bool test_main(void) {
     EXECUTE_TEST(result, keymgr_rom_ext_test);
     return result == kErrorOk;
   } else {
-    LOG_FATAL("Unexpected reset reason unexpected: %0x", info);
+    LOG_FATAL("Unexpected reset reason unexpected: %08x", info);
   }
 
   return false;

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -83,7 +83,7 @@ void ottf_external_isr(void) {
                       kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
 
     // We should not get aon timer interrupts since escalation suppresses them.
-    LOG_ERROR("Unexpected aon timer interrupt %0d", irq);
+    LOG_ERROR("Unexpected aon timer interrupt %d", irq);
   } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
     // Check the class.
     dif_alert_handler_class_state_t state;

--- a/sw/device/tests/autogen/alert_test.c
+++ b/sw/device/tests/autogen/alert_test.c
@@ -288,7 +288,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdAdcCtrlAonFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -303,7 +303,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdAesRecovCtrlUpdateErr + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -318,7 +318,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdAonTimerAonFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -333,7 +333,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdClkmgrAonRecovFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -348,7 +348,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdCsrngRecovAlert + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -363,7 +363,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdEdn0RecovAlert + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -378,7 +378,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdEdn1RecovAlert + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -393,7 +393,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdEntropySrcRecovAlert + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -408,7 +408,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdFlashCtrlRecovErr + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -423,7 +423,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdGpioFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -438,7 +438,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdHmacFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -453,7 +453,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdI2c0FatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -468,7 +468,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdI2c1FatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -483,7 +483,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdI2c2FatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -498,7 +498,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdKeymgrRecovOperationErr + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -513,7 +513,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdKmacRecovOperationErr + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -528,7 +528,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdLcCtrlFatalProgError + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -543,7 +543,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdOtbnFatal + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -558,7 +558,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdOtpCtrlFatalMacroError + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -573,7 +573,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdPattgenFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -588,7 +588,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdPinmuxAonFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -603,7 +603,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdPwmAonFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -618,7 +618,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdPwrmgrAonFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -633,7 +633,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdRomCtrlFatal + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -648,7 +648,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdRstmgrAonFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -663,7 +663,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdRvCoreIbexFatalSwErr + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -678,7 +678,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdRvPlicFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -693,7 +693,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdRvTimerFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -708,7 +708,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdSensorCtrlRecovAlert + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -723,7 +723,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdSpiDeviceFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -738,7 +738,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdSpiHost0FatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -753,7 +753,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdSpiHost1FatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -768,7 +768,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdSramCtrlMainFatalError + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -783,7 +783,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdSramCtrlRetAonFatalError + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -798,7 +798,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdSysrstCtrlAonFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -813,7 +813,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdUart0FatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -828,7 +828,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdUart1FatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -843,7 +843,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdUart2FatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -858,7 +858,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdUart3FatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
@@ -873,7 +873,7 @@ static void trigger_alert_test(void) {
     exp_alert = kTopEarlgreyAlertIdUsbdevFatalFault + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(

--- a/sw/device/tests/flash_ctrl_idle_low_power_test.c
+++ b/sw/device/tests/flash_ctrl_idle_low_power_test.c
@@ -160,7 +160,7 @@ bool test_main(void) {
 
     rstmgr_testutils_reason_clear();
   } else {
-    LOG_ERROR("Unexepected reset type detected. Reset info = %0x",
+    LOG_ERROR("Unexepected reset type detected. Reset info = %08x",
               rstmgr_reset_info);
     return false;
   }

--- a/sw/device/tests/flash_ctrl_ops_test.c
+++ b/sw/device/tests/flash_ctrl_ops_test.c
@@ -136,7 +136,7 @@ static void flash_ctrl_init_with_irqs(mmio_region_t base_addr,
  */
 static void compare_and_clear_irq_variables(void) {
   for (int i = 0; i < FLASH_CTRL_NUM_IRQS; ++i) {
-    CHECK(expected_irqs[i] == fired_irqs[i], "expected IRQ mismatch = %0d", i);
+    CHECK(expected_irqs[i] == fired_irqs[i], "expected IRQ mismatch = %d", i);
   }
   clear_irq_variables();
 }

--- a/sw/device/tests/kmac_idle_test.c
+++ b/sw/device/tests/kmac_idle_test.c
@@ -51,7 +51,7 @@ static void check_clock_state(dif_toggle_t expected_clock_state) {
   CHECK_DIF_OK(
       dif_clkmgr_hintable_clock_get_enabled(&clkmgr, kmac_clock, &clock_state));
   CHECK(clock_state == expected_clock_state,
-        "Clock enabled state is not as expected (%0d).", expected_clock_state);
+        "Clock enabled state is not as expected (%d).", expected_clock_state);
 }
 
 static void do_sha3_test(void) {

--- a/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
+++ b/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
@@ -66,7 +66,7 @@ bool test_main(void) {
                          &otp_device_id);
 
     CHECK(otp_device_id == lc_device_id.data[i],
-          "Device_ID_%0d mismatch bewtween otp_ctrl: %0h and lc_ctrl: %0h", i,
+          "Device_ID_%d mismatch bewtween otp_ctrl: %08x and lc_ctrl: %08x", i,
           otp_device_id, lc_device_id.data[i]);
   }
   return true;

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -634,7 +634,7 @@ static void collect_alert_dump_and_compare(test_round_t round) {
     // dut to short timeout value.
     // However, alert source of this ping timeout can be choosen randomly,
     // as documented in issue #2321, so we conly check local alert cause.
-    LOG_INFO("loc_alert_cause: exp: %0x   obs: %0x",
+    LOG_INFO("loc_alert_cause: exp: %08x   obs: %08x",
              kExpectedInfo[round].loc_alert_cause, actual_info.loc_alert_cause);
     CHECK(kExpectedInfo[round].loc_alert_cause == actual_info.loc_alert_cause);
   } else {

--- a/sw/device/tests/sim_dv/all_escalation_resets_test.c
+++ b/sw/device/tests/sim_dv/all_escalation_resets_test.c
@@ -428,7 +428,7 @@ void ottf_external_isr(void) {
                       kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
 
     // We should not get aon timer interrupts since escalation suppresses them.
-    CHECK(false, "Unexpected aon timer interrupt %0d", irq);
+    CHECK(false, "Unexpected aon timer interrupt %d", irq);
   } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
     // Don't acknowledge the interrupt to alert_handler so it escalates.
     CHECK(fault_checker.function);
@@ -563,7 +563,7 @@ static void alert_handler_config(void) {
   uint32_t deadline_cycles =
       udiv64_slow(kEscalationStartMicros * kClockFreqPeripheralHz, 1000000,
                   /*rem_out=*/NULL);
-  LOG_INFO("Configuring class A with %0d cycles and %0d occurrences",
+  LOG_INFO("Configuring class A with %d cycles and %d occurrences",
            deadline_cycles, UINT16_MAX);
   dif_alert_handler_class_config_t class_config[] = {{
       .auto_lock_accumulation_counter = kDifToggleDisabled,

--- a/sw/device/tests/sim_dv/clkmgr_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/clkmgr_escalation_reset_test.c
@@ -89,7 +89,7 @@ void ottf_external_isr(void) {
                       kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
 
     // We should not get aon timer interrupts since escalation suppresses them.
-    CHECK(false, "Unexpected aon timer interrupt %0d", irq);
+    CHECK(false, "Unexpected aon timer interrupt %d", irq);
   } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
     // Check the class.
     dif_alert_handler_class_state_t state;

--- a/sw/device/tests/sim_dv/lc_ctrl_kmac_reset_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_kmac_reset_test.c
@@ -65,7 +65,7 @@ bool test_main(void) {
   // Get LC count.
   uint8_t lc_count;
   CHECK_DIF_OK(dif_lc_ctrl_get_attempts(&lc, &lc_count));
-  LOG_INFO("LC_COUNT is %0d.", lc_count);
+  LOG_INFO("LC_COUNT is %d.", lc_count);
 
   dif_lc_ctrl_token_t token;
   switch (lc_count) {
@@ -89,7 +89,7 @@ bool test_main(void) {
       return true;
     default:
       // Unexpected value, exit test with error.
-      LOG_ERROR("Unexpected lc_count value %0d", lc_count);
+      LOG_ERROR("Unexpected lc_count value %d", lc_count);
       return false;
   }
 

--- a/sw/device/tests/sim_dv/lc_walkthrough_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_test.c
@@ -154,7 +154,7 @@ static void lock_otp_secret2_partition() {
  */
 
 bool test_main(void) {
-  LOG_INFO("Start LC walkthrough %0d test.", kDestState);
+  LOG_INFO("Start LC walkthrough %d test.", kDestState);
 
   mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
   CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
@@ -184,7 +184,7 @@ bool test_main(void) {
       wait_for_interrupt();
       // Print out LcRmaToken to avoid SW compile error saying kLcRmaToken is
       // unused in certain state trasition tests.
-      LOG_INFO("LC RMA token start with %0h", kLcRmaToken[0]);
+      LOG_INFO("LC RMA token start with %08x", kLcRmaToken[0]);
       // Unreachable
       return false;
     } else {

--- a/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
@@ -123,7 +123,7 @@ static void get_dest_state_and_cnt(dif_lc_ctrl_state_t *curr_state,
       *exp_cnt = 15;
       break;
     default:
-      LOG_FATAL("Unexpected state = %0d", curr_state);
+      LOG_FATAL("Unexpected state = %d", curr_state);
       abort();
   }
 }
@@ -200,7 +200,7 @@ bool test_main(void) {
                  "LC transition configuration failed!");
     CHECK_DIF_OK(dif_lc_ctrl_transition(&lc), "LC transition failed!");
 
-    LOG_INFO("Waiting for LC transtition %0d done and reboot.", kDestState);
+    LOG_INFO("Waiting for LC transtition %d done and reboot.", kDestState);
     wait_for_interrupt();
 
     // Unreachable.

--- a/sw/device/tests/sim_dv/rom_ctrl_integrity_check_test.c
+++ b/sw/device/tests/sim_dv/rom_ctrl_integrity_check_test.c
@@ -48,7 +48,7 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_rom_ctrl_get_expected_digest(&rom_ctrl, &expected_digest));
   CHECK(expected_digest.digest[ROM_CTRL_DIGEST_MULTIREG_COUNT - 1] !=
             computed_digest.digest[ROM_CTRL_DIGEST_MULTIREG_COUNT - 1],
-        "Expected and computed digests match. Digests = %0x",
+        "Expected and computed digests match. Digests = %08x",
         expected_digest.digest[ROM_CTRL_DIGEST_MULTIREG_COUNT - 1]);
 
   // set test_status to wfi and call wait_for_interrupt to make

--- a/sw/device/tests/sim_dv/spi_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_tx_rx_test.c
@@ -240,10 +240,10 @@ static bool execute_test(dif_spi_device_handle_t *spi_device) {
                                    &bytes_transferred));
   if (bytes_transferred != SPI_DEVICE_DATASET_SIZE) {
     LOG_ERROR(
-        "SPI_DEVICE TX_FIFO transferred bytes mismatched: {act: %0d, exp: %0d}",
+        "SPI_DEVICE TX_FIFO transferred bytes mismatched: {act: %d, exp: %d}",
         bytes_transferred, SPI_DEVICE_DATASET_SIZE);
   } else {
-    LOG_INFO("Transferred %0d bytes to SPI_DEVICE TX_FIFO.", bytes_transferred);
+    LOG_INFO("Transferred %d bytes to SPI_DEVICE TX_FIFO.", bytes_transferred);
   }
 
   CHECK_DIF_OK(dif_spi_device_set_irq_levels(
@@ -277,11 +277,11 @@ static bool execute_test(dif_spi_device_handle_t *spi_device) {
       CHECK_DIF_OK(dif_spi_device_recv(spi_device, spi_device_rx_data,
                                        SPI_DEVICE_DATASET_SIZE, &bytes_recved));
       if (bytes_recved == SPI_DEVICE_DATASET_SIZE) {
-        LOG_INFO("Received %0d bytes from SPI_DEVICE RX_FIFO.", bytes_recved);
+        LOG_INFO("Received %d bytes from SPI_DEVICE RX_FIFO.", bytes_recved);
         read_rx_fifo_done = true;
       } else {
         LOG_ERROR(
-            "SPI_DEVICE RX_FIFO recvd bytes mismatched: {act: %0d, exp: %0d}",
+            "SPI_DEVICE RX_FIFO recvd bytes mismatched: {act: %d, exp: %d}",
             bytes_recved, SPI_DEVICE_DATASET_SIZE);
       }
       LOG_INFO("SPI_DEVICE read out RX FIFO.");
@@ -293,8 +293,8 @@ static bool execute_test(dif_spi_device_handle_t *spi_device) {
       LOG_INFO("Checking the received SPI_HOST RX_FIFO data for consistency.");
       for (int i = 0; i < SPI_DEVICE_DATASET_SIZE; ++i) {
         CHECK(spi_device_rx_data[i] == exp_spi_device_rx_data[i],
-              "SPI_DEVICE RX_FIFO data[%0d] mismatched: {act: %x, exp: %x}", i,
-              spi_device_rx_data[i], exp_spi_device_rx_data[i]);
+              "SPI_DEVICE RX_FIFO data[%d] mismatched: {act: %08x, exp: %08x}",
+              i, spi_device_rx_data[i], exp_spi_device_rx_data[i]);
       }
     }
 

--- a/sw/device/tests/sim_dv/sysrst_ctrl_outputs_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_outputs_test.c
@@ -102,7 +102,7 @@ static void wait_next_test_phase(void) {
   test_status_set(kTestStatusInWfi);
   test_status_set(kTestStatusInTest);
   IBEX_SPIN_FOR(current_phase != kTestPhase, kTestPhaseTimeoutUsec);
-  LOG_INFO("Test phase = %0d", kTestPhase);
+  LOG_INFO("Test phase = %d", kTestPhase);
 }
 
 // Enables the sysrst_ctrl overrides for the output pins. Allows

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -314,7 +314,7 @@ static void uart_init_with_irqs(mmio_region_t base_addr, dif_uart_t *uart) {
  * Initializes PLIC and enables the relevant UART interrupts.
  */
 static void plic_init_with_irqs(mmio_region_t base_addr, dif_rv_plic_t *plic) {
-  LOG_INFO("Initializing the PLIC. %0x", uart_irq_tx_watermartk_id);
+  LOG_INFO("Initializing the PLIC. %08x", uart_irq_tx_watermartk_id);
 
   CHECK_DIF_OK(dif_rv_plic_init(base_addr, plic));
 
@@ -498,8 +498,8 @@ static void execute_test(const dif_uart_t *uart) {
   LOG_INFO("Checking the received UART RX data for consistency.");
   for (int i = 0; i < UART_DATASET_SIZE; ++i) {
     CHECK(uart_rx_data[i] == kExpUartRxData[i],
-          "UART RX data[%0d] mismatched: {act: %x, exp: %x}", i,
-          uart_rx_data[i], kExpUartRxData[i]);
+          "UART RX data[%d] mismatched: {act: %x, exp: %x}", i, uart_rx_data[i],
+          kExpUartRxData[i]);
   }
 }
 

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
@@ -58,7 +58,7 @@ bool test_main(void) {
   dif_rstmgr_reset_info_bitfield_t rstmgr_reset_info;
   rstmgr_reset_info = rstmgr_testutils_reason_get();
 
-  LOG_INFO("Reset info = %0x", rstmgr_reset_info);
+  LOG_INFO("Reset info = %08x", rstmgr_reset_info);
 
   if (rstmgr_reset_info == kDifRstmgrResetInfoPor) {
     LOG_INFO("POR reset");

--- a/util/topgen/templates/alert_test.c.tpl
+++ b/util/topgen/templates/alert_test.c.tpl
@@ -106,7 +106,7 @@ static void trigger_alert_test(void) {
     exp_alert = ${p.top_alert_name} + i;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
         &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %0d!", exp_alert);
+    CHECK(is_cause, "Expect alert %d!", exp_alert);
 
     // Clear alert cause register
     CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(


### PR DESCRIPTION
If the width starts with zero, it is interpreted as "pad with zero" and must be followed by the actual width of the field. For example:
* `%0d`: Invalid
* `%5d`: width: 5
* `%05d`: width: 5, pad with zeros.

This PR makes the following changes: 
* `%0d` -> `%d`
* `%0x` -> `%08x`

Signed-off-by: Alphan Ulusoy <alphan@google.com>