### PR TITLE
[dv/kmac] Add coverpoints for entropy timer

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -361,6 +361,13 @@
             '''
    }
    {
+      name: entropy_timer_cg
+      desc: '''
+            Cover the values for the entropy_period register's `prescaler` and `wait_timer` fields.
+            Cross these field ranges with whether the entropy EDN mode is on or off.
+            '''
+   }
+   {
       name: edn_cg
       desc: '''
             Covers that EDN entropy can be received by KMAC while keccak rounds are active/inactive,

--- a/hw/ip/kmac/dv/env/kmac_env_cov.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cov.sv
@@ -392,6 +392,22 @@ class kmac_env_cov extends cip_base_env_cov #(.CFG_T(kmac_env_cfg));
     end
   endfunction
 
+  covergroup entropy_timer_cg with function sample (bit [9:0]  prescaler,
+                                                    bit [15:0] wait_timer,
+                                                    bit        entropy_edn_mode);
+    prescaler_val: coverpoint prescaler {
+      bins zero_val   = {0};
+      bins lower_val  = {[1             : {9{1'b1}} / 2]};
+      bins higher_val = {[{9{1'b1}} / 2 : {9{1'b1}}]};
+    }
+    wait_timer_val: coverpoint prescaler {
+      bins zero_val   = {0};
+      bins lower_val  = {[1              : {16{1'b1}} / 2]};
+      bins higher_val = {[{16{1'b1}} / 2 : {16{1'b1}}]};
+    }
+    entropy_edn_mode_enabled: coverpoint entropy_edn_mode;
+    entropy_timer_cross: cross prescaler_val, wait_timer_val, entropy_edn_mode_enabled;
+  endgroup
 
   function new(string name, uvm_component parent);
     kmac_app_e app_name = app_name.first;
@@ -406,6 +422,7 @@ class kmac_env_cov extends cip_base_env_cov #(.CFG_T(kmac_env_cfg));
     state_read_mask_cg = new();
     sideload_cg = new();
     error_cg = new();
+    entropy_timer_cg = new();
     do begin
       app_cg_wrappers[app_name] = new({app_name.name(), "_cg"});
       app_name = app_name.next;

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -987,6 +987,12 @@ class kmac_scoreboard extends cip_base_scoreboard #(
           end
         end
       end
+      "entropy_period": begin
+        if (cfg.en_cov && addr_phase_write) begin
+          cov.entropy_timer_cg.sample(item.a_data[9:0], item.a_data[31:16],
+                                      entropy_mode == EntropyModeEdn);
+        end
+      end
       default: begin
         // regex match the key_share csrs
         string full_idx;


### PR DESCRIPTION
This PR adds coverpoint for entropy timer to make sure all values ranges are configured when kmac masking is enabled/disabled, and when edn mode is set or not.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>