### PR TITLE
[dv, entropy_src] Fix the test chip_sw_entropy_src_fuse_en_fw_read_test

### DIFF
--- a/sw/device/tests/sim_dv/entropy_src_fuse_en_fw_read_test.c
+++ b/sw/device/tests/sim_dv/entropy_src_fuse_en_fw_read_test.c
@@ -61,6 +61,9 @@ static void entropy_with_fw_override_enable(dif_entropy_src_t *entropy_src) {
       .fips_enable = true,
       .route_to_firmware = true,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+      .health_test_threshold_scope = false,
+      .health_test_window_size = 0x0200,
+      .alert_threshold = 2,
   };
   CHECK_DIF_OK(
       dif_entropy_src_configure(entropy_src, config, kDifToggleEnabled));


### PR DESCRIPTION
This PR is a clone of the PR #4976 that was closed accidentally.

Add a mandatory configuration for the function `dif_entropy_src_configure()`.

This PR fixes this issue: #14840