### PR TITLE
[dv/rstmgr] Fix dv for recent changes in reset

### DIFF
--- a/hw/ip/rstmgr/dv/env/rstmgr_env_pkg.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_env_pkg.sv
@@ -44,8 +44,10 @@ package rstmgr_env_pkg;
     "u_d0_i2c1",
     "u_d0_i2c2",
     "u_d0_lc",
-    "u_d0_lc_io_div4",
-    "u_d0_lc_io_div4_shadowed",
+    // There are 4 rstmgr_leaf_rst instances with security checks disabled.
+    // TODO(#15093) Perhaps adjust it depending on this issue.
+    // "u_d0_lc_io_div4",
+    // "u_d0_lc_io_div4_shadowed",
     "u_d0_spi_device",
     "u_d0_spi_host0",
     "u_d0_spi_host1",
@@ -61,12 +63,15 @@ package rstmgr_env_pkg;
     "u_daon_lc_aon",
     "u_daon_lc_io",
     "u_daon_lc_io_div2",
-    "u_daon_lc_io_div4",
-    "u_daon_lc_io_div4_shadowed",
+    // Same as comment above.
+    // "u_daon_lc_io_div4",
+    // "u_daon_lc_io_div4_shadowed",
     "u_daon_lc_usb",
+    "u_daon_por",
     "u_daon_por_io",
-    // The leaf below doesn't implement consistency checks.
-    // "u_daon_por_io_div4",
+    "u_daon_por_io_div2",
+    "u_daon_por_io_div4",
+    "u_daon_por_usb",
     "u_daon_sys_aon",
     "u_daon_sys_io_div4"
   };

--- a/hw/ip/rstmgr/dv/env/rstmgr_if.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_if.sv
@@ -65,4 +65,6 @@ interface rstmgr_if (
   logic cpu_info_en;
   always_comb cpu_info_en = `PATH_TO_DUT.reg2hw.cpu_info_ctrl.en.q;
 
+  bit rst_ni_inactive;
+  always_comb rst_ni_inactive = resets_o.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel];
 endinterface

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_por_stretcher_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_por_stretcher_vseq.sv
@@ -36,9 +36,7 @@ class rstmgr_por_stretcher_vseq extends rstmgr_base_vseq;
       cfg.aon_clk_rst_vif.wait_clks(glitch_duration_cycles);
       `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel], 1'b0)
     end
-    cfg.rstmgr_vif.por_n = 1'b1;
-    cfg.aon_clk_rst_vif.wait_clks(AON_CYCLES_BEFORE_RESET_CHECK);
-    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel], 1'b1)
+    por_reset_done();
     csr_rd_check(.ptr(ral.reset_info.por), .compare_value(1'b1),
                  .err_msg("Unexpected reset_info.por low"));
   endtask

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv
@@ -112,12 +112,13 @@ class rstmgr_reset_vseq extends rstmgr_base_vseq;
         default: `uvm_fatal(`gfn, $sformatf("Unexpected reset type %0d", which_reset))
       endcase
 
-      cfg.clk_rst_vif.wait_clks(8);
+      cfg.io_div4_clk_rst_vif.wait_clks(8);
       wait(cfg.rstmgr_vif.resets_o.rst_lc_n[1]);
       check_reset_info(expected_reset_info_code, reset_test_info.description);
       check_alert_info_after_reset(.alert_dump(expected_alert_dump),
                                    .enable(expected_alert_enable));
       check_cpu_info_after_reset(.cpu_dump(expected_cpu_dump), .enable(expected_cpu_enable));
+      if (which_reset == ResetPOR) read_and_check_all_csrs_after_reset();
       prev_alert_dump = expected_alert_dump;
       prev_cpu_dump   = expected_cpu_dump;
     end

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_vseq.sv
@@ -16,7 +16,6 @@ class rstmgr_sw_rst_vseq extends rstmgr_base_vseq;
   task body();
     bit [NumSwResets-1:0] exp_ctrl_n;
     bit [NumSwResets-1:0] sw_rst_regwen = '1;
-    bit [NumSwResets-1:0] all_ones = '1;
     alert_crashdump_t bogus_alert_dump = '1;
     cpu_crash_dump_t bogus_cpu_dump = '1;
     set_alert_and_cpu_info_for_capture(bogus_alert_dump, bogus_cpu_dump);
@@ -40,7 +39,7 @@ class rstmgr_sw_rst_vseq extends rstmgr_base_vseq;
         `uvm_info(`gfn, $sformatf("compare sw_rst_regwen against %b", exp_regwen[i]), UVM_LOW)
         csr_rd_check(.ptr(ral.sw_rst_regwen[i]), .compare_value(exp_regwen[i]),
                      .err_msg($sformatf("The expected value is %b", exp_regwen[i])));
-        check_sw_rst_ctrl_n(.sw_rst_ctrl_n('0), .sw_rst_regen(exp_regwen), .erase_ctrl_n(1'b1));
+        check_sw_rst_ctrl_n(.sw_rst_ctrl_n('0), .sw_rst_regwen(exp_regwen), .erase_ctrl_n(1'b1));
       end
       check_alert_and_cpu_info_after_reset(.alert_dump('0), .cpu_dump('0), .enable(1'b1));
     end

--- a/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -32,8 +32,10 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
-                // Disable until the stress_all sequence is created.
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
+                // Just run the stress_all sequence, and don't inject random
+                // resets since we may get overlapping resets due to sequences
+                // that inject them.
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_all_test.hjson"
                 ]
 
   // Specific exclusion files.

--- a/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
@@ -6,7 +6,7 @@ module rstmgr_bind;
 
   bind rstmgr tlul_assert #(
     .EndpointType("Device")
-  ) tlul_assert_device (.clk_i , .rst_ni (resets_o.rst_por_n[Domain0Sel]), .h2d(tl_i), .d2h(tl_o));
+  ) tlul_assert_device (.clk_i, .rst_ni(resets_o.rst_por_n[Domain0Sel]), .h2d(tl_i), .d2h(tl_o));
 
   bind rstmgr rstmgr_cascading_sva_if rstmgr_cascading_sva_if (
     .clk_i,

--- a/hw/ip/rstmgr/dv/tb.sv
+++ b/hw/ip/rstmgr/dv/tb.sv
@@ -56,7 +56,7 @@ module tb;
   pins_if #(1) devmode_if (devmode);
   tl_if tl_if (
     .clk,
-    .rst_n(rstmgr_if.resets_o.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel])
+    .rst_n(rstmgr_if.resets_o.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
 
   rstmgr_if rstmgr_if (
@@ -82,14 +82,14 @@ module tb;
   // This is consistent with rstmgr being the only source of resets.
   rstmgr dut (
     .clk_i        (clk),
-    .rst_ni       (rstmgr_if.resets_o.rst_lc_io_div4_n[rstmgr_pkg::DomainAonSel]),
+    .rst_ni       (rstmgr_if.resets_o.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
     .clk_aon_i    (clk_aon),
     .clk_io_div4_i(clk_io_div4),
     .clk_main_i   (clk_main),
     .clk_io_i     (clk_io),
     .clk_io_div2_i(clk_io_div2),
     .clk_usb_i    (clk_usb),
-    .clk_por_i    (clk),
+    .clk_por_i    (clk_io_div4),
     .rst_por_ni   (rstmgr_if.resets_o.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]),
 
     .tl_i      (tl_if.h2d),
@@ -102,7 +102,7 @@ module tb;
     .pwr_i(rstmgr_if.pwr_i),
     .pwr_o(rstmgr_if.pwr_o),
 
-    .sw_rst_req_o(rstmgr_if.sw_rst_req_o),
+    .sw_rst_req_o  (rstmgr_if.sw_rst_req_o),
     .ndmreset_req_i(rstmgr_if.cpu_i.ndmreset_req),
 
     .alert_dump_i(rstmgr_if.alert_dump_i),
@@ -133,7 +133,7 @@ module tb;
     uvm_config_db#(virtual pwrmgr_rstmgr_sva_if)::set(null, "*.env", "pwrmgr_rstmgr_sva_vif",
                                                       dut.pwrmgr_rstmgr_sva_if);
     uvm_config_db#(virtual rstmgr_cascading_sva_if)::set(null, "*.env", "rstmgr_cascading_sva_vif",
-                                                      dut.rstmgr_cascading_sva_if);
+                                                         dut.rstmgr_cascading_sva_if);
     uvm_config_db#(virtual rstmgr_if)::set(null, "*.env", "rstmgr_vif", rstmgr_if);
 
     $timeformat(-12, 0, " ps", 12);
@@ -141,8 +141,10 @@ module tb;
   end
 
   initial begin
+    // This may help any code that depends on clk_rst_vif.rst_n in the infrastructure: they won't
+    // be able to change but at least the reset value will be true to the environment.
     clk_rst_if.drive_rst_n = 1'b0;
-    force clk_rst_if.rst_n = rstmgr_if.resets_o.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel];
+    force clk_rst_if.rst_n = rstmgr_if.resets_o.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel];
   end
 
 endmodule


### PR DESCRIPTION
The recent RTL changes required big changes in the dv environment. This change disables non-aon clocks upon reset, and improves the flow of reset stimulus.

Signed-off-by: Guillermo Maturana <maturana@google.com>