### PR TITLE
[bazel] rollback #14924 and #14927

### DIFF
--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -140,8 +140,6 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   ${BAZELISK} fetch \
     --repository_cache=${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR} \
     //... \
-    @rules_rust_bindgen__bindgen__0_58_1//... \
-    @bindgen_clang_linux//... \
     @lowrisc_rv32imcb_files//... \
     @local_config_cc_toolchains//... \
     @local_config_platform//... \


### PR DESCRIPTION
Since #14860 was rolled back, #14924 and #14927 should also be rolled back since they were fixes in response to #14860 to begin with.

Signed-off-by: Timothy Trippel <ttrippel@google.com>