### PR TITLE
[otbn] Remove DMEM zeroing before loading applications.

### DIFF
--- a/sw/device/lib/crypto/impl/otbn_util.c
+++ b/sw/device/lib/crypto/impl/otbn_util.c
@@ -66,7 +66,6 @@ otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
 
   OTBN_RETURN_IF_ERROR(otbn_imem_write(0, app.imem_start, imem_num_words));
 
-  otbn_zero_dmem();
   if (data_num_words > 0) {
     OTBN_RETURN_IF_ERROR(
         otbn_dmem_write(0, app.dmem_data_start, data_num_words));


### PR DESCRIPTION
Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>