### PR TITLE
[bazel] rollback #15119

### DIFF
--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -154,9 +154,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @rust_freebsd_x86_64_toolchains//... \
     @rust_linux_aarch64_toolchains//... \
     @rust_linux_x86_64_toolchains//... \
-    @rust_windows_x86_64_toolchains//... \
-    @lowrisc_lint//... \
-    //quality/...
+    @rust_windows_x86_64_toolchains//...
   cp -R "$(${BAZELISK} info output_base)"/external/${BAZEL_PYTHON_WHEEL_REPO} \
     ${BAZEL_AIRGAPPED_DIR}/
   # We don't need all bitstreams in the cache, we just need the latest one so


### PR DESCRIPTION
Rolling back #15119, as this did not fix bazel airgapped builds.

Signed-off-by: Timothy Trippel <ttrippel@google.com>