### PR TITLE
Fix OTP bitstream splicing

### DIFF
--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:splice.bzl", "bitstream_splice")
+load("//rules:otp.bzl", "get_otp_images")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -60,6 +61,7 @@ filegroup(
         "bitstream_gcp_splice": [":gcp_spliced_test_rom"],
         "//conditions:default": ["@bitstreams//:bitstream_test_rom"],
     }),
+    tags = ["manual"],
 )
 
 filegroup(
@@ -70,18 +72,7 @@ filegroup(
         "bitstream_gcp_splice": [":gcp_spliced_rom"],
         "//conditions:default": ["@bitstreams//:bitstream_rom"],
     }),
-)
-
-filegroup(
-    name = "rom_otp_dev",
-    srcs = select({
-        "bitstream_skip": ["skip.bit"],
-        "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_rom_otp_dev"],
-        "bitstream_gcp_splice": [":gcp_spliced_rom_otp_dev"],
-        # FIXME(#13603) By default, this will actually do a local splice instead
-        # of retrieving the pre-spliced bitstream from the cache.
-        "//conditions:default": [":gcp_spliced_rom_otp_dev"],
-    }),
+    tags = ["manual"],
 )
 
 filegroup(
@@ -91,6 +82,7 @@ filegroup(
         "bitstream_vivado": ["//hw/bitstream/vivado:rom_mmi"],
         "//conditions:default": ["@bitstreams//:rom_mmi"],
     }),
+    tags = ["manual"],
 )
 
 filegroup(
@@ -100,7 +92,27 @@ filegroup(
         "bitstream_vivado": ["//hw/bitstream/vivado:otp_mmi"],
         "//conditions:default": ["@bitstreams//:otp_mmi"],
     }),
+    tags = ["manual"],
 )
+
+[
+    filegroup(
+        name = "rom_otp_" + otp_name,
+        srcs = select({
+            "bitstream_skip": ["skip.bit"],
+            "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_rom_otp_" + otp_name],
+            "bitstream_gcp_splice": [":gcp_spliced_rom_otp_" + otp_name],
+
+            # FIXME(#13807) By default, this will actually do a local splice
+            # instead of retrieving the pre-spliced bitstream from the cache.
+            # Before we cache OTP-spliced bitstreams, we need to work out the
+            # details of the naming scheme.
+            "//conditions:default": [":gcp_spliced_rom_otp_" + otp_name],
+        }),
+        tags = ["manual"],
+    )
+    for (otp_name, _) in get_otp_images()
+]
 
 # Build the Test ROM and splice it into a cached bitstream.
 bitstream_splice(
@@ -124,13 +136,16 @@ bitstream_splice(
     visibility = ["//visibility:private"],
 )
 
-# Splice the OTP Dev image into `:gcp_spliced_rom`.
-bitstream_splice(
-    name = "gcp_spliced_rom_otp_dev",
-    src = ":gcp_spliced_rom",
-    data = "//hw/ip/otp_ctrl/data:img_dev",
-    meminfo = ":otp_mmi",
-    tags = ["manual"],
-    update_usr_access = True,
-    visibility = ["//visibility:private"],
-)
+# Splice OTP images into the locally-spliced ROM bitstream.
+[
+    bitstream_splice(
+        name = "gcp_spliced_rom_otp_" + otp_name,
+        src = ":gcp_spliced_rom",
+        data = img_target,
+        meminfo = ":otp_mmi",
+        tags = ["manual"],
+        update_usr_access = True,
+        visibility = ["//visibility:private"],
+    )
+    for (otp_name, img_target) in get_otp_images()
+]

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -4,6 +4,7 @@
 
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load("//rules:fusesoc.bzl", "fusesoc_build")
+load("//rules:otp.bzl", "get_otp_images")
 load("//rules:splice.bzl", "bitstream_splice")
 
 package(default_visibility = ["//visibility:public"])
@@ -80,14 +81,17 @@ bitstream_splice(
     tags = ["manual"],
 )
 
-# Splice in the dev OTP image, replacing the RMA image.
-bitstream_splice(
-    name = "fpga_cw310_rom_otp_dev",
-    src = ":fpga_cw310_rom",
-    data = "//hw/ip/otp_ctrl/data:img_dev",
-    meminfo = ":otp_mmi",
-    tags = ["manual"],
-)
+# Splice OTP images into the ROM bitstream.
+[
+    bitstream_splice(
+        name = "fpga_cw310_rom_otp_" + otp_name,
+        src = ":fpga_cw310_rom",
+        data = img_target,
+        meminfo = ":otp_mmi",
+        tags = ["manual"],
+    )
+    for (otp_name, img_target) in get_otp_images()
+]
 
 # Standalone CW310 image for use with hyperdebug.
 fusesoc_build(
@@ -139,10 +143,12 @@ pkg_files(
     name = "standard",
     srcs = [
         ":fpga_cw310_rom",
-        ":fpga_cw310_rom_otp_dev",
         ":fpga_cw310_test_rom",
         ":otp_mmi",
         ":rom_mmi",
+    ] + [
+        ":fpga_cw310_rom_otp_" + otp_name
+        for (otp_name, _) in get_otp_images()
     ],
     prefix = "earlgrey/fpga_cw310/standard",
     tags = ["manual"],

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -8,6 +8,10 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
+# This package must be kept in sync with get_otp_images() from //rules:otp.bzl.
+# That is, each OTP image referenced by the macro should have a definition in
+# this BUILD file.
+
 autogen_hjson_header(
     name = "otp_ctrl_regs",
     srcs = [
@@ -57,6 +61,18 @@ otp_json(
 otp_image(
     name = "img_prod",
     src = ":otp_ctrl_prod_json",
+)
+
+otp_json(
+    name = "otp_exec_disabled_json",
+    creator_sw_cfg_rom_exec_en = "0x0",
+    lc_count = 8,
+    lc_state = "RMA",
+)
+
+otp_image(
+    name = "img_exec_disabled",
+    src = ":otp_exec_disabled_json",
 )
 
 filegroup(

--- a/hw/ip/rom_ctrl/util/BUILD
+++ b/hw/ip/rom_ctrl/util/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
@@ -20,6 +20,12 @@ py_binary(
     name = "gen_vivado_mem_image",
     srcs = ["gen_vivado_mem_image.py"],
     deps = [":mem"],
+)
+
+py_test(
+    name = "gen_vivado_mem_image_test",
+    srcs = ["gen_vivado_mem_image_test.py"],
+    deps = [":gen_vivado_mem_image"],
 )
 
 py_binary(

--- a/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
+++ b/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
@@ -3,7 +3,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-'''Script for generating a splicable Vivado ROM image
+'''Tool for generating updatemem-compatible MEM files for ROM or OTP splicing.
 
 This script takes a .vmem file as input and converts that into a format usable
 by Vivado for splicing FPGA bitstreams via updatemem. For details on the
@@ -19,8 +19,167 @@ import argparse
 import sys
 import math
 import re
+import logging
+from typing import List
 
 from mem import MemFile
+
+logger = logging.getLogger('gen_vivado_mem_image')
+
+
+class UpdatememSimulator:
+    """Simulate the externally-visible behavior of updatemem."""
+
+    def __init__(self, num_bitlanes: int, width: int):
+        self.num_bitlanes_ = num_bitlanes
+        self.brams_ = [[0 for _ in range(num_bitlanes)] for _ in range(width)]
+        self.lane_index_ = 0
+        self.block_index_ = 0
+        self.bit_index_ = 0
+
+    def write_updatemem_hex_string(self, hex_word: str) -> None:
+        """Simulate consuming a data column from a MEM file."""
+
+        for nibble in hex_word:
+            value = int(nibble, base=16)
+
+            for _ in range(4):
+                bit = 1 if value & 0b1000 else 0
+                value <<= 1
+                assert bit in [0, 1]
+                assert self.block_index_ != self.num_bitlanes_
+                self.brams_[self.lane_index_][self.block_index_] |= bit << self.bit_index_
+
+                self.lane_index_ += 1
+                if self.lane_index_ == len(self.brams_):
+                    self.lane_index_ = 0
+
+                    self.bit_index_ += 1
+                    if self.bit_index_ == 64 * 4:
+                        self.bit_index_ = 0
+
+                        self.block_index_ += 1
+
+    def render_init_lines(self) -> List[List[str]]:
+        """Render INIT_XX lines like the ones that updatemem would print."""
+
+        line_groups = []
+        for i, bram in enumerate(self.brams_):
+            group = []
+            for j, row in enumerate(bram):
+                group.append(f"simulated INIT_{j:02X}: 256'h{row:064X}")
+            line_groups.append(group)
+
+        return line_groups
+
+
+def parse_otp_init_strings(init_line_groups: List[List[str]]) -> List[int]:
+    """Parse a sequence of 22-bit OTP words from Vivado INIT_XX lines.
+
+    The data layout was determined by running a full Vivado bitstream build and
+    comparing the OTP image (//hw/ip/otp_ctrl/data:img_rma) with the INIT_XX
+    strings that Vivado produces (see the otp_init_strings.txt artifact).
+    """
+
+    out = []
+    brams = []
+
+    for i, lines in enumerate(init_line_groups):
+        bram_scratch = []
+        for line in lines:
+            match = re.search('INIT_.*h([0-9a-fA-F]+)$', line)
+            if not match:
+                continue
+
+            data = match.group(1)
+            bits = []
+            while len(data) > 0:
+                chunk = data[:4]
+                data = data[4:]
+                if chunk == '0000':
+                    bits.append(0)
+                elif chunk == '0001':
+                    bits.append(1)
+                else:
+                    raise Exception("Unexpected chunk in OTP init string:", chunk)
+
+            bram_scratch.append(bits)
+        brams.append(bram_scratch)
+
+    for i in range(1024):
+        # Slice off the first 22 bits.
+        bits = []
+        for bram in brams:
+            if bram[0] == []:
+                bram.pop(0)
+            bits.append(bram[0].pop())
+
+        value = 0
+        for bit in reversed(bits):
+            value = (value << 1) | bit
+
+        logger.debug(f'@{i:06x}: {value:06x} = {bits}')
+        out.append(value)
+
+    return out
+
+
+def otp_words_to_updatemem_pieces(words: List[int]) -> List[str]:
+    """Transform `words` into pieces of an updatemem-compatible MEM file."""
+
+    assert len(words) % 4 == 0
+    assert len(words) <= 1024
+    mask_22_bits = (1 << 22) - 1
+    assert all(word == (word & mask_22_bits) for word in words)
+
+    # The first line indicates that we're starting from the zero address. For
+    # simplicity, we will not print any subsequent addresses.
+    mem_pieces = ['@0']
+    for word in words:
+        # Examining the INIT_XX strings from a full Vivado bitstream build, it
+        # appears that each 22-bit word has its bits reversed and is padded with
+        # 15 zeroes. As a result, the hexadecimal init strings will only contain
+        # '0' and '1' characters.
+        rev = 0
+        for _ in range(22):
+            rev = (rev << 1) | (word & 1)
+            word >>= 1
+
+        words_to_write = [rev] + [0] * 15
+
+        # Concatenate sequential pairs of OTP words before emitting a hex
+        # string. If we naively encoded each 22-bit OTP word as a 6-digit hex
+        # string, updatemem would dutifully write two unwanted zero bits. To
+        # work around this, we concatenate two words for each hex string; 11 hex
+        # digits cleanly represent 44 bits.
+        #
+        # Note that this complexity cannot be avoided by concatenating all the
+        # words and emitting a single hex string because updatemem rejects long
+        # hex strings, saying that they exceed data limits.
+        while len(words_to_write) > 0:
+            word1, word2 = words_to_write[:2]
+            words_to_write = words_to_write[2:]
+
+            # Write 44 bits in hexadecimal.
+            value = word1 << 22 | word2
+            col_string = f'{value:011X}'
+            mem_pieces.append(col_string)
+
+    # Self-check: test the correctness of `mem_pieces` by feeding into a model
+    # of updatemem's behavior. The model can predict the INIT_XX strings that
+    # the real updatemem would print. We also know how to recover OTP memory
+    # contents from INIT_XX strings. Composing these two functions should bring
+    # us back to the original `words` input.
+    updatemem_sim = UpdatememSimulator(0x40, 22)
+    for piece in mem_pieces[1:]:
+        updatemem_sim.write_updatemem_hex_string(piece)
+    init_lines = updatemem_sim.render_init_lines()
+
+    reconstructed = parse_otp_init_strings(init_lines)
+    if len(reconstructed) < len(words) or reconstructed[:len(words)] != words:
+        raise Exception("Generated updatemem data for OTP failed self-check")
+
+    return mem_pieces
 
 
 def swap_bytes(width: int, orig: int, swap_nibbles: bool) -> int:
@@ -35,6 +194,9 @@ def swap_bytes(width: int, orig: int, swap_nibbles: bool) -> int:
 
 
 def main() -> int:
+    logging.basicConfig(format='%(asctime)s [%(filename)s] %(message)s')
+    logger.setLevel(logging.INFO)
+
     parser = argparse.ArgumentParser()
     parser.add_argument('infile', type=argparse.FileType('rb'))
     parser.add_argument('outfile', type=argparse.FileType('w'))
@@ -55,14 +217,23 @@ def main() -> int:
 
     # OpenTitan vmem files should always contain one single contiguous chunk.
     assert len(vmem.chunks) == 1
+    words = vmem.chunks[0].words
 
+    if width == 24:
+        logger.info("Generating updatemem-compatible MEM file for OTP image.")
+        updatemem_pieces = otp_words_to_updatemem_pieces(words)
+        updatemem_line = ' '.join(updatemem_pieces)
+        args.outfile.write(updatemem_line + '\n')
+        return 0
+
+    logger.info("Generating updatemem-compatible MEM file for ROM.")
     # Loop over all words, and:
     # 1) Generate the address,
     # 2) convert the endianness, and
     # 3) write this to the output file.
     addr_chars = 8
     word_chars = math.ceil(width / 4)
-    for idx, word in enumerate(vmem.chunks[0].words):
+    for idx, word in enumerate(words):
         # Generate the address.
         addr = idx * math.ceil(width / 8)
         # Convert endianness.

--- a/hw/ip/rom_ctrl/util/gen_vivado_mem_image_test.py
+++ b/hw/ip/rom_ctrl/util/gen_vivado_mem_image_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from gen_vivado_mem_image import (UpdatememSimulator,
+                                  otp_words_to_updatemem_pieces, swap_bytes)
+
+
+class TestGenVivadoMemImage(unittest.TestCase):
+
+    def test_swap_bytes(self) -> None:
+        swapped = swap_bytes(39, 0x01, swap_nibbles=False)
+        self.assertEqual(swapped, 0x0100000000)
+
+        swapped = swap_bytes(39, 0x0102030405, swap_nibbles=False)
+        self.assertEqual(swapped, 0x0504030201)
+
+        swapped = swap_bytes(39, 0x0102030405, swap_nibbles=True)
+        self.assertEqual(swapped, 0x5040302010)
+
+
+class TestOtpWordsToUpdatememPieces(unittest.TestCase):
+
+    def test_all_ones(self) -> None:
+        words = [0x3fffff] * 4
+        updatemem_pieces = otp_words_to_updatemem_pieces(words)
+        expected = ["@0"] + \
+            ["FFFFFC00000"] + ["00000000000"] * 7 + \
+            ["FFFFFC00000"] + ["00000000000"] * 7 + \
+            ["FFFFFC00000"] + ["00000000000"] * 7 + \
+            ["FFFFFC00000"] + ["00000000000"] * 7
+        self.assertEqual(updatemem_pieces, expected)
+
+    def test_reverses_bits(self) -> None:
+        words = [0x3df00d for _ in range(4)]
+        updatemem_pieces = otp_words_to_updatemem_pieces(words)
+        expected = ["@0"] + \
+            ["B00FBC00000"] + ["00000000000"] * 7 + \
+            ["B00FBC00000"] + ["00000000000"] * 7 + \
+            ["B00FBC00000"] + ["00000000000"] * 7 + \
+            ["B00FBC00000"] + ["00000000000"] * 7
+        self.assertEqual(updatemem_pieces, expected)
+
+    def test_many_words(self) -> None:
+        words = [0x3df00d, 0x2df00d, 0x1df00d, 0x0df00d] * 4 + \
+                [0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff] * 3 + \
+                [0x3df00d, 0x2df00d, 0x1df00d, 0x0df00d]
+        updatemem_pieces = otp_words_to_updatemem_pieces(words)
+
+        quadword1 = ["B00FBC00000"] + ["00000000000"] * 7 + \
+            ["B00FB400000"] + ["00000000000"] * 7 + \
+            ["B00FB800000"] + ["00000000000"] * 7 + \
+            ["B00FB000000"] + ["00000000000"] * 7
+
+        quadword2 = ["FFFFFC00000"] + ["00000000000"] * 7 + \
+            ["FFFFFC00000"] + ["00000000000"] * 7 + \
+            ["FFFFFC00000"] + ["00000000000"] * 7 + \
+            ["FFFFFC00000"] + ["00000000000"] * 7
+
+        expected = ["@0"] + (quadword1 * 4) + (quadword2 * 3) + quadword1
+        self.assertEqual(updatemem_pieces, expected)
+
+    def test_updatemem_simulator(self) -> None:
+
+        def make_init_line(num: int, data: int) -> str:
+            return f"simulated INIT_{num:02X}: 256'h{data:064X}"
+
+        all_zero_init_lines = [make_init_line(i, 0) for i in range(0x40)]
+
+        updatemem = UpdatememSimulator(0x40, 22)
+        updatemem.write_updatemem_hex_string('F')
+        # The first four INIT_00 lines should end with '1'.
+        for i, init_lines in enumerate(updatemem.render_init_lines()):
+            if i < 4:
+                self.assertEqual(init_lines[0], make_init_line(0, 1))
+                self.assertListEqual(init_lines[1:], all_zero_init_lines[1:])
+            else:
+                self.assertListEqual(init_lines, all_zero_init_lines)
+
+        updatemem = UpdatememSimulator(0x40, 22)
+        updatemem.write_updatemem_hex_string('FF')
+        # The first eight INIT_00 lines should end with '1'.
+        for i, init_lines in enumerate(updatemem.render_init_lines()):
+            if i < 8:
+                self.assertEqual(init_lines[0], make_init_line(0, 1))
+                self.assertListEqual(init_lines[1:], all_zero_init_lines[1:])
+            else:
+                self.assertListEqual(init_lines, all_zero_init_lines)
+
+        updatemem = UpdatememSimulator(0x40, 22)
+        updatemem.write_updatemem_hex_string('0F')
+        # The first four INIT_00 lines should be zero, and the next four should
+        # end with '1'.
+        for i, init_lines in enumerate(updatemem.render_init_lines()):
+            if 4 <= i < 8:
+                self.assertEqual(init_lines[0], make_init_line(0, 1))
+                self.assertListEqual(init_lines[1:], all_zero_init_lines[1:])
+            else:
+                self.assertListEqual(init_lines, all_zero_init_lines)
+
+        updatemem = UpdatememSimulator(0x40, 22)
+        updatemem.write_updatemem_hex_string('FFFFFC')
+        # All 22 INIT_00 lines should end with '1'.
+        for i, init_lines in enumerate(updatemem.render_init_lines()):
+            self.assertEqual(init_lines[0], make_init_line(0, 1))
+            self.assertListEqual(init_lines[1:], all_zero_init_lines[1:])
+
+        updatemem = UpdatememSimulator(0x40, 22)
+        updatemem.write_updatemem_hex_string('FFFFFFFFFFF')
+        # All 22 INIT_00 lines should end with '3'.
+        for i, init_lines in enumerate(updatemem.render_init_lines()):
+            self.assertEqual(init_lines[0], make_init_line(0, 0b11))
+            self.assertListEqual(init_lines[1:], all_zero_init_lines[1:])
+
+        updatemem = UpdatememSimulator(0x40, 22)
+        for i in range(256):
+            updatemem.write_updatemem_hex_string('FFFFFFFFFFF')
+        # All INIT_00 and INIT_01 lines should be all 'F'.
+        for i, init_lines in enumerate(updatemem.render_init_lines()):
+            self.assertEqual(init_lines[0], make_init_line(0, 2**256 - 1))
+            self.assertEqual(init_lines[1], make_init_line(1, 2**256 - 1))
+            self.assertListEqual(init_lines[2:], all_zero_init_lines[2:])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
@@ -17,7 +17,7 @@ set_property BITSTREAM.CONFIG.USR_ACCESS TIMESTAMP [current_design]
 
 # Dump MMI for Boot ROM.
 
-proc generate_mmi {filename brams designtask_count} {
+proc generate_mmi {filename brams addr_space_name mem_type loc_prefix designtask_count} {
     send_msg "${designtask_count}-1" INFO "Dumping MMI to ${filename}"
 
     set workroot [file dirname [info script]]
@@ -32,9 +32,10 @@ proc generate_mmi {filename brams designtask_count} {
         if {$slice_begin eq {} || $slice_end eq {}} {
             send_msg "${designtask_count}-2" ERROR "Extraction of ${filename} information failed."
         }
+
         # The scrambled Boot ROM is actually 39 bits wide but the updatemem tool segfaults
         # for slice sizes not divisible by 8.
-        if {[expr {($slice_end - $slice_begin + 1) < 8}]} {
+        if {$filename eq "rom.mmi" && [expr {($slice_end - $slice_begin + 1) < 8}]} {
             set slice_end [expr {$slice_begin + 7}]
         }
         set addr_begin [get_property ram_addr_begin [get_cells $inst]]
@@ -42,32 +43,40 @@ proc generate_mmi {filename brams designtask_count} {
         if {$addr_begin eq {} || $addr_end eq {}} {
             send_msg "${designtask_count}-3" ERROR "Extraction of ${filename} MMI information failed."
         }
+
         # Calculate total number of bits.
         set space [expr {$space + ($addr_end - $addr_begin + 1) * ($slice_end - $slice_begin + 1)}]
+    }
+
+    if {$filename eq "otp.mmi"} {
+        set space [expr {$space * 16}]
     }
 
     # Generate the MMI.
     set space [expr {($space / 8) - 1}]
     puts $fileout "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-    puts $fileout "<MemInfo Version=\"1\" Minor=\"0\">"
+    puts $fileout "<MemInfo Version=\"1\" Minor=\"1\">"
     puts $fileout "  <Processor Endianness=\"Little\" InstPath=\"dummy\">"
-    puts $fileout "  <AddressSpace Name=\"rom\" Begin=\"0\" End=\"$space\">"
+    puts $fileout "  <AddressSpace Name=\"$addr_space_name\" Begin=\"0\" End=\"$space\">"
     puts $fileout "      <BusBlock>"
 
     set part [get_property PART [current_design]]
     foreach inst [lsort -dictionary $brams] {
         set loc [get_property LOC [get_cells $inst]]
-        set loc [string trimleft $loc RAMB36_]
+        set loc [string trimleft $loc $loc_prefix]
         set slice_begin [get_property ram_slice_begin [get_cells $inst]]
         set slice_end [get_property ram_slice_end [get_cells $inst]]
         # The scrambled Boot ROM is actually 39 bits wide but the updatemem tool segfaults
         # for slice sizes not divisible by 4.
-        if {[expr {($slice_end - $slice_begin + 1) < 4}]} {
+        if {$filename eq "rom.mmi" && [expr {($slice_end - $slice_begin + 1) < 4}]} {
             set slice_end [expr {$slice_begin + 3}]
         }
         set addr_begin [get_property ram_addr_begin [get_cells $inst]]
         set addr_end [get_property ram_addr_end [get_cells $inst]]
-        puts $fileout "        <BitLane MemType=\"RAMB32\" Placement=\"$loc\">"
+        if {$filename eq "otp.mmi"} {
+            set addr_end [expr {($addr_end + 1) * 16 - 1}]
+        }
+        puts $fileout "        <BitLane MemType=\"$mem_type\" Placement=\"$loc\">"
         puts $fileout "          <DataWidth MSB=\"$slice_end\" LSB=\"$slice_begin\"/>"
         puts $fileout "          <AddressRange Begin=\"$addr_begin\" End=\"$addr_end\"/>"
         puts $fileout "          <Parity ON=\"false\" NumBits=\"0\"/>"
@@ -84,8 +93,40 @@ proc generate_mmi {filename brams designtask_count} {
     send_msg "${designtask_count}-4" INFO "MMI dumped to ${filepath}"
 }
 
+proc dump_init_strings {filename brams designtask_count} {
+    # For each OTP BRAM, dump all the INIT_XX strings.
+    send_msg "${designtask_count}-1" INFO "Dumping INIT_XX strings to ${filename}"
+
+    set workroot [file dirname [info script]]
+    set filepath "${workroot}/${filename}"
+    set fileout [open $filepath "w"]
+
+    foreach inst [lsort -dictionary $brams] {
+        set bram [get_cells $inst]
+
+        set loc [get_property LOC $bram]
+        puts $fileout "LOC: $loc"
+
+        set init_count 0
+        while 1 {
+            set key [format "INIT_%.2X" $init_count]
+            if { [llength [list_property $bram $key]] eq 0 } {
+                break
+            }
+            set val [get_property $key $bram]
+            puts $fileout "$key $val"
+            incr init_count
+        }
+
+        puts $fileout ""
+    }
+    close $fileout
+    send_msg "${designtask_count}-4" INFO "INIT_XX strings dumped to ${filepath}"
+}
+
 set brams [split [get_cells -hierarchical -filter { PRIMITIVE_TYPE =~ BMEM.bram.* && NAME =~ *u_rom_ctrl*}] " "]
-generate_mmi "rom.mmi" $brams 1
+generate_mmi "rom.mmi" $brams "rom" "RAMB36" "RAMB36_" 1
 
 set brams [split [get_cells -hierarchical -filter { PRIMITIVE_TYPE =~ BMEM.bram.* && NAME =~ *u_otp_ctrl*}] " "]
-generate_mmi "otp.mmi" $brams 2
+generate_mmi "otp.mmi" $brams "otp" "RAMB18" "RAMB18_" 2
+dump_init_strings "otp_init_strings.txt" $brams 3

--- a/sw/device/examples/sram_program/BUILD
+++ b/sw/device/examples/sram_program/BUILD
@@ -106,6 +106,9 @@ opentitan_gdb_fpga_cw310_test(
         monitor reg pmpcfg0 0x9f9f9f9f
         monitor reg pmpaddr0 0x7fffffff
 
+        echo :::: Value of CREATOR_SW_CFG_ROM_EXEC_EN.\\n
+        monitor mdw 0x40131108
+
         echo :::: Load the SRAM program onto the device and check integrity.\\n
         file sram_program.elf
         load sram_program.elf
@@ -125,10 +128,7 @@ opentitan_gdb_fpga_cw310_test(
         ":sram_program_fpga_cw310.elf": "sram_program.elf",
         "//sw/device/silicon_creator/rom:rom_fpga_cw310.elf": "rom.elf",
     },
-    rom_bitstream = "//hw/bitstream:rom",
+    rom_bitstream = "//hw/bitstream:rom_otp_exec_disabled",
     rom_kind = "Rom",
-    tags = [
-        "flaky",
-        "manual",
-    ],
+    tags = ["manual"],
 )


### PR DESCRIPTION
A series of miracles occurred on Friday, enabling me to deduce how updatemem interprets its input and how Vivado lays out data in the BRAMs. With these changes, I can splice OTP values into a bitstream and observe the result in a GDB test! (Now we can disable ROM execution for the SRAM GDB test and drop the flaky tag!)

I think that OTP splicing never worked. To prevent regressions, I think I'll write an "OTP dumper" functest. We can instantiate the functest a few times with a variety of OTP-spliced bitstreams and assert that it prints the expected values.

Fixes #15162
Fixes #15174