### PR TITLE
[dv/kmac] Force random internal mubi values

### DIFF
--- a/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
@@ -93,13 +93,13 @@
       name: sec_cm_logic_integrity
       desc: "Verify the countermeasure(s) LOGIC.INTEGRITY."
       stage: V2S
-      tests: []
+      tests: ["N/A"]
     }
     {
       name: sec_cm_absorbed_ctrl_mubi
       desc: "Verify the countermeasure(s) ABSORBED.CTRL.INTEGRITY"
       stage: V2S
-      tests: []
+      tests: ["{variant}_mubi"]
     }
     {
       name: sec_cm_sw_cmd_ctrl_sparse

--- a/hw/ip/kmac/dv/cov/kmac_cov.core
+++ b/hw/ip/kmac/dv/cov/kmac_cov.core
@@ -2,8 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:kmac_sim:0.1"
-description: "KMAC DV sim target"
+name: "lowrisc:dv:kmac_cov"
+description: "KMAC functional coverage and bind files"
 filesets:
   files_rtl:
     depend:
@@ -11,20 +11,13 @@ filesets:
 
   files_dv:
     depend:
-      - lowrisc:dv:kmac_test
-      - lowrisc:dv:kmac_sva
-      - lowrisc:dv:kmac_cov
+      - lowrisc:dv:dv_utils
     files:
-      - tb.sv
+      - kmac_cov_bind.sv
     file_type: systemVerilogSource
 
 targets:
-  sim: &sim_target
-    toplevel: tb
+  default:
     filesets:
       - files_rtl
       - files_dv
-    default_tool: vcs
-
-  lint:
-    <<: *sim_target

--- a/hw/ip/kmac/dv/cov/kmac_cov_bind.sv
+++ b/hw/ip/kmac/dv/cov/kmac_cov_bind.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module kmac_cov_bind;
+  bind kmac cip_mubi_cov_if #(.Width(4)) kmac_sha3_done_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (sha3_done)
+  );
+
+    bind kmac cip_mubi_cov_if #(.Width(4)) kmac_sha3_absorb_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (sha3_absorbed)
+  );
+
+endmodule

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -39,6 +39,7 @@ filesets:
       - seq_lib/kmac_app_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_app_with_partial_data_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_entropy_refresh_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_mubi_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_key_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_edn_timeout_error_vseq.sv: {is_include_file: true}

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_mubi_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_mubi_vseq.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_mubi_vseq extends kmac_app_vseq;
+
+  `uvm_object_utils(kmac_mubi_vseq)
+  `uvm_object_new
+
+  constraint en_app_c {
+    en_app dist {
+      0 :/ 1,
+      1 :/ 1
+    };
+  }
+
+  virtual task kmac_init(bit wait_init = 1, bit keymgr_app_intf = 0);
+    string sha3_done_path = "tb.dut.sha3_done";
+    string sha3_absorbed_path = "tb.dut.sha3_absorbed";
+    super.kmac_init(wait_init, keymgr_app_intf);
+    // Randomly deposit mubi values to values other than mubi_true.
+    `DV_CHECK_FATAL(
+        uvm_hdl_deposit(sha3_done_path, get_rand_mubi4_val(.t_weight(0), .f_weight(0))))
+    `DV_CHECK_FATAL(
+        uvm_hdl_deposit(sha3_absorbed_path, get_rand_mubi4_val(.t_weight(0), .f_weight(0))))
+  endtask
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_stress_all_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_stress_all_vseq.sv
@@ -16,7 +16,9 @@ class kmac_stress_all_vseq extends kmac_base_vseq;
     // plusarg - excluding them does not detract much from the stress_all test
     "kmac_test_vectors_kmac_vseq",
     "kmac_test_vectors_kmac_xof_vseq",
-    "kmac_app_vseq"
+    "kmac_app_vseq",
+    "kmac_mubi_vseq",
+    "kmac_entropy_refresh_vseq"
   };
 
   virtual task pre_start();

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -15,6 +15,7 @@
 `include "kmac_burst_write_vseq.sv"
 `include "kmac_app_vseq.sv"
 `include "kmac_app_with_partial_data_vseq.sv"
+`include "kmac_mubi_vseq.sv"
 `include "kmac_entropy_refresh_vseq.sv"
 `include "kmac_error_vseq.sv"
 `include "kmac_key_error_vseq.sv"

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -37,7 +37,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["kmac_bind", "sec_cm_prim_onehot_check_bind"]
+  sim_tops: ["kmac_bind", "sec_cm_prim_onehot_check_bind", "kmac_cov_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
@@ -152,6 +152,11 @@
     {
       name: "{variant}_entropy_refresh"
       uvm_test_seq: kmac_entropy_refresh_vseq
+   }
+   {
+      name: "{variant}_mubi"
+      uvm_test_seq: kmac_mubi_vseq
+      reseed: 10
    }
    {
       name: "{variant}_error"


### PR DESCRIPTION
This PR adds a sequence for mubi sec countermeasures to make sure when forcing mubi value to non-true or non-false, the IP behaves as expected.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>