### PR TITLE
[rom/e2e] add smoke testpoint and map unmapped test in DV

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -9,9 +9,9 @@
   tests: [
     // ROM E2E tests.
     {
-      name: rom_e2e_bootup_success
+      name: rom_e2e_smoke
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/silicon_creator/rom/e2e:e2e_bootup_success:1:signed"]
+      sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_smoke:1:signed"]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
     }

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1271,7 +1271,7 @@
               "chip_sw_example_flash",
               "chip_sw_example_rom",
               "chip_sw_example_manufacturer"]
-              // TODO: add this test after enabling HW verification: "rom_e2e_bootup_success"]
+              // TODO: add this test after enabling HW verification: "rom_e2e_smoke"]
     }
     {
       name: jitter

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -7,6 +7,18 @@
 
   testpoints: [
     {
+      name: rom_e2e_smoke
+      desc: '''Verify that ROM can boot a ROM_EXT with default infrastructure configurations.
+
+            - The valid ROM_EXT should be a test program that returns `true`, optimizing for speed.
+            - The test program should be launched via the OTTF.
+            '''
+      tags: ["rom", "verilator", "dv", "fpga", "silicon"]
+      stage: V2
+      tests: ["rom_e2e_smoke"]
+    }
+
+    {
       name: rom_e2e_shutdown_output
       desc: '''Verify that ROM can properly report errors over UART.
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -44,7 +44,7 @@ opentitan_functest(
 )
 
 opentitan_functest(
-    name = "e2e_bootup_success",
+    name = "rom_e2e_smoke",
     srcs = ["empty_test.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom",


### PR DESCRIPTION
The simplest of ROM E2E tests, that checked if ROM could successfully boot and execute a test (that simple returned `true`) via the OTTF using default test infrastructure configurations, was running in DV but was not mapped to a test point in the ROM E2E testplan. This adds a testpoint for said test and fixes #14679.

Signed-off-by: Timothy Trippel <ttrippel@google.com>