### PR TITLE
[otbn,dv] Initialize `insn_addr_cg`

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -2114,6 +2114,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     scratchpad_writes_cg = new;
 
     bad_internal_state_cg = new;
+    internal_intg_err_cg = new;
     insn_addr_cg = new;
     call_stack_cg = new;
     flag_write_cg = new;


### PR DESCRIPTION
This covergroup had not been initialized prior to this commit, so calls to `sample()` would result in an error.  This likely caused the last two OTBN nightly regression runs to fail.