### PR TITLE
[runtime, sw/silicon_creator, dif, test] Flush icache after addr translation config change, make addr translation test compatible with rom

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -842,6 +842,7 @@ cc_library(
         "//hw/ip/rv_core_ibex/data:rv_core_ibex_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
+        "//sw/device/lib/runtime:hart",
     ],
 )
 

--- a/sw/device/lib/dif/dif_rv_core_ibex.c
+++ b/sw/device/lib/dif/dif_rv_core_ibex.c
@@ -10,6 +10,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/runtime/hart.h"
 
 // #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
@@ -124,7 +125,7 @@ dif_result_t dif_rv_core_ibex_configure_addr_translation(
   uint32_t mask = to_napot(addr_map.matching_addr, addr_map.size);
   mmio_region_write32(rv_core_ibex->base_addr, regs.maching, mask);
   mmio_region_write32(rv_core_ibex->base_addr, regs.remap, addr_map.remap_addr);
-
+  icache_invalidate();
   return kDifOk;
 }
 
@@ -141,6 +142,7 @@ dif_result_t dif_rv_core_ibex_enable_addr_translation(
     return kDifLocked;
   }
   mmio_region_write32(rv_core_ibex->base_addr, regs.en, 1);
+  icache_invalidate();
   return kDifOk;
 }
 
@@ -157,6 +159,7 @@ dif_result_t dif_rv_core_ibex_disable_addr_translation(
     return kDifLocked;
   }
   mmio_region_write32(rv_core_ibex->base_addr, regs.en, 0);
+  icache_invalidate();
   return kDifOk;
 }
 

--- a/sw/device/lib/runtime/hart.c
+++ b/sw/device/lib/runtime/hart.c
@@ -27,3 +27,4 @@ noreturn void abort(void) {
 // corresponding header a link location.
 
 extern void wait_for_interrupt(void);
+extern void icache_invalidate(void);

--- a/sw/device/lib/runtime/hart.h
+++ b/sw/device/lib/runtime/hart.h
@@ -31,6 +31,15 @@ inline void wait_for_interrupt(void) {
 }
 
 /**
+ * Invalidates the instruction cache.
+ */
+inline void icache_invalidate(void) {
+#ifdef OT_PLATFORM_RV32
+  asm volatile("fence.i");
+#endif
+}
+
+/**
  * Spin for at least the given number of microseconds.
  *
  * @param usec Duration in microseconds.

--- a/sw/device/lib/runtime/hart_polyfills.c
+++ b/sw/device/lib/runtime/hart_polyfills.c
@@ -20,3 +20,4 @@ void busy_spin_micros(uint32_t usec) { usleep(usec); }
 // corresponding header a link location.
 
 extern void wait_for_interrupt(void);
+extern void icache_invalidate(void);

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -225,6 +225,7 @@ cc_library(
         "//hw/ip/rv_core_ibex/data:rv_core_ibex_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/runtime:hart",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/ibex.c
+++ b/sw/device/silicon_creator/lib/drivers/ibex.c
@@ -5,6 +5,7 @@
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
 
 #include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/runtime/hart.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -31,6 +32,7 @@ void ibex_addr_remap_0_set(uint32_t matching_addr, uint32_t remap_addr,
 
   sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET, 1);
   sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET, 1);
+  icache_invalidate();
 }
 
 void ibex_addr_remap_1_set(uint32_t matching_addr, uint32_t remap_addr,
@@ -46,4 +48,5 @@ void ibex_addr_remap_1_set(uint32_t matching_addr, uint32_t remap_addr,
 
   sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_1_REG_OFFSET, 1);
   sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_EN_1_REG_OFFSET, 1);
+  icache_invalidate();
 }

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1518,13 +1518,9 @@ opentitan_functest(
         "rv_core_ibex_address_translation_test.S",
         "rv_core_ibex_address_translation_test.c",
     ],
-    targets = [
-        "cw310_test_rom",
-        "verilator",
-        "dv",
-    ],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:csr",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:rv_core_ibex",
@@ -1532,6 +1528,7 @@ opentitan_functest(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:epmp",
     ],
 )
 

--- a/sw/device/tests/rv_core_ibex_address_translation_test.S
+++ b/sw/device/tests/rv_core_ibex_address_translation_test.S
@@ -10,6 +10,7 @@
  */
   .globl make_lower_case
   .type make_lower_case, @function
+  .balign 256
 make_lower_case:
   // a0: beginning of string
   // t0, t1: lower and upper bound of ascii capital letters
@@ -53,6 +54,7 @@ kMakeLowerCaseFnSize:
  */
   .globl get_name
   .type get_name, @function
+  .balign 256
 get_name:
   // a0: beginning of string.
   // t0: beginning of replace string.


### PR DESCRIPTION
This PR
* adds `icache_invalidate()` to `sw/lib/runtime:hart`,
* calls it after address translation config changes in silicon creator `ibex` driver and `dif_rv_core_ibex`, and
* makes `rv_core_ibex_address_translation_test` compatible with `rom` (also simplifies it by removing the unnecessary `flash_ctrl` dependency).

See #15052.