### PR TITLE
[opentitantool] More verbose listing of verilator invocation for copying

### DIFF
--- a/sw/host/opentitanlib/src/transport/verilator/subprocess.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/subprocess.rs
@@ -50,7 +50,12 @@ impl Subprocess {
         args.extend_from_slice(&options.extra_args);
         command.args(&args[..]);
 
-        log::info!("Spawning verilator: {:?} {:?}", options.executable, args);
+        log::info!("CWD: {:?}", std::env::current_dir());
+        log::info!(
+            "Spawning verilator: {:?} {:?}",
+            options.executable,
+            args.join(" ")
+        );
 
         let mut child = command
             .stdin(Stdio::null())


### PR DESCRIPTION
Fixes: #15104
Makes opentitantool print the CWD for verilator invocations and prints the command in a copy-pasteable format for easier use and to aid with location of output artifacts like the sim.fst file.

Signed-off-by: Drew Macrae <drewmacrae@google.com>