### PR TITLE
[ottool] Emit results as colorized hjson

### DIFF
--- a/rules/scripts/cargo_raze.template.sh
+++ b/rules/scripts/cargo_raze.template.sh
@@ -14,5 +14,5 @@ if ! cd "$BUILD_WORKSPACE_DIRECTORY"; then
 fi
 
 for F in "${FILES[@]}"; do
-    bazel run @@CARGO_RAZE@@ -- --manifest-path="$BUILD_WORKSPACE_DIRECTORY/$F"
+    bazel run @@CARGO_RAZE@@ -- --manifest-path="$BUILD_WORKSPACE_DIRECTORY/$F" "$@"
 done

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -163,6 +163,7 @@ rust_library(
         "//third_party/rust/crates:rsa",
         "//third_party/rust/crates:rusb",
         "//third_party/rust/crates:serde",
+        "//third_party/rust/crates:serde_annotate",
         "//third_party/rust/crates:serde_json",
         "//third_party/rust/crates:serialport",
         "//third_party/rust/crates:sha2",

--- a/sw/host/opentitanlib/src/app/config/mod.rs
+++ b/sw/host/opentitanlib/src/app/config/mod.rs
@@ -46,7 +46,7 @@ pub fn process_config_file(env: &mut TransportWrapper, conf_file: &Path) -> Resu
         read_into_string(conf_file, &mut string)
             .map_err(|e| Error::ConfigReadError(conf_file.to_path_buf(), e.into()))?
     };
-    let res: ConfigurationFile = serde_json::from_str(conf_data)
+    let res: ConfigurationFile = serde_annotate::from_str(conf_data)
         .map_err(|e| Error::ConfigParseError(conf_file.to_path_buf(), e.into()))?;
 
     let subdir = conf_file.parent().unwrap_or_else(|| Path::new(""));

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -35,6 +35,7 @@ rust_binary(
     deps = [
         "//sw/host/opentitanlib",
         "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:atty",
         "//third_party/rust/crates:directories",
         "//third_party/rust/crates:env_logger",
         "//third_party/rust/crates:erased_serde",
@@ -45,6 +46,7 @@ rust_binary(
         "//third_party/rust/crates:raw_tty",
         "//third_party/rust/crates:regex",
         "//third_party/rust/crates:serde",
+        "//third_party/rust/crates:serde_annotate",
         "//third_party/rust/crates:serde_json",
         "//third_party/rust/crates:shellwords",
         "//third_party/rust/crates:structopt",

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -3,14 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use atty::Stream;
 use directories::ProjectDirs;
 use erased_serde::Serialize;
 use log::LevelFilter;
+use serde_annotate::ColorProfile;
 use std::env::{args_os, ArgsOs};
 use std::ffi::OsString;
 use std::io::ErrorKind;
 use std::iter::{IntoIterator, Iterator};
 use std::path::PathBuf;
+use structopt::clap::arg_enum;
 use structopt::StructOpt;
 
 mod command;
@@ -44,6 +47,16 @@ enum RootCommandHierarchy {
     Greetings(command::hello::Greetings),
 }
 
+arg_enum! {
+    #[derive(Clone, Copy, Debug)]
+    enum Format {
+        Json,
+        Json5,
+        HJson,
+        Yaml,
+    }
+}
+
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "opentitantool",
@@ -59,6 +72,24 @@ struct Opts {
 
     #[structopt(long, default_value = "off")]
     logging: LevelFilter,
+
+    #[structopt(
+        short,
+        long,
+        possible_values = &Format::variants(),
+        case_insensitive = true,
+        default_value = "hjson",
+        help = "Preferred output format"
+    )]
+    format: Format,
+
+    #[structopt(
+        short,
+        long,
+        parse(try_from_str),
+        help = "Use color in the output"
+    )]
+    color: Option<bool>,
 
     #[structopt(
         long,
@@ -131,11 +162,23 @@ fn parse_command_line(opts: Opts, mut args: ArgsOs) -> Result<Opts> {
 
 // Print the result of a command.
 // If there is an error and `RUST_BACKTRACE=1`, print a backtrace.
-fn print_command_result(result: Result<Option<Box<dyn Serialize>>>) -> Result<()> {
+fn print_command_result(opts: &Opts, result: Result<Option<Box<dyn Serialize>>>) -> Result<()> {
     match result {
         Ok(Some(value)) => {
             log::info!("Command result: success.");
-            println!("{}", serde_json::to_string_pretty(&value)?);
+            let profile = if atty::is(Stream::Stdout) && opts.color.unwrap_or(true) {
+                ColorProfile::basic()
+            } else {
+                ColorProfile::default()
+            };
+            let doc = serde_annotate::serialize(&value)?;
+            let string = match opts.format {
+                Format::Json => doc.to_json().color(profile).to_string(),
+                Format::Json5 => doc.to_json5().color(profile).to_string(),
+                Format::HJson => doc.to_hjson().color(profile).to_string(),
+                Format::Yaml => doc.to_yaml().color(profile).to_string(),
+            };
+            println!("{}", string);
             Ok(())
         }
         Ok(None) => {
@@ -158,7 +201,7 @@ where
     let command = RootCommandHierarchy::from_iter(
         std::iter::once(OsString::from("opentitantool")).chain(args),
     );
-    print_command_result(command.run(opts, &transport))?;
+    print_command_result(opts, command.run(opts, &transport))?;
     Ok(())
 }
 
@@ -174,6 +217,6 @@ fn main() -> Result<()> {
             &transport,
         )?;
     }
-    print_command_result(opts.command.run(&opts, &transport))?;
+    print_command_result(&opts, opts.command.run(&opts, &transport))?;
     Ok(())
 }

--- a/third_party/rust/crates/BUILD.bazel
+++ b/third_party/rust/crates/BUILD.bazel
@@ -14,7 +14,16 @@ licenses([
 # Aliased targets
 alias(
     name = "anyhow",
-    actual = "@raze__anyhow__1_0_64//:anyhow",
+    actual = "@raze__anyhow__1_0_65//:anyhow",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "atty",
+    actual = "@raze__atty__0_2_14//:atty",
     tags = [
         "cargo-raze",
         "manual",
@@ -301,6 +310,15 @@ alias(
 )
 
 alias(
+    name = "serde_annotate",
+    actual = "@raze__serde_annotate__0_1_0//:serde_annotate",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "serde_json",
     actual = "@raze__serde_json__1_0_85//:serde_json",
     tags = [
@@ -320,7 +338,7 @@ alias(
 
 alias(
     name = "sha2",
-    actual = "@raze__sha2__0_10_5//:sha2",
+    actual = "@raze__sha2__0_10_6//:sha2",
     tags = [
         "cargo-raze",
         "manual",
@@ -347,7 +365,7 @@ alias(
 
 alias(
     name = "syn",
-    actual = "@raze__syn__1_0_99//:syn",
+    actual = "@raze__syn__1_0_100//:syn",
     tags = [
         "cargo-raze",
         "manual",
@@ -365,7 +383,7 @@ alias(
 
 alias(
     name = "thiserror",
-    actual = "@raze__thiserror__1_0_34//:thiserror",
+    actual = "@raze__thiserror__1_0_35//:thiserror",
     tags = [
         "cargo-raze",
         "manual",

--- a/third_party/rust/crates/Cargo.raze.lock
+++ b/third_party/rust/crates/Cargo.raze.lock
@@ -55,6 +55,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate_derive"
+version = "0.1.0"
+source = "git+https://github.com/lowRISC/serde-annotate#35a4bba49cf6814ac15abbe25a6ff588ffa06d2d"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.100",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 dependencies = [
  "backtrace",
 ]
@@ -126,6 +137,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,9 +174,12 @@ name = "cargo_raze_deps"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "atty",
  "bitflags",
+ "bitvec",
  "byteorder",
  "chrono",
+ "crc",
  "deser-hjson",
  "directories",
  "env_logger",
@@ -180,12 +206,13 @@ dependencies = [
  "rsa",
  "rusb",
  "serde",
+ "serde_annotate",
  "serde_json",
  "serialport",
  "sha2",
  "shellwords",
  "structopt",
- "syn 1.0.99",
+ "syn 1.0.100",
  "tempfile",
  "thiserror",
  "typetag",
@@ -275,6 +302,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,7 +353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
 ]
 
 [[package]]
@@ -356,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -432,6 +474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,7 +508,7 @@ checksum = "eb19fe8de3ea0920d282f7b77dd4227aea6b8b999b42cdf0ca41b2472b14443a"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
 ]
 
 [[package]]
@@ -501,9 +549,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.47"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+checksum = "237a0714f28b1ee39ccec0770ccb544eb02c9ef2c82bb096230eefcffa6468b0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -570,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "libm"
@@ -797,7 +845,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
 ]
 
 [[package]]
@@ -838,6 +886,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
 dependencies = [
  "base64ct",
+]
+
+[[package]]
+name = "pest"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.100",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha1",
 ]
 
 [[package]]
@@ -896,7 +988,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
  "version_check",
 ]
 
@@ -948,6 +1040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -1109,6 +1207,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_annotate"
+version = "0.1.0"
+source = "git+https://github.com/lowRISC/serde-annotate#35a4bba49cf6814ac15abbe25a6ff588ffa06d2d"
+dependencies = [
+ "annotate_derive",
+ "ansi_term",
+ "inventory",
+ "num-traits",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,7 +1231,7 @@ checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
 ]
 
 [[package]]
@@ -1148,14 +1263,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
+name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.5",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -1216,7 +1342,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
 ]
 
 [[package]]
@@ -1238,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -1255,9 +1381,15 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
- "unicode-xid 0.2.3",
+ "syn 1.0.100",
+ "unicode-xid 0.2.4",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1303,22 +1435,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
 ]
 
 [[package]]
@@ -1368,26 +1500,32 @@ checksum = "e60147782cc30833c05fba3bab1d9b5771b2685a2557672ac96fa5d154099c0e"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.3"
+name = "ucd-trie"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -1397,9 +1535,9 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "vcpkg"
@@ -1458,7 +1596,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -1480,7 +1618,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1523,6 +1661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,7 +1686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
 dependencies = [
  "proc-macro2 1.0.43",
- "syn 1.0.99",
+ "syn 1.0.100",
  "synstructure",
 ]
 
@@ -1560,6 +1707,6 @@ checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
- "syn 1.0.99",
+ "syn 1.0.100",
  "synstructure",
 ]

--- a/third_party/rust/crates/Cargo.toml
+++ b/third_party/rust/crates/Cargo.toml
@@ -14,6 +14,7 @@ path = "empty_file_to_appease_cargo.rs"
 # Please avoid version numbers that only have one component.
 [dependencies]
 anyhow = { version = "1.0.57", features=["backtrace"] }
+atty = "0.2"
 bitflags = "1.0"
 bitvec = "1.0.1"
 byteorder = "1.4.3"
@@ -45,6 +46,7 @@ regex = "1.5.4"
 rsa = "0.5.0"
 rusb = "0.8.1"
 serde = { version="1.0.130", features=["serde_derive"] }
+serde_annotate = { git = "https://github.com/lowRISC/serde-annotate" }
 serde_json = "1.0.69"
 serialport = "4.0.1"
 sha2 = "0.10.1"
@@ -76,3 +78,6 @@ patch_args = ["-p1"]
 # Workaround for https://github.com/google/cargo-raze/issues/480
 [workspace.metadata.raze.crates.bitvec.'1.0.1']
 data_attr = 'glob(["**/*.md"])'
+
+[package.metadata.raze.crates.serde_annotate.'*']
+compile_data_attr = '[ "src/relax.pest" ]'

--- a/third_party/rust/crates/crates.bzl
+++ b/third_party/rust/crates/crates.bzl
@@ -12,7 +12,8 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")  # buildifier: di
 # EXPERIMENTAL -- MAY CHANGE AT ANY TIME: A mapping of package names to a set of normal dependencies for the Rust targets of that package.
 _DEPENDENCIES = {
     "third_party/rust/crates": {
-        "anyhow": "@raze__anyhow__1_0_64//:anyhow",
+        "anyhow": "@raze__anyhow__1_0_65//:anyhow",
+        "atty": "@raze__atty__0_2_14//:atty",
         "bitflags": "@raze__bitflags__1_3_2//:bitflags",
         "bitvec": "@raze__bitvec__1_0_1//:bitvec",
         "byteorder": "@raze__byteorder__1_4_3//:byteorder",
@@ -44,14 +45,15 @@ _DEPENDENCIES = {
         "rsa": "@raze__rsa__0_5_0//:rsa",
         "rusb": "@raze__rusb__0_8_1//:rusb",
         "serde": "@raze__serde__1_0_144//:serde",
+        "serde_annotate": "@raze__serde_annotate__0_1_0//:serde_annotate",
         "serde_json": "@raze__serde_json__1_0_85//:serde_json",
         "serialport": "@raze__serialport__4_2_0//:serialport",
-        "sha2": "@raze__sha2__0_10_5//:sha2",
+        "sha2": "@raze__sha2__0_10_6//:sha2",
         "shellwords": "@raze__shellwords__1_1_0//:shellwords",
         "structopt": "@raze__structopt__0_3_26//:structopt",
-        "syn": "@raze__syn__1_0_99//:syn",
+        "syn": "@raze__syn__1_0_100//:syn",
         "tempfile": "@raze__tempfile__3_3_0//:tempfile",
-        "thiserror": "@raze__thiserror__1_0_34//:thiserror",
+        "thiserror": "@raze__thiserror__1_0_35//:thiserror",
         "typetag": "@raze__typetag__0_1_8//:typetag",
         "zerocopy": "@raze__zerocopy__0_5_0//:zerocopy",
     },
@@ -212,176 +214,363 @@ def raze_fetch_remote_crates(
         # Each of these may be used to temporarily override the location of
         # the crate to a path on your local filesystem for local development
         # of crates you may be using in your project.
-        CoreFoundation_sys__0_1_4 = None,
-        IOKit_sys__0_1_5 = None,
-        addr2line__0_17_0 = None,
-        adler__1_0_2 = None,
-        aho_corasick__0_7_19 = None,
-        android_system_properties__0_1_5 = None,
-        ansi_term__0_12_1 = None,
-        anyhow__1_0_64 = None,
-        atty__0_2_14 = None,
-        autocfg__0_1_8 = None,
-        autocfg__1_1_0 = None,
-        backtrace__0_3_66 = None,
-        base64ct__1_1_1 = None,
-        bitflags__1_3_2 = None,
-        bitvec__1_0_1 = None,
-        block_buffer__0_10_3 = None,
-        bumpalo__3_11_0 = None,
-        byteorder__1_4_3 = None,
-        cc__1_0_73 = None,
-        cfg_if__0_1_10 = None,
-        cfg_if__1_0_0 = None,
-        chrono__0_4_22 = None,
-        clap__2_34_0 = None,
-        console__0_15_1 = None,
-        const_oid__0_6_2 = None,
-        core_foundation_sys__0_8_3 = None,
-        cpufeatures__0_2_5 = None,
-        crc__3_0_0 = None,
-        crc_catalog__2_1_0 = None,
-        crc32fast__1_3_2 = None,
-        crypto_bigint__0_2_11 = None,
-        crypto_common__0_1_6 = None,
-        ctor__0_1_23 = None,
-        der__0_4_5 = None,
-        derive_more__0_14_1 = None,
-        deser_hjson__1_0_2 = None,
-        digest__0_10_3 = None,
-        digest__0_9_0 = None,
-        directories__4_0_1 = None,
-        dirs_sys__0_3_7 = None,
-        encode_unicode__0_3_6 = None,
-        env_logger__0_8_4 = None,
-        erased_serde__0_3_23 = None,
-        fastrand__1_8_0 = None,
-        flate2__1_0_24 = None,
-        funty__2_0_0 = None,
-        generic_array__0_14_6 = None,
-        getrandom__0_2_7 = None,
-        ghost__0_1_6 = None,
-        gimli__0_26_2 = None,
-        heck__0_3_3 = None,
-        hermit_abi__0_1_19 = None,
-        hex__0_4_3 = None,
-        humantime__2_1_0 = None,
-        iana_time_zone__0_1_47 = None,
-        indicatif__0_16_2 = None,
-        instant__0_1_12 = None,
-        inventory__0_2_3 = None,
-        itoa__1_0_3 = None,
-        js_sys__0_3_60 = None,
-        lazy_static__1_4_0 = None,
-        libc__0_2_132 = None,
-        libm__0_2_5 = None,
-        libudev__0_3_0 = None,
-        libudev_sys__0_1_4 = None,
-        libusb1_sys__0_5_0 = None,
-        log__0_4_17 = None,
-        mach__0_1_2 = None,
-        mach__0_3_2 = None,
-        memchr__2_5_0 = None,
-        memoffset__0_6_5 = None,
-        miniz_oxide__0_5_4 = None,
-        mio__0_7_14 = None,
-        mio_signals__0_1_5 = None,
-        miow__0_3_7 = None,
-        nix__0_17_0 = None,
-        nix__0_24_2 = None,
-        ntapi__0_3_7 = None,
-        num_bigint_dig__0_7_0 = None,
-        num_integer__0_1_45 = None,
-        num_iter__0_1_43 = None,
-        num_traits__0_2_15 = None,
-        num_enum__0_5_7 = None,
-        num_enum_derive__0_5_7 = None,
-        number_prefix__0_4_0 = None,
-        object__0_25_3 = None,
-        object__0_29_0 = None,
-        once_cell__1_14_0 = None,
-        pem_rfc7468__0_2_4 = None,
-        pkcs1__0_2_4 = None,
-        pkcs8__0_7_6 = None,
-        pkg_config__0_3_25 = None,
-        ppv_lite86__0_2_16 = None,
-        proc_macro_crate__1_2_1 = None,
-        proc_macro_error__1_0_4 = None,
-        proc_macro_error_attr__1_0_4 = None,
-        proc_macro2__0_4_30 = None,
-        proc_macro2__1_0_43 = None,
-        quote__0_6_13 = None,
-        quote__1_0_21 = None,
-        radium__0_7_0 = None,
-        rand__0_8_5 = None,
-        rand_chacha__0_3_1 = None,
-        rand_core__0_6_3 = None,
-        raw_tty__0_1_0 = None,
-        redox_syscall__0_2_16 = None,
-        redox_users__0_4_3 = None,
-        regex__1_6_0 = None,
-        regex_syntax__0_6_27 = None,
-        remove_dir_all__0_5_3 = None,
-        rsa__0_5_0 = None,
-        rusb__0_8_1 = None,
-        rustc_demangle__0_1_21 = None,
-        rustc_version__0_2_3 = None,
-        ryu__1_0_11 = None,
-        semver__0_9_0 = None,
-        semver_parser__0_7_0 = None,
-        serde__1_0_144 = None,
-        serde_derive__1_0_144 = None,
-        serde_json__1_0_85 = None,
-        serialport__4_2_0 = None,
-        sha2__0_10_5 = None,
-        shellwords__1_1_0 = None,
-        smallvec__1_9_0 = None,
-        spin__0_5_2 = None,
-        spki__0_4_1 = None,
-        strsim__0_8_0 = None,
-        structopt__0_3_26 = None,
-        structopt_derive__0_4_18 = None,
-        subtle__2_4_1 = None,
-        syn__0_15_44 = None,
-        syn__1_0_99 = None,
-        synstructure__0_12_6 = None,
-        tap__1_0_1 = None,
-        tempfile__3_3_0 = None,
-        termcolor__1_1_3 = None,
-        terminal_size__0_1_17 = None,
-        textwrap__0_11_0 = None,
-        thiserror__1_0_34 = None,
-        thiserror_impl__1_0_34 = None,
-        time__0_1_44 = None,
-        toml__0_5_9 = None,
-        typenum__1_15_0 = None,
-        typetag__0_1_8 = None,
-        typetag_impl__0_1_8 = None,
-        unicode_ident__1_0_3 = None,
-        unicode_segmentation__1_9_0 = None,
-        unicode_width__0_1_9 = None,
-        unicode_xid__0_1_0 = None,
-        unicode_xid__0_2_3 = None,
-        vcpkg__0_2_15 = None,
-        vec_map__0_8_2 = None,
-        version_check__0_9_4 = None,
-        void__1_0_2 = None,
-        wasi__0_10_0_wasi_snapshot_preview1 = None,
-        wasi__0_11_0_wasi_snapshot_preview1 = None,
-        wasm_bindgen__0_2_83 = None,
-        wasm_bindgen_backend__0_2_83 = None,
-        wasm_bindgen_macro__0_2_83 = None,
-        wasm_bindgen_macro_support__0_2_83 = None,
-        wasm_bindgen_shared__0_2_83 = None,
-        winapi__0_3_9 = None,
-        winapi_i686_pc_windows_gnu__0_4_0 = None,
-        winapi_util__0_1_5 = None,
-        winapi_x86_64_pc_windows_gnu__0_4_0 = None,
-        wyz__0_5_0 = None,
-        zerocopy__0_5_0 = None,
-        zerocopy_derive__0_3_1 = None,
-        zeroize__1_4_3 = None,
-        zeroize_derive__1_3_2 = None):
+        CoreFoundation_sys__0_1_4=None,
+
+        IOKit_sys__0_1_5=None,
+
+        addr2line__0_17_0=None,
+
+        adler__1_0_2=None,
+
+        aho_corasick__0_7_19=None,
+
+        android_system_properties__0_1_5=None,
+
+        annotate_derive__0_1_0=None,
+
+        ansi_term__0_12_1=None,
+
+        anyhow__1_0_65=None,
+
+        atty__0_2_14=None,
+
+        autocfg__0_1_8=None,
+
+        autocfg__1_1_0=None,
+
+        backtrace__0_3_66=None,
+
+        base64ct__1_1_1=None,
+
+        bitflags__1_3_2=None,
+
+        bitvec__1_0_1=None,
+
+        block_buffer__0_10_3=None,
+
+        bumpalo__3_11_0=None,
+
+        byteorder__1_4_3=None,
+
+        cc__1_0_73=None,
+
+        cfg_if__0_1_10=None,
+
+        cfg_if__1_0_0=None,
+
+        chrono__0_4_22=None,
+
+        clap__2_34_0=None,
+
+        console__0_15_1=None,
+
+        const_oid__0_6_2=None,
+
+        core_foundation_sys__0_8_3=None,
+
+        cpufeatures__0_2_5=None,
+
+        crc__3_0_0=None,
+
+        crc_catalog__2_1_0=None,
+
+        crc32fast__1_3_2=None,
+
+        crypto_bigint__0_2_11=None,
+
+        crypto_common__0_1_6=None,
+
+        ctor__0_1_23=None,
+
+        der__0_4_5=None,
+
+        derive_more__0_14_1=None,
+
+        deser_hjson__1_0_2=None,
+
+        digest__0_10_5=None,
+
+        digest__0_9_0=None,
+
+        directories__4_0_1=None,
+
+        dirs_sys__0_3_7=None,
+
+        encode_unicode__0_3_6=None,
+
+        env_logger__0_8_4=None,
+
+        erased_serde__0_3_23=None,
+
+        fastrand__1_8_0=None,
+
+        flate2__1_0_24=None,
+
+        funty__2_0_0=None,
+
+        generic_array__0_14_6=None,
+
+        getrandom__0_2_7=None,
+
+        ghost__0_1_6=None,
+
+        gimli__0_26_2=None,
+
+        heck__0_3_3=None,
+
+        hermit_abi__0_1_19=None,
+
+        hex__0_4_3=None,
+
+        humantime__2_1_0=None,
+
+        iana_time_zone__0_1_48=None,
+
+        indicatif__0_16_2=None,
+
+        instant__0_1_12=None,
+
+        inventory__0_2_3=None,
+
+        itoa__1_0_3=None,
+
+        js_sys__0_3_60=None,
+
+        lazy_static__1_4_0=None,
+
+        libc__0_2_133=None,
+
+        libm__0_2_5=None,
+
+        libudev__0_3_0=None,
+
+        libudev_sys__0_1_4=None,
+
+        libusb1_sys__0_5_0=None,
+
+        log__0_4_17=None,
+
+        mach__0_1_2=None,
+
+        mach__0_3_2=None,
+
+        memchr__2_5_0=None,
+
+        memoffset__0_6_5=None,
+
+        miniz_oxide__0_5_4=None,
+
+        mio__0_7_14=None,
+
+        mio_signals__0_1_5=None,
+
+        miow__0_3_7=None,
+
+        nix__0_17_0=None,
+
+        nix__0_24_2=None,
+
+        ntapi__0_3_7=None,
+
+        num_bigint_dig__0_7_0=None,
+
+        num_integer__0_1_45=None,
+
+        num_iter__0_1_43=None,
+
+        num_traits__0_2_15=None,
+
+        num_enum__0_5_7=None,
+
+        num_enum_derive__0_5_7=None,
+
+        number_prefix__0_4_0=None,
+
+        object__0_25_3=None,
+
+        object__0_29_0=None,
+
+        once_cell__1_14_0=None,
+
+        pem_rfc7468__0_2_4=None,
+
+        pest__2_3_1=None,
+
+        pest_derive__2_3_1=None,
+
+        pest_generator__2_3_1=None,
+
+        pest_meta__2_3_1=None,
+
+        pkcs1__0_2_4=None,
+
+        pkcs8__0_7_6=None,
+
+        pkg_config__0_3_25=None,
+
+        ppv_lite86__0_2_16=None,
+
+        proc_macro_crate__1_2_1=None,
+
+        proc_macro_error__1_0_4=None,
+
+        proc_macro_error_attr__1_0_4=None,
+
+        proc_macro2__0_4_30=None,
+
+        proc_macro2__1_0_43=None,
+
+        quote__0_6_13=None,
+
+        quote__1_0_21=None,
+
+        radium__0_7_0=None,
+
+        rand__0_8_5=None,
+
+        rand_chacha__0_3_1=None,
+
+        rand_core__0_6_4=None,
+
+        raw_tty__0_1_0=None,
+
+        redox_syscall__0_2_16=None,
+
+        redox_users__0_4_3=None,
+
+        regex__1_6_0=None,
+
+        regex_syntax__0_6_27=None,
+
+        remove_dir_all__0_5_3=None,
+
+        rsa__0_5_0=None,
+
+        rusb__0_8_1=None,
+
+        rustc_demangle__0_1_21=None,
+
+        rustc_version__0_2_3=None,
+
+        ryu__1_0_11=None,
+
+        semver__0_9_0=None,
+
+        semver_parser__0_7_0=None,
+
+        serde__1_0_144=None,
+
+        serde_annotate__0_1_0=None,
+
+        serde_derive__1_0_144=None,
+
+        serde_json__1_0_85=None,
+
+        serialport__4_2_0=None,
+
+        sha1__0_10_5=None,
+
+        sha2__0_10_6=None,
+
+        shellwords__1_1_0=None,
+
+        smallvec__1_9_0=None,
+
+        spin__0_5_2=None,
+
+        spki__0_4_1=None,
+
+        strsim__0_8_0=None,
+
+        structopt__0_3_26=None,
+
+        structopt_derive__0_4_18=None,
+
+        subtle__2_4_1=None,
+
+        syn__0_15_44=None,
+
+        syn__1_0_100=None,
+
+        synstructure__0_12_6=None,
+
+        tap__1_0_1=None,
+
+        tempfile__3_3_0=None,
+
+        termcolor__1_1_3=None,
+
+        terminal_size__0_1_17=None,
+
+        textwrap__0_11_0=None,
+
+        thiserror__1_0_35=None,
+
+        thiserror_impl__1_0_35=None,
+
+        time__0_1_44=None,
+
+        toml__0_5_9=None,
+
+        typenum__1_15_0=None,
+
+        typetag__0_1_8=None,
+
+        typetag_impl__0_1_8=None,
+
+        ucd_trie__0_1_5=None,
+
+        unicode_ident__1_0_4=None,
+
+        unicode_segmentation__1_10_0=None,
+
+        unicode_width__0_1_10=None,
+
+        unicode_xid__0_1_0=None,
+
+        unicode_xid__0_2_4=None,
+
+        vcpkg__0_2_15=None,
+
+        vec_map__0_8_2=None,
+
+        version_check__0_9_4=None,
+
+        void__1_0_2=None,
+
+        wasi__0_10_0_wasi_snapshot_preview1=None,
+
+        wasi__0_11_0_wasi_snapshot_preview1=None,
+
+        wasm_bindgen__0_2_83=None,
+
+        wasm_bindgen_backend__0_2_83=None,
+
+        wasm_bindgen_macro__0_2_83=None,
+
+        wasm_bindgen_macro_support__0_2_83=None,
+
+        wasm_bindgen_shared__0_2_83=None,
+
+        winapi__0_3_9=None,
+
+        winapi_i686_pc_windows_gnu__0_4_0=None,
+
+        winapi_util__0_1_5=None,
+
+        winapi_x86_64_pc_windows_gnu__0_4_0=None,
+
+        wyz__0_5_0=None,
+
+        zerocopy__0_5_0=None,
+
+        zerocopy_derive__0_3_1=None,
+
+        zeroize__1_4_3=None,
+
+        zeroize_derive__1_3_2=None,
+
+    ):
     """This function defines a collection of repos and should be called in a WORKSPACE file"""
     if CoreFoundation_sys__0_1_4:
         maybe(
@@ -491,6 +680,23 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.android_system_properties-0.1.5.bazel"),
         )
 
+    if annotate_derive__0_1_0:
+        maybe(
+            native.new_local_repository,
+            name = "raze__annotate_derive__0_1_0",
+            path = annotate_derive__0_1_0,
+            build_file = "//third_party/rust/crates/remote:BUILD.annotate_derive-0.1.0.bazel",
+        )
+    else:
+        maybe(
+            new_git_repository,
+            name = "raze__annotate_derive__0_1_0",
+            remote = "https://github.com/lowRISC/serde-annotate",
+            commit = "35a4bba49cf6814ac15abbe25a6ff588ffa06d2d",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.annotate_derive-0.1.0.bazel"),
+            init_submodules = True,
+        )
+
     if ansi_term__0_12_1:
         maybe(
             native.new_local_repository,
@@ -509,22 +715,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.ansi_term-0.12.1.bazel"),
         )
 
-    if anyhow__1_0_64:
+    if anyhow__1_0_65:
         maybe(
             native.new_local_repository,
-            name = "raze__anyhow__1_0_64",
-            path = anyhow__1_0_64,
-            build_file = "//third_party/rust/crates/remote:BUILD.anyhow-1.0.64.bazel",
+            name = "raze__anyhow__1_0_65",
+            path = anyhow__1_0_65,
+            build_file = "//third_party/rust/crates/remote:BUILD.anyhow-1.0.65.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__anyhow__1_0_64",
-            url = "https://crates.io/api/v1/crates/anyhow/1.0.64/download",
+            name = "raze__anyhow__1_0_65",
+            url = "https://crates.io/api/v1/crates/anyhow/1.0.65/download",
             type = "tar.gz",
-            sha256 = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7",
-            strip_prefix = "anyhow-1.0.64",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.anyhow-1.0.64.bazel"),
+            sha256 = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602",
+            strip_prefix = "anyhow-1.0.65",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.anyhow-1.0.65.bazel"),
         )
 
     if atty__0_2_14:
@@ -1031,22 +1237,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.deser-hjson-1.0.2.bazel"),
         )
 
-    if digest__0_10_3:
+    if digest__0_10_5:
         maybe(
             native.new_local_repository,
-            name = "raze__digest__0_10_3",
-            path = digest__0_10_3,
-            build_file = "//third_party/rust/crates/remote:BUILD.digest-0.10.3.bazel",
+            name = "raze__digest__0_10_5",
+            path = digest__0_10_5,
+            build_file = "//third_party/rust/crates/remote:BUILD.digest-0.10.5.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__digest__0_10_3",
-            url = "https://crates.io/api/v1/crates/digest/0.10.3/download",
+            name = "raze__digest__0_10_5",
+            url = "https://crates.io/api/v1/crates/digest/0.10.5/download",
             type = "tar.gz",
-            sha256 = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506",
-            strip_prefix = "digest-0.10.3",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.digest-0.10.3.bazel"),
+            sha256 = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c",
+            strip_prefix = "digest-0.10.5",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.digest-0.10.5.bazel"),
         )
 
     if digest__0_9_0:
@@ -1355,22 +1561,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.humantime-2.1.0.bazel"),
         )
 
-    if iana_time_zone__0_1_47:
+    if iana_time_zone__0_1_48:
         maybe(
             native.new_local_repository,
-            name = "raze__iana_time_zone__0_1_47",
-            path = iana_time_zone__0_1_47,
-            build_file = "//third_party/rust/crates/remote:BUILD.iana-time-zone-0.1.47.bazel",
+            name = "raze__iana_time_zone__0_1_48",
+            path = iana_time_zone__0_1_48,
+            build_file = "//third_party/rust/crates/remote:BUILD.iana-time-zone-0.1.48.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__iana_time_zone__0_1_47",
-            url = "https://crates.io/api/v1/crates/iana-time-zone/0.1.47/download",
+            name = "raze__iana_time_zone__0_1_48",
+            url = "https://crates.io/api/v1/crates/iana-time-zone/0.1.48/download",
             type = "tar.gz",
-            sha256 = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7",
-            strip_prefix = "iana-time-zone-0.1.47",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.iana-time-zone-0.1.47.bazel"),
+            sha256 = "237a0714f28b1ee39ccec0770ccb544eb02c9ef2c82bb096230eefcffa6468b0",
+            strip_prefix = "iana-time-zone-0.1.48",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.iana-time-zone-0.1.48.bazel"),
         )
 
     if indicatif__0_16_2:
@@ -1481,22 +1687,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.lazy_static-1.4.0.bazel"),
         )
 
-    if libc__0_2_132:
+    if libc__0_2_133:
         maybe(
             native.new_local_repository,
-            name = "raze__libc__0_2_132",
-            path = libc__0_2_132,
-            build_file = "//third_party/rust/crates/remote:BUILD.libc-0.2.132.bazel",
+            name = "raze__libc__0_2_133",
+            path = libc__0_2_133,
+            build_file = "//third_party/rust/crates/remote:BUILD.libc-0.2.133.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__libc__0_2_132",
-            url = "https://crates.io/api/v1/crates/libc/0.2.132/download",
+            name = "raze__libc__0_2_133",
+            url = "https://crates.io/api/v1/crates/libc/0.2.133/download",
             type = "tar.gz",
-            sha256 = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5",
-            strip_prefix = "libc-0.2.132",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.libc-0.2.132.bazel"),
+            sha256 = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966",
+            strip_prefix = "libc-0.2.133",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.libc-0.2.133.bazel"),
         )
 
     if libm__0_2_5:
@@ -1550,12 +1756,12 @@ def raze_fetch_remote_crates(
             type = "tar.gz",
             sha256 = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324",
             strip_prefix = "libudev-sys-0.1.4",
-            patches = [
-                "@//third_party/rust/crates/patches:libudev-sys-0.1.4.patch",
-            ],
-            patch_args = [
-                "-p1",
-            ],
+        patches = [
+            "@//third_party/rust/crates/patches:libudev-sys-0.1.4.patch",
+        ],
+        patch_args = [
+            "-p1",
+        ],
             build_file = Label("//third_party/rust/crates/remote:BUILD.libudev-sys-0.1.4.bazel"),
         )
 
@@ -1991,6 +2197,78 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.pem-rfc7468-0.2.4.bazel"),
         )
 
+    if pest__2_3_1:
+        maybe(
+            native.new_local_repository,
+            name = "raze__pest__2_3_1",
+            path = pest__2_3_1,
+            build_file = "//third_party/rust/crates/remote:BUILD.pest-2.3.1.bazel",
+        )
+    else:
+        maybe(
+            http_archive,
+            name = "raze__pest__2_3_1",
+            url = "https://crates.io/api/v1/crates/pest/2.3.1/download",
+            type = "tar.gz",
+            sha256 = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048",
+            strip_prefix = "pest-2.3.1",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.pest-2.3.1.bazel"),
+        )
+
+    if pest_derive__2_3_1:
+        maybe(
+            native.new_local_repository,
+            name = "raze__pest_derive__2_3_1",
+            path = pest_derive__2_3_1,
+            build_file = "//third_party/rust/crates/remote:BUILD.pest_derive-2.3.1.bazel",
+        )
+    else:
+        maybe(
+            http_archive,
+            name = "raze__pest_derive__2_3_1",
+            url = "https://crates.io/api/v1/crates/pest_derive/2.3.1/download",
+            type = "tar.gz",
+            sha256 = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1",
+            strip_prefix = "pest_derive-2.3.1",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.pest_derive-2.3.1.bazel"),
+        )
+
+    if pest_generator__2_3_1:
+        maybe(
+            native.new_local_repository,
+            name = "raze__pest_generator__2_3_1",
+            path = pest_generator__2_3_1,
+            build_file = "//third_party/rust/crates/remote:BUILD.pest_generator-2.3.1.bazel",
+        )
+    else:
+        maybe(
+            http_archive,
+            name = "raze__pest_generator__2_3_1",
+            url = "https://crates.io/api/v1/crates/pest_generator/2.3.1/download",
+            type = "tar.gz",
+            sha256 = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c",
+            strip_prefix = "pest_generator-2.3.1",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.pest_generator-2.3.1.bazel"),
+        )
+
+    if pest_meta__2_3_1:
+        maybe(
+            native.new_local_repository,
+            name = "raze__pest_meta__2_3_1",
+            path = pest_meta__2_3_1,
+            build_file = "//third_party/rust/crates/remote:BUILD.pest_meta-2.3.1.bazel",
+        )
+    else:
+        maybe(
+            http_archive,
+            name = "raze__pest_meta__2_3_1",
+            url = "https://crates.io/api/v1/crates/pest_meta/2.3.1/download",
+            type = "tar.gz",
+            sha256 = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6",
+            strip_prefix = "pest_meta-2.3.1",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.pest_meta-2.3.1.bazel"),
+        )
+
     if pkcs1__0_2_4:
         maybe(
             native.new_local_repository,
@@ -2243,22 +2521,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.rand_chacha-0.3.1.bazel"),
         )
 
-    if rand_core__0_6_3:
+    if rand_core__0_6_4:
         maybe(
             native.new_local_repository,
-            name = "raze__rand_core__0_6_3",
-            path = rand_core__0_6_3,
-            build_file = "//third_party/rust/crates/remote:BUILD.rand_core-0.6.3.bazel",
+            name = "raze__rand_core__0_6_4",
+            path = rand_core__0_6_4,
+            build_file = "//third_party/rust/crates/remote:BUILD.rand_core-0.6.4.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__rand_core__0_6_3",
-            url = "https://crates.io/api/v1/crates/rand_core/0.6.3/download",
+            name = "raze__rand_core__0_6_4",
+            url = "https://crates.io/api/v1/crates/rand_core/0.6.4/download",
             type = "tar.gz",
-            sha256 = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7",
-            strip_prefix = "rand_core-0.6.3",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.rand_core-0.6.3.bazel"),
+            sha256 = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+            strip_prefix = "rand_core-0.6.4",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.rand_core-0.6.4.bazel"),
         )
 
     if raw_tty__0_1_0:
@@ -2513,6 +2791,23 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.serde-1.0.144.bazel"),
         )
 
+    if serde_annotate__0_1_0:
+        maybe(
+            native.new_local_repository,
+            name = "raze__serde_annotate__0_1_0",
+            path = serde_annotate__0_1_0,
+            build_file = "//third_party/rust/crates/remote:BUILD.serde_annotate-0.1.0.bazel",
+        )
+    else:
+        maybe(
+            new_git_repository,
+            name = "raze__serde_annotate__0_1_0",
+            remote = "https://github.com/lowRISC/serde-annotate",
+            commit = "35a4bba49cf6814ac15abbe25a6ff588ffa06d2d",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.serde_annotate-0.1.0.bazel"),
+            init_submodules = True,
+        )
+
     if serde_derive__1_0_144:
         maybe(
             native.new_local_repository,
@@ -2567,22 +2862,40 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.serialport-4.2.0.bazel"),
         )
 
-    if sha2__0_10_5:
+    if sha1__0_10_5:
         maybe(
             native.new_local_repository,
-            name = "raze__sha2__0_10_5",
-            path = sha2__0_10_5,
-            build_file = "//third_party/rust/crates/remote:BUILD.sha2-0.10.5.bazel",
+            name = "raze__sha1__0_10_5",
+            path = sha1__0_10_5,
+            build_file = "//third_party/rust/crates/remote:BUILD.sha1-0.10.5.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__sha2__0_10_5",
-            url = "https://crates.io/api/v1/crates/sha2/0.10.5/download",
+            name = "raze__sha1__0_10_5",
+            url = "https://crates.io/api/v1/crates/sha1/0.10.5/download",
             type = "tar.gz",
-            sha256 = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5",
-            strip_prefix = "sha2-0.10.5",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.sha2-0.10.5.bazel"),
+            sha256 = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3",
+            strip_prefix = "sha1-0.10.5",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.sha1-0.10.5.bazel"),
+        )
+
+    if sha2__0_10_6:
+        maybe(
+            native.new_local_repository,
+            name = "raze__sha2__0_10_6",
+            path = sha2__0_10_6,
+            build_file = "//third_party/rust/crates/remote:BUILD.sha2-0.10.6.bazel",
+        )
+    else:
+        maybe(
+            http_archive,
+            name = "raze__sha2__0_10_6",
+            url = "https://crates.io/api/v1/crates/sha2/0.10.6/download",
+            type = "tar.gz",
+            sha256 = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0",
+            strip_prefix = "sha2-0.10.6",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.sha2-0.10.6.bazel"),
         )
 
     if shellwords__1_1_0:
@@ -2747,22 +3060,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.syn-0.15.44.bazel"),
         )
 
-    if syn__1_0_99:
+    if syn__1_0_100:
         maybe(
             native.new_local_repository,
-            name = "raze__syn__1_0_99",
-            path = syn__1_0_99,
-            build_file = "//third_party/rust/crates/remote:BUILD.syn-1.0.99.bazel",
+            name = "raze__syn__1_0_100",
+            path = syn__1_0_100,
+            build_file = "//third_party/rust/crates/remote:BUILD.syn-1.0.100.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__syn__1_0_99",
-            url = "https://crates.io/api/v1/crates/syn/1.0.99/download",
+            name = "raze__syn__1_0_100",
+            url = "https://crates.io/api/v1/crates/syn/1.0.100/download",
             type = "tar.gz",
-            sha256 = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13",
-            strip_prefix = "syn-1.0.99",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.syn-1.0.99.bazel"),
+            sha256 = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e",
+            strip_prefix = "syn-1.0.100",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.syn-1.0.100.bazel"),
         )
 
     if synstructure__0_12_6:
@@ -2873,40 +3186,40 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.textwrap-0.11.0.bazel"),
         )
 
-    if thiserror__1_0_34:
+    if thiserror__1_0_35:
         maybe(
             native.new_local_repository,
-            name = "raze__thiserror__1_0_34",
-            path = thiserror__1_0_34,
-            build_file = "//third_party/rust/crates/remote:BUILD.thiserror-1.0.34.bazel",
+            name = "raze__thiserror__1_0_35",
+            path = thiserror__1_0_35,
+            build_file = "//third_party/rust/crates/remote:BUILD.thiserror-1.0.35.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__thiserror__1_0_34",
-            url = "https://crates.io/api/v1/crates/thiserror/1.0.34/download",
+            name = "raze__thiserror__1_0_35",
+            url = "https://crates.io/api/v1/crates/thiserror/1.0.35/download",
             type = "tar.gz",
-            sha256 = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252",
-            strip_prefix = "thiserror-1.0.34",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.thiserror-1.0.34.bazel"),
+            sha256 = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85",
+            strip_prefix = "thiserror-1.0.35",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.thiserror-1.0.35.bazel"),
         )
 
-    if thiserror_impl__1_0_34:
+    if thiserror_impl__1_0_35:
         maybe(
             native.new_local_repository,
-            name = "raze__thiserror_impl__1_0_34",
-            path = thiserror_impl__1_0_34,
-            build_file = "//third_party/rust/crates/remote:BUILD.thiserror-impl-1.0.34.bazel",
+            name = "raze__thiserror_impl__1_0_35",
+            path = thiserror_impl__1_0_35,
+            build_file = "//third_party/rust/crates/remote:BUILD.thiserror-impl-1.0.35.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__thiserror_impl__1_0_34",
-            url = "https://crates.io/api/v1/crates/thiserror-impl/1.0.34/download",
+            name = "raze__thiserror_impl__1_0_35",
+            url = "https://crates.io/api/v1/crates/thiserror-impl/1.0.35/download",
             type = "tar.gz",
-            sha256 = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487",
-            strip_prefix = "thiserror-impl-1.0.34",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.thiserror-impl-1.0.34.bazel"),
+            sha256 = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783",
+            strip_prefix = "thiserror-impl-1.0.35",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.thiserror-impl-1.0.35.bazel"),
         )
 
     if time__0_1_44:
@@ -2999,58 +3312,76 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.typetag-impl-0.1.8.bazel"),
         )
 
-    if unicode_ident__1_0_3:
+    if ucd_trie__0_1_5:
         maybe(
             native.new_local_repository,
-            name = "raze__unicode_ident__1_0_3",
-            path = unicode_ident__1_0_3,
-            build_file = "//third_party/rust/crates/remote:BUILD.unicode-ident-1.0.3.bazel",
+            name = "raze__ucd_trie__0_1_5",
+            path = ucd_trie__0_1_5,
+            build_file = "//third_party/rust/crates/remote:BUILD.ucd-trie-0.1.5.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__unicode_ident__1_0_3",
-            url = "https://crates.io/api/v1/crates/unicode-ident/1.0.3/download",
+            name = "raze__ucd_trie__0_1_5",
+            url = "https://crates.io/api/v1/crates/ucd-trie/0.1.5/download",
             type = "tar.gz",
-            sha256 = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf",
-            strip_prefix = "unicode-ident-1.0.3",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.unicode-ident-1.0.3.bazel"),
+            sha256 = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81",
+            strip_prefix = "ucd-trie-0.1.5",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.ucd-trie-0.1.5.bazel"),
         )
 
-    if unicode_segmentation__1_9_0:
+    if unicode_ident__1_0_4:
         maybe(
             native.new_local_repository,
-            name = "raze__unicode_segmentation__1_9_0",
-            path = unicode_segmentation__1_9_0,
-            build_file = "//third_party/rust/crates/remote:BUILD.unicode-segmentation-1.9.0.bazel",
+            name = "raze__unicode_ident__1_0_4",
+            path = unicode_ident__1_0_4,
+            build_file = "//third_party/rust/crates/remote:BUILD.unicode-ident-1.0.4.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__unicode_segmentation__1_9_0",
-            url = "https://crates.io/api/v1/crates/unicode-segmentation/1.9.0/download",
+            name = "raze__unicode_ident__1_0_4",
+            url = "https://crates.io/api/v1/crates/unicode-ident/1.0.4/download",
             type = "tar.gz",
-            sha256 = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99",
-            strip_prefix = "unicode-segmentation-1.9.0",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.unicode-segmentation-1.9.0.bazel"),
+            sha256 = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd",
+            strip_prefix = "unicode-ident-1.0.4",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.unicode-ident-1.0.4.bazel"),
         )
 
-    if unicode_width__0_1_9:
+    if unicode_segmentation__1_10_0:
         maybe(
             native.new_local_repository,
-            name = "raze__unicode_width__0_1_9",
-            path = unicode_width__0_1_9,
-            build_file = "//third_party/rust/crates/remote:BUILD.unicode-width-0.1.9.bazel",
+            name = "raze__unicode_segmentation__1_10_0",
+            path = unicode_segmentation__1_10_0,
+            build_file = "//third_party/rust/crates/remote:BUILD.unicode-segmentation-1.10.0.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__unicode_width__0_1_9",
-            url = "https://crates.io/api/v1/crates/unicode-width/0.1.9/download",
+            name = "raze__unicode_segmentation__1_10_0",
+            url = "https://crates.io/api/v1/crates/unicode-segmentation/1.10.0/download",
             type = "tar.gz",
-            sha256 = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973",
-            strip_prefix = "unicode-width-0.1.9",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.unicode-width-0.1.9.bazel"),
+            sha256 = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a",
+            strip_prefix = "unicode-segmentation-1.10.0",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.unicode-segmentation-1.10.0.bazel"),
+        )
+
+    if unicode_width__0_1_10:
+        maybe(
+            native.new_local_repository,
+            name = "raze__unicode_width__0_1_10",
+            path = unicode_width__0_1_10,
+            build_file = "//third_party/rust/crates/remote:BUILD.unicode-width-0.1.10.bazel",
+        )
+    else:
+        maybe(
+            http_archive,
+            name = "raze__unicode_width__0_1_10",
+            url = "https://crates.io/api/v1/crates/unicode-width/0.1.10/download",
+            type = "tar.gz",
+            sha256 = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b",
+            strip_prefix = "unicode-width-0.1.10",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.unicode-width-0.1.10.bazel"),
         )
 
     if unicode_xid__0_1_0:
@@ -3071,22 +3402,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.unicode-xid-0.1.0.bazel"),
         )
 
-    if unicode_xid__0_2_3:
+    if unicode_xid__0_2_4:
         maybe(
             native.new_local_repository,
-            name = "raze__unicode_xid__0_2_3",
-            path = unicode_xid__0_2_3,
-            build_file = "//third_party/rust/crates/remote:BUILD.unicode-xid-0.2.3.bazel",
+            name = "raze__unicode_xid__0_2_4",
+            path = unicode_xid__0_2_4,
+            build_file = "//third_party/rust/crates/remote:BUILD.unicode-xid-0.2.4.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__unicode_xid__0_2_3",
-            url = "https://crates.io/api/v1/crates/unicode-xid/0.2.3/download",
+            name = "raze__unicode_xid__0_2_4",
+            url = "https://crates.io/api/v1/crates/unicode-xid/0.2.4/download",
             type = "tar.gz",
-            sha256 = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04",
-            strip_prefix = "unicode-xid-0.2.3",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.unicode-xid-0.2.3.bazel"),
+            sha256 = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c",
+            strip_prefix = "unicode-xid-0.2.4",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.unicode-xid-0.2.4.bazel"),
         )
 
     if vcpkg__0_2_15:
@@ -3448,3 +3779,4 @@ def raze_fetch_remote_crates(
             strip_prefix = "zeroize_derive-1.3.2",
             build_file = Label("//third_party/rust/crates/remote:BUILD.zeroize_derive-1.3.2.bazel"),
         )
+

--- a/third_party/rust/crates/remote/BUILD.CoreFoundation-sys-0.1.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.CoreFoundation-sys-0.1.4.bazel
@@ -81,7 +81,7 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":CoreFoundation_sys_build_script",
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
         "@raze__mach__0_1_2//:mach",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.IOKit-sys-0.1.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.IOKit-sys-0.1.5.bazel
@@ -85,7 +85,7 @@ rust_library(
     deps = [
         ":IOKit_sys_build_script",
         "@raze__CoreFoundation_sys__0_1_4//:CoreFoundation_sys",
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
         "@raze__mach__0_1_2//:mach",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.android_system_properties-0.1.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.android_system_properties-0.1.5.bazel
@@ -52,6 +52,6 @@ rust_library(
     version = "0.1.5",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.annotate_derive-0.1.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.annotate_derive-0.1.0.bazel
@@ -26,42 +26,33 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT"
+    "restricted",  # no license
 ])
 
 # Generated Targets
 
-# Unsupported target "ansi_parser" with type "bench" omitted
-
-# Unsupported target "colors" with type "example" omitted
-
-# Unsupported target "colors256" with type "example" omitted
-
-# Unsupported target "cursor_at" with type "example" omitted
-
-# Unsupported target "term" with type "example" omitted
-
-rust_library(
-    name = "console",
+rust_proc_macro(
+    name = "annotate_derive",
     srcs = glob(["**/*.rs"]),
     crate_features = [
     ],
-    crate_root = "src/lib.rs",
+    crate_root = "annotate_derive/src/lib.rs",
     data = [],
-    edition = "2018",
+    edition = "2021",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=console",
+        "crate-name=annotate_derive",
         "manual",
     ],
-    version = "0.15.1",
+    version = "0.1.0",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_133//:libc",
-        "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__terminal_size__0_1_17//:terminal_size",
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro_error__1_0_4//:proc_macro_error",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_100//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.anyhow-1.0.65.bazel
+++ b/third_party/rust/crates/remote/BUILD.anyhow-1.0.65.bazel
@@ -26,7 +26,7 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 # Generated Targets
@@ -38,15 +38,18 @@ load(
 )
 
 cargo_build_script(
-    name = "nix_build_script",
+    name = "anyhow_build_script",
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
     crate_features = [
+        "backtrace",
+        "default",
+        "std",
     ],
     crate_root = "build.rs",
     data = glob(["**"]),
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -54,45 +57,63 @@ cargo_build_script(
         "cargo-raze",
         "manual",
     ],
-    version = "0.17.0",
+    version = "1.0.65",
     visibility = ["//visibility:private"],
     deps = [
     ],
 )
 
 rust_library(
-    name = "nix",
+    name = "anyhow",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "backtrace",
+        "default",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=nix",
+        "crate-name=anyhow",
         "manual",
     ],
-    version = "0.17.0",
+    version = "1.0.65",
     # buildifier: leave-alone
     deps = [
-        ":nix_build_script",
-        "@raze__bitflags__1_3_2//:bitflags",
-        "@raze__cfg_if__0_1_10//:cfg_if",
-        "@raze__libc__0_2_133//:libc",
-        "@raze__void__1_0_2//:void",
+        ":anyhow_build_script",
+        "@raze__backtrace__0_3_66//:backtrace",
     ],
 )
 
-# Unsupported target "test" with type "test" omitted
+# Unsupported target "compiletest" with type "test" omitted
 
-# Unsupported target "test-aio-drop" with type "test" omitted
+# Unsupported target "test_autotrait" with type "test" omitted
 
-# Unsupported target "test-lio-listio-resubmit" with type "test" omitted
+# Unsupported target "test_backtrace" with type "test" omitted
 
-# Unsupported target "test-mount" with type "test" omitted
+# Unsupported target "test_boxed" with type "test" omitted
 
-# Unsupported target "test-ptymaster-drop" with type "test" omitted
+# Unsupported target "test_chain" with type "test" omitted
+
+# Unsupported target "test_context" with type "test" omitted
+
+# Unsupported target "test_convert" with type "test" omitted
+
+# Unsupported target "test_downcast" with type "test" omitted
+
+# Unsupported target "test_ensure" with type "test" omitted
+
+# Unsupported target "test_ffi" with type "test" omitted
+
+# Unsupported target "test_fmt" with type "test" omitted
+
+# Unsupported target "test_macros" with type "test" omitted
+
+# Unsupported target "test_repr" with type "test" omitted
+
+# Unsupported target "test_source" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.atty-0.2.14.bazel
+++ b/third_party/rust/crates/remote/BUILD.atty-0.2.14.bazel
@@ -59,7 +59,7 @@ rust_library(
         (
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@raze__libc__0_2_132//:libc",
+            "@raze__libc__0_2_133//:libc",
         ],
         "//conditions:default": [],
     }),

--- a/third_party/rust/crates/remote/BUILD.backtrace-0.3.66.bazel
+++ b/third_party/rust/crates/remote/BUILD.backtrace-0.3.66.bazel
@@ -93,7 +93,7 @@ rust_library(
         ":backtrace_build_script",
         "@raze__addr2line__0_17_0//:addr2line",
         "@raze__cfg_if__1_0_0//:cfg_if",
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
         "@raze__miniz_oxide__0_5_4//:miniz_oxide",
         "@raze__object__0_29_0//:object",
         "@raze__rustc_demangle__0_1_21//:rustc_demangle",

--- a/third_party/rust/crates/remote/BUILD.chrono-0.4.22.bazel
+++ b/third_party/rust/crates/remote/BUILD.chrono-0.4.22.bazel
@@ -64,7 +64,7 @@ rust_library(
     version = "0.4.22",
     # buildifier: leave-alone
     deps = [
-        "@raze__iana_time_zone__0_1_47//:iana_time_zone",
+        "@raze__iana_time_zone__0_1_48//:iana_time_zone",
         "@raze__num_integer__0_1_45//:num_integer",
         "@raze__num_traits__0_2_15//:num_traits",
         "@raze__time__0_1_44//:time",

--- a/third_party/rust/crates/remote/BUILD.clap-2.34.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.clap-2.34.0.bazel
@@ -63,7 +63,7 @@ rust_library(
         "@raze__bitflags__1_3_2//:bitflags",
         "@raze__strsim__0_8_0//:strsim",
         "@raze__textwrap__0_11_0//:textwrap",
-        "@raze__unicode_width__0_1_9//:unicode_width",
+        "@raze__unicode_width__0_1_10//:unicode_width",
         "@raze__vec_map__0_8_2//:vec_map",
     ] + selects.with_or({
         # cfg(not(windows))

--- a/third_party/rust/crates/remote/BUILD.crypto-bigint-0.2.11.bazel
+++ b/third_party/rust/crates/remote/BUILD.crypto-bigint-0.2.11.bazel
@@ -55,7 +55,7 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         "@raze__generic_array__0_14_6//:generic_array",
-        "@raze__rand_core__0_6_3//:rand_core",
+        "@raze__rand_core__0_6_4//:rand_core",
         "@raze__subtle__2_4_1//:subtle",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.ctor-0.1.23.bazel
+++ b/third_party/rust/crates/remote/BUILD.ctor-0.1.23.bazel
@@ -53,6 +53,6 @@ rust_proc_macro(
     # buildifier: leave-alone
     deps = [
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.digest-0.10.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.digest-0.10.5.bazel
@@ -31,10 +31,15 @@ licenses([
 
 # Generated Targets
 
-rust_proc_macro(
-    name = "thiserror_impl",
+rust_library(
+    name = "digest",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "alloc",
+        "block-buffer",
+        "core-api",
+        "default",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -44,14 +49,13 @@ rust_proc_macro(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=thiserror-impl",
+        "crate-name=digest",
         "manual",
     ],
-    version = "1.0.34",
+    version = "0.10.5",
     # buildifier: leave-alone
     deps = [
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
-        "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__block_buffer__0_10_3//:block_buffer",
+        "@raze__crypto_common__0_1_6//:crypto_common",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.dirs-sys-0.3.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.dirs-sys-0.3.7.bazel
@@ -57,7 +57,7 @@ rust_library(
         (
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@raze__libc__0_2_132//:libc",
+            "@raze__libc__0_2_133//:libc",
         ],
         "//conditions:default": [],
     }),

--- a/third_party/rust/crates/remote/BUILD.getrandom-0.2.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.getrandom-0.2.7.bazel
@@ -61,7 +61,7 @@ rust_library(
         (
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@raze__libc__0_2_132//:libc",
+            "@raze__libc__0_2_133//:libc",
         ],
         "//conditions:default": [],
     }),

--- a/third_party/rust/crates/remote/BUILD.ghost-0.1.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.ghost-0.1.6.bazel
@@ -52,7 +52,7 @@ rust_proc_macro(
     deps = [
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.heck-0.3.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.heck-0.3.3.bazel
@@ -50,6 +50,6 @@ rust_library(
     version = "0.3.3",
     # buildifier: leave-alone
     deps = [
-        "@raze__unicode_segmentation__1_9_0//:unicode_segmentation",
+        "@raze__unicode_segmentation__1_10_0//:unicode_segmentation",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.hermit-abi-0.1.19.bazel
+++ b/third_party/rust/crates/remote/BUILD.hermit-abi-0.1.19.bazel
@@ -51,6 +51,6 @@ rust_library(
     version = "0.1.19",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.iana-time-zone-0.1.48.bazel
+++ b/third_party/rust/crates/remote/BUILD.iana-time-zone-0.1.48.bazel
@@ -52,7 +52,7 @@ rust_library(
         "crate-name=iana-time-zone",
         "manual",
     ],
-    version = "0.1.47",
+    version = "0.1.48",
     # buildifier: leave-alone
     deps = [
     ],

--- a/third_party/rust/crates/remote/BUILD.libc-0.2.133.bazel
+++ b/third_party/rust/crates/remote/BUILD.libc-0.2.133.bazel
@@ -30,43 +30,63 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
 
-# Unsupported target "mod" with type "bench" omitted
-
-rust_library(
-    name = "sha2",
+cargo_build_script(
+    name = "libc_build_script",
     srcs = glob(["**/*.rs"]),
-    aliases = {
+    build_script_env = {
     },
     crate_features = [
         "default",
+        "extra_traits",
         "std",
     ],
-    crate_root = "src/lib.rs",
-    data = [],
-    edition = "2018",
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=sha2",
         "manual",
     ],
-    version = "0.10.5",
-    # buildifier: leave-alone
+    version = "0.2.133",
+    visibility = ["//visibility:private"],
     deps = [
-        "@raze__cfg_if__1_0_0//:cfg_if",
-        "@raze__digest__0_10_3//:digest",
-    ] + selects.with_or({
-        # cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))
-        (
-            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
-        ): [
-            "@raze__cpufeatures__0_2_5//:cpufeatures",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
 )
 
-# Unsupported target "mod" with type "test" omitted
+rust_library(
+    name = "libc",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "extra_traits",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=libc",
+        "manual",
+    ],
+    version = "0.2.133",
+    # buildifier: leave-alone
+    deps = [
+        ":libc_build_script",
+    ],
+)
+
+# Unsupported target "const_fn" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.libudev-0.3.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.libudev-0.3.0.bazel
@@ -54,7 +54,7 @@ rust_library(
     version = "0.3.0",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
         "@raze__libudev_sys__0_1_4//:libudev_sys",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.libudev-sys-0.1.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.libudev-sys-0.1.4.bazel
@@ -88,6 +88,6 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":libudev_sys_build_script",
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.libusb1-sys-0.5.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.libusb1-sys-0.5.0.bazel
@@ -83,7 +83,7 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":libusb1_sys_build_script",
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.mach-0.1.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.mach-0.1.2.bazel
@@ -52,6 +52,6 @@ rust_library(
     version = "0.1.2",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.mio-0.7.14.bazel
+++ b/third_party/rust/crates/remote/BUILD.mio-0.7.14.bazel
@@ -66,7 +66,7 @@ rust_library(
         (
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@raze__libc__0_2_132//:libc",
+            "@raze__libc__0_2_133//:libc",
         ],
         "//conditions:default": [],
     }),

--- a/third_party/rust/crates/remote/BUILD.mio-signals-0.1.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.mio-signals-0.1.5.bazel
@@ -50,7 +50,7 @@ rust_library(
     version = "0.1.5",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
         "@raze__log__0_4_17//:log",
         "@raze__mio__0_7_14//:mio",
     ],

--- a/third_party/rust/crates/remote/BUILD.nix-0.24.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.nix-0.24.2.bazel
@@ -58,7 +58,7 @@ rust_library(
     deps = [
         "@raze__bitflags__1_3_2//:bitflags",
         "@raze__cfg_if__1_0_0//:cfg_if",
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.num_enum_derive-0.5.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.num_enum_derive-0.5.7.bazel
@@ -55,6 +55,6 @@ rust_proc_macro(
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__proc_macro_crate__1_2_1//:proc_macro_crate",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.pest-2.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.pest-2.3.1.bazel
@@ -31,53 +31,35 @@ licenses([
 
 # Generated Targets
 
+# Unsupported target "parens" with type "example" omitted
+
 rust_library(
-    name = "thiserror",
+    name = "pest",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "default",
+        "std",
+        "thiserror",
     ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",
-    proc_macro_deps = [
-        "@raze__thiserror_impl__1_0_34//:thiserror_impl",
-    ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=thiserror",
+        "crate-name=pest",
         "manual",
     ],
-    version = "1.0.34",
+    version = "2.3.1",
     # buildifier: leave-alone
     deps = [
+        "@raze__thiserror__1_0_35//:thiserror",
+        "@raze__ucd_trie__0_1_5//:ucd_trie",
     ],
 )
 
-# Unsupported target "compiletest" with type "test" omitted
+# Unsupported target "calculator" with type "test" omitted
 
-# Unsupported target "test_backtrace" with type "test" omitted
-
-# Unsupported target "test_deprecated" with type "test" omitted
-
-# Unsupported target "test_display" with type "test" omitted
-
-# Unsupported target "test_error" with type "test" omitted
-
-# Unsupported target "test_expr" with type "test" omitted
-
-# Unsupported target "test_from" with type "test" omitted
-
-# Unsupported target "test_generics" with type "test" omitted
-
-# Unsupported target "test_lints" with type "test" omitted
-
-# Unsupported target "test_option" with type "test" omitted
-
-# Unsupported target "test_path" with type "test" omitted
-
-# Unsupported target "test_source" with type "test" omitted
-
-# Unsupported target "test_transparent" with type "test" omitted
+# Unsupported target "json" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.pest_derive-2.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.pest_derive-2.3.1.bazel
@@ -31,12 +31,11 @@ licenses([
 
 # Generated Targets
 
-rust_library(
-    name = "rand_core",
+rust_proc_macro(
+    name = "pest_derive",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "alloc",
-        "getrandom",
+        "default",
         "std",
     ],
     crate_root = "src/lib.rs",
@@ -47,12 +46,21 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=rand_core",
+        "crate-name=pest_derive",
         "manual",
     ],
-    version = "0.6.3",
+    version = "2.3.1",
     # buildifier: leave-alone
     deps = [
-        "@raze__getrandom__0_2_7//:getrandom",
+        "@raze__pest__2_3_1//:pest",
+        "@raze__pest_generator__2_3_1//:pest_generator",
     ],
 )
+
+# Unsupported target "grammar" with type "test" omitted
+
+# Unsupported target "grammar_inline" with type "test" omitted
+
+# Unsupported target "lists" with type "test" omitted
+
+# Unsupported target "reporting" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.pest_generator-2.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.pest_generator-2.3.1.bazel
@@ -26,25 +26,16 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 # Generated Targets
 
-# Unsupported target "ansi_parser" with type "bench" omitted
-
-# Unsupported target "colors" with type "example" omitted
-
-# Unsupported target "colors256" with type "example" omitted
-
-# Unsupported target "cursor_at" with type "example" omitted
-
-# Unsupported target "term" with type "example" omitted
-
 rust_library(
-    name = "console",
+    name = "pest_generator",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -54,14 +45,16 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=console",
+        "crate-name=pest_generator",
         "manual",
     ],
-    version = "0.15.1",
+    version = "2.3.1",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_133//:libc",
-        "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__terminal_size__0_1_17//:terminal_size",
+        "@raze__pest__2_3_1//:pest",
+        "@raze__pest_meta__2_3_1//:pest_meta",
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_100//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.pest_meta-2.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.pest_meta-2.3.1.bazel
@@ -26,23 +26,13 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 # Generated Targets
 
-# Unsupported target "ansi_parser" with type "bench" omitted
-
-# Unsupported target "colors" with type "example" omitted
-
-# Unsupported target "colors256" with type "example" omitted
-
-# Unsupported target "cursor_at" with type "example" omitted
-
-# Unsupported target "term" with type "example" omitted
-
 rust_library(
-    name = "console",
+    name = "pest_meta",
     srcs = glob(["**/*.rs"]),
     crate_features = [
     ],
@@ -54,14 +44,13 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=console",
+        "crate-name=pest_meta",
         "manual",
     ],
-    version = "0.15.1",
+    version = "2.3.1",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_133//:libc",
         "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__terminal_size__0_1_17//:terminal_size",
+        "@raze__pest__2_3_1//:pest",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.proc-macro-crate-1.2.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro-crate-1.2.1.bazel
@@ -51,7 +51,7 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__thiserror__1_0_34//:thiserror",
+        "@raze__thiserror__1_0_35//:thiserror",
         "@raze__toml__0_5_9//:toml",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.proc-macro-error-1.0.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro-error-1.0.4.bazel
@@ -92,7 +92,7 @@ rust_library(
         ":proc_macro_error_build_script",
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.proc-macro2-1.0.43.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro2-1.0.43.bazel
@@ -84,7 +84,7 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":proc_macro2_build_script",
-        "@raze__unicode_ident__1_0_3//:unicode_ident",
+        "@raze__unicode_ident__1_0_4//:unicode_ident",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.rand-0.8.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.rand-0.8.5.bazel
@@ -60,13 +60,13 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         "@raze__rand_chacha__0_3_1//:rand_chacha",
-        "@raze__rand_core__0_6_3//:rand_core",
+        "@raze__rand_core__0_6_4//:rand_core",
     ] + selects.with_or({
         # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@raze__libc__0_2_132//:libc",
+            "@raze__libc__0_2_133//:libc",
         ],
         "//conditions:default": [],
     }),

--- a/third_party/rust/crates/remote/BUILD.rand_chacha-0.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.rand_chacha-0.3.1.bazel
@@ -52,6 +52,6 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         "@raze__ppv_lite86__0_2_16//:ppv_lite86",
-        "@raze__rand_core__0_6_3//:rand_core",
+        "@raze__rand_core__0_6_4//:rand_core",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.rand_core-0.6.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.rand_core-0.6.4.bazel
@@ -26,25 +26,18 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 # Generated Targets
 
-# Unsupported target "ansi_parser" with type "bench" omitted
-
-# Unsupported target "colors" with type "example" omitted
-
-# Unsupported target "colors256" with type "example" omitted
-
-# Unsupported target "cursor_at" with type "example" omitted
-
-# Unsupported target "term" with type "example" omitted
-
 rust_library(
-    name = "console",
+    name = "rand_core",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "alloc",
+        "getrandom",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -54,14 +47,12 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=console",
+        "crate-name=rand_core",
         "manual",
     ],
-    version = "0.15.1",
+    version = "0.6.4",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_133//:libc",
-        "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__terminal_size__0_1_17//:terminal_size",
+        "@raze__getrandom__0_2_7//:getrandom",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.raw_tty-0.1.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.raw_tty-0.1.0.bazel
@@ -53,6 +53,6 @@ rust_library(
     version = "0.1.0",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.redox_users-0.4.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.redox_users-0.4.3.bazel
@@ -52,6 +52,6 @@ rust_library(
     deps = [
         "@raze__getrandom__0_2_7//:getrandom",
         "@raze__redox_syscall__0_2_16//:redox_syscall",
-        "@raze__thiserror__1_0_34//:thiserror",
+        "@raze__thiserror__1_0_35//:thiserror",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.rusb-0.8.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.rusb-0.8.1.bazel
@@ -89,7 +89,7 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":rusb_build_script",
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
         "@raze__libusb1_sys__0_5_0//:libusb1_sys",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.serde_annotate-0.1.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_annotate-0.1.0.bazel
@@ -26,42 +26,50 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT"
+    "restricted",  # no license
 ])
 
 # Generated Targets
 
-# Unsupported target "ansi_parser" with type "bench" omitted
+# Unsupported target "autoschema" with type "example" omitted
 
-# Unsupported target "colors" with type "example" omitted
+# Unsupported target "samples" with type "example" omitted
 
-# Unsupported target "colors256" with type "example" omitted
-
-# Unsupported target "cursor_at" with type "example" omitted
-
-# Unsupported target "term" with type "example" omitted
+# Unsupported target "transcode" with type "example" omitted
 
 rust_library(
-    name = "console",
+    name = "serde_annotate",
     srcs = glob(["**/*.rs"]),
     crate_features = [
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2018",
+    compile_data = [ "src/relax.pest" ],
+    edition = "2021",
+    proc_macro_deps = [
+        "@raze__annotate_derive__0_1_0//:annotate_derive",
+        "@raze__pest_derive__2_3_1//:pest_derive",
+    ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=console",
+        "crate-name=serde_annotate",
         "manual",
     ],
-    version = "0.15.1",
+    version = "0.1.0",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_133//:libc",
+        "@raze__ansi_term__0_12_1//:ansi_term",
+        "@raze__inventory__0_2_3//:inventory",
+        "@raze__num_traits__0_2_15//:num_traits",
         "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__terminal_size__0_1_17//:terminal_size",
+        "@raze__pest__2_3_1//:pest",
+        "@raze__regex__1_6_0//:regex",
+        "@raze__serde__1_0_144//:serde",
+        "@raze__thiserror__1_0_35//:thiserror",
     ],
 )
+
+# Unsupported target "test_format" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.serde_derive-1.0.144.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_derive-1.0.144.bazel
@@ -84,6 +84,6 @@ rust_proc_macro(
         ":serde_derive_build_script",
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.sha1-0.10.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.sha1-0.10.5.bazel
@@ -26,16 +26,18 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 # Generated Targets
 
-# Unsupported target "xid" with type "bench" omitted
+# Unsupported target "mod" with type "bench" omitted
 
 rust_library(
-    name = "unicode_ident",
+    name = "sha1",
     srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
     crate_features = [
     ],
     crate_root = "src/lib.rs",
@@ -46,15 +48,23 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=unicode-ident",
+        "crate-name=sha1",
         "manual",
     ],
-    version = "1.0.3",
+    version = "0.10.5",
     # buildifier: leave-alone
     deps = [
-    ],
+        "@raze__cfg_if__1_0_0//:cfg_if",
+        "@raze__digest__0_10_5//:digest",
+    ] + selects.with_or({
+        # cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))
+        (
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__cpufeatures__0_2_5//:cpufeatures",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
-# Unsupported target "compare" with type "test" omitted
-
-# Unsupported target "static_size" with type "test" omitted
+# Unsupported target "mod" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.sha2-0.10.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.sha2-0.10.6.bazel
@@ -31,13 +31,14 @@ licenses([
 
 # Generated Targets
 
+# Unsupported target "mod" with type "bench" omitted
+
 rust_library(
-    name = "digest",
+    name = "sha2",
     srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
     crate_features = [
-        "alloc",
-        "block-buffer",
-        "core-api",
         "default",
         "std",
     ],
@@ -49,13 +50,23 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=digest",
+        "crate-name=sha2",
         "manual",
     ],
-    version = "0.10.3",
+    version = "0.10.6",
     # buildifier: leave-alone
     deps = [
-        "@raze__block_buffer__0_10_3//:block_buffer",
-        "@raze__crypto_common__0_1_6//:crypto_common",
-    ],
+        "@raze__cfg_if__1_0_0//:cfg_if",
+        "@raze__digest__0_10_5//:digest",
+    ] + selects.with_or({
+        # cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))
+        (
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__cpufeatures__0_2_5//:cpufeatures",
+        ],
+        "//conditions:default": [],
+    }),
 )
+
+# Unsupported target "mod" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.structopt-derive-0.4.18.bazel
+++ b/third_party/rust/crates/remote/BUILD.structopt-derive-0.4.18.bazel
@@ -54,6 +54,6 @@ rust_proc_macro(
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__proc_macro_error__1_0_4//:proc_macro_error",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.syn-1.0.100.bazel
+++ b/third_party/rust/crates/remote/BUILD.syn-1.0.100.bazel
@@ -64,7 +64,7 @@ cargo_build_script(
         "cargo-raze",
         "manual",
     ],
-    version = "1.0.99",
+    version = "1.0.100",
     visibility = ["//visibility:private"],
     deps = [
     ],
@@ -100,13 +100,13 @@ rust_library(
         "crate-name=syn",
         "manual",
     ],
-    version = "1.0.99",
+    version = "1.0.100",
     # buildifier: leave-alone
     deps = [
         ":syn_build_script",
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__unicode_ident__1_0_3//:unicode_ident",
+        "@raze__unicode_ident__1_0_4//:unicode_ident",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.synstructure-0.12.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.synstructure-0.12.6.bazel
@@ -54,7 +54,7 @@ rust_library(
     deps = [
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
-        "@raze__unicode_xid__0_2_3//:unicode_xid",
+        "@raze__syn__1_0_100//:syn",
+        "@raze__unicode_xid__0_2_4//:unicode_xid",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.tempfile-3.3.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.tempfile-3.3.0.bazel
@@ -60,7 +60,7 @@ rust_library(
         (
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@raze__libc__0_2_132//:libc",
+            "@raze__libc__0_2_133//:libc",
         ],
         "//conditions:default": [],
     }),

--- a/third_party/rust/crates/remote/BUILD.terminal_size-0.1.17.bazel
+++ b/third_party/rust/crates/remote/BUILD.terminal_size-0.1.17.bazel
@@ -59,7 +59,7 @@ rust_library(
         (
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@raze__libc__0_2_132//:libc",
+            "@raze__libc__0_2_133//:libc",
         ],
         "//conditions:default": [],
     }),

--- a/third_party/rust/crates/remote/BUILD.textwrap-0.11.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.textwrap-0.11.0.bazel
@@ -56,7 +56,7 @@ rust_library(
     version = "0.11.0",
     # buildifier: leave-alone
     deps = [
-        "@raze__unicode_width__0_1_9//:unicode_width",
+        "@raze__unicode_width__0_1_10//:unicode_width",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.thiserror-1.0.35.bazel
+++ b/third_party/rust/crates/remote/BUILD.thiserror-1.0.35.bazel
@@ -38,14 +38,11 @@ load(
 )
 
 cargo_build_script(
-    name = "anyhow_build_script",
+    name = "thiserror_build_script",
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
     crate_features = [
-        "backtrace",
-        "default",
-        "std",
     ],
     crate_root = "build.rs",
     data = glob(["**"]),
@@ -57,63 +54,60 @@ cargo_build_script(
         "cargo-raze",
         "manual",
     ],
-    version = "1.0.64",
+    version = "1.0.35",
     visibility = ["//visibility:private"],
     deps = [
     ],
 )
 
 rust_library(
-    name = "anyhow",
+    name = "thiserror",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "backtrace",
-        "default",
-        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",
+    proc_macro_deps = [
+        "@raze__thiserror_impl__1_0_35//:thiserror_impl",
+    ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=anyhow",
+        "crate-name=thiserror",
         "manual",
     ],
-    version = "1.0.64",
+    version = "1.0.35",
     # buildifier: leave-alone
     deps = [
-        ":anyhow_build_script",
-        "@raze__backtrace__0_3_66//:backtrace",
+        ":thiserror_build_script",
     ],
 )
 
 # Unsupported target "compiletest" with type "test" omitted
 
-# Unsupported target "test_autotrait" with type "test" omitted
-
 # Unsupported target "test_backtrace" with type "test" omitted
 
-# Unsupported target "test_boxed" with type "test" omitted
+# Unsupported target "test_deprecated" with type "test" omitted
 
-# Unsupported target "test_chain" with type "test" omitted
+# Unsupported target "test_display" with type "test" omitted
 
-# Unsupported target "test_context" with type "test" omitted
+# Unsupported target "test_error" with type "test" omitted
 
-# Unsupported target "test_convert" with type "test" omitted
+# Unsupported target "test_expr" with type "test" omitted
 
-# Unsupported target "test_downcast" with type "test" omitted
+# Unsupported target "test_from" with type "test" omitted
 
-# Unsupported target "test_ensure" with type "test" omitted
+# Unsupported target "test_generics" with type "test" omitted
 
-# Unsupported target "test_ffi" with type "test" omitted
+# Unsupported target "test_lints" with type "test" omitted
 
-# Unsupported target "test_fmt" with type "test" omitted
+# Unsupported target "test_option" with type "test" omitted
 
-# Unsupported target "test_macros" with type "test" omitted
-
-# Unsupported target "test_repr" with type "test" omitted
+# Unsupported target "test_path" with type "test" omitted
 
 # Unsupported target "test_source" with type "test" omitted
+
+# Unsupported target "test_transparent" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.thiserror-impl-1.0.35.bazel
+++ b/third_party/rust/crates/remote/BUILD.thiserror-impl-1.0.35.bazel
@@ -31,25 +31,27 @@ licenses([
 
 # Generated Targets
 
-rust_library(
-    name = "unicode_width",
+rust_proc_macro(
+    name = "thiserror_impl",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "default",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=unicode-width",
+        "crate-name=thiserror-impl",
         "manual",
     ],
-    version = "0.1.9",
+    version = "1.0.35",
     # buildifier: leave-alone
     deps = [
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_100//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.time-0.1.44.bazel
+++ b/third_party/rust/crates/remote/BUILD.time-0.1.44.bazel
@@ -50,6 +50,6 @@ rust_library(
     version = "0.1.44",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_132//:libc",
+        "@raze__libc__0_2_133//:libc",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.typetag-impl-0.1.8.bazel
+++ b/third_party/rust/crates/remote/BUILD.typetag-impl-0.1.8.bazel
@@ -52,6 +52,6 @@ rust_proc_macro(
     deps = [
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.ucd-trie-0.1.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.ucd-trie-0.1.5.bazel
@@ -31,16 +31,13 @@ licenses([
 
 # Generated Targets
 
-# Unsupported target "graphemes" with type "bench" omitted
-
-# Unsupported target "unicode_words" with type "bench" omitted
-
-# Unsupported target "word_bounds" with type "bench" omitted
+# Unsupported target "bench" with type "bench" omitted
 
 rust_library(
-    name = "unicode_segmentation",
+    name = "ucd_trie",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -50,10 +47,10 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=unicode-segmentation",
+        "crate-name=ucd-trie",
         "manual",
     ],
-    version = "1.9.0",
+    version = "0.1.5",
     # buildifier: leave-alone
     deps = [
     ],

--- a/third_party/rust/crates/remote/BUILD.unicode-ident-1.0.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.unicode-ident-1.0.4.bazel
@@ -26,23 +26,15 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT"
+    "notice",  # MIT from expression "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
 ])
 
 # Generated Targets
 
-# Unsupported target "ansi_parser" with type "bench" omitted
-
-# Unsupported target "colors" with type "example" omitted
-
-# Unsupported target "colors256" with type "example" omitted
-
-# Unsupported target "cursor_at" with type "example" omitted
-
-# Unsupported target "term" with type "example" omitted
+# Unsupported target "xid" with type "bench" omitted
 
 rust_library(
-    name = "console",
+    name = "unicode_ident",
     srcs = glob(["**/*.rs"]),
     crate_features = [
     ],
@@ -54,14 +46,15 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=console",
+        "crate-name=unicode-ident",
         "manual",
     ],
-    version = "0.15.1",
+    version = "1.0.4",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_133//:libc",
-        "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__terminal_size__0_1_17//:terminal_size",
     ],
 )
+
+# Unsupported target "compare" with type "test" omitted
+
+# Unsupported target "static_size" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.unicode-segmentation-1.10.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.unicode-segmentation-1.10.0.bazel
@@ -26,23 +26,19 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 # Generated Targets
 
-# Unsupported target "ansi_parser" with type "bench" omitted
+# Unsupported target "graphemes" with type "bench" omitted
 
-# Unsupported target "colors" with type "example" omitted
+# Unsupported target "unicode_words" with type "bench" omitted
 
-# Unsupported target "colors256" with type "example" omitted
-
-# Unsupported target "cursor_at" with type "example" omitted
-
-# Unsupported target "term" with type "example" omitted
+# Unsupported target "word_bounds" with type "bench" omitted
 
 rust_library(
-    name = "console",
+    name = "unicode_segmentation",
     srcs = glob(["**/*.rs"]),
     crate_features = [
     ],
@@ -54,14 +50,11 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=console",
+        "crate-name=unicode-segmentation",
         "manual",
     ],
-    version = "0.15.1",
+    version = "1.10.0",
     # buildifier: leave-alone
     deps = [
-        "@raze__libc__0_2_133//:libc",
-        "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__terminal_size__0_1_17//:terminal_size",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.unicode-width-0.1.10.bazel
+++ b/third_party/rust/crates/remote/BUILD.unicode-width-0.1.10.bazel
@@ -31,10 +31,8 @@ licenses([
 
 # Generated Targets
 
-# Unsupported target "xid" with type "bench" omitted
-
 rust_library(
-    name = "unicode_xid",
+    name = "unicode_width",
     srcs = glob(["**/*.rs"]),
     crate_features = [
         "default",
@@ -47,13 +45,11 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=unicode-xid",
+        "crate-name=unicode-width",
         "manual",
     ],
-    version = "0.2.3",
+    version = "0.1.10",
     # buildifier: leave-alone
     deps = [
     ],
 )
-
-# Unsupported target "exhaustive_tests" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.unicode-xid-0.2.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.unicode-xid-0.2.4.bazel
@@ -30,46 +30,14 @@ licenses([
 ])
 
 # Generated Targets
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load-on-top
-load(
-    "@rules_rust//cargo:cargo_build_script.bzl",
-    "cargo_build_script",
-)
 
-cargo_build_script(
-    name = "libc_build_script",
-    srcs = glob(["**/*.rs"]),
-    build_script_env = {
-    },
-    crate_features = [
-        "default",
-        "extra_traits",
-        "std",
-    ],
-    crate_root = "build.rs",
-    data = glob(["**"]),
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    version = "0.2.132",
-    visibility = ["//visibility:private"],
-    deps = [
-    ],
-)
+# Unsupported target "xid" with type "bench" omitted
 
 rust_library(
-    name = "libc",
+    name = "unicode_xid",
     srcs = glob(["**/*.rs"]),
     crate_features = [
         "default",
-        "extra_traits",
-        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -79,14 +47,13 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=libc",
+        "crate-name=unicode-xid",
         "manual",
     ],
-    version = "0.2.132",
+    version = "0.2.4",
     # buildifier: leave-alone
     deps = [
-        ":libc_build_script",
     ],
 )
 
-# Unsupported target "const_fn" with type "test" omitted
+# Unsupported target "exhaustive_tests" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.wasm-bindgen-backend-0.2.83.bazel
+++ b/third_party/rust/crates/remote/BUILD.wasm-bindgen-backend-0.2.83.bazel
@@ -56,7 +56,7 @@ rust_library(
         "@raze__once_cell__1_14_0//:once_cell",
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
         "@raze__wasm_bindgen_shared__0_2_83//:wasm_bindgen_shared",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.wasm-bindgen-macro-support-0.2.83.bazel
+++ b/third_party/rust/crates/remote/BUILD.wasm-bindgen-macro-support-0.2.83.bazel
@@ -53,7 +53,7 @@ rust_library(
     deps = [
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
         "@raze__wasm_bindgen_backend__0_2_83//:wasm_bindgen_backend",
         "@raze__wasm_bindgen_shared__0_2_83//:wasm_bindgen_shared",
     ],

--- a/third_party/rust/crates/remote/BUILD.zerocopy-derive-0.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.zerocopy-derive-0.3.1.bazel
@@ -51,7 +51,7 @@ rust_proc_macro(
     # buildifier: leave-alone
     deps = [
         "@raze__proc_macro2__1_0_43//:proc_macro2",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
         "@raze__synstructure__0_12_6//:synstructure",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.zeroize_derive-1.3.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.zeroize_derive-1.3.2.bazel
@@ -52,7 +52,7 @@ rust_proc_macro(
     deps = [
         "@raze__proc_macro2__1_0_43//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_99//:syn",
+        "@raze__syn__1_0_100//:syn",
         "@raze__synstructure__0_12_6//:synstructure",
     ],
 )


### PR DESCRIPTION
1. Use serde_annotate as the emitter.
1a. Select an output format with `-f` or `--format`.  `json`, `json5`,
    `hjson` and `yaml` are available as output formats.
1b. If stdout is a terminal, default to color output.
2. Use serde_annotate to parse the opentitantool config files.  This
   means the various json configs no longer have to be strict-json and
   can use hjson or json5 extensions like comments or hex-literals.
