### PR TITLE
[fpv/pwrmgr] Add assertions to check escalation

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -69,8 +69,27 @@ if {$stopat ne ""} {
 # tlul_assert.sv operates on the negedge clock
 # even clock this sampled at both_edges, input should only change at posedge clock cycle
 # TODO: create each DUT_TOP's individual config file
+if {$env(DUT_TOP) == "pinmux_tb"} {
+  clock clk_i -both_edges
+  clock clk_aon_i -factor 5
+  clock -rate -default clk_i
+  reset -expr {!rst_ni !rst_aon_ni}
 
-if {$env(DUT_TOP) == "rv_dm"} {
+} elseif {$env(DUT_TOP) == "prim_fifo_async_sram_adapter_tb"} {
+  clock clk_wr_i -factor 2
+  clock -rate {wvalid_i, wready_o, wdata_i} clk_wr_i
+  clock clk_rd_i -factor 3
+  clock -rate {rvalid_o, rready_i, rdata_o} clk_rd_i
+  reset -expr {!rst_ni}
+
+} elseif {$env(DUT_TOP) == "pwrmgr"} {
+  clock clk_i -both_edges
+  clock clk_slow_i -factor 3
+  clock clk_lc_i
+  clock -rate {esc_rst_tx_i} clk_lc_i
+  reset -expr {!rst_ni !rst_slow_ni !rst_main_ni !rst_lc_ni}
+
+} elseif {$env(DUT_TOP) == "rv_dm"} {
   clock clk_i -both_edges
   clock jtag_i.tck
   clock -rate {testmode, unavailable_i, reg_tl_d_i, sba_tl_h_i} clk_i
@@ -97,23 +116,6 @@ if {$env(DUT_TOP) == "rv_dm"} {
   clock -rate {tl_i, cio_d_i, cio_dp_i, cio_dn_i, cio_sense_i} clk_i
   reset -expr {!rst_ni !rst_aon_ni}
 
-# TODO: work with the block owner and re-define FPV checkings for xbar
-# } elseif {$env(DUT_TOP) == "xbar_main"} {
-#   clock clk_main_i -both_edges
-#   reset -expr {!rst_main_ni}
-
-} elseif {$env(DUT_TOP) == "prim_fifo_async_sram_adapter_tb"} {
-  clock clk_wr_i -factor 2
-  clock -rate {wvalid_i, wready_o, wdata_i} clk_wr_i
-  clock clk_rd_i -factor 3
-  clock -rate {rvalid_o, rready_i, rdata_o} clk_rd_i
-  reset -expr {!rst_ni}
-
-} elseif {$env(DUT_TOP) == "pinmux_tb"} {
-  clock clk_i -both_edges
-  clock clk_aon_i -factor 5
-  clock -rate -default clk_i
-  reset -expr {!rst_ni !rst_aon_ni}
 } else {
   clock clk_i -both_edges
   reset -expr {!rst_ni}

--- a/hw/ip/prim/lint/prim_count.waiver
+++ b/hw/ip/prim/lint/prim_count.waiver
@@ -7,5 +7,5 @@
 waive -rules {PARAM_NOT_USED} -location {prim_count.sv} -regexp {.*EnableAlertTriggerSVA.*} \
       -comment "The disable parameter is used only during DV / FPV."
 
-waive -rules {IFDEF_CODE} -location {prim_count.sv} -msg {Assignment to 'fpv_force' contained within `ifndef 'FPV_ON' block at} \
+waive -rules {IFDEF_CODE} -location {prim_count.sv} -msg {Assignment to 'fpv_force' contained within `ifndef 'FPV_SEC_CM_ON' block at} \
       -comment "This ifdef segment is ok, since it is used to provide the tool with a symbolic variable for error injection during FPV."

--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -55,7 +55,7 @@ module prim_count #(
 
   logic [NumCnt-1:0][Width-1:0] cnt_d, cnt_q, fpv_force;
 
-`ifndef FPV_ON
+`ifndef FPV_SEC_CM_ON
   // This becomes a free variable in FPV.
   assign fpv_force = '0;
 `endif

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -116,6 +116,11 @@ module pwrmgr
     .esc_tx_i(esc_rst_tx_i)
   );
 
+  // This assertion uses formal to approve that once esc_rst_req is latched, we always expect to
+  // see the pwr_rst_o to latch.
+  // Use `s_eventually` because this signal crosses clock domains.
+  `ASSERT(PwrmgrSecCmEscO, esc_rst_req_d |-> s_eventually(pwr_rst_o), clk_slow_i, !rst_slow_ni)
+
   always_ff @(posedge clk_lc or negedge rst_lc_n) begin
     if (!rst_lc_n) begin
       esc_rst_req_q <= '0;

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -497,6 +497,23 @@
                task: "FpvSecCm"
                stopats: ["*u_state_regs.state_o"]
              }
+             // This testbench verifies once esc request is received, it should always trigger a
+             // reset request.
+             {
+               name: pwrmgr_esc_unstoppable
+               dut: pwrmgr
+               fusesoc_core: lowrisc:dv:pwrmgr_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/pwrmgr/{sub_flow}/{tool}"
+               cov: false
+               overrides: [
+                 {
+                   name:  design_level
+                   value: "top"
+                 }
+               ]
+               task: "PwrmgrSecCmEsc"
+             }
              {
                name: rom_ctrl_sec_cm
                dut: rom_ctrl


### PR DESCRIPTION
This PR adds an assertion to check that the escalation request is unstoppable and will always trigger reset request.
This PR addresses issue #12075

Signed-off-by: Cindy Chen <chencindy@opentitan.org>