### PR TITLE
[ottool] Initial hyperdebug pin configuration

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
@@ -1,0 +1,31 @@
+{
+  "includes": ["/__builtin__/opentitan.json"],
+  "interface": "hyperdebug",
+  "pins": [
+      {
+          "name": "RESET",
+          "mode": "OpenDrain",
+          "level": true,
+          "pull_mode": "PullUp",
+          "alias_of": "CN10_29"
+      },
+      {
+          "name": "SW_STRAP0",
+          "alias_of": "CN9_13"
+      },
+      {
+          "name": "SW_STRAP1",
+          "alias_of": "CN9_15"
+      },
+      {
+          "name": "SW_STRAP2",
+          "alias_of": "CN9_17"
+      }
+  ],
+  "uarts": [
+    {
+      "name": "console",
+      "alias_of": "UART2"
+    }
+  ]
+}

--- a/sw/host/opentitanlib/src/app/config/mod.rs
+++ b/sw/host/opentitanlib/src/app/config/mod.rs
@@ -64,6 +64,7 @@ lazy_static! {
         "/__builtin__/ti50emulator.json" => include_str!("ti50emulator.json"),
         "/__builtin__/opentitan_cw310.json" => include_str!("opentitan_cw310.json"),
         "/__builtin__/opentitan.json" => include_str!("opentitan.json"),
+        "/__builtin__/hyperdebug_cw310.json" => include_str!("hyperdebug_cw310.json"),
         "/__builtin__/opentitan_ultradebug.json" => include_str!("opentitan_ultradebug.json"),
         "/__builtin__/opentitan_verilator.json" => include_str!("opentitan_verilator.json"),
     };

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -250,7 +250,7 @@ impl TransportWrapper {
         std::thread::sleep(reset_delay);
         if clear_uart_rx {
             log::info!("Clearing the UART RX buffer");
-            self.uart("0")?.clear_rx_buffer()?;
+            self.uart("console")?.clear_rx_buffer()?;
         }
         log::info!("Deasserting the reset signal");
         self.remove_pin_strapping("RESET")?;

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -77,7 +77,7 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
         ),
         "hyperdebug" => (
             hyperdebug::create::<StandardFlavor>(args)?,
-            Some(Path::new("/__builtin__/opentitan_verilator.json")),
+            Some(Path::new("/__builtin__/hyperdebug_cw310.json")),
         ),
         "c2d2" => (
             hyperdebug::create::<C2d2Flavor>(args)?,

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -111,7 +111,7 @@ fn test_bootstrap_enabled_requested(opts: &Opts, transport: &TransportWrapper) -
     // TODO: Should really `opts.init.uart_params.create()` here, but we need to refactor
     // BootstrapOptions first.
     //let uart = opts.init.uart_params.create(&transport)?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(opts.timeout),
         exit_success: Some(Regex::new(r"bootstrap:1\r\n")?),
@@ -138,7 +138,7 @@ fn test_bootstrap_enabled_not_requested(opts: &Opts, transport: &TransportWrappe
     // TODO: Should really `opts.init.uart_params.create()` here, but we need to refactor
     // BootstrapOptions first.
     //let uart = opts.init.uart_params.create(&transport)?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(opts.timeout),
         exit_success: Some(Regex::new(r"BFV:")?),
@@ -261,7 +261,7 @@ fn test_bootstrap_shutdown(
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
     let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(2, 0)),
         // `kErrorBootPolicyBadIdentifier` (0142500d) is defined in `error.h`.
@@ -299,7 +299,7 @@ fn test_bootstrap_phase1_reset(opts: &Opts, transport: &TransportWrapper) -> Res
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
     let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     // RESET should be ignored and we should not see any messages.
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
@@ -321,7 +321,7 @@ fn test_bootstrap_phase1_page_program(opts: &Opts, transport: &TransportWrapper)
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
     let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
         // `kErrorBootPolicyBadIdentifier` (0142500d) is defined in `error.h`.
@@ -354,7 +354,7 @@ fn test_bootstrap_phase1_erase(
 ) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
     let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     let spiflash = SpiFlash::from_spi(&*spi)?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
@@ -402,7 +402,7 @@ fn test_bootstrap_phase1_erase(
 fn test_bootstrap_phase1_read(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
     let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
         ..Default::default()
@@ -439,7 +439,7 @@ fn test_bootstrap_phase2_reset(opts: &Opts, transport: &TransportWrapper) -> Res
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
     let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
         // `kErrorBootPolicyBadIdentifier` (0142500d) is defined in `error.h`.
@@ -472,7 +472,7 @@ fn test_bootstrap_phase2_reset(opts: &Opts, transport: &TransportWrapper) -> Res
 fn test_bootstrap_phase2_page_program(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
     let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     SpiFlash::from_spi(&*spi)?
         // Send CHIP_ERASE to transition to phase 2.
         .chip_erase(&*spi)?
@@ -503,7 +503,7 @@ fn test_bootstrap_phase2_erase(
 ) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
     let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     let spiflash = SpiFlash::from_spi(&*spi)?;
     let erase = || match erase_cmd {
         // We should erase the page of the identifier of the second slot.
@@ -539,7 +539,7 @@ fn test_bootstrap_phase2_erase(
 fn test_bootstrap_phase2_read(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
     let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     let mut read_buf = [0u8; 8];
 
     SpiFlash::from_spi(&*spi)?

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
@@ -32,7 +32,7 @@ fn test_chip_specific_startup(opts: &Opts, transport: &TransportWrapper) -> Resu
     // TODO: Should really `opts.init.uart_params.create()` here, but we need to refactor
     // BootstrapOptions first.
     //let uart = opts.init.uart_params.create(&transport)?;
-    let uart = transport.uart("0")?;
+    let uart = transport.uart("console")?;
     let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
 
     TestCommand::ChipStartup.send(&*uart)?;


### PR DESCRIPTION
1. Write an initial configuration for hyperdebug pins to allow resets and setting the SW straps.
2. Most transports call their console UART "0".  Hyperdebug does not. All of the opentitantool configs have an alias named "console"; change all references to uart "0" to "console".
3. Fix the hyperdebug SPI implementation.
3a. Set the max chunk size to a power of two.
3b. Assert CS over an entire SPI transaction; refactor CS assert
    counting.

Signed-off-by: Chris Frantz <cfrantz@google.com>