### PR TITLE
[spi_device] Add TPM CSb to STATUS CSR

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -394,6 +394,16 @@
             '''
           resval: "1" },
         { bits: "5", name: "csb",        desc: "Direct input of CSb signal", resval: "1" },
+        { bits: "6"
+          name: "tpm_csb"
+          desc: "Direct input of TPM CSb"
+          resval: "1"
+          tags: [
+            // the value of tpm_csb is determined by the
+            // value on the pins, hence it cannot be predicted.
+            "excl:CsrAllTests:CsrExclCheck"
+          ]
+        }
       ]
       tags: [// Status reads back unexpected values due to writes to other CSRs.
              "excl:CsrNonInitTests:CsrExclWriteCheck"]

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -559,6 +559,9 @@ package spi_device_reg_pkg;
     struct packed {
       logic        d;
     } csb;
+    struct packed {
+      logic        d;
+    } tpm_csb;
   } spi_device_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -724,10 +727,10 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [289:266]
-    spi_device_hw2reg_cfg_reg_t cfg; // [265:264]
-    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [263:248]
-    spi_device_hw2reg_status_reg_t status; // [247:242]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [290:267]
+    spi_device_hw2reg_cfg_reg_t cfg; // [266:265]
+    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [264:249]
+    spi_device_hw2reg_status_reg_t status; // [248:242]
     spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [241:225]
     spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [224:208]
     spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [207:176]
@@ -840,11 +843,12 @@ package spi_device_reg_pkg;
   parameter logic [0:0] SPI_DEVICE_ALERT_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_DEVICE_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [23:0] SPI_DEVICE_ASYNC_FIFO_LEVEL_RESVAL = 24'h 0;
-  parameter logic [5:0] SPI_DEVICE_STATUS_RESVAL = 6'h 3a;
+  parameter logic [6:0] SPI_DEVICE_STATUS_RESVAL = 7'h 7a;
   parameter logic [0:0] SPI_DEVICE_STATUS_RXF_EMPTY_RESVAL = 1'h 1;
   parameter logic [0:0] SPI_DEVICE_STATUS_TXF_EMPTY_RESVAL = 1'h 1;
   parameter logic [0:0] SPI_DEVICE_STATUS_ABORT_DONE_RESVAL = 1'h 1;
   parameter logic [0:0] SPI_DEVICE_STATUS_CSB_RESVAL = 1'h 1;
+  parameter logic [0:0] SPI_DEVICE_STATUS_TPM_CSB_RESVAL = 1'h 1;
   parameter logic [31:0] SPI_DEVICE_LAST_READ_ADDR_RESVAL = 32'h 0;
   parameter logic [23:0] SPI_DEVICE_FLASH_STATUS_RESVAL = 24'h 0;
   parameter logic [7:0] SPI_DEVICE_UPLOAD_CMDFIFO_RESVAL = 8'h 0;

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -281,6 +281,7 @@ module spi_device_reg_top (
   logic status_txf_empty_qs;
   logic status_abort_done_qs;
   logic status_csb_qs;
+  logic status_tpm_csb_qs;
   logic rxf_ptr_we;
   logic [15:0] rxf_ptr_rptr_qs;
   logic [15:0] rxf_ptr_rptr_wd;
@@ -2893,6 +2894,21 @@ module spi_device_reg_top (
     .q      (),
     .ds     (),
     .qs     (status_csb_qs)
+  );
+
+  //   F[tpm_csb]: 6:6
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_status_tpm_csb (
+    .re     (status_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.status.tpm_csb.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .ds     (),
+    .qs     (status_tpm_csb_qs)
   );
 
 
@@ -20670,6 +20686,7 @@ module spi_device_reg_top (
         reg_rdata_next[3] = status_txf_empty_qs;
         reg_rdata_next[4] = status_abort_done_qs;
         reg_rdata_next[5] = status_csb_qs;
+        reg_rdata_next[6] = status_tpm_csb_qs;
       end
 
       addr_hit[9]: begin


### PR DESCRIPTION
Related Issue: https://github.com/lowRISC/opentitan/issues/15135

For debug, now TPM CSb can be read out from STATUS.tpm_csb CSR field.
The signal is not accurate in timing as it went through 2FF (+ any SW read latency)