### PR TITLE
[prim_sync_reqack] Modify/extend SVAs with respect to reset

### DIFF
--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -85,28 +85,6 @@ module tb;
 
   `DV_ALERT_IF_CONNECT
 
-  // TODO(#8758): This disables an assertion that fires if we happen to drop the edn_rst_n line
-  // before rst_n when the EDN is providing data to the DUT. The proper fix is either to change the
-  // design, change the assertion, or change the DV code so this doesn't happen.
-`define RND_REQ_PATH \
-    dut.u_prim_edn_rnd_req.u_prim_sync_reqack_data.gen_assert_data_dst2src
-
-`define URND_REQ_PATH \
-    dut.u_prim_edn_urnd_req.u_prim_sync_reqack_data.gen_assert_data_dst2src
-  always @(negedge edn_rst_n or posedge edn_rst_n) begin
-    if (!edn_rst_n) begin
-      $assertoff(0, `RND_REQ_PATH.SyncReqAckDataHoldDst2SrcA);
-      $assertoff(0, `URND_REQ_PATH.SyncReqAckDataHoldDst2SrcA);
-      $assertoff(0, `RND_REQ_PATH.SyncReqAckDataHoldDst2SrcB);
-      $assertoff(0, `URND_REQ_PATH.SyncReqAckDataHoldDst2SrcB);
-    end else begin
-      $asserton(0, `RND_REQ_PATH.SyncReqAckDataHoldDst2SrcA);
-      $asserton(0, `URND_REQ_PATH.SyncReqAckDataHoldDst2SrcA);
-      $asserton(0, `RND_REQ_PATH.SyncReqAckDataHoldDst2SrcB);
-      $asserton(0, `URND_REQ_PATH.SyncReqAckDataHoldDst2SrcB);
-    end
-  end
-
   // dut
   otbn # (
     .RndCnstOtbnKey(TestScrambleKey),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1017,6 +1017,7 @@ module otbn
   // internal entropy width of 256 bit.
 
   prim_edn_req #(
+    .EnRstChks(1'b1),
     .OutWidth(EdnDataWidth),
     // SEC_CM: RND.BUS.CONSISTENCY
     .RepCheck(1'b1)
@@ -1036,6 +1037,7 @@ module otbn
   );
 
   prim_edn_req #(
+    .EnRstChks(1'b1),
     .OutWidth(EdnDataWidth)
   ) u_prim_edn_urnd_req (
     .clk_i,

--- a/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
+++ b/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
@@ -226,6 +226,7 @@ module otbn_scramble_ctrl
 
   prim_sync_reqack_data #(
     .Width($bits(otp_ctrl_pkg::otbn_otp_key_rsp_t)-1),
+    .EnRstChks(1'b1),
     .DataSrc2Dst(1'b0)
   ) u_otp_key_req_sync (
     .clk_src_i (clk_i),

--- a/hw/ip/prim/rtl/prim_edn_req.sv
+++ b/hw/ip/prim/rtl/prim_edn_req.sv
@@ -19,6 +19,8 @@ module prim_edn_req
   parameter int OutWidth = 32,
   // Repetition check for incoming edn data
   parameter bit RepCheck = 0,
+  // Disable reset-related assertion checks inside prim_sync_reqack primitives.
+  parameter bit EnRstChks = 0,
 
   // EDN Request latency checker
   //
@@ -56,6 +58,7 @@ module prim_edn_req
   localparam int SyncWidth = $bits({edn_i.edn_fips, edn_i.edn_bus});
   prim_sync_reqack_data #(
     .Width(SyncWidth),
+    .EnRstChks(EnRstChks),
     .DataSrc2Dst(1'b0),
     .DataReg(1'b0)
   ) u_prim_sync_reqack_data (

--- a/hw/ip/prim/rtl/prim_sync_reqack.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack.sv
@@ -25,7 +25,9 @@
 
 `include "prim_assert.sv"
 
-module prim_sync_reqack (
+module prim_sync_reqack #(
+  parameter bit EnRstChks = 1'b0 // Enable reset-related assertion checks, disabled by default.
+) (
   input  clk_src_i,       // REQ side, SRC domain
   input  rst_src_ni,      // REQ side, SRC domain
   input  clk_dst_i,       // ACK side, DST domain
@@ -180,12 +182,14 @@ module prim_sync_reqack (
   `ASSERT(SyncReqAckAckNeedsReq, dst_ack_i |->
       dst_req_o, clk_dst_i, !rst_src_ni || !rst_dst_ni)
 
-  // Always reset both domains. Both resets need to be active at the same time.
-  `ASSERT(SyncReqAckRstSrc, $fell(rst_src_ni) |->
-      (##[0:$] !rst_dst_ni within !rst_src_ni [*1:$]),
-      clk_src_i, 0)
-  `ASSERT(SyncReqAckRstDst, $fell(rst_dst_ni) |->
-      (##[0:$] !rst_src_ni within !rst_dst_ni [*1:$]),
-      clk_dst_i, 0)
+  if (EnRstChks) begin : gen_assert_en_rst_chks
+    // Always reset both domains. Both resets need to be active at the same time.
+    `ASSERT(SyncReqAckRstSrc, $fell(rst_src_ni) |->
+        (##[0:$] !rst_dst_ni within !rst_src_ni [*1:$]),
+        clk_src_i, 0)
+    `ASSERT(SyncReqAckRstDst, $fell(rst_dst_ni) |->
+        (##[0:$] !rst_src_ni within !rst_dst_ni [*1:$]),
+        clk_dst_i, 0)
+  end
 
 endmodule

--- a/hw/ip/prim/rtl/prim_sync_reqack.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack.sv
@@ -10,6 +10,8 @@
 // Notes:
 // - Once asserted, the source (SRC) domain is not allowed to de-assert REQ without ACK.
 // - The destination (DST) domain is not allowed to send an ACK without a REQ.
+// - When resetting one domain, also the other domain needs to be reset with both resets being
+//   active at the same time.
 // - This module works both when syncing from a faster to a slower clock domain and vice versa.
 // - Internally, this module uses a non-return-to-zero, two-phase handshake protocol. Assuming the
 //   DST domain responds with an ACK immediately, the latency from asserting the REQ in the
@@ -172,9 +174,18 @@ module prim_sync_reqack (
 
   // SRC domain can only de-assert REQ after receiving ACK.
   `ASSERT(SyncReqAckHoldReq, $fell(src_req_i) && req_chk_i |->
-      $fell(src_ack_o), clk_src_i, !rst_src_ni || !req_chk_i)
+      $fell(src_ack_o), clk_src_i, !rst_src_ni || !rst_dst_ni || !req_chk_i)
 
   // DST domain cannot assert ACK without REQ.
-  `ASSERT(SyncReqAckAckNeedsReq, dst_ack_i |-> dst_req_o, clk_dst_i, !rst_dst_ni)
+  `ASSERT(SyncReqAckAckNeedsReq, dst_ack_i |->
+      dst_req_o, clk_dst_i, !rst_src_ni || !rst_dst_ni)
+
+  // Always reset both domains. Both resets need to be active at the same time.
+  `ASSERT(SyncReqAckRstSrc, $fell(rst_src_ni) |->
+      (##[0:$] !rst_dst_ni within !rst_src_ni [*1:$]),
+      clk_src_i, 0)
+  `ASSERT(SyncReqAckRstDst, $fell(rst_dst_ni) |->
+      (##[0:$] !rst_src_ni within !rst_dst_ni [*1:$]),
+      clk_dst_i, 0)
 
 endmodule

--- a/hw/ip/prim/rtl/prim_sync_reqack_data.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack_data.sv
@@ -92,7 +92,7 @@ module prim_sync_reqack_data #(
     // SRC domain cannot change data while waiting for ACK.
     `ASSERT(SyncReqAckDataHoldSrc2Dst, !$stable(data_i) |->
         (!src_req_i || (src_req_i && src_ack_o)),
-        clk_src_i, !rst_src_ni)
+        clk_src_i, !rst_src_ni || !rst_dst_ni)
 
     // Register stage cannot be used.
     `ASSERT_INIT(SyncReqAckDataReg, DataSrc2Dst && !DataReg)
@@ -121,10 +121,10 @@ module prim_sync_reqack_data #(
     // checks that the DST side doesn't do anything that it shouldn't know is safe.
     `ASSERT(SyncReqAckDataHoldDst2SrcA,
             src_req_i && src_ack_o |-> $past(data_o, 2) == data_o && $past(data_o) == data_o,
-            clk_src_i, !rst_src_ni)
+            clk_src_i, !rst_src_ni || !rst_dst_ni)
     `ASSERT(SyncReqAckDataHoldDst2SrcB,
             $past(src_req_i && src_ack_o) |-> $past(data_o) == data_o,
-            clk_src_i, !rst_src_ni)
+            clk_src_i, !rst_src_ni || !rst_dst_ni)
   end
 
 endmodule

--- a/hw/ip/prim/rtl/prim_sync_reqack_data.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack_data.sv
@@ -18,6 +18,8 @@
 
 module prim_sync_reqack_data #(
   parameter int unsigned Width       = 1,
+  parameter bit          EnRstChks   = 1'b0, // Enable reset-related assertion checks, disabled by
+                                             // default.
   parameter bit          DataSrc2Dst = 1'b1, // Direction of data flow: 1'b1 = SRC to DST,
                                              //                         1'b0 = DST to SRC
   parameter bit          DataReg     = 1'b0  // Enable optional register stage for data,
@@ -42,7 +44,9 @@ module prim_sync_reqack_data #(
   ////////////////////////////////////
   // REQ/ACK synchronizer primitive //
   ////////////////////////////////////
-  prim_sync_reqack u_prim_sync_reqack (
+  prim_sync_reqack #(
+    .EnRstChks(EnRstChks)
+  ) u_prim_sync_reqack (
     .clk_src_i,
     .rst_src_ni,
     .clk_dst_i,


### PR DESCRIPTION
This PR modifies/extends the SVAs as follows:
- If any of the two domains is reset, all other assertions are disabled.
- If one domain is reset, also the other domain is expected to be reset.
- After releasing the reset of the first domain, also the second reset needs to be released before receiving the first request.

In addition, the expected reset sequence is documented.

This resolves https://github.com/lowRISC/opentitan/issues/8758.
This is related to https://github.com/lowRISC/opentitan/issues/14287.