### PR TITLE
[flash_ctrl,dv] update read path mem.bus.intg test

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -29,6 +29,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
 
   int eg_exp_cnt = 0;
   bit comp_off = 0;
+  bit derr_expected = 0;
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
@@ -264,7 +265,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
         end else if (cfg.ierr_addr_tbl[err_addr].exists(exp.cmd.partition)) begin
           `uvm_info("process_read",
                     $sformatf("expected icv error 0x%x", err_addr), UVM_MEDIUM)
-        end else begin
+        end else if (derr_expected == 0) begin
           `uvm_error("process_read",
                      $sformatf("unexpected double bit error 0x%x", err_addr))
         end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -35,6 +35,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
 
   rand flash_mp_region_cfg_t rand_regions[MpRegions];
   rand flash_bank_mp_info_page_cfg_t rand_info[NumBanks][InfoTypes][$];
+  flash_mem_init_e otf_flash_init = FlashMemInitEccMode;
 
   constraint all_ent_c {
     solve all_entry_en before rand_regions, rand_info;
@@ -136,7 +137,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
                   UVM_MEDIUM)
       end
     end
-    flash_init = FlashMemInitEccMode;
+    flash_init = otf_flash_init;
+
 
     init_p2r_map();
     `uvm_info("cfg_summary",

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
@@ -2,34 +2,110 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This sequence sends read and write traffic with or without tlul memory
-// bus read path error injection.
-// Error response will be sent to tl_agent(flash_ctrl_eflash_reg_block)
-// with d_error=1.
+// This sequence sends read traffic with error injection
+// at the output of read_buffer.
+// Read response will trigger fatal_err.storage_err.
 class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_rw_vseq;
   `uvm_object_utils(flash_ctrl_rd_path_intg_vseq)
   `uvm_object_new
 
   task body();
-    string path1 = {"tb.dut.u_eflash.gen_flash_cores[0].u_core",
-                    ".u_rd.u_bus_intg.data_intg_o[38]"};
-    string path2 = {"tb.dut.u_eflash.gen_flash_cores[1].u_core",
-                    ".u_rd.u_bus_intg.data_intg_o[38]"};
+    int idx1, idx2;
+    string path1, path2;
+    int    state_timeout_ns = 100000; // 100us
 
-    `uvm_info(`gfn, "Assert read path err", UVM_LOW)
-    `DV_CHECK(uvm_hdl_force(path1, 1'b1))
-    `DV_CHECK(uvm_hdl_force(path2, 1'b1))
-    cfg.scb_h.exp_tl_rsp_intg_err = 1;
+    repeat(5) begin
+      // Enable ecc for all regions
+      flash_otf_region_cfg(.scr_mode(scr_ecc_cfg), .ecc_mode(OTFCfgTrue));
+      idx1 = $urandom_range(0, 63);
+      idx2 = $urandom_range(0, 63);
+      path1 = {"tb.dut.u_eflash.gen_flash_cores[0].u_core",
+               $sformatf(".u_rd.gen_bufs[0].u_rd_buf.data_i[%0d]", idx1)};
+      path2 = {"tb.dut.u_eflash.gen_flash_cores[1].u_core",
+               $sformatf(".u_rd.gen_bufs[0].u_rd_buf.data_i[%0d]", idx2)};
 
-    super.body();
-    `uvm_info(`gfn, "Wait until all drain", UVM_LOW)
-    cfg.clk_rst_vif.wait_clks(100);
-    `DV_CHECK(uvm_hdl_release(path1))
-    `DV_CHECK(uvm_hdl_release(path2))
-    `uvm_info(`gfn, "Normal traffic START", UVM_LOW)
-    cfg.scb_h.exp_tl_rsp_intg_err = 0;
+      `uvm_info(`gfn, $sformatf("Assert read path err idx1:%0d idx2:%0d", idx1, idx2), UVM_LOW)
+      `DV_CHECK(uvm_hdl_force(path1, 1'b0))
+      `DV_CHECK(uvm_hdl_force(path2, 1'b0))
+      cfg.scb_h.exp_alert["fatal_err"] = 1;
+      cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+      cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
-    super.body();
+      fork
+        begin
+          cfg.otf_scb_h.derr_expected = 1;
+          repeat(cfg.otf_num_rw) begin
+            `DV_CHECK_RANDOMIZE_FATAL(this)
+            ctrl = rand_op;
+            bank = rand_op.addr[OTFBankId];
+            if (ctrl.partition == FlashPartData) begin
+              num = ctrl_num;
+            end else begin
+              num = ctrl_info_num;
+            end
+            if (fractions < 4) begin
+              fractions = 4;
+            end
+            // recov_err(rd_err)
+            // fatal_err.phy_storage_err
+            set_otf_exp_alert("recov_err");
+            read_flash(ctrl, bank, num, fractions, ,1);
+          end
+        end
+        begin
+          flash_op_t host;
+          int host_num, host_bank;
+          bit [TL_AW-1:0] tl_addr;
+          bit             saw_err, completed;
+          data_4s_t rdata;
+
+          cfg.scb_h.exp_tl_rsp_intg_err = 1;
+          tl_addr[OTFHostId-2:0] = $urandom();
+          tl_addr[1:0] = 'h0;
+          tl_addr[OTFBankId] = $urandom_range(0, 1);
+
+          for (int i = 0; i < cfg.otf_num_hr; ++i) begin
+
+            fork
+              begin
+                bit local_saw_err;
+                // fatal_err.phy_storage_err
+                tl_access_w_abort(
+                  .addr(tl_addr), .write(1'b0), .completed(completed),
+                  .saw_err(local_saw_err),
+                  .tl_access_timeout_ns(cfg.seq_cfg.erase_timeout_ns),
+                  .data(rdata), .check_rsp(1'b0), .blocking(1),
+                  .tl_sequencer_h(p_sequencer.tl_sequencer_hs[cfg.flash_ral_name]));
+                saw_err |= local_saw_err;
+              end
+            join_none
+            #0;
+            if ((i % 2)== 1) tl_addr += 4;
+
+          end
+          csr_utils_pkg::wait_no_outstanding_access();
+          `DV_CHECK_EQ(saw_err, 1)
+        end
+      join
+      `uvm_info(`gfn, "Wait until all drain", UVM_LOW)
+      cfg.clk_rst_vif.wait_clks(100);
+      `DV_CHECK(uvm_hdl_release(path1))
+      `DV_CHECK(uvm_hdl_release(path2))
+
+      cfg.seq_cfg.disable_flash_init = 1;
+      cfg.seq_cfg.en_init_keys_seeds = 0;
+      apply_reset();
+      csr_wr(.ptr(ral.init), .value(1));
+      `uvm_info("Test","OTP",UVM_LOW)
+      otp_model();
+      `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rd_buf_en == 1);,
+                   "Timed out waiting for rd_buf_en",
+                   state_timeout_ns)
+      cfg.clk_rst_vif.wait_clks(10);
+    end
+
+    // disable tlul_err_cnt check
+    cfg.tlul_core_obs_cnt = cfg.tlul_core_exp_cnt;
   endtask
 
 endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
@@ -11,65 +11,84 @@ class flash_ctrl_wr_path_intg_vseq extends flash_ctrl_rw_vseq;
 
   task body();
     string path = "tb.dut.u_prog_fifo.wdata_i[38]";
-    `uvm_info(`gfn, "Assert write path err", UVM_LOW)
-    `DV_CHECK(uvm_hdl_force(path, 1'b1))
-     $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
+    int    state_timeout_ns = 100000; // 100us
 
-    // disable tl_rsp error check
-    cfg.m_tl_agent_cfg.check_tl_errs = 0;
-    fork
-      begin
-        repeat(cfg.otf_num_rw) begin
-          `DV_CHECK_RANDOMIZE_FATAL(this)
-          ctrl = rand_op;
-          bank = rand_op.addr[OTFBankId];
-          if (ctrl.partition == FlashPartData) begin
-            num = ctrl_num;
-          end else begin
-            num = ctrl_info_num;
-          end
-          randcase
-            cfg.otf_wr_pct: begin
-              uvm_reg_data_t ldata;
-              cfg.scb_h.exp_alert["fatal_std_err"] = 1;
-              cfg.scb_h.alert_chk_max_delay["fatal_std_err"] = 2000;
-              cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
+    repeat(5) begin
+      flash_otf_region_cfg(.scr_mode(scr_ecc_cfg), .ecc_mode(scr_ecc_cfg));
+      `uvm_info(`gfn, "Assert write path err", UVM_LOW)
+      `DV_CHECK(uvm_hdl_force(path, 1'b1))
+      $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
 
-              prog_flash(ctrl, bank, 1, fractions, 1);
-              // Check std_fault.prog_intg_err,  err_code.prog_err
-              csr_rd_check(.ptr(ral.std_fault_status.prog_intg_err), .compare_value(1));
-              csr_rd_check(.ptr(ral.err_code.prog_err), .compare_value(1));
-              csr_rd_check(.ptr(ral.op_status.err), .compare_value(1));
+      // disable tl_rsp error check
+      cfg.m_tl_agent_cfg.check_tl_errs = 0;
+      fork
+        begin
+          uvm_reg_data_t ldata;
+          repeat(cfg.otf_num_rw) begin
+            `DV_CHECK_RANDOMIZE_FATAL(this)
+            ctrl = rand_op;
+            bank = rand_op.addr[OTFBankId];
 
-              ldata = get_csr_val_with_updated_field(ral.err_code.prog_err, ldata, 1);
-              csr_wr(.ptr(ral.err_code), .value(ldata));
-
-              ldata = get_csr_val_with_updated_field(ral.op_status.err, ldata, 0);
-              csr_wr(.ptr(ral.op_status), .value(ldata));
+            if (ctrl.partition == FlashPartData) begin
+              num = ctrl_num;
+            end else begin
+              num = ctrl_info_num;
             end
-            cfg.otf_rd_pct:read_flash(ctrl, bank, num, fractions);
-          endcase
-        end
-      end
-      begin
-        for (int i = 0; i < cfg.otf_num_hr; ++i) begin
-          fork
-            send_rand_host_rd();
-          join_none
-          #0;
-        end
-        csr_utils_pkg::wait_no_outstanding_access();
-      end
-    join
+            if (fractions < 4) begin
+              fractions = 4;
+            end
 
-    `uvm_info(`gfn, "Wait until all drain", UVM_LOW)
-    cfg.clk_rst_vif.wait_clks(100);
-    `DV_CHECK(uvm_hdl_release(path))
+            randcase
+              cfg.otf_wr_pct: begin
+                cfg.scb_h.exp_alert["fatal_std_err"] = 1;
+                cfg.scb_h.alert_chk_max_delay["fatal_std_err"] = 2000;
+                cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
+
+                // prog_err and mp_err
+                set_otf_exp_alert("recov_err");
+                prog_flash(ctrl, bank, 1, fractions, 1);
+                csr_spinwait(.ptr(ral.op_status.err), .exp_data(1'b1));
+              end
+              cfg.otf_rd_pct:read_flash(ctrl, bank, num, fractions);
+            endcase
+          end // repeat (cfg.otf_num_rw)
+          // Check std_fault.prog_intg_err,  err_code.prog_err
+          csr_rd_check(.ptr(ral.std_fault_status.prog_intg_err), .compare_value(1));
+          csr_rd_check(.ptr(ral.err_code.prog_err), .compare_value(1));
+          csr_rd_check(.ptr(ral.op_status.err), .compare_value(1));
+          ldata = get_csr_val_with_updated_field(ral.err_code.prog_err, ldata, 1);
+          csr_wr(.ptr(ral.err_code), .value(ldata));
+          ldata = get_csr_val_with_updated_field(ral.op_status.err, ldata, 0);
+          csr_wr(.ptr(ral.op_status), .value(ldata));
+        end
+        begin
+          for (int i = 0; i < cfg.otf_num_hr; ++i) begin
+            fork
+              send_rand_host_rd();
+            join_none
+            #0;
+          end
+          csr_utils_pkg::wait_no_outstanding_access();
+        end
+      join
+
+      `uvm_info(`gfn, "Wait until all drain", UVM_LOW)
+      cfg.clk_rst_vif.wait_clks(100);
+      `DV_CHECK(uvm_hdl_release(path))
+
+      cfg.seq_cfg.disable_flash_init = 1;
+      cfg.seq_cfg.en_init_keys_seeds = 0;
+      apply_reset();
+      csr_wr(.ptr(ral.init), .value(1));
+      `uvm_info("Test","OTP",UVM_LOW)
+      otp_model();
+      `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rd_buf_en == 1);,
+                   "Timed out waiting for rd_buf_en",
+                   state_timeout_ns)
+      cfg.clk_rst_vif.wait_clks(10);
+    end
     // disable tlul_err_cnt check
     cfg.tlul_core_obs_cnt = cfg.tlul_core_exp_cnt;
-    flash_init_c.constraint_mode(0);
-    flash_init = FlashMemInitRandomize;
-    apply_reset();
   endtask
 
 endclass

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -354,13 +354,15 @@
     {
       name: flash_ctrl_rd_intg
       uvm_test_seq: flash_ctrl_rd_path_intg_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=50"]
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=4", "+otf_num_rw=5",
+                 "+otf_num_hr=40", "+en_always_read=1"]
       reseed: 1
     }
     {
       name: flash_ctrl_wr_intg
       uvm_test_seq: flash_ctrl_wr_path_intg_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=0", "+otf_rd_pct=0"]
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=0",
+                 "+en_always_prog=1", "+otf_rd_pct=0"]
       reseed: 1
     }
   ]


### PR DESCRIPTION
- Shift error injection point to the output of read buffer
- Add ecc_mode=1 init option
- Change parent class from rw_vseq to otf_base_vseq
- Add multiple runs to write path

Signed-off-by: Jaedon Kim <jdonjdon@google.com>