### PR TITLE
[ci] attempt to fix flakiness of bazel prefetch job

### DIFF
--- a/third_party/python/pip.bzl
+++ b/third_party/python/pip.bzl
@@ -39,6 +39,8 @@ def _pip_wheel_impl(rctx):
         "-m",
         "pip",
         "install",
+        "-U",
+        "--ignore-installed",
         "wheel",
     ]
     rctx.report_progress("Installing the Python wheel package")


### PR DESCRIPTION
This attempts to fix the transient error that occurs in the Bazel prefect job:

```
Installing collected packages: wheel
 (ERROR: Could not install packages due to an OSError:
  [Errno 17] File exists: '/home/vsts/.local/lib/python3.9/site-packages')
```

Signed-off-by: Timothy Trippel <ttrippel@google.com>