### PR TITLE
[fpv] fix random seed syntax error

### DIFF
--- a/hw/ip/prim/rtl/prim_lfsr.sv
+++ b/hw/ip/prim/rtl/prim_lfsr.sv
@@ -312,10 +312,7 @@ module prim_lfsr #(
   logic [LfsrDw-1:0] next_lfsr_state, coeffs;
 
   // Enable the randomization of DefaultSeed using DefaultSeedLocal in DV simulations.
-  `ifdef SYNTHESIS
-    localparam logic [LfsrDw-1:0] DefaultSeedLocal = DefaultSeed;
-
-  `elsif VERILATOR
+  `ifndef SIMULATION
     localparam logic [LfsrDw-1:0] DefaultSeedLocal = DefaultSeed;
 
   `else


### PR DESCRIPTION
FPV does not support rand dist and FPV_INIT with a non-constant. So this PR fixes the syntax error by using the default LFSR seed.

Signed-off-by: Cindy <chencindy@google.com>