### PR TITLE
[spi_device/dv] Update spi_agent interface

### DIFF
--- a/hw/dv/sv/spi_agent/spi_if.sv
+++ b/hw/dv/sv/spi_agent/spi_if.sv
@@ -6,13 +6,18 @@ interface spi_if
   import spi_agent_pkg::*;
   import uvm_pkg::*;
 (
-  input rst_n
+  input rst_n,
+  inout wire [3:0] sio
 );
-
   // standard spi interface pins
   logic       sck;
   logic [CSB_WIDTH-1:0] csb;
-  logic [3:0] sio;
+
+  // spi host drives sio to x when idle. release to z in case the io is used for other peripheral
+  bit disconnected;
+
+  logic [3:0] sio_out;
+  assign sio = disconnected ? 'z : sio_out;
 
   // debug signals
   logic [7:0] host_byte;
@@ -27,6 +32,10 @@ interface spi_if
   //---------------------------------
   // common tasks
   //---------------------------------
+  function automatic void disconnect(bit set_disconnect = 1);
+    disconnected = set_disconnect;
+  endfunction : disconnect
+
   task automatic wait_for_clks(int clks);
     repeat (clks) @(posedge sck);
   endtask : wait_for_clks

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -174,18 +174,17 @@ interface chip_if;
 
 
   // Functional (dedicated) interface: SPI host interface (drives traffic into the chip).
-  // TODO: Update spi_if to emit all signals as inout ports.
-  // spi_if spi_host_if(.rst_n(`SPI_DEVICE_HIER.rst_ni),
-  //                    .sck(ios[SpiDevClk]),
-  //                    .csb(ios[SpiDevCsL]),
-  //                    .sio(ios[SpiDevD3:SpiDevD0]));
-
-  bit enable_spi_host;
-  spi_if spi_host_if(.rst_n(`SPI_DEVICE_HIER.rst_ni));
+  bit enable_spi_host = 1;
+  spi_if spi_host_if(.rst_n(`SPI_DEVICE_HIER.rst_ni),
+                     .sio({ios[SpiDevD3], ios[SpiDevD2], ios[SpiDevD1], ios[SpiDevD0]}));
   assign ios[SpiDevClk] = enable_spi_host ? spi_host_if.sck : 1'bz;
   assign ios[SpiDevCsL] = enable_spi_host ? spi_host_if.csb : 1'bz;
-  assign ios[SpiDevD0] = enable_spi_host ? spi_host_if.sio[0] : 1'bz;
-  assign spi_host_if.sio[1] = enable_spi_host ? ios[SpiDevD1] : 1'bz;
+  initial begin
+    do begin
+      spi_host_if.disconnect(!enable_spi_host);
+      @(enable_spi_host);
+    end while (1);
+  end
 
   // Functional (dedicated) interface: SPI device 0 interface (receives traffic from the chip).
   // TODO: Update spi_if to emit all signals as inout ports.
@@ -616,6 +615,8 @@ interface chip_if;
   // Provides the test sequence a fresh start to connect specific interfaces needed by the test.
   // The por_n_if is exempt from this. The disconnection of default pulls using ios_if is
   // conditioned on the `disconnect_default_pulls` arg.
+  // spi_host isn't disconnected in this function as it uses dedicated IOs and default connected
+  // also CSB should be high to put it inactive. Set enable_spi_host = 0 explicitely when needed.
   function automatic void disconnect_all_interfaces(bit disconnect_default_pulls);
     `uvm_info(MsgId, "Disconnecting all interfaces from the chip IOs", UVM_LOW)
     if (disconnect_default_pulls) ios_if.disconnect();
@@ -623,7 +624,6 @@ interface chip_if;
     flash_test_volt_if.disconnect();
     flash_test_mode_if.disconnect();
     otp_ext_volt_if.disconnect();
-    enable_spi_host = 0;
     ec_rst_l_if.disconnect();
     flash_wp_l_if.disconnect();
     pwrb_in_if.disconnect();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -27,8 +27,6 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
     void'($value$plusargs("+csr_%0s", csr_test_type));
     // These types of CSR tests are quite long; run them only once.
     if (csr_test_type inside {"bit_bash", "aliasing"}) num_trans = 1;
-    // Connect the dedicated SPI host to avoid CSR mismatches from the SPI device IP.
-    cfg.chip_vif.enable_spi_host = 1;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_tx_rx_vseq.sv
@@ -32,9 +32,6 @@ class chip_sw_spi_tx_rx_vseq extends chip_sw_base_vseq;
     bit [7:0] spi_device_tx_data[$];
     super.body();
 
-    // Connect the SPI host interface to chip IOs.
-    cfg.chip_vif.enable_spi_host = 1;
-
     // Wait SPI_DEVICE filled TX FIFO, otherwise SDO will be X
     cfg.clk_rst_vif.wait_clks(100);
     csr_spinwait(.ptr(ral.spi_device.status.txf_full), .exp_data('b1), .backdoor(1),


### PR DESCRIPTION
1. Updated interface to take sio as inout ports
2. Fixed an issue caused by recent update that SPI host assigns z when it's idle, while the sio[1] is assigned with a DUT output. Thanks @a-will for pointing this out.
3. This enables chip-level to test dual/quad mode on SPI device

Also fixed failed test - chip_sw_spi_device_tx_rx

Signed-off-by: Weicai Yang <weicai@google.com>