### PR TITLE
refactor(dvsim): Remove `verdi` checker

### DIFF
--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -543,13 +543,9 @@ def parse_args():
     waveg.add_argument(
         "--waves",
         "-w",
-        nargs="?",
-        choices=["default", "fsdb", "shm", "vpd", "vcd", "evcd", "fst"],
-        const="default",
-        help=("Enable dumping of waves. It takes an optional "
-              "argument to pick the desired wave format. If "
-              "the optional argument is not supplied, it picks "
-              "whatever is the default for the chosen tool. "
+        choices=["fsdb", "shm", "vpd", "vcd", "evcd", "fst"],
+        help=("Enable dumping of waves. It takes an "
+              "argument to pick the desired wave format."
               "By default, dumping waves is not enabled."))
 
     waveg.add_argument("--max-waves",


### PR DESCRIPTION
dvsim checks if `verdi` tool is searchable to dump `.fsdb` waveform. However, it is not applicable if dvsim launches the task to LSF or cloud farm.

This commit removes the checker and let users to specify the waveform type with `-w {type}` argument.
