### PR TITLE
[dv/kmac] Add more coverage sampling points

### DIFF
--- a/hw/ip/kmac/dv/cov/kmac_cov.core
+++ b/hw/ip/kmac/dv/cov/kmac_cov.core
@@ -13,6 +13,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_utils
     files:
+      - kmac_cov_if.sv
       - kmac_cov_bind.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/kmac/dv/cov/kmac_cov_bind.sv
+++ b/hw/ip/kmac/dv/cov/kmac_cov_bind.sv
@@ -3,6 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module kmac_cov_bind;
+  bind kmac kmac_cov_if kmac_cov_if (
+    .sw_cmd_process (reg2msgfifo_process),
+    .keccak_st      (u_sha3.u_keccak.keccak_st),
+    .msgfifo_depth  (msgfifo_depth),
+    .msgfifo_full   (msgfifo_full),
+    .msgfifo_empty  (msgfifo_empty)
+  );
+
   bind kmac cip_mubi_cov_if #(.Width(4)) kmac_sha3_done_mubi_cov_if (
     .rst_ni (rst_ni),
     .mubi   (sha3_done)

--- a/hw/ip/kmac/dv/cov/kmac_cov_if.sv
+++ b/hw/ip/kmac/dv/cov/kmac_cov_if.sv
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface kmac_cov_if
+  (
+   input logic     sw_cmd_process,
+   input bit [5:0] keccak_st,
+   input bit [3:0] msgfifo_depth,
+   input bit       msgfifo_full,
+   input bit       msgfifo_empty
+   );
+
+  `include "dv_fcov_macros.svh"
+  typedef enum logic [5:0] {
+      StIdle = 6'b011111,
+
+      StActive = 6'b000100,
+
+      StPhase1 = 6'b101101,
+
+      StPhase2Cycle1 = 6'b000011,
+
+      StPhase2Cycle2 = 6'b011000,
+
+      StPhase2Cycle3 = 6'b101010,
+
+      StError = 6'b110001,
+
+      StTerminalError = 6'b110110
+  } keccak_st_e;
+
+  covergroup cmd_process_cg @(sw_cmd_process == 1);
+    kmac_keccak_state: coverpoint keccak_st {
+      bins active = {StActive, StPhase1, StPhase2Cycle1, StPhase2Cycle2, StPhase2Cycle3};
+      bins inactive = {StIdle};
+    }
+
+    // TODO: check with designer, this might be unreachable.
+    kmac_msgfifo_full: coverpoint msgfifo_full {
+      bins full     = {1};
+      bins not_full = {0};
+    }
+
+    kmac_msgfifo_empty: coverpoint msgfifo_empty {
+      bins empty     = {1};
+      bins not_empty = {0};
+    }
+
+    kmac_msgfifo_has_data: coverpoint msgfifo_depth {
+      bins has_data = {[1:15]};
+    }
+  endgroup
+
+  `DV_FCOV_INSTANTIATE_CG(cmd_process_cg)
+endinterface

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -59,6 +59,10 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
         num_interrupts = ral.intr_state.get_n_used_bits();
       end
     end
+
+    // only support 1 outstanding TL items in tlul_adapter
+    m_tl_agent_cfg.max_outstanding_req = 1;
+
   endfunction
 
 endclass

--- a/hw/ip/kmac/dv/env/kmac_env_cov.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cov.sv
@@ -291,12 +291,6 @@ class kmac_env_cov extends cip_base_env_cov #(.CFG_T(kmac_env_cfg));
     state_mask_share_cross: cross share, state_read_mask;
   endgroup
 
-  covergroup cmd_process_cg with function sample(bit in_keccak_rounds, bit keccak_complete_cycle);
-    in_keccak: coverpoint in_keccak_rounds;
-
-    in_keccak_complete_cycle: coverpoint keccak_complete_cycle;
-  endgroup
-
   covergroup sideload_cg with function sample(bit en_sideload, bit in_kmac, bit app_keymgr);
     sideload:       coverpoint en_sideload;
     kmac_mode:      coverpoint in_kmac;
@@ -410,7 +404,6 @@ class kmac_env_cov extends cip_base_env_cov #(.CFG_T(kmac_env_cfg));
     msgfifo_level_cg = new();
     sha3_status_cg = new();
     state_read_mask_cg = new();
-    cmd_process_cg = new();
     sideload_cg = new();
     error_cg = new();
     do begin


### PR DESCRIPTION
This PR fixes three empty fcov bins:
1). Cmd_process_cg: this samples when command process is issued, what is
  the internal state. I created an interface to probe and sample it.
2). Msgfifo_level_cg: add sampling in scb.
3). Sha3_status_cg: add sampling in scb.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>