### PR TITLE
[dv] Reduce the length of POR and fix regression failures

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -43,7 +43,7 @@ class chip_base_vseq #(
     // assert_por_reset();
     `uvm_info(`gfn, "Asserting POR_N", UVM_LOW)
     cfg.chip_vif.por_n_if.drive(0);
-    #100us;  // TODO: revisit this.
+    #10us;  // TODO: revisit this.
     cfg.chip_vif.por_n_if.drive(1);
     `uvm_info(`gfn, "POR_N complete", UVM_LOW)
     // TODO: Cannot assert different types of resets in parallel; due to randomization


### PR DESCRIPTION
Reset took too long which caused wait timeout.

Addressed #15026 and fixed these 2 tests
- chip_sw_lc_ctrl_transition
- chip_sw_clkmgr_external_clk_src_for_lc

Signed-off-by: Weicai Yang <weicai@google.com>