### PR TITLE
[otbn, util] Simplified OTBN test interface.

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -54,6 +54,9 @@ class StandaloneSim(OTBNSim):
         return insn_count
 
     def dump_regs(self, tgt: TextIO) -> None:
+        for reg in ['ERR_BITS', 'INSN_CNT', 'STOP_PC']:
+            value = self.state.ext_regs.read(reg, False)
+            tgt.write(' {} = 0x{:08x}\n'.format(reg, value))
         for idx, value in enumerate(self.state.gprs.peek_unsigned_values()):
             tgt.write(' x{:<2} = 0x{:08x}\n'.format(idx, value))
         for idx, value in enumerate(self.state.wdrs.peek_unsigned_values()):

--- a/hw/ip/otbn/util/BUILD
+++ b/hw/ip/otbn/util/BUILD
@@ -58,3 +58,12 @@ py_binary(
         "//hw/ip/otbn/util/shared:instruction_count_range",
     ],
 )
+
+py_binary(
+    name = "otbn_sim_test",
+    srcs = ["otbn_sim_test.py"],
+    deps = [
+        "//hw/ip/otbn/util/shared:check",
+        "//hw/ip/otbn/util/shared:reg_dump",
+    ],
+)

--- a/hw/ip/otbn/util/otbn_sim_test.py
+++ b/hw/ip/otbn/util/otbn_sim_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+'''Run a test on the OTBN simulator.'''
+
+import argparse
+import subprocess
+import sys
+
+from shared.check import CheckResult
+from shared.reg_dump import parse_reg_dump
+
+# Names of special registers
+ERR_BITS = 'ERR_BITS'
+INSN_CNT = 'INSN_CNT'
+STOP_PC = 'STOP_PC'
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('simulator',
+                        help='Path to the standalone OTBN simulator.')
+    parser.add_argument('expected',
+                        metavar='FILE',
+                        type=argparse.FileType('r'),
+                        help=(f'File containing expected register values. '
+                              f'Registers that are not listed are allowed to '
+                              f'have any value, except for {ERR_BITS}. If '
+                              f'{ERR_BITS} is not listed, the test will assume '
+                              f'there are no errors expected (i.e. {ERR_BITS}'
+                              f'= 0).'))
+    parser.add_argument('elf',
+                        help='Path to the .elf file for the OTBN program.')
+    parser.add_argument('-v', '--verbose', action='store_true')
+    args = parser.parse_args()
+
+    # Parse expected values.
+    result = CheckResult()
+    expected_regs = parse_reg_dump(args.expected.read())
+
+    # Run the simulation and produce a register dump.
+    cmd = [args.simulator, '--dump-regs', '-', args.elf]
+    sim_proc = subprocess.run(cmd, check=True,
+                              stdout=subprocess.PIPE, universal_newlines=True)
+    actual_regs = parse_reg_dump(sim_proc.stdout)
+
+    # Special handling for the ERR_BITS register.
+    expected_err = expected_regs.get(ERR_BITS, 0)
+    actual_err = actual_regs[ERR_BITS]
+    insn_cnt = actual_regs[INSN_CNT]
+    stop_pc = actual_regs[STOP_PC]
+    if expected_err == 0 and actual_err != 0:
+        # Test is expected to have no errors, but an error occurred. In this
+        # case, give a special error message and exit rather than print all the
+        # mismatched registers.
+        if actual_err != 0:
+            result.err(f'OTBN encountered an unexpected error.\n'
+                       f'  {ERR_BITS}\t= {actual_err:#010x}\n'
+                       f'  {INSN_CNT}\t= {insn_cnt:#010x}\n'
+                       f'  {STOP_PC}\t= {stop_pc:#010x}')
+    else:
+        for reg, expected_value in expected_regs.items():
+            actual_value = actual_regs.get(reg, None)
+            if actual_value != expected_value:
+                if reg.startswith('w'):
+                    expected_str = f'{expected_value:#066x}'
+                    actual_str = f'{actual_value:#066x}'
+                else:
+                    expected_str = f'{expected_value:#010x}'
+                    actual_str = f'{actual_value:#010x}'
+                result.err(f'Mismatch for register {reg}:\n'
+                           f'  Expected: {expected_str}\n'
+                           f'  Actual:   {actual_str}')
+
+    if result.has_errors() or result.has_warnings() or args.verbose:
+        print(result.report())
+
+    return 1 if result.has_errors() else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hw/ip/otbn/util/shared/BUILD
+++ b/hw/ip/otbn/util/shared/BUILD
@@ -166,6 +166,11 @@ py_library(
 )
 
 py_library(
+    name = "reg_dump",
+    srcs = ["reg_dump.py"],
+)
+
+py_library(
     name = "section",
     srcs = ["section.py"],
     deps = [

--- a/hw/ip/otbn/util/shared/reg_dump.py
+++ b/hw/ip/otbn/util/shared/reg_dump.py
@@ -1,0 +1,45 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+from typing import Dict
+
+_REG_RE = re.compile(r'\s*([a-zA-Z0-9_]+)\s*=\s*((:?0x[0-9a-f]+)|([0-9]+))$')
+
+
+def parse_reg_dump(dump: str) -> Dict[str, int]:
+    '''Parse the output from a register dump.
+
+    Expects all non-empty lines of the dump to be in the form <name> = <value>,
+    e.g.
+      x0 = 0x00000000
+      x1 = 0x11111111
+      ...
+
+    Registers may appear in any order and values may be hexadecimal or decimal
+    integers. Comments use '#'; any content in a line following '#' will be
+    ignored.
+
+    Returns a dictionary mapping register names to their integer values.
+    '''
+
+    out = {}
+    for line in dump.split('\n'):
+        # Remove comments and ignore blank lines.
+        line = line.split('#', 1)[0].strip()
+        if not line:
+            continue
+        m = _REG_RE.match(line)
+        if not m:
+            raise ValueError(f'Failed to parse reg dump line ({line:!r}).')
+        reg = m.group(1)
+        value = int(m.group(2), 0)
+
+        if reg in out:
+            raise ValueError(f'Register dump contains multiple values '
+                             f'for {reg}.')
+        out[reg] = value
+
+    return out


### PR DESCRIPTION
Previously, the Bazel rule for OTBN simulator tests worked by creating a hardcoded script that grepped the simulator's register dump for `w0 = 0x0000000000000000000000000000`. This meant that tests all had to be written so that `w0` would be 0 if they passed (i.e. manually checking all the expected values). Practically, we have a lot of tests that haven't been ported to this format, so there are a lot of OTBN tests that a) can't be run via Bazel and b) rely on human eyeballs checking the register dump against expected values in comments. Additionally, if the program executed early due to an error, the Bazel test would still pass as long as `w0` was 0, which is of course not ideal.

This PR simplifies that setup as described in https://github.com/lowRISC/opentitan/issues/12223, plus some extra logic for error-handling:
- I modified the simulator register dump to also print the special registers `ERR_BITS`, `INSN_CNT`, and `STOP_PC`. This allows tests to set specific expectations for when and how the program will stop.
- I moved some code from the DV `simple_test.py` script to `hw/ip/otbn/util/shared` so it could be imported both by `simple_test` and by the new wrapper.
- I created `otbn_sim_test.py`, a thin wrapper along the lines of `simple_test.py` which takes in a file with expected register values and compares its values to the simulator's results.
- As a temporary measure, I set the `otbn_sim_test` rule to create an expected-values file that always says `w0=0`; creating expected-values files for existing tests will come in a follow-up PR.