### PR TITLE
[otbn,dv] Various OTBN regression failure fixes

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -43,6 +43,8 @@ class otbn_common_vseq extends otbn_base_vseq;
     // If we see a write which causes an integrity error AND we've disabled the scoreboard (which
     // has its own predictor), we update the predicted value of the STATUS register to be LOCKED.
     if (completed && saw_err && !cfg.en_scb && tl_intg_err_type != TlIntgErrNone) begin
+      `DV_WAIT(!(cfg.model_agent_cfg.vif.status inside {otbn_pkg::StatusBusyExecute,
+                                                     otbn_pkg::StatusBusySecWipeInt}));
       `DV_CHECK_FATAL(ral.status.status.predict(otbn_pkg::StatusLocked, .kind(UVM_PREDICT_READ)),
                       "Failed to update STATUS register")
     end
@@ -125,6 +127,8 @@ class otbn_common_vseq extends otbn_base_vseq;
       end
     end
     csr_utils_pkg::csr_rd_check(.ptr(fatal_cause), .compare_value(1));
+    `DV_WAIT(!(cfg.model_agent_cfg.vif.status inside {otbn_pkg::StatusBusyExecute,
+                                                      otbn_pkg::StatusBusySecWipeInt}));
     csr_utils_pkg::csr_rd_check(.ptr(ral.status), .compare_value('hFF));
   endtask : check_sec_cm_fi_resp
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -28,6 +28,9 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
     bit [3:0] mask;
     bit [31:0] err_val = 32'd1 << 20;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(err_type, err_type inside {[0:6]};)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 0)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 0)
+    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 0)
     case(err_type)
       // Injecting error on ispr_addr during a write
       0: begin
@@ -252,6 +255,9 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
     `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked)
     `DV_CHECK_FATAL(uvm_hdl_release(err_path) == 1);
     reset_if_locked();
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 1)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 1)
+    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 1)
   endtask
 
 endclass : otbn_ctrl_redun_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
@@ -28,7 +28,7 @@ class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
 
     `DV_CHECK_STD_RANDOMIZE_FATAL(choose_mem)
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
-
+    `DV_ASSERT_CTRL_REQ("DMemAsserts", 0)
     case(choose_mem)
       0: begin // Dmem
         gnt_path = "tb.dut.u_dmem.gnt_o";
@@ -36,6 +36,7 @@ class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
           do begin
             @(cfg.clk_rst_vif.cb);
             uvm_hdl_read("tb.dut.u_dmem.req_i", req);
+    `DV_ASSERT_CTRL_REQ("DMemAsserts", 0)
           end while(!req);
         )
         `DV_CHECK_FATAL(uvm_hdl_force(gnt_path, 0) == 1)
@@ -60,5 +61,6 @@ class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
       `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked)
       `DV_CHECK_FATAL(uvm_hdl_release(gnt_path) == 1);
       reset_if_locked();
+      `DV_ASSERT_CTRL_REQ("DMemAsserts", 1)
   endtask: inject_gnt_err
 endclass : otbn_mem_gnt_acc_err_vseq

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -9,6 +9,7 @@ module tb;
   import mem_bkdr_util_pkg::mem_bkdr_util;
   import otbn_env_pkg::*;
   import otbn_test_pkg::*;
+  import otbn_pkg::NGpr, otbn_pkg::NWdr;
 
   // dep packages (rtl)
   import otbn_reg_pkg::*;
@@ -30,10 +31,6 @@ module tb;
   otbn_escalate_if              escalate_if (.clk_i (clk), .rst_ni (rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if     (interrupts);
   assign interrupts[0] = {intr_done};
-
-  // A hook to allow sequences to enable or disable the MatchingStatus_A assertion below. This is
-  // needed for sequences that trigger alerts (locking OTBN) without telling the model.
-  `DV_ASSERT_CTRL("otbn_status_assert_en", tb.MatchingStatus_A)
 
   otbn_key_req_t sideload_key;
   key_sideload_if#(keymgr_pkg::otbn_key_req_t) keymgr_if (
@@ -361,5 +358,61 @@ module tb;
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end
+
+  // Assertion controls for turning them on/off easily
+
+  // A hook to allow sequences to enable or disable the MatchingStatus_A assertion below. This is
+  // needed for sequences that trigger alerts (locking OTBN) without telling the model.
+  `DV_ASSERT_CTRL("otbn_status_assert_en", tb.MatchingStatus_A)
+
+  // We need to turn off blanking related assertions in redundancy related fault injection tests.
+  `DV_ASSERT_CTRL("BlankingAssertsALU", tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluXOp_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU",
+                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluYOpA_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU",
+                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluYOpShft_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU",
+                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluYResUsed_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU",
+                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluShftA_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU",
+                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluShftB_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU",
+                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluShftRes_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU",
+                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluLogicOpA_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU",
+                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluLogicShft_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU",
+                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluLogicRes_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU", tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingIsprMod_A)
+  `DV_ASSERT_CTRL("BlankingAssertsALU", tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingIsprACC_A)
+  `DV_ASSERT_CTRL("BlankingAssertsRF", tb.dut.u_otbn_core.u_otbn_rf_bignum.BlankingBignumRegReadA_A)
+  `DV_ASSERT_CTRL("BlankingAssertsRF", tb.dut.u_otbn_core.u_otbn_rf_bignum.BlankingBignumRegReadB_A)
+
+  // We need to turn off DMEM related assertions in the tests where we force internals of DMEM to generate errors
+  `DV_ASSERT_CTRL("DMemAsserts", tb.dut.u_otbn_core.u_otbn_lsu.DMemRValidAfterReq)
+  `DV_ASSERT_CTRL("DMemAsserts", tb.dut.u_otbn_core.OnlyWriteLoadDataBaseWhenDMemValid_A)
+  `DV_ASSERT_CTRL("DMemAsserts", tb.dut.u_otbn_core.OnlyWriteLoadDataBignumWhenDMemValid_A)
+
+  // GPR assertions for secure wipe
+  for (genvar i = 2; i < NGpr; ++i) begin : gen_sec_wipe_gpr_asserts
+    `DV_ASSERT_CTRL("SecWipeAsserts",
+                    tb.dut.gen_sec_wipe_gpr_asserts[i].InitSecWipeNonZeroBaseRegs_A)
+    `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.gen_sec_wipe_gpr_asserts[i].SecWipeChangedBaseRegs_A)
+  end
+
+  // WDR assertions for secure wipe
+  for (genvar i = 0; i < NWdr; ++i) begin : gen_sec_wipe_wdr_asserts
+    `DV_ASSERT_CTRL("SecWipeAsserts",
+                    tb.dut.gen_sec_wipe_wdr_asserts[i].InitSecWipeNonZeroWideRegs_A)
+    `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.gen_sec_wipe_wdr_asserts[i].SecWipeChangedWideRegs_A)
+  end
+
+  `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.SecWipeNonZeroMod_A)
+  `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.SecWipeNonZeroACC_A)
+  `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.SecWipeNonZeroFlags_A)
+  `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.SecWipeInvalidCallStack_A)
+  `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.SecWipeInvalidLoopStack_A)
 
 endmodule


### PR DESCRIPTION
First commit includes fixes to test failures `otbn_tl_intg_err` and `otbn_sec_cm` by waiting until internal secure wipe ends. That was not the case beforehand because the status was at BusyExecute while wiping. That changed with commit b550aa2.

Second commit introduces assertion groups `BlankingAssertsALU`, `BlankingAssertsRF`, `DMemAsserts` and `SecWipeAsserts` to disable them in the tests we inject faults by forcing some internal signals. DMEM related assertions are only turned off in the test `otbn_mem_gnt_acc_err`, others are turned off only in `otbn_ctrl_redun` for now.

Blanking related assertions are also causing regression failures in tests: `otbn_ispr_rdata_err`, `otbn_mac_bignum_acc_err`, `otbn_alu_bignum_mod_err`, `otbn_imem_err`, `otbn_dmem_err` and `otbn_multi_err`. I believe those need more investigation so this PR does not touch them.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>