### PR TITLE
[sw/silicon_creator] Harden ROM exception handler

### DIFF
--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -456,7 +456,11 @@ void rom_main(void) {
   shutdown_finalize(rom_try_boot());
 }
 
-void rom_interrupt_handler(void) { shutdown_finalize(rom_irq_error()); }
+void rom_interrupt_handler(void) {
+  register rom_error_t error asm("a0") = rom_irq_error();
+  asm volatile("tail shutdown_finalize;" ::"r"(error));
+  OT_UNREACHABLE();
+}
 
 // We only need a single handler for all ROM interrupts, but we want to
 // keep distinct symbols to make writing tests easier.  In the ROM,

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -77,7 +77,8 @@ lifecycle_state_t lc_state = (lifecycle_state_t)0;
 // Boot data from flash.
 boot_data_t boot_data = {0};
 
-static inline rom_error_t rom_irq_error(void) {
+OT_ALWAYS_INLINE
+static rom_error_t rom_irq_error(void) {
   uint32_t mcause;
   CSR_READ(CSR_REG_MCAUSE, &mcause);
   // Shuffle the mcause bits into the uppermost byte of the word and report
@@ -461,7 +462,7 @@ void rom_interrupt_handler(void) { shutdown_finalize(rom_irq_error()); }
 // keep distinct symbols to make writing tests easier.  In the ROM,
 // alias all interrupt handler symbols to the single handler.
 OT_ALIAS("rom_interrupt_handler")
-void rom_exception_handler(void);
+noreturn void rom_exception_handler(void);
 
 OT_ALIAS("rom_interrupt_handler")
-void rom_nmi_handler(void);
+noreturn void rom_nmi_handler(void);

--- a/sw/device/silicon_creator/rom/rom.h
+++ b/sw/device/silicon_creator/rom/rom.h
@@ -14,9 +14,11 @@ extern "C" {
 /**
  * Denotes functions that have to use the interrupt handler ABI.
  *
- * These must be 4-byte aligned, and they use a different calling convention.
+ * These must be 4-byte aligned. Note that they don't use the `interrupt`
+ * attribute since ROM handlers shut down the chip instead of returning like
+ * regular handlers.
  */
-#define ROM_INTERRUPT_HANDLER_ABI __attribute__((aligned(4), interrupt))
+#define ROM_INTERRUPT_HANDLER_ABI __attribute__((aligned(4)))
 
 /**
  * Denotes functions that have to be near the interrupt vector, because they
@@ -32,7 +34,7 @@ extern "C" {
  * must not be called from other C code.
  */
 ROM_VECTOR_FUNCTION
-void _rom_start_boot(void);
+noreturn void _rom_start_boot(void);
 
 /**
  * The first C function executed by the ROM (defined in `rom.c`)
@@ -44,7 +46,7 @@ noreturn void rom_main(void);
  */
 ROM_VECTOR_FUNCTION
 ROM_INTERRUPT_HANDLER_ABI
-void rom_interrupt_handler(void);
+noreturn void rom_interrupt_handler(void);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
This PR
* Always inlines `rom_irq_error()` to eliminate an unnecessary function call and stack usage in the ROM exception handler,
* Removes the `interrupt` attribute from the exception handler to eliminate unnecessary stack usage,
  * `interrupt` instructs the compiler to generate special entry/exit code but this is relevant only for _regular_ interrupts that are expected to return. ROM exception handler shuts down the chip. See [here](https://clang.llvm.org/docs/AttributeReference.html#interrupt-riscv).
* Makes ROM exception handler `noreturn` (along with `_rom_start_boot`), and
* Uses inline `asm` to avoid the unnecessary `jal` and stack usage for calling `shutdown_finalize()`.

Before:
```
00008180 <rom_exception_handler>:
rom_interrupt_handler():
/proc/self/cwd/sw/device/silicon_creator/rom/rom.c:458
  // `rom_try_boot` will not return unless there is an error.
  CFI_FUNC_COUNTER_PREPCALL(rom_counters, kCfiRomMain, 4, kCfiRomTryBoot);
  shutdown_finalize(rom_try_boot());
}

void rom_interrupt_handler(void) { shutdown_finalize(rom_irq_error()); }
    8180:       7139                    addi    sp,sp,-64                     <- Unnecessary SP usage, this handler does not return.
    8182:       de06                    sw      ra,60(sp)
    8184:       dc16                    sw      t0,56(sp)
    8186:       da1a                    sw      t1,52(sp)
    8188:       d81e                    sw      t2,48(sp)
    818a:       d62a                    sw      a0,44(sp)
    818c:       d42e                    sw      a1,40(sp)
    818e:       d232                    sw      a2,36(sp)
    8190:       d036                    sw      a3,32(sp)
    8192:       ce3a                    sw      a4,28(sp)
    8194:       cc3e                    sw      a5,24(sp)
    8196:       ca42                    sw      a6,20(sp)
    8198:       c846                    sw      a7,16(sp)
    819a:       c672                    sw      t3,12(sp)
    819c:       c476                    sw      t4,8(sp)
    819e:       c27a                    sw      t5,4(sp)
    81a0:       c07e                    sw      t6,0(sp)
    81a2:       710000ef                jal     ra,88b2 <rom_irq_error>       <- Unnecessary jal, could be inlined.
    81a6:       4a7040ef                jal     ra,ce4c <shutdown_finalize>   <- Unnecessary jal, shutdown_finalize does not return
    81aa:       0000                    unimp

000088b2 <rom_irq_error>:
rom_irq_error():
/proc/self/cwd/sw/device/silicon_creator/rom/rom.c:82
  CSR_READ(CSR_REG_MCAUSE, &mcause);
    88b2:       34202573                csrr    a0,mcause
    88b6:       800005b7                lui     a1,0x80000
/proc/self/cwd/sw/device/silicon_creator/rom/rom.c:93
  mcause = (mcause & 0x80000000) | ((mcause & 0x7f) << 24);
    88ba:       8de9                    and     a1,a1,a0
    88bc:       0566                    slli    a0,a0,0x19
    88be:       8105                    srli    a0,a0,0x1
/proc/self/cwd/sw/device/silicon_creator/rom/rom.c:94
  return kErrorInterrupt + mcause;
    88c0:       8d4d                    or      a0,a0,a1
    88c2:       004955b7                lui     a1,0x495
    88c6:       20258593                addi    a1,a1,514 # 495202 <_rom_ext_virtual_size+0x415202>
    88ca:       8d4d                    or      a0,a0,a1
    88cc:       8082                    ret
```


After:
```
00008180 <rom_exception_handler>:
rom_irq_error():
/proc/self/cwd/sw/device/silicon_creator/rom/rom.c:83
boot_data_t boot_data = {0};

OT_ALWAYS_INLINE
static rom_error_t rom_irq_error(void) {
  uint32_t mcause;
  CSR_READ(CSR_REG_MCAUSE, &mcause);
    8180:       34202573                csrr    a0,mcause
    8184:       800005b7                lui     a1,0x80000
/proc/self/cwd/sw/device/silicon_creator/rom/rom.c:94
  //
  // Preserve the MSB and shift the 7 LSBs into the upper byte.
  // (we preserve 7 instead of 5 because the verilog hardcodes the unused bits
  // as zero and those would be the next bits used should the number of
  // interrupt causes increase).
  mcause = (mcause & 0x80000000) | ((mcause & 0x7f) << 24);
    8188:       8de9                    and     a1,a1,a0
    818a:       0566                    slli    a0,a0,0x19
    818c:       8105                    srli    a0,a0,0x1
/proc/self/cwd/sw/device/silicon_creator/rom/rom.c:95
  return kErrorInterrupt + mcause;
    818e:       8d4d                    or      a0,a0,a1
    8190:       004955b7                lui     a1,0x495
    8194:       20258593                addi    a1,a1,514 # 495202 <_rom_ext_virtual_size+0x415202>
    8198:       8d4d                    or      a0,a0,a1
rom_interrupt_handler():
/proc/self/cwd/sw/device/silicon_creator/rom/rom.c:461
  shutdown_finalize(rom_try_boot());
}

noreturn void rom_interrupt_handler(void) {
  register rom_error_t error asm("a0") = rom_irq_error();
  asm volatile("tail shutdown_finalize;" ::"r"(error));
    819a:       4970406f                j       ce30 <shutdown_finalize>
    819e:       0000                    unimp
```

Noticed while working on #14483