### PR TITLE
[python] pin package version numbers

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -3,47 +3,47 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Keep sorted.
-hjson
-libcst
-mako
-pluralizer
-pycryptodome >= 3.11.0
-pyelftools
-pytest
-pytest-timeout
-pyyaml
-rich
-tabulate
-typer
+hjson==3.1.0
+libcst==0.4.1
+mako==1.1.6
+pluralizer==1.2.0
+pycryptodome==3.15.0
+pyelftools==0.29
+pytest==7.0.1
+pytest-timeout==2.1.0
+rich==12.5.1
+pyyaml==6.0
+tabulate==0.8.10
+typer==0.6.1
 
 # Dependencies: dv_sim
-enlighten
-mistletoe >= 0.7.2
+enlighten==1.10.2
+mistletoe==0.9.0
 # Premailer 3.9.0 broke the API by introducing an allow_loading_external_files
 # argument that is now mandatory, but didn't exist in previous versions.
 # To relax the constraint we either need to do a runtime detection, or switch all
 # users to a newer version.
-premailer < 3.9.0
+premailer==3.8.0
 
 # Dependencies: check_dif_statuses.py
-pydriller
-termcolor
+pydriller==2.1
+termcolor==1.1.0
 
 # Linters
-flake8
-isort
-mypy
-yapf
+flake8==5.0.4
+isort==5.10.1
+mypy==0.971
+yapf==0.32.0
 
 # Type stubs for mypy checking.
 # types-dataclasses is only needed for Python <= 3.6.
-types-dataclasses
-types-pkg_resources
-types-pyyaml
-types-tabulate
+types-dataclasses==0.6.6
+types-pkg_resources==0.1.3
+types-pyyaml==6.0.11
+types-tabulate==0.8.11
 
 # Dependency of sw/host/vendor/google_verible_verilog_syntax_py
-anytree
+anytree==2.8.0
 
 # Development version with OT-specific changes
 git+https://github.com/lowRISC/fusesoc.git@ot-0.3


### PR DESCRIPTION
Having unpinned package versions reduces reproducibility and was causing unncessary Bazel airgapped image updates.

This fixes #14939.

Signed-off-by: Timothy Trippel <ttrippel@google.com>