### PR TITLE
[dv/kmac] Check kmac lock after global/local escalation

### DIFF
--- a/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
@@ -87,7 +87,7 @@
       name: sec_cm_fsm_local_esc
       desc: "Verify the countermeasure(s) FSM.LOCAL_ESC."
       stage: V2S
-      tests: []
+      tests: ["kmac_sec_cm"]
     }
     {
       name: sec_cm_logic_integrity

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -31,6 +31,7 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
     has_shadowed_regs = 1;
     list_of_alerts = kmac_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_fault_err";
+    sec_cm_alert_name  = "fatal_fault_err";
     super.initialize(csr_base_addr);
 
     tl_intg_alert_fields[ral.status.alert_fatal_fault] = 1;

--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -21,6 +21,7 @@ package kmac_env_pkg;
   import kmac_pkg::*;
   import keymgr_pkg::*;
   import key_sideload_agent_pkg::*;
+  import sec_cm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
@@ -70,4 +70,25 @@ class kmac_common_vseq extends kmac_base_vseq;
     super.check_tl_intg_error_response();
   endtask
 
+  virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
+    super.check_sec_cm_fi_resp(if_proxy);
+    kmac_app_lock_check();
+    kmac_sw_lock_check();
+  endtask
+
+  virtual function void sec_cm_fi_ctrl_svas(sec_cm_base_if_proxy if_proxy, bit enable);
+    if (!uvm_re_match("*.u_sha3.u_state_regs*", if_proxy.path)) begin
+      if (!enable) $assertoff(0, "tb.dut.u_sha3.FsmKnown_A");
+      else         $asserton(0, "tb.dut.u_sha3.FsmKnown_A");
+    end else if (!uvm_re_match("*.u_msgfifo.gen_normal_fifo.u_fifo_cnt*", if_proxy.path)) begin
+      if (!enable) begin
+        $assertoff(0, "tb.dut.u_msgfifo.u_msgfifo.DataKnown_A");
+        $assertoff(0, "tb.dut.u_msgfifo.u_msgfifo.gen_normal_fifo.depthShallNotExceedParamDepth");
+      end else begin
+        $asserton(0, "tb.dut.u_msgfifo.u_msgfifo.DataKnown_A");
+        $asserton(0, "tb.dut.u_msgfifo.u_msgfifo.gen_normal_fifo.depthShallNotExceedParamDepth");
+      end
+    end
+  endfunction: sec_cm_fi_ctrl_svas
+
 endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
@@ -27,8 +27,6 @@ class kmac_lc_escalation_vseq extends kmac_app_vseq;
 
     // Check only if lc_escalate_en is not `Off`.
     if (cfg.en_scb == 0) begin
-      kmac_pkg::kmac_cmd_e rand_cmd;
-      bit [7:0] share[];
       cfg.clk_rst_vif.wait_clks($urandom_range(5, 100));
 
       // Randomly turns off lc_escalate_en.
@@ -38,21 +36,11 @@ class kmac_lc_escalation_vseq extends kmac_app_vseq;
       end
 
       `DV_CHECK_RANDOMIZE_FATAL(this)
-      `DV_CHECK_STD_RANDOMIZE_FATAL(rand_cmd)
+
+      check_lc_escalate_status();
 
       // Check if kmac will accept any SW request.
-      check_lc_escalate_status();
-      kmac_init(0);
-      set_prefix();
-      write_key_shares();
-      provide_sw_entropy();
-      issue_cmd(rand_cmd);
-      write_msg(msg);
-      check_lc_escalate_status();
-      read_digest_chunk(KMAC_STATE_SHARE0_BASE, keccak_block_size, share);
-      foreach (share[i]) `DV_CHECK_EQ_FATAL(share[i], '0)
-      read_digest_chunk(KMAC_STATE_SHARE1_BASE, keccak_block_size, share);
-      foreach (share[i]) `DV_CHECK_EQ_FATAL(share[i], '0)
+      kmac_sw_lock_check();
 
       // TODO: Add checking for kmac app request.
     end

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -37,7 +37,11 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["kmac_bind", "sec_cm_prim_onehot_check_bind", "kmac_cov_bind"]
+  sim_tops: ["kmac_bind",
+             "kmac_cov_bind",
+             "sec_cm_prim_onehot_check_bind",
+             "sec_cm_prim_sparse_fsm_flop_bind",
+             "sec_cm_prim_count_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -186,7 +186,7 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     end
   endtask : check_sec_cm_fi_resp
 
-   virtual function void sec_cm_fi_ctrl_svas(sec_cm_base_if_proxy if_proxy, bit enable);
+  virtual function void sec_cm_fi_ctrl_svas(sec_cm_base_if_proxy if_proxy, bit enable);
     case (if_proxy.sec_cm_type)
       SecCmPrimCount: begin
         if (!enable) begin


### PR DESCRIPTION
This PR adds checkings after kmac global/local escalation to make sure 
1). Kmac does not take any SW requests
2). Kmac does not take any APP requests

Signed-off-by: Cindy Chen <chencindy@opentitan.org>