### PR TITLE
[rv_dm] Return a TL-UL error on writes to ROM region

### DIFF
--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -369,7 +369,9 @@ module rv_dm
     .Outstanding(1),
     .ByteAccess(1),
     .CmdIntgCheck(1),
-    .EnableRspIntgGen(1)
+    .EnableRspIntgGen(1),
+    // This is a ROM region, hence write requests are not expected.
+    .ErrOnWrite(1)
   ) tl_adapter_device_mem (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
This fixes multiple TL-UL errors that we are currently seeing at the chip-level: #14200, #14653 and #14921. I am currently running the seeds mentioned on these issues to double check whether they can be closed.

Signed-off-by: Michael Schaffner <msf@google.com>