### PR TITLE
feat(chip): Add Deep Powerdown Indicator

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -418,7 +418,8 @@ interface chip_if;
   pwrmgr_low_power_if pwrmgr_low_power_if(.clk     (`CLKMGR_HIER.clocks_o.clk_aon_powerup),
                                           .fast_clk(`CLKMGR_HIER.clocks_o.clk_io_div4_powerup),
                                           .rst_n   (`RSTMGR_HIER.resets_o.rst_por_io_div4_n[0]));
-  assign pwrmgr_low_power_if.low_power = `PWRMGR_HIER.low_power_o;
+  assign pwrmgr_low_power_if.low_power      = `PWRMGR_HIER.low_power_o;
+  assign pwrmgr_low_power_if.deep_powerdown = ~`PWRMGR_HIER.pwr_ast_i.main_pok;
 
   // Use this until we decide what to do with m_tl_agent_rv_dm_debug_mem_reg_block
   // TODO reveiw m_tl_agent_rv_dm_debug_mem_reg_block.

--- a/hw/top_earlgrey/dv/env/pwrmgr_low_power_if.sv
+++ b/hw/top_earlgrey/dv/env/pwrmgr_low_power_if.sv
@@ -15,6 +15,9 @@ interface pwrmgr_low_power_if (
 );
   logic       low_power;
 
+  // Deep Power down indicator (while `low_power` is high)
+  logic deep_powerdown;
+
   // slow clock
   clocking cb @(posedge clk);
   endclocking


### PR DESCRIPTION
`pwrmgr_low_power_if.low_power` represents if the chip enters low power mode or not. The low power is the moment PWRMGR gating clocks to peri.

Deep powerdown happens after a few additional steps.

This commit uses AST main_pok feeding into pwrmgr as deep powerdown indicator.