### PR TITLE
[chip] sleep_pin_mio_dio_val #2

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
@@ -107,6 +107,9 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
 
     // TODO: Fins out how to pass the test (maybe just $display()?)
 
+    // Fail the test until full checks are ready
+    override_test_status_and_finish(.passed(1'b 0));
+
   endtask : body
 
 endclass : chip_sw_sleep_pin_mio_dio_val_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
@@ -101,6 +101,8 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
     // Wait until Chip enters Low Power Mode
     wait (cfg.chip_vif.pwrmgr_low_power_if.low_power);
 
+    `uvm_info(`gfn, "Chip Entered Deep Powerdown mode.", UVM_LOW)
+
     // TODO: Sample the PADs and check with expected values
 
     // TODO: Fins out how to pass the test (maybe just $display()?)

--- a/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
+++ b/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
@@ -62,8 +62,29 @@ OTTF_DEFINE_TEST_CONFIG();
  * }
  * ```
  */
+
+typedef enum uint8_t {
+  kDioUsbP,       /* DIO 0                INOUT  */
+  kDioUsbN,       /* DIO 1                INOUT  */
+  kDioSpiHostD0,  /* DIO 2                INOUT  */
+  kDioSpiHostD1,  /* DIO 3                INOUT  */
+  kDioSpiHostD2,  /* DIO 4                INOUT  */
+  kDioSpiHostD3,  /* DIO 5                INOUT  */
+  kDioSpiDevD0,   /* DIO 6                INOUT  */
+  kDioSpiDevD1,   /* DIO 7                INOUT  */
+  kDioSpiDevD2,   /* DIO 8                INOUT  */
+  kDioSpiDevD3,   /* DIO 9                INOUT  */
+  kDioIoR8,       /* DIO 10 EC_RST_L      INOUT  */
+  kDioIoR9,       /* DIO 11 FLASH_WP_L    INOUT  */
+  kDioSpiDevClk,  /* DIO 12               INPUT  */
+  kDioSpiDevCsL,  /* DIO 13               INPUT  */
+  kDioSpiHostClk, /* DIO 14               OUTPUT */
+  kDioSpiHostCsL  /* DIO 15               OUTPUT */
+} dio_pad_idx_t;
+
 #define NUM_OPTOUT_DIO 2
-static const uint8_t kOptOutDio[NUM_OPTOUT_DIO] = {12, 13};
+static const uint8_t kOptOutDio[NUM_OPTOUT_DIO] = {kDioSpiDevClk,
+                                                   kDioSpiDevCsL};
 
 static uint8_t kMioPads[NUM_MIO_PADS] = {0};
 static uint8_t kDioPads[NUM_DIO_PADS] = {0};
@@ -79,7 +100,7 @@ void draw_pinmux_ret(const uint32_t num_pins, uint8_t *arr) {
     uint32_t min_idx = (i + 16 < num_pins) ? i + 16 : num_pins;
 
     for (int j = i; j < min_idx; j++) {
-      /* bit slice 2b at a time and if it is 3, redraw */
+      /* Bit slice 2b at a time and if it is 3, redraw */
       arr[j] = (val >> ((j & 0xF) * 2)) & 0x3;
       if (arr[j] == 3) {
         arr[j] = (uint8_t)rand_testutils_gen32_range(0, 2);

--- a/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
+++ b/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
@@ -114,6 +114,7 @@ void print_chosen_values(void) {
 
 bool lowpower_prep(dif_pwrmgr_t *pwrmgr, dif_pinmux_t *pinmux) {
   bool result = false;
+  dif_pwrmgr_domain_config_t pwrmgr_domain_cfg;
 
   LOG_INFO("Selecting PADs retention modes...");
 
@@ -124,7 +125,12 @@ bool lowpower_prep(dif_pwrmgr_t *pwrmgr, dif_pinmux_t *pinmux) {
 
   // Configure pwrmgr to deep powerdown.
 
-  wait_for_interrupt();
+  CHECK_DIF_OK(dif_pwrmgr_set_domain_config(pwrmgr, pwrmgr_domain_cfg,
+                                            kDifToggleEnabled));
+  CHECK_DIF_OK(dif_pwrmgr_low_power_set_enabled(pwrmgr, kDifToggleEnabled,
+                                                kDifToggleEnabled));
+
+  wait_for_interrupt();  // Entering deep power down.
 
   return result;
 }


### PR DESCRIPTION
This is a follow-up PR to https://github.com/lowRISC/opentitan/pull/14952 .

In this PR, the test configures PWRMGR to turn off the main power in the low power state then enters deep power down by calling WFI().

Please review last two commits.