### PR TITLE
[chip dv] Fix JTAG interface enablement

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -350,7 +350,7 @@ interface chip_if;
   // Whether the desired JTAG TAP will actually selected or not depends on the LC state and the
   // window of time when the TAP straps are set. It is upto the test sequence to orchestrate it
   // correctly. Disconnect the TAP strap interface to free up the muxed IOs.
-  wire __enable_jtag = (tap_straps_if.pins != 0);
+  wire __enable_jtag = (|(tap_straps_if.pins_oe & tap_straps_if.pins_o));
   wire lc_hw_debug_en = (`LC_CTRL_HIER.lc_hw_debug_en_o == lc_ctrl_pkg::On);
   jtag_if jtag_if();
 


### PR DESCRIPTION
THe previous code relied on the test bench setting the TAP strap pins to enable the JTAG interface, rather than adding a dedicated `enable_jtag` mux signal.

The existing code looked at the `tap_straps_if.pins`, which is just a wire which will reflect the value of the pins IOC5,8 which may have been wiggled for a different test with a different interface, and that would inadvertantly end up enabling JTAG, causing contention.

This commit makes it look at both, the `pins_o` and `pins_oe` values, so that the actual intent of setting the TAP straps is what causes the JTAG to be enabled.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>