### PR TITLE
[doc] Update motivation and objectives of DIFs in RM

### DIFF
--- a/doc/rm/device_interface_functions.md
+++ b/doc/rm/device_interface_functions.md
@@ -5,12 +5,13 @@ title: "Device Interface Functions (DIFs)"
 ## Motivation
 
 Every hardware peripheral needs some form of higher-level software to actuate it to perform its intended function.
-Device Interface Functions (DIFs) aim to make it easy to use hardware for its intended purposes while making it difficult, or impossible, to misuse.
-DIFs can be seen as a living best-practices document for interacting with a given piece of hardware.
+Device Interface Functions (DIFs) aim to make it easy to use hardware for its intended purposes.
+DIFs can be seen as a working code reference for interacting with a given piece of hardware.
 
 ## Objectives
 
-DIFs provide extensively reviewed APIs for actuating hardware for three separate use cases: design verification, FPGA + post-silicon validation, and providing example code to aid the implementation of reference firmware including end-consumer applications.
+DIFs provide extensively reviewed APIs for actuating hardware for three separate use cases: design verification, FPGA + post-silicon validation, and providing example code to aid the implementation of non-production firmware.
+DIFs may be illustrative for writing device drivers but should not be considered drivers themselves.
 
 ## Requirements
 


### PR DESCRIPTION
The current DIF reference manual (RM) text emphasizes error checking and robustness of DIFs quite heavily ("making it difficult, or impossible, to misuse [hardware]" and "providing example code to aid the implementation of reference firmware including end-consumer applications").  However, DIFs are called in test code, some of which deliberately misuses a hardware module, so error checking and robustness are not a primary objective for DIFs and could hinder their use for tests.

This PR changes the wording of the DIF RM to de-emphasize error checking and robustness.  The revised text is aligned with the understanding of the Software WG at their meeting on 2022-09-27.  It also matches the description in `sw/device/lib/dif/_index.md` more closely.