### PR TITLE
[dv] Fix clk_rst_if limitation

### DIFF
--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -149,16 +149,10 @@ interface clk_rst_if #(
     clk_freq_scale_up = freq_scale_up;
   endfunction
 
-  // call this function at t=0 (from tb top) to enable clk and rst_n to be driven
+  // Enables the clock and reset to be driven.
   function automatic void set_active(bit drive_clk_val = 1'b1, bit drive_rst_n_val = 1'b1);
-    time t = $time;
-    if (t == 0) begin
-      drive_clk = drive_clk_val;
-      drive_rst_n = drive_rst_n_val;
-    end
-    else begin
-      `dv_fatal("This function can only be called at t=0", msg_id)
-    end
+    drive_clk = drive_clk_val;
+    drive_rst_n = drive_rst_n_val;
   endfunction
 
   // set the clk period in ps

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -639,10 +639,7 @@ interface chip_if;
     for (int i = 0; i < NUM_UARTS; i++) enable_uart(.inst_num(i), .enable(0));
     for (int i = 0; i < NUM_SPI_HOSTS; i++) enable_spi_device(.inst_num(i), .enable(0));
     for (int i = 0; i < NUM_I2CS; i++) enable_i2c(.inst_num(i), .enable(0));
-
-    // Set Active only can be called @ t=0
-    ext_clk_if.drive_clk   = 1'b 0;
-    ext_clk_if.drive_rst_n = 1'b 0;
+    ext_clk_if.set_active(0, 0);
   endfunction
 
   // Verifies an LC control signal broadcast by the LC controller.


### PR DESCRIPTION
The clock and reset drivability was limited to
t = 0 time setting. There is no need to have
this limitation.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>