### PR TITLE
[i2c dif] Add functions to control i2c device

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -126,11 +126,11 @@
       fields: [
         { bits: "0"
           name: "FMTFULL"
-          desc: "FMT buffer is full"
+          desc: "FMT FIFO is full"
         }
         { bits: "1"
           name: "RXFULL"
-          desc: "RX buffer is full"
+          desc: "RX FIFO is full"
         }
         { bits: "2"
           name: "FMTEMPTY"

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -351,17 +351,21 @@ module i2c_fsm (
 
   // State definitions
   typedef enum logic [5:0] {
-    Idle, PopFmtFifo, SetupStart, HoldStart, SetupStop, HoldStop,
-        ClockLow, SetupBit, ClockPulse, HoldBit,
-        ClockLowAck, SetupDevAck, ClockPulseAck, HoldDevAck,
-        ReadClockLow, ReadSetupBit, ReadClockPulse, ReadHoldBit,
-        HostClockLowAck, HostSetupBitAck, HostClockPulseAck, HostHoldBitAck,
-        Active, ClockStart, ClockStop,
-        AcquireStart, AddrRead, AddrAckWait, AddrAckSetup, AddrAckPulse, AddrAckHold,
-        TransmitWait, TransmitSetup, TransmitPulse, TransmitHold, TransmitAck,
-        AcquireByte, AcquireAckWait, AcquireAckSetup, AcquireAckPulse, AcquireAckHold,
-        PopTxFifo, AcquireSrP, StretchTxEmpty, StretchAcqFull, StretchAddrTransmit,
-        StretchAddrAcquire
+    // Shared between all modes
+    Idle,
+    // Exclusive to host mode
+    PopFmtFifo, SetupStart, HoldStart, SetupStop, HoldStop,
+    ClockLow, SetupBit, ClockPulse, HoldBit,
+    ClockLowAck, SetupDevAck, ClockPulseAck, HoldDevAck,
+    ReadClockLow, ReadSetupBit, ReadClockPulse, ReadHoldBit,
+    HostClockLowAck, HostSetupBitAck, HostClockPulseAck, HostHoldBitAck,
+    Active, ClockStart, ClockStop,
+    // Exclusive to device mode
+    AcquireStart, AddrRead, AddrAckWait, AddrAckSetup, AddrAckPulse, AddrAckHold,
+    TransmitWait, TransmitSetup, TransmitPulse, TransmitHold, TransmitAck,
+    AcquireByte, AcquireAckWait, AcquireAckSetup, AcquireAckPulse, AcquireAckHold,
+    PopTxFifo, AcquireSrP, StretchTxEmpty, StretchAcqFull, StretchAddrTransmit,
+    StretchAddrAcquire
   } state_e;
 
   state_e state_q, state_d;

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -256,7 +256,8 @@
             - Program the I2C to be in device mode.
             - The testbench writes a known payload over the chip's I2C device interface, which is
               received and verified by the SW test for correctness.
-            - SW validates the reception of RX watermark and trans complete interrupts.
+            - The testbench reads and verifies a known payload over the chip's I2C device interface,
+            - SW validates the reception of tx empty and trans complete interrupts.
             - Verify the virtual / true open drain capability.
 
             Verify all instances of I2C in the chip.

--- a/sw/device/lib/dif/dif_i2c_unittest.cc
+++ b/sw/device/lib/dif/dif_i2c_unittest.cc
@@ -46,6 +46,39 @@ std::ostream &operator<<(std::ostream &os, const dif_i2c_config_t &params) {
             << "}";
 }
 
+// We define global namespace == and << to make `dif_i2c_status_t` work
+// nicely with EXPECT_EQ.
+bool operator==(dif_i2c_status_t a, dif_i2c_status_t b) {
+  return a.enable_host == b.enable_host && a.enable_target == b.enable_target &&
+         a.line_loopback == b.line_loopback &&
+         a.fmt_fifo_full == b.fmt_fifo_full &&
+         a.rx_fifo_full == b.rx_fifo_full &&
+         a.fmt_fifo_empty == b.fmt_fifo_empty &&
+         a.rx_fifo_empty == b.rx_fifo_empty && a.host_idle == b.host_idle &&
+         a.target_idle == b.target_idle && a.tx_fifo_full == b.tx_fifo_full &&
+         a.acq_fifo_full == b.acq_fifo_full &&
+         a.tx_fifo_empty == b.tx_fifo_empty &&
+         a.acq_fifo_empty == b.acq_fifo_empty;
+}
+
+std::ostream &operator<<(std::ostream &os, const dif_i2c_status_t &params) {
+  return os << "{\n"
+            << "  .enable_host = " << params.enable_host << ",\n"
+            << "  .enable_target = " << params.enable_target << ",\n"
+            << "  .line_loopback = " << params.line_loopback << ",\n"
+            << "  .fmt_fifo_full = " << params.fmt_fifo_full << ",\n"
+            << "  .rx_fifo_full = " << params.rx_fifo_full << ",\n"
+            << "  .fmt_fifo_empty = " << params.fmt_fifo_empty << ",\n"
+            << "  .rx_fifo_empty = " << params.rx_fifo_empty << ",\n"
+            << "  .host_idle = " << params.host_idle << ",\n"
+            << "  .target_idle = " << params.target_idle << ",\n"
+            << "  .tx_fifo_full = " << params.tx_fifo_full << ",\n"
+            << "  .acq_fifo_full = " << params.acq_fifo_full << ",\n"
+            << "  .tx_fifo_empty = " << params.tx_fifo_empty << ",\n"
+            << "  .acq_fifo_empty = " << params.acq_fifo_empty << ",\n"
+            << "}";
+}
+
 namespace dif_i2c_unittest {
 namespace {
 using ::mock_mmio::LeInt;
@@ -278,9 +311,28 @@ TEST_F(ConfigTest, NormalInit) {
       });
 
   EXPECT_DIF_OK(dif_i2c_configure(&i2c_, config));
+
+  dif_i2c_status status, expectedStatus;
+  EXPECT_READ32(I2C_CTRL_REG_OFFSET, 0x00000003);    // Host and Target active
+  EXPECT_READ32(I2C_STATUS_REG_OFFSET, 0x0000033c);  // All empty and idle
+  EXPECT_DIF_OK(dif_i2c_get_status(&i2c_, &status));
+  expectedStatus = {
+      .enable_host = true,
+      .enable_target = true,
+      .fmt_fifo_empty = true,
+      .rx_fifo_empty = true,
+      .host_idle = true,
+      .target_idle = true,
+      .tx_fifo_empty = true,
+      .acq_fifo_empty = true,
+  };
+  EXPECT_EQ(status, expectedStatus);
 }
 
 TEST_F(ConfigTest, NullArgs) {
+  dif_i2c_status status;
+  EXPECT_DIF_BADARG(dif_i2c_get_status(nullptr, &status));
+  EXPECT_DIF_BADARG(dif_i2c_get_status(&i2c_, nullptr));
   EXPECT_DIF_BADARG(dif_i2c_configure(nullptr, {}));
 }
 
@@ -304,6 +356,26 @@ TEST_F(FifoCtrlTest, FmtReset) {
 
 TEST_F(FifoCtrlTest, FmtNullArgs) {
   EXPECT_DIF_BADARG(dif_i2c_reset_fmt_fifo(nullptr));
+}
+
+TEST_F(FifoCtrlTest, AcqReset) {
+  EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
+                {{I2C_FIFO_CTRL_ACQRST_BIT, 0x1, 0x1}});
+  EXPECT_DIF_OK(dif_i2c_reset_acq_fifo(&i2c_));
+}
+
+TEST_F(FifoCtrlTest, AcqNullArgs) {
+  EXPECT_DIF_BADARG(dif_i2c_reset_acq_fifo(nullptr));
+}
+
+TEST_F(FifoCtrlTest, TxReset) {
+  EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
+                {{I2C_FIFO_CTRL_TXRST_BIT, 0x1, 0x1}});
+  EXPECT_DIF_OK(dif_i2c_reset_tx_fifo(&i2c_));
+}
+
+TEST_F(FifoCtrlTest, TxNullArgs) {
+  EXPECT_DIF_BADARG(dif_i2c_reset_tx_fifo(nullptr));
 }
 
 TEST_F(FifoCtrlTest, SetLevels) {
@@ -378,6 +450,31 @@ TEST_F(ControlTest, HostEnableNullArgs) {
   EXPECT_DIF_BADARG(dif_i2c_host_set_enabled(nullptr, kDifToggleEnabled));
 }
 
+TEST_F(ControlTest, DeviceEnable) {
+  EXPECT_MASK32(I2C_CTRL_REG_OFFSET, {{I2C_CTRL_ENABLETARGET_BIT, 0x1, 0x1}});
+  EXPECT_DIF_OK(dif_i2c_device_set_enabled(&i2c_, kDifToggleEnabled));
+
+  EXPECT_MASK32(I2C_CTRL_REG_OFFSET, {{I2C_CTRL_ENABLETARGET_BIT, 0x1, 0x0}});
+  EXPECT_DIF_OK(dif_i2c_device_set_enabled(&i2c_, kDifToggleDisabled));
+}
+
+TEST_F(ControlTest, DeviceEnableNullArgs) {
+  EXPECT_DIF_BADARG(dif_i2c_device_set_enabled(nullptr, kDifToggleEnabled));
+}
+
+TEST_F(ControlTest, LLPBK) {
+  EXPECT_MASK32(I2C_CTRL_REG_OFFSET, {{I2C_CTRL_LLPBK_BIT, 0x1, 0x1}});
+  EXPECT_DIF_OK(dif_i2c_line_loopback_set_enabled(&i2c_, kDifToggleEnabled));
+
+  EXPECT_MASK32(I2C_CTRL_REG_OFFSET, {{I2C_CTRL_LLPBK_BIT, 0x1, 0x0}});
+  EXPECT_DIF_OK(dif_i2c_line_loopback_set_enabled(&i2c_, kDifToggleDisabled));
+}
+
+TEST_F(ControlTest, LLPBKNullArgs) {
+  EXPECT_DIF_BADARG(
+      dif_i2c_line_loopback_set_enabled(nullptr, kDifToggleEnabled));
+}
+
 class OverrideTest : public I2cTest {};
 
 TEST_F(OverrideTest, Enable) {
@@ -444,28 +541,69 @@ TEST_F(OverrideTest, SampleNullArgs) {
 class FifoTest : public I2cTest {};
 
 TEST_F(FifoTest, GetLevels) {
-  uint8_t rx, fmt;
+  uint8_t rx, fmt, tx, acq;
   EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
-  EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, &rx, &fmt));
-  EXPECT_EQ(rx, 0x47);
-  EXPECT_EQ(fmt, 0x29);
+  EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, &fmt, &rx, &tx, &acq));
+  EXPECT_EQ(fmt, 0x47);
+  EXPECT_EQ(rx, 0x29);
+  EXPECT_EQ(tx, 0x38);
+  EXPECT_EQ(acq, 0x10);
 
-  rx = 0, fmt = 0;
+  rx = 0, fmt = 0, tx = 0, acq = 0;
   EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
-  EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, nullptr, &fmt));
+  EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, &fmt, &rx, nullptr, nullptr));
+  EXPECT_EQ(fmt, 0x47);
+  EXPECT_EQ(rx, 0x29);
+  EXPECT_EQ(tx, 0x0);
+  EXPECT_EQ(acq, 0x0);
+
+  rx = 0, fmt = 0, tx = 0, acq = 0;
+  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_DIF_OK(
+      dif_i2c_get_fifo_levels(&i2c_, &fmt, nullptr, nullptr, nullptr));
   EXPECT_EQ(rx, 0x0);
-  EXPECT_EQ(fmt, 0x29);
+  EXPECT_EQ(fmt, 0x47);
+  EXPECT_EQ(tx, 0x0);
+  EXPECT_EQ(acq, 0x0);
 
-  rx = 0, fmt = 0;
+  rx = 0, fmt = 0, tx = 0, acq = 0;
   EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
-  EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, &rx, nullptr));
-  EXPECT_EQ(rx, 0x47);
+  EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, nullptr, &rx, nullptr, nullptr));
+  EXPECT_EQ(rx, 0x29);
   EXPECT_EQ(fmt, 0x0);
+  EXPECT_EQ(tx, 0x0);
+  EXPECT_EQ(acq, 0x0);
+
+  rx = 0, fmt = 0, tx = 0, acq = 0;
+  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, nullptr, nullptr, &tx, &acq));
+  EXPECT_EQ(fmt, 0x0);
+  EXPECT_EQ(rx, 0x0);
+  EXPECT_EQ(tx, 0x38);
+  EXPECT_EQ(acq, 0x10);
+
+  rx = 0, fmt = 0, tx = 0, acq = 0;
+  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, nullptr, nullptr, &tx, nullptr));
+  EXPECT_EQ(rx, 0x0);
+  EXPECT_EQ(fmt, 0x0);
+  EXPECT_EQ(tx, 0x38);
+  EXPECT_EQ(acq, 0x0);
+
+  rx = 0, fmt = 0, tx = 0, acq = 0;
+  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_DIF_OK(
+      dif_i2c_get_fifo_levels(&i2c_, nullptr, nullptr, nullptr, &acq));
+  EXPECT_EQ(rx, 0x0);
+  EXPECT_EQ(fmt, 0x0);
+  EXPECT_EQ(tx, 0x0);
+  EXPECT_EQ(acq, 0x10);
 }
 
 TEST_F(FifoTest, GetLevelsNullArgs) {
   uint8_t rx, fmt;
-  EXPECT_DIF_BADARG(dif_i2c_get_fifo_levels(nullptr, &rx, &fmt));
+  EXPECT_DIF_BADARG(
+      dif_i2c_get_fifo_levels(nullptr, &rx, &fmt, nullptr, nullptr));
 }
 
 TEST_F(FifoTest, Read) {
@@ -488,9 +626,35 @@ TEST_F(FifoTest, ReadNullArgs) {
   EXPECT_DIF_BADARG(dif_i2c_read_byte(nullptr, &val));
 }
 
-// NOTE: `false` settings on the below designated initializers are only
-// for a workaround in GCC 5, and should be removed once the host toolchain is
-// upgraded.
+TEST_F(FifoTest, Acquire) {
+  uint8_t val;
+  dif_i2c_signal_t signal;
+
+  EXPECT_READ32(I2C_ACQDATA_REG_OFFSET, 0x0ab);
+  EXPECT_READ32(I2C_ACQDATA_REG_OFFSET, 0x3cd);
+  EXPECT_READ32(I2C_ACQDATA_REG_OFFSET, 0x2ef);
+  EXPECT_READ32(I2C_ACQDATA_REG_OFFSET, 0x101);
+
+  EXPECT_DIF_OK(dif_i2c_acquire_byte(&i2c_, &val, &signal));
+  EXPECT_EQ(val, 0xab);
+  EXPECT_EQ(signal, kDifI2cSignalNone);
+  EXPECT_DIF_OK(dif_i2c_acquire_byte(&i2c_, &val, &signal));
+  EXPECT_EQ(val, 0xcd);
+  EXPECT_EQ(signal, kDifI2cSignalRepeat);
+  EXPECT_DIF_OK(dif_i2c_acquire_byte(&i2c_, nullptr, &signal));
+  EXPECT_EQ(val, 0xcd);
+  EXPECT_EQ(signal, kDifI2cSignalStop);
+  EXPECT_DIF_OK(dif_i2c_acquire_byte(&i2c_, &val, nullptr));
+  EXPECT_EQ(val, 0x01);
+  EXPECT_EQ(signal, kDifI2cSignalStop);
+}
+
+TEST_F(FifoTest, AcqNullArgs) {
+  uint8_t val;
+  dif_i2c_signal_t signal;
+
+  EXPECT_DIF_BADARG(dif_i2c_acquire_byte(nullptr, &val, &signal));
+}
 
 TEST_F(FifoTest, WriteRaw) {
   EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
@@ -514,10 +678,7 @@ TEST_F(FifoTest, WriteRaw) {
                                        });
   EXPECT_DIF_OK(dif_i2c_write_byte_raw(&i2c_, 0x66,
                                        {
-                                           .start = false,
                                            .stop = true,
-                                           .read = false,
-                                           .read_cont = false,
                                            .suppress_nak_irq = true,
                                        }));
 
@@ -528,8 +689,6 @@ TEST_F(FifoTest, WriteRaw) {
                                        });
   EXPECT_DIF_OK(dif_i2c_write_byte_raw(&i2c_, 0x00,
                                        {
-                                           .start = false,
-                                           .stop = false,
                                            .read = true,
                                            .read_cont = true,
                                        }));
@@ -540,8 +699,6 @@ TEST_F(FifoTest, WriteRaw) {
                                        });
   EXPECT_DIF_OK(dif_i2c_write_byte_raw(&i2c_, 0x77,
                                        {
-                                           .start = false,
-                                           .stop = false,
                                            .read = true,
                                        }));
 }
@@ -551,17 +708,131 @@ TEST_F(FifoTest, WriteRawBadArgs) {
   EXPECT_DIF_BADARG(dif_i2c_write_byte_raw(&i2c_, 0xff,
                                            {
                                                .start = true,
-                                               .stop = false,
                                                .read = true,
                                            }));
   EXPECT_DIF_BADARG(dif_i2c_write_byte_raw(&i2c_, 0xff,
                                            {
-                                               .start = false,
-                                               .stop = false,
-                                               .read = false,
                                                .read_cont = true,
                                                .suppress_nak_irq = true,
                                            }));
+}
+
+TEST_F(FifoTest, TransmitByte) {
+  EXPECT_WRITE32(I2C_TXDATA_REG_OFFSET, 0x00000044);
+  EXPECT_DIF_OK(dif_i2c_transmit_byte(&i2c_, 0x44));
+}
+
+TEST_F(FifoTest, TransmitBadArgs) {
+  EXPECT_DIF_BADARG(dif_i2c_transmit_byte(nullptr, 0xff));
+}
+
+class StretchTest : public I2cTest {};
+
+TEST_F(StretchTest, ConfigTimeouts) {
+  EXPECT_WRITE32(I2C_TIMEOUT_CTRL_REG_OFFSET, 0x81234567);
+  EXPECT_DIF_OK(dif_i2c_enable_clock_stretching_timeout(
+      &i2c_, kDifToggleEnabled, 0x01234567));
+  EXPECT_WRITE32(I2C_HOST_TIMEOUT_CTRL_REG_OFFSET, 0x81234567);
+  EXPECT_DIF_OK(dif_i2c_set_host_timeout(&i2c_, 0x81234567));
+}
+
+TEST_F(StretchTest, ConfigTimeoutsBadArgs) {
+  EXPECT_DIF_BADARG(dif_i2c_enable_clock_stretching_timeout(
+      nullptr, kDifToggleEnabled, 0x01234567));
+  EXPECT_DIF_BADARG(dif_i2c_set_host_timeout(nullptr, 0x81234567));
+}
+
+TEST_F(StretchTest, DeviceSchedulesStretches) {
+  EXPECT_READ32(I2C_STRETCH_CTRL_REG_OFFSET, 0x00);
+  EXPECT_WRITE32(I2C_STRETCH_CTRL_REG_OFFSET,
+                 {
+                     {I2C_STRETCH_CTRL_EN_ADDR_TX_BIT, 0x1},
+                     {I2C_STRETCH_CTRL_EN_ADDR_ACQ_BIT, 0x0},
+                 });
+  EXPECT_DIF_OK(
+      dif_i2c_config_stretch(&i2c_, kDifToggleEnabled, kDifToggleDisabled));
+
+  EXPECT_READ32(I2C_STRETCH_CTRL_REG_OFFSET, 0x01);
+  EXPECT_WRITE32(I2C_STRETCH_CTRL_REG_OFFSET,
+                 {
+                     {I2C_STRETCH_CTRL_EN_ADDR_TX_BIT, 0x0},
+                     {I2C_STRETCH_CTRL_EN_ADDR_ACQ_BIT, 0x1},
+                 });
+  EXPECT_DIF_OK(
+      dif_i2c_config_stretch(&i2c_, kDifToggleDisabled, kDifToggleEnabled));
+
+  EXPECT_READ32(I2C_STRETCH_CTRL_REG_OFFSET, 0x02);
+  EXPECT_WRITE32(I2C_STRETCH_CTRL_REG_OFFSET,
+                 {
+                     {I2C_STRETCH_CTRL_STOP_TX_BIT, 0x1},
+                     {I2C_STRETCH_CTRL_STOP_ACQ_BIT, 0x0},
+                     {I2C_STRETCH_CTRL_EN_ADDR_ACQ_BIT, 0x1},
+                 });
+  EXPECT_DIF_OK(
+      dif_i2c_stop_stretch(&i2c_, kDifToggleEnabled, kDifToggleDisabled));
+
+  EXPECT_READ32(I2C_STRETCH_CTRL_REG_OFFSET, 0x06);
+  EXPECT_WRITE32(I2C_STRETCH_CTRL_REG_OFFSET,
+                 {
+                     {I2C_STRETCH_CTRL_STOP_TX_BIT, 0x1},
+                     {I2C_STRETCH_CTRL_STOP_ACQ_BIT, 0x1},
+                     {I2C_STRETCH_CTRL_EN_ADDR_ACQ_BIT, 0x1},
+                 });
+  EXPECT_DIF_OK(
+      dif_i2c_stop_stretch(&i2c_, kDifToggleDisabled, kDifToggleEnabled));
+}
+
+TEST_F(StretchTest, DeviceStretchBadArgs) {
+  EXPECT_DIF_BADARG(
+      dif_i2c_config_stretch(nullptr, kDifToggleEnabled, kDifToggleEnabled));
+  EXPECT_DIF_BADARG(
+      dif_i2c_stop_stretch(nullptr, kDifToggleEnabled, kDifToggleEnabled));
+}
+
+// Assemble 2 Ids to the byte to form the expections checked in the address test
+uint32_t assemble_address(dif_i2c_id_t *id0, dif_i2c_id_t *id1) {
+  uint32_t config = 0x00000000;
+  if (id0 == NULL) {
+    config = bitfield_field32_write(config, I2C_TARGET_ID_ADDRESS0_FIELD, 0x7f);
+  } else {
+    config = bitfield_field32_write(config, I2C_TARGET_ID_ADDRESS0_FIELD,
+                                    id0->address);
+    config =
+        bitfield_field32_write(config, I2C_TARGET_ID_MASK0_FIELD, id0->mask);
+  }
+
+  if (id1 == NULL) {
+    config = bitfield_field32_write(config, I2C_TARGET_ID_ADDRESS1_FIELD, 0x7f);
+  } else {
+    config = bitfield_field32_write(config, I2C_TARGET_ID_ADDRESS1_FIELD,
+                                    id1->address);
+    config =
+        bitfield_field32_write(config, I2C_TARGET_ID_MASK1_FIELD, id1->mask);
+  }
+  return config;
+}
+
+class AddressTest : public I2cTest {};
+TEST_F(AddressTest, SetDeviceAddress) {
+  // dif_i2c_id_t id0 = NULL, id1 = NULL;
+  EXPECT_WRITE32(I2C_TARGET_ID_REG_OFFSET, assemble_address(nullptr, nullptr));
+  EXPECT_DIF_OK(dif_i2c_set_device_id(&i2c_, nullptr, nullptr));
+
+  dif_i2c_id_t id0 = {.mask = 0x12, .address = 0x34};
+  EXPECT_WRITE32(I2C_TARGET_ID_REG_OFFSET, assemble_address(&id0, nullptr));
+  EXPECT_DIF_OK(dif_i2c_set_device_id(&i2c_, &id0, nullptr));
+
+  dif_i2c_id_t id1 = {.mask = 0x56, .address = 0x78};
+  EXPECT_WRITE32(I2C_TARGET_ID_REG_OFFSET, assemble_address(nullptr, &id1));
+  EXPECT_DIF_OK(dif_i2c_set_device_id(&i2c_, nullptr, &id1));
+
+  EXPECT_WRITE32(I2C_TARGET_ID_REG_OFFSET, assemble_address(&id0, &id1));
+  EXPECT_DIF_OK(dif_i2c_set_device_id(&i2c_, &id0, &id1));
+}
+
+TEST_F(AddressTest, SetAddressBadArgs) {
+  dif_i2c_id_t id0, id1;
+  EXPECT_DIF_BADARG(dif_i2c_set_device_id(nullptr, &id0, &id1));
 }
 
 }  // namespace

--- a/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
@@ -174,7 +174,8 @@ bool test_main(void) {
 
   // Make sure all fifo entries have been drained.
   do {
-    CHECK_DIF_OK(dif_i2c_get_fifo_levels(&i2c, &tx_fifo_lvl, &rx_fifo_lvl));
+    CHECK_DIF_OK(
+        dif_i2c_get_fifo_levels(&i2c, &tx_fifo_lvl, &rx_fifo_lvl, NULL, NULL));
   } while (tx_fifo_lvl > 0);
   CHECK(fmt_irq_seen);
   fmt_irq_seen = false;
@@ -185,7 +186,8 @@ bool test_main(void) {
 
   // Make sure all data has been read back.
   do {
-    CHECK_DIF_OK(dif_i2c_get_fifo_levels(&i2c, &tx_fifo_lvl, &rx_fifo_lvl));
+    CHECK_DIF_OK(
+        dif_i2c_get_fifo_levels(&i2c, &tx_fifo_lvl, &rx_fifo_lvl, NULL, NULL));
   } while (rx_fifo_lvl < byte_count);
   CHECK(rx_irq_seen);
 


### PR DESCRIPTION
* Changed documentation references to consistently refer to FMT and RX buffers as FIFOs when applying names and short descriptions
* Added a documentation referring to ability to reset the I2C block (because it might be useful)
* Changed documentation references to RESTART to repeated START to make them more consistent with I2C standards
* Annotated states with Shared, host and device mode to help track which features acted in which modes
* Updated header for i2c_dif to support device mode and clarify which registers control which modes
* corrected FIFO references in device tx rx test portion of testplan and added requirement to perform an I2C read

This will then support the i2c_device_tx_rx_test

The header and implementation should reflect what I think is necessary to get the DIFs to where they achieve the standards in S2
Fixes: #14931

Signed-off-by: Drew Macrae <drewmacrae@google.com>