### PR TITLE
[bazel,ci] add CI check to test airgapped bazel builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,27 +139,16 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Confirm no .bazelrc-site files
 
-- job: download_bazel_dependencies
-  displayName: Prefetch Bazel deps
-  # Download Bazel fetched dependencies
+- job: airgapped_bazel_build
+  displayName: Test an airgapped Bazel build
   dependsOn: checkout
+  condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:
     vmImage: ubuntu-20.04
   steps:
   - template: ci/checkout-template.yml
-  - bash: |
-      set -x -e
-      util/prep-bazel-airgapped-build.sh || {
-        echo -n "##vso[task.logissue type=warning]Failed to prefetch Bazel dependencies";
-        exit 1;
-      }
-      rm -rf bazel-airgapped/bitstreams-cache
-      tar -cf bazel-airgapped.tar.gz bazel-airgapped
-    displayName: Pre-fetch and package Bazel dependencies
-    continueOnError: True # This step is flaky on the ubuntu-18.04 image
-  - publish: $(System.DefaultWorkingDirectory)/bazel-airgapped.tar.gz
-    artifact: bazel-dependencies
-    condition: eq(variables['Agent.JobStatus'], 'Succeeded')
+  - template: ci/install-package-dependencies.yml
+  - bash: ci/scripts/test-airgapped-build.sh
 
 - job: slow_lints
   displayName: Quality (in-depth lint)

--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+# Prefetch bazel airgapped dependencies.
+util/prep-bazel-airgapped-build.sh -f
+
+# Remove the airgapped network namespace.
+remove_airgapped_netns() {
+  sudo ip netns delete airgapped
+}
+trap remove_airgapped_netns EXIT
+
+# Set up a network namespace named "airgapped" with access to loopback.
+sudo ip netns add airgapped
+sudo ip netns exec airgapped ip addr add 127.0.0.1/8 dev lo
+sudo ip netns exec airgapped ip link set dev lo up
+
+# Enter the network namespace and perform a build test.
+sudo ip netns exec airgapped sudo -u "$USER" bash -c \
+  "export BAZEL_BITSTREAMS_CACHE=$(pwd)/bazel-airgapped/bitstreams-cache;
+  export BITSTREAM=--offline;
+  export BAZEL_PYTHON_WHEELS_REPO=$(pwd)/bazel-airgapped/ot_python_wheels;
+  bazel-airgapped/bazel build \
+    --distdir=bazel-airgapped/bazel-distdir \
+    --repository_cache=bazel-airgapped/bazel-cache \
+    //sw/device/tests:uart_smoketest_signed_sim_dv;"
+exit 0


### PR DESCRIPTION
This reconfigures the CI job that previously just prefetched the external Bazel dependencies to also run an airgapped Bazel build (using network namespace isolation).

This fixes #15136.