### PR TITLE
fix(kmac): Check SHA3 done loosely for false value

### DIFF
--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -740,7 +740,7 @@ module kmac
           // if it receives absorbed signal.
           kmac_st_d = KmacIdle;
         end else if (prim_mubi_pkg::mubi4_test_true_strict(sha3_absorbed) &&
-          prim_mubi_pkg::mubi4_test_false_strict(sha3_done)) begin
+          prim_mubi_pkg::mubi4_test_false_loose(sha3_done)) begin
           kmac_st_d = KmacDigest;
         end else begin
           kmac_st_d = KmacMsgFeed;


### PR DESCRIPTION
Related Issue: https://github.com/lowRISC/opentitan/issues/15002

KMAC checks `sha3_done` false value strictly. It opened the attackers making KMAC not finished and keep feeding messages.

By checking `sha3_done` loosely in this commit, the state always moves to next state when `sha3_absorbed` is true.
