### PR TITLE
[test] Run additional functests with rom

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -148,11 +148,6 @@ cc_library(
 opentitan_functest(
     name = "irq_asm_functest",
     srcs = ["irq_asm_functest.c"],
-    targets = [
-        "cw310_test_rom",
-        "verilator",
-        "dv",
-    ],
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -576,11 +576,6 @@ cc_test(
 opentitan_functest(
     name = "rstmgr_functest",
     srcs = ["rstmgr_functest.c"],
-    targets = [
-        "cw310_test_rom",
-        "verilator",
-        "dv",
-    ],
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -665,11 +660,6 @@ cc_test(
 opentitan_functest(
     name = "watchdog_functest",
     srcs = ["watchdog_functest.c"],
-    targets = [
-        "cw310_test_rom",
-        "verilator",
-        "dv",
-    ],
     verilator = verilator_params(
         timeout = "long",
     ),


### PR DESCRIPTION
This PR enables

* `//sw/device/silicon_creator/lib:irq_asm_functest_fpga_cw310_rom`,
* `//sw/device/silicon_creator/lib/drivers:rstmgr_functest_fpga_cw310_rom`, and
* `//sw/device/silicon_creator/lib/drivers:watchdog_functest_fpga_cw310_rom`

Signed-off-by: Alphan Ulusoy <alphan@google.com>