### PR TITLE
[dv/kmac] Check app interface is blocked after lc_escalation

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
@@ -71,6 +71,6 @@ interface kmac_app_intf (input clk, input rst_n);
   // Done should be asserted after last, before we start another request
   `ASSERT(DoneAssertAfterLast_A,
     (kmac_data_req.last && kmac_data_req.valid && kmac_data_rsp.ready) |=>
-    !kmac_data_req.valid throughout rsp_done[->1], clk, !rst_n)
+    !kmac_data_req.valid throughout rsp_done[->1], clk, !rst_n || rsp_error)
 
 endinterface

--- a/hw/ip/kmac/dv/env/kmac_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_if.sv
@@ -4,11 +4,13 @@
 
 interface kmac_if(input clk_i, input rst_ni);
 
-  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i;
+  import kmac_env_pkg::*;
 
-  prim_mubi_pkg::mubi4_t idle_o;
-  logic en_masking_o;
-  logic [kmac_pkg::NumAppIntf-1:0] app_err_o;
+  logic                                          en_masking_o;
+  lc_ctrl_pkg::lc_tx_t                           lc_escalate_en_i;
+  prim_mubi_pkg::mubi4_t                         idle_o;
+  kmac_pkg::app_req_t [kmac_pkg::NumAppIntf-1:0] app_req;
+  kmac_pkg::app_rsp_t [kmac_pkg::NumAppIntf-1:0] app_rsp;
 
   function automatic void drive_lc_escalate(lc_ctrl_pkg::lc_tx_t val);
     lc_escalate_en_i = val;
@@ -16,7 +18,12 @@ interface kmac_if(input clk_i, input rst_ni);
 
   `ASSERT(KmacMaskingO_A, `EN_MASKING == en_masking_o)
 
-  // TODO(#10804): confirm with designer if we need to set app_err_o as error.
-  // `ASSERT(LcEscalationAppErr_A, lc_escalate_en_i != lc_ctrl_pkg::Off |->
-  //        ##3 ((app_err_o == 3'b111) throughout (rst_ni == 1)))
+  `ASSERT(AppKeymgrErrOutputZeros_A, app_rsp[AppKeymgr].error |->
+          app_rsp[AppKeymgr].digest_share0 == 0 && app_rsp[AppKeymgr].digest_share1 == 0)
+
+  `ASSERT(AppLcErrOutputZeros_A, app_rsp[AppLc].error |->
+          app_rsp[AppLc].digest_share0 == 0 && app_rsp[AppLc].digest_share1 == 0)
+
+  `ASSERT(AppRomErrOutputZeros_A, app_rsp[AppRom].error |->
+          app_rsp[AppRom].digest_share0 == 0 && app_rsp[AppRom].digest_share1 == 0)
 endinterface

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -970,6 +970,7 @@ class kmac_base_vseq extends cip_base_vseq #(
           send_kmac_app_req(kmac_app_mode);
           wait (cfg.under_reset);
         join_any
+        p_sequencer.kmac_app_sequencer_h[kmac_app_mode].stop_sequences();
         disable fork;
         `DV_CHECK_EQ_FATAL(cfg.under_reset, 1,
             $sformatf("App interface %0s should not response during fatal error", mode.name))

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
@@ -61,6 +61,7 @@ class kmac_lc_escalation_vseq extends kmac_app_vseq;
       kmac_sw_lock_check();
 
       // TODO: Add checking for kmac app request.
+      kmac_app_lock_check();
     end
   endtask
 

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -91,7 +91,8 @@ module tb;
   for (genvar i = 0; i < kmac_pkg::NumAppIntf; i++) begin : gen_kmac_app_intf
     assign app_req[i]                   = kmac_app_if[i].kmac_data_req;
     assign kmac_app_if[i].kmac_data_rsp = app_rsp[i];
-    assign kmac_if.app_err_o[i] = app_rsp[i].error;
+    assign kmac_if.app_req[i] = app_req[i];
+    assign kmac_if.app_rsp[i] = app_rsp[i];
 
     initial begin
       uvm_config_db#(virtual kmac_app_intf)::set(null,


### PR DESCRIPTION
This PR adds a task in lc_escalation sequence to check after lc_escalation is issued, if app requests are sent out, they are ignored by kmac.

Signed-off-by: Cindy Chen <chencindy@google.com>