### PR TITLE
[ci,doc] Add lld as a package requirement

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -34,6 +34,7 @@ libncursesw5
 libssl-dev
 libudev-dev
 libusb-1.0-0
+lld
 lsb-release
 make
 ninja-build

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -24,11 +24,12 @@ elfutils-libelf
 elfutils-libelf-devel
 libftdi
 libftdi-devel
-openssl-devel
 libudev-devel
 libusbx
-redhat-lsb-core
+lld
 make
+openssl-devel
+redhat-lsb-core
 # A requirement of the prebuilt clang toolchain.
 ncurses
 ninja-build


### PR DESCRIPTION
Add `lld` to `apt-requirements.txt`.
This is to avoid an error raised by `rustc` during bazel builds:
```
collect2: fatal error: cannot find 'ld' compilation terminated.
```