### PR TITLE
[util] Print stderr if generate_compilation_db.py fails

### DIFF
--- a/util/generate_compilation_db.py
+++ b/util/generate_compilation_db.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import subprocess
+import sys
 from typing import Dict, List
 
 
@@ -103,10 +104,16 @@ def main(args):
         '--output=jsonproto',
         args.target,
     ]
-    completed_process = subprocess.run(bazel_aquery_command,
-                                       stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE,
-                                       check=True)
+    try:
+        completed_process = subprocess.run(bazel_aquery_command,
+                                           stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE,
+                                           check=True)
+    except subprocess.CalledProcessError as e:
+        print(e.stderr.decode('utf-8'), file=sys.stderr)
+        raise
+    except BaseException:
+        raise
     aquery_results = BazelAqueryResults(completed_process.stdout)
 
     compile_commands = []


### PR DESCRIPTION
Makes it easier to understand if an error is caused by the script (most likely not) or the `BUILD` files.

Signed-off-by: Alphan Ulusoy <alphan@google.com>