### PR TITLE
[dv/scb] Fix alert unexpected ping faliures

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -196,8 +196,6 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
             `uvm_error(`gfn, $sformatf("alert %s has unexpected signal int error", alert_name))
           end else if (item.ping_timeout && cfg.en_scb_ping_chk == 1) begin
             `uvm_error(`gfn, $sformatf("alert %s has unexpected timeout error", alert_name))
-          end else if (item.alert_esc_type == AlertEscPingTrans && cfg.en_scb_ping_chk == 1) begin
-            `uvm_error(`gfn, $sformatf("alert %s has unexpected alert ping response", alert_name))
           end
         end
       join_none


### PR DESCRIPTION
This PR fixes the regression error from alert_test:
```
UVM_ERROR @ 3371.559689 us: (cip_base_scoreboard.sv:200) uvm_test_top.env.scoreboard [uvm_test_top.env.scoreboard] alert lc_ctrl_fatal_prog_error has unexpected alert ping response
```

This check is not necessary because:
1). In chip level, having alert/esc ping from the background is normal
  and expected, should not flag an error
2). We cannot accurately predict when we are expecting a ping request,
  so there is no need to add this checking in chip level scb.

Fix issue #15029 

Signed-off-by: Cindy Chen <chencindy@opentitan.org>