### PR TITLE
[SYSRST_CTRL] Added sysrst_ctrl_ec_rst_l test in #14116 and #14119

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1733,7 +1733,7 @@
               with a suitable pulse width.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_sysrst_ctrl_ec_rst_l"]
     }
     {
       name: chip_sw_sysrst_ctrl_flash_wp_l
@@ -1742,7 +1742,7 @@
             - Exactly the same as chip_sysrst_ctrl_ec_rst_l, but covers the flash_wp_l pin.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_sysrst_ctrl_ec_rst_l"]
     }
     {
       name: chip_sw_sysrst_ctrl_ulp_z3_wakeup

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -658,6 +658,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_sysrst_ctrl_ec_rst_l
+      uvm_test_seq: chip_sw_sysrst_ctrl_ec_rst_l_vseq
+      sw_images: ["//sw/device/tests/sim_dv:sysrst_ctrl_ec_rst_l_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_aon_timer_irq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aon_timer_irq_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -67,6 +67,7 @@ filesets:
       - seq_lib/chip_sw_sysrst_ctrl_inputs_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv
@@ -1,0 +1,178 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_sysrst_ctrl_ec_rst_l_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_sysrst_ctrl_ec_rst_l_vseq)
+
+  `uvm_object_new
+
+  localparam time AON_CYCLE_PERIOD = 5us;
+  localparam bit [1:0] OUTPUT_ALL_SET = 2'b11;
+  localparam bit [1:0] OUTPUT_NONE_SET = 2'b00;
+  localparam uint TIMEOUT_VALUE = 5000000;
+  localparam int EC_RST_TIMER = 512;
+
+  localparam string PWRMGR_RSTREQ_PATH = "tb.dut.top_earlgrey.u_pwrmgr_aon.rstreqs_i[0]";
+  localparam string RST_AON_NI_PATH = "tb.dut.top_earlgrey.u_sysrst_ctrl_aon.rst_aon_ni";
+
+  localparam int PAD_KEY0 = 0;
+  localparam int PAD_KEY1 = 1;
+
+  typedef enum {
+    PHASE_INITIAL               = 0,
+    PHASE_COMBO_RESET           = 1,
+    PHASE_OVERRIDE_SETUP        = 2,
+    PHASE_OVERRIDE_ZEROS        = 3,
+    PHASE_OVERRIDE_ONES         = 4,
+    PHASE_DONE                  = 5
+  } test_phases_e;
+
+  logic [1:0] output_pad_read_values;
+  logic       output_ec_rst_read_values;
+  logic       ec_rst_timer_over;
+
+  virtual function void write_test_phase(input test_phases_e phase);
+    sw_symbol_backdoor_overwrite("kTestPhase", {<<8{phase}});
+  endfunction
+
+  virtual task set_combo0_pads_low();
+    cfg.chip_vif.sysrst_ctrl_if.drive_pin(PAD_KEY0, 0);
+    cfg.chip_vif.sysrst_ctrl_if.drive_pin(PAD_KEY1, 0);
+  endtask
+
+  virtual task set_combo0_pads_high();
+    cfg.chip_vif.sysrst_ctrl_if.drive_pin(PAD_KEY0, 1);
+    cfg.chip_vif.sysrst_ctrl_if.drive_pin(PAD_KEY1, 1);
+  endtask
+
+  virtual task check_ec_rst_pads(bit exp_ec_rst_l);
+    #(3 * AON_CYCLE_PERIOD);
+    `DV_CHECK_EQ_FATAL(cfg.chip_vif.ec_rst_l_if.sample_pin(0), exp_ec_rst_l)
+  endtask
+
+  virtual task check_output_pads(bit exp_ec_rst_l, bit exp_flash_wp_l);
+    #(3 * AON_CYCLE_PERIOD);
+    `DV_CHECK_EQ_FATAL(cfg.chip_vif.ec_rst_l_if.sample_pin(0), exp_ec_rst_l)
+    `DV_CHECK_EQ_FATAL(cfg.chip_vif.flash_wp_l_if.sample_pin(0), exp_flash_wp_l)
+  endtask
+
+  virtual task sync_with_sw();
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+  endtask
+
+  virtual task wait_for_ec_rst_high();
+    int timeout_count = 0;
+    forever begin
+      if (cfg.chip_vif.ec_rst_l_if.sample_pin(0) == 0) begin
+        timeout_count++;
+        if (timeout_count >= TIMEOUT_VALUE) begin
+          `uvm_error(`gfn, "Timed out waiting for ec_rst to go high.")
+        end
+      end else begin
+        break;
+      end
+      // Some amount of delay between samples of ec_rst.
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+  endtask
+
+  virtual task control_ec_rst_low(int min_exp_cycles);
+    int timeout_count = 0;
+    `DV_WAIT(cfg.chip_vif.ec_rst_l_if.pins[0] === 0)
+    // wait until ec_rst is de-active and check the length.
+    `DV_SPINWAIT(
+    forever begin
+      if (cfg.chip_vif.ec_rst_l_if.sample_pin(0) == 0) begin
+        timeout_count++;
+        if (timeout_count >= EC_RST_TIMER) begin
+          ec_rst_timer_over = 1; // set this for the other thread to continue
+        end
+      end else begin
+        break;
+      end
+      // Some amount of delay between samples of ec_rst.
+      #(AON_CYCLE_PERIOD);
+    end)
+    `DV_CHECK(timeout_count > min_exp_cycles) // check ec_rst length
+  endtask
+
+  virtual task check_ec_rst_with_transition(string path, int exp_value);
+    bit retval = 0;
+    int timeout_count = 0;
+    forever begin
+      `DV_CHECK(uvm_hdl_read(path, retval));
+      if (retval == exp_value) begin
+        timeout_count++;
+        if (timeout_count >= TIMEOUT_VALUE) begin
+          `uvm_error(`gfn, $sformatf("Timed out waiting for %0s to go to %d \n",
+              path, exp_value))
+        end
+      end else begin
+        break;
+      end
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+    // Check that ec_rst is low.
+    cfg.clk_rst_vif.wait_clks(1);
+    if (cfg.chip_vif.ec_rst_l_if.sample_pin(0) == 1) begin
+      `uvm_error(`gfn, "Unexpected ec_rst high after reset request.")
+    end
+  endtask
+
+  virtual task check_flash_wp_value(input bit level_to_check);
+    if (cfg.chip_vif.flash_wp_l_if.sample_pin(0) != level_to_check) begin
+      `uvm_error(`gfn, $sformatf("Flash write protect signal expected %0d.", level_to_check))
+    end
+  endtask
+
+  virtual task body();
+    super.body();
+
+    // TODO(lowRISC/opentitan:#13373): Revisit pad assignments.
+    // pinmux_wkup_vif (at Iob7) is re-used for PinZ3WakeupOut
+    // due to lack of unused pins. Disable the default drive
+    // to this pin.
+    cfg.chip_vif.pinmux_wkup_if.drive_en_pin(0, 0);
+    set_combo0_pads_high();
+
+    write_test_phase(PHASE_INITIAL);
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
+
+    check_flash_wp_value(1);
+    wait_for_ec_rst_high();
+    set_combo0_pads_low();
+    ec_rst_timer_over = 0;
+
+    fork
+      begin
+        control_ec_rst_low(EC_RST_TIMER);
+      end
+      begin
+        check_ec_rst_with_transition(PWRMGR_RSTREQ_PATH, 1'b0);
+        check_ec_rst_with_transition(RST_AON_NI_PATH , 1'b0);
+        sync_with_sw();
+        write_test_phase(PHASE_COMBO_RESET);
+        `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+        `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
+        `DV_WAIT(ec_rst_timer_over)
+
+        write_test_phase(PHASE_OVERRIDE_SETUP);
+        sync_with_sw();
+        check_ec_rst_pads(1'b0);
+
+        write_test_phase(PHASE_OVERRIDE_ZEROS);
+        sync_with_sw();
+        check_output_pads(1'b0, 1'b0);
+
+        write_test_phase(PHASE_OVERRIDE_ONES);
+        sync_with_sw();
+        check_output_pads(1'b1, 1'b1);
+
+        write_test_phase(PHASE_DONE);
+      end
+    join
+  endtask
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -26,6 +26,7 @@
 `include "chip_sw_sysrst_ctrl_inputs_vseq.sv"
 `include "chip_sw_sysrst_ctrl_reset_vseq.sv"
 `include "chip_sw_sysrst_ctrl_outputs_vseq.sv"
+`include "chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv"
 `include "chip_sw_gpio_smoke_vseq.sv"
 `include "chip_sw_gpio_vseq.sv"
 `include "chip_sw_flash_ctrl_lc_rw_en_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -192,6 +192,24 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "sysrst_ctrl_ec_rst_l_test",
+    srcs = ["sysrst_ctrl_ec_rst_l_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "keymgr_key_derivation_test",
     srcs = ["keymgr_key_derivation_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/sysrst_ctrl_ec_rst_l_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_ec_rst_l_test.c
@@ -1,0 +1,222 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_pinmux_t pinmux;
+static dif_sysrst_ctrl_t sysrst_ctrl;
+static dif_pwrmgr_t pwrmgr;
+static dif_rstmgr_t rstmgr;
+static dif_rstmgr_reset_info_bitfield_t rstmgr_reset_info;
+
+const uint32_t kTestPhaseTimeoutUsec = 2500;
+
+typedef enum {
+  kTestPhaseSetup = 0,
+  kTestPhaseCheckComboReset = 1,
+  kTestPhaseOverrideSetup = 2,
+  kTestPhaseOverrideZeros = 3,
+  kTestPhaseOverrideOnes = 4,
+  kTestPhaseDone = 5,
+} test_phases_e;
+
+enum {
+  kAllZero = 0x0,
+  kAllOne = 0xff,
+  kLoopbackPartial = 0x5,
+  kNumMioInputs = 0x4,
+  kNumMioOutputs = 0x6,
+  kOutputNumPads = 0x8,
+};
+
+static const dif_pinmux_index_t kPeripheralInputs[] = {
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey0In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey1In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey2In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonPwrbIn,
+};
+
+static const dif_pinmux_index_t kInputPads[] = {
+    kTopEarlgreyPinmuxInselIob3,
+    kTopEarlgreyPinmuxInselIob6,
+    kTopEarlgreyPinmuxInselIob8,
+    kTopEarlgreyPinmuxInselIor13,
+};
+
+static const dif_pinmux_index_t kPeripheralOutputs[] = {
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonKey0Out,
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonKey1Out,
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonKey2Out,
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonPwrbOut,
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonBatDisable,
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonZ3Wakeup,
+};
+
+static const dif_pinmux_index_t kOutputPads[] = {
+    kTopEarlgreyPinmuxMioOutIob9, kTopEarlgreyPinmuxMioOutIor5,
+    kTopEarlgreyPinmuxMioOutIor6, kTopEarlgreyPinmuxMioOutIoc7,
+    kTopEarlgreyPinmuxMioOutIoc9, kTopEarlgreyPinmuxMioOutIob7,
+};
+
+static const dif_sysrst_ctrl_pin_t kSysrstCtrlOutputs[] = {
+    kDifSysrstCtrlPinKey0Out,           kDifSysrstCtrlPinKey1Out,
+    kDifSysrstCtrlPinKey2Out,           kDifSysrstCtrlPinPowerButtonOut,
+    kDifSysrstCtrlPinBatteryDisableOut, kDifSysrstCtrlPinZ3WakeupOut,
+    kDifSysrstCtrlPinEcResetInOut,      kDifSysrstCtrlPinFlashWriteProtectInOut,
+};
+
+// Threshold/Duration values are not specific to a real-world debounce
+// scenario so are kept short to avoid excessive simulation time.
+// Assuming a 5us aon clock period.
+enum {
+  kDetectionTimeThreshold = 1024,  // ~5ms
+  kEcResetDuration = 512,          // ~2.5ms
+  kDebounceTimeThreshold = 128,    // ~0.6ms
+};
+
+// Test phase written by testbench.
+static volatile const test_phases_e kTestPhase = 0;
+
+// Sets up the pinmux to assign input and output pads
+// to the sysrst_ctrl peripheral as required.
+static void pinmux_setup(void) {
+  for (int i = 0; i < kNumMioInputs; ++i) {
+    CHECK_DIF_OK(
+        dif_pinmux_input_select(&pinmux, kPeripheralInputs[i], kInputPads[i]));
+  }
+  for (int i = 0; i < kNumMioOutputs; ++i) {
+    CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kOutputPads[i],
+                                          kPeripheralOutputs[i]));
+  }
+}
+
+static void check_combo_reset(void) {
+  CHECK_DIF_OK(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl, kDifSysrstCtrlKeyCombo0,
+      (dif_sysrst_ctrl_key_combo_config_t){
+          .actions = kDifSysrstCtrlKeyComboActionEcReset |
+                     kDifSysrstCtrlKeyComboActionSelfReset,
+          .detection_time_threshold = kDetectionTimeThreshold,
+          .embedded_controller_reset_duration = kEcResetDuration,
+          .keys = kDifSysrstCtrlKey0 | kDifSysrstCtrlKey1}));
+
+  CHECK_DIF_OK(dif_sysrst_ctrl_input_change_detect_configure(
+      &sysrst_ctrl, (dif_sysrst_ctrl_input_change_config_t){
+                        .debounce_time_threshold = kDebounceTimeThreshold,
+                        .input_changes = kDifSysrstCtrlInputKey0H2L |
+                                         kDifSysrstCtrlInputKey1H2L}));
+  CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_configure(
+      &sysrst_ctrl, kDifSysrstCtrlPinFlashWriteProtectInOut,
+      (dif_sysrst_ctrl_pin_config_t){.allow_one = true,
+                                     .allow_zero = true,
+                                     .enabled = kDifToggleEnabled,
+                                     .override_value = true}));
+  // Prepare rstmgr for a reset with sysrst_ctrl (source one).
+  rstmgr_testutils_pre_reset(&rstmgr);
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
+                                              kDifPwrmgrResetRequestSourceOne,
+                                              kDifToggleEnabled));
+  // Issue WFI and wait for reset condition.
+  test_status_set(kTestStatusInWfi);
+  wait_for_interrupt();
+}
+
+// Waits for the kTestPhase variable to be changed by a backdoor overwrite
+// from the testbench in chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv. This will
+// indicate that the testbench is ready to proceed with the
+// next phase of the test.
+static void wait_next_test_phase(void) {
+  uint8_t current_phase = kTestPhase;
+  // Set WFI status for testbench synchronization,
+  // no actual WFI instruction is issued.
+  test_status_set(kTestStatusInWfi);
+  test_status_set(kTestStatusInTest);
+  IBEX_SPIN_FOR(current_phase != kTestPhase, kTestPhaseTimeoutUsec);
+}
+
+// Enables the sysrst_ctrl overrides for the output pins. Allows
+// both low and high override values.
+static void override_setup(uint8_t pins_to_override) {
+  for (int i = 0; i < kOutputNumPads; ++i) {
+    if ((pins_to_override >> i) & 0x1) {
+      CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_enabled(
+          &sysrst_ctrl, kSysrstCtrlOutputs[i], kDifToggleEnabled));
+      CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_allowed(
+          &sysrst_ctrl, kSysrstCtrlOutputs[i], true, true));
+    }
+  }
+}
+
+// Disables the overrides. Allows the outputs to pass-through the
+// values from the relevant input pins.
+static void override_disable(void) {
+  for (int i = 0; i < kOutputNumPads; ++i) {
+    CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_enabled(
+        &sysrst_ctrl, kSysrstCtrlOutputs[i], kDifToggleDisabled));
+  }
+}
+
+// Sets the values of the output overrides as required.
+static void set_output_overrides(uint8_t override_value) {
+  for (int i = 0; i < kOutputNumPads; ++i) {
+    CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_set_override(
+        &sysrst_ctrl, kSysrstCtrlOutputs[i], (override_value >> i) & 0x1));
+  }
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
+      &sysrst_ctrl));
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  pinmux_setup();
+  rstmgr_reset_info = rstmgr_testutils_reason_get();
+  CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_enabled(
+      &sysrst_ctrl, kDifSysrstCtrlPinEcResetInOut, kDifToggleDisabled));
+
+  while (kTestPhase < kTestPhaseDone) {
+    switch (kTestPhase) {
+      case kTestPhaseSetup:
+        CHECK(rstmgr_reset_info == kDifRstmgrResetInfoPor);
+        check_combo_reset();
+        return true;
+      case kTestPhaseCheckComboReset:
+        CHECK(rstmgr_reset_info == kDifRstmgrResetInfoSysRstCtrl);
+        break;
+      case kTestPhaseOverrideSetup:
+        override_setup(kAllOne);
+        break;
+      case kTestPhaseOverrideZeros:
+        set_output_overrides(kAllZero);
+        break;
+      case kTestPhaseOverrideOnes:
+        set_output_overrides(kAllOne);
+        break;
+      default:
+        LOG_ERROR("Unexpected test phase : %d", kTestPhase);
+        break;
+    }
+    wait_next_test_phase();
+  }
+  return true;
+}


### PR DESCRIPTION
- Verify that ec_rst_l stays asserted as the chip is brought out of reset.
- Verify that the pin continues to remain low until SW is alive.
- Have the SW write to pin_allowed|out_ctrl CSRs to control the ec_rst_l value and verify the value at the chip output.
- Verify ec_rst_l pulse stretching by setting the ec_rst_ctl register with a suitable pulse width.
- Verify that the flash_wp_l stays asserted on power-on-reset until SW can control it.

Signed-off-by: Joshua Park <jeoong@google.com>