### PR TITLE
feat(chip_sw_base_vseq): function to finish chip test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -533,6 +533,20 @@ class chip_sw_base_vseq extends chip_base_vseq;
     end
   endfunction
 
+  // End the test with status.
+  //
+  // SW test code finishes the test sequence usually by returing true or false
+  // in the `test_main()` function. However, some tests may need vseq to
+  // finish the tests. For example, `chip_sw_sleep_pin_mio_dio_val` checks the
+  // PADs output value then finishes the test without waking up the SW again.
+  //
+  // If pass is 1, then `sw_test_status` is set to SwTestStatusPassed.
+  virtual function void override_test_status_and_finish(bit passed);
+    cfg.sw_test_status_vif.sw_test_status = (passed) ? SwTestStatusPassed
+                                                     : SwTestStatusFailed;
+    cfg.sw_test_status_vif.sw_test_done   = 1'b 1;
+  endfunction : override_test_status_and_finish
+
   task assert_por_reset_deep_sleep (int delay = 0);
     repeat (delay) @cfg.chip_vif.pwrmgr_low_power_if.cb;
     cfg.chip_vif.por_n_if.drive(0);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv
@@ -70,8 +70,7 @@ class chip_sw_flash_ctrl_lc_rw_en_vseq extends chip_sw_base_vseq;
                          "Mismatch for exepcted rw_en value [%0d] in Scrap LC state", i)
     end
 
-    cfg.sw_test_status_vif.sw_test_status = SwTestStatusPassed;
-    cfg.sw_test_status_vif.sw_test_done   = 1'b1;
+    override_test_status_and_finish(.passed(1'b 1));
 
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
@@ -49,8 +49,7 @@ class chip_sw_rom_ctrl_integrity_check_vseq extends chip_sw_base_vseq;
       end
       begin
         #(TimeoutNs * 1ns);
-        cfg.sw_test_status_vif.sw_test_status = SwTestStatusPassed;
-        cfg.sw_test_status_vif.sw_test_done   = 1'b1;
+        override_test_status_and_finish(.passed(1'b 1));
       end
     join_any
     disable fork;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv
@@ -48,8 +48,7 @@ class chip_sw_sram_ctrl_execution_main_vseq extends chip_sw_base_vseq;
     // State 3 - SRAM_IFETCH = True, LC_STATE = LcStProd.
     do_test(MUBI8TRUE, 1);
 
-    cfg.sw_test_status_vif.sw_test_status = SwTestStatusPassed;
-    cfg.sw_test_status_vif.sw_test_done   = 1'b1;
+    override_test_status_and_finish(.passed(1'b 1));
 
   endtask
 


### PR DESCRIPTION
This commit implements a virtual function in `chip_sw_base_vseq.sv`, which can finish the test with Pass/Fail status.

Usually, SW test code decides if the test is finished or not by exiting the `test_main()` function. In some tests, SW may stay in low power mode or doing other stuff and UVM tb checks the result. In this case, by calling the function, the test can be finished without any extra latency of waking up the SW (including boot sequence).
