### PR TITLE
[chip dv] More regression fixes

### DIFF
--- a/hw/dv/sv/pwm_monitor/pwm_if.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_if.sv
@@ -4,10 +4,9 @@
 
 interface pwm_if (
   input logic clk,
-  input logic rst_n
+  input logic rst_n,
+  input logic pwm
 );
-
-  logic pwm;
 
   clocking cb @(posedge clk);
     input pwm;

--- a/hw/dv/sv/pwm_monitor/pwm_item.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_item.sv
@@ -26,7 +26,6 @@ class pwm_item extends uvm_sequence_item;
 
     function string convert2string();
       string txt ="";
-
       txt = "\n------| PWM ITEM |------";
       txt = { txt, $sformatf("\n Item from monitor %d", monitor_id) };
       txt = { txt, $sformatf("\n Period %d clocks", period) };

--- a/hw/dv/sv/pwm_monitor/pwm_monitor_cfg.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_monitor_cfg.sv
@@ -10,6 +10,9 @@ class pwm_monitor_cfg  extends dv_base_agent_cfg;
   bit active     = 1'b0; // 1: collect items 0: ignore
   int resolution = 0;
 
+  // interface handle
+  virtual pwm_if vif;
+
   `uvm_object_utils_begin(pwm_monitor_cfg)
   `uvm_object_utils_end
   `uvm_object_new

--- a/hw/ip/pwm/dv/env/pwm_env.sv
+++ b/hw/ip/pwm/dv/env/pwm_env.sv
@@ -18,11 +18,9 @@ class pwm_env extends cip_base_env #(
 
     // instantiate pwm_monitor
     foreach(m_pwm_monitor[i]) begin
-      m_pwm_monitor[i] = pwm_monitor::type_id::create(.name($sformatf("m_pwm_monitor_%0d", i)),
-                                      .parent(this));
-      uvm_config_db#(pwm_monitor_cfg)::set(this, "*",
-          $sformatf("m_pwm_monitor_%0d_cfg", i), cfg.m_pwm_monitor_cfg[i]);
-      cfg.m_pwm_monitor_cfg[i].monitor_id = i;
+      m_pwm_monitor[i] = pwm_monitor::type_id::create($sformatf("m_pwm_monitor%0d", i), this);
+      uvm_config_db#(pwm_monitor_cfg)::set(this, $sformatf("m_pwm_monitor%0d", i), "cfg",
+                                           cfg.m_pwm_monitor_cfg[i]);
       cfg.m_pwm_monitor_cfg[i].ok_to_end_delay_ns = 2000;
     end
 
@@ -41,7 +39,7 @@ class pwm_env extends cip_base_env #(
     super.connect_phase(phase);
     if (cfg.en_scb) begin
       for (int i = 0; i < PWM_NUM_CHANNELS; i++) begin
-        m_pwm_monitor[i].item_port.connect(scoreboard.item_fifo[i].analysis_export);
+        m_pwm_monitor[i].analysis_port.connect(scoreboard.item_fifo[i].analysis_export);
       end
     end
   endfunction : connect_phase

--- a/hw/ip/pwm/dv/env/pwm_env_cfg.sv
+++ b/hw/ip/pwm/dv/env/pwm_env_cfg.sv
@@ -29,10 +29,11 @@ class pwm_env_cfg extends cip_base_env_cfg #(.RAL_T(pwm_reg_block));
     super.initialize(csr_base_addr);
 
     // create pwm_agent_cfg
-    foreach(m_pwm_monitor_cfg[i]) begin
-      m_pwm_monitor_cfg[i] = pwm_monitor_cfg::type_id::
-              create($sformatf("m_pwm_monitor_%0d_cfg", i));
+    foreach (m_pwm_monitor_cfg[i]) begin
+      m_pwm_monitor_cfg[i] = pwm_monitor_cfg::type_id::create($sformatf("m_pwm_monitor%0d_cfg", i));
       m_pwm_monitor_cfg[i].if_mode = Device;
+      m_pwm_monitor_cfg[i].is_active = 0;
+      m_pwm_monitor_cfg[i].monitor_id = i;
     end
 
     // only support 1 outstanding TL items in tlul_adapter

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -23,6 +23,7 @@
       sw_images: ["//sw/device/tests:uart_smoketest_signed:1:signed"]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
+      run_timeout_mins: 180
     }
 
     // ROM func tests to be run with test ROM.

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -94,8 +94,8 @@ class chip_env extends cip_base_env #(
     // instantiate pwm_monitor
     foreach (m_pwm_monitor[i]) begin
       m_pwm_monitor[i] = pwm_monitor::type_id::create($sformatf("m_pwm_monitor%0d", i), this);
-      uvm_config_db#(pwm_monitor_cfg)::set(this, $sformatf("m_pwm_monitor%0d*", i), $sformatf(
-                                           "m_pwm_monitor%0d_cfg", i), cfg.m_pwm_monitor_cfg[i]);
+      uvm_config_db#(pwm_monitor_cfg)::set(this, $sformatf("m_pwm_monitor%0d*", i), "cfg",
+                                           cfg.m_pwm_monitor_cfg[i]);
     end
 
     // disable alert_esc_agent's driver and only use its monitor
@@ -131,7 +131,7 @@ class chip_env extends cip_base_env #(
           virtual_sequencer.uart_tx_fifos[i].analysis_export);
     end
     foreach (m_pwm_monitor[i]) begin
-      m_pwm_monitor[i].item_port.connect(virtual_sequencer.pwm_rx_fifo[i].analysis_export);
+      m_pwm_monitor[i].analysis_port.connect(virtual_sequencer.pwm_rx_fifo[i].analysis_export);
     end
   endfunction
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwm_pulses_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwm_pulses_vseq.sv
@@ -25,7 +25,6 @@ class chip_sw_pwm_pulses_vseq extends chip_sw_base_vseq;
     foreach (duty_cycle[i]) duty_cycle[i] inside {[1 : BEATS_PER_PULSE_CYCLE - 1]};
   }
 
-
   virtual task cpu_init();
     bit[7:0] byte_arr[];
     super.cpu_init();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_tx_rx_vseq.sv
@@ -32,6 +32,9 @@ class chip_sw_spi_tx_rx_vseq extends chip_sw_base_vseq;
     bit [7:0] spi_device_tx_data[$];
     super.body();
 
+    // Connect the SPI host interface to chip IOs.
+    cfg.chip_vif.enable_spi_host = 1;
+
     // Wait SPI_DEVICE filled TX FIFO, otherwise SDO will be X
     cfg.clk_rst_vif.wait_clks(100);
     csr_spinwait(.ptr(ral.spi_device.status.txf_full), .exp_data('b1), .backdoor(1),

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_smoke_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_smoke_vseq.sv
@@ -22,6 +22,11 @@ class chip_sw_uart_smoke_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
     configure_and_connect_uart(uart_idx);
+    if ("signed" inside {cfg.sw_image_flags[SwTypeTest]}) begin
+      // The ROM enables weak pull down on IOC3,4, which contends with the weak pull up we set in
+      // chip_if. TODO: Revisit the whole default pull down strategy.
+      cfg.chip_vif.no_x_check[IoC4:IoC3] = '1;
+    end
   endtask
 
   // Configures the UART agent and connects uart_if to the chip IOs for the given instance.


### PR DESCRIPTION
The first commit fixes the SPI device test (forgot to connect the SPI host agent interface to the chip IOs).
The second commit fixes the PWM sleep test (connect the AON clock / reset instead of the bus clock / reset) to the PWM monitor agent. In addition, it refactors the PWM agent (monitor) code to make it more efficient. The third commit fixes the UART smoketest with real ROM (signed) - the ROM pulls down the IOs assigned for UART0 briefly before pulling then up, which causes contention with the weak pull up enabled by the test. 