### PR TITLE
[dv/clkmgr] Fix handling of lost calibration

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_env_cfg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_cfg.sv
@@ -33,6 +33,7 @@ class clkmgr_env_cfg extends cip_base_env_cfg #(
     super.initialize(csr_base_addr);
 
     // This is for the integrity error test.
+    tl_intg_alert_name = "fatal_fault";
     tl_intg_alert_fields[ral.fatal_err_code.reg_intg] = 1;
     m_tl_agent_cfg.max_outstanding_req = 1;
 

--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -354,6 +354,7 @@ interface clkmgr_if (
   end
 
   clocking clk_cb @(posedge clk);
+    input calib_rdy;
     input extclk_ctrl_csr_sel;
     input extclk_ctrl_csr_step_down;
     input lc_hw_debug_en_i;

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -260,52 +260,146 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     endcase
   endtask
 
-  task enable_frequency_measurement(clk_mesr_e which, int min_threshold, int max_threshold);
+  local function int get_meas_ctrl_value(int min_threshold, int max_threshold, uvm_reg_field lo,
+                                         uvm_reg_field hi);
+    int lo_mask = (1 << lo.get_n_bits()) - 1;
+    int hi_mask = (1 << hi.get_n_bits()) - 1;
+
+    int value = (((min_threshold & lo_mask) << lo.get_lsb_pos()) |
+                 ((max_threshold & hi_mask) << hi.get_lsb_pos()));
+    return value;
+  endfunction
+
+  task enable_frequency_measurement(clk_mesr_e which, int min_threshold, int max_threshold,
+                                    bit block_meas_en = 1'b0);
+    mubi4_t expected_en_value = block_meas_en ? MuBi4False : MuBi4True;
     `uvm_info(`gfn, $sformatf(
-              "Enabling frequency measurement for %0s, min=%0d, max=%0d, expected=%0d",
+              "Enabling frequency measurement for %0s, min=0x%x, max=0x%x, expected=0x%x",
               which.name,
               min_threshold,
               max_threshold,
               ExpectedCounts[which]
               ), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf(
+              "measure_ctrl_regwen predicted value 0x%x, mirrored 0x%x",
+              ral.measure_ctrl_regwen.get(),
+              `gmv(ral.measure_ctrl_regwen)
+              ), UVM_MEDIUM)
     case (which)
       ClkMesrIo: begin
-        ral.io_meas_ctrl_shadowed.lo.set(min_threshold);
-        ral.io_meas_ctrl_shadowed.hi.set(max_threshold);
-        csr_update(.csr(ral.io_meas_ctrl_shadowed));
-        ral.io_meas_ctrl_en.en.set(MuBi4True);
-        csr_update(.csr(ral.io_meas_ctrl_en));
+        int value = get_meas_ctrl_value(
+            min_threshold, max_threshold, ral.io_meas_ctrl_shadowed.lo, ral.io_meas_ctrl_shadowed.hi
+        );
+        csr_wr(.ptr(ral.io_meas_ctrl_shadowed), .value(value));
+        `uvm_info(`gfn, $sformatf(
+                  "Wrote 0x%x to %s, predict 0x%x, mirrored 0x%x",
+                  value,
+                  which.name(),
+                  ral.io_meas_ctrl_shadowed.get(),
+                  `gmv(ral.io_meas_ctrl_shadowed)
+                  ), UVM_MEDIUM)
+        csr_wr(.ptr(ral.io_meas_ctrl_en), .value(MuBi4True));
       end
       ClkMesrIoDiv2: begin
-        ral.io_div2_meas_ctrl_shadowed.lo.set(min_threshold);
-        ral.io_div2_meas_ctrl_shadowed.hi.set(max_threshold);
-        csr_update(.csr(ral.io_div2_meas_ctrl_shadowed));
-        ral.io_div2_meas_ctrl_en.en.set(MuBi4True);
-        csr_update(.csr(ral.io_div2_meas_ctrl_en));
+        int value = get_meas_ctrl_value(
+            min_threshold,
+            max_threshold,
+            ral.io_div2_meas_ctrl_shadowed.lo,
+            ral.io_div2_meas_ctrl_shadowed.hi
+        );
+        csr_wr(.ptr(ral.io_div2_meas_ctrl_shadowed), .value(value));
+        `uvm_info(`gfn, $sformatf(
+                  "Wrote 0x%x to %s, predict 0x%x, mirrored 0x%x",
+                  value,
+                  which.name(),
+                  ral.io_div2_meas_ctrl_shadowed.get(),
+                  `gmv(ral.io_div2_meas_ctrl_shadowed)
+                  ), UVM_MEDIUM)
+        csr_wr(.ptr(ral.io_div2_meas_ctrl_en), .value(MuBi4True));
       end
       ClkMesrIoDiv4: begin
-        ral.io_div4_meas_ctrl_shadowed.lo.set(min_threshold);
-        ral.io_div4_meas_ctrl_shadowed.hi.set(max_threshold);
-        csr_update(.csr(ral.io_div4_meas_ctrl_shadowed));
-        ral.io_div4_meas_ctrl_en.en.set(MuBi4True);
-        csr_update(.csr(ral.io_div4_meas_ctrl_en));
+        int value = get_meas_ctrl_value(
+            min_threshold,
+            max_threshold,
+            ral.io_div4_meas_ctrl_shadowed.lo,
+            ral.io_div4_meas_ctrl_shadowed.hi
+        );
+        csr_wr(.ptr(ral.io_div4_meas_ctrl_shadowed), .value(value));
+        `uvm_info(`gfn, $sformatf(
+                  "Wrote 0x%x to %s, predict 0x%x, mirrored 0x%x",
+                  value,
+                  which.name(),
+                  ral.io_div4_meas_ctrl_shadowed.get(),
+                  `gmv(ral.io_div4_meas_ctrl_shadowed)
+                  ), UVM_MEDIUM)
+        csr_wr(.ptr(ral.io_div4_meas_ctrl_en), .value(MuBi4True));
       end
       ClkMesrMain: begin
-        ral.main_meas_ctrl_shadowed.lo.set(min_threshold);
-        ral.main_meas_ctrl_shadowed.hi.set(max_threshold);
-        csr_update(.csr(ral.main_meas_ctrl_shadowed));
-        ral.main_meas_ctrl_en.en.set(MuBi4True);
-        csr_update(.csr(ral.main_meas_ctrl_en));
+        int value = get_meas_ctrl_value(
+            min_threshold,
+            max_threshold,
+            ral.main_meas_ctrl_shadowed.lo,
+            ral.main_meas_ctrl_shadowed.hi
+        );
+        csr_wr(.ptr(ral.main_meas_ctrl_shadowed), .value(value));
+        `uvm_info(`gfn, $sformatf(
+                  "Wrote 0x%x to %s, predict 0x%x, mirrored 0x%x",
+                  value,
+                  which.name(),
+                  ral.main_meas_ctrl_shadowed.get(),
+                  `gmv(ral.main_meas_ctrl_shadowed)
+                  ), UVM_MEDIUM)
+        csr_wr(.ptr(ral.main_meas_ctrl_en), .value(MuBi4True));
       end
       ClkMesrUsb: begin
-        ral.usb_meas_ctrl_shadowed.lo.set(min_threshold);
-        ral.usb_meas_ctrl_shadowed.hi.set(max_threshold);
-        csr_update(.csr(ral.usb_meas_ctrl_shadowed));
-        ral.usb_meas_ctrl_en.en.set(MuBi4True);
-        csr_update(.csr(ral.usb_meas_ctrl_en));
+        int value = get_meas_ctrl_value(
+            min_threshold,
+            max_threshold,
+            ral.usb_meas_ctrl_shadowed.lo,
+            ral.usb_meas_ctrl_shadowed.hi
+        );
+        csr_wr(.ptr(ral.usb_meas_ctrl_shadowed), .value(value));
+        `uvm_info(`gfn, $sformatf(
+                  "Wrote 0x%x to %s, predict 0x%x, mirrored 0x%x",
+                  value,
+                  which.name(),
+                  ral.usb_meas_ctrl_shadowed.get(),
+                  `gmv(ral.usb_meas_ctrl_shadowed)
+                  ), UVM_MEDIUM)
+        csr_wr(.ptr(ral.usb_meas_ctrl_en), .value(MuBi4True));
       end
       default: ;
     endcase
+  endtask
+
+  // This checks that when calibration is lost regwen should be re-enabled and measurements
+  // disabled.
+  task calibration_lost_checks();
+    ral.measure_ctrl_regwen.predict(1);
+    csr_rd_check(.ptr(ral.measure_ctrl_regwen), .compare_value(1));
+    foreach (ExpectedCounts[clk]) begin
+      clk_mesr_e clk_mesr = clk_mesr_e'(clk);
+      case (clk_mesr)
+        ClkMesrIo: begin
+          csr_rd_check(.ptr(ral.io_meas_ctrl_en.en), .compare_value(MuBi4False));
+          `uvm_info(`gfn, $sformatf("CSR %s meas_ctrl_en mirrored value 0x%x",
+                                    clk_mesr.name(), `gmv(ral.io_meas_ctrl_en)), UVM_MEDIUM)
+        end
+        ClkMesrIoDiv2: begin
+          csr_rd_check(.ptr(ral.io_div2_meas_ctrl_en.en), .compare_value(MuBi4False));
+        end
+        ClkMesrIoDiv4: begin
+          csr_rd_check(.ptr(ral.io_div4_meas_ctrl_en.en), .compare_value(MuBi4False));
+        end
+        ClkMesrMain: begin
+          csr_rd_check(.ptr(ral.main_meas_ctrl_en.en), .compare_value(MuBi4False));
+        end
+        ClkMesrUsb: begin
+          csr_rd_check(.ptr(ral.usb_meas_ctrl_en.en), .compare_value(MuBi4False));
+        end
+        default: ;
+      endcase
+    end
   endtask
 
   local function void control_sync_pulse_assert(clk_mesr_e clk, bit enable);

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -55,8 +55,11 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
       bool_idle = mubi_hintables_to_hintables(idle);
       value = initial_hints | ~bool_idle;
       csr_rd_check(.ptr(ral.clk_hints_status), .compare_value(value),
-                   .err_msg($sformatf("Busy units have status high: hints=0x%x, idle=0x%x",
-                                      initial_hints, bool_idle)));
+                   .err_msg($sformatf(
+                       "Busy units have status high: hints=0x%x, idle=0x%x",
+                       initial_hints,
+                       bool_idle
+                   )));
 
       // Setting all idle should make hint_status match hints.
       `uvm_info(`gfn, "Setting all units idle", UVM_MEDIUM)

--- a/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
@@ -352,6 +352,49 @@ module clkmgr_bind;
     .cg_en(cg_en_o.main_otbn == prim_mubi_pkg::MuBi4True)
   );
 
+  // Calibration assertions.
+  bind clkmgr clkmgr_lost_calib_regwen_sva_if clkmgr_lost_calib_regwen_sva_if (
+    .clk(clk_i),
+    .rst_n(rst_ni),
+    .calib_rdy(calib_rdy_i),
+    .meas_ctrl_regwen(u_reg.measure_ctrl_regwen_qs)
+  );
+
+  bind clkmgr clkmgr_lost_calib_ctrl_en_sva_if clkmgr_lost_calib_io_ctrl_en_sva_if (
+    .clk(clk_i),
+    .rst_n(rst_ni),
+    .calib_rdy(calib_rdy_i),
+    .meas_ctrl_en(u_reg.io_meas_ctrl_en_qs)
+  );
+
+  bind clkmgr clkmgr_lost_calib_ctrl_en_sva_if clkmgr_lost_calib_io_div2_ctrl_en_sva_if (
+    .clk(clk_i),
+    .rst_n(rst_ni),
+    .calib_rdy(calib_rdy_i),
+    .meas_ctrl_en(u_reg.io_div2_meas_ctrl_en_qs)
+  );
+
+  bind clkmgr clkmgr_lost_calib_ctrl_en_sva_if clkmgr_lost_calib_io_div4_ctrl_en_sva_if (
+    .clk(clk_i),
+    .rst_n(rst_ni),
+    .calib_rdy(calib_rdy_i),
+    .meas_ctrl_en(u_reg.io_div4_meas_ctrl_en_qs)
+  );
+
+  bind clkmgr clkmgr_lost_calib_ctrl_en_sva_if clkmgr_lost_calib_main_ctrl_en_sva_if (
+    .clk(clk_i),
+    .rst_n(rst_ni),
+    .calib_rdy(calib_rdy_i),
+    .meas_ctrl_en(u_reg.main_meas_ctrl_en_qs)
+  );
+
+  bind clkmgr clkmgr_lost_calib_ctrl_en_sva_if clkmgr_lost_calib_usb_ctrl_en_sva_if (
+    .clk(clk_i),
+    .rst_n(rst_ni),
+    .calib_rdy(calib_rdy_i),
+    .meas_ctrl_en(u_reg.usb_meas_ctrl_en_qs)
+  );
+
   bind clkmgr clkmgr_sec_cm_checker_assert clkmgr_sec_cm_checker_assert (
     .clk_i,
     .rst_ni,

--- a/hw/ip/clkmgr/dv/sva/clkmgr_lost_calib_ctrl_en_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_lost_calib_ctrl_en_sva_if.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This contains SVA assertions to check loosing calibration turns off clock measurements.
+
+interface clkmgr_lost_calib_ctrl_en_sva_if (
+  input logic clk,
+  input logic rst_n,
+  input logic [$bits(prim_mubi_pkg::mubi4_t)-1:0] calib_rdy,
+  input logic [$bits(prim_mubi_pkg::mubi4_t)-1:0] meas_ctrl_en
+);
+  // There are two clocks involved, the clock measured and the clkmgr clk_i.
+  // The latter is io_div4 so it is pretty slow compared to all others. There
+  // are a number of clock domain crossings, so this needs a large number of
+  // wait cycles to account for the worst case.
+  localparam int MAX_CYCLES = 32;
+  `ASSERT(CtrlEnOn_A,
+          (calib_rdy == prim_mubi_pkg::MuBi4False && meas_ctrl_en != prim_mubi_pkg::MuBi4False) |=>
+          ##[0:MAX_CYCLES] (meas_ctrl_en == prim_mubi_pkg::MuBi4False),
+          clk, !rst_n)
+endinterface

--- a/hw/ip/clkmgr/dv/sva/clkmgr_lost_calib_regwen_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_lost_calib_regwen_sva_if.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This contains SVA assertions to check loosing calibration enables crtl regwen.
+
+interface clkmgr_lost_calib_regwen_sva_if (
+  input logic clk,
+  input logic rst_n,
+  input prim_mubi_pkg::mubi4_t calib_rdy,
+  input logic meas_ctrl_regwen
+);
+  localparam int MAX_CYCLES = 6;
+  `ASSERT(RegwenOff_A,
+          (calib_rdy == prim_mubi_pkg::MuBi4False) |=> ##[0:MAX_CYCLES] meas_ctrl_regwen, clk,
+          !rst_n)
+endinterface

--- a/hw/ip/clkmgr/dv/sva/clkmgr_sec_cm_checker_assert.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_sec_cm_checker_assert.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Assertion checker for
+// Assertion checker for external clock bypass
 // sec cm test
 module clkmgr_sec_cm_checker_assert (
   input clk_i,

--- a/hw/ip/clkmgr/dv/sva/clkmgr_sva_ifs.core
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_sva_ifs.core
@@ -12,11 +12,13 @@ filesets:
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:dv:clkmgr_pwrmgr_sva_if
     files:
-      - clkmgr_div_sva_if.sv
-      - clkmgr_gated_clock_sva_if.sv
       - clkmgr_aon_cg_en_sva_if.sv
       - clkmgr_cg_en_sva_if.sv
+      - clkmgr_div_sva_if.sv
       - clkmgr_extclk_sva_if.sv
+      - clkmgr_gated_clock_sva_if.sv
+      - clkmgr_lost_calib_ctrl_en_sva_if.sv
+      - clkmgr_lost_calib_regwen_sva_if.sv
       - clkmgr_trans_sva_if.sv
     file_type: systemVerilogSource
 


### PR DESCRIPTION
Add stimulus to trigger a loss of clock calibration. When calibration is expect the measure_ctrl_regwen CSR is set to 1, and all *meas_ctrl_en CSR to be set to MuBi4False.
Add SVAs to check on these changes.

Signed-off-by: Guillermo Maturana <maturana@google.com>