### PR TITLE
[crypto] Change DMEM interface for ECDSA-P256.

### DIFF
--- a/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.c
+++ b/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.c
@@ -20,15 +20,6 @@ OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, y);     // The public key y-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, d);     // The private key scalar d.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x_r);   // Verification result.
 
-/* Declare symbols for DMEM pointers */
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_msg);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_r);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_s);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_x);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_y);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_d);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_x_r);
-
 static const otbn_app_t kOtbnAppEcdsa = OTBN_APP_T_INIT(p256_ecdsa);
 static const otbn_addr_t kOtbnVarEcdsaMode = OTBN_ADDR_T_INIT(p256_ecdsa, mode);
 static const otbn_addr_t kOtbnVarEcdsaMsg = OTBN_ADDR_T_INIT(p256_ecdsa, msg);

--- a/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.c
+++ b/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.c
@@ -29,65 +29,11 @@ static const otbn_addr_t kOtbnVarEcdsaX = OTBN_ADDR_T_INIT(p256_ecdsa, x);
 static const otbn_addr_t kOtbnVarEcdsaY = OTBN_ADDR_T_INIT(p256_ecdsa, y);
 static const otbn_addr_t kOtbnVarEcdsaD = OTBN_ADDR_T_INIT(p256_ecdsa, d);
 static const otbn_addr_t kOtbnVarEcdsaXr = OTBN_ADDR_T_INIT(p256_ecdsa, x_r);
-static const otbn_addr_t kOtbnVarEcdsaDptrMsg =
-    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_msg);
-static const otbn_addr_t kOtbnVarEcdsaDptrR =
-    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_r);
-static const otbn_addr_t kOtbnVarEcdsaDptrS =
-    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_s);
-static const otbn_addr_t kOtbnVarEcdsaDptrX =
-    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_x);
-static const otbn_addr_t kOtbnVarEcdsaDptrY =
-    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_y);
-static const otbn_addr_t kOtbnVarEcdsaDptrD =
-    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_d);
-static const otbn_addr_t kOtbnVarEcdsaDptrXr =
-    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_x_r);
 
 /* Mode is represented by a single word, 1 for sign and 2 for verify */
 static const uint32_t kOtbnEcdsaModeNumWords = 1;
 static const uint32_t kOtbnEcdsaModeSign = 1;
 static const uint32_t kOtbnEcdsaModeVerify = 2;
-
-/**
- * Makes a single dptr in the P256 library point to where its value is stored.
- */
-static otbn_error_t setup_data_pointer(otbn_t *otbn, otbn_addr_t dptr,
-                                       otbn_addr_t value) {
-  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(otbn, 1, &value, dptr));
-  return kOtbnErrorOk;
-}
-
-/**
- * Sets up all data pointers used by the P256 library to point to DMEM.
- *
- * The ECDSA P256 OTBN library makes use of "named" data pointers as part of
- * its calling convention, which are exposed as symbol starting with `dptr_`.
- * The DMEM locations these pointers refer to is not mandated by the P256
- * calling convention; the values can be placed anywhere in OTBN DMEM.
- *
- * For convenience, `p256_ecdsa.s` pre-allocates space for the data values.
- *
- * This function makes the data pointers refer to the pre-allocated DMEM
- * regions to store the actual values.
- */
-static otbn_error_t setup_data_pointers(otbn_t *otbn) {
-  OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrMsg, kOtbnVarEcdsaMsg));
-  OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrR, kOtbnVarEcdsaR));
-  OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrS, kOtbnVarEcdsaS));
-  OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrX, kOtbnVarEcdsaX));
-  OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrY, kOtbnVarEcdsaY));
-  OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrD, kOtbnVarEcdsaD));
-  OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrXr, kOtbnVarEcdsaXr));
-  return kOtbnErrorOk;
-}
 
 // TODO: This implementation waits while OTBN is processing; it should be
 // modified to be non-blocking.
@@ -99,7 +45,6 @@ otbn_error_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
 
   // Load the ECDSA/P-256 app and set up data pointers
   OTBN_RETURN_IF_ERROR(otbn_load_app(&otbn, kOtbnAppEcdsa));
-  OTBN_RETURN_IF_ERROR(setup_data_pointers(&otbn));
 
   // Set mode so start() will jump into p256_ecdsa_sign.
   OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(
@@ -144,7 +89,6 @@ otbn_error_t ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
 
   // Load the ECDSA/P-256 app and set up data pointers
   OTBN_RETURN_IF_ERROR(otbn_load_app(&otbn, kOtbnAppEcdsa));
-  OTBN_RETURN_IF_ERROR(setup_data_pointers(&otbn));
 
   // Set mode so start() will jump into p256_ecdsa_verify.
   OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(

--- a/sw/device/sca/ecc_serial.c
+++ b/sw/device/sca/ecc_serial.c
@@ -67,15 +67,6 @@ uint8_t ecc256_msg[32] = {"Hello OTBN."};
 
 OTBN_DECLARE_APP_SYMBOLS(p256_ecdsa_sca);
 
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, dptr_msg);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, dptr_r);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, dptr_s);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, dptr_x);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, dptr_y);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, dptr_d);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, dptr_x_r);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, dptr_k);
-
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, mode);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, msg);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, r);
@@ -88,23 +79,6 @@ OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, x_r);
 
 static const otbn_app_t kOtbnAppP256Ecdsa = OTBN_APP_T_INIT(p256_ecdsa_sca);
 
-static const otbn_addr_t kOtbnVarDptrMsg =
-    OTBN_ADDR_T_INIT(p256_ecdsa_sca, dptr_msg);
-static const otbn_addr_t kOtbnVarDptrR =
-    OTBN_ADDR_T_INIT(p256_ecdsa_sca, dptr_r);
-static const otbn_addr_t kOtbnVarDptrS =
-    OTBN_ADDR_T_INIT(p256_ecdsa_sca, dptr_s);
-static const otbn_addr_t kOtbnVarDptrX =
-    OTBN_ADDR_T_INIT(p256_ecdsa_sca, dptr_x);
-static const otbn_addr_t kOtbnVarDptrY =
-    OTBN_ADDR_T_INIT(p256_ecdsa_sca, dptr_y);
-static const otbn_addr_t kOtbnVarDptrD =
-    OTBN_ADDR_T_INIT(p256_ecdsa_sca, dptr_d);
-static const otbn_addr_t kOtbnVarDptrXR =
-    OTBN_ADDR_T_INIT(p256_ecdsa_sca, dptr_x_r);
-static const otbn_addr_t kOtbnVarDptrK =
-    OTBN_ADDR_T_INIT(p256_ecdsa_sca, dptr_k);
-
 static const otbn_addr_t kOtbnVarMode = OTBN_ADDR_T_INIT(p256_ecdsa_sca, mode);
 static const otbn_addr_t kOtbnVarMsg = OTBN_ADDR_T_INIT(p256_ecdsa_sca, msg);
 static const otbn_addr_t kOtbnVarR = OTBN_ADDR_T_INIT(p256_ecdsa_sca, r);
@@ -114,39 +88,6 @@ static const otbn_addr_t kOtbnVarY = OTBN_ADDR_T_INIT(p256_ecdsa_sca, y);
 static const otbn_addr_t kOtbnVarD = OTBN_ADDR_T_INIT(p256_ecdsa_sca, d);
 static const otbn_addr_t kOtbnVarXR = OTBN_ADDR_T_INIT(p256_ecdsa_sca, x_r);
 static const otbn_addr_t kOtbnVarK = OTBN_ADDR_T_INIT(p256_ecdsa_sca, k);
-
-/**
- * Makes a single dptr in the P256 library point to where its value is stored.
- */
-static void setup_data_pointer(otbn_t *otbn_ctx, const otbn_addr_t dptr,
-                               const otbn_addr_t value) {
-  SS_CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(value), &value, dptr) ==
-           kOtbnOk);
-}
-
-/**
- * Sets up all data pointers used by the P256 library to point to DMEM.
- *
- * The ECDSA P256 OTBN library makes use of "named" data pointers as part of
- * its calling convention, which are exposed as symbol starting with `dptr_`.
- * The DMEM locations these pointers refer to is not mandated by the P256
- * calling convention; the values can be placed anywhere in OTBN DMEM.
- *
- * As convenience, `ecdsa_p256.s` pre-allocates space for the data values.
- *
- * This function makes the data pointers refer to the pre-allocated DMEM
- * regions to store the actual values.
- */
-static void setup_data_pointers(otbn_t *otbn_ctx) {
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrMsg, kOtbnVarMsg);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrR, kOtbnVarR);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrS, kOtbnVarS);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrX, kOtbnVarX);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrY, kOtbnVarY);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrD, kOtbnVarD);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrXR, kOtbnVarXR);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrK, kOtbnVarK);
-}
 
 /**
  * Simple serial 'd' (set private key) command handler.
@@ -199,10 +140,6 @@ static void p256_ecdsa_sign(otbn_t *otbn_ctx, const uint8_t *msg,
                             const uint8_t *private_key_d, uint8_t *signature_r,
                             uint8_t *signature_s, const uint8_t *k) {
   SS_CHECK(otbn_ctx != NULL);
-
-  // Set pointers to input arguments.
-  LOG_INFO("Setup data pointers");
-  setup_data_pointers(otbn_ctx);
 
   // Write input arguments.
   uint32_t mode = 1;  // mode 1 => sign

--- a/sw/device/tests/otbn_ecdsa_op_irq_test.c
+++ b/sw/device/tests/otbn_ecdsa_op_irq_test.c
@@ -36,14 +36,6 @@
 
 OTBN_DECLARE_APP_SYMBOLS(p256_ecdsa);
 
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_msg);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_r);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_s);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_x);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_y);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_d);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_x_r);
-
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, mode);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, msg);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, r);
@@ -54,16 +46,6 @@ OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, d);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x_r);
 
 static const otbn_app_t kOtbnAppP256Ecdsa = OTBN_APP_T_INIT(p256_ecdsa);
-
-static const otbn_addr_t kOtbnVarDptrMsg =
-    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_msg);
-static const otbn_addr_t kOtbnVarDptrR = OTBN_ADDR_T_INIT(p256_ecdsa, dptr_r);
-static const otbn_addr_t kOtbnVarDptrS = OTBN_ADDR_T_INIT(p256_ecdsa, dptr_s);
-static const otbn_addr_t kOtbnVarDptrX = OTBN_ADDR_T_INIT(p256_ecdsa, dptr_x);
-static const otbn_addr_t kOtbnVarDptrY = OTBN_ADDR_T_INIT(p256_ecdsa, dptr_y);
-static const otbn_addr_t kOtbnVarDptrD = OTBN_ADDR_T_INIT(p256_ecdsa, dptr_d);
-static const otbn_addr_t kOtbnVarDptrXR =
-    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_x_r);
 
 static const otbn_addr_t kOtbnVarMode = OTBN_ADDR_T_INIT(p256_ecdsa, mode);
 static const otbn_addr_t kOtbnVarMsg = OTBN_ADDR_T_INIT(p256_ecdsa, msg);
@@ -247,38 +229,6 @@ static void profile_end(uint64_t t_start, const char *msg) {
 }
 
 /**
- * Makes a single dptr in the P256 library point to where its value is stored.
- */
-static void setup_data_pointer(otbn_t *otbn_ctx, otbn_addr_t dptr,
-                               otbn_addr_t value) {
-  CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(value), &value, dptr) ==
-        kOtbnOk);
-}
-
-/**
- * Sets up all data pointers used by the P256 library to point to DMEM.
- *
- * The ECDSA P256 OTBN library makes use of "named" data pointers as part of
- * its calling convention, which are exposed as symbol starting with `dptr_`.
- * The DMEM locations these pointers refer to is not mandated by the P256
- * calling convention; the values can be placed anywhere in OTBN DMEM.
- *
- * As convenience, `ecdsa_p256.s` pre-allocates space for the data values.
- *
- * This function makes the data pointers refer to the pre-allocated DMEM
- * regions to store the actual values.
- */
-static void setup_data_pointers(otbn_t *otbn_ctx) {
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrMsg, kOtbnVarMsg);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrR, kOtbnVarR);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrS, kOtbnVarS);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrX, kOtbnVarX);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrY, kOtbnVarY);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrD, kOtbnVarD);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrXR, kOtbnVarXR);
-}
-
-/**
  * Signs a message with ECDSA using the P-256 curve.
  *
  * @param otbn_ctx            The OTBN context object.
@@ -293,9 +243,6 @@ static void p256_ecdsa_sign(otbn_t *otbn_ctx, const uint8_t *msg,
                             const uint8_t *private_key_d, uint8_t *signature_r,
                             uint8_t *signature_s) {
   CHECK(otbn_ctx != NULL);
-
-  // Set pointers to input arguments.
-  setup_data_pointers(otbn_ctx);
 
   // Write input arguments.
   uint32_t mode = 1;  // mode 1 => sign
@@ -336,9 +283,6 @@ static void p256_ecdsa_verify(otbn_t *otbn_ctx, const uint8_t *msg,
                               const uint8_t *public_key_y,
                               uint8_t *signature_x_r) {
   CHECK(otbn_ctx != NULL);
-
-  // Set pointers to input arguments.
-  setup_data_pointers(otbn_ctx);
 
   // Write input arguments.
   uint32_t mode = 2;  // mode 2 => verify

--- a/sw/otbn/crypto/p256_base_mult_test.s
+++ b/sw/otbn/crypto/p256_base_mult_test.s
@@ -16,34 +16,14 @@
 
 p256_base_mult_test:
 
-  /* set dmem pointer to point to scalar (private key) d */
-  la       x2, scalar
-  la       x3, dptr_d
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to blinding parameter */
-  la       x2, blinding_param
-  la       x3, dptr_rnd
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to x-coordinate */
-  la       x2, p1_x
-  la       x3, dptr_x
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to y-coordinate */
-  la       x2, p1_y
-  la       x3, dptr_y
-  sw       x2, 0(x3)
-
   /* call base point multiplication routine in P-256 lib */
   jal      x1, p256_base_mult
 
   /* load result to WDRs for comparison with reference */
   li        x2, 0
-  la        x3, p1_x
+  la        x3, x
   bn.lid    x2++, 0(x3)
-  la        x3, p1_y
+  la        x3, y
   bn.lid    x2, 0(x3)
 
   ecall
@@ -52,7 +32,9 @@ p256_base_mult_test:
 .data
 
 /* scalar d */
-scalar:
+.globl d
+.balign 32
+d:
   .word 0xc7df1a56
   .word 0xfbd94efe
   .word 0xaa847f52
@@ -62,8 +44,10 @@ scalar:
   .word 0x9144233d
   .word 0xc0fbe256
 
-   /* blinding parameter rnd */
- blinding_param:
+/* blinding parameter rnd */
+.globl rnd
+.balign 32
+rnd:
   .word 0x7ab203c3
   .word 0xd6ee4951
   .word 0xd5b89b43
@@ -74,11 +58,15 @@ scalar:
   .word 0xa21c2147
 
 /* result buffer x-coordinate */
-p1_x:
+.globl x
+.balign 32
+x:
   .zero 32
 
 /* result buffer y-coordinate */
-p1_y:
+.globl y
+.balign 32
+y:
   .zero 32
 
 /* Expected values in wide register file (x- and y-coordinates of result):

--- a/sw/otbn/crypto/p256_ecdsa.s
+++ b/sw/otbn/crypto/p256_ecdsa.s
@@ -43,24 +43,14 @@ p256_ecdsa_setup_rand:
   la        x10, rnd
   bn.sid    x0, 0(x10)
 
-  /* Point dptr_rnd to rnd. */
-  la        x11, dptr_rnd
-  sw        x10, 0(x11)
-
   /* Obtain the nonce (k) from RND. */
   bn.wsrr   w0, 0x1 /* RND */
   la        x10, k
   bn.sid    x0, 0(x10)
 
-  /* Point dptr_k to k. */
-  la        x11, dptr_k
-  sw        x10, 0(x11)
-
   ret
 
-.data
-
-/* Freely available DMEM space. */
+.bss
 
 /* Operation mode (1 = sign; 2 = verify) */
 .globl mode
@@ -68,56 +58,58 @@ p256_ecdsa_setup_rand:
 mode:
   .zero 4
 
-/* All constants below must be 256b-aligned. */
-
-/* random scalar k */
-.balign 32
-k:
-  .zero 32
-
-/* randomness for blinding */
-.balign 32
-rnd:
-  .zero 32
-
-/* message digest */
+/* Message digest. */
 .globl msg
 .balign 32
 msg:
   .zero 32
 
-/* signature R */
+/* Signature R. */
 .globl r
 .balign 32
 r:
   .zero 32
 
-/* signature S */
+/* Signature S. */
 .globl s
 .balign 32
 s:
   .zero 32
 
-/* public key x-coordinate */
+/* Public key x-coordinate. */
 .globl x
 .balign 32
 x:
   .zero 32
 
-/* public key y-coordinate */
+/* Public key y-coordinate. */
 .globl y
 .balign 32
 y:
   .zero 32
 
-/* private key d */
+/* Private key (d). */
 .globl d
 .balign 32
 d:
   .zero 32
 
-/* verification result x_r (aka x_1) */
+/* Verification result x_r (aka x_1). */
 .globl x_r
 .balign 32
 x_r:
+  .zero 32
+
+.section .scratchpad
+
+/* Secret scalar k. */
+.globl k
+.balign 32
+k:
+  .zero 32
+
+/* Random number for blinding. */
+.globl rnd
+.balign 32
+rnd:
   .zero 32

--- a/sw/otbn/crypto/p256_ecdsa_sca.s
+++ b/sw/otbn/crypto/p256_ecdsa_sca.s
@@ -26,7 +26,6 @@ start:
 
 .text
 p256_ecdsa_sign:
-  jal      x1, p256_ecdsa_setup_rand
   jal      x1, p256_sign
   ecall
 
@@ -34,31 +33,7 @@ p256_ecdsa_verify:
   jal      x1, p256_verify
   ecall
 
-/**
- * Populate the variables rnd and k with randomness, and setup data pointers.
- */
-p256_ecdsa_setup_rand:
-  /* Obtain the blinding constant from URND, and write it to `rnd` in DMEM. */
-  /* bn.wsrr   w0, 0x2 */ /* URND */
-  la        x10, rnd
-  /* bn.sid    x0, 0(x10) */
-
-  /* Point dptr_rnd to rnd. */
-  la        x11, dptr_rnd
-  sw        x10, 0(x11)
-
-  /* Obtain the nonce (k) from RND. */
-  /*bn.wsrr   w0, 0x1 *//* RND */
-  la        x10, k
-  /*bn.sid    x0, 0(x10)*/
-
-  /* Point dptr_k to k. */
-  la        x11, dptr_k
-  sw        x10, 0(x11)
-
-  ret
-
-.data
+.bss
 
 /* Freely available DMEM space. */
 

--- a/sw/otbn/crypto/p256_ecdsa_sign_test.s
+++ b/sw/otbn/crypto/p256_ecdsa_sign_test.s
@@ -19,43 +19,15 @@
 
 ecdsa_sign_test:
 
-  /* set dmem pointer to nonce k */
-  la       x2, nonce_k
-  la       x3, dptr_k
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to blinding parameter */
-  la       x2, blinding_param
-  la       x3, dptr_rnd
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to message */
-  la       x2, msg
-  la       x3, dptr_msg
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to private key d */
-  la       x2, priv_key_d
-  la       x3, dptr_d
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to signature */
-  la       x2, sig_r
-  la       x3, dptr_r
-  sw       x2, 0(x3)
-  la       x2, sig_s
-  la       x3, dptr_s
-  sw       x2, 0(x3)
-
   /* call ECDSA signing subroutine in P-256 lib */
   jal      x1, p256_sign
 
   /* load signature to wregs for comparison with reference */
   li        x2, 0
-  la        x3, sig_r
+  la        x3, r
   bn.lid    x2, 0(x3)
   li        x2, 1
-  la        x3, sig_s
+  la        x3, s
   bn.lid    x2, 0(x3)
 
   ecall
@@ -64,7 +36,9 @@ ecdsa_sign_test:
 .data
 
 /* nonce k */
-nonce_k:
+.globl k
+.balign 32
+k:
   .word 0xfe6d1071
   .word 0x21d0a016
   .word 0xb0b2c781
@@ -75,7 +49,9 @@ nonce_k:
   .word 0x1420fc41
 
 /* random number for blinding */
-blinding_param:
+.globl rnd
+.balign 32
+rnd:
   .word 0x7ab203c3
   .word 0xd6ee4951
   .word 0xd5b89b43
@@ -86,6 +62,8 @@ blinding_param:
   .word 0xa21c2147
 
 /* message digest */
+.globl msg
+.balign 32
 msg:
   .word 0x4456fd21
   .word 0x400bdd7d
@@ -97,7 +75,9 @@ msg:
   .word 0x06d71207
 
 /* private key d */
-priv_key_d:
+.globl d
+.balign 32
+d:
   .word 0xc7df1a56
   .word 0xfbd94efe
   .word 0xaa847f52
@@ -108,11 +88,15 @@ priv_key_d:
   .word 0xc0fbe256
 
 /* signature R */
-sig_r:
+.globl r
+.balign 32
+r:
   .zero 32
 
 /* signature S */
-sig_s:
+.globl s
+.balign 32
+s:
   .zero 32
 
 /* Expected values wide register file (w0=R, w1=S):

--- a/sw/otbn/crypto/p256_ecdsa_verify_test.s
+++ b/sw/otbn/crypto/p256_ecdsa_verify_test.s
@@ -17,38 +17,12 @@
 
 ecdsa_verify_test:
 
-  /* set dmem pointer to point to message */
-  la       x2, msg
-  la       x3, dptr_msg
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to signature */
-  la       x2, sig_r
-  la       x3, dptr_r
-  sw       x2, 0(x3)
-  la       x2, sig_s
-  la       x3, dptr_s
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to public key */
-  la       x2, pub_x
-  la       x3, dptr_x
-  sw       x2, 0(x3)
-  la       x2, pub_y
-  la       x3, dptr_y
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to signature verifcation result */
-  la       x2, sig_x_r
-  la       x3, dptr_x_r
-  sw       x2, 0(x3)
-
   /* call ECDSA signature verification subroutine in P-256 lib */
   jal      x1, p256_verify
 
   /* load signature to wregs for comparison with reference */
   li        x2, 0
-  la        x3, sig_x_r
+  la        x3, x_r
   bn.lid    x2, 0(x3)
 
   ecall
@@ -56,6 +30,8 @@ ecdsa_verify_test:
 
 .data
 
+.globl msg
+.balign 32
 msg:
   .word 0x4456fd21
   .word 0x400bdd7d
@@ -67,7 +43,9 @@ msg:
   .word 0x06d71207
 
 /* signature R */
-sig_r:
+.globl r
+.balign 32
+r:
   .word 0x80a9674a
   .word 0x1147ea56
   .word 0x0c7d87dd
@@ -78,7 +56,9 @@ sig_r:
   .word 0x815215ad
 
 /* signature S */
-sig_s:
+.globl s
+.balign 32
+s:
   .word 0xc93fd605
   .word 0xd0b1051e
   .word 0xe90a6d17
@@ -89,7 +69,9 @@ sig_s:
   .word 0xa3991e01
 
 /* public key x-coordinate */
-pub_x:
+.globl x
+.balign 32
+x:
   .word 0xbfa8c334
   .word 0x9773b7b3
   .word 0xf36b0689
@@ -100,7 +82,9 @@ pub_x:
   .word 0xb5511a6a
 
 /* public key y-coordinate */
-pub_y:
+.globl y
+.balign 32
+y:
   .word 0x9e008c2e
   .word 0xa8707058
   .word 0xab9c6924
@@ -111,7 +95,9 @@ pub_y:
   .word 0x42a1c697
 
 /* signature verification result x_r */
-sig_x_r:
+.globl x_r
+.balign 32
+x_r:
   .zero 32
 
 /* Expected values wide register file (w0=x_r == R):

--- a/sw/otbn/crypto/p256_isoncurve_test.s
+++ b/sw/otbn/crypto/p256_isoncurve_test.s
@@ -14,30 +14,14 @@
 
 p256_oncurve_test:
 
-  /* set dmem pointers to result */
-  la       x2, res_r
-  la       x3, dptr_r
-  sw       x2, 0(x3)
-  la       x2, res_l
-  la       x3, dptr_s
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to curve point */
-  la       x2, point_x
-  la       x3, dptr_x
-  sw       x2, 0(x3)
-  la       x2, point_y
-  la       x3, dptr_y
-  sw       x2, 0(x3)
-
   /* call curve point test routine in P-256 lib */
   jal      x1, p256_isoncurve
 
   /* load result to WDRs for comparison with reference */
   li        x2, 0
-  la        x3, res_r
+  la        x3, r
   bn.lid    x2++, 0(x3)
-  la        x3, res_l
+  la        x3, s
   bn.lid    x2, 0(x3)
 
   ecall
@@ -46,15 +30,21 @@ p256_oncurve_test:
 .data
 
 /* buffer for right side result of Weierstrass equation */
-res_r:
+.globl r
+.balign 32
+r:
   .zero 32
 
 /* buffer for left side result of Weierstrass equation */
-res_l:
+.globl s
+.balign 32
+s:
   .zero 32
 
 /* point affine x-coordinate */
-point_x:
+.globl x
+.balign 32
+x:
   .word 0xbfa8c334
   .word 0x9773b7b3
   .word 0xf36b0689
@@ -65,7 +55,9 @@ point_x:
   .word 0xb5511a6a
 
 /* point affine y-coordinate */
-point_y:
+.globl y
+.balign 32
+y:
   .word 0x9e008c2e
   .word 0xa8707058
   .word 0xab9c6924

--- a/sw/otbn/crypto/p256_scalar_mult_test.s
+++ b/sw/otbn/crypto/p256_scalar_mult_test.s
@@ -17,34 +17,14 @@
 
 scalar_mult_test:
 
-  /* set dmem pointer to point to x-coordinate */
-  la       x2, p1_x
-  la       x3, dptr_x
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to y-coordinate */
-  la       x2, p1_y
-  la       x3, dptr_y
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to scalar k */
-  la       x2, scalar
-  la       x3, dptr_k
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to blinding parameter */
-  la       x2, blinding_param
-  la       x3, dptr_rnd
-  sw       x2, 0(x3)
-
   /* call scalar point multiplication routine in P-256 lib */
   jal      x1, p256_scalar_mult
 
   /* copy result to wide reg file */
   li       x2, 0
-  la       x3, p1_x
+  la       x3, x
   bn.lid   x2++, 0(x3)
-  la       x3, p1_y
+  la       x3, y
   bn.lid   x2, 0(x3)
 
   ecall
@@ -53,7 +33,9 @@ scalar_mult_test:
 .data
 
 /* scalar k */
-scalar:
+.globl d
+.balign 32
+d:
   .word 0xfe6d1071
   .word 0x21d0a016
   .word 0xb0b2c781
@@ -64,7 +46,9 @@ scalar:
   .word 0x1420fc41
 
 /* random number for blinding */
-blinding_param:
+.globl rnd
+.balign 32
+rnd:
   .word 0x7ab203c3
   .word 0xd6ee4951
   .word 0xd5b89b43
@@ -75,7 +59,9 @@ blinding_param:
   .word 0xa21c2147
 
 /* example curve point x-coordinate */
-p1_x:
+.globl x
+.balign 32
+x:
   .word 0xbfa8c334
   .word 0x9773b7b3
   .word 0xf36b0689
@@ -86,7 +72,9 @@ p1_x:
   .word 0xb5511a6a
 
 /* example curve point y-coordinate */
-p1_y:
+.globl y
+.balign 32
+y:
   .word 0x9e008c2e
   .word 0xa8707058
   .word 0xab9c6924


### PR DESCRIPTION
Previously, the P256 program expected indirect references for every DMEM buffer; it would read a 32-bit address from a location in DMEM called `dptr_X`, and then would read the full 256-big value from the address contained in that pointer. This PR changes all the P256 code to refer to `X` directly via DMEM symbols, saving instructions and simplifying the interface considerably.

My motivation for this change is that I'm about to add support for sideloaded keys and deterministic ECDSA to P-256, and these changes will make all of that simpler. I couldn't figure out the original reason to use this setup though, which makes me worry I might be missing something; @felixmiller, do you know? My best guess is that before we had the `.bss` section, setting up pointers like this saved binary space by only allocating the buffers that would be used for a particular program (e.g. not allocating `x_r` for signing). But now that we have `.bss`, the binary size is the same either way.

I also moved `k` and `rnd` to `.scratchpad` for `p256_ecdsa`, since Ibex should never read or write these values.