### PR TITLE
[chip dv] chip_sw_sleep_pin_mio_dio_val #4

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
@@ -104,7 +104,7 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
      */
 
     // High-Z for all ports
-    cfg.chip_vif.ios_if.pins_pd = '1;
+    cfg.chip_vif.ios_if.pins_pd = '0;
     cfg.chip_vif.ios_if.pins_pu = '0;
     pad = cfg.chip_vif.ios_if.sample();
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
@@ -88,7 +88,7 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
     `uvm_info(`gfn, $sformatf("END Received PAD Retention Types"), UVM_LOW)
   endtask : receive_chosen_values
 
-  task check_pad_retention_type();
+  task check_pads_retention_type();
     logic [IoNumTotal-1:0] pad;
     /**
      * How to check 0, 1, High-Z
@@ -134,7 +134,7 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
 
     // TODO: Fins out how to pass the test (maybe just $display()?)
 
-  endtask : check_pad_retention_type
+  endtask : check_pads_retention_type
 
   virtual task body();
     super.body();
@@ -159,7 +159,7 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
 
     `uvm_info(`gfn, "Chip Entered Deep Powerdown mode.", UVM_LOW)
 
-    check_pad_retention_type();
+    check_pads_retention_type();
 
     // If `chech_pad_retention_type()` runs without uvm_error and reach this point, the test passed full check
     override_test_status_and_finish(.passed(1'b 1));

--- a/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
+++ b/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
@@ -93,14 +93,10 @@ typedef enum {
 } mio_pad_idx_t;
 
 /**
- * IOR[0:4] in chip_if are connected to JTAG interface.
- * If tap_strap_if is disconnected (IoC5, IoC8), those signals become unknown.
- *
- * Issue(#15006) for debugging.
+ * If certain MIOs need to be skipped due to tied functionality, specify here.
  */
-enum { kNumOptOutMio = 4 };
-static const uint8_t kOptOutMio[kNumOptOutMio] = {kMioIoR0, kMioIoR2, kMioIoR3,
-                                                  kMioIoR4};
+enum { kNumOptOutMio = 0 };
+static const uint8_t kOptOutMio[kNumOptOutMio] = {};
 
 static uint8_t kMioPads[NUM_MIO_PADS] = {0};
 static uint8_t kDioPads[NUM_DIO_PADS] = {0};


### PR DESCRIPTION
This PR cleans up the PAD limitation due to `tap_strap_if` and refactors the code to be reusable later (for pull up / pull down checkers)
