### PR TITLE
fix(chip_if): Direct disconnect for ext_clk_rst

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -640,7 +640,10 @@ interface chip_if;
     for (int i = 0; i < NUM_UARTS; i++) enable_uart(.inst_num(i), .enable(0));
     for (int i = 0; i < NUM_SPI_HOSTS; i++) enable_spi_device(.inst_num(i), .enable(0));
     for (int i = 0; i < NUM_I2CS; i++) enable_i2c(.inst_num(i), .enable(0));
-    ext_clk_if.set_active(0, 0);
+
+    // Set Active only can be called @ t=0
+    ext_clk_if.drive_clk   = 1'b 0;
+    ext_clk_if.drive_rst_n = 1'b 0;
   endfunction
 
   // Verifies an LC control signal broadcast by the LC controller.


### PR DESCRIPTION
vseq can only call `set_active()` function in `clk_rst_if.sv` at t=0. This commit revises disconnect_all_interfaces() to avoid the fatal error.