### PR TITLE
[top-test] entropy_src_csrng_test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2044,10 +2044,19 @@
 
             Verify the entropy valid interrupt.
             At the CSRNG, validate the reception of entropy req interrupt.
-            Details TBD.
+
+            - Disable edn0, edn1, csrng and entropy_src, as these are enabled by the test ROM.
+            - Enable entropy_src in fips mode routing data to csrng.
+            - Enable csrng and enable the entropy request interrupt.
+            - Issue csrng instantiate and reseed commands. Check that for each csrng command,
+              there is a corresponding entropy request interrupt.
+            - Generate output and ensure the data output is valid, and that csrng is not reporting
+              any errors.
+            - Issue instantiate and reseed commands from edn0 and edn1. Check that for each
+              command, there is a corresponding entropy request interrupt.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_entropy_src_csrng"]
     }
     {
       name: chip_sw_entropy_src_cs_aes_halt

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -900,6 +900,13 @@
       run_opts: ["+sw_test_timeout_ns=15_000_000"]
     }
     {
+      name: chip_sw_entropy_src_csrng
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:entropy_src_csrng_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=15_000_000", "+rng_srate_value_min=15"]
+    }
+    {
       name: chip_sw_edn_entropy_reqs
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_edn_reqs_test:1"]

--- a/sw/device/lib/testing/csrng_testutils.h
+++ b/sw/device/lib/testing/csrng_testutils.h
@@ -48,4 +48,22 @@ void csrng_testutils_fips_instantiate_kat(const dif_csrng_t *csrng,
  */
 void csrng_testutils_fips_generate_kat(const dif_csrng_t *csrng);
 
+/**
+ * Checks CSRNG command status.
+ *
+ * Asserts error if the command or internal FIFO status contains any errors.
+ *
+ * @param csrng Handle.
+ */
+void csrng_testutils_cmd_status_check(const dif_csrng_t *csrng);
+
+/**
+ * Checks CSRNG recoverable alerts.
+ *
+ * Asserts error if there are any CSRNG recoverable alerts set.
+ *
+ * @param csrng Handle.
+ */
+void csrng_testutils_recoverable_alerts_check(const dif_csrng_t *csrng);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_CSRNG_TESTUTILS_H_

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -1,6 +1,7 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+#include "sw/device/lib/testing/entropy_testutils.h"
 
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_csrng.h"
@@ -11,15 +12,18 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 static void setup_entropy_src(const dif_entropy_src_t *entropy_src) {
-  const dif_entropy_src_config_t config = {
+  CHECK_DIF_OK(dif_entropy_src_configure(
+      entropy_src, entropy_testutils_config_default(), kDifToggleEnabled));
+}
+
+dif_entropy_src_config_t entropy_testutils_config_default(void) {
+  return (dif_entropy_src_config_t){
       .fips_enable = true,
       .route_to_firmware = false,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
-      .health_test_window_size = 0x0200, /*default*/
-      .alert_threshold = 2,              /*default*/
+      .health_test_window_size = 0x0200,
+      .alert_threshold = 2,
   };
-  CHECK_DIF_OK(
-      dif_entropy_src_configure(entropy_src, config, kDifToggleEnabled));
 }
 
 void entropy_testutils_auto_mode_init(void) {
@@ -32,11 +36,7 @@ void entropy_testutils_auto_mode_init(void) {
   const dif_edn_t edn1 = {
       .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR)};
 
-  // Disable entropy complex
-  CHECK_DIF_OK(dif_edn_stop(&edn0));
-  CHECK_DIF_OK(dif_edn_stop(&edn1));
-  CHECK_DIF_OK(dif_csrng_stop(&csrng));
-  CHECK_DIF_OK(dif_entropy_src_stop(&entropy_src));
+  entropy_testutils_stop_all();
 
   // re-eanble entropy src and csrng
   setup_entropy_src(&entropy_src);
@@ -87,10 +87,7 @@ void entropy_testutils_boot_mode_init(void) {
   const dif_edn_t edn1 = {
       .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR)};
 
-  CHECK_DIF_OK(dif_entropy_src_stop(&entropy_src));
-  CHECK_DIF_OK(dif_csrng_stop(&csrng));
-  CHECK_DIF_OK(dif_edn_stop(&edn0));
-  CHECK_DIF_OK(dif_edn_stop(&edn1));
+  entropy_testutils_stop_all();
 
   setup_entropy_src(&entropy_src);
   CHECK_DIF_OK(dif_csrng_configure(&csrng));
@@ -107,4 +104,20 @@ void entropy_testutils_wait_for_state(const dif_entropy_src_t *entropy_src,
   do {
     CHECK_DIF_OK(dif_entropy_src_get_main_fsm_state(entropy_src, &cur_state));
   } while (cur_state != state);
+}
+
+void entropy_testutils_stop_all(void) {
+  const dif_entropy_src_t entropy_src = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR)};
+  const dif_csrng_t csrng = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR)};
+  const dif_edn_t edn0 = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
+  const dif_edn_t edn1 = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR)};
+
+  CHECK_DIF_OK(dif_edn_stop(&edn0));
+  CHECK_DIF_OK(dif_edn_stop(&edn1));
+  CHECK_DIF_OK(dif_csrng_stop(&csrng));
+  CHECK_DIF_OK(dif_entropy_src_stop(&entropy_src));
 }

--- a/sw/device/lib/testing/entropy_testutils.h
+++ b/sw/device/lib/testing/entropy_testutils.h
@@ -8,6 +8,11 @@
 #include "sw/device/lib/dif/dif_entropy_src.h"
 
 /**
+ * Returns default entropy source configuration.
+ */
+dif_entropy_src_config_t entropy_testutils_config_default(void);
+
+/**
  * Initialize the entropy complex in auto-request mode.
  *
  * Initializes the CSRNG, EDN0, and EDN1 in automatic request mode, with EDN1
@@ -30,5 +35,12 @@ void entropy_testutils_boot_mode_init(void);
  */
 void entropy_testutils_wait_for_state(const dif_entropy_src_t *entropy_src,
                                       dif_entropy_src_main_fsm_t state);
+
+/**
+ * Stops all entropy complex blocks.
+ *
+ * Stops EDN and CSRNG instances before stopping the entropy source.
+ */
+void entropy_testutils_stop_all(void);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_ENTROPY_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -611,6 +611,29 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "entropy_src_csrng_test",
+    srcs = ["entropy_src_csrng_test.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:base",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:edn",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:csrng_testutils",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "entropy_src_edn_reqs_test",
     srcs = ["entropy_src_edn_reqs_test.c"],
     deps = [

--- a/sw/device/tests/entropy_src_csrng_test.c
+++ b/sw/device/tests/entropy_src_csrng_test.c
@@ -1,0 +1,219 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/csrng_testutils.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
+
+static dif_csrng_t csrng;
+static dif_edn_t edn0;
+static dif_edn_t edn1;
+static dif_entropy_src_t entropy_src;
+static dif_rv_plic_t plic;
+
+// Set by `ottf_external_isr()` and cleared by
+// `csrng_entropy_req_irq_enable()`.
+static volatile bool entropy_src_isr_csrng_req_set;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  /**
+   * The size of the buffer used in firmware to process the entropy bits in
+   * firmware override mode.
+   */
+  kTestParamFifoBufferSize = 12,
+  /**
+   * The number of test iterations per target.
+   */
+  kTestParamNumIterationsSim = 1,
+  kTestParamNumIterationsOther = 100,
+};
+
+/**
+ * Initializes the peripherals used in this test.
+ */
+static void init_peripherals(void) {
+  CHECK_DIF_OK(dif_csrng_init(
+      mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
+  CHECK_DIF_OK(
+      dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));
+  CHECK_DIF_OK(
+      dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR), &edn1));
+  CHECK_DIF_OK(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
+}
+
+/**
+ * Enables the CSRNG entropy request interrupt.
+ */
+static void csrng_entropy_req_irq_enable(void) {
+  irq_external_ctrl(false);
+  irq_global_ctrl(false);
+
+  entropy_src_isr_csrng_req_set = false;
+
+  dif_rv_plic_irq_id_t irq_id = kTopEarlgreyPlicIrqIdCsrngCsEntropyReq;
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(&plic, irq_id, /*priority=*/1u));
+
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      &plic, irq_id, kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_rv_plic_target_set_threshold(
+      &plic, kTopEarlgreyPlicTargetIbex0, /*threshold=*/0u));
+
+  CHECK_DIF_OK(dif_csrng_irq_set_enabled(&csrng, kDifCsrngIrqCsEntropyReq,
+                                         kDifToggleEnabled));
+
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+}
+
+/**
+ * Blocks until a CSRNG entropy request interrupt is received.
+ */
+static void csrng_entropy_req_irq_block_wait(void) {
+  // The interrupt can come before we enter sleep, so we check beforehand.
+  while (true) {
+    if (entropy_src_isr_csrng_req_set) {
+      break;
+    }
+    wait_for_interrupt();
+  }
+  CHECK_DIF_OK(dif_csrng_irq_set_enabled(&csrng, kDifCsrngIrqCsEntropyReq,
+                                         kDifToggleDisabled));
+}
+
+/**
+ * Requests data from CSRNG software instance.
+ *
+ * Asserts error if there are any repeated words in the output data, or if there
+ * are any errors set in the CSRNG status registers.
+ */
+static void csrng_generate_output_check(void) {
+  uint32_t output[kTestParamFifoBufferSize] = {0};
+  csrng_testutils_cmd_generate_run(&csrng, output, ARRAYSIZE(output));
+
+  uint32_t prev_data = 0;
+  for (size_t i = 0; i < ARRAYSIZE(output); ++i) {
+    CHECK(prev_data != output[i],
+          "Received duplicate data. Last index: %d, value: 0x%x", i, prev_data);
+  }
+}
+
+/**
+ * Verifies that the entropy req interrupt is triggered on CSRNG instantiate and
+ * reseed commands.
+ */
+static void test_csrng_sw_entropy_req_interrupt(void) {
+  entropy_testutils_stop_all();
+  CHECK_DIF_OK(dif_entropy_src_configure(
+      &entropy_src, entropy_testutils_config_default(), kDifToggleEnabled));
+  CHECK_DIF_OK(dif_csrng_configure(&csrng));
+
+  // Instantiate the CSRNG instance with no seed material to use the seed
+  // provided by entropy_src exclusively.
+  const dif_csrng_seed_material_t kEntropyInput = {0};
+  csrng_testutils_cmd_ready_wait(&csrng);
+  csrng_entropy_req_irq_enable();
+  CHECK_DIF_OK(dif_csrng_instantiate(&csrng, kDifCsrngEntropySrcToggleEnable,
+                                     &kEntropyInput));
+  csrng_entropy_req_irq_block_wait();
+  csrng_generate_output_check();
+
+  csrng_entropy_req_irq_enable();
+  CHECK_DIF_OK(dif_csrng_reseed(&csrng, &kEntropyInput));
+  csrng_entropy_req_irq_block_wait();
+  csrng_generate_output_check();
+
+  csrng_testutils_cmd_status_check(&csrng);
+  csrng_testutils_recoverable_alerts_check(&csrng);
+}
+
+/**
+ * Verifies that the entropy req interrupt is triggered on EDN instantiate and
+ * reseed commands.
+ */
+static void test_csrng_edn_entropy_req_interrupt(void) {
+  entropy_testutils_stop_all();
+  CHECK_DIF_OK(dif_entropy_src_configure(
+      &entropy_src, entropy_testutils_config_default(), kDifToggleEnabled));
+  CHECK_DIF_OK(dif_csrng_configure(&csrng));
+
+  const dif_edn_seed_material_t kEntropyInput = {0};
+  CHECK_DIF_OK(dif_edn_configure(&edn0));
+  csrng_entropy_req_irq_enable();
+  CHECK_DIF_OK(dif_edn_instantiate(&edn0, kDifEdnEntropySrcToggleEnable,
+                                   &kEntropyInput));
+  csrng_entropy_req_irq_block_wait();
+
+  csrng_entropy_req_irq_enable();
+  CHECK_DIF_OK(dif_edn_reseed(&edn0, &kEntropyInput));
+  csrng_entropy_req_irq_block_wait();
+  CHECK_DIF_OK(dif_edn_uninstantiate(&edn0));
+
+  CHECK_DIF_OK(dif_edn_configure(&edn1));
+  csrng_entropy_req_irq_enable();
+  CHECK_DIF_OK(dif_edn_instantiate(&edn1, kDifEdnEntropySrcToggleEnable,
+                                   &kEntropyInput));
+  csrng_entropy_req_irq_block_wait();
+
+  csrng_entropy_req_irq_enable();
+  CHECK_DIF_OK(dif_edn_reseed(&edn1, &kEntropyInput));
+  csrng_entropy_req_irq_block_wait();
+  CHECK_DIF_OK(dif_edn_uninstantiate(&edn1));
+
+  csrng_testutils_recoverable_alerts_check(&csrng);
+}
+
+void ottf_external_isr(void) {
+  top_earlgrey_plic_peripheral_t plic_peripheral;
+  dif_csrng_irq_t irq;
+  isr_testutils_csrng_isr(
+      (plic_isr_ctx_t){
+          .rv_plic = &plic,
+          .hart_id = kTopEarlgreyPlicTargetIbex0,
+      },
+      (csrng_isr_ctx_t){
+          .csrng = &csrng,
+          .plic_csrng_start_irq_id = kTopEarlgreyPlicIrqIdCsrngCsCmdReqDone,
+          .expected_irq = kDifCsrngIrqCsEntropyReq,
+          .is_only_irq = false,
+      },
+      &plic_peripheral, &irq);
+  CHECK(plic_peripheral == kTopEarlgreyPlicPeripheralCsrng,
+        "Interrupt from incorrect peripheral: (expected: %d, got: %d)",
+        kTopEarlgreyPlicPeripheralCsrng, plic_peripheral);
+  CHECK(irq == kDifCsrngIrqCsEntropyReq);
+  entropy_src_isr_csrng_req_set = true;
+}
+
+bool test_main(void) {
+  init_peripherals();
+
+  uint32_t num_iterations = kTestParamNumIterationsSim;
+  if (kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator) {
+    num_iterations = kTestParamNumIterationsOther;
+  }
+
+  for (size_t i = 0; i < num_iterations; ++i) {
+    test_csrng_sw_entropy_req_interrupt();
+    test_csrng_edn_entropy_req_interrupt();
+  }
+
+  return true;
+}


### PR DESCRIPTION
Adds entropy_src_csrng_test, which tests the CSRNG interrupt request interrupt
whenever a seed or reseed operation is triggered by the CSRNG software
interface, or by EDN0/EDN1.

Fixes #13227 
