### PR TITLE
[entropy_src/rtl] Cleanup timing enable network

### DIFF
--- a/hw/ip/entropy_src/dv/sva/entropy_src_assert_if.sv
+++ b/hw/ip/entropy_src/dv/sva/entropy_src_assert_if.sv
@@ -24,7 +24,7 @@
 `define PATH9 \
     tb.dut.u_entropy_src_core.u_prim_mubi4_sync_es_enable
 `define PATH10 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_es_prebitsel_enable
+    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_es_enable_pulse
 `define CORE \
     tb.dut.u_entropy_src_core
 `define SHA3 \


### PR DESCRIPTION
As discussed in PR #14660 there are many places where enable-clearing RNG data or masking internal control signals can cause verification challenges. This is a primary motivation for keeping delayed copies of the enable signals, to apply delayed enable signals at the appropriate points in the pipeline.

Such fine-tooth timing management of the enable/disable signals is not good for maintainability.  This commit aims to simplify the network of enable signals in the entropy_src core, while fixing a number of regression failures.

Data pathways that had previously been blocked the instance the module was disabled have now been allowed to flow, letting data propagate until it stalls at the SHA3 conditioner or gets dropped at the bypass FIFO.

At the same time, this commit simplifies and documents the timing of the module enable signals, both the `es_enable` level signal as well as the `module_enable_pulse`.

The module_enable_pulse is now one cycle long, and generated from an explicit flop. (As opposed to using a prim_mubi4_sync),  AsyncOn=1. The es_enable level signal starts in the cycle right after the module_enable_pulse, but falls immediately when the module_enable register is set to MuBi4False.

Since both the enable pulse, and the enable level signal are derived from the same Mubi field, they are fanned-out in MuBi representation.

All of the prim_mubi_sync's now use AsyncOn(0).

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>