### PR TITLE
[otbn,dv] Add dist to offset in sw_no_acc test

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -568,7 +568,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     // See attempted writes to the bottom and top address in the scratchpad memory
     addr_cp: coverpoint addr {
       bins low  = {OTBN_DMEM_OFFSET + OTBN_DMEM_SIZE};
-      bins high = {OTBN_DMEM_OFFSET + DmemSizeByte - 1};
+      bins high = {OTBN_DMEM_OFFSET + DmemSizeByte - 4};
     }
   endgroup
 


### PR DESCRIPTION
This commit makes it more likely to pick beginning or end of the Scratchpad memory in DMEM.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>

This change is for fixing a coverage hole in daily regression. Resolves https://github.com/lowRISC/opentitan/issues/14973