### PR TITLE
[adc_ctrl test] Fix ADC enum kPowerUpTimeAonCycles from 2 to 6

### DIFF
--- a/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
+++ b/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
@@ -17,7 +17,7 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 enum {
-  kPowerUpTimeAonCycles = 2,
+  kPowerUpTimeAonCycles = 6,
 };
 
 // These constants will be setup from the testbench


### PR DESCRIPTION
The ADC conversion can start 30us after power-up.
See "[test-triage] Issues with ADC's chip_sw_adc_ctrl_sleep_debug_cable_wakeup #14945" issue (1).

@ariel9678 @sha-ron 
Signed-off-by: Jacob Levy <jacob.levy@nuvoton.com>