### PR TITLE
[chip-test] Add i2c_device_tx_rx test

### DIFF
--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -31,9 +31,17 @@ void i2c_testutils_wr(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count,
   dif_i2c_fmt_flags_t flags = kDefaultFlags;
   uint8_t data_frame;
 
+  // The current function does not support initializing a write while another
+  // transaction is in progress
+
   // TODO: The current function does not support write payloads
   // larger than the fifo depth.
   CHECK(byte_count < I2C_PARAM_FIFO_DEPTH);
+
+  // TODO: #15377 The I2C DIF says: "Callers should prefer
+  // `dif_i2c_write_byte()` instead, since that function provides clearer
+  // semantics. This function should only really be used for testing or
+  // troubleshooting a device.
 
   // First write the address.
   flags.start = true;
@@ -56,12 +64,14 @@ void i2c_testutils_rd(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count) {
   uint8_t data_frame;
   uint8_t fifo_level;
 
+  // The current function doesn't check for space in the FIFOs
+
   // First write the address.
   flags.start = true;
   data_frame = (addr << 1) | kI2cRead;
   CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, data_frame, flags));
 
-  // Once address phase is through, issue the read transaction.
+  // Schedule the read transaction by writing flags to the fifo.
   flags = kDefaultFlags;
   flags.read = true;
   flags.stop = true;
@@ -70,4 +80,87 @@ void i2c_testutils_rd(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count) {
   CHECK_DIF_OK(dif_i2c_write_byte_raw(i2c, byte_count, flags));
 
   // TODO: Check for errors / status.
+}
+
+bool i2c_testutils_target_check_start(dif_i2c_t *i2c, uint8_t *addr) {
+  uint8_t acq_fifo_lvl;
+  CHECK_DIF_OK(dif_i2c_get_fifo_levels(i2c, NULL, NULL, NULL, &acq_fifo_lvl));
+  CHECK(acq_fifo_lvl > 1);
+
+  dif_i2c_signal_t signal;
+  uint8_t byte;
+  CHECK_DIF_OK(dif_i2c_acquire_byte(i2c, &byte, &signal));
+  // Check acq_fifo is as expected and write addr and continue
+  CHECK(signal == kDifI2cSignalStart);
+  *addr = byte >> 1;
+  return byte & kI2cRead;
+}
+
+bool i2c_testutils_target_check_end(dif_i2c_t *i2c, uint8_t *cont_byte) {
+  uint8_t acq_fifo_lvl;
+  CHECK_DIF_OK(dif_i2c_get_fifo_levels(i2c, NULL, NULL, NULL, &acq_fifo_lvl));
+  CHECK(acq_fifo_lvl > 1);
+
+  dif_i2c_signal_t signal;
+  uint8_t byte;
+  CHECK_DIF_OK(dif_i2c_acquire_byte(i2c, &byte, &signal));
+  // Check transaction is terminated with a stop or a continue that the caller
+  // is prepared to handle
+  if (signal == kDifI2cSignalStop) {
+    return false;
+  }
+  CHECK(cont_byte != NULL);
+  *cont_byte = byte;
+  CHECK(signal == kDifI2cSignalRepeat);
+  return true;
+}
+
+void i2c_testutils_target_rd(dif_i2c_t *i2c, uint8_t byte_count,
+                             uint8_t *data) {
+  uint8_t tx_fifo_lvl, acq_fifo_lvl;
+  CHECK_DIF_OK(
+      dif_i2c_get_fifo_levels(i2c, NULL, NULL, &tx_fifo_lvl, &acq_fifo_lvl));
+  // Check there's space in tx_fifo and acq_fifo
+  CHECK(tx_fifo_lvl + byte_count <= I2C_PARAM_FIFO_DEPTH);
+  CHECK(acq_fifo_lvl + 2 <= I2C_PARAM_FIFO_DEPTH);
+
+  for (uint8_t i = 0; i < byte_count; ++i) {
+    CHECK_DIF_OK(dif_i2c_transmit_byte(i2c, data[i]));
+  }
+  // TODO: Check for errors / status.
+}
+
+bool i2c_testutils_target_check_rd(dif_i2c_t *i2c, uint8_t *addr,
+                                   uint8_t *cont_byte) {
+  CHECK(i2c_testutils_target_check_start(i2c, addr) == kI2cRead);
+  // TODO: Check for errors / status.
+  return i2c_testutils_target_check_end(i2c, cont_byte);
+}
+
+void i2c_testutils_target_wr(dif_i2c_t *i2c, uint8_t byte_count) {
+  uint8_t acq_fifo_lvl;
+  CHECK_DIF_OK(dif_i2c_get_fifo_levels(i2c, NULL, NULL, NULL, &acq_fifo_lvl));
+  CHECK(acq_fifo_lvl + 2 + byte_count <= I2C_PARAM_FIFO_DEPTH);
+
+  // TODO: Check for errors / status.
+}
+
+bool i2c_testutils_target_check_wr(dif_i2c_t *i2c, uint8_t byte_count,
+                                   uint8_t *addr, uint8_t *bytes,
+                                   uint8_t *cont_byte) {
+  uint8_t acq_fifo_lvl;
+  CHECK_DIF_OK(dif_i2c_get_fifo_levels(i2c, NULL, NULL, NULL, &acq_fifo_lvl));
+  CHECK(acq_fifo_lvl >= 2 + byte_count);
+
+  CHECK(i2c_testutils_target_check_start(i2c, addr) == kI2cWrite);
+
+  for (uint8_t i = 0; i < byte_count; ++i) {
+    dif_i2c_signal_t signal;
+    CHECK_DIF_OK(dif_i2c_acquire_byte(i2c, bytes, &signal));
+    CHECK(signal == kDifI2cSignalNone);
+  }
+
+  // TODO: Check for errors / status.
+
+  return i2c_testutils_target_check_end(i2c, cont_byte);
 }

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -30,4 +30,70 @@ void i2c_testutils_wr(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count,
  */
 void i2c_testutils_rd(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count);
 
+/**
+ * Check that the i2c target received the start of a transaction
+ *
+ * @param i2c A i2c dif handle.
+ * @param [out] addr The address that was used for the transaction.
+ * @return read Direction of transaction is signaled as Read and not Write
+ */
+bool i2c_testutils_target_check_start(dif_i2c_t *i2c, uint8_t *addr);
+
+/**
+ * Check that the i2c target received the end of a transaction
+ *
+ * @param i2c A i2c dif handle.
+ * @param cont_byte The contents of the acquired restart byte if host has
+ * signaled a repeated START, can be null if test
+ * doesn't accept a repeated start
+ * @return continue
+ */
+bool i2c_testutils_target_check_end(dif_i2c_t *i2c, uint8_t *cont_byte);
+
+/**
+ * Prepare for and respond to an I2C read as a target device
+ *
+ * @param i2c A i2c dif handle.
+ * @param byte_count The number of bytes to be read.
+ * @param data Array of data bytes to be sent.
+ */
+void i2c_testutils_target_rd(dif_i2c_t *i2c, uint8_t byte_count, uint8_t *data);
+
+/**
+ * Check completion of an I2C read as a target device
+ *
+ * @param i2c A i2c dif handle.
+ * @param [out] addr Address that received the i2c read.
+ * @param [out] cont_byte received continuation byte. Can be null if test
+ * expects STOP signal.
+ * @return continue Repeated start has signaled that the transaction should
+ * continue and the contents of cont_byte are valid.
+ */
+bool i2c_testutils_target_check_rd(dif_i2c_t *i2c, uint8_t *addr,
+                                   uint8_t *cont_byte);
+
+/**
+ * Prepare for an I2C write as a target device
+ *
+ * @param i2c A i2c dif handle.
+ * @param byte_count The number of bytes to be written.
+ */
+void i2c_testutils_target_wr(dif_i2c_t *i2c, uint8_t byte_count);
+
+/**
+ * Check completion of an I2C write as a target device
+ *
+ * @param i2c A i2c dif handle.
+ * @param byte_count The number of bytes to be written.
+ * @param [out] addr Address that received the i2c write.
+ * @param bytes Array of bytes to store the result of the write
+ * @param cont_byte received continuation byte. Can be null if test expects STOP
+ * signal.
+ * @return continue Repeated START has signaled that the transaction should
+ * continue and the contents of cont_byte are valid.
+ */
+bool i2c_testutils_target_check_wr(dif_i2c_t *i2c, uint8_t byte_count,
+                                   uint8_t *addr, uint8_t *bytes,
+                                   uint8_t *cont_byte);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_I2C_TESTUTILS_H_

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -50,6 +50,28 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "i2c_device_tx_rx_test",
+    srcs = ["i2c_device_tx_rx_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
+        "//hw/top_earlgrey/ip/clkmgr/data/autogen:clkmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:i2c_testutils",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "flash_ctrl_lc_rw_en_test",
     srcs = ["flash_ctrl_lc_rw_en_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
@@ -20,18 +20,13 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 
-// TODO, remove it once pinout configuration is provided
+// TODO #14111, remove it once pinout configuration is provided
+#include "i2c_regs.h"
 #include "pinmux_regs.h"
 
 static dif_i2c_t i2c;
 static dif_pinmux_t pinmux;
 static dif_rv_plic_t plic;
-
-static const dif_i2c_fmt_flags_t default_flags = {.start = false,
-                                                  .stop = false,
-                                                  .read = false,
-                                                  .read_cont = false,
-                                                  .suppress_nak_irq = false};
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -39,6 +34,8 @@ OTTF_DEFINE_TEST_CONFIG();
  * This symbol is meant to be backdoor loaded by the testbench.
  * The testbench will inform the test the rough speed of the clock
  * used by the I2C modules.
+ *
+ * The I2C Device state machine does depend on the I2C timing configuration
  */
 static volatile const uint8_t kClockPeriodNanos = 0;
 static volatile const uint8_t kI2cRiseFallNanos = 0;
@@ -52,14 +49,32 @@ static volatile const uint32_t kI2cClockPeriodNanos = 0;
 static volatile const uint8_t kI2cIdx = 0;
 
 /**
+ * This set of symbols is meant to be backdoor loaded by the testbench.
+ * to indicate the address that will be listened to by the device.
+ */
+static volatile const uint8_t kI2cDeviceAddress0 = 0x55;
+static volatile const uint8_t kI2cDeviceMask0 = 0x7f;
+static volatile const uint8_t kI2cDeviceAddress1 = 0x7f;  // disable match on
+                                                          // second address
+static volatile const uint8_t kI2cDeviceMask1 = 0x00;
+
+/**
+ * This symbol is meant to be backdoor loaded by the testbench.
+ * to indicate the number of bytes that should be sent.
+ *
+ * Because the test doesn't manage the FIFO during transaction, there's a limit
+ * to the number of bytes we can loopback in the test. I2C_PARAM_FIFO_DEPTH - 4
+ */
+static volatile const uint8_t kI2cByteCount = 0;
+
+static volatile bool tx_empty_irq_seen = false;
+static volatile bool trans_complete_irq_seen = false;
+
+/**
  * Provides external irq handling for this test.
  *
  * This function overrides the default OTTF external ISR.
  */
-static volatile bool fmt_irq_seen = false;
-static volatile bool rx_irq_seen = false;
-static volatile bool done_irq_seen = false;
-
 void ottf_external_isr(void) {
   plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
                              .hart_id = kTopEarlgreyPlicTargetIbex0};
@@ -75,16 +90,12 @@ void ottf_external_isr(void) {
   isr_testutils_i2c_isr(plic_ctx, i2c_ctx, &peripheral, &i2c_irq);
 
   switch (i2c_irq) {
-    case kDifI2cIrqFmtWatermark:
-      fmt_irq_seen = true;
-      i2c_irq = kDifI2cIrqFmtWatermark;
-      break;
-    case kDifI2cIrqRxWatermark:
-      rx_irq_seen = true;
-      i2c_irq = kDifI2cIrqRxWatermark;
+    case kDifI2cIrqTxEmpty:
+      tx_empty_irq_seen = true;
+      i2c_irq = kDifI2cIrqTxEmpty;
       break;
     case kDifI2cIrqTransComplete:
-      done_irq_seen = true;
+      trans_complete_irq_seen = true;
       i2c_irq = kDifI2cIrqTransComplete;
       break;
     default:
@@ -93,51 +104,18 @@ void ottf_external_isr(void) {
   }
 }
 
-static void en_plic_irqs(dif_rv_plic_t *plic) {
-  // Enable functional interrupts as well as error interrupts to make sure
-  // everything is behaving as expected.
-  top_earlgrey_plic_irq_id_t plic_irqs[] = {
-      kTopEarlgreyPlicIrqIdI2c0FmtWatermark,
-      kTopEarlgreyPlicIrqIdI2c0RxWatermark,
-      kTopEarlgreyPlicIrqIdI2c0FmtOverflow, kTopEarlgreyPlicIrqIdI2c0RxOverflow,
-      kTopEarlgreyPlicIrqIdI2c0Nak, kTopEarlgreyPlicIrqIdI2c0SclInterference,
-      kTopEarlgreyPlicIrqIdI2c0SdaInterference,
-      kTopEarlgreyPlicIrqIdI2c0StretchTimeout,
-      // Leave out sda unstable for now until DV side is improved.  Sda
-      // instability during the high cycle is intentionally being introduced
-      // right now.
-      // kTopEarlgreyPlicIrqIdI2c0SdaUnstable,
-      kTopEarlgreyPlicIrqIdI2c0TransComplete};
-
-  for (uint32_t i = 0; i < ARRAYSIZE(plic_irqs); ++i) {
-    CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
-        plic, plic_irqs[i], kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
-
-    // Assign a default priority
-    CHECK_DIF_OK(dif_rv_plic_irq_set_priority(plic, plic_irqs[i],
-                                              kDifRvPlicMaxPriority));
-  }
-
-  // Enable the external IRQ at Ibex.
-  irq_global_ctrl(true);
-  irq_external_ctrl(true);
-}
-
-static void en_i2c_irqs(dif_i2c_t *i2c) {
-  dif_i2c_irq_t i2c_irqs[] = {
-      kDifI2cIrqFmtWatermark, kDifI2cIrqRxWatermark, kDifI2cIrqFmtOverflow,
-      kDifI2cIrqRxOverflow, kDifI2cIrqNak, kDifI2cIrqSclInterference,
-      kDifI2cIrqSdaInterference, kDifI2cIrqStretchTimeout,
-      // Removed for now, see plic_irqs above for explanation
-      // kDifI2cIrqSdaUnstable,
-      kDifI2cIrqTransComplete};
-
-  for (uint32_t i = 0; i <= ARRAYSIZE(i2c_irqs); ++i) {
-    CHECK_DIF_OK(dif_i2c_irq_set_enabled(i2c, i2c_irqs[i], kDifToggleEnabled));
-  }
+void check_addr(uint8_t addr, dif_i2c_id_t id0, dif_i2c_id_t id1) {
+  CHECK(((addr & id0.mask) == id0.address) ||
+        ((addr & id1.mask) == id1.address));
 }
 
 bool test_main(void) {
+  if (kI2cByteCount > I2C_PARAM_FIFO_DEPTH - 4) {
+    LOG_ERROR(
+        "Test cannot fit %d bytes, 2 START records, and 2 STOP records in "
+        "buffers of depth %d",
+        kI2cByteCount, I2C_PARAM_FIFO_DEPTH);
+  }
   CHECK_DIF_OK(
       dif_i2c_init(mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR), &i2c));
   CHECK_DIF_OK(dif_pinmux_init(
@@ -145,7 +123,20 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_rv_plic_init(
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
 
-  en_plic_irqs(&plic);
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      &plic, kTopEarlgreyPlicIrqIdI2c0TxEmpty, kTopEarlgreyPlicTargetIbex0,
+      kDifToggleEnabled));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      &plic, kTopEarlgreyPlicIrqIdI2c0TransComplete,
+      kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      &plic, kTopEarlgreyPlicIrqIdI2c0TxEmpty, kDifRvPlicMaxPriority));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      &plic, kTopEarlgreyPlicIrqIdI2c0TransComplete, kDifRvPlicMaxPriority));
+
+  // Enable the external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
 
   // Temporary hack that connects i2c to a couple of open drain pins.
   CHECK_DIF_OK(dif_pinmux_input_select(&pinmux,
@@ -170,59 +161,65 @@ bool test_main(void) {
   dif_i2c_config_t config;
   CHECK_DIF_OK(dif_i2c_compute_timing(timing_config, &config));
   CHECK_DIF_OK(dif_i2c_configure(&i2c, config));
-  CHECK_DIF_OK(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
-  CHECK_DIF_OK(
-      dif_i2c_set_watermarks(&i2c, kDifI2cLevel30Byte, kDifI2cLevel4Byte));
+  dif_i2c_id_t id0 = {.mask = kI2cDeviceMask0, .address = kI2cDeviceAddress0},
+               id1 = {.mask = kI2cDeviceMask1, .address = kI2cDeviceAddress1};
+  CHECK_DIF_OK(dif_i2c_set_device_id(&i2c, &id0, &id1));
+  CHECK_DIF_OK(dif_i2c_device_set_enabled(&i2c, kDifToggleEnabled));
 
-  en_i2c_irqs(&i2c);
+  // TODO #15081, transaction complete may not be set by i2c device.
+  CHECK(!trans_complete_irq_seen);
+
+  CHECK_DIF_OK(
+      dif_i2c_irq_set_enabled(&i2c, kDifI2cIrqTxEmpty, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_i2c_irq_set_enabled(&i2c, kDifI2cIrqTransComplete,
+                                       kDifToggleEnabled));
 
   // Randomize variables.
-  uint8_t byte_count = rand_testutils_gen32_range(30, 64);
-  uint8_t device_addr = rand_testutils_gen32_range(0, 16);
-  uint8_t expected_data[byte_count];
-  LOG_INFO("Loopback %d bytes with device %d", byte_count, device_addr);
+  uint8_t expected_data[kI2cByteCount];
+  LOG_INFO("Loopback %d bytes with addresses %0h, %0h", kI2cByteCount,
+           kI2cDeviceAddress0, kI2cDeviceAddress1);
 
   // Controlling the randomization from C side is a bit slow, but might be
   // easier for portability to a different setup later.
-  for (uint32_t i = 0; i < byte_count; ++i) {
+  for (uint32_t i = 0; i < kI2cByteCount; ++i) {
     expected_data[i] = rand_testutils_gen32_range(0, 0xff);
   };
 
-  // Write expected data to i2c device.
-  CHECK(!fmt_irq_seen);
-  i2c_testutils_wr(&i2c, device_addr, byte_count, expected_data, false);
+  while (tx_empty_irq_seen == false) {
+  }
+  i2c_testutils_target_rd(&i2c, kI2cByteCount, expected_data);
+  tx_empty_irq_seen = false;
 
-  uint8_t tx_fifo_lvl, rx_fifo_lvl;
-
-  // Make sure all fifo entries have been drained.
+  uint8_t tx_fifo_lvl, acq_fifo_lvl;
   do {
     CHECK_DIF_OK(
-        dif_i2c_get_fifo_levels(&i2c, &tx_fifo_lvl, &rx_fifo_lvl, NULL, NULL));
-  } while (tx_fifo_lvl > 0);
-  CHECK(fmt_irq_seen);
-  fmt_irq_seen = false;
+        dif_i2c_get_fifo_levels(&i2c, NULL, NULL, &tx_fifo_lvl, &acq_fifo_lvl));
+  } while (acq_fifo_lvl < 2);
+
+  CHECK(tx_fifo_lvl == 0);
+
+  uint8_t addr;
+  i2c_testutils_target_check_rd(&i2c, &addr, NULL);
+  check_addr(addr, id0, id1);
 
   // Read data from i2c device.
-  CHECK(!rx_irq_seen);
-  i2c_testutils_rd(&i2c, device_addr, byte_count);
-
-  // Make sure all data has been read back.
+  i2c_testutils_target_wr(&i2c, kI2cByteCount);
   do {
     CHECK_DIF_OK(
-        dif_i2c_get_fifo_levels(&i2c, &tx_fifo_lvl, &rx_fifo_lvl, NULL, NULL));
-  } while (rx_fifo_lvl < byte_count);
-  CHECK(rx_irq_seen);
+        dif_i2c_get_fifo_levels(&i2c, NULL, NULL, &tx_fifo_lvl, &acq_fifo_lvl));
+  } while (acq_fifo_lvl < kI2cByteCount + 2);  // acquired message, address and
+                                               // junk
 
-  // Make sure every read is the same.
-  for (uint32_t i = 0; i < byte_count; ++i) {
-    uint8_t byte;
-    CHECK_DIF_OK(dif_i2c_read_byte(&i2c, &byte));
-    if (expected_data[i] != byte) {
-      LOG_ERROR("Byte %d, Expected data 0x%x, read data 0x%x", i,
-                expected_data[i], byte);
-    }
-  };
-  CHECK(done_irq_seen);
+  uint8_t received_data[kI2cByteCount];
+  i2c_testutils_target_check_wr(&i2c, kI2cByteCount, &addr, received_data,
+                                NULL);
+  check_addr(addr, id0, id1);
+
+  for (uint8_t i = 0; i < kI2cByteCount; ++i) {
+    CHECK(expected_data[i] == received_data[i]);
+  }
+
+  CHECK(trans_complete_irq_seen);
 
   return true;
 }


### PR DESCRIPTION
- Test must be configured by loads so that it sends a set number of bytes in response to an I2c read transaction and then expects them to be written back with an I2c write.
- Address and mask may also be loaded
- TB may send other messages addressed to other I2C devices but should signal the end of transmission with a STOP
- This test contains only the C side Changes

- This test currently relies on an interpretation of the trans_complete interrupt that is consistent with the HWIP, and matches the test-plan. It's also just more useful as an implementation, but it's not currently consistent with the RTL.

Signed-off-by: Drew Macrae <drewmacrae@google.com>