### PR TITLE
[top/dv] Test triage fix

### DIFF
--- a/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
@@ -155,7 +155,7 @@ bool test_main(void) {
                                        kDifToggleEnabled));
 
   // Randomize variables.
-  uint8_t byte_count = rand_testutils_gen32_range(1, 64);
+  uint8_t byte_count = rand_testutils_gen32_range(30, 64);
   uint8_t device_addr = rand_testutils_gen32_range(0, 16);
   uint8_t expected_data[byte_count];
   LOG_INFO("Loopback %d bytes with device %d", byte_count, device_addr);


### PR DESCRIPTION
ensure the test sends enough bytes to trigger the rx watermark

Signed-off-by: Timothy Chen <timothytim@google.com>