### PR TITLE
[spi_device/dv] Add random idle after CSB de-asserts

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -61,6 +61,13 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   uint max_extra_dly_ns_btw_word    = 1000; // no timeout btw word
   uint extra_dly_chance_pc_btw_word = 5;    // percentage of extra delay btw each word
 
+  // min_idle_ns_after_csb_drop and its max_* sibling specify the range for
+  // which CSB will be held inactive at the end of a host sequence item.
+  // A value will be randomly chosen in the range. CSB is guaranteed to be inactive for
+  // at least min_idle_ns_after_csb_drop before the next transaction begins.
+  uint min_idle_ns_after_csb_drop = 1;
+  uint max_idle_ns_after_csb_drop = 1000;
+
   // interface handle used by driver, monitor & the sequencer
   virtual spi_if vif;
 
@@ -80,6 +87,8 @@ class spi_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int (en_extra_dly_btw_word,        UVM_DEFAULT)
     `uvm_field_int (max_extra_dly_ns_btw_word,    UVM_DEFAULT)
     `uvm_field_int (extra_dly_chance_pc_btw_word, UVM_DEFAULT)
+    `uvm_field_int (min_idle_ns_after_csb_drop,   UVM_DEFAULT)
+    `uvm_field_int (max_idle_ns_after_csb_drop,   UVM_DEFAULT)
 
     `uvm_field_sarray_int(sck_polarity,   UVM_DEFAULT)
     `uvm_field_sarray_int(sck_phase,      UVM_DEFAULT)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_all_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_all_vseq.sv
@@ -57,7 +57,6 @@ class spi_device_flash_all_vseq extends spi_device_pass_base_vseq;
         `uvm_info(`gfn, $sformatf("Testing op_num %0d/20, op = 0x%0h", j, opcode), UVM_MEDIUM)
 
         spi_host_xfer_flash_item(opcode, payload_size, read_start_addr);
-        cfg.clk_rst_vif.wait_clks(10);
       end
     end
   endtask : main_seq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_mode_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_mode_vseq.sv
@@ -37,7 +37,6 @@ class spi_device_flash_mode_vseq extends spi_device_intercept_vseq;
       `uvm_info(`gfn, $sformatf("sending op 0x%0h addr: 0x%0x", opcode, read_start_addr),
                 UVM_MEDIUM)
       spi_host_xfer_flash_item(opcode, payload_size, read_start_addr);
-      cfg.clk_rst_vif.wait_clks(10);
     end
   endtask
 endclass : spi_device_flash_mode_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -296,6 +296,10 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
   virtual task spi_device_flash_pass_init();
     spi_device_init();
     `uvm_info(`gfn, "Initialize flash/passthrough mode", UVM_MEDIUM)
+
+    // TODO, #14940. EN4B/EX4B may fail if the next item comes very shortly
+    cfg.spi_host_agent_cfg.min_idle_ns_after_csb_drop = 500;
+
     // TODO, fixed config for now
     cfg.spi_host_agent_cfg.sck_polarity[0] = 0;
     cfg.spi_host_agent_cfg.sck_phase[0] = 0;

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_cmd_filtering_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_cmd_filtering_vseq.sv
@@ -28,7 +28,6 @@ class spi_device_pass_cmd_filtering_vseq extends spi_device_pass_base_vseq;
         cfg_cmd_filter(cmd_filter, opcode);
         // Prepare data for transfer
         spi_host_xfer_flash_item(opcode, payload_size, read_start_addr);
-        cfg.clk_rst_vif.wait_clks(10);
       end
     end
 

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -111,7 +111,8 @@ module tb;
 
   assign spi_if_pass.sck = pass_out.sck;
   // if passthrough_en is low, set csb inactive as the whole passthrough interface is off
-  assign spi_if_pass.csb = pass_out.csb ||  !pass_out.passthrough_en;
+  assign spi_if_pass.csb[0] = pass_out.csb ||  !pass_out.passthrough_en;
+  assign spi_if_pass.csb[1] = 1; // only 1 passthrough CSB
   `CONNECT_SPI_IO_PASS(spi_if_pass, pass_in.s, pass_out.s, pass_out.s_en, 0)
   `CONNECT_SPI_IO_PASS(spi_if_pass, pass_in.s, pass_out.s, pass_out.s_en, 1)
   `CONNECT_SPI_IO_PASS(spi_if_pass, pass_in.s, pass_out.s, pass_out.s_en, 2)

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -2035,6 +2035,9 @@ module spi_device
   // Assume the tpm_en is set when TPM transaction is idle.
   `ASSUME(TpmEnableWhenTpmCsbIdle_M, $rose(cfg_tpm_en) |-> cio_tpm_csb_i)
 
+  // When CSBs are inactive, spi_device shouldn't drive the CIO
+  `ASSERT(CioSdoEnOffWhenInactive, cio_csb_i && cio_tpm_csb_i -> cio_sd_en_o === 0)
+
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])
 endmodule


### PR DESCRIPTION
2 commits to address #14914

[spi_device] Add an assertion to check cio_en off when csb is inactive

[spi_device/dv] Add random idle after CSB de-asserts
1. add max/min_idle_ns_after_csb_drop in agent_cfg to control the idle period
2. consolidate csb drops, and cio = x to one place
3. removed delay after a flash item in vseq
4. fix regression failures - in passthrough interface more than one CSB is active

Signed-off-by: Weicai Yang <weicai@google.com>