### PR TITLE
DONOTMERGE - flash_ctrl_integrity fail

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -784,7 +784,7 @@ class flash_ctrl_scoreboard #(
     // For flash, address has to be 8byte aligned.
     ecc_err = ecc_error_addr.exists({item.a_addr[AddrWidth-1:3],3'b0});
     in_err = in_error_addr.exists({item.a_addr[AddrWidth-1:3],3'b0});
-    `uvm_info("predic_tl_err_dbg",
+    `uvm_info("predict_tl_err_dbg",
               $sformatf({"addr:0x%x(%x) ecc_err:%0d in_err:%0d channel:%s ral_name:%s",
                          " tlul_exp_cnt:%0d"},
                         {item.a_addr[AddrWidth-1:3],3'b0},
@@ -809,16 +809,18 @@ class flash_ctrl_scoreboard #(
           cfg.tlul_core_obs_cnt++;
           return 1;
        end
-       if (ecc_err | in_err) begin
-          if (channel == DataChannel) begin
-             `DV_CHECK_EQ(item.d_error, 1,
-                          $sformatf("On interface %s, TL item: %s, ecc_err:%0d in_err:%0d",
-                                    ral_name, item.sprint(uvm_default_line_printer),
-                                    ecc_err, in_err))
-             return 1;
-          end
-       end
     end
+
+    if (ecc_err | in_err) begin
+      if (channel == DataChannel) begin
+        `DV_CHECK_EQ(item.d_error, 1,
+                     $sformatf("On interface %s, TL item: %s, ecc_err:%0d in_err:%0d",
+                               ral_name, item.sprint(uvm_default_line_printer),
+                               ecc_err, in_err))
+        return 1;
+      end
+    end
+
     if (exp_tl_rsp_intg_err) begin
       return (!item.is_d_chan_intg_ok(.throw_error(0)));
     end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -212,6 +212,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     if (flash_ctrl_pkg::InfoTypeSize[info_part] > 1) begin
       csr_name = $sformatf({csr_name, "_%0d"}, page);
     end
+    `uvm_info("mp_info_page_cfg", $sformatf("%s: %p", csr_name, page_cfg), UVM_DEBUG)
     csr = ral.get_reg_by_name(csr_name);
     data = get_csr_val_with_updated_field(csr.get_field_by_name("en"), data, page_cfg.en);
     data = data |
@@ -1301,7 +1302,16 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // This function checks wheter input 'sig' is lc_ctrl_pkg::On or lc_ctrl_pkg::Off
   function bit is_lc_ctrl_valid(lc_ctrl_pkg::lc_tx_t sig, bit is_true_valid = 1);
-    return (sig == (is_true_valid)? lc_ctrl_pkg::On : lc_ctrl_pkg::Off);
+
+    return ((sig == lc_ctrl_pkg::On && is_true_valid == 1) ||
+            (sig == lc_ctrl_pkg::Off && is_true_valid == 0));
   endfunction // is_lc_ctrl_valid
+
+  function void all_sw_rw_en();
+    cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en     = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en     = lc_ctrl_pkg::On;
+  endfunction // all_sw_rw_en
 
 endclass : flash_ctrl_base_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
@@ -32,7 +32,7 @@ class flash_ctrl_connect_vseq extends flash_ctrl_base_vseq;
     mystr = {flash_path, ".tdo_o"};
     `DV_CHECK(uvm_hdl_force(mystr, jtag_src_rsp.tdo))
     // tdo_oe : dut.eflash
-
+    $assertoff(0, "prim_lc_sync");
     lc_nvm_debug_en = $urandom_range(0, 1);
     cfg.flash_ctrl_vif.lc_nvm_debug_en = (lc_nvm_debug_en)?
       lc_ctrl_pkg::On : get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
@@ -13,6 +13,7 @@ class flash_ctrl_disable_vseq extends flash_ctrl_otf_base_vseq;
   virtual task body();
     bit exp_err;
 
+    $assertoff(0, "tb.dut.u_lc_escalation_en_sync");
     send_rand_ops();
     set_flash_disable(exp_err);
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_filesystem_support_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_filesystem_support_vseq.sv
@@ -21,6 +21,7 @@ class flash_ctrl_filesystem_support_vseq extends flash_ctrl_otf_base_vseq;
     bit all_zero;
     special_info_acc_c.constraint_mode(0);
     allow_spec_info_acc = 3'h7;
+    update_partition_access(allow_spec_info_acc);
     // Disable scramble, enable ECC
     flash_otf_region_cfg(.scr_mode(OTFCfgFalse), .ecc_mode(OTFCfgTrue));
 
@@ -56,9 +57,11 @@ class flash_ctrl_filesystem_support_vseq extends flash_ctrl_otf_base_vseq;
       if (readback_data.exists(mypage)) continue;
 
       all_zero = (erased_page.exists(mypage))? 0 : 1;
+      `uvm_info("program_page", $sformatf("%p %p all_zero:%0b",
+                                          rand_op, mypage, all_zero), UVM_MEDIUM)
       filesys_ctrl_prgm_page(.flash_op_p(rand_op), .all_zero(all_zero),
                              .wdata(readback_data[mypage]));
-      `uvm_info("program_page", $sformatf("%p all_zero:%0b", mypage, all_zero), UVM_MEDIUM)
+
       `uvm_info("program_page", $sformatf("size:%0d data: %p",
                             readback_data[mypage].size(), readback_data[mypage]), UVM_HIGH)
       fs_wr_page.push_back(mypage);
@@ -82,6 +85,7 @@ class flash_ctrl_filesystem_support_vseq extends flash_ctrl_otf_base_vseq;
     flash_op_p.op = flash_ctrl_pkg::FlashOpProgram;
     flash_op_p.num_words = 16;
     flash_op_p.addr = {flash_op_p.addr[19:11], {11{1'b0}}};
+
     for (int i = 0; i < 32; i++) begin
       `uvm_info(`gfn, $sformatf("PROGRAM ADDRESS: 0x%0h", flash_op_p.addr), UVM_HIGH)
       // Randomize Write Data

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -123,11 +123,15 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
 
   virtual task pre_start();
     bit csr_test_mode = 0;
+    string run_seq_name = "";
     // Erased page doesn't go through descramble.
     // To maintain high stress rate,
     // keep flash_init to FlashMemInitRandomize
+
     void'($value$plusargs("csr_test_mode=%0b", csr_test_mode));
-    if (csr_test_mode) begin
+    void'($value$plusargs("run_%0s", run_seq_name));
+    if (csr_test_mode == 1 ||
+        run_seq_name inside{"tl_intg_err"}) begin
       super.pre_start();
     end else begin
       flash_init_c.constraint_mode(0);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
@@ -32,7 +32,7 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
                 } reset_index_e;
 
   task body();
-    int state_wait_timeout_ns = 10000; // 10 us
+    int state_wait_timeout_ns = 50000; // 50 us
     int long_wait_timeout_ns = 5000000; // 5ms
     int wait_time;
     string path;
@@ -110,7 +110,8 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
                 end
                 2'b11: begin
                   if (reset_index == DVWaitDataKey) begin
-                    cfg.flash_ctrl_vif.lc_seed_hw_rd_en = lc_ctrl_pkg::Off;
+                    cfg.flash_ctrl_vif.lc_seed_hw_rd_en =
+                      get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
                   end
                 end
                 default: begin

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -70,20 +70,21 @@
       desc: '''Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI.
         - Creator info partition can be read, written, erased when lc_creator_seed_sw_rw_en is true.
           Owner info partition can be read, written, erased when lc_owner_seed_sw_rw_en is true.
-          Both partition can be read when lc_seed_hw_rd_en is true.
           Isolated info partition can be written whwen lc_iso_part_sw_wr_en is true,
           and can be read when lc_iso_part_sw_rd_en is true.
           Run test for each partition and check whether each partition can be accessed
           only when each lc_ctrl input is valid.
           If lc_ctrl inputs are invalid, the access to the secret info region will trigger
           recoverable fatal alert.
+        - lc_seed_hw_rd_en is covered by flash_ctrl_otp_reset test.
         - lc_escalate_en_i is covered by flash_ctrl_disable test. See 'flash_ctrl_disable`
           from the flash_ctrl_testpan.hjson
         - lc_nvm_debug_en_i is covered by flash_ctrl_connect. See 'flash_ctrl_connect'
           from the flash_ctrl_testplan.hjson
       '''
       stage: V2S
-      tests: ["flash_ctrl_sec_info_access", "flash_ctrl_disable", "flash_ctrl_connect"]
+      tests: ["flash_ctrl_sec_info_access", "flash_ctrl_disable",
+             "flash_ctrl_connect", "flash_ctrl_otp_reset"]
     }
     {
       name: sec_cm_ctrl_config_regwen


### PR DESCRIPTION
cmd:
./util/dvsim/dvsim.py ./hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson -i flash_ctrl_integrity -r 1 -s 1670833615 --waves

Looks like 
tb.dut.u_eflash.gen_flash_cores[1].u_core.rd_err_o  can only be captured when
tb.dut.u_eflash.gen_flash_cores[1].u_core.rd_done_o = 1.

See @17320.6 and 18040.6 ns 
tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd.intg_ecc_err_o
tb.dut.u_eflash.gen_flash_cores[1].u_core.rd_err_o
tb.dut.u_eflash.gen_flash_cores[1].u_core.rd_done_o
tb.dut.u_reg_core.u_err_code_rd_err.qs[0:0]

Signed-off-by: Jaedon Kim <jdonjdon@google.com>