### PR TITLE
[dv/kmac] Add random pre-scaler and edn timeout val

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -125,7 +125,7 @@ package kmac_env_pkg;
 
   typedef enum int {
     KmacPrescaler = 0,
-    entropy_period_reserved = 10,
+    EntropyPeriodReserved = 10,
     KmacWaitTimer = 16
   } kmac_entropy_period_e;
 


### PR DESCRIPTION
Previously if we do not want EDN timeout, we will just turn off the timer. This pr calculates the max edn return time with some buffer, then configure the EDN prescaler and wait time to make sure it should not timeout.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>