### PR TITLE
[rtl/tlul] Fix typo in tlul_cmd_intg_gen.sv

### DIFF
--- a/hw/ip/tlul/rtl/tlul_cmd_intg_gen.sv
+++ b/hw/ip/tlul/rtl/tlul_cmd_intg_gen.sv
@@ -57,4 +57,4 @@ module tlul_cmd_intg_gen import tlul_pkg::*; #(
 
   `ASSERT_INIT(PayMaxWidthCheck_A, $bits(tl_h2d_cmd_intg_t) <= H2DCmdMaxWidth)
 
-endmodule // tlul_rsp_intg_gen
+endmodule : tlul_cmd_intg_gen


### PR DESCRIPTION
Also, it is much better to use SV a ":" module_identifier with an endmodule, since the compiler checks the identifier matches the module name. This is also a good practice for other constructs, like tasks, functions, interfaces, packages, classes, etc.

Signed-off-by: Guillermo Maturana <maturana@google.com>