### PR TITLE
[ci] Build bitstream with bazel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,37 +227,6 @@ jobs:
       includePatterns:
         - "/sw/***"
 
-- job: cw310_sw_build
-  displayName: CW310 Bitstream Software
-  # Build Earl Grey Software required for CW310 FPGA synthesis
-  dependsOn: lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
-  pool:
-    vmImage: ubuntu-20.04
-  steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - bash: |
-      . util/build_consts.sh
-      ci/bazelisk.sh build \
-        //hw/ip/otp_ctrl/data:img_rma \
-        //sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem \
-        //sw/device/lib/testing/test_rom:test_rom_fpga_cw310_bin
-      mkdir -p $BIN_DIR/sw/device/otp_img
-      mkdir -p $BIN_DIR/sw/device/lib/testing/test_rom
-      cp $(ci/scripts/target-location.sh //hw/ip/otp_ctrl/data:img_rma) $BIN_DIR/sw/device/otp_img/otp_img_fpga_cw310.vmem
-      TEST_ROM=$(ci/scripts/target-location.sh //sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem)
-      TEST_ROM_DIR=$(dirname $TEST_ROM)
-      TEST_ROM_TARGET=$BIN_DIR/sw/device/lib/testing/test_rom
-      cp $TEST_ROM $TEST_ROM_TARGET/test_rom_fpga_cw310.scr.39.vmem
-      cp $TEST_ROM_DIR/*fpga_cw310.elf $TEST_ROM_TARGET/test_rom_fpga_cw310.elf
-      cp $TEST_ROM_DIR/*fpga_cw310.bin $TEST_ROM_TARGET/test_rom_fpga_cw310.bin
-    displayName: Build embedded targets
-  - template: ci/upload-artifacts-template.yml
-    parameters:
-      includePatterns:
-        - "/sw/***"
-
 - job: chip_englishbreakfast_verilator
   displayName: Verilated English Breakfast
   # Build Verilator simulation of the English Breakfast toplevel design
@@ -443,8 +412,6 @@ jobs:
   # Build CW310-hyperdebug variant of the Earl Grey toplevel design using Vivado
   dependsOn:
     - lint
-    # The bootrom is built into the FPGA image at synthesis time.
-    - cw310_sw_build
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'), eq(variables['Build.SourceBranchName'], 'master'))
   pool: ci-public
   timeoutInMinutes: 180
@@ -458,18 +425,17 @@ jobs:
       mkdir -p $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/
       mkdir -p $BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/
       ci/bazelisk.sh build //hw/bitstream/vivado:fpga_cw310_hyperdebug
-      cp -r -t $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/ \
-        $($REPO_TOP/bazelisk.sh cquery --output=starlark --starlark:expr "' '.join([x.path for x in target.files.to_list()])" //hw/bitstream/vivado:fpga_cw310_hyperdebug)
-      cp -t $BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/ \
-        $($REPO_TOP/bazelisk.sh cquery --output=starlark --starlark:expr "' '.join([x.path for x in target.files.to_list()])" //hw/bitstream/vivado:hyperdebug)
+      cp -rLvt $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/ \
+        $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:fpga_cw310_hyperdebug)
+      cp -rLvt $BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/ \
+        $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:hyperdebug)
     displayName: Build bitstream with Vivado
   - bash: |
       . util/build_consts.sh
       echo Synthesis log
-      cat $BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.runs/synth_1/runme.log || true
-
+      cat $OUT_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/build.fpga_cw310_hyperdebug/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.runs/synth_1/runme.log || true
       echo Implementation log
-      cat $BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.runs/impl_1/runme.log || true
+      cat $OUT_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/build.fpga_cw310_hyperdebug/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.runs/impl_1/runme.log || true
     displayName: Display synthesis & implementation logs
   - template: ci/upload-artifacts-template.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -388,40 +388,45 @@ jobs:
   # Build CW310 variant of the Earl Grey toplevel design using Vivado
   dependsOn:
     - lint
-    # The bootrom is built into the FPGA image at synthesis time.
-    - cw310_sw_build
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public
   timeoutInMinutes: 180
   steps:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml
-  - template: ci/download-artifacts-template.yml
-    parameters:
-      downloadPartialBuildBinFrom:
-        - cw310_sw_build
   - bash: |
       ci/scripts/get-bitstream-strategy.sh "@bitstreams//:bitstream_test_rom" ':!/sw/' ':!/*testplan.hjson' ':!/site/' ':!/doc/' ':!/COMMITTERS' ':!/CLA' ':!/*.md' ':!/hw/**/dv/*'
     displayName: Configure bitstream strategy
   - bash: |
-      set -e
+      set -ex
       module load "xilinx/vivado/$(VIVADO_VERSION)"
       ci/scripts/prepare-cached-bitstream.sh
     condition: eq(variables.bitstreamStrategy, 'cached')
     displayName: Prepare cached bitstream
   - bash: |
-      set -e
+      set -ex
+      . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/build-bitstream-vivado.sh top_earlgrey cw310
+      SUB_PATH=hw/top_earlgrey
+      mkdir -p "$OBJ_DIR/$SUB_PATH" "$BIN_DIR/$SUB_PATH"
+      ci/bazelisk.sh build //hw/bitstream/vivado:standard
+      cp -rLvt "$OBJ_DIR/$SUB_PATH/" \
+        $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:fpga_cw310)
+      cp -rLvt "$BIN_DIR/$SUB_PATH/" \
+        $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:standard)
+      # Rename bitstreams to be compatible with subsequent steps
+      # TODO(#13807): replace this after choosing a naming scheme
+      mv "$BIN_DIR/$SUB_PATH/lowrisc_systems_chip_earlgrey_cw310_0.1.bit" "$BIN_DIR/$SUB_PATH/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig"
+      mv "$BIN_DIR/$SUB_PATH/fpga_cw310_rom.bit" "$BIN_DIR/$SUB_PATH/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice"
     condition: ne(variables.bitstreamStrategy, 'cached')
-    displayName: Build bitstream with Vivado
+    displayName: Build and splice bitstream with Vivado
   - bash: |
       . util/build_consts.sh
       echo Synthesis log
-      cat $OBJ_DIR/hw/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.runs/synth_1/runme.log || true
+      cat $OBJ_DIR/hw/top_earlgrey/build.fpga_cw310/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.runs/synth_1/runme.log || true
 
       echo Implementation log
-      cat $OBJ_DIR/hw/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.runs/impl_1/runme.log || true
+      cat $OBJ_DIR/hw/top_earlgrey/build.fpga_cw310/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.runs/impl_1/runme.log || true
     condition: ne(variables.bitstreamStrategy, 'cached')
     displayName: Display synthesis & implementation logs
   - template: ci/upload-artifacts-template.yml
@@ -474,69 +479,6 @@ jobs:
     artifact: chip_earlgrey_cw310_hyperdebug-build-out
     displayName: Upload artifacts for CW310
     condition: failed()
-
-- job: chip_earlgrey_cw310_splice_rom
-  displayName: Splice ROM into CW310 bitstream
-  dependsOn:
-    - chip_earlgrey_cw310
-    - chip_earlgrey_cw310_hyperdebug
-    - sw_build
-  condition: |
-    and
-    (
-      succeeded('chip_earlgrey_cw310'),
-      succeeded('sw_build'),
-      in(dependencies.chip_earlgrey_cw310_hyperdebug.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
-    )
-  pool: ci-public
-  timeoutInMinutes: 10
-  steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - template: ci/download-artifacts-template.yml
-    parameters:
-      downloadPartialBuildBinFrom:
-        - chip_earlgrey_cw310
-        - sw_build
-        - ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
-          - chip_earlgrey_cw310_hyperdebug
-  - bash: |
-      set -e
-      . util/build_consts.sh
-
-      module load "xilinx/vivado/$(VIVADO_VERSION)"
-
-      util/fpga/splice_rom.sh -t cw310 -T earlgrey -b PROD
-
-    displayName: Splicing bitstream with Vivado
-  - template: ci/upload-artifacts-template.yml
-    parameters:
-      unconditionalIncludePatterns:
-        - "/hw/top_earlgrey/rom.mmi"
-        - "/hw/top_earlgrey/otp.mmi"
-        - ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
-          - "/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/***"
-      includePatterns:
-        - "/hw/***"
-  - ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
-    - template: ci/gcp-upload-bitstream-template.yml
-      parameters:
-        parentDir: "$BIN_DIR/hw/top_earlgrey"
-        includeFiles:
-          - "lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig"
-          - "lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice"
-          - "rom.mmi"
-          - "otp.mmi"
-          - "chip_earlgrey_cw310_hyperdebug/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.bit"
-          - "chip_earlgrey_cw310_hyperdebug/rom.mmi"
-          - "chip_earlgrey_cw310_hyperdebug/otp.mmi"
-        gcpKeyFile: "gcpkey.json"
-        bucketURI: "gs://opentitan-bitstreams/master"
-  - publish: "$(Build.ArtifactStagingDirectory)"
-    artifact: chip_earlgrey_cw310-splice-rom-build-out
-    displayName: Upload artifacts for CW310
-    condition: failed()
-
 - job: chip_englishbreakfast_cw305
   displayName: CW305's Bitstream
   # Build CW305 variant of the English Breakfast toplevel design using Vivado
@@ -561,6 +503,37 @@ jobs:
       includePatterns:
         - "/hw/top_englishbreakfast/lowrisc_systems_chip_englishbreakfast_cw305_0.1.bit"
 
+- job: cache_bitstreams
+  displayName: Cache bitstreams to GCP
+  pool:
+    vmImage: ubuntu-20.04
+  dependsOn:
+    - chip_earlgrey_cw310
+    - chip_earlgrey_cw310_hyperdebug
+  condition: eq(variables['Build.SourceBranchName'], 'master')
+  steps:
+    - template: ci/download-artifacts-template.yml
+      parameters:
+        downloadPartialBuildBinFrom:
+          - chip_earlgrey_cw310
+          - chip_earlgrey_cw310_hyperdebug
+    - bash: |
+        set -x
+        . util/build_consts.sh
+    - template: ci/gcp-upload-bitstream-template.yml
+      parameters:
+        parentDir: "$BIN_DIR/hw/top_earlgrey"
+        includeFiles:
+          - "lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig"
+          - "lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice"
+          - "rom.mmi"
+          - "otp.mmi"
+          - "chip_earlgrey_cw310_hyperdebug/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.bit"
+          - "chip_earlgrey_cw310_hyperdebug/rom.mmi"
+          - "chip_earlgrey_cw310_hyperdebug/otp.mmi"
+        gcpKeyFile: "gcpkey.json"
+        bucketURI: "gs://opentitan-bitstreams/master"
+
 - job: execute_fpga_tests_cw310
   displayName: CW310 Tests
   # Execute tests on ChipWhisperer CW310 FPGA board
@@ -568,19 +541,19 @@ jobs:
   timeoutInMinutes: 45
   dependsOn:
     - chip_earlgrey_cw310
-    - chip_earlgrey_cw310_splice_rom
     - sw_build
-  condition: succeeded( 'chip_earlgrey_cw310', 'chip_earlgrey_cw310_splice_rom', 'sw_build' )
+  condition: succeeded( 'chip_earlgrey_cw310', 'sw_build' )
   steps:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml
   - template: ci/download-artifacts-template.yml
     parameters:
       downloadPartialBuildBinFrom:
-        - chip_earlgrey_cw310_splice_rom
+        - chip_earlgrey_cw310
         - sw_build
   - bash: |
       set -e
+      . util/build_consts.sh
       ci/scripts/run-fpga-cw310-tests.sh || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
 

--- a/ci/scripts/make_distribution.sh
+++ b/ci/scripts/make_distribution.sh
@@ -25,7 +25,8 @@ readonly DIST_ARTIFACTS=(
   'sw/device/*.bin'
   'sw/device/*.vmem'
   'hw/top_earlgrey/Vchip_earlgrey_verilator'
-  'hw/top_earlgrey/lowrisc_systems_chip_earlgrey_*.bit'
+  'hw/top_earlgrey/lowrisc_systems_chip_earlgrey_*.bit.*'
+  'hw/top_earlgrey/*.mmi'
 )
 
 DIST_DIR="$OBJ_DIR/$OT_VERSION"

--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -43,7 +43,7 @@ By default, the bitstream is built with a version of the boot ROM used for testi
 There is also a version of the boot ROM used in production (called the _ROM_; pulled from `sw/device/silicon_creator/rom`).
 This can be spliced into the bitstream to overwrite the testing boot ROM as described in the [FPGA Reference Manual]({{< relref "ref_manual_fpga.md#boot-rom-development" >}}).
 However, if you do not want to do the splicing yourself, both versions of the bitstream are available in the download as `*.bit.orig` and `*.bit.splice` (containing the test ROM and the ROM respectively).
-The metadata for the latest bitstream (the approximate creation time and the associated commit hash) is also available as a text file and can be [downloaded separately](https://storage.googleapis.com/opentitan-bitstreams/master/latest/latest.txt).
+The metadata for the latest bitstream (the approximate creation time and the associated commit hash) is also available as a text file and can be [downloaded separately](https://storage.googleapis.com/opentitan-bitstreams/master/latest.txt).
 
 ### Build an FPGA bitstream
 
@@ -419,7 +419,7 @@ To download the bitstream:
 1. On the left sidebar, expand the "Azure Pipelines" menu.
 1. Open the "CI (CW310's Earl Grey Bitstream)" job and click on "View more details on Azure Pipelines".
 1. Click on "1 artifact produced".
-1. Click on the three dots for "partial-build-bin-chip_earlgrey_cw310_splice_rom".
+1. Click on the three dots for "partial-build-bin-chip_earlgrey_cw310".
 1. You can either download the artifact directly or download with the URL.
 
 Note that Azure does not allow you to download the artifact with `wget` or `curl` by default, so to use the download URL, you need to specify a `user-agent` header.

--- a/doc/rm/ref_manual_fpga.md
+++ b/doc/rm/ref_manual_fpga.md
@@ -96,14 +96,15 @@ These cached bitstreams can be downloaded and used as-is, or we can splice in fr
 
 ### Building bitstreams on CI and uploading artifacts to GCS
 
-The `chip_earlgrey_cw310` job produces a bitstream and MMI files, which are a necessary input for splicing.
-Specifically, this job runs `ci/scripts/build-bitstream-vivado.sh` and produces the following files:
+The `chip_earlgrey_cw310` CI job builds the `//hw/bitstream/vivado:standard` target which will build a bitstream with the test ROM and RMA OTP image.
+This target will also produce bitstreams with the ROM spliced in and the DEV OTP image spliced in.
+The following files are produced as a result:
 
-* `lowrisc_systems_chip_earlgrey_cw310_0.1.bit`
-* `rom.mmi`
+* `fpga_cw310_rom.bit` (ROM, RMA OTP image)
+* `fpga_cw310_rom_otp_dev.bit` (ROM, DEV OTP image)
+* `lowrisc_systems_chip_earlgrey_cw310_0.1.bit` (test ROM, RMA OTP image)
 * `otp.mmi`
-
-The `chip_earlgrey_cw310_splice_rom` job receives those files and splices the ROM into the bitstream.
+* `rom.mmi`
 
 If CI is working on the `master` branch, it puts selected build artifacts into a tarball, which it then uploads to the GCS bucket. The latest tarball is available here: https://storage.googleapis.com/opentitan-bitstreams/master/bitstream-latest.tar.gz
 


### PR DESCRIPTION
This PR uses Bazel to build and splice the bitstream in CI instead of the shell scripts and refactors the `azure-pipelines.yml` file.
1. Use the Bazel target instead of the `ci/scripts/build-bitstream-vivado.sh` to build the bitstreams
    - Building and splicing now happen in the same step. `chip_earlgrey_cw310_splice_rom` can now be removed
    - `chip_earlgrey_cw310` no longer depends on `cw310_sw_build` since Bazel will now build the necessary dependencies
    - The GCP bitstream upload is moved out of the splice step into its own step
2. Clean up the hyperdebug rule
    - Use our custom `bazel outquery` rule to find generated outputs
    - Remove dependency on `cw310_sw_build` step; this step can now be removed entirely
3. Update website documentation

Addresses Step 1 of #15007 