### PR TITLE
fix(tpm): TPM_HASH_START address

### DIFF
--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -175,7 +175,7 @@ module spi_tpm
     12'h 010, // 013:010 Interrupt Status
     12'h 014, // 017:014 Interface Capability
     12'h 018, // 01B:018 Status_x
-    12'h 020, // 023:020 Hash Start
+    12'h 028, // 02B:028 Hash Start
     12'h F00, // F03:F00 DID_VID
     12'h F04  // F04:F04 RID
   };


### PR DESCRIPTION
Related Issue: https://github.com/lowRISC/opentitan/issues/15133

The TPM spec mentioned `TPM_HASH_START` should be return in one wait state or less. TPM IP processes the request in HW to meet the requirement.

However, TPM spec describes the HASH_START address as **0x20** in one part and **0x28** in other parts (register table). The typo has existed from early verion till now (v1.05).

This commit changes the address to **0x28** following the register table. However, the register table also seems to have another typo, which describes the `TPM_HASH_START` register size as two DWORDs (0x28 to 0x2F) not one DWORD (0x28 to 0x2B).
