### PR TITLE
[pwrmgr,dv] Add more test to stretch coverage

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
@@ -128,7 +128,7 @@
               `abort` events when capture is enabled.
             '''
       stage: V2
-      tests: ["pwrmgr_aborted_low_power"]
+      tests: ["pwrmgr_aborted_low_power", "pwrmgr_lowpower_invalid"]
     }
     {
       name: reset
@@ -157,7 +157,7 @@
              conditional resets inputs.
             '''
       stage: V2
-      tests: ["pwrmgr_reset"]
+      tests: ["pwrmgr_reset", "pwrmgr_reset_invalid"]
     }
     {
       name: main_power_glitch_reset
@@ -222,6 +222,27 @@
             '''
       stage: V2
       tests: ["pwrmgr_lowpower_wakeup_race"]
+    }
+    {
+      name: disable_rom_integrity_check
+      desc: '''
+            Test rom integrity check is disabled under life cycle test states.
+
+            While running a series of reset event, at FastPwrStateRomCheck
+            state,
+            - Drive lc_hw_debug_en_i and lc_dft_en_i to random value
+              excluding {lc_ctrl_pkg::On, lc_ctrl_pkg::On} for both ports.
+            - Set rom_ctrl_i.good = Mubi4False.
+            - Wait for a while to make sure fsm state check is not FastPwrStateActive.
+
+            Then,
+            - Drive lc_hw_debug_en_i and lc_dft_en_i to {lc_ctrl_pkg::On, lc_ctrl_pkg::On}
+            - Check test finish gracefully.
+
+            Try these steps with different lc_ctrl inputs.
+            '''
+      stage: V2
+      tests: ["pwrmgr_disable_rom_integrity_check"]
     }
     {
       name: stress_all

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
@@ -34,6 +34,9 @@ filesets:
       - seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_global_esc_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_glitch_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_reset_invalid_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_lowpower_invalid_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -8,6 +8,10 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
 
   // disable fault csr read check from scoreboard
   bit disable_csr_rd_chk = 0;
+
+  // Invalid state test. Used to disable interrupt check.
+  bit invalid_st_test = 0;
+
   // ext component cfgs
   alert_esc_agent_cfg        m_esc_agent_cfg;
   pwrmgr_clk_ctrl_agent_cfg  m_pcc_agent_cfg;

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -131,6 +131,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg        csr;
     bit            do_read_check = ~(cfg.disable_csr_rd_chk);
+    bit            skip_intr_chk = cfg.invalid_st_test;
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
@@ -160,6 +161,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin
+        if (skip_intr_chk) return;
         if (data_phase_write) begin
           exp_intr &= ~item.a_data;
         end else if (data_phase_read) begin

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
@@ -1,0 +1,103 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test multiple resets with setting lc_* inputs with random value.
+class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
+
+  `uvm_object_utils(pwrmgr_disable_rom_integrity_check_vseq)
+  `uvm_object_new
+
+  constraint wakeups_c {wakeups == 0;}
+  constraint wakeups_en_c {wakeups_en == 0;}
+
+  function void post_randomize();
+    sw_rst_from_rstmgr = get_rand_mubi4_val(8, 4, 4);
+    super.post_randomize();
+  endfunction
+
+  task body();
+    resets_t enabled_resets;
+    wait_for_fast_fsm_active();
+    check_reset_status('0);
+
+    for (int i = 0; i < 5; ++i) begin
+      `uvm_info(`gfn, $sformatf("Starting new round%0d", i), UVM_MEDIUM)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      setup_interrupt(.enable(en_intr));
+
+      // set lc ctrl input to random value
+      cfg.pwrmgr_vif.lc_hw_debug_en =
+        get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
+      cfg.pwrmgr_vif.lc_dft_en =
+        get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
+      cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+      cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+      enabled_resets = resets_en & resets;
+      `uvm_info(`gfn, $sformatf(
+                "Enabled resets=0x%x, power_reset=%b, escalation=%b, sw_reset=%b",
+                enabled_resets,
+                power_glitch_reset,
+                escalation_reset,
+                sw_rst_from_rstmgr
+                ), UVM_MEDIUM)
+
+      csr_wr(.ptr(ral.reset_en[0]), .value(resets_en));
+      // This is necessary to propagate reset_en.
+      wait_for_csr_to_propagate_to_slow_domain();
+
+      // Trigger resets. The glitch is sent prior to the externals since if it is delayed
+      // it will cause a separate reset after the externals, which complicates the checks.
+      if (power_glitch_reset) begin
+        `uvm_info(`gfn, "Sending power glitch", UVM_MEDIUM)
+        // expected alerts
+        expect_fatal_alerts = 1;
+        cfg.exp_alert_q.push_back(1);
+        cfg.pwrmgr_vif.glitch_power_reset();
+      end
+      cfg.clk_rst_vif.wait_clks(cycles_before_reset);
+
+      if (cycles_before_reset == 0) enabled_resets = 0;
+
+      `uvm_info(`gfn, $sformatf("Sending resets=0x%x", resets), UVM_MEDIUM)
+      cfg.pwrmgr_vif.update_resets(resets);
+      `uvm_info(`gfn, $sformatf("Sending sw reset from rstmgr=%b",
+                                sw_rst_from_rstmgr), UVM_MEDIUM)
+      if (escalation_reset) send_escalation_reset();
+      cfg.pwrmgr_vif.update_sw_rst_req(sw_rst_from_rstmgr);
+
+      cfg.slow_clk_rst_vif.wait_clks(2);
+      // Wait until fast clock comes back
+      repeat(4) @cfg.clk_rst_vif.cb;
+
+      // This read is not always possible since the CPU may be off.
+      check_reset_status(enabled_resets);
+
+      // Check fast state is not FastPwrStateActive for a while
+      `uvm_info(`gfn, "Check Fast State NE FastPwrStateActive", UVM_MEDIUM)
+      repeat(20) begin
+        @cfg.slow_clk_rst_vif.cb;
+        `DV_CHECK_NE(cfg.pwrmgr_vif.fast_state, pwrmgr_pkg::FastPwrStateActive)
+      end
+
+      `uvm_info(`gfn, "Set lc ctrl input On", UVM_MEDIUM)
+      cfg.pwrmgr_vif.lc_hw_debug_en = lc_ctrl_pkg::On;
+      cfg.pwrmgr_vif.lc_dft_en = lc_ctrl_pkg::On;
+
+      wait(cfg.pwrmgr_vif.pwr_clk_req.main_ip_clk_en == 1'b1);
+
+      wait_for_fast_fsm_active();
+      `uvm_info(`gfn, "Back from reset", UVM_MEDIUM)
+
+      check_wake_info(.reasons('0), .fall_through(1'b0), .abort(1'b0));
+
+      cfg.slow_clk_rst_vif.wait_clks(4);
+      check_reset_status('0);
+
+      // And check interrupt is not set.
+      check_and_clear_interrupt(.expected(1'b0));
+    end
+    clear_wake_info();
+  endtask
+
+endclass : pwrmgr_disable_rom_integrity_check_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
@@ -1,0 +1,142 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// The test to create transition to invalid state from any lowpower transitions.
+class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
+
+  `uvm_object_utils(pwrmgr_lowpower_invalid_vseq)
+  `uvm_object_new
+
+  // Create enum to map rtl local sparse state
+  // to continuous dv state.
+  typedef enum bit [3:0] {
+                DVWaitDisClks      = 0,
+                DVWaitFallThrough  = 1,
+                DVWaitNvmIdleChk   = 2,
+                DVWaitLowPowerPrep = 3,
+                DVWaitReqPwrDn     = 4,
+                DVWaitLowPower     = 5,
+                DVWaitEnableClocks = 6,
+                DVWaitReleaseLcRst = 7,
+                DVWaitOtpInit      = 8,
+                DVWaitLcInit       = 9,
+                DVWaitAckPwrUp     = 10,
+                DVWaitRomCheck     = 11,
+                DVWaitStrap        = 12,
+                DVWaitActive       = 13,
+                DVWaitInvalid      = 14
+                } reset_index_e;
+
+  constraint wakeups_c {wakeups != 0;}
+  constraint wakeup_en_c {
+    solve wakeups before wakeups_en;
+    |(wakeups_en & wakeups) == 1'b1;
+  }
+
+  task body();
+    reset_index_e reset_index;
+    resets_t enabled_resets;
+    string path = "tb.dut.u_fsm.fsm_invalid_i";
+    int    num_of_target_states = 4;
+
+    // Spurious interrupt check can be executed by
+    // residue of lowpower task. Since we cannot kill csr op
+    // by disable fork, we have to disable spurious interrup check.
+    cfg.invalid_st_test = 1;
+
+    wait_for_fast_fsm_active();
+    check_wake_status('0);
+    reset_index = DVWaitFallThrough;
+
+    for (int i = 0; i < num_of_target_states; ++i) begin
+      `uvm_info(`gfn, $sformatf("Starting new round%0d %s", i, reset_index.name), UVM_MEDIUM)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      setup_interrupt(.enable(en_intr));
+      fork
+        stat_lowpower_transition();
+        begin
+          int wait_time_ns = 10000;
+          `DV_SPINWAIT(wait(cfg.pwrmgr_vif.fast_state == dv2rtl_st(reset_index));,
+                       $sformatf("Timed out waiting for state %s", reset_index.name),
+                       wait_time_ns)
+
+          @cfg.clk_rst_vif.cbn;
+          `DV_CHECK(uvm_hdl_force(path, 1))
+          @cfg.clk_rst_vif.cb;
+        end
+      join_any
+      @cfg.clk_rst_vif.cb;
+      `DV_CHECK(uvm_hdl_release(path))
+      `DV_CHECK(cfg.pwrmgr_vif.fast_state, pwrmgr_pkg::FastPwrStateInvalid)
+
+      repeat(10) @cfg.clk_rst_vif.cb;
+
+      apply_reset();
+      reset_index++;
+    end // for (int i = 0; i < 4; ++i)
+  endtask
+
+  task stat_lowpower_transition();
+    wakeups_t enabled_wakeups = wakeups_en & wakeups;
+    `DV_CHECK(enabled_wakeups, $sformatf(
+       "Some wakeup must be enabled: wkups=%b, wkup_en=%b", wakeups, wakeups_en))
+    `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
+    csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeups_en));
+    low_power_hint = 1;
+    update_control_csr();
+
+    wait_for_csr_to_propagate_to_slow_domain();
+
+    // Initiate low power transition.
+    cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
+    set_nvms_idle();
+
+    if (ral.control.main_pd_n.get_mirrored_value() == 1'b0) begin
+      wait_for_reset_cause(pwrmgr_pkg::LowPwrEntry);
+    end
+
+    // Now bring it back.
+    cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
+    cfg.pwrmgr_vif.update_wakeups(wakeups);
+    // Check wake_status prior to wakeup, or the unit requesting wakeup will have been reset.
+    // This read will not work in the chip, since the processor will be asleep.
+    cfg.slow_clk_rst_vif.wait_clks(4);
+    // wait for clock is on
+    cfg.clk_rst_vif.wait_clks(10);
+
+    check_wake_status(enabled_wakeups);
+    `uvm_info(`gfn, $sformatf("Got wake_status=0x%x", enabled_wakeups), UVM_MEDIUM)
+    wait(cfg.pwrmgr_vif.pwr_clk_req.main_ip_clk_en == 1'b1);
+
+    // wakeups should be registered.
+    cfg.pwrmgr_vif.update_wakeups('1);
+
+    wait_for_fast_fsm_active();
+    `uvm_info(`gfn, "Back from wakeup", UVM_MEDIUM)
+  endtask // stat_lowpower_transition
+
+  function pwrmgr_pkg::fast_pwr_state_e dv2rtl_st(reset_index_e idx);
+    case (idx)
+      DVWaitDisClks: return pwrmgr_pkg::FastPwrStateDisClks;
+      DVWaitFallThrough: return pwrmgr_pkg::FastPwrStateFallThrough;
+      DVWaitNvmIdleChk: return pwrmgr_pkg::FastPwrStateNvmIdleChk;
+      DVWaitLowPowerPrep: return pwrmgr_pkg::FastPwrStateLowPowerPrep;
+      DVWaitReqPwrDn: return pwrmgr_pkg::FastPwrStateReqPwrDn;
+      DVWaitLowPower: return pwrmgr_pkg::FastPwrStateLowPower;
+      DVWaitEnableClocks: return pwrmgr_pkg::FastPwrStateEnableClocks;
+      DVWaitReleaseLcRst: return pwrmgr_pkg::FastPwrStateReleaseLcRst;
+      DVWaitOtpInit: return pwrmgr_pkg::FastPwrStateOtpInit;
+      DVWaitLcInit: return pwrmgr_pkg::FastPwrStateLcInit;
+      DVWaitAckPwrUp: return pwrmgr_pkg::FastPwrStateAckPwrUp;
+      DVWaitRomCheck: return pwrmgr_pkg::FastPwrStateRomCheck;
+      DVWaitStrap: return pwrmgr_pkg::FastPwrStateStrap;
+      DVWaitActive: return pwrmgr_pkg::FastPwrStateActive;
+      DVWaitInvalid: return pwrmgr_pkg::FastPwrStateInvalid;
+      default: begin
+        `uvm_error("dv2rma_st", $sformatf("unknown index:%0d", idx))
+      end
+    endcase
+  endfunction // dv2rtl_st
+
+endclass // pwrmgr_lowpower_invalid_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
@@ -1,0 +1,133 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// The test to create transition to invalid state from any reset transitions.
+class pwrmgr_reset_invalid_vseq extends pwrmgr_base_vseq;
+
+  `uvm_object_utils(pwrmgr_reset_invalid_vseq)
+  `uvm_object_new
+
+  // Create enum to map rtl local sparse state
+  // to continuous dv state.
+  typedef enum bit [3:0] {
+                DVWaitDisClks      = 0,
+                DVWaitNvmShutDown  = 1,
+                DVWaitResetPrep    = 2,
+                DVWaitLowPower     = 3,
+                DVWaitEnableClocks = 4,
+                DVWaitReleaseLcRst = 5,
+                DVWaitOtpInit      = 6,
+                DVWaitLcInit       = 7,
+                DVWaitAckPwrUp     = 8,
+                DVWaitRomCheck     = 9,
+                DVWaitStrap        = 10,
+                DVWaitActive       = 11,
+                DVWaitInvalid      = 12
+                } reset_index_e;
+
+  constraint wakeups_c {wakeups == 0;}
+  constraint wakeups_en_c {wakeups_en == 0;}
+
+  function void post_randomize();
+    sw_rst_from_rstmgr = get_rand_mubi4_val(8, 4, 4);
+    super.post_randomize();
+  endfunction
+
+  task body();
+    reset_index_e reset_index;
+    resets_t enabled_resets;
+    string path = "tb.dut.u_fsm.fsm_invalid_i";
+    int    num_of_target_states = 11;
+
+    wait_for_fast_fsm_active();
+    check_reset_status('0);
+    $assertoff(0, "tb.dut.u_cdc.u_clr_reqack.SyncReqAckHoldReq");
+
+    for (int i = 0; i < num_of_target_states; ++i) begin
+      `uvm_info(`gfn, $sformatf("Starting new round%0d", i), UVM_MEDIUM)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      setup_interrupt(.enable(en_intr));
+
+      fork
+         create_any_reset_event();
+         begin
+            int wait_time_ns = 10000;
+            `DV_SPINWAIT(wait(cfg.pwrmgr_vif.fast_state == dv2rtl_st(reset_index));,
+                         $sformatf("Timed out waiting for state %s", reset_index.name),
+                         wait_time_ns)
+
+            @cfg.clk_rst_vif.cbn;
+            `DV_CHECK(uvm_hdl_force(path, 1))
+            @cfg.clk_rst_vif.cb;
+
+         end
+      join
+      @cfg.clk_rst_vif.cb;
+      `DV_CHECK(uvm_hdl_release(path))
+      `DV_CHECK(cfg.pwrmgr_vif.fast_state, pwrmgr_pkg::FastPwrStateInvalid)
+
+      repeat(10) @cfg.clk_rst_vif.cb;
+      apply_reset();
+      reset_index++;
+    end
+  endtask
+
+  task create_any_reset_event();
+    resets_t enabled_resets = resets_en & resets;
+    `uvm_info(`gfn, $sformatf(
+       "Enabled resets=0x%x, power_reset=%b, escalation=%b, sw_reset=%b",
+                              enabled_resets,
+                              power_glitch_reset,
+                              escalation_reset,
+                              sw_rst_from_rstmgr
+                              ), UVM_MEDIUM)
+
+    csr_wr(.ptr(ral.reset_en[0]), .value(resets_en));
+    // This is necessary to propagate reset_en.
+    wait_for_csr_to_propagate_to_slow_domain();
+
+    // Trigger resets. The glitch is sent prior to the externals since if it is delayed
+    // it will cause a separate reset after the externals, which complicates the checks.
+    if (power_glitch_reset) begin
+      `uvm_info(`gfn, "Sending power glitch", UVM_MEDIUM)
+      // expected alerts
+      expect_fatal_alerts = 1;
+      cfg.exp_alert_q.push_back(1);
+      cfg.pwrmgr_vif.glitch_power_reset();
+    end
+    cfg.clk_rst_vif.wait_clks(cycles_before_reset);
+
+    if (cycles_before_reset == 0) enabled_resets = 0;
+
+    `uvm_info(`gfn, $sformatf("Sending resets=0x%x", resets), UVM_MEDIUM)
+    cfg.pwrmgr_vif.update_resets(resets);
+    `uvm_info(`gfn, $sformatf("Sending sw reset from rstmgr=%b", sw_rst_from_rstmgr),
+              UVM_MEDIUM)
+    if (escalation_reset) send_escalation_reset();
+    cfg.pwrmgr_vif.update_sw_rst_req(sw_rst_from_rstmgr);
+
+  endtask // create_any_reset_event
+
+  function pwrmgr_pkg::fast_pwr_state_e dv2rtl_st(reset_index_e idx);
+    case (idx)
+      DVWaitDisClks: return pwrmgr_pkg::FastPwrStateDisClks;
+      DVWaitNvmShutDown: return pwrmgr_pkg::FastPwrStateNvmShutDown;
+      DVWaitResetPrep: return pwrmgr_pkg::FastPwrStateResetPrep;
+      DVWaitLowPower: return pwrmgr_pkg::FastPwrStateLowPower;
+      DVWaitEnableClocks: return pwrmgr_pkg::FastPwrStateEnableClocks;
+      DVWaitReleaseLcRst: return pwrmgr_pkg::FastPwrStateReleaseLcRst;
+      DVWaitOtpInit: return pwrmgr_pkg::FastPwrStateOtpInit;
+      DVWaitLcInit: return pwrmgr_pkg::FastPwrStateLcInit;
+      DVWaitAckPwrUp: return pwrmgr_pkg::FastPwrStateAckPwrUp;
+      DVWaitRomCheck: return pwrmgr_pkg::FastPwrStateRomCheck;
+      DVWaitStrap: return pwrmgr_pkg::FastPwrStateStrap;
+      DVWaitActive: return pwrmgr_pkg::FastPwrStateActive;
+      DVWaitInvalid: return pwrmgr_pkg::FastPwrStateInvalid;
+      default: begin
+        `uvm_error("dv2rma_st", $sformatf("unknown index:%0d", idx))
+      end
+    endcase
+  endfunction // dv2rtl_st
+
+endclass // pwrmgr_reset_invalid_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
@@ -17,3 +17,6 @@
 `include "pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv"
 `include "pwrmgr_global_esc_vseq.sv"
 `include "pwrmgr_glitch_vseq.sv"
+`include "pwrmgr_disable_rom_integrity_check_vseq.sv"
+`include "pwrmgr_reset_invalid_vseq.sv"
+`include "pwrmgr_lowpower_invalid_vseq.sv"

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -123,6 +123,21 @@
       uvm_test_seq: pwrmgr_glitch_vseq
       run_opts: ["+test_timeout_ns=1000000"]
     }
+    {
+      name: pwrmgr_disable_rom_integrity_check
+      uvm_test_seq: pwrmgr_disable_rom_integrity_check_vseq
+      run_opts: ["+test_timeout_ns=1000000"]
+    }
+    {
+      name: pwrmgr_reset_invalid
+      uvm_test_seq: pwrmgr_reset_invalid_vseq
+      run_opts: ["+test_timeout_ns=1000000"]
+    }
+    {
+      name: pwrmgr_lowpower_invalid
+      uvm_test_seq: pwrmgr_lowpower_invalid_vseq
+      run_opts: ["+test_timeout_ns=1000000"]
+    }
     // TODO: add more tests here
   ]
 


### PR DESCRIPTION
- Add disable_rom_integrity_check test #11773
- Add all states to invalid_state test to improve fsm coverage

Signed-off-by: Jaedon Kim <jdonjdon@google.com>