### PR TITLE
[chip] Add random sleep (normal vs deep) for pin_wake test

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -612,7 +612,9 @@ module spi_host
   `ASSERT_KNOWN(CioSdEnKnownO_A, cio_sd_en_o)
   `ASSERT_KNOWN(IntrSpiEventKnownO_A, intr_spi_event_o)
   `ASSERT_KNOWN(IntrErrorKnownO_A, intr_error_o)
-  `ASSERT_KNOWN(PassthroughKnownO_A, passthrough_o)
+
+  `ASSERT_KNOWN_IF(PassthroughKnownO_A, passthrough_o,
+    passthrough_i.passthrough_en && passthrough_i.csb_en && !passthrough_i.csb)
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -389,7 +389,7 @@
     }
     {
       name: chip_sw_sleep_pin_wake
-      desc: '''Verify pin wake up from deep sleep state.
+      desc: '''Verify pin wake up from any sleep states.
 
             Verify one of the 8 possible MIO or DIO pad inputs (randomly configured) can cause the
             chip to wake up from sleep state. Verifying wake on posedge is sufficient for the chip

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_wake_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_wake_vseq.sv
@@ -165,76 +165,18 @@ class chip_sw_sleep_pin_wake_vseq extends chip_sw_base_vseq;
 
     `uvm_info(`gfn, $sformatf("VSEQ: Pad Selection %d / %d", mio0_dio1, pad_sel), UVM_LOW)
 
-    // Check if selected PAD is pull up
-    // UsbP, IoR8, IoR9 are pull up
+    cfg.chip_vif.disconnect_all_interfaces(.disconnect_default_pulls(1'b 1));
+    cfg.chip_vif.ios_if.pins_pd                      = '1;
+    cfg.chip_vif.ios_if.pins_pd[SpiHostD3:SpiHostD0] = '1;
+    cfg.chip_vif.ios_if.pins_pu[SpiDevCsL]           = 1'b 1;
+    cfg.chip_vif.ios_if.pins_pu[UsbP]                = 1'b 1;
+    cfg.chip_vif.ios_if.pins_pd[UsbN]                = 1'b 1;
+
+    // Drive selected pad to 0
     if (mio0_dio1) begin
-      case (DioPads[pad_sel])
-        UsbP: begin
-          cfg.chip_vif.ios_if.drive_pin(UsbP, 1'b 0);
-        end
-
-        IoR8, IoR9: begin
-          cfg.chip_vif.ec_rst_l_if.drive_en('0);
-          cfg.chip_vif.flash_wp_l_if.drive_en('0);
-          cfg.chip_vif.ios_if.drive_pin(DioPads[pad_sel], 1'b 0);
-        end
-
-        default:;
-      endcase
+      cfg.chip_vif.ios_if.drive_pin(DioPads[pad_sel], 1'b 0);
     end else begin
-
-      // GPIO ports are many. Blindly turning them off.
-      cfg.chip_vif.gpio_pins_if.drive_en('0);
-
-      case (MioPads[pad_sel-2]) inside
-        [IoC0:IoC2]: begin
-          cfg.chip_vif.sw_straps_if.drive_en(3'b 000);
-        end
-
-        [IoC3:IoC4]: begin
-          // Disable Uart0
-          cfg.chip_vif.enable_uart(0, 1'b0);
-
-          // DFT
-          cfg.chip_vif.dft_straps_if.drive_en('0);
-        end
-
-        [IoB4:IoB5]: begin
-          // Disable Uart1
-          cfg.chip_vif.enable_uart(1, 1'b0);
-        end
-
-        [IoA4:IoA5]: begin
-          // Disable Uart2
-          cfg.chip_vif.enable_uart(2, 1'b0);
-        end
-
-        [IoA0:IoA1]: begin
-          // Disable Uart3
-          cfg.chip_vif.enable_uart(3, 1'b0);
-        end
-
-        IoR4: begin
-          // jtag rst_n
-          //   It is pull up PADs. Need to off it first
-          cfg.chip_vif.ios_if.pins_pu[IoR4] = 1'b 0;
-        end
-
-        IoC6: begin
-          // Ext Clk needs to be off
-          cfg.chip_vif.ext_clk_if.set_active(0, 0);
-        end
-
-        IoC8, IoC5: begin
-          cfg.chip_vif.tap_straps_if.drive_en('0);
-        end
-
-        IoB3, IoB6, IoB8, IoB9, IoC7, IoC9, IoR5, IoR6: begin
-          cfg.chip_vif.sysrst_ctrl_if.drive_en('0);
-        end
-
-        default:;
-      endcase
+      cfg.chip_vif.ios_if.drive_pin(MioPads[pad_sel-2], 1'b 0);
     end
 
     // Wait until chip enters low power (sleep or deep sleep).

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_wake_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_wake_vseq.sv
@@ -122,6 +122,12 @@ class chip_sw_sleep_pin_wake_vseq extends chip_sw_base_vseq;
     };
   }
 
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStProd);
+  endtask : dut_init
+
   virtual task cpu_init();
     bit [7:0] byte_arr [];
 

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -617,13 +617,15 @@ opentitan_functest(
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
-        "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/sim_dv/sleep_pin_wake_test.c
+++ b/sw/device/tests/sim_dv/sleep_pin_wake_test.c
@@ -3,22 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/mmio.h"
-#include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/dif/dif_pinmux.h"
 #include "sw/device/lib/dif/dif_pwrmgr.h"
 #include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/irq.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/pwrmgr_testutils.h"
 #include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
 // PLIC structures
 static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
+static dif_pwrmgr_t pwrmgr;
+static dif_pinmux_t pinmux;
 static dif_rv_plic_t plic;
 
 // Volatile for vseq to assign random constant to select one of 8 MIO DIO
@@ -31,16 +35,40 @@ static const uint32_t kNumDio = 16;  // top_earlgrey has 16 DIOs
 #define NUM_DIRECT_DIO 5
 static const uint32_t kDirectDio[NUM_DIRECT_DIO] = {6, 12, 13, 14, 15};
 
-bool test_main(void) {
-  dif_pwrmgr_t pwrmgr;
-  dif_pinmux_t pinmux;
-  dif_gpio_t gpio;
+static plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
+                                  .hart_id = kTopEarlgreyPlicTargetIbex0};
 
+static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
+    .pwrmgr = &pwrmgr,
+    .plic_pwrmgr_start_irq_id = kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+    .expected_irq = kDifPwrmgrIrqWakeup,
+    .is_only_irq = true};
+
+/**
+ * External interrupt handler.
+ */
+void ottf_external_isr(void) {
+  dif_pwrmgr_irq_t irq_id;
+  top_earlgrey_plic_peripheral_t peripheral;
+
+  isr_testutils_pwrmgr_isr(plic_ctx, pwrmgr_isr_ctx, &peripheral, &irq_id);
+
+  // Check that both the peripheral and the irq id is correct
+  CHECK(peripheral == kTopEarlgreyPlicPeripheralPwrmgrAon,
+        "IRQ peripheral: %d is incorrect", peripheral);
+  CHECK(irq_id == kDifPwrmgrIrqWakeup, "IRQ ID: %d is incorrect", irq_id);
+}
+
+bool test_main(void) {
   dif_pinmux_index_t detector;
   dif_pinmux_wakeup_config_t wakeup_cfg;
 
   // Default Deep Power Down
   dif_pwrmgr_domain_config_t pwrmgr_domain_cfg = 0;
+
+  // Enable global and external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
 
   // Initialize power manager
   CHECK_DIF_OK(dif_pwrmgr_init(
@@ -61,6 +89,16 @@ bool test_main(void) {
     // Prepare which PAD SW want to select
     uint32_t mio0_dio1 = rand_testutils_gen32_range(0, 1);
     uint32_t pad_sel = 0;
+
+    // Enable AonWakeup Interrupt if normal sleep
+    if (deep_powerdown_en == 0) {
+      // Enable all the AON interrupts used in this test.
+      rv_plic_testutils_irq_range_enable(&plic, kTopEarlgreyPlicTargetIbex0,
+                                         kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+                                         kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+      // Enable pwrmgr interrupt
+      CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, 0, kDifToggleEnabled));
+    }
 
     // SpiDev CLK(idx 12), CS#(idx 13), D0(idx 6) and SpiHost CLK (14), CS#
     // (15) are directly connected to the SPI IF. Cannot control them. Roll 3
@@ -108,11 +146,11 @@ bool test_main(void) {
 
     LOG_INFO("Entering low power mode.");
     wait_for_interrupt();
+  }
 
-    // TODO: Check WAKEUP_INFO and pin wake
-
-  } else if (pwrmgr_testutils_is_wakeup_reason(
-                 &pwrmgr, kDifPwrmgrWakeupRequestSourceThree)) {
+  // SW passed WFI() or wakeup from Deep Powerdown.
+  if (pwrmgr_testutils_is_wakeup_reason(&pwrmgr,
+                                        kDifPwrmgrWakeupRequestSourceThree)) {
     // Pinmux wakeup
     LOG_INFO("PINMUX PIN Wakeup");
 
@@ -120,8 +158,9 @@ bool test_main(void) {
 
     return true;
   } else {
-    // Other wakeup. This is a failure.
     dif_pwrmgr_wakeup_reason_t wakeup_reason;
+
+    // Other wakeup. This is a failure.
     CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason));
     LOG_ERROR("Unexpected wakeup detected: type = %d, request_source = %d",
               wakeup_reason.types, wakeup_reason.request_sources);


### PR DESCRIPTION
This PR adds randomization to the pin_wake test. The test now selects between normal sleep and deep sleep (previously, the test entered to deep sleep only)

