### PR TITLE
[doc] Fix typos, mostly in Markdown files

### DIFF
--- a/_index.md
+++ b/_index.md
@@ -17,7 +17,7 @@ For details on coding styles or how to use our project-specific tooling, see the
 Lastly, the [Hardware Dashboard page]({{< relref "hw" >}}) contains technical documentation on the SoC, the Ibex processor core, and the individual IP blocks.
 For questions about how the project is organized, see the [project]({{< relref "doc/project" >}}) landing spot for more information.
 
-## Understaning OpenTitan
+## Understanding OpenTitan
 
 * [Use Cases]({{< relref "doc/use_cases" >}})
 * [Threat Model]({{< relref "doc/security/threat_model" >}})

--- a/hw/ip/adc_ctrl/doc/_index.md
+++ b/hw/ip/adc_ctrl/doc/_index.md
@@ -194,7 +194,7 @@ In this case the values in the {{< regref "adc_lp_sample_ctl" >}} are not used.
 The ADC will always be enabled and consuming power.
 
 If power saving is required then the controller can be set to operate in low power mode by setting {{< regref "adc_pd_ctl.lp_mode" >}}.
-The {{< regref "adc_lp_sample_ctl" >}} must be programed prior to setting this bit.
+The {{< regref "adc_lp_sample_ctl" >}} must be programmed prior to setting this bit.
 
 ## Running with the rest of the chip in sleep
 

--- a/hw/ip/adc_ctrl/doc/dv/index.md
+++ b/hw/ip/adc_ctrl/doc/dv/index.md
@@ -73,7 +73,7 @@ These are sampled by the scoreboard when the ADC_CRTL is enabled by register and
 and  wakeup line assertion. To distinguish between these situations and the fast clock gating
 status additional flags are also sampled enabling cross coverage.
 * adc_ctrl_testmode_cg: The mode of operation of the ADC_CTRL with transition bins to show modes can be selected
-independantly of a previous selected mode.
+independently of a previous selected mode.
 * adc_ctrl_hw_reset_cg: The state of the FSM and counters when a hardware reset is applied.
 * adc_ctrl_fsm_reset_cg: The state of the FSM and counters when a FSM reset is applied.
 
@@ -81,9 +81,9 @@ independantly of a previous selected mode.
 #### Scoreboard
 The `adc_ctrl_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_[a_chan, d_chan, dir]_fifo_lc_ctrl_reg_block.analysis_export: Tile Link CSR reads/writes.
+* tl_[a_chan, d_chan, dir]_fifo_lc_ctrl_reg_block.analysis_export: TileLink CSR reads/writes.
 * m_adc_push_pull_fifo_[0,1,...].analysis_export: Transactions representing the ADC channel data
-Using data fron the Tile Link and ADC data streams a model within the scoreboard predicts the interrupt and
+Using data from the TileLink and ADC data streams a model within the scoreboard predicts the interrupt and
 wakeup line logic level at any point in the simulation. It also predicts various volatile register content.
 The scoreboard uses the predictions to compare against the RTL signals and register read data.
 
@@ -105,10 +105,10 @@ initialized to known values after coming out of reset.
 * Assertions in `tb.sv`
   * ChannelSelOnehot_A: Checks at most one ADC channel select is asserted at any time
   * ChannelSelKnown_A: Checks all ADC channel selects have a known logic value
-  * PwrupTime_A: Checks the time period between low power sampling cycles is consistant
+  * PwrupTime_A: Checks the time period between low power sampling cycles is consistent
   with the value in the configuration object.
   * WakeupTime_A: Checks the time period between power up and first channel selected
-  is consistant with the value in the configuration object.
+  is consistent with the value in the configuration object.
   * EnterLowPower_A: Checks the ADC power down is asserted between sampling periods in
   low power mode.
 

--- a/hw/ip/clkmgr/doc/_index.md
+++ b/hw/ip/clkmgr/doc/_index.md
@@ -285,7 +285,7 @@ Assume a 24MHz clock and an always-on clock of 200KHz.
 The minimal error detection is then 200KHz / 24MHz, or approximately 0.83%.
 
 This means if the clock's actual value is between 23.8MHz and 24.2MHz, this deviation will not be detected.
-Conversely, if the clock's natural operation has an error range wider than this resoltion, the min / max counts must be adjusted to account for this error.
+Conversely, if the clock's natural operation has an error range wider than this resolution, the min / max counts must be adjusted to account for this error.
 
 Additionally, clock manager uses a similar time-out mechanism to see if any of the root clocks have stopped toggling for an extended period of time.
 This is done by creating an artificial handshake between the root clock domain and the always on clock domain that must complete within a certain amount of time based on known clock ratios.

--- a/hw/ip/csrng/doc/_index.md
+++ b/hw/ip/csrng/doc/_index.md
@@ -33,13 +33,13 @@ This IP block is attached to the chip interconnect bus as a peripheral module co
     - All other instances route to other hardware peripherals (e.g. the key manager, obfuscation engines etc.) and in normal operation these other instances are inaccessible from software.
     - The IP may be configured to support "debug mode" wherein all instances can be accessed by software.
       For security reasons this mode may be permanently disabled using one-time programmable (OTP) memory.
-- The IP interfaces with external entropy sources to obtain any required non-determinstic seed material (entropy) and nonces.
+- The IP interfaces with external entropy sources to obtain any required non-deterministic seed material (entropy) and nonces.
     - Requires an external entropy source which is compliant with NIST SP 800-90B, and which also satisfies the requirements for a PTG.2 class physical non-deterministic random number generator as defined in AIS31.
     - Dedicated hardware interface with external entropy source satisfies requirements for `get_entropy_input()` interface as defined in SP 800-90A.
     - When needed, utilizes the `Block_Cipher_df` derivation function (as defined in SP 800-90A) for assembling seed material.
       This allows the use of entropy sources which are not full-entropy (less than one bit of entropy per bit generated).
 - Also supports the optional use of personalization strings or other application inputs (e.g. OTP memory values) during instantiation.
-- Assuming a continuously-live entropy source, each instance can also optionally be used as a non-determinstic TRNG (true random number generator, also called a non-deterministic random bit generator or NRBG in SP 800-90C).
+- Assuming a continuously-live entropy source, each instance can also optionally be used as a non-deterministic TRNG (true random number generator, also called a non-deterministic random bit generator or NRBG in SP 800-90C).
     - In this mode, an instance also meets the requirements laid out for a PTG.3 class RNG, the strongest class laid out in AIS31.
     - Implementation follows the NRBG "Oversampling Construction" approved by SP 800-90C, to meet both [Common Criteria (CC, ISO/IEC 15408)](https://www.iso.org/standard/50341.html) and FIPS TRNG constructions.
 - In addition to the approved DRNG mode, any instance can also operate in "Fully Deterministic mode", meaning the seed depends entirely on application inputs or personalization strings.
@@ -95,7 +95,7 @@ In CC terms, "entropy strings" (when used in this document without a qualifier) 
 ### Security
 
 All module assets and countermeasures performed by hardware are listed in the hjson countermeasures section.
-Labels for each instance of asset and coutermeasure are located throughout the RTL source code.
+Labels for each instance of asset and countermeasure are located throughout the RTL source code.
 
 The bus integrity checking for genbits is different for software and hardware.
 Only the application interface software port will have a hardware check on the genbits data bus.
@@ -300,7 +300,7 @@ Below is a description of the fields of this header:
   <tr>
     <td>24:12</td>
     <td>glen</td>
-    <td> Generate Length: Only defined for the generate command, this field is the total number of crytographic entropy blocks requested.
+    <td> Generate Length: Only defined for the generate command, this field is the total number of cryptographic entropy blocks requested.
          Each unit represents 128 bits of entropy returned.
          The NIST reference name is <tt>max_number_of_bit_per_request</tt>, and this field size supports the maximum size of 2<sup>19</sup> bits.
          For the maximum size, this field should be set to 4096, resulting in a <tt>max_number_of_bit_per_request</tt> value of 4096 x 128 bits.
@@ -335,7 +335,7 @@ The actions performed by each command, as well as which flags are supported, are
     <td> Initializes an instance in CSRNG.
          When seeding, the following table describes how the seed is determined based on <tt>flag0</tt> and the <tt>clen</tt> field.
          Note that the last table entry (<tt>flag0</tt> is set and <tt>clen</tt> is set to non-zero) is intended for known answer testing (KAT).
-        WARNING: Though <tt>flag0</tt> may be useful for generating fully-determininistic bit sequences, the use of this flag will render the instance non-FIPS compliant until it is re-instantiated.
+        WARNING: Though <tt>flag0</tt> may be useful for generating fully-deterministic bit sequences, the use of this flag will render the instance non-FIPS compliant until it is re-instantiated.
          When the <tt>Instantiate</tt> command is completed, the active bit in the CSRNG working state will be set.
         <table>
           <thead>
@@ -364,11 +364,11 @@ The actions performed by each command, as well as which flags are supported, are
   <tr>
     <td>Generate</td>
     <td>0x3</td>
-    <td> Starts a request to CSRNG to generate crytographic entropy bits.
+    <td> Starts a request to CSRNG to generate cryptographic entropy bits.
          The <tt>glen</tt> field defines how many 128-bit words are to be returned to the application interface.
          The <tt>glen</tt> field needs to be a minimum value of one.
          The NIST reference to the <tt>prediction_resistance_flag</tt> is not directly supported as a flag.
-         It is the resposibility of the calling application to reseed as needed before the <tt>Generate</tt> command to properly support prediction resistance.
+         It is the responsibility of the calling application to reseed as needed before the <tt>Generate</tt> command to properly support prediction resistance.
          Note that additional data is also supported when the <tt>clen</tt> field is set to non-zero.
     </td>
   </tr>
@@ -389,7 +389,7 @@ The actions performed by each command, as well as which flags are supported, are
     <td>0x5</td>
     <td> Resets an instance in CSRNG.
          Values in the instance are zeroed out.
-         When the <tt>Uninstantiate</tt> comand is completed, the <tt>Status</tt> bit in the CSRNG working state will be cleared.
+         When the <tt>Uninstantiate</tt> command is completed, the <tt>Status</tt> bit in the CSRNG working state will be cleared.
          Uninstantiating an instance effectively resets it, clearing any errors that it may have encountered due to bad command syntax or entropy source failures.
          Only a value of zero should be used for <tt>clen</tt>, since any additional data will be ignored.
     </td>

--- a/hw/ip/edn/doc/_index.md
+++ b/hw/ip/edn/doc/_index.md
@@ -68,7 +68,7 @@ Note that the EDNs and CSRNG should always be reset together to ensure proper in
 ### Security
 
 All module assets and countermeasures performed by hardware are listed in the hjson countermeasures section.
-Labels for each instance of asset and coutermeasure are located throughout the RTL source code.
+Labels for each instance of asset and countermeasure are located throughout the RTL source code.
 
 The receiving FIFO for genbits from CSRNG will have a hardware check on the output bus.
 This is done to make sure repeated values are not occurring.
@@ -185,7 +185,7 @@ Fresh (i.e. previously unseen) random values are distributed to the endpoints vi
 Whenever new values are placed on the `bus`, the `ack` is asserted until the values are consumed by the endpoint, as indicated by simultaneous assertion of the `req` and `ack` signals in the same cycle.
 Otherwise `ack` is deasserted until enough fresh bits are received from CSRNG.
 The bus data will persist on the bus until a new `req` is asserted.
-This persistance will allow an asynchonous endpoint to capture the correct data sometime after the `ack` de-asserts.
+This persistence will allow an asynchronous endpoint to capture the correct data sometime after the `ack` de-asserts.
 
 The `fips` signal is used to identify whether the values received on the `bus` have been prepared with complete adherence to the recommendations in NIST SP 800-90.
 If the `fips` signal is deasserted, it means the associated CSRNG instance has been instantiated with a pre-FIPS seed.

--- a/hw/ip/entropy_src/doc/_index.md
+++ b/hw/ip/entropy_src/doc/_index.md
@@ -127,7 +127,7 @@ Once firmware has processed the entropy,  it can then write the results back int
 The `FW_OV_ENTROPY_INSERT` in the {{< regref "FW_OV_CONTROL" >}} register will enable inserting entropy bits back into the entropy flow.
 The firmware override control fields will be set such that the new entropy will resume normal flow operation.
 
-An additional feature of the firmware override function is to insert entropy bits into the flow and still use the condtioning function in the hardware.
+An additional feature of the firmware override function is to insert entropy bits into the flow and still use the conditioning function in the hardware.
 Setting the `FW_OV_INSERT_START` field in the {{< regref "FW_OV_SHA3_START" >}} register will prepare the hardware for this flow.
 Once this field is set true, the {{< regref "FW_OV_WR_DATA" >}} register can be written with entropy bits.
 The {{< regref "FW_OV_WR_FIFO_FULL" >}} register should be monitored after each write to ensure data is not dropped.
@@ -219,7 +219,7 @@ If firmware is not currently reading entropy bits, all processed entropy bits wi
 ### Security
 
 All module assets and countermeasures performed by hardware are listed in the hjson countermeasures section.
-Labels for each instance of asset and coutermeasure are located throughout the RTL source code.
+Labels for each instance of asset and countermeasure are located throughout the RTL source code.
 
 For all of the health test threshold registers, these registers could be protected with shadow registers.
 A design choice was made here to not use shadow registers and save on silicon cost.

--- a/hw/ip/flash_ctrl/doc/_index.md
+++ b/hw/ip/flash_ctrl/doc/_index.md
@@ -319,7 +319,7 @@ Currently there is only one such attribute {{< regref "MP_REGION_CFG_0.HE" >}}.
 #### Idle Indication to External Power Manager
 
 The flash controller provides an idle indication to an external power manager.
-This idle indication does not mean the controller is doing "nothing", but rather the controller is not doing anything "stateful", ie program or erase.
+This idle indication does not mean the controller is doing "nothing", but rather the controller is not doing anything "stateful", e.g. program or erase.
 
 This is because an external power manager event (such as shutting off power) while a flash stateful transaction is ongoing may be damaging to the vendor flash module.
 
@@ -500,7 +500,7 @@ Note that the ICV (integrity ECC) is calculated over the descrambled data and is
 
 ##### ICV
 
-The purpose of the ICV (integrity check value, implemnted as an ECC) is to emulate end-to-end integrity like the other memories.
+The purpose of the ICV (integrity check value, implemented as an ECC) is to emulate end-to-end integrity like the other memories.
 This is why the data is calculated over the descrambled data as it can be stored alongside for continuous checks.
 When descrambled data is returned to the host, the ICV is used to validate the data is correct.
 

--- a/hw/ip/flash_ctrl/doc/dv/index.md
+++ b/hw/ip/flash_ctrl/doc/dv/index.md
@@ -18,7 +18,7 @@ title: "FLASH_CTRL DV document"
 For detailed information on `flash_ctrl` design features, please see the [`flash_ctrl` HWIP technical specification]({{< relref ".." >}}).
 The design-under-test (DUT) wraps the `flash_ctrl` IP, `flash_phy` and the TLUL SRAM adapter that converts the incoming TL accesses from the from host (CPU) interface into flash requests.
 These modules are instantiated and connected to each other and to the rest of the design at the top level.
-For the IP level DV, we replicate the instantiations and connections in `flash_ctrl_wrapper` module mainained in DV, located at `hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv`.
+For the IP level DV, we replicate the instantiations and connections in `flash_ctrl_wrapper` module maintained in DV, located at `hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv`.
 In future, we will consider having the wrapper maintained in the RTL area instead.
 
 ## Testbench architecture
@@ -34,7 +34,7 @@ In addition, the testbench instantiates the following interfaces, connects them 
 * [Clock and reset interface]({{< relref "hw/dv/sv/common_ifs" >}})
 * [TileLink host interface for the flash controller]({{< relref "hw/dv/sv/tl_agent/doc" >}})
 * [TileLink host interface for the eflash]({{< relref "hw/dv/sv/tl_agent/doc" >}})
-* TileLine host interface for the prim registers
+* TileLink host interface for the prim registers
 * Interrupts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
 * [Memory backdoor utility]({{< relref "hw/dv/sv/mem_bkdr_util/doc" >}})
 * Secret key interface from the OTP
@@ -60,10 +60,10 @@ The `flash_ctrl` RAL model is created with the [`ralgen`]({{< relref "hw/dv/tool
 It can be created manually by invoking [`regtool`]({{< relref "util/reggen/doc" >}}):
 
 #### Sequence cfg
-An efficient way to develop test sequences is by providing some random varibles that are used to configure the DUT / drive stimulus.
+An efficient way to develop test sequences is by providing some random variables that are used to configure the DUT / drive stimulus.
 The random variables are constrained using weights and knobs that can be controlled.
 These weights and knobs take on a "default" value that will result in the widest exploration of the design state space, when the test sequence is randomized and run as-is.
-To steer the randomization towards a particular distribution or to achieve interesting combinations of the random variables, the test sequence can be extended to create a spacialized variant.
+To steer the randomization towards a particular distribution or to achieve interesting combinations of the random variables, the test sequence can be extended to create a specialized variant.
 In this extended sequence, nothing would need to be done, other than setting those weights and knobs appropriately.
 This helps increase the likelihood of hitting the design corners that would otherwise be difficult to achieve, while maximizing reuse.
 
@@ -114,7 +114,7 @@ The following covergroups have been developed to prove that the test intent has 
 * control_cg
   Collects operation types, partition and cross coverage of both.
 * erase_susp_cg
-  Check if request of erase suspension occured.
+  Check if request of erase suspension occurred.
 * msgfifo_level_cg
   Covers all possible fifo status to generate interrupt for read / program.
 * rd_buff_evict_cg
@@ -123,7 +123,7 @@ The following covergroups have been developed to prove that the test intent has 
   Check whether eviction happens at all 4 caches with write / erase operation.
   Also check each address belongs to randomly enabled scramble and ecc.
 * error_cg
-  Check errors degined in error code registers.
+  Check errors defined in error code registers.
 ### Self-checking strategy
 #### Scoreboard
 The `flash_ctrl_scoreboard` is primarily used for csr transaction integrity.
@@ -137,7 +137,7 @@ Instead, it creates reference data for each operation.
 For the program(write) operation, rtl output is collected from flash phy interface and compared with each operation's pre calculated write data.
 For the read operation, the expected data is written via memory backdoor interface, read back, and compared.
 The `flash_ctrl_otf_scoreboard` is used for `on-the-fly` mode flash transaction integrity check, while `flash_ctrl_scoreboard` is still used for csr transaction integrity check.
-Since there is still uncovered logic stil within the model before data reaches the actual device, we add extra scoreboard to check that path and call it `last mile scoreboard`.
+Since there is still uncovered logic within the model before data reaches the actual device, we add extra scoreboard to check that path and call it `last mile scoreboard`.
 The `last mile scoreboard` is added to compensate `on-the-fly` model.
 For the write transaction, `on-the-fly` model collects rtl data at the boundary of the controller and flash model.
 

--- a/hw/ip/gpio/doc/dv/index.md
+++ b/hw/ip/gpio/doc/dv/index.md
@@ -27,7 +27,7 @@ GPIO testbench has been constructed based on the [CIP testbench architecture]({{
 Top level testbench is located at `hw/ip/gpio/dv/tb/tb.sv`. It instantiates the GPIO DUT module `hw/ip/gpio/rtl/gpio.sv`.
 In addition, it instantiates the following interfaces and sets their handle into `uvm_config_db`:
 * [Clock and reset interface]({{< relref "hw/dv/sv/common_ifs" >}})
-* [TileLink host interfac]({{< relref "hw/dv/sv/tl_agent/doc" >}})
+* [TileLink host interface]({{< relref "hw/dv/sv/tl_agent/doc" >}})
 * GPIO IOs ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}}))
 * Interrupts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}}))
 

--- a/hw/ip/hmac/doc/_index.md
+++ b/hw/ip/hmac/doc/_index.md
@@ -240,7 +240,7 @@ More detailed and complete code can be found in the software under `sw/`, [ROM c
 ## Initialization
 
 This section of the code describes initializing the HMAC-SHA256, setting up the
-interrupts, endianess, and HMAC, SHA-256 mode. {{< regref "CFG.endian_swap" >}} reverses
+interrupts, endianness, and HMAC, SHA-256 mode. {{< regref "CFG.endian_swap" >}} reverses
 the byte-order of input words when software writes into the message FIFO.
 {{< regref "CFG.digest_swap" >}} reverses the byte-order in the final HMAC or SHA hash.
 

--- a/hw/ip/hmac/doc/dv/index.md
+++ b/hw/ip/hmac/doc/dv/index.md
@@ -72,7 +72,7 @@ virtual sequence is extended from `cip_base_vseq` and serves as a starting point
 All test sequences are extended from `hmac_base_vseq`. It provides commonly used handles,
 variables, functions and tasks that the test sequences can simple use / call.
 Some of the most commonly used tasks / functions are as follows:
-* `hmac_init`     : initialize hmac settings including configurations and interrupte
+* `hmac_init`     : initialize hmac settings including configurations and interrupt
   enables
 * `csr_rd_digest` : read digest values from the CSR registers
 * `wr_key`        : write key values into the CSR registers
@@ -80,7 +80,7 @@ Some of the most commonly used tasks / functions are as follows:
 * `compare_digest`: compare the read digest result with the expected values
 
 ##### Standard test vectors
-Besides contrained random test sequences, hmac test sequences also includes [standard
+Besides constrained random test sequences, hmac test sequences also includes [standard
 SHA256 and HMAC test vectors]({{< relref "hw/dv/sv/test_vectors/doc.md" >}}) from
 [NIST](https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Secure-Hashing#shavs)
 and [IETF](https://tools.ietf.org/html/rfc4868).

--- a/hw/ip/i2c/doc/_index.md
+++ b/hw/ip/i2c/doc/_index.md
@@ -304,7 +304,7 @@ If SCL is pulled low during an SCL pulse which has already started, this interru
   {name: 'SCL bus', wave: '0.u..0|...u..0|..u0..'},
   {name: 'scl_interference', wave: '0.....|.......|....1.'},
 ],
-  head: {text: 'SCL pulses: Normal SCL pulse (Cycle 3),  SCL pulse with clock strectching (cycle 11), and SCL interference (interrupted SCL pulse)',tick:1}}
+  head: {text: 'SCL pulses: Normal SCL pulse (Cycle 3),  SCL pulse with clock stretching (cycle 11), and SCL interference (interrupted SCL pulse)',tick:1}}
 {{</wavejson>}}
 
 
@@ -329,7 +329,7 @@ Except for START and STOP symbols, the I2C specification requires that the SDA s
 The `sda_unstable` interrupt is asserted if, when receiving data or acknowledgement pulse, the value of the SDA signal does not remain constant over the duration of the SCL pulse.
 
 Transactions are terminated by a STOP signal.
-The host may send a repeated START signal instead of a STOP, which also terminates the preceeding transaction.
+The host may send a repeated START signal instead of a STOP, which also terminates the preceding transaction.
 In both cases, the `trans_complete` interrupt is asserted, in the beginning of a repeated START or at the end of a STOP.
 
 #### Target Mode
@@ -392,7 +392,7 @@ The values of these parameters will depend primarily on three bus details:
 Rather, it is a function of the capacitance and physical design of the bus.
 The specification provides detailed guidelines on how to manage capacitance in an I2C system:
    - Section 5.2 of the I2C specification indicates that Fast-mode plus devices may operate at reduced clock speeds if the bus capacitance drives signal rise times (t<sub>r</sub>) outside the nominal 120ns limit.
-Excess capacitance can also be compensated for by reducing the size of the bus pullup resistor, so long as the total open-drain current does not exceed 20mA for fast-mode plus devices (as described in section 7.1 of the I2C specificaion).
+Excess capacitance can also be compensated for by reducing the size of the bus pullup resistor, so long as the total open-drain current does not exceed 20mA for fast-mode plus devices (as described in section 7.1 of the I2C specification).
 However the specification places a hard limit on rise times capping them at 1000ns.
     - If there are standard- or fast-mode target devices on the bus, the specified open-drain current limit is reduced to 3mA (section 7.1), thus further restricting the minimum value of the pull-up resistor.
     - In fast-mode bus designs, where the total line capacitance exceeds 200pF, the specification recommends replacing the pull-up resistor with an active current source, supplying 3mA or less (section 5.1).
@@ -404,7 +404,7 @@ Regardless of the physical construction of the bus, the rise time (t<sub>r</sub>
    - By default the device should operate at the maximum frequency for that mode.
 However, If the system developer wishes to operate at slower than the mode-specific maximum, a larger than minimum period  could be allowed as an additional functional parameter when calculating the timing parameters.
 
-Based on the inputs, the timing paramaters may be chosen using the following algorithm:
+Based on the inputs, the timing parameters may be chosen using the following algorithm:
 1. The physical timing parameters t<sub>HD,STA</sub>, t<sub>SU,STA</sub>, t<sub>HD.DAT</sub>, t<sub>SU,DAT</sub>, t<sub>BUF</sub>, and t<sub>STO</sub>, t<sub>HIGH</sub>, and t<sub>LOW</sub> all have minimum allowed values which depend on the choice of speed mode (standard-mode, fast-mode or fast-mode plus).
 Using the speed mode input, look up the appropriate minimum value (in ns) for each parameter (i.e. t<sub>HD,STA,min</sub>, t<sub>SU,STA,min</sub>, etc)
 1. For each of these eight parameters, obtain an integer minimum by dividing the physical minimum parameter by the clock frequency and rounding up to the next highest integer:
@@ -424,7 +424,7 @@ $$ \textrm{T_STO_MIN}= \lceil{t\_{STO,min}/t\_{clk}}\rceil $$
 $$ \textrm{T_R}= \lceil{t\_{r}/t\_{clk}}\rceil $$
 $$ \textrm{T_F}= \lceil{t\_{f}/t\_{clk}}\rceil $$
 1. Store T_R and T_F in their corresponding registers: `TIMING1.T_R` and `TIMING1.T_F`.
-1. Based on the input speed mode, look up the maximum permissable SCL frequency (f<sub>SCL,max</sub>)and calculate the minimum permissable SCL period:
+1. Based on the input speed mode, look up the maximum permissible SCL frequency (f<sub>SCL,max</sub>)and calculate the minimum permissible SCL period:
 $$ t\_{SCL,min}= 1/f\_{SCL,max} $$
 1. As with each of the other physical parameters convert t<sub>SCL,min</sub> and, if provided, the t<sub>SCL,user</sub> to integers, MINPERIOD and USERPERIOD..
 $$ MINPERIOD = \lceil{t\_{SCL,min}/t\_{clk}}\rceil $$
@@ -438,7 +438,7 @@ $$ \textrm{THIGH}+\textrm{TLOW} \ge\textrm{PERIOD}-\textrm{T_F}-\textrm{T_R} $$
     - The balance between t<sub>HIGH</sub> and t<sub>LOW</sub> can be manipulated in a variety of different ways (depending on the desired SCL duty cycle).
     - It is, for instance, perfectly acceptable to simply set TLOW to the minimum possible value:
 $$ \textrm{TIMING0.TLOW}=\textrm{TLOW_MIN} $$
-1. THIGH is then set to satisfy both constraints in the desired SCL period and in the minimum permissable values for t<sub>HIGH</sub>:
+1. THIGH is then set to satisfy both constraints in the desired SCL period and in the minimum permissible values for t<sub>HIGH</sub>:
 $$ \textrm{TIMING0.THIGH}=\max(\textrm{PERIOD}-\textrm{T_R} - \textrm{TIMING0.TLOW} -\textrm{T_F}, \textrm{THIGH_MIN}) $$
 
 
@@ -470,7 +470,7 @@ All other parameters in registers `TIMING2`, `TIMING3`, `TIMING4` are unchanged 
 | TIMING0.THIGH   | 260              | 87         | 261            | Spec. t<sub>HIGH</sub> Minimum                |
 | TIMING0.TLOW    | 500              | 167        | 501            | Spec. t<sub>LOW</sub> Minimum                 |
 | TIMING1.T_F     | 20ns * (VDD/5.5V)| 7          | 21             | Signal slew-rate should be controlled         |
-| TIMING1.T_R     | 0                | 134        | 402            | Atypicallly high line capacitance             |
+| TIMING1.T_R     | 0                | 134        | 402            | Atypically high line capacitance             |
 | SCL Period      | 1000             | N/A        | 395            | Forced longer than minimum by long T_R        |
 
 ## Device Interface Functions (DIFs)

--- a/hw/ip/keymgr/doc/_index.md
+++ b/hw/ip/keymgr/doc/_index.md
@@ -351,7 +351,7 @@ For the Attestation CDI, the {{< regref "ATTEST_SW_BINDING" >}} is used, all oth
 
 When invoking an advance operation, both versions are advanced, one after the other.
 There are thus two KMAC transactions.
-The first trasnaction uses the Sealing CDI internal key, {{< regref "SEALING_SW_BINDING" >}} and other common inputs.
+The first transaction uses the Sealing CDI internal key, {{< regref "SEALING_SW_BINDING" >}} and other common inputs.
 The second transaction uses the Attestation CDI internal key, {{< regref "ATTEST_SW_BINDING" >}} and other common inputs.
 
 When invoking a generate operation, the software must specify which CDI to use as the source key.

--- a/hw/ip/kmac/doc/_index.md
+++ b/hw/ip/kmac/doc/_index.md
@@ -201,7 +201,7 @@ However, the recommended approach to write messages is:
 #### Masking
 
 The message FIFO does not generate the masked message data.
-Incoming message bistream is not sensitive to the leakage.
+Incoming message bitstream is not sensitive to the leakage.
 If the `EnMasking` parameter is set and {{<regref "CFG_SHADOWED.msg_mask" >}} is enabled, the message is masked upon loading into the Keccak core using the internal entropy generator.
 The secret key, however, is stored as masked form always.
 

--- a/hw/ip/lc_ctrl/doc/_index.md
+++ b/hw/ip/lc_ctrl/doc/_index.md
@@ -639,7 +639,7 @@ The former provides status info such as idle state, number of address bits and R
 The latter exposes an address, data and operation field for accessing a CSR space.
 
 In order to interact with the LC controller through JTAG, the debugging agent should read out the `abits` field from 0x10 in order to determine the address width in the DMI, and verify that the `version` field is indeed set to 1 to confirm that the DTM implements v0.13 of the spec.
-Then, the debbuger can issue a CSR read or write operation via the 0x11 register as explained in more detail in [the RISC-V external specification, Chapter 6.1.5](https://github.com/riscv/riscv-debug-spec/blob/release/riscv-debug-release.pdf).
+Then, the debugger can issue a CSR read or write operation via the 0x11 register as explained in more detail in [the RISC-V external specification, Chapter 6.1.5](https://github.com/riscv/riscv-debug-spec/blob/release/riscv-debug-release.pdf).
 
 ### TAP and Isolation
 

--- a/hw/ip/lc_ctrl/doc/dv/index.md
+++ b/hw/ip/lc_ctrl/doc/dv/index.md
@@ -57,7 +57,7 @@ uses the jtag_if interface in the testbench.
 
 ### PUSH/PULL Agent
 [push_pull_agent]({{< relref "hw/dv/sv/push_pull_agent/doc" >}}) is used to emulate the Token and
-OTP programing interfaces.
+OTP programming interfaces.
 
 ### UVM RAL Model
 The LC_CTRL RAL model is created with the [`ralgen`]({{< relref "hw/dv/tools/ralgen/doc" >}}) FuseSoC generator script automatically when the simulation is at the build stage.
@@ -83,7 +83,7 @@ The following covergroups have been developed to prove that the test intent has 
 #### Scoreboard
 The `lc_ctrl_scoreboard` is primarily used for end to end checking.
 It creates the following analysis exports to retrieve the data monitored by corresponding interface agents:
-* tl_[a_chan, d_chan, dir]_fifo_lc_ctrl_reg_block.analysis_export: Tile Link CSR reads/writes.
+* tl_[a_chan, d_chan, dir]_fifo_lc_ctrl_reg_block.analysis_export: TileLink CSR reads/writes.
 * jtag_riscv_fifo.analysis_export: JTAG CSR reads/writes
 * alert_fifo[fatal_bus_integ_error, fatal_prog_error, fatal_state_error].analysis_export: Alert traffic from DUT
 * otp_prog_fifo.analysis_export:  OTP program data from LC_CTRL and response to LC_CTRL.
@@ -94,7 +94,7 @@ It creates the following analysis exports to retrieve the data monitored by corr
 It also updates the UVM register model.
 * JTAG CSR data is used to check against expected values predicted by the scoreboard.
 It also updates the UVM register model.
-* Alert data is decoded and used to indicate an alert has occured
+* Alert data is decoded and used to indicate an alert has occurred
 
 #### Assertions
 * TLUL assertions: The `tb/lc_ctrl_bind.sv` binds the `tlul_assert` [assertions]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}}) to the IP to ensure TileLink interface protocol compliance.

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_jtag_access_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_jtag_access_vseq.sv
@@ -36,7 +36,7 @@ class lc_ctrl_jtag_access_vseq extends lc_ctrl_base_vseq;
   dv_base_reg m_claim_transition_if;
   // regwen register
   dv_base_reg m_transition_regwen;
-  // Acccess maps [LcCtrlTLUL] -> Tile Link, [LcCtrlJTAG] -> JTAG
+  // Acccess maps [LcCtrlTLUL] -> TileLink, [LcCtrlJTAG] -> JTAG
   uvm_reg_map m_map[lc_ctrl_csr_intf_e];
   // Queue of register access specs
   reg_access_t m_reg_accesses[$];

--- a/hw/ip/otbn/doc/dv/fcov.md
+++ b/hw/ip/otbn/doc/dv/fcov.md
@@ -975,7 +975,7 @@ The instruction-specific covergroup is `insn_bn_xid_cg` (shared with `BN.SID`).
 - Misaligned address tracking.
   Track loads from addresses that are in range for the size of the memory.
   We track all possible alignments of the sum as `addr_align_cross`.
-  The reason for not tracking offset and register value misalignments seperately is because the offset would always be shifted by 5 bits, which makes it always aligned.
+  The reason for not tracking offset and register value misalignments separately is because the offset would always be shifted by 5 bits, which makes it always aligned.
 - See an invalid instruction with both increments specified
   Tracked in `enc_bnxid_cg` as a bin of `incd_inc1_cross`.
 - See `grd` greater than 31, giving an illegal instruction error
@@ -1031,7 +1031,7 @@ The instruction-specific covergroup is `insn_bn_xid_cg` (shared with `BN.LID`).
 - Misaligned address tracking.
   Track stores to addresses that are in range for the size of the memory.
   We track all possible alignments of the sum as `addr_align_cross`.
-  The reason for not tracking offset and register value misalignments seperately is because the offset would always be shifted by 5 bits, which makes it always aligned.
+  The reason for not tracking offset and register value misalignments separately is because the offset would always be shifted by 5 bits, which makes it always aligned.
 - See an invalid instruction with both increments specified
   Tracked in `enc_bnxid_cg` as a bin of `incd_inc1_cross`.
 - See `grd` greater than 31, giving an illegal instruction error

--- a/hw/ip/otbn/doc/dv/fcov.md
+++ b/hw/ip/otbn/doc/dv/fcov.md
@@ -1126,4 +1126,3 @@ There is no instruction-specific covergroup.
 - Write to an invalid WSR
 
 These points are tracked with `wsr_cross` in `enc_wcsr_cg`.
-

--- a/hw/ip/otp_ctrl/doc/_index.md
+++ b/hw/ip/otp_ctrl/doc/_index.md
@@ -348,7 +348,7 @@ The `lc_otp_vendor_test_i` and `lc_otp_vendor_test_o` signals are connected to a
 These control and status signals may be used by the silicon creator to exercise the OTP programming smoke checks on the VENDOR_TEST partition.
 The signals are gated with the life cycle state inside the life cycle controller such that they do not have any effect in production life cycle states.
 
-##### State, Counter and Token Ouput
+##### State, Counter and Token Output
 
 After initialization, the life cycle partition contents, as well as the tokens and personalization status is output to the life cycle controller via the `otp_lc_data_o` struct.
 The life cycle controller uses this information to determine the life cycle state, and steer the appropriate qualifier signals.

--- a/hw/ip/otp_ctrl/doc/checklist.md
+++ b/hw/ip/otp_ctrl/doc/checklist.md
@@ -183,7 +183,7 @@ Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 Documentation | [DESIGN_DELTAS_CAPTURED_V2][]           | Done        |
 Documentation | [DV_DOC_COMPLETED][]                    | Done        |
 Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Done        |
-Testbench     | [ALL_INTERFACES_EXERCISED][]            | Done        | `prim_tl_o/i` has a simple prim_tl_agent support, but needto be replaced with auto-generated tl_agent once reggen tool is optimized.
+Testbench     | [ALL_INTERFACES_EXERCISED][]            | Done        | `prim_tl_o/i` has a simple prim_tl_agent support, but need to be replaced with auto-generated tl_agent once reggen tool is optimized.
 Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Done        |
 Testbench     | [SIM_TB_ENV_COMPLETED][]                | Done        |
 Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        |

--- a/hw/ip/pattgen/doc/_index.md
+++ b/hw/ip/pattgen/doc/_index.md
@@ -82,10 +82,10 @@ The `bit_ctr` counter increments on every falling edge of `clk_int`, until it ov
 In the `ACTIVE` state, the FSM `pda` output is driven by a multiplexer, connected to the `pattern` input.
 The value of `bit_ctr` selects the bit value from the appropriate sequence position, via this multiplexor.
 
-Finally whevever `bit_ctr` overflows and reverts to zero, the `repeat_ctr` increments, and the pattern starts again.
+Finally whenever `bit_ctr` overflows and reverts to zero, the `repeat_ctr` increments, and the pattern starts again.
 Finally `repeat_ctr` overflows to zero as it reaches the input value `n_repeats`.
 When this overflow occurs, the FSM transitions to the `END` state.
-All counters halt, the `pda` data lines reset to zero, and an interupt event is sent out to signal completion.
+All counters halt, the `pda` data lines reset to zero, and an interrupt event is sent out to signal completion.
 
 The entire sequence can be restarted either by resetting or disabling and re-enabling the FSM.
 
@@ -99,7 +99,7 @@ To clear the interrupts, bit `1` must be written the corresponding bits of {{< r
 
 To start pattern generation, the register interface of the pattern generator HWIP should be properly initialized and configured.
 
-The guide that follows provides instuctions for configuring Channel 0.
+The guide that follows provides instructions for configuring Channel 0.
 To configure Channel 1, use the registers with the "CH1" suffix, instead of the "CH0" registers.
 
 To configure a single channel:
@@ -108,7 +108,7 @@ To configure a single channel:
 For either channel, a zero in the polarity bit indicates that the channel clock line (`pcl`) should start low, and the channel data line `pda` transitions on every falling edge of `pcl`.
 A one in the polarity bit inverts the `pcl` clock so that it starts high and `pda` transitions on the rising edge.
 The following waveform illustrates the effect of the `POLARITY` bit.
-Here both channels are configured for simulatenous pattern generation, but the two channels are configured for opposite polarity.
+Here both channels are configured for simultaneous pattern generation, but the two channels are configured for opposite polarity.
 {{<wavejson>}}
 {signal: [
   {name: 'CTRL.ENABLE_CH0', wave: 'lh......'},
@@ -134,7 +134,7 @@ $$f_{pclx}=\frac{f_\textrm{I/O clk}}{2(\textrm{CLK_RATIO}+1)}$$
 Note that since the allowed number of pattern repetitions ranges from 1-1024, the value of this field should be one less than the desired repetition count.
 For example, to repeat a pattern 30, a value of 29 should written to the field {{< regref "SIZE.REPS_CH0" >}}.
 1. Finally to start the pattern, set the {{< regref "CTRL.ENABLE_CH0" >}}.
-To start both channel patterns at the same time, configure both channels then simulataneously assert both the {{< regref "CTRL.ENABLE_CH0" >}} and {{< regref "CTRL.ENABLE_CH1" >}} bits in the same register access.
+To start both channel patterns at the same time, configure both channels then simultaneously assert both the {{< regref "CTRL.ENABLE_CH0" >}} and {{< regref "CTRL.ENABLE_CH1" >}} bits in the same register access.
 
 ## Device Interface Functions (DIFs)
 

--- a/hw/ip/pattgen/doc/dv/index.md
+++ b/hw/ip/pattgen/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "PATTGEN DV document"
 ## Goals
 * **DV**
   * Verify all PATTGEN IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and func  tional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
   * Build comprehensive coverage framework to measure coverage provided by existing tests

--- a/hw/ip/pinmux/doc/_index.md
+++ b/hw/ip/pinmux/doc/_index.md
@@ -208,7 +208,7 @@ TAP strap 1                     | Continuously   | Continuously | Once at boot |
 
 *Once at boot:* Sampled once after life cycle initialization (sampling event is initiated by pwrmgr).
 
-*Continously:* Sampled continuously after life cycle initialization.
+*Continuously:* Sampled continuously after life cycle initialization.
 
 The TAP muxing logic is further qualified by the life cycle state in order to isolate the TAPs in certain life cycle states.
 The following table lists the TAP strap encoding and the life cycle states in which the associated TAPs can be selected and accessed.

--- a/hw/ip/prim/doc/prim_flash.md
+++ b/hw/ip/prim/doc/prim_flash.md
@@ -69,7 +69,7 @@ part               | input  | requested transaction partition
 info_sel           | input  | if requested transaction is information partition, the type of information partition accessed
 he                 | input  | high endurance enable for requested address
 prog_data          | input  | program data
-ack                | output | transction acknowledge
+ack                | output | transaction acknowledge
 rd_data            | output | transaction read data
 done               | output | transaction done
 
@@ -126,9 +126,9 @@ The following are examples for read, program and erase transactions.
 ]}
 {{< /wavejson >}}
 
-## Initlialization
+## Initialization
 
-The flash wrapper may undergo technology specific intializations when it is first powered up.
+The flash wrapper may undergo technology specific initializations when it is first powered up.
 During this state, it asserts the `init_busy` to inform the outside world that it is not ready for transactions.
 During this time, if a transaction is issued towards the flash wrapper, the transaction is not acknowledged until the initialization is complete.
 

--- a/hw/ip/prim/doc/prim_keccak.md
+++ b/hw/ip/prim/doc/prim_keccak.md
@@ -35,7 +35,7 @@ Signal | Type          | Description
 -------|---------------|------------------------------
 rnd_i  | input [RndW]  | current round number [0..(MaxRound-1)]
 s_i    | input [Width] | state input
-s_o    | output[Width] | permutated state output
+s_o    | output[Width] | permuted state output
 
 `s_i` and `s_o` are little-endian bitarrays.
 The [SHA3 spec][fibs-pub-202] shows how to convert the bitstream into the 5x5xW state cube.

--- a/hw/ip/prim/doc/prim_keccak.md
+++ b/hw/ip/prim/doc/prim_keccak.md
@@ -86,4 +86,3 @@ The recommended default value of 24 rounds is used in this design,
 but an argument (changed with the `-r` flag) is provided for reference.
 The `keccak_rc.py` script creates 64 bit of constants and the `prim_keccak` module uses only lower bits of the constants if the `Width` is less than 1600.
 For instance, if `Width` is 800, lower 32bits of the round constant are used.
-

--- a/hw/ip/prim/doc/prim_packer.md
+++ b/hw/ip/prim/doc/prim_packer.md
@@ -33,7 +33,7 @@ flush_i      | input  | Send out stored data and clear state.
 flush_done_o | output | Indicates flush operation is completed.
 err_o        | output | When EnProtection is set, the error is reported through this port. This signal is asynchronous to the datapath.
 
-# Theory of Opeations
+# Theory of Operations
 
 ```code
            /----------\

--- a/hw/ip/prim/doc/prim_packer_fifo.md
+++ b/hw/ip/prim/doc/prim_packer_fifo.md
@@ -47,8 +47,8 @@ wvalid_i   |          |      rvalid_o
 wdata_i    |   Flop   |      rdata_o
 =====/====>|   FIFO   |=======/=======>
   [InW]    |          |      [OutW]
-           |          |      depth_o    
-           |          |--------------->   
+           |          |      depth_o
+           |          |--------------->
 wready_o   |          |      rready_i
 <----------|          |<---------------
            |          |
@@ -64,4 +64,3 @@ module is in unpack mode.
 
 The internal register size is the greate of `InW` and `OutW` bits.
 Timing diagrams are shown in the header of the `prim_packer_fifo` module.
-

--- a/hw/ip/prim/doc/prim_packer_fifo.md
+++ b/hw/ip/prim/doc/prim_packer_fifo.md
@@ -38,7 +38,7 @@ rdata_o[OutW]| output | Output data.
 rready_i     | input  | Output data is popped from the FIFO.
 depth_o      | output | Indicates the fullness of the FIFO.
 
-# Theory of Opeations
+# Theory of Operations
 
 ```code
            /----------\
@@ -62,5 +62,5 @@ rvalid_o and rready_i are coincident), will clear the data and depth values on
 the next clock cycle. The complimentary flow occurs when the`prim_packer_fifo`
 module is in unpack mode.
 
-The internal register size is the greate of `InW` and `OutW` bits.
+The internal register size is the greater of `InW` and `OutW` bits.
 Timing diagrams are shown in the header of the `prim_packer_fifo` module.

--- a/hw/ip/prim/doc/prim_xoshiro256pp.md
+++ b/hw/ip/prim/doc/prim_xoshiro256pp.md
@@ -60,7 +60,7 @@ state-update function contains a lockup protection which re-seeds the state with
 
 When the seed enable signal `seed_en_i` is raised, the internal state of xoshiro256++ is updated
 with the value provided at the 256b input 'seed_i'.
-The state is internaly updated in every clock cycle whenever the enable signal `xoshiro_en_i` is raised.
+The state is internally updated in every clock cycle whenever the enable signal `xoshiro_en_i` is raised.
 The timing diagram below visualizes this process.
 
 {{< wavejson >}}

--- a/hw/ip/prim/pre_dv/prim_sync_reqack/README.md
+++ b/hw/ip/prim/pre_dv/prim_sync_reqack/README.md
@@ -1,4 +1,4 @@
-REQ/ACK Syncronizer Verilator Testbench
+REQ/ACK Synchronizer Verilator Testbench
 =======================================
 
 This directory contains a basic, scratch Verilator testbench targeting

--- a/hw/ip/pwm/doc/_index.md
+++ b/hw/ip/pwm/doc/_index.md
@@ -12,7 +12,7 @@ See that document for integration overview within the broader top-level system.
 
 - Pulse-width modulated (PWM) with adjustable duty cycle
 - Suitable for general-purpose use, but primarily designed for control of tri-color LEDs
-- Parametrizable number of output channels
+- Parameterizable number of output channels
 - Separate clock domains for TL-UL I/O vs. core operations
    - PWM operation can continue in low-power state.
 - Independent control of duty cycle, phase, and polarity for all channels
@@ -29,7 +29,7 @@ See that document for integration overview within the broader top-level system.
 
 ## Description
 
-The PWM IP is primarily designed to drive a parametrizable number of pulse-width modulated outputs with periodic pulses each with a programmable frequency, phase, and duty cycle (i.e. the ratio between the pulse duration and the overall period between pulses.)
+The PWM IP is primarily designed to drive a parameterizable number of pulse-width modulated outputs with periodic pulses each with a programmable frequency, phase, and duty cycle (i.e. the ratio between the pulse duration and the overall period between pulses.)
 
 The phase and duty cycle of each output channel can then be controlled with programmable resolution, from 1-bit (half-cycle resolution) to 16-bit (in which case pulse width and timing can be controlled to one part in 2<sup>16</sup> relative to the pulse period)
 

--- a/hw/ip/pwm/doc/dv/index.md
+++ b/hw/ip/pwm/doc/dv/index.md
@@ -120,7 +120,7 @@ Some of the most commonly used tasks / functions are as follows:
 * set_ch_enables(bit [PWM_NUM_CHANNELS-1:0] enables): used to enable and disable the different channels
 * set_duty_cycle(bit [$bits(PWM_NUM_CHANNELS)-1:0] channel, dc_blink_t value ,bit [3:0] resn) set the A and B values for channel
 * set_blink(bit [$bits(PWM_NUM_CHANNELS)-1:0] channel, dc_blink_t value): set X and Y value for pulse and heart bit
-* set_param(bit [$bits(PWM_NUM_CHANNELS)-1:0] channel, param_reg_t value): set channel configuration (blink/heatbeat/phase)
+* set_param(bit [$bits(PWM_NUM_CHANNELS)-1:0] channel, param_reg_t value): set channel configuration (blink/heartbeat/phase)
 * shutdown_dut(): this will disable all channels as an indication for the scoreboard to verify all remaining items.
 
 #### Functional coverage

--- a/hw/ip/pwrmgr/doc/_index.md
+++ b/hw/ip/pwrmgr/doc/_index.md
@@ -199,7 +199,7 @@ In additional to external requests, the power manager maintains 2 internal reset
 
 #### Escalation Reset Request
 
-Alert escalation resets in general behave similarly to peripehral requested resets.
+Alert escalation resets in general behave similarly to peripheral requested resets.
 However, peripheral resets are always handled gracefully and follow the normal FSM transition.
 
 Alert escalations can happen at any time and do not always obey normal rules.

--- a/hw/ip/pwrmgr/doc/dv/index.md
+++ b/hw/ip/pwrmgr/doc/dv/index.md
@@ -83,7 +83,7 @@ The `pwrmgr_base_vseq` virtual sequence is extended from `cip_base_vseq` and ser
 It provides commonly used handles, variables, functions and tasks used by the test sequences.
 Some of the most commonly used tasks and functions are as follows:
 * task `wait_for_fast_fsm_active`:
-  Waits for the `fetch_en_o` output to become 1, indicating the fast fsm is active and the cpu can fetch instructions.
+  Waits for the `fetch_en_o` output to become 1, indicating the fast fsm is active and the CPU can fetch instructions.
   We wait for this before the tests can start, since any CSR accesses require the CPU to be running.
   Due to complexities in the UVM sequences this task is called in the virtual post_apply_reset task of dv_base_vseq.
 * task `wait_for_csr_to_propagate_to_slow_domain`:
@@ -147,7 +147,7 @@ The `pwrmgr_scoreboard` is primarily used for end to end checking.
 
 Many inputs must have specific transitions to prevent the pwrmgr fsms from wait forever.
 When possible the transitions are triggered by pwrmgr output changes.
-These are described according to the unit that originates or is the recepient of the ports.
+These are described according to the unit that originates or is the recipient of the ports.
 See also the test plan for specific ways these are driven to trigger different testpoints.
 
 ##### AST
@@ -224,7 +224,7 @@ The pins connecting to LC behave pretty much the same way as those to OTP.
   After the transition is under way it is a don't care.
   The `pwrmgr_aborted_low_power_vseq` sequence sets it carefully to abort a low power entry soon after the attempt because the processor wakes up.
 
-##### Wakepus and Resets
+##### Wakeups and Resets
 There are a number of wakeup and reset requests.
 They are driven by sequences as they need to.
 

--- a/hw/ip/rom_ctrl/doc/_index.md
+++ b/hw/ip/rom_ctrl/doc/_index.md
@@ -231,7 +231,7 @@ The {{< regref "FATAL_ALERT_CAUSE" >}} register might change value during operat
 To get the computed ROM digest, software can read {{< regref "DIGEST_0" >}} through {{< regref "DIGEST_7" >}}.
 The ROM also contains an expected ROM digest.
 Unlike the rest of the contents of ROM, this isn't scrambled.
-As such, software can't read it through the standard ROM interface (which would try to unscramble it again, resulting in rubbish data that woud cause a failed ECC check).
+As such, software can't read it through the standard ROM interface (which would try to unscramble it again, resulting in rubbish data that would cause a failed ECC check).
 In case software needs access to this value, it can be read at {{< regref "EXP_DIGEST_0" >}} through {{< regref "EXP_DIGEST_7" >}}.
 
 ## Device Interface Functions (DIFs)

--- a/hw/ip/rstmgr/doc/_index.md
+++ b/hw/ip/rstmgr/doc/_index.md
@@ -15,7 +15,7 @@ This document describes the functionality of the reset controller and its intera
 *   Limited and selective software controlled module reset.
 *   Always-on reset information register.
 *   Always-on alert crash dump register.
-*   Always-on cpu crash dump register.
+*   Always-on CPU crash dump register.
 *   Reset consistency checks.
 
 # Theory of Operation
@@ -312,9 +312,9 @@ This behavioral difference may be important to software, as it implies the confi
 ## Crash Dump Information
 
 The reset manager manages crash dump information for software debugging across unexpected resets and watchdogs.
-When enabled, the latest alert information and latest cpu information are captured in always-on registers.
+When enabled, the latest alert information and latest CPU information are captured in always-on registers.
 
-When the software resumes after the reset, it is then able to examine the last cpu state or the last set of alert information to understand why the system has reset.
+When the software resumes after the reset, it is then able to examine the last CPU state or the last set of alert information to understand why the system has reset.
 
 The enable for such debug capture can be locked such that it never captures.
 
@@ -330,10 +330,10 @@ Set {{< regref "ALERT_INFO_CTRL.INDEX" >}} to the desired segment, and then read
 
 ### CPU Information
 
-The cpu information register contains the value of the cpu state prior to a triggered reset.
+The CPU information register contains the value of the CPU state prior to a triggered reset.
 Since this information differs in length between system implementation, the information register only displays 32-bits at a time.
 
-For more details on the cpu dump details, please see [crash dump]({{< relref "hw/ip/rv_core_ibex/doc/_index.md#crash-dump-collection" >}}).
+For more details on the CPU dump details, please see [crash dump]({{< relref "hw/ip/rv_core_ibex/doc/_index.md#crash-dump-collection" >}}).
 
 The {{< regref "CPU_INFO_ATTR" >}} register indicates how many 32-bit data segments must be read.
 Software then simply needs to write in {{< regref "CPU_INFO_CTRL.INDEX" >}} which segment it wishes and then read out the {{< regref "CPU_INFO" >}} register.

--- a/hw/ip/rv_core_ibex/doc/dv/_index.md
+++ b/hw/ip/rv_core_ibex/doc/dv/_index.md
@@ -26,7 +26,7 @@ For more information please see the [Ibex RISC-V Core Wrapper Technical Specific
 ## Verification strategy
 
 The main Ibex testbench is not contained in the OpenTitan repository.
-Verification is primarily done by the testbench in the Ibex reposity, see the [Ibex Testplan](https://ibex-core.readthedocs.io/en/latest/03_reference/testplan.html) for more details.
+Verification is primarily done by the testbench in the Ibex repository, see the [Ibex Testplan](https://ibex-core.readthedocs.io/en/latest/03_reference/testplan.html) for more details.
 
 The additional features provided by the RISC-V Core Wrapper are verified at a chip level only (See the [Earlgrey Chip DV testplan]({{< relref "hw/top_earlgrey/doc/dv" >}}).
 As they are simple features chip level only verification suffices to meet our goals.

--- a/hw/ip/rv_dm/doc/checklist.md
+++ b/hw/ip/rv_dm/doc/checklist.md
@@ -133,7 +133,7 @@ Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |
 Testbench     | [SIM_RAL_MODEL_GEN_AUTOMATED][]       | Done        | Done for both, regs and debug mem RAL. JTAG DTM and DMI RAL models are hand-written.
 Testbench     | [CSR_CHECK_GEN_AUTOMATED][]           | Done        | Done for both, regs and debug mem RAL.
-Testbench     | [TB_GEN_AUTOMATED][]                  | N.A.        | Design is not parameterized into multiple varaints.
+Testbench     | [TB_GEN_AUTOMATED][]                  | N.A.        | Design is not parameterized into multiple variants.
 Tests         | [SIM_SMOKE_TEST_PASSING][]            | Done        |
 Tests         | [SIM_CSR_MEM_TEST_SUITE_PASSING][]    | Done        | CSR tests run on all 4 RAL models.
 Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | N.A.        |

--- a/hw/ip/rv_dm/doc/dv/index.md
+++ b/hw/ip/rv_dm/doc/dv/index.md
@@ -124,7 +124,7 @@ It provides the following commonly used handles, variables, functions and tasks 
   The task provides some arguments to "pattern" the kind of randomized responses that are sent.
 
 * sba_tl_device_seq_stop(): This method stops the previously spawned SBA TL device sequence from executing further.
-  If the invocation of this task coincides with a new SBA TL request from RV_DM then the noew request is accepted.
+  If the invocation of this task coincides with a new SBA TL request from RV_DM then the new request is accepted.
   The task waits for all accepted requests to be serviced (i.e. responded to) before returning back to the caller.
 
 All test sequences extend from `rv_dm_base_vseq`.

--- a/hw/ip/rv_timer/doc/_index.md
+++ b/hw/ip/rv_timer/doc/_index.md
@@ -73,7 +73,7 @@ The timer IP supports more than one HART and/or more than one timer per hart.
 Each hart has a set of tick generator and counter. It means the timer IP has the
 same number of prescalers, steps, and `mtime` registers as the number of harts.
 
-Each hart can have multiple sets of `mtimecmp`, comparater logic, and expire
+Each hart can have multiple sets of `mtimecmp`, comparator logic, and expire
 interrupt signals. This version of the IP is fixed to have one Hart and one
 Timer per Hart.
 
@@ -235,9 +235,9 @@ between `mtime` and `mtimecmp` care is needed. A couple of cases are:
 ## Interrupt Handling
 
 If `mtime` is greater than or equal to the value of `mtimecmp`, the interrupt is generated from the RV_TIMER module.
-If the core enables the timer interrupt in `MIE` CSR, it jumps into the timer interupt service routine.
+If the core enables the timer interrupt in `MIE` CSR, it jumps into the timer interrupt service routine.
 Clearing the interrupt can be done by writing 1 into the Interrupt Status register {{<regref "INTR_STATE0">}}.
-The RV_TIMER module also follows RISC-V Previliged spec that requires the interrupt to be cleared by updating `mtimecmp` memory-mapped CSRs.
+The RV_TIMER module also follows RISC-V Privileged spec that requires the interrupt to be cleared by updating `mtimecmp` memory-mapped CSRs.
 In this case both {{<regref "COMPARE_LOWER0_0">}} and {{<regref "COMPARE_UPPER0_0">}} can clear the interrupt source.
 
 ## Device Interface Functions (DIFs)

--- a/hw/ip/rv_timer/doc/dv/index.md
+++ b/hw/ip/rv_timer/doc/dv/index.md
@@ -81,8 +81,8 @@ It creates the following analysis ports to retrieve the data monitored by corres
 rv_timer scoreboard monitors all CSR registers and interrupt pins.
 
 For a write transaction, during the address channel, CSR values are updated in RAL and config values (timer enable, step, prescale, timer value, compare value) are updated in internal arrays.
-When particular timer is enabled, rv_timer scoreboard calculate timeout clocks and start a thread to wait for timeout, then if any of timer configuration updated on active timer, rv_timer scoreboard recalculate and update the timeout clocks in ther running timeout thread.
-If multiple timers are enabled, multipe threads will be initiated. On timeout scoreboard calculate the expected interrupt status and update RAL registers.
+When particular timer is enabled, rv_timer scoreboard calculate timeout clocks and start a thread to wait for timeout, then if any of timer configuration updated on active timer, rv_timer scoreboard recalculate and update the timeout clocks in their running timeout thread.
+If multiple timers are enabled, multiple threads will be initiated. On timeout scoreboard calculate the expected interrupt status and update RAL registers.
 
 For a read transaction, during the address channel for interrupt status CSR rv_timer will predict its value according to the timer timeout threads.
 During the data channel, rv_timer scoreboard will compare the read data with expected data in RAL.

--- a/hw/ip/spi_device/doc/_index.md
+++ b/hw/ip/spi_device/doc/_index.md
@@ -397,7 +397,7 @@ See [Command Upload](#command-upload) section for details.
 
 Command parser (*cmdparse*) processes the first byte of the SPI and activates the processing submodules depending on the received opcode and the *cmd_info* list described in the previous section.
 
-The cmdparse compares the recevied opcode with the *cmd_info.opcode* data structure.
+The cmdparse compares the received opcode with the *cmd_info.opcode* data structure.
 If any entry matches to the received opcode, the cmdparse hands over the matched command information entry with the index to the corresponding submodule.
 As explained in the [previous section](#command-information-list), the command parser checks the index to activate Read Status / Read JEDEC ID/ Read Command / Address 4B modules.
 Other than the first 11 slots and last two slots (the last two slots are not visible to SW), the cmdparse checks the *upload* field and activates the upload module if the field is set.
@@ -413,7 +413,7 @@ Except BUSY bit and WEL bit, other bits are controlled by SW.
 BUSY bit is set by HW when it receives any commands that are uploaded to the FIFOs and their `busy` fields are 1 in the command information entry.
 SW may clear BUSY bit when it completes the received commands (e.g Erase/ Program).
 
-If BUSY is set, SPI_DEVICE IP blocks the passhthrough interface in Passthrough mode.
+If BUSY is set, SPI_DEVICE IP blocks the passthrough interface in Passthrough mode.
 The blocking of the interface occurs in SPI transaction idle state (CSb == 1).
 When SW clears the BUSY bit, it is applied to the STATUS register in the SPI clock domain when SPI clock toggles.
 It means the update happens when the next SPI transaction is received.
@@ -462,7 +462,7 @@ HW repeats the operation until CSb is de-asserted.
 The read command block has multiple sub-blocks to process normal Read, Fast Read, Fast Read Dual/ Quad from the internal DPSRAM.
 The DPSRAM has a 2kB region for the read command access.
 The read command region has two 1kB buffers.
-If HW recives the read access to the other half of the space first time, then the HW reports to the SW to refill the current 1kB region with new content.
+If HW receives the read access to the other half of the space first time, then the HW reports to the SW to refill the current 1kB region with new content.
 
 The double buffering scheme aids the SW to prepare the next chunk of data.
 SW copies a portion of data (1kB) from the internal flash memory into SPI_DEVICE DPSRAM.
@@ -477,7 +477,7 @@ The state machine in this block shifts the address one-by-one and decrements the
 When it reaches the 4B address (`addr[2]`), the module triggers the DPSRAM state machine to fetch data from the DPSRAM.
 When the module receives `addr[0]`, at the positive edge of SCK, the module moves to appropriate command state based on the given CMD_INFO data.
 
-If the received address falls into mailbox address ragne and mailbox feature is enabled, the module turns on the mailbox selection bit.
+If the received address falls into mailbox address range and mailbox feature is enabled, the module turns on the mailbox selection bit.
 Then all out-going requests to the DPSRAM are forwarded to the mailbox section, not the read buffer section.
 
 #### Dummy Cycle
@@ -561,7 +561,7 @@ The module also manipulates the data if needed.
 
 #### Command Filtering
 
-Fitering the incoming command is the key role of the Passthrough module.
+Filtering the incoming command is the key role of the Passthrough module.
 
 ![Command Filtering logic in Passthrough mode](passthrough-filter.svg)
 
@@ -614,7 +614,7 @@ The passthrough module consumes the lower byte first as SPI flash writes byte 0 
 For example, bit `[7:0]` is processed then `[15:8]`, `[23:16]`, and `[31:24]` at last.
 
 The CSRs affect the commands that have *payload_swap_en* as 1 in their command list entries.
-SW may use additional command informatio slots for the passthrough (index 11 to 23).
+SW may use additional command information slots for the passthrough (index 11 to 23).
 SW must configure *payload_dir* to **PayloadIn** and *payload_en* to `4'b 0001` in order for the payload translation feature to work correctly.
 
 #### Output Enable Control
@@ -630,7 +630,7 @@ SW is recommended to set the filter bit for Passthrough to not deliver the unmat
 #### Internally processed Commands
 
 As described in [SPI Device Modes](#spi-device-modes-and-active-submodules), SPI_DEVICE may return the data from the IP even if the passthrough mode is set.
-The HW can process Read Status, Read JEDEC ID, Read SFDP, Read commands accessing themailbox region, and EN4B/EX4B.
+The HW can process Read Status, Read JEDEC ID, Read SFDP, Read commands accessing the mailbox region, and EN4B/EX4B.
 
 SW configures {{<regref "INTERCEPT_EN">}} CSR to enable the feature.
 SW may selectively enable/disable commands.
@@ -871,7 +871,7 @@ In the TPM CRB mode (TPM_CFG.tpm_mode is 1), the logic always upload the command
 
 ### Return-by-HW register update
 
-The SW manages the retun-by-HW registers.
+The SW manages the return-by-HW registers.
 The contents are placed inside the SPI_DEVICE CSRs.
 The SW must maintain the other TPM registers outside of the SPI_DEVICE HWIP and use write/read FIFOs to receive the content from/ send the register value to the host system.
 

--- a/hw/ip/spi_host/doc/_index.md
+++ b/hw/ip/spi_host/doc/_index.md
@@ -409,10 +409,10 @@ In Pass-though mode, control of the CSB lines passes directly to the inter-modul
 
 The command interface can allows for any number of segments in a given command.
 
-Since most SPI Flash transactions typically consist of 3 or 4 segemnts, there is a small command FIFO for submitting segments to the SPI_HOST IP, so that firmware can issue the entire transaction at one time.
+Since most SPI Flash transactions typically consist of 3 or 4 segments, there is a small command FIFO for submitting segments to the SPI_HOST IP, so that firmware can issue the entire transaction at one time.
 
 Writing a segment description to {{< regref "COMMAND" >}} when {{< regref "STATUS.READY" >}} is low will trigger an error condition, which must be acknowledged by software.
-When submitting multiple segments to the the command queue, firmware can also check the {{< regref "STATUS.CMDQD" >}} register to determine how many unprocessed segements are in the FIFO.
+When submitting multiple segments to the the command queue, firmware can also check the {{< regref "STATUS.CMDQD" >}} register to determine how many unprocessed segments are in the FIFO.
 
 ## Data Formatting
 
@@ -614,7 +614,7 @@ There are six types of error events which each represent a violation of the SPI_
 - If {{< regref "COMMAND" >}} is written when {{< regref "STATUS.READY">}} is zero, the IP will assert {{< regref "ERROR_STATUS.CMDERR" >}}.
 - The IP asserts {{< regref "ERROR_STATUS.OVERFLOW" >}} if it receives a write to {{< regref "TXDATA" >}} when the TX FIFO is full.
 - The IP asserts {{< regref "ERROR_STATUS.UNDERFLOW" >}} if it software attempts to read {{< regref "RXDATA" >}} when the RX FIFO is empty.
-- Specifying a command segment with an invalid width (speed), or making a request for a Bidirectional Dual- or Quad-width segement will trigger a {{< regref "ERROR_STATUS.CMDINVAL" >}} error event.
+- Specifying a command segment with an invalid width (speed), or making a request for a Bidirectional Dual- or Quad-width segment will trigger a {{< regref "ERROR_STATUS.CMDINVAL" >}} error event.
 - Submitting a command segment to an invalid CSID (one larger or equal to `NumCS`) will trigger a {{< regref "ERROR_STATUS.CSIDINVAL" >}} event.
 - {{< regref "ERROR_STATUS.ACCESSINVAL" >}} is asserted if the IP receives a write event to the {{< regref "TXDATA" >}} window that does not correspond to any known processor data type (byte, half- or full-word).
 
@@ -627,7 +627,7 @@ Clearing the bit corresponding bit in the {{< regref "ERROR_ENABLE" >}} register
 The {{< regref "ERROR_STATUS" >}} register will continue to report all violations even if a particular class of error event has been disabled.
 
 Of the six error event classes, `ACCESSINVAL` error events are the only ones which cannot be disabled.
-This is because `ACCESSINVAL` events are caused by anomolous TLUL byte-enable masks that do not correspond to any known software instructions, and can only occur through a fault in the hardware integration.
+This is because `ACCESSINVAL` events are caused by anomalous TLUL byte-enable masks that do not correspond to any known software instructions, and can only occur through a fault in the hardware integration.
 
 When handling SPI_HOST `error` interrupts, the {{< regref "ERROR_STATUS" >}} bit should be cleared *before* clearing the error interrupt in the {{< regref "INTR_STATE" >}} register.
 Failure do to so may result in a repeated interrupt.
@@ -835,7 +835,7 @@ head: {
 The connection from the shift register to the `sd` bus depends on the speed of the current segment.
 - In Standard-mode, only the most significant shift register bit, `sr_q[7]` is connected to the outputs using `sd_o[0]`.
 In this mode, each `shift_en_i` pulse is induces a shift of only one bit.
-- In Dual-mode, the two most significant bits, `sr_q[7:6]`, are connected to `sd_o[1:0]` and the shift register shifts by two bits with eery `shift_en_i` pulse.
+- In Dual-mode, the two most significant bits, `sr_q[7:6]`, are connected to `sd_o[1:0]` and the shift register shifts by two bits with every `shift_en_i` pulse.
 - In Quad-mode, the four most significant bits, `sr_q[7:4]`, are connected to `sd_o[3:0]` and the shift register shifts four bits with every pulse.
 
 The connections to the shift register inputs are similar.
@@ -1238,7 +1238,7 @@ From an implementation standpoint, the presence of a stall condition has two eff
 1. No flops or registers may be updated during a stall condition.
 Thus the FSM may not progress while stalled.
 
-2. All handshaking or control signals to other blocks must be surpressed during a stall condition, placing backpressure on the rest the blocks within the IP to also stop operations until the stall is resolved.
+2. All handshaking or control signals to other blocks must be suppressed during a stall condition, placing backpressure on the rest the blocks within the IP to also stop operations until the stall is resolved.
 
 # Programmer's Guide
 
@@ -1395,7 +1395,7 @@ To enable interrupts when ever the RX FIFO reaches the watermark, assert {{< reg
 
 ## Exception Handling
 
-The SPI_HOST will assert one of the {{< regref "ERROR_STATUS" >}} bits in the event of a firmware programming error, and will become unreponsive until firmware acknowledges the error by clearing the corresponding error bit.
+The SPI_HOST will assert one of the {{< regref "ERROR_STATUS" >}} bits in the event of a firmware programming error, and will become unresponsive until firmware acknowledges the error by clearing the corresponding error bit.
 
 The SPI_HOST interrupt handler should clear any bits in {{< regref "ERROR_STATUS" >}} bit before clearing {{< regref "INTR_STATE.error" >}}.
 

--- a/hw/ip/spi_host/doc/dv/index.md
+++ b/hw/ip/spi_host/doc/dv/index.md
@@ -48,7 +48,7 @@ The following utilities provide generic helper tasks and functions to perform ac
   parameter int NumCS = 1;
 ```
 Currently there verification only covers NumCS = 1 since this is the configuration that will be used in tapeout.
-Endianess implemented and verified is only Little Endian with ByteOrder set to 1
+Endianness implemented and verified is only Little Endian with ByteOrder set to 1
 
 ### Global types & methods
 All common types and methods defined at the package level can be found in
@@ -192,7 +192,7 @@ In the current state the agent recognises 6 commands:
 
 for V1 only ReadStd, WriteStd and CmdOnly has been implemented.
 
-The agent monitor will capture both the outgoing host transactions where it creates an item for the device sequence and for the scoreboard to check agains the configuration.
+The agent monitor will capture both the outgoing host transactions where it creates an item for the device sequence and for the scoreboard to check against the configuration.
 and the incoming device transactions where it will capture the response items and forward them to another tlm_analysis_port in the host scoreboard.
 
 
@@ -211,7 +211,7 @@ It provides commonly used handles, variables, functions and tasks that the test 
 Some of the most commonly used tasks / functions are as follows:
 * generate_transaction()
 
-  Generates a SPI transaction of n segments with command, address, dummy and data segements
+  Generates a SPI transaction of n segments with command, address, dummy and data segments
 
 * read_rx_fifo()
 

--- a/hw/ip/sysrst_ctrl/doc/_index.md
+++ b/hw/ip/sysrst_ctrl/doc/_index.md
@@ -140,7 +140,7 @@ Software should therefore read and clear the {{< regref WKUP_STATUS >}} register
 Also note that the detection status is sticky.
 I.e., software needs to explicitly disable this feature by setting {{< regref ULP_CTL >}} to 0 in order to clear the FSM state.
 If software wants to re-arm the mechanism right away, it should first read back {{< regref ULP_CTL >}} to make sure it has been cleared before setting that register to 1 again.
-This is needed because this register has to be syncronized over to the AON clock domain.
+This is needed because this register has to be synchronized over to the AON clock domain.
 
 ## Pin input value accessibility
 

--- a/hw/ip/tlul/doc/TlulProtocolChecker.md
+++ b/hw/ip/tlul/doc/TlulProtocolChecker.md
@@ -15,7 +15,7 @@ for TL-UL (TileLink Uncached Lightweight), based on
 The next sections list the checks for each signal of TL-UL channels A and D.
 More details:
 
-*   The source fields (`a_source` and `d_source`) identify inflight
+*   The source fields (`a_source` and `d_source`) identify in-flight
 transactions rather than physical agents. A single agent can use multiple
 source IDs to track multiple outstanding transactions. See spec section 5.4
 "Source and Sink Identifiers" for more details.

--- a/hw/ip/tlul/doc/_index.md
+++ b/hw/ip/tlul/doc/_index.md
@@ -101,12 +101,12 @@ The function of the user bits are separately described in a separate table.
 | `d_sink[DIW-1:0]`   | input  | Response ID of configurable width (possibly unused) |
 | `d_user[DUW-1:0]`   | input  | Response attributes of configurable width; includes error responses plus other attributes TBD. **This is an augmentation to the TL-UL specification.** |
 
-The `a_user` bus contains serveral signals
+The `a_user` bus contains several signals
 - `instr_type` - controls whether the transaction is an instruction fetch type
 - `cmd_intg`   - carries the command integrity of the transaction
 - `data_intg`  - carries the write data integrity of the transaction
 
-The `d_user` bus contains serveral signals
+The `d_user` bus contains several signals
 - `rsp_intg`   - carries the response integrity of the transaction
 - `data_intg`  - carries the read data integrity of the transaction
 
@@ -208,12 +208,11 @@ endpackage
 
 #### Usage of Address
 
-All signaling for host-request routing is encapsulated in the `a_addr`
-signal. (See section 5.3 of the TileLink specification). Ie. for a bus
-host to designate which device it is talking to, it only needs to indicate
-the correct device register/memory address. The other host signals (namely
-`a_source` and `a_user`) do not enter into the address calculation. All
-request steering must thus be made as a function of the address.
+All signaling for host-request routing is encapsulated in the `a_addr` signal.
+(See section 5.3 of the TileLink specification).
+For a bus host to designate which device it is talking to, it only needs to indicate the correct device register/memory address.
+The other host signals (namely `a_source` and `a_user`) do not enter into the address calculation.
+All request steering must thus be made as a function of the address.
 
 #### Usage of Source and Sink ID Bits
 
@@ -297,7 +296,7 @@ The following list gives examples of future usage for `a_user` and
 - `a_user` modifications
   - Instruction Type
     - This indicates whether the transaction originates from a code fetch or data fetch.
-    - This attribute is used by downstream consumers to provide separate priviledge control based on transaction type.
+    - This attribute is used by downstream consumers to provide separate privilege control based on transaction type.
   - Command Integrity
     - This is the calculated integrity of the instruction type, transaction address, transaction op code and mask.
     - The integrity is checked by downstream consumers to ensure the transaction has not been tampered.

--- a/hw/ip/tlul/doc/dv/index.md
+++ b/hw/ip/tlul/doc/dv/index.md
@@ -76,7 +76,7 @@ Some of the most commonly used tasks / functions are as follows:
 #### Functional coverage
 To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
 The following covergroups have been developed to prove that the test intent has been adequately met:
-* common covergroup from tl_agent:  Cover each host/device reaches its maximum outsanding requests
+* common covergroup from tl_agent:  Cover each host/device reaches its maximum outstanding requests
 * same_device_access_cg:            Cover each device has been accessed by all its hosts at the same time
 * same_source_access_cg:            Cover all hosts use the same ID at the same time and all the IDs have been used at this sequence
 * max_delay_cg:                     Cover zero delay, small delay and large delay have been used in every host and device
@@ -97,7 +97,7 @@ Due to this limitation, scoreboard is designed as following:
   When device receives a transaction, check if there is a same item in its queue and the item is allowed to be appeared out of order.
 * For d_channel, use same structure to check items from device to host.
 * If the transaction is unmapped, it won't be sent to any device. Host will return an error response with `d_error = 1`.
-  Each host has a queue used only for unmapped items. It stores the unmapped item from a_channal, then compare it with the same source ID response received in d_channel.
+  Each host has a queue used only for unmapped items. It stores the unmapped item from a_channel, then compare it with the same source ID response received in d_channel.
 
 Following analysis fifos are created to retrieve the data monitored by corresponding interface agents:
 * a_chan_host/device_name, d_chan_host/device_name: These fifos provide transaction items at the end of address channel and data channel respectively from host/device

--- a/hw/ip/uart/doc/_index.md
+++ b/hw/ip/uart/doc/_index.md
@@ -95,7 +95,7 @@ TX pin on positive edges of the baud clock.
 If TX is not enabled, written DATA into FIFO will be stacked up and sent out
 when TX is enabled.
 
-When the FIFO becomes empty as part of transmittion, a TX FIFO empty interrupt will be raised.
+When the FIFO becomes empty as part of transmission, a TX FIFO empty interrupt will be raised.
 This is separate from the TX FIFO water mark interrupt.
 
 
@@ -107,8 +107,8 @@ half a bit-time later (i.e. 8 cycles of the oversample clock) that the
 line is still low before detecting the START bit. If the line has
 returned high the glitch is ignored. After it detects the START bit,
 the RX module samples at the center of each bit-time and gathers
-incoming serial bits into a charcter buffer. If the STOP bit is
-detected as high and the optional partity bit is correct the data byte
+incoming serial bits into a character buffer. If the STOP bit is
+detected as high and the optional parity bit is correct the data byte
 is pushed into a 32 byte deep RX FIFO. The data can be read out by
 reading {{< regref "RDATA" >}} register.
 
@@ -119,13 +119,13 @@ initial sample point is aligned with the center of the START bit. The
 receiver will then sample every 16 cycles of the 16 x baud clock, the
 diagram below shows the number of ticks after the centering that each
 bit is captured. Because of the frequency difference between the
-transmiter and receiver the actual sample point will drift compared to
+transmitter and receiver the actual sample point will drift compared to
 the ideal center of the bit. In order to correctly receive the STOP
 bit it must be sampled between the "early" and "late" points shown
 on the diagram, which are half a bit-time or 8 ticks of the 16x baud
 clock before or after the center. If the transmitter is considered
 "ideal" then the local clock must thus differ by no more than plus or
-minus 8 ticks in 144 or aproximately +/- 5.5%. If parity is enabled
+minus 8 ticks in 144 or approximately +/- 5.5%. If parity is enabled
 the stop bit will be a bit time later, so this becomes 8/160 or about
 +/- 5%.
 
@@ -214,7 +214,7 @@ If the RX FIFO level becomes greater than or equal to RX water mark level (confi
 Note that the watermark interrupts are edge triggered events.
 This means the interrupt only triggers when the condition transitions from untrue->true.
 This is especially important in the tx_watermark case.
-When the TX FIFO is empty, it by default satisifies all the watermark conditions.
+When the TX FIFO is empty, it by default satisfies all the watermark conditions.
 In order for the interrupt to trigger then, it is required that software initiates a write burst that is greater than the programmed watermark value.
 
 For example, assume TX watermark is programmed to be less than 4 bytes, and software programs one byte at a time, waits for it to finish transmitting, before supplying the next byte.
@@ -316,7 +316,7 @@ character from the RX FIFO and right after it there is a baud clock tick and the
 start of a new RX transaction from the host, the timeout time is reduced by 1
 and half baud clock periods.
 
-#### rx_partity_err
+#### rx_parity_err
 The `rx_parity_err` interrupt is triggered if parity is enabled and
 the RX parity bit does not match the expected polarity as programmed
 in {{< regref "CTRL.PARITY_ODD" >}}.
@@ -343,7 +343,7 @@ baud rate error target and when care is needed.
 Also note that because the baud rate is multiplied by 2^20 care is
 needed not to overflow 32-bit registers. Baud rates can easily be more
 than 12 bits. The code below is careful to force 64-bit
-arithmetic. (Even if the complier is pre-computing constants there can
+arithmetic. (Even if the compiler is pre-computing constants there can
 be unexpected overflow).
 
 ```cpp

--- a/hw/ip/uart/doc/dv/index.md
+++ b/hw/ip/uart/doc/dv/index.md
@@ -75,7 +75,7 @@ Some of the most commonly used tasks / functions are as follows:
 #### Functional coverage
 To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
 The following covergroups have been developed to prove that the test intent has been adequately met:
-* common covergroup for interrupts `hw/dv/sv/cip_lib/cip_base_env_cov.sv`: Cover interrupt value, interrupt enable, intr_test, interrup pin
+* common covergroup for interrupts `hw/dv/sv/cip_lib/cip_base_env_cov.sv`: Cover interrupt value, interrupt enable, intr_test, interrupt pin
 * uart_cg in uart_agent_cov `hw/dv/sv/uart_agent/uart_agent_cov.sv`:       Cover direction, uart data, en_parity, odd_parity and baud rate
 * fifo_level_cg `hw/ip/uart/dv/env/uart_env_cov.sv`:                       Cover all fifo level with fifo reset for both TX and RX
 

--- a/hw/lint/doc/index.md
+++ b/hw/lint/doc/index.md
@@ -16,7 +16,7 @@ The lint flow run scripts and waiver files are available in the GitHub repositor
 However, the _"lowRISC Lint Rules"_ are available as part of the default policies in AscentLint release 2019.A.p3 or newer (as `LRLR-v1.0.policy`).
 This enables designers that have access to this tool to run the lint flow provided locally on their premises.
 
-Our linting flow leverages FuseSoC to resolve dependencies, build file lists and call the linting tools. See [here](https://github.com/olofk/fusesoc) for an introduction to this opensource package manager and [here](https://docs.opentitan.org/doc/ug/install_instructions/) for installation instructions.
+Our linting flow leverages FuseSoC to resolve dependencies, build file lists and call the linting tools. See [here](https://github.com/olofk/fusesoc) for an introduction to this open source package manager and [here](https://docs.opentitan.org/doc/ug/install_instructions/) for installation instructions.
 
 In order to run lint on a [comportable IP](https://docs.opentitan.org/doc/rm/comportability_specification/) block, the corresponding FuseSoC core file must have a lint target and include (optional) waiver files as shown in the following example taken from the FuseSoC core of the AES comportable IP:
 ```

--- a/hw/top_earlgrey/_index.md
+++ b/hw/top_earlgrey/_index.md
@@ -44,12 +44,12 @@ Modify `xbar_main.hjson` for the host / device connectivity
 
 Main configuration for Top Earlgrey is in `data/top_earlgrey.hjson`. The users
 need to specify the list of peripherals, memories, crossbars, and the interrupts
-in the configuration file. The tool then reads relavant information from the
+in the configuration file. The tool then reads relevant information from the
 each peripheral blocks' configuration. For instance, if `uart` module is used,
 the tool reads `hw/ip/uart/data/uart{_reg}.hjson` and parses the information such
 as input/output, the size of its register space, and interrupts.
 
-For the memories, the tool utilizes the `type` and instantiates relavant modules
+For the memories, the tool utilizes the `type` and instantiates relevant modules
 including the converter from TL-UL interface to the native interfaces (SRAM,
 ROM, eFlash). The user only needs to describe the base address and the memory
 size.

--- a/hw/top_earlgrey/doc/_index.md
+++ b/hw/top_earlgrey/doc/_index.md
@@ -9,7 +9,7 @@ title: "OpenTitan Earl Grey Chip Datasheet"
 The OpenTitan Earl Grey chip is a low-power secure microcontroller that is designed for several use cases requiring hardware security.
 The block diagram is shown above and shows the system configuration, including the Ibex processor and all of the memories and comportable IPs.
 
-As can be seen in the blockdiagram, the system is split into a fast processor core domain that runs on a 100MHz jittery clock, and a peripheral domain that runs at 24MHz.
+As can be seen in the block diagram, the system is split into a fast processor core domain that runs on a 100MHz jittery clock, and a peripheral domain that runs at 24MHz.
 Further, a portion of the peripheral domain, the analog sensor top and the padring can stay always-on.
 The rest of the system can be shut off as part of the sleep mode.
 

--- a/hw/top_earlgrey/doc/design/index.md
+++ b/hw/top_earlgrey/doc/design/index.md
@@ -170,7 +170,7 @@ See the [UART specification]({{< relref "hw/ip/uart/doc" >}}) for more details o
 
 ##### GPIO
 
-The chip contains one GPIO peripheral that creates 32 bits of bidrectional communication with the outside world via the pinmux.
+The chip contains one GPIO peripheral that creates 32 bits of bidirectional communication with the outside world via the pinmux.
 Via pinmux any of the 32 pins of GPIO can be connected to any of the 32 MIO chip pins, in any direction.
 See the [GPIO specification]({{< relref "hw/ip/gpio/doc" >}}) for more details on this peripheral.
 See the [pinmux specification]({{< relref "hw/ip/pinmux/doc" >}}) for how to connect peripheral IO to chip IO.

--- a/hw/top_earlgrey/doc/dv/index.md
+++ b/hw/top_earlgrey/doc/dv/index.md
@@ -40,7 +40,7 @@ In addition, it instantiates the following interfaces, connects them to the DUT 
 * [JTAG interface]()
 * SPI interface
 * UART interface
-* SW logger inteface (for test boot ROM as well as the test SW)
+* SW logger interface (for test boot ROM as well as the test SW)
 * SW test status monitor
 * Backdoor memory interfaces (for ROM, SRAM and the flask banks)
 * Individual control pins:

--- a/hw/top_earlgrey/ip/ast/doc/_index.md
+++ b/hw/top_earlgrey/ip/ast/doc/_index.md
@@ -963,7 +963,7 @@ synchronous to the adc controller.
 3.   Select an analog channel to measure by setting the corresponding
      bit in ‘adc\_chnsel\_i’ bus. This triggers a measurement.
 
-4.   Wait unitl ‘adc\_d\_val’ is set and read the result via
+4.   Wait until ‘adc\_d\_val’ is set and read the result via
      ‘adc\_d\_o’
 
 5.   Clear ‘adc\_chnsel\_i’ bus to 0. Note that adc\_chnsel must be

--- a/hw/top_earlgrey/ip/ast/doc/_index.md
+++ b/hw/top_earlgrey/ip/ast/doc/_index.md
@@ -976,7 +976,7 @@ synchronous to the adc controller.
 
 {{< wavejson >}}
 {
-  signal: [ 
+  signal: [
     {node: '.a..b........', phase:0.2},
     {name: 'adc_pd_i' ,     wave: '10|..|.....|....|..1'},
     {name: 'clk_ast_adc_i', wave: 'p.|..|.....|....|...'},
@@ -985,7 +985,7 @@ synchronous to the adc controller.
     {name: 'adc_d_o' ,      wave: 'x.|..|.3.x.|.4..|.x.', data: ['ch0', 'ch1', 'ch1']},
    ],
 
-  edge: [ 'a<->b wakeup time', ] 
+  edge: [ 'a<->b wakeup time', ]
 }
 {{< /wavejson >}}
 
@@ -1026,7 +1026,7 @@ CSRNG. The details of this interface are still under discussion.
     {name: 'entropy_req_o' , wave: '01|.0.1.....0'},
     {name: 'entropy_ack_i' , wave: '0.|10.1.01..0'},
     {name: 'entropy_i',      wave: 'xx|2x.22x222x'},
-  ] 
+  ]
 }
 {{< /wavejson >}}
 

--- a/hw/top_earlgrey/ip/xbar/doc/checklist.md
+++ b/hw/top_earlgrey/ip/xbar/doc/checklist.md
@@ -45,7 +45,7 @@ Documentation | [DOC_INTEGRATION_GUIDE][] | Waived      | This checklist item ha
 Documentation | [MISSING_FUNC][]          | N/A         |
 Documentation | [FEATURE_FROZEN][]        | Done        |
 RTL           | [FEATURE_COMPLETE][]      | Done        |
-RTL           | [PORT_FROZEN][]           | Done        | Targetting for current top_earlgrey( Port can be changed later based on top_earlgrey config)
+RTL           | [PORT_FROZEN][]           | Done        | Targeting for current top_earlgrey( Port can be changed later based on top_earlgrey config)
 RTL           | [ARCHITECTURE_FROZEN][]   | Done        |
 RTL           | [REVIEW_TODO][]           | Done        | PR [#837][] is pending
 RTL           | [STYLE_X][]               | Done        |

--- a/sw/device/lib/base/README.md
+++ b/sw/device/lib/base/README.md
@@ -5,7 +5,7 @@ This subtree provides headers and libraries known collectively as `libbase`, whi
 ## Differences from a `libc`
 
 `libbase` is not a `libc`, even though it implements a number of `libc` symbols, and should not be used as such.
-`libbase` is, rather, a place for base libraries which may need to make use of more compiler/platform intrinsics than average, in order to present a safe, stable, and uesful interface that other parts of OpenTitan can rely on.
+`libbase` is, rather, a place for base libraries which may need to make use of more compiler/platform intrinsics than average, in order to present a safe, stable, and useful interface that other parts of OpenTitan can rely on.
 
 In general, a library exposing general utilities for working close to the hardware should live in this subtree: for example, a library providing `memcpy` and related symbols.
 A library for talking to a particular peripheral, like a UART port, is a non-example.

--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -20,7 +20,7 @@ libraries.
 
 There is one DIF library per hardware IP, and each one contains the DIFs
 required to actuate all of the specification-required functionality of the
-hardware they are written for. 
+hardware they are written for.
 
 Each DIF library contains both auto-generated (which are checked-in to our
 repository under the `autogen/` subtree), and manually-implemented DIFs (which
@@ -42,7 +42,7 @@ be subsequently edited. Specifically, the script will create:
   `util/make_new_dif/templates/dif_autogen_unittest.cc.tpl`.
 2. boilerplate templates (that should be manually edited/enhanced) for the
    the portion of the IP DIF library that is manually implemented, including:
-  * a (public) header for the DIF, based on 
+  * a (public) header for the DIF, based on
   `util/make_new_dif/templates/dif_template.h.tpl`], and
   * a checklist for the DIF, based on `doc/project/sw_checklist.md.tpl`.
 
@@ -138,7 +138,7 @@ The base types defined in `sw/device/lib/dif/dif_base.h` include:
 
 The base types that are expected to be defined separately by all DIF libraries
 include:
-* `dif_<ip>_t` -- an **auto-generated** type representing a handle to the 
+* `dif_<ip>_t` -- an **auto-generated** type representing a handle to the
   peripheral. Its first (and only) field is always the base address for the
   peripheral registers, styled `mmio_region_t base_addr;`.
   This type is usually passed by `const` pointer, except when it is
@@ -233,14 +233,14 @@ interrupt DIFs may not exist._
 * `dif_<ip>_irq_t` is an enum that lists all of the interrupt types for this
   peripheral. These derrived from the `interrupt_list` attribute within an IP's
   HJSON file.
-* `dif_result_t dif_<ip>_irq_get_state(const dif_<ip>_t *handle, 
+* `dif_result_t dif_<ip>_irq_get_state(const dif_<ip>_t *handle,
   dif_<ip>_irq_state_snapshot_t *snapshot, bool *is_pending);` returns a
   snapshot of the entire interrupt state register, to check the status of all
-  interrupts for a peripheral. 
+  interrupts for a peripheral.
 * `dif_result_t dif_<ip>_irq_is_pending(const dif_<ip>_t *handle, dif_<ip>_irq_t
   irq, bool *is_pending);` checks whether a specific interrupt is
   pending (i.e., if the interrupt has been asserted but not yet cleared).
-* `dif_result_t dif_<ip>_irq_acknowledge_all(const dif_<ip>_t *handle);` 
+* `dif_result_t dif_<ip>_irq_acknowledge_all(const dif_<ip>_t *handle);`
   acknowledges all interrupts have been serviced, marking them as
   complete by clearing all pending bits. This function does nothing and returns
   `kDifOk` if no interrupts were pending.

--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -173,7 +173,7 @@ are **manually-implemented**.
 * `dif_<ip>_transaction_t` is a struct representing runtime parameters for
   starting a hardware transaction. It is only present when `dif_<ip>_start()` is
   defined. This type is always passed by value. A DIF library my opt to use
-  another pre-existing type instead, when that type provides a more semanticly
+  another pre-existing type instead, when that type provides a more semantically
   appropriate meaning.
 * `dif_<ip>_output_t` is a struct describing how to output a completed
   transaction. Often, this will be a type like `uint8_t *`. The same caveats
@@ -195,7 +195,7 @@ dif_result_t dif_<ip>_mode_<mode>_end(const dif_<ip>_t *handle,
 ```
 There is no requirement that `_start()` and `_end()` share the same set of
 `<mode>`s; for example, there might be a single `dif_<ip>_start()` but many
-`dif_<ip>_mode_<mode>_end()`s. This style of API is prefered over using
+`dif_<ip>_mode_<mode>_end()`s. This style of API is preferred over using
 `union`s with `dif_<ip>_transaction_t` and `dif_<ip>_output_t`.
 
 #### Register Locking
@@ -223,7 +223,7 @@ for interrupt management. A DIF library for a peripheral providing such
 registers must provide this interface. To ensure this, all interrupt DIFs,
 including: headers, (C) implementations, and unit tests, are *auto-generated* from
 templates and an IP's HJSON configuration file using the `util/make_new_dif.py`
-tool (decribed above).
+tool (described above).
 
 If a peripheral is defined with `no_auto_intr_regs: true`, this exact API is not
 required even if the `INTR_` registers are provided (though DIF libraries are
@@ -231,7 +231,7 @@ encouraged to follow it where it makes sense). _In these cases, auto-generated
 interrupt DIFs may not exist._
 
 * `dif_<ip>_irq_t` is an enum that lists all of the interrupt types for this
-  peripheral. These derrived from the `interrupt_list` attribute within an IP's
+  peripheral. These derived from the `interrupt_list` attribute within an IP's
   HJSON file.
 * `dif_result_t dif_<ip>_irq_get_state(const dif_<ip>_t *handle,
   dif_<ip>_irq_state_snapshot_t *snapshot, bool *is_pending);` returns a

--- a/sw/device/lib/dif/_index.md
+++ b/sw/device/lib/dif/_index.md
@@ -173,7 +173,7 @@ are **manually-implemented**.
 * `dif_<ip>_transaction_t` is a struct representing runtime parameters for
   starting a hardware transaction. It is only present when `dif_<ip>_start()` is
   defined. This type is always passed by value. A DIF library my opt to use
-  another pre-existing type instead, when that type provides a more semanticly
+  another pre-existing type instead, when that type provides a more semantically
   appropriate meaning.
 * `dif_<ip>_output_t` is a struct describing how to output a completed
   transaction. Often, this will be a type like `uint8_t *`. The same caveats
@@ -195,7 +195,7 @@ dif_result_t dif_<ip>_mode_<mode>_end(const dif_<ip>_t *handle,
 ```
 There is no requirement that `_start()` and `_end()` share the same set of
 `<mode>`s; for example, there might be a single `dif_<ip>_start()` but many
-`dif_<ip>_mode_<mode>_end()`s. This style of API is prefered over using
+`dif_<ip>_mode_<mode>_end()`s. This style of API is preferred over using
 `union`s with `dif_<ip>_transaction_t` and `dif_<ip>_output_t`.
 
 #### Register Locking
@@ -223,7 +223,7 @@ for interrupt management. A DIF library for a peripheral providing such
 registers must provide this interface. To ensure this, all interrupt DIFs,
 including: headers, (C) implementations, and unit tests, are *auto-generated* from
 templates and an IP's HJSON configuration file using the `util/make_new_dif.py`
-tool (decribed above).
+tool (described above).
 
 If a peripheral is defined with `no_auto_intr_regs: true`, this exact API is not
 required even if the `INTR_` registers are provided (though DIF libraries are
@@ -231,7 +231,7 @@ encouraged to follow it where it makes sense). _In these cases, auto-generated
 interrupt DIFs may not exist._
 
 * `dif_<ip>_irq_t` is an enum that lists all of the interrupt types for this
-  peripheral. These derrived from the `interrupt_list` attribute within an IP's
+  peripheral. These derived from the `interrupt_list` attribute within an IP's
   HJSON file.
 * `dif_result_t dif_<ip>_irq_get_state(const dif_<ip>_t *handle,
   dif_<ip>_irq_state_snapshot_t *snapshot, bool *is_pending);` returns a

--- a/sw/device/lib/testing/_index.md
+++ b/sw/device/lib/testing/_index.md
@@ -4,7 +4,7 @@ title: "Chip-Level Test Libraries"
 
 # Overview
 
-This subtree contains _test libary code_ that could aid in the writing of [chip-level tests]({{< relref "sw/device/tests/index.md" >}}).
+This subtree contains _test library code_ that could aid in the writing of [chip-level tests]({{< relref "sw/device/tests/index.md" >}}).
 Test library code consists of two components:
 1. `testutils` libraries, and
 2. the [on-device test framework]({{< relref "sw/device/lib/testing/test_framework/index.md" >}}).
@@ -31,6 +31,6 @@ code will live in: `sw/device/lib/testing/test\_framework`.
 - Pass-through `sw/device/lib/dif_base.h` types where appropriate.
   This allows testutils functions to easily mix with DIFs within chip-level tests.
 - Avoid defining testutils that call a single DIF, and use the DIF directly.
-  If a DIF does not exist for your needs, create one by following the [DIF developement guide]({{< relref "sw/device/lib/dif" >}}).
+  If a DIF does not exist for your needs, create one by following the [DIF development guide]({{< relref "sw/device/lib/dif" >}}).
 
 {{% sectionContent %}}

--- a/sw/device/lib/testing/test_rom/README.md
+++ b/sw/device/lib/testing/test_rom/README.md
@@ -21,4 +21,4 @@ In DV, a subset of tests will indeed exercise the the bootstrap code paths since
 In FPGA, bootstrap is required and requested by an external host via GPIO.
 Bootstrap can be requested by driving TAP\_STRAP0 (USB\_A18) and TAP\_STRAP1 (USB\_A19) to 0 and 1, respectively, and presenting strong pull-ups on all SW\_STRAP* pins (USB\_A15, USB\_A16, and USB\_A17).
 If bootstrap is requested, the boot ROM initializes the SPI interface and flash controller.
-OpenTitan uses a SPI Flash based boostrap protocol and can be programmed using the `opentitantool`.
+OpenTitan uses a SPI Flash based bootstrap protocol and can be programmed using the `opentitantool`.


### PR DESCRIPTION
Fixes #14805 