### PR TITLE
[DV|CSR BIT BASH] Excluded two watermark RO registers

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -709,6 +709,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext: "true",
+      tags: [// Internal HW can modify status register
+             "excl:CsrNonInitTests:CsrExclCheck"]
       fields: [
         { bits: "15:0",
           name: "FIPS_WATERMARK",
@@ -745,6 +747,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext: "true",
+      tags: [// Internal HW can modify status register
+             "excl:CsrNonInitTests:CsrExclCheck"]
       fields: [
         { bits: "15:0",
           name: "FIPS_WATERMARK",
@@ -761,6 +765,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext: "true",
+      tags: [// Internal HW can modify status register
+             "excl:CsrNonInitTests:CsrExclCheck"]
       fields: [
         { bits: "15:0",
           name: "FIPS_WATERMARK",
@@ -779,6 +785,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext: "true",
+      tags: [// Internal HW can modify status register
+             "excl:CsrNonInitTests:CsrExclCheck"]
       fields: [
         { bits: "15:0",
           name: "FIPS_WATERMARK",
@@ -795,6 +803,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext: "true",
+      tags: [// Internal HW can modify status register
+             "excl:CsrNonInitTests:CsrExclCheck"]
       fields: [
         { bits: "15:0",
           name: "FIPS_WATERMARK",
@@ -811,6 +821,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext: "true",
+      tags: [// Internal HW can modify status register
+             "excl:CsrNonInitTests:CsrExclCheck"]
       fields: [
         { bits: "15:0",
           name: "FIPS_WATERMARK",


### PR DESCRIPTION
- This issue was reported by #15027
- watermarks (RD CSR) is updated by internal HW when reg2hw.health_test_window.fips_window is updated multiple times like a sweep test. When it is written by 0, the watermark is also cleared to 0.

Signed-off-by: Joshua Park <jeoong@google.com>