### PR TITLE
[test] Run functests with both rom and test_rom

### DIFF
--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -32,13 +32,16 @@ export BITSTREAM="--offline --list ${SHA}"
 # in case we've crashed the UART handler on the CW310's SAM3U
 trap 'python3 ./util/fpga/cw310_reboot.py' EXIT
 
-./bazelisk.sh query 'rdeps(//..., @bitstreams//...)' |
-    xargs ci/bazelisk.sh test \
-        --define DISABLE_VERILATOR_BUILD=true \
-        --nokeep_going \
-        --test_tag_filters=cw310,-broken,-manual \
-        --test_timeout_filters=short,moderate \
-        --test_output=all \
-        --build_tests_only \
-        --define cw310=lowrisc \
-        --flaky_test_attempts=2
+cw310_tags=( "cw310_test_rom" "cw310_rom" )
+for tag in "${cw310_tags[@]}"; do
+    ./bazelisk.sh query 'rdeps(//..., @bitstreams//...)' |
+        xargs ci/bazelisk.sh test \
+            --define DISABLE_VERILATOR_BUILD=true \
+            --nokeep_going \
+            --test_tag_filters="${tag}",-broken,-manual \
+            --test_timeout_filters=short,moderate \
+            --test_output=all \
+            --build_tests_only \
+            --define cw310=lowrisc \
+            --flaky_test_attempts=2
+done

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -878,8 +878,8 @@ def opentitan_flash_binary(
         devices = PER_DEVICE_DEPS.keys(),
         platform = OPENTITAN_PLATFORM,
         signing_keys = DEFAULT_SIGNING_KEYS,
-        signed = False,
-        manifest = None,
+        signed = True,
+        manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
         **kwargs):
     """A helper macro for generating OpenTitan binary artifacts for flash.
 

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -320,10 +320,12 @@ def opentitan_functest(
             if "test_rom" in target:
                 cw310_["rom_kind"] = "testrom"
                 cw310_["bitstream"] = "@//hw/bitstream:test_rom"
+                cw310_["tags"] = [t for t in cw310_["tags"]] + ["cw310_test_rom"]
                 target_params["fpga_cw310_test_rom"] = cw310_
             elif "rom" in target:
                 cw310_["rom_kind"] = "rom"
                 cw310_["bitstream"] = "@//hw/bitstream:rom"
+                cw310_["tags"] = [t for t in cw310_["tags"]] + ["cw310_rom"]
                 target_params["fpga_cw310_rom"] = cw310_
             else:
                 fail("Expected to find `test_rom` or `rom` in the target name")

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -248,7 +248,8 @@ def opentitan_functest(
         data = [],
         test_in_rom = False,
         ot_flash_binary = None,
-        signed = False,
+        signed = True,
+        manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
         slot = "silicon_creator_a",
         test_harness = "@//sw/host/opentitantool",
         key = "test_key_0",
@@ -276,7 +277,8 @@ def opentitan_functest(
       @param ot_flash_binary: Use the named `opentitan_flash_binary` as the
                               flash image for the test rather than building one
                               from srcs/deps.
-      @param signed: Whether to sign the test image. Unsigned by default.
+      @param signed: Whether to sign the test image. Signed by default.
+      @param manifest: Partially populated manifest to set boot stage/slot configs.
       @param slot: What slot to build the image for.
       @param test_harness: The binary on the host side that runs the test.
       @param key: Which signed test image (by key) to use.
@@ -336,6 +338,7 @@ def opentitan_functest(
             signed = signed,
             deps = deps,
             devices = devices_to_build_for,
+            manifest = manifest,
             **kwargs
         )
 

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -101,7 +101,7 @@ opentitan_functest(
         ],
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
-    targets = ["cw310"],
+    targets = ["cw310_test_rom"],
     deps = [
         ":macros",
         ":memory",

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -45,6 +45,11 @@ dual_cc_library(
 opentitan_functest(
     name = "boot_data_functest",
     srcs = ["boot_data_functest.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "eternal",
         tags = ["flaky"],
@@ -148,6 +153,11 @@ cc_library(
 opentitan_functest(
     name = "irq_asm_functest",
     srcs = ["irq_asm_functest.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -267,6 +267,11 @@ cc_test(
 opentitan_functest(
     name = "keymgr_functest",
     srcs = ["keymgr_functest.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -451,6 +456,11 @@ cc_test(
 opentitan_functest(
     name = "retention_sram_functest",
     srcs = ["retention_sram_functest.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -570,6 +580,11 @@ cc_test(
 opentitan_functest(
     name = "rstmgr_functest",
     srcs = ["rstmgr_functest.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -654,6 +669,11 @@ cc_test(
 opentitan_functest(
     name = "watchdog_functest",
     srcs = ["watchdog_functest.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -79,7 +79,7 @@ opentitan_functest(
     cw310 = cw310_params(
         timeout = "long",
     ),
-    targets = ["cw310"],  # Test set is too large to run in simulation
+    targets = ["cw310_test_rom"],  # Test set is too large to run in simulation
     deps = [
         ":mod_exp_ibex",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -145,6 +145,11 @@ opentitan_functest(
 opentitan_functest(
     name = "mod_exp_otbn_functest_wycheproof",
     srcs = ["mod_exp_otbn_functest.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "long",
         tags = [
@@ -279,7 +284,7 @@ opentitan_functest(
     cw310 = cw310_params(
         timeout = "long",
     ),
-    targets = ["cw310"],  # Test set is too large to run in simulation
+    targets = ["cw310_test_rom"],  # Test set is too large to run in simulation
     deps = [
         ":sigverify",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -18,16 +18,14 @@ opentitan_functest(
     name = "rom_e2e_shutdown_exception_c",
     srcs = ["rom_e2e_shutdown_exception_c_test.c"],
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
         # Note: This test never prints a failure message so it will fail only
         # when it times out.
         exit_failure = "NO_FAILURE_MESSAGE",
         exit_success = "BFV:01495202(?s:.*)BFV:01495202",
     ),
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
     targets = [
-        "cw310",
+        "cw310_rom",
         "verilator",
     ],
     verilator = verilator_params(
@@ -53,8 +51,12 @@ opentitan_functest(
     dv = dv_params(
         rom = "//sw/device/silicon_creator/rom",
     ),
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
+    targets = [
+        "cw310_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "eternal",
         rom = "//sw/device/silicon_creator/rom",
@@ -67,13 +69,9 @@ opentitan_functest(
 opentitan_functest(
     name = "rom_e2e_static_critical",
     srcs = ["rom_e2e_static_critical_test.c"],
-    cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
-    ),
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
     targets = [
-        "cw310",
+        "cw310_rom",
         "verilator",
     ],
     verilator = verilator_params(
@@ -99,9 +97,8 @@ opentitan_functest(
         # bitstream target can fetch pre-spliced bitstream from GCP.
         tags = ["manual"],
     ),
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
-    targets = ["cw310"],
+    targets = ["cw310_rom"],
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -111,11 +108,11 @@ opentitan_functest(
     name = "e2e_bootup_no_rom_ext_signature",
     srcs = ["empty_test.c"],
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
         exit_failure = DEFAULT_TEST_SUCCESS_MSG,
         exit_success = DEFAULT_TEST_FAILURE_MSG,
     ),
     signed = False,
+    targets = ["cw310_rom"],
     verilator = verilator_params(
         exit_failure = DEFAULT_TEST_SUCCESS_MSG,
         exit_success = DEFAULT_TEST_FAILURE_MSG,
@@ -131,16 +128,14 @@ opentitan_functest(
     srcs = ["empty_test.c"],
     args = [],
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
         test_cmds = [
             "--bitstream=\"$(location //hw/bitstream:rom)\"",
             "--rom-kind=rom",
             "--rom-ext=\"$(location {flash})\"",
         ],
     ),
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
-    targets = ["cw310"],
+    targets = ["cw310_rom"],
     test_harness = "//sw/host/tests/rom/e2e_bootup_bad_rom_ext_signature",
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -151,19 +146,17 @@ opentitan_functest(
     name = "e2e_bootstrap_entry",
     srcs = ["empty_test.c"],
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
         test_cmds = [
             "--rom-kind=rom",
             "--bitstream=\"$(location //hw/bitstream:rom)\"",
             "--bootstrap=\"$(location {flash})\"",
         ],
     ),
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     # We don't want the `empty_test` to run, but we _also_ don't want some
     # leftover flash image from a previous test to run.  So, bootstrap an
     # unsigned image to force a boot failure.
     signed = False,
-    targets = ["cw310"],
+    targets = ["cw310_rom"],
     test_harness = "//sw/host/tests/rom/e2e_bootstrap_entry",
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -175,16 +168,14 @@ opentitan_functest(
     srcs = ["chip_specific_startup.c"],
     args = [],
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
         test_cmds = [
-            "--bitstream=\"$(location //hw/bitstream:rom)\"",
             "--rom-kind=rom",
+            "--bitstream=\"$(location //hw/bitstream:rom)\"",
             "--bootstrap=\"$(location {flash})\"",
         ],
     ),
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
-    targets = ["cw310"],
+    targets = ["cw310_rom"],
     test_harness = "//sw/host/tests/rom/e2e_chip_specific_startup",
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -195,12 +195,11 @@ BOOT_SUCCESS_MSG = "Starting ROM_EXT"
 opentitan_functest(
     name = "rom_ext_slot_a_boot_test",
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
         exit_success = BOOT_SUCCESS_MSG,
     ),
     ot_flash_binary = ":rom_ext_slot_a",
     signed = True,
-    targets = ["cw310"],
+    targets = ["cw310_rom"],
 )
 
 # TODO(#13511): Add a positive test for slot_b.
@@ -208,10 +207,9 @@ opentitan_functest(
 opentitan_functest(
     name = "rom_ext_slot_virtual_boot_test",
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
         exit_success = BOOT_SUCCESS_MSG,
     ),
     ot_flash_binary = ":rom_ext_slot_virtual",
     signed = True,
-    targets = ["cw310"],
+    targets = ["cw310_rom"],
 )

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -135,13 +135,12 @@ BOOT_SUCCESS_MSG = "Bare metal PASS!"
 opentitan_functest(
     name = "rom_ext_virtual_bare_metal_virtual_boot_test",
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
         exit_success = BOOT_SUCCESS_MSG,
     ),
     key = "multislot",
     ot_flash_binary = ":rom_ext_virtual_bare_metal_virtual",
     signed = True,
-    targets = ["cw310"],
+    targets = ["cw310_rom"],
 )
 
 ################################################################################
@@ -175,11 +174,8 @@ opentitan_multislot_flash_binary(
 
 opentitan_functest(
     name = "rom_ext_virtual_ottf_bl0_virtual_test",
-    cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
-    ),
     key = "multislot",
     ot_flash_binary = ":rom_ext_virtual_ottf_bl0_virtual",
     signed = True,
-    targets = ["cw310"],
+    targets = ["cw310_rom"],
 )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -46,6 +46,11 @@ opentitan_functest(
 opentitan_functest(
     name = "aes_sideload_test",
     srcs = ["aes_sideload_test.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -136,7 +141,7 @@ opentitan_functest(
         # The test requires to run for > 0.2s, thus not recommended for
         # Verilator as this will slow down CI too much. It should still
         # be run as part of the DV nightly regression.
-        "cw310",
+        "cw310_test_rom",
         "dv",
     ],
     deps = [
@@ -771,7 +776,7 @@ opentitan_functest(
     srcs = ["gpio_smoketest.c"],
     targets = [
         #not compatible with the verilated top level
-        "cw310",
+        "cw310_test_rom",
         "dv",
     ],
     deps = [
@@ -1073,6 +1078,11 @@ opentitan_functest(
 opentitan_functest(
     name = "pmp_smoketest_tor",
     srcs = ["pmp_smoketest_tor.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:csr",
@@ -1234,7 +1244,7 @@ opentitan_functest(
 opentitan_functest(
     name = "spi_host_smoketest",
     srcs = ["spi_host_smoketest.c"],
-    targets = ["cw310"],  # Can only run on CW310 board right now.
+    targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -1330,6 +1340,11 @@ opentitan_functest(
 opentitan_functest(
     name = "sram_ctrl_execution_test",
     srcs = ["sram_ctrl_execution_test.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/examples/sram_program",
@@ -1379,7 +1394,6 @@ opentitan_functest(
     name = "uart_smoketest_signed",
     srcs = ["uart_smoketest.c"],
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom",
         exit_failure = ROM_BOOT_FAILURE_MSG,
     ),
     dv = dv_params(
@@ -1387,6 +1401,11 @@ opentitan_functest(
     ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     signed = True,
+    targets = [
+        "cw310_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "eternal",
         exit_failure = ROM_BOOT_FAILURE_MSG,
@@ -1434,6 +1453,11 @@ opentitan_functest(
 opentitan_functest(
     name = "rstmgr_alert_info_test",
     srcs = ["rstmgr_alert_info_test.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "long",
         tags = ["broken"],
@@ -1492,6 +1516,11 @@ opentitan_functest(
     srcs = [
         "rv_core_ibex_address_translation_test.S",
         "rv_core_ibex_address_translation_test.c",
+    ],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
     ],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/autogen/BUILD
+++ b/sw/device/tests/autogen/BUILD
@@ -13,6 +13,11 @@ load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 opentitan_functest(
     name = "plic_all_irqs_test",
     srcs = ["plic_all_irqs_test.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "eternal",
         tags = ["flaky"],

--- a/sw/device/tests/closed_source/BUILD.bazel
+++ b/sw/device/tests/closed_source/BUILD.bazel
@@ -131,6 +131,8 @@ cc_library(
 opentitan_functest(
     name = "example_test",
     srcs = ["example_test.c"],
+    signed = False,
+    targets = ["dv"],
     deps = [
         "@//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -157,6 +159,8 @@ opentitan_functest(
 opentitan_functest(
     name = "statically_hooked_opensource_test",
     srcs = ["@//sw/device/tests:example_test_from_flash.c"],
+    signed = False,
+    targets = ["dv"],
     deps = [
         "@//sw/device/lib/testing/test_framework:ottf_main",
         "@manufacturer_test_hooks//:test_hooks_1",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -117,6 +117,11 @@ opentitan_functest(
     cw310 = cw310_params(
         timeout = "long",
     ),
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/util/topgen/templates/BUILD.tpl
+++ b/util/topgen/templates/BUILD.tpl
@@ -13,6 +13,11 @@ load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 opentitan_functest(
     name = "plic_all_irqs_test",
     srcs = ["plic_all_irqs_test.c"],
+    targets = [
+        "cw310_test_rom",
+        "verilator",
+        "dv",
+    ],
     verilator = verilator_params(
         timeout = "eternal",
         tags = ["flaky"],


### PR DESCRIPTION
This PR updates `opentitan_flash_binary()` and `opentitan_functest()` so that 
* flash binaries are signed by default,
* functests are run with both `rom` and `test_rom` by default, and
* FPGA tests are grouped by rom type in CI so that the CI job doesn't time out due to bitstream programming overhead (15+ seconds per test)

FPGA test targets are now named `...fpga_cw310_rom` and `...fpga_cw310_test_rom`.

In addition to the e2e tests that we have been adding, we can now run most of our functests (all except 17) with production ROM.

See #14503.