### PR TITLE
[chip] sleep_pin_mio_dio_val #3

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
@@ -104,7 +104,7 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
      */
 
     // High-Z for all ports
-    cfg.chip_vif.ios_if.pins_pd = '0;
+    cfg.chip_vif.ios_if.pins_pd = '1;
     cfg.chip_vif.ios_if.pins_pu = '0;
     pad = cfg.chip_vif.ios_if.sample();
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
@@ -91,6 +91,9 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
 
+    // Wait until we reach the SW test state.
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+
     // TODO: Get expected MIO DIO value from SW
     fork
       receive_chosen_values();
@@ -99,7 +102,10 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
     // Release any driver interfaces.
 
     // Wait until Chip enters Low Power Mode
-    wait (cfg.chip_vif.pwrmgr_low_power_if.low_power);
+    wait (cfg.chip_vif.pwrmgr_low_power_if.low_power
+      && cfg.chip_vif.pwrmgr_low_power_if.deep_powerdown);
+
+    @(cfg.chip_vif.pwrmgr_low_power_if.cb);
 
     `uvm_info(`gfn, "Chip Entered Deep Powerdown mode.", UVM_LOW)
 

--- a/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
+++ b/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
@@ -83,8 +83,7 @@ typedef enum {
 } dio_pad_idx_t;
 
 enum { kNumOptOutDio = 2 };
-static const uint8_t kOptOutDio[kNumOptOutDio] = {kDioSpiDevClk,
-                                                  kDioSpiDevCsL};
+static const uint8_t kOptOutDio[kNumOptOutDio] = {kDioSpiDevClk, kDioSpiDevCsL};
 
 typedef enum {
   kMioIoR0 = 35,
@@ -100,9 +99,7 @@ typedef enum {
  * Issue(#15006) for debugging.
  */
 enum { kNumOptOutMio = 4 };
-static const uint8_t kOptOutMio[kNumOptOutMio] = {kMioIoR0,
-                                                  kMioIoR2,
-                                                  kMioIoR3,
+static const uint8_t kOptOutMio[kNumOptOutMio] = {kMioIoR0, kMioIoR2, kMioIoR3,
                                                   kMioIoR4};
 
 static uint8_t kMioPads[NUM_MIO_PADS] = {0};
@@ -113,7 +110,8 @@ static uint8_t kDioPads[NUM_DIO_PADS] = {0};
  * Each gen32 can cover 16 PADs randomization. When each pad ret val draws
  * **3**, the code calls gen32_range to choose from 0 to 2.
  */
-void draw_pinmux_ret(const uint32_t num_pins, uint8_t *arr, const uint8_t *optout, const uint8_t num_optout) {
+void draw_pinmux_ret(const uint32_t num_pins, uint8_t *arr,
+                     const uint8_t *optout, const uint8_t num_optout) {
   for (int i = 0; i < num_pins; i += 16) {
     uint32_t val = rand_testutils_gen32();
     uint32_t min_idx = (i + 16 < num_pins) ? i + 16 : num_pins;
@@ -129,7 +127,7 @@ void draw_pinmux_ret(const uint32_t num_pins, uint8_t *arr, const uint8_t *optou
 
   // OptOut processing after draw.
   for (int i = 0; i < num_optout; i++) {
-    arr[optout[i]] = 2; // High-Z always
+    arr[optout[i]] = 2;  // High-Z always
   }
 }
 

--- a/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
+++ b/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
@@ -82,9 +82,9 @@ typedef enum uint8_t {
   kDioSpiHostCsL  /* DIO 15               OUTPUT */
 } dio_pad_idx_t;
 
-#define NUM_OPTOUT_DIO 2
-static const uint8_t kOptOutDio[NUM_OPTOUT_DIO] = {kDioSpiDevClk,
-                                                   kDioSpiDevCsL};
+enum { kNumOptOutDio = 2 };
+static const uint8_t kOptOutDio[kNumOptOutDio] = {kDioSpiDevClk,
+                                                  kDioSpiDevCsL};
 
 static uint8_t kMioPads[NUM_MIO_PADS] = {0};
 static uint8_t kDioPads[NUM_DIO_PADS] = {0};
@@ -216,5 +216,3 @@ bool test_main(void) {
 
   return result;
 }
-
-#undef NUM_OPTOUT_DIO


### PR DESCRIPTION
This PR contains #15011 

In this PR, the test now checks the Retention outputs. If PADs are configured to drive 0 or 1, vseq checks the PAD output when the chip enters deep powerdown.

A few PADs are opted out due to the pad characteristics or issues.