### PR TITLE
[bazel] remove unused build targets

### DIFF
--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -151,7 +151,6 @@ def verilator_params(
     required_data = [
         "@//hw:verilator",
         "@//hw:fusesoc_ignore",
-        "@//sw/host/opentitantool:test_resources",
     ]
     required_tags = ["verilator"]
     kwargs.update(
@@ -219,16 +218,13 @@ def cw310_params(
     required_test_cmds = [
         "--interface=cw310",
     ]
-    required_data = [
-        "@//sw/host/opentitantool:test_resources",
-    ]
     required_tags = [
         "cw310",
         "exclusive",
     ]
     kwargs.update(
         args = default_args + args,
-        data = required_data + data,
+        data = data,
         exit_success = exit_success,
         exit_failure = exit_failure,
         local = local,

--- a/sw/host/opentitansession/BUILD
+++ b/sw/host/opentitansession/BUILD
@@ -28,8 +28,3 @@ rust_binary(
         "//third_party/rust/crates:thiserror",
     ],
 )
-
-filegroup(
-    name = "test_resources",
-    srcs = [":opentitansession"],
-)

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -52,13 +52,6 @@ rust_binary(
     ],
 )
 
-filegroup(
-    name = "test_resources",
-    srcs = [
-        ":opentitantool",
-    ],
-)
-
 pkg_files(
     name = "binary",
     srcs = [":opentitantool"],


### PR DESCRIPTION
It looks like these build targets are unused / unnecessary as they are file groups that export a single target that could each be used directly.

Signed-off-by: Timothy Trippel <ttrippel@google.com>