### PR TITLE
[otbn] Fix-up invalid lifecycle signal modelling in DV

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -456,6 +456,14 @@ interface otbn_trace_if
   assign controller_bad_int_i.state_err = u_otbn_controller.state_error;
   assign controller_bad_int_i.controller_mubi_err = u_otbn_controller.mubi_err_q;
 
+  // Probe Start Stop Control module FSM to inject escalate signals in specific states.
+  otbn_start_stop_state_e otbn_start_stop_state;
+  // Use this to mute Verilator unused errors.
+  otbn_start_stop_state_e unused_start_stop_state;
+
+  assign otbn_start_stop_state = u_otbn_start_stop_control.state_q;
+  assign unused_start_stop_state = otbn_start_stop_state;
+
   // Only define force/release functions if we're not running Verilator. This is because the version
   // we currently use does not support force/release.
   `ifndef VERILATOR

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -578,7 +578,8 @@ class otbn_base_vseq extends cip_base_vseq #(
 
       // Loop warping assumes we're not manipulating the loop stack (i.e. no new loop starting or
       // current loop finishing the same cycle we warp).
-      `DV_CHECK_FATAL(!(cfg.loop_vif.loop_stack_push || cfg.loop_vif.loop_stack_pop))
+      `DV_CHECK_FATAL(!(cfg.loop_vif.loop_stack_push || cfg.loop_vif.loop_stack_pop) &&
+                      !cfg.trace_vif.locking_o)
 
       // Convert loop warp's remaining iteration count to "RTL view"
       new_iters = cfg.loop_vif.loop_count_to_iters(new_count);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_escalate_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_escalate_vseq.sv
@@ -20,7 +20,7 @@ class otbn_escalate_vseq extends otbn_base_vseq;
     `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
 
     // Pick whether we're going to send RMA request or escalation to OTBN.
-    select_rma_req = $urandom_range(1);
+    select_rma_req = $urandom_range(0, 1);
 
     // Pick whether we're going before (5%), during (90%), or after (5%).
     bda_idx = $urandom_range(100);

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -208,15 +208,15 @@ name:
       reseed: 15
     }
 
-    // This test sets the lc_escalate_en_i signal somewhere in the middle of an
-    // operation and makes sure that we see an alert. There's not much
-    // interesting that can happen here, so a small number of seeds should
+    // This test sets the lc_escalate_en_i and lc_rma_req_i signals somewhere in
+    // the middle of an operation and makes sure that we see an alert. There's
+    // not much interesting that can happen here, so a small number of seeds should
     // suffice.
     {
       name: "otbn_escalate"
       uvm_test_seq: "otbn_escalate_vseq"
       en_run_modes: ["build_otbn_rig_binary_mode"]
-      reseed: 10
+      reseed: 20
     }
 
     {

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -216,7 +216,7 @@ name:
       name: "otbn_escalate"
       uvm_test_seq: "otbn_escalate_vseq"
       en_run_modes: ["build_otbn_rig_binary_mode"]
-      reseed: 20
+      reseed: 60
     }
 
     {

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -210,8 +210,8 @@ module tb;
     .cmd_i   (model_if.cmd_q),
     .cmd_en_i(model_if.cmd_qe),
 
-    .lc_escalate_en_i(escalate_if.enable != lc_ctrl_pkg::Off),
-    .lc_rma_req_i    (escalate_if.req != lc_ctrl_pkg::Off),
+    .lc_escalate_en_i(escalate_if.enable),
+    .lc_rma_req_i    (escalate_if.req),
 
     .err_bits_o(model_if.err_bits),
 

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -271,7 +271,11 @@ module tb;
 
   // Check that if the modelled EDN requests are matching with the requests from DUT
   `ASSERT(MatchingReqRND_A, dut.u_otbn_core.edn_rnd_req_o == edn_rnd_req_model, clk, !rst_n)
-  `ASSERT(MatchingReqURND_A, dut.u_otbn_core.edn_urnd_req_o == edn_urnd_req_model, clk, !rst_n)
+  // Disable checking URND in the case of Locked status since it's modelling is not exactly accurate
+  // for that state.
+  // TODO (#15710): Fix modelling of URND in the locked state.
+  `ASSERT(MatchingReqURND_A, dut.u_otbn_core.edn_urnd_req_o == edn_urnd_req_model,
+    clk, !rst_n || model_if.status == otbn_pkg::StatusLocked)
 
   initial begin
     mem_bkdr_util imem_util, dmem_util;

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -359,8 +359,8 @@ module otbn_top_sim (
     .cmd_i                 ( otbn_pkg::CmdExecute ),
     .cmd_en_i              ( otbn_start ),
 
-    .lc_escalate_en_i      ( 1'b0 ),
-    .lc_rma_req_i          ( 1'b0 ),
+    .lc_escalate_en_i      ( lc_ctrl_pkg::Off ),
+    .lc_rma_req_i          ( lc_ctrl_pkg::Off ),
 
     .err_bits_o            ( otbn_model_err_bits ),
 

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1210,16 +1210,17 @@ module otbn
   // 1. urnd_reseed_err disables the assertion because secure wipe finishes with failure and OTBN
   // goes to LOCKED state immediately after this error which means that it's not guaranteed to have
   // secure wiping complete.
-  // 2. bad_internal_state disables the initial internal secure wipe related assertion because a
-  // fatal error affecting internal secure wiping could cause an immediate locking behaviour
-  // in which it's not guaranteed to see all registers initialised.
+  // 2. mubi_err_d of start_stop_control disables the internal secure wipe related assertion
+  // because a fatal error affecting internal secure wiping could cause an immediate locking
+  // behaviour in which it's not guaranteed to see a succesful secure wipe.
   for (genvar i = 2; i < NGpr; ++i) begin : gen_sec_wipe_gpr_asserts
     // Initial secure wipe needs to initialise all registers to nonzero
     `ASSERT(InitSecWipeNonZeroBaseRegs_A,
       $fell(busy_secure_wipe) |->
       u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.g_rf_flops[i].rf_reg_q !=
         EccZeroWord,
-      clk_i, !rst_ni || u_otbn_core.urnd_reseed_err || err_bits.bad_internal_state)
+      clk_i,
+      !rst_ni || u_otbn_core.urnd_reseed_err || u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
     // After execution, it's expected to see a change resulting with a nonzero register value
     `ASSERT(SecWipeChangedBaseRegs_A,
       $rose(busy_secure_wipe) |-> (##[0:$]
@@ -1228,23 +1229,26 @@ module otbn
         $changed(
           u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.g_rf_flops[i].rf_reg_q)
         within $rose(busy_secure_wipe) ##[0:$] $fell(busy_secure_wipe)),
-      clk_i, !rst_ni || u_otbn_core.urnd_reseed_err)
+      clk_i,
+      !rst_ni || u_otbn_core.urnd_reseed_err || u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
   end
 
   // WDR assertions for secure wipe
   // 1. urnd_reseed_err disables the assertion because secure wipe finishes with failure and OTBN
   // goes to LOCKED state immediately after this error which means that it's not guaranteed to have
   // secure wiping complete.
-  // 2. bad_internal_state disables the initial internal secure wipe related assertion because a
-  // fatal error affecting internal secure wiping could cause an immediate locking behaviour
-  // in which it's not guaranteed to see all registers initialised.
+  // 2. mubi_err_d of start_stop_control disables the internal secure wipe related assertion
+  // because a fatal error affecting internal secure wiping could cause an immediate locking
+  // behaviour in which it's not guaranteed to see a succesful secure wipe.
   for (genvar i = 0; i < NWdr; ++i) begin : gen_sec_wipe_wdr_asserts
     // Initial secure wipe needs to initialise all registers to nonzero
     `ASSERT(InitSecWipeNonZeroWideRegs_A,
             $fell(busy_secure_wipe) |->
               u_otbn_core.u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.rf[i] !=
                 EccWideZeroWord,
-            clk_i, !rst_ni || u_otbn_core.urnd_reseed_err || err_bits.bad_internal_state)
+            clk_i,
+            !rst_ni || u_otbn_core.urnd_reseed_err ||
+              u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
 
     // After execution, it's expected to see a change resulting with a nonzero register value
     `ASSERT(SecWipeChangedWideRegs_A,
@@ -1254,7 +1258,8 @@ module otbn
               $changed(
                 u_otbn_core.u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.rf[i])
               within $rose(busy_secure_wipe) ##[0:$] $fell(busy_secure_wipe)),
-          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err)
+          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err ||
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
   end
 
   // Secure wipe needs to invalidate call and loop stack, initialize MOD, ACC to nonzero and set
@@ -1262,44 +1267,65 @@ module otbn
   // 1. urnd_reseed_err disables the assertion because secure wipe finishes with failure and OTBN
   // goes to LOCKED state immediately after this error which means that it's not guaranteed to have
   // secure wiping complete.
+  // 2. mubi_err_d of start_stop_control disables the secure wipe related assertions because a
+  // fatal error affecting internal secure wiping could cause an immediate locking behaviour
+  // in which it's not guaranteed to see a succesful secure wipe.
   `ASSERT(SecWipeInvalidCallStack_A,
           $fell(busy_secure_wipe) |-> (!u_otbn_core.u_otbn_rf_base.u_call_stack.top_valid_o),
-          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err)
+          clk_i,
+          !rst_ni || u_otbn_core.urnd_reseed_err ||
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
   `ASSERT(SecWipeInvalidLoopStack_A,
           $fell(busy_secure_wipe) |->
             (!u_otbn_core.u_otbn_controller.u_otbn_loop_controller.loop_info_stack.top_valid_o),
-          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err)
+          clk_i,
+          !rst_ni || u_otbn_core.urnd_reseed_err ||
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
 
   `ASSERT(SecWipeNonZeroMod_A,
           $fell(busy_secure_wipe) |-> u_otbn_core.u_otbn_alu_bignum.mod_intg_q != EccWideZeroWord,
-          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err)
+          clk_i,
+          !rst_ni || u_otbn_core.urnd_reseed_err ||
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
 
   `ASSERT(SecWipeNonZeroACC_A,
           $fell(busy_secure_wipe) |->
             u_otbn_core.u_otbn_alu_bignum.ispr_acc_intg_i != EccWideZeroWord,
-          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err)
+          clk_i,
+          !rst_ni || u_otbn_core.urnd_reseed_err ||
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
 
   `ASSERT(SecWipeNonZeroFlags_A,
           $fell(busy_secure_wipe) |-> (!u_otbn_core.u_otbn_alu_bignum.flags_flattened),
-          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err)
+          clk_i,
+          !rst_ni || u_otbn_core.urnd_reseed_err ||
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
 
   // Secure wipe of IMEM and DMEM first happens with a key change from URND (while valid is zero)
   `ASSERT(ImemSecWipeRequiresUrndKey_A,
           $rose(imem_sec_wipe) |=> (otbn_imem_scramble_key == $past(imem_sec_wipe_urnd_key)),
-          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err)
+          clk_i,
+          !rst_ni || u_otbn_core.urnd_reseed_err ||
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
   `ASSERT(DmemSecWipeRequiresUrndKey_A,
           $rose(dmem_sec_wipe) |=> (otbn_dmem_scramble_key == $past(dmem_sec_wipe_urnd_key)),
-          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err)
+          clk_i,
+          !rst_ni || u_otbn_core.urnd_reseed_err ||
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
 
   // Then it is guaranteed to have a valid key from OTP interface which is different from URND key
   `ASSERT(ImemSecWipeRequiresOtpKey_A,
           $rose(imem_sec_wipe) ##1 (otbn_imem_scramble_key == $past(imem_sec_wipe_urnd_key)) |=>
             ##[0:$] otbn_imem_scramble_valid && $changed(otbn_imem_scramble_key),
-          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err)
+          clk_i,
+          !rst_ni || u_otbn_core.urnd_reseed_err ||
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
   `ASSERT(DmemSecWipeRequiresOtpKey_A,
           $rose(dmem_sec_wipe) ##1 (otbn_dmem_scramble_key == $past(dmem_sec_wipe_urnd_key)) |=>
             ##[0:$] otbn_dmem_scramble_valid && $changed(otbn_dmem_scramble_key),
-          clk_i, !rst_ni || u_otbn_core.urnd_reseed_err )
+          clk_i,
+          !rst_ni || u_otbn_core.urnd_reseed_err ||
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
 
   // All outputs should be known value after reset
   `ASSERT_KNOWN(TlODValidKnown_A, tl_o.d_valid)

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -377,7 +377,7 @@ module otbn_controller
   // running involves `secure_wipe_running_i`, which is high for the initial secure wipe, and
   // `secure_wipe_req_o`, which is high for post-execution secure wipes.
   assign locking_o = (state_d == OtbnStateLocked) & (~(secure_wipe_running_i | secure_wipe_req_o) |
-                                                     urnd_reseed_err_i);
+                                                     urnd_reseed_err_i | mubi_err_d);
 
   assign start_secure_wipe = executing & (done_complete | err);
 

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -341,7 +341,7 @@ module otbn_start_stop_control
                     mubi4_test_false_strict(wipe_after_urnd_refresh_q)) ||
                    (spurious_urnd_ack_error && !(state_q inside {OtbnStartStopStateHalt,
                                                                  OtbnStartStopStateLocked}) &&
-                    init_sec_wipe_done_q));
+                    init_sec_wipe_done_q) || (mubi_err_d && !mubi_err_q));
 
   assign addr_cnt_d = addr_cnt_inc ? (addr_cnt_q + 6'd1) : 6'd0;
 


### PR DESCRIPTION
1st commit: Introduces `new_lc_mubi_err` which signals to the golden model whenever we see an invalid `lc_tx_t` type signal we'd expect to immediately lock down with bad_internal_state error set.

2nd commit: Tweaks `otbn_escalate` test to inject random  `lc_tx_t` type signals more on the edge cases (from 95% while running to 40% while running and 60% sometime else)

3rd commit: Disables SecWipe related assertions when we see `bad_internal_state` fatal error because that specific fatal error does not guarantee a proper secure wipe behaviour.

4th commit: A small RTL change to make two modules behaviour consistent with each other. Detailed description is in the commit message. I would really appreciate a feedback from OTBN designers for this change specifically.   

Resolves https://github.com/lowRISC/opentitan/issues/15505