### PR TITLE
[doc] Cleanup and fixes for install guide.

### DIFF
--- a/doc/getting_started/install_openocd.md
+++ b/doc/getting_started/install_openocd.md
@@ -13,12 +13,12 @@ As most distributions do not yet include OpenOCD 0.11 in its package repositorie
 The following steps build OpenOCD (this should be done outside the `$REPO_TOP` directory):
 
 ```console
-$ wget https://downloads.sourceforge.net/project/openocd/openocd/0.11.0/openocd-0.11.0.tar.bz2
-$ tar -xf openocd-0.11.0.tar.bz2
-$ cd openocd-0.11.0/
-$ mkdir build
-$ cd build
-$ ../configure --enable-ftdi --enable-verbose-jtag-io --disable-vsllink --enable-remote-bitbang --prefix=/tools/openocd
-$ make -j4
-$ sudo make install
+wget https://downloads.sourceforge.net/project/openocd/openocd/0.11.0/openocd-0.11.0.tar.bz2
+tar -xf openocd-0.11.0.tar.bz2
+cd openocd-0.11.0/
+mkdir build
+cd build
+../configure --enable-ftdi --enable-verbose-jtag-io --disable-vsllink --enable-remote-bitbang --prefix=/tools/openocd
+make -j4
+sudo make install
 ```

--- a/doc/getting_started/install_vivado/index.md
+++ b/doc/getting_started/install_vivado/index.md
@@ -125,5 +125,5 @@ ACTION=="add|change", SUBSYSTEM=="usb|tty", ATTRS{idVendor}=="0403", ATTRS{idPro
 You then need to reload the udev rules:
 
 ```console
-$ sudo udevadm control --reload
+sudo udevadm control --reload
 ```

--- a/doc/getting_started/setup_formal.md
+++ b/doc/getting_started/setup_formal.md
@@ -16,7 +16,7 @@ Please refer to the [OpenTitan Assertions]({{< relref "hw/formal/doc" >}}) for i
 It is recommended to use the [fpvgen]({{< relref "util/fpvgen/doc" >}}) tool to automatically create an FPV testbench template.
 To run the FPV tests in `dvsim`, please add the target in `hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson`, then run with command:
 ```console
-$ util/dvsim/dvsim.py hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson --select-cfgs {target_name}
+util/dvsim/dvsim.py hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson --select-cfgs {target_name}
 ```
 It is recommended to add the FPV target to [lint]({{< relref "hw/lint/doc" >}}) script `hw/top_earlgrey/lint/top_earlgrey_fpv_lint_cfgs.hjson` to quickly find typos.
 
@@ -26,5 +26,5 @@ The connectivity verification is mainly used for exhaustively verifying system-l
 User can specify the connection ports via a CSV format file in `hw/top_earlgrey/formal/conn_csvs` folder.
 User can trigger top_earlgrey's connectivity test using `dvsim`:
 ```
-  util/dvsim/dvsim.py hw/top_earlgrey/formal/chip_conn_cfgs.hjson
+util/dvsim/dvsim.py hw/top_earlgrey/formal/chip_conn_cfgs.hjson
 ```

--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -272,10 +272,10 @@ To connect the JTAG chain to the CPU's TAP, adjust the strap values with opentit
 Assuming opentitantool has been built and that the current directory is the root of the workspace, run these commands:
 
 ```console
-$ ./bazel-bin/sw/host/opentitantool/opentitantool \
+./bazel-bin/sw/host/opentitantool/opentitantool \
         --interface cw310 \
         gpio write TAP_STRAP0 false
-$ ./bazel-bin/sw/host/opentitantool/opentitantool \
+./bazel-bin/sw/host/opentitantool/opentitantool \
         --interface cw310 \
         gpio write TAP_STRAP1 true
 ```

--- a/doc/getting_started/setup_verilator.md
+++ b/doc/getting_started/setup_verilator.md
@@ -4,7 +4,7 @@ aliases:
     - /doc/ug/getting_started_verilator
 ---
 
-_Before following this guide, make sure you've followed the [dependency installation and software build instructions]({{< relref "getting_started" >}})._
+_Before following this guide, make sure you've followed the [dependency installation instructions]({{< relref "getting_started" >}})._
 
 ## About Verilator
 
@@ -32,6 +32,7 @@ CC=gcc-11 CXX=g++-11 ./configure --prefix=/tools/verilator/$VERILATOR_VERSION
 CC=gcc-11 CXX=g++-11 make
 CC=gcc-11 CXX=g++-11 make install
 ```
+The `make` step can take several minutes.
 
 After installation you need to add `/tools/verilator/$VERILATOR_VERSION/bin` to your `PATH` environment variable.
 Also add it to your `~/.bashrc` or equivalent so that it's on the `PATH` in the future, like this:
@@ -67,12 +68,12 @@ Moreover, Bazel automatically connects to the simulated UART (via `opentitantool
 For example, to run the UART smoke test on Verilator simulated hardware, and see the output in real time, use
 ```console
 cd $REPO_TOP
-bazel test --test_tag_filters=verilator --test_output=streamed //sw/device/tests:uart_smoketest
+bazel test --test_output=streamed //sw/device/tests:uart_smoketest_sim_verilator
 ```
 or
 ```console
 cd $REPO_TOP
-bazel test --test_output=streamed //sw/device/tests:uart_smoketest_sim_verilator
+bazel test --test_tag_filters=verilator --test_output=streamed //sw/device/tests:uart_smoketest
 ```
 
 You should expect to see something like:


### PR DESCRIPTION
Adjust the install guide pages based on feedback from a live-install at CHES and on a read-through:
- Reverses the order of the Verilator install and the software build, since Bazel tests essentially require Verilator
- Changes the tl;dr section of the software build page to something that should succeed on the first try (the previous example required Verible)
- Adds troubleshooting notes and information about RAM requirements
- Adds notes and time estimates for long-running steps
- Updates information about the CI setup (we now use Ubuntu 20.04, not 18.04)
- Removes `$` before console commands to make them easier to copy-paste