### PR TITLE
[dv,rom_e2e] update testplan to only track P1 tests in nightlies

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -18,7 +18,7 @@
   fusesoc_core: lowrisc:dv:chip_sim:0.1
 
   // Testplan hjson file, excluding the connectivity tests.
-  testplan: "{proj_root}/hw/top_earlgrey/data/chip_testplan.hjson:-conn"
+  testplan: "{proj_root}/hw/top_earlgrey/data/chip_testplan.hjson:-conn:-no_dv"
 
   // RAL spec - used to generate the RAL model.
   ral_spec: "{proj_root}/hw/top_earlgrey/data/top_earlgrey.hjson"

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -58,7 +58,7 @@
             |   0x1e791123 (Module)   | 0100000d |
             |   0x48eb4bd9 (All)      | ffffffff |
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -76,7 +76,7 @@
                `0x00061a80` (2 s).
               - Verify that watchdog is disabled when `WATCHDOG_BITE_THRESHOLD_CYCLES` is `0`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: ["rom_e2e_shutdown_watchdog"]
     }
@@ -97,7 +97,7 @@
             - Continue and verify that the asm exception handler resets the chip by confirming that
               execution halts at `_rom_start_boot`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -128,7 +128,7 @@
             - Verify that ROM_EXT boots and the chip resets after the write to the ALERT_TEST
               register.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -144,7 +144,7 @@
             - Verify that the chip reports `bootstrap:1` over the UART.
             - Verify that the chip responds to `READ_STATUS` (`0x05`) with `0x00`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -161,7 +161,7 @@
               - ROM will continously reset the chip and output the same `BFV`.
             - Verify that the chip does not respond to `READ_SFDP` (`0x5a`).
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -179,7 +179,7 @@
             - Verify that the chip does not respond to `READ_STATUS` (`0x05`).
               - The data on the CIPO line must be `0xff`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -197,7 +197,7 @@
             - Verify that the chip does not respond to `READ_STATUS` (`0x05`).
               - The data on the CIPO line must be `0xff`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -214,7 +214,7 @@
 
             See `rom_e2e_bootstrap_enabled_requested`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -236,7 +236,7 @@
               - Verify that the chip responds to `READ_STATUS` (`0x05`) with `0x00`.
               - Verify that there was no output from UART.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -255,7 +255,7 @@
               - device ID `0x08`, and
               - density `0x14`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -274,7 +274,7 @@
             - Verify the JEDEC Basic Flash Parameter Table. See this
               [spreadsheet](https://docs.google.com/spreadsheets/d/1cioU3HgsWZXD4-eoUiH9TuVLZeFpucSdjyq5HND-FpQ/edit#gid=0).
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -293,7 +293,7 @@
             - Send `WRITE_DISABLE` (`0x04`) and `READ_STATUS` (`0x05`).
             - Verify that the chip responds with `0x00`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -309,7 +309,7 @@
             - Send `RESET` (`0x99`).
             - Verify that the chip does not output anything over UART for at least 1 s.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -332,7 +332,7 @@
                 (`kErrorBootPolicyBadLength`).
               - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -360,7 +360,7 @@
                 over UART (`kErrorBootPolicyBadIdentifier`).
                 - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -386,7 +386,7 @@
               - This is the start address of the write operation performed above.
             - Verify that the data on the CIPO line does not match `0x4552544f_00000000`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -405,7 +405,7 @@
               - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             - Verify that the chip does not respond to `READ_SFDP` (`0x5a`).
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -424,7 +424,7 @@
             - Verify that the chip outputs the expected `BFV`: `0242500d` over UART (`kErrorBootPolicyBadLength`).
               - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -446,7 +446,7 @@
               - Verify that the chip outputs the expected `BFV`: `0142500d` over UART (`rom_e2e_bootstrap_phase2_page_program`).
                 - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -468,7 +468,7 @@
             - Verify that the chip outputs the expected `BFV`: `0242500d` over UART (`kErrorBootPolicyBadLength`).
               - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -487,7 +487,7 @@
                 - For `SECTOR_ERASE`: `BFV:01425303` (`kErrorBootstrapEraseAddress`) followed by `BFV:0142500d` (`kErrorBootPolicyBadIdentifier`)
                 - For `PAGE_PROGRAM`: `BFV:02425303` (`kErrorBootstrapProgramAddress`) followed by `BFV:0142500d` (`kErrorBootPolicyBadIdentifier`)
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -501,7 +501,7 @@
               - ROM will continously reset the chip and output the same `BFV` and `LCV`.
             - Repeat for all life cycle states: TEST, DEV, PROD, PROD_END, and RMA.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -522,7 +522,7 @@
             |            1            |             0           |   a    |
             |            1            |             1           |   a    |
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -568,7 +568,7 @@
             |   a  | `entry_point` in range, unaligned | `0142500d`                      |
             |   a  | `security_version = 0`            | `0142500d`                      |
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -616,7 +616,7 @@
             |    2   |    0   |   a    |
             |    1   |    1   |   a    |
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -641,7 +641,7 @@
             |   RMA    |                 0                  |            `kHardenedBoolFalse`          |
 
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -673,7 +673,7 @@
             - Attempt to boot.
             - Verify that boot fails with `BFV:kErrorSigverifyBadKey`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -694,7 +694,7 @@
             | PROD_END | Prod              |
             |   RMA    | Test, Prod        |
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -716,7 +716,7 @@
             | PROD_END | Prod              |
             |   RMA    | Test, Prod        |
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -738,7 +738,7 @@
             | `kHardenedBoolFalse`               | Success |
             | `0`                                | Failure |
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -767,7 +767,7 @@
               - All constraints specified
               - Corrupt usage constraints data, e.g. wrong unselected word value.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -790,7 +790,7 @@
             |         Invalid     |   Virtual  |     A     |  Yes  |
             |         Invalid     |   Virtual  |     B     |  Yes  |
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -819,7 +819,7 @@
 
             - Verify that ROM cannot be debugged in PROD and PROD_END.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -864,7 +864,7 @@
             - Load a ROM_EXT with securiy version = 0.
             - Verify that ROM fails to boot with `BFV:kErrorBootPolicyRollback`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -886,7 +886,7 @@
             - Verify that ROM_EXT can detect the interruption and increment the minimum required
               security version.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -904,7 +904,7 @@
               instruction access fault.
             - Verify that execution breaks at the asm handler.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -922,7 +922,7 @@
             - Wait until execution breaks at the first breakpoint, wait ~1s before continuing.
             - Verify that watchdog expires and execution breaks at the asm handler.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -946,7 +946,7 @@
             - Verify that execution breaks at the C interrupt handler.
             - Verify that chip resets with `BFV:kErrorInterrupt`.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -1003,7 +1003,7 @@
             - Verify that `reset_reasons` reports a SW request.
             - Verify that all previously written sections are different.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
 
@@ -1022,7 +1022,7 @@
             - Verify that `reset_reasons` reports a SW request.
             - Verify that all previously written sections are intact.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -1035,7 +1035,7 @@
             - UART
             - Bits 0-5 of the `cpuctrl` CSR: `CREATOR_SW_CFG_CPUCTRL`
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -1047,7 +1047,7 @@
             - ePMP Debug ROM region should be enabled in TEST, DEV, and RMA, anddisabled in PROD and
               PROD_END.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -1061,7 +1061,7 @@
               `OWNER_SW_CFG_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES` if greater than or equal to
               `kWatchdogMinThreshold`, disabled otherwise.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -1074,7 +1074,7 @@
             - Read from OTP in DEV, PROD, PROD_END, and RMA. Checksum of config registers must match
               the OTP value.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -1092,7 +1092,7 @@
             - Verify that `kFlashCtrlInfoPageCreatorSecret` is locked down.
             - Verify that flash_ctrl is initialized.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -1110,7 +1110,7 @@
               - sealing sw binding equals the `binding_value` field of the manifest, and
               - max creator key version equals the `max_key_version` field of the manifest,
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -1125,7 +1125,7 @@
               `sec_mmio_check_counters()`.
             - Verify that a failed sec_mmio check triggers an illegal instruction exception.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }
@@ -1142,7 +1142,7 @@
             Determine which functests can be executed using ROM to understand which tests can be
             reused on the silicon.
             '''
-      tags: ["rom", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
       tests: []
     }


### PR DESCRIPTION
This updates the ROM E2E testplan and chip_sim_cfg.hjson file on only track P1 ROM E2E tests in the DV nightly regression to reflect current efforts.

This fixes #15009.

Signed-off-by: Timothy Trippel <ttrippel@google.com>