### PR TITLE
[flash_ctrl,dv] Add fault tests

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -85,6 +85,10 @@ filesets:
       - seq_lib/flash_ctrl_filesystem_support_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_access_after_disable_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_err_base_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_phy_arb_redun_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -188,6 +188,8 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   int       tlul_core_exp_cnt = 0;
   int       tlul_core_obs_cnt = 0;
 
+  int       tlul_eflash_exp_cnt = 0;
+  int       tlul_eflash_obs_cnt = 0;
 
 
   `uvm_object_utils(flash_ctrl_env_cfg)

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
@@ -58,4 +58,8 @@ interface flash_ctrl_if ();
   logic [10:0] lcmgr_state;
   logic        init;
 
+  // v2s error injection
+  logic        host_gnt;
+  logic ctrl_fsm_idle;
+  logic [1:0] host_outstanding;
 endinterface : flash_ctrl_if

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -804,6 +804,10 @@ class flash_ctrl_scoreboard #(
 
     if (ral_name == cfg.flash_ral_name) begin
        if (get_flash_instr_type_err(item, channel)) return (1);
+       if (cfg.tlul_eflash_exp_cnt > 0 && item.d_error == 1) begin
+          cfg.tlul_eflash_obs_cnt++;
+          return 1;
+       end
     end else begin
        if (cfg.tlul_core_exp_cnt > 0 && item.d_error == 1) begin
           cfg.tlul_core_obs_cnt++;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_err_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_err_base_vseq.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Base sequence for fault tests
+class flash_ctrl_err_base_vseq extends flash_ctrl_rw_vseq;
+  `uvm_object_utils(flash_ctrl_err_base_vseq)
+  `uvm_object_new
+
+  task body();
+    int    state_timeout_ns = 100000; // 100us
+    fork
+      begin
+        super.body();
+      end
+      begin
+        run_error_event();
+      end
+    join
+    cfg.seq_cfg.disable_flash_init = 1;
+    cfg.seq_cfg.en_init_keys_seeds = 0;
+    apply_reset();
+    csr_wr(.ptr(ral.init), .value(1));
+    `uvm_info(`gfn,"Test: OTP",UVM_LOW)
+    otp_model();
+    `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rd_buf_en == 1);,
+                 "Timed out waiting for rd_buf_en",
+                 state_timeout_ns)
+    cfg.clk_rst_vif.wait_clks(10);
+  endtask
+
+  virtual task run_error_event(); endtask
+
+  task check_fault(input uvm_object ptr,
+                   input uvm_reg_data_t exp_data = 1);
+    `uvm_info(`gfn, "err assert is done", UVM_MEDIUM)
+    csr_spinwait(.ptr(ptr), .exp_data(exp_data));
+    `uvm_info(`gfn, "csr wait is done is done", UVM_MEDIUM)
+  endtask
+
+endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -15,6 +15,9 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   // Double bit err is created
   bit        global_derr_is_set = 0;
 
+  // Trace host read ountstanding
+  int        d_cnt1, d_cnt2;
+
   // Number of controller transactions per a single task
   // Min: 1 Max:32
   rand int  ctrl_num;
@@ -779,9 +782,12 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       end
 
       cfg.inc_otd_tbl(bank, tl_addr, FlashPartData);
+      d_cnt1++;
       do_direct_read(.addr(tl_addr), .mask('1), .blocking(1), .rdata(rdata),
                      .completed(completed), .exp_err_rsp(derr));
-
+      d_cnt2++;
+      `uvm_info(`gfn, $sformatf("direct_read_trace: sent:%0d rcvd:%0d", d_cnt1, d_cnt2),
+                UVM_HIGH)
       // issue csr rd to capture coverpoint at sb.
       if (derr) begin
         uvm_reg_data_t ldata;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test triggers tb.dut.u_eflash.gen_flash_cores[0].u_core.spurious_ack_o
+// by force.
+class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_vseq;
+  `uvm_object_utils(flash_ctrl_phy_ack_consistency_vseq)
+  `uvm_object_new
+
+  task run_error_event();
+    int delay;
+    bit add_err1, add_err2;
+    string path1 = "tb.dut.u_eflash.gen_flash_cores[0].u_core.ctrl_rsp_vld";
+    string path2 = "tb.dut.u_eflash.gen_flash_cores[0].u_core.host_req_done_o";
+
+    cfg.scb_h.exp_alert["fatal_err"] = 1;
+    cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+    cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
+
+    repeat (2) begin
+      // unit 100 ns;
+      delay = $urandom_range(1, 10);
+      #(delay * 100ns);
+
+      if (add_err1) begin
+        `DV_CHECK(uvm_hdl_release(path1))
+      end
+      if (add_err2) begin
+        `DV_CHECK(uvm_hdl_release(path2))
+      end
+
+      if (add_err1 == 0 && add_err2 == 0) begin
+        randcase
+          1: begin
+            add_err1 = 1;
+            @(posedge cfg.flash_ctrl_vif.ctrl_fsm_idle);
+            `DV_CHECK(uvm_hdl_force(path1, 1))
+          end
+          1: begin
+            add_err2 = 1;
+            wait(cfg.flash_ctrl_vif.host_outstanding == 0);
+            `DV_CHECK(uvm_hdl_force(path2, 1))
+          end
+        endcase // randcase
+      end
+    end // repeat (2)
+    check_fault(ral.fault_status.spurious_ack);
+  endtask
+endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
+  `uvm_object_utils(flash_ctrl_phy_arb_redun_vseq)
+  `uvm_object_new
+
+  task run_error_event();
+    int delay;
+    bit arb_err;
+    string path = {"tb.dut.u_eflash.gen_flash_cores[0].",
+                   "u_core.u_host_arb.gen_input_bufs[1].u_req_buf.out_o[1:0]"};
+    cfg.scb_h.exp_alert["fatal_err"] = 1;
+    cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+    cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
+
+    repeat (2) begin
+      // unit 100 ns;
+      delay = $urandom_range(1, 10);
+      #(delay * 100ns);
+      if (arb_err) begin
+        `DV_CHECK(uvm_hdl_release(path))
+      end else begin
+        arb_err = 1;
+        `DV_CHECK(uvm_hdl_force(path, 2'h0))
+      end
+    end // repeat (2)
+    check_fault(ral.fault_status.arb_err);
+  endtask
+endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence force host read to non data partition
+// to trigger fatal error.
+class flash_ctrl_phy_host_grant_err_vseq extends flash_ctrl_err_base_vseq;
+  `uvm_object_utils(flash_ctrl_phy_host_grant_err_vseq)
+  `uvm_object_new
+
+  task run_error_event();
+    int delay;
+    bit add_err;
+    string path = "tb.dut.u_eflash.gen_flash_cores[0].u_core.muxed_part";
+
+    cfg.scb_h.exp_alert["fatal_err"] = 1;
+    cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+    cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
+
+    repeat (2) begin
+      // unit 100 ns;
+      delay = $urandom_range(1, 10);
+      #(delay * 100ns);
+
+      if (add_err) begin
+        `DV_CHECK(uvm_hdl_release(path))
+      end else begin
+        // This can haapen when host_read is sent to info partition (by force).
+        // After that, fatal error happen. So turning off these assertion
+        // just to make sure test run to complete.
+        $assertoff(0, "tb.dut.u_sw_rd_fifo.DataKnown_A");
+        $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd.u_rd_storage.DataKnown_A");
+        $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd.u_rd_storage.DataKnown_A");
+        $assertoff(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
+        $assertoff(0, "tb.dut.RspPayLoad_A");
+        $assertoff(0, "tb.dut.u_reg_core.u_socket.gen_dfifo[0].fifo_d.rspfifo.DataKnown_A");
+        $assertoff(0, "tb.dut.u_reg_core.u_socket.gen_dfifo[1].fifo_d.rspfifo.DataKnown_A");
+        $assertoff(0, "tb.dut.u_reg_core.u_socket.fifo_h.rspfifo.DataKnown_A");
+        $assertoff(0, "tb.dut.u_to_rd_fifo.TlOutPayloadKnown_A");
+        $assertoff(0, "tb.dut.u_to_rd_fifo.u_rspfifo.DataKnown_A");
+        $assertoff(0, "tb.dut.tlul_assert_device.dKnown_A");
+
+        // set error counter high number to skip unpredictable error
+        cfg.scb_h.exp_tl_rsp_intg_err = 1;
+        cfg.tlul_eflash_exp_cnt = 1;
+        cfg.tlul_core_exp_cnt = 1;
+        cfg.otf_scb_h.comp_off = 1;
+
+        add_err = 1;
+        @(posedge cfg.flash_ctrl_vif.host_gnt);
+        `DV_CHECK(uvm_hdl_force(path, 1))
+
+      end
+    end // repeat (2)
+
+    check_fault(ral.fault_status.host_gnt_err);
+    cfg.tlul_core_exp_cnt = cfg.tlul_core_obs_cnt;
+  endtask
+
+  task launch_host_rd();
+    bit [TL_AW-1:0] tl_addr;
+    bit             saw_err, completed;
+    data_4s_t rdata;
+
+    for (int i = 0; i < cfg.otf_num_hr; ++i) begin
+      tl_addr[OTFHostId-2:0] = $urandom();
+      tl_addr[OTFBankId] = $urandom_range(0, 1);
+      fork
+        tl_access_w_abort(
+                          .addr(tl_addr), .write(1'b0), .completed(completed),
+                          .saw_err(saw_err),
+                          .tl_access_timeout_ns(cfg.seq_cfg.erase_timeout_ns),
+                          .data(rdata), .check_rsp(1'b0), .blocking(1),
+                          .tl_sequencer_h(p_sequencer.tl_sequencer_hs[cfg.flash_ral_name]));
+
+      join_none
+      #0;
+    end
+    csr_utils_pkg::wait_no_outstanding_access();
+  endtask // launch_host_rd
+endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
@@ -29,14 +29,18 @@ class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
         end
       end
       begin
-        for (int i = 0; i < cfg.otf_num_hr; ++i) begin
-          fork
-            send_rand_host_rd();
-          join_none
-          #0;
-        end
-        csr_utils_pkg::wait_no_outstanding_access();
+        launch_host_rd();
       end
     join
+  endtask
+
+  virtual task launch_host_rd();
+    for (int i = 0; i < cfg.otf_num_hr; ++i) begin
+      fork
+        send_rand_host_rd();
+      join_none
+      #0;
+    end
+    csr_utils_pkg::wait_no_outstanding_access();
   endtask
 endclass // flash_ctrl_rw_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -54,3 +54,7 @@
 `include "flash_ctrl_filesystem_support_vseq.sv"
 `include "flash_ctrl_stress_all_vseq.sv"
 `include "flash_ctrl_access_after_disable_vseq.sv"
+`include "flash_ctrl_err_base_vseq.sv"
+`include "flash_ctrl_phy_arb_redun_vseq.sv"
+`include "flash_ctrl_phy_host_grant_err_vseq.sv"
+`include "flash_ctrl_phy_ack_consistency_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -385,7 +385,28 @@
       run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_all=1"]
       reseed: 5
     }
-  ]
+    {
+      name: flash_ctrl_phy_arb_redun
+      uvm_test_seq: flash_ctrl_phy_arb_redun_vseq
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=10",
+                 "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_phy_host_grant_err
+      uvm_test_seq: flash_ctrl_phy_host_grant_err_vseq
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=5",
+                 "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_phy_ack_consistency
+      uvm_test_seq: flash_ctrl_phy_ack_consistency_vseq
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=5",
+                 "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
+      reseed: 5
+    }
+ ]
 
   // List of regressions.
   regressions: [

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -115,6 +115,11 @@ module tb;
                tb.dut.u_eflash.gen_flash_cores[1].u_core.gen_prog_data.u_prog.state_q;
   assign flash_ctrl_if.lcmgr_state = tb.dut.u_flash_hw_if.state_q;
   assign flash_ctrl_if.init = tb.dut.u_flash_hw_if.init_i;
+  assign flash_ctrl_if.host_gnt = tb.dut.u_eflash.gen_flash_cores[0].u_core.host_gnt;
+  assign flash_ctrl_if.ctrl_fsm_idle = tb.dut.u_eflash.gen_flash_cores[0].u_core.ctrl_fsm_idle;
+  assign flash_ctrl_if.host_outstanding =
+               tb.dut.u_eflash.gen_flash_cores[0].u_core.host_outstanding[1:0];
+
 
   wire flash_test_v;
   assign (pull1, pull0) flash_test_v = 1'b1;

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -246,35 +246,39 @@
 
       The phy arbiter for controller and host is redundant.
       The arbiter has two instance underneath that are constantly compared to each other.
-      fault_status.arb_err:
+      tb.dut.u_eflash.gen_flash_cores[0].u_core.u_host_arb.gen_input_bufs[1].u_req_buf.out_o[1:0]
       tb.dut.u_eflash.gen_flash_cores[0].u_core.u_host_arb.gen_input_bufs[0]
       tb.dut.u_eflash.gen_flash_cores[0].u_core.u_host_arb.gen_input_bufs[1]
-      make output of both mismatch
+      make output of both mismatch and check fault_status.arb_err is triggered.
       '''
       stage: V2S
-      tests: []
+      tests: ["flash_ctrl_phy_arb_redun"]
     }
     {
       name: sec_cm_phy_host_grant_ctrl_consistency
       desc: '''Verify the countermeasure(s) PHY_HOST_GRANT.CTRL.CONSISTENCY.
 
-      fault_status.host_gnt_err
-       two error conditions
-       1. a host transaction was granted to the muxed partition, this is illegal
-       2. a host transaction was granted last cycle but somehow controller
-          operations have been kicked off, this is illegal
+      A host transaction was granted to the muxed partition, this is illegal.
+      @ tb.dut.u_eflash.gen_flash_cores[0].u_core.host_gnt,
+      force tb.dut.u_eflash.gen_flash_cores[0].u_core.muxed_part = 1 and check
+      fault_status.host_gnt_err.
       '''
       stage: V2S
-      tests: []
+      tests: ["flash_ctrl_phy_host_grant_err"]
     }
     {
       name: sec_cm_phy_ack_ctrl_consistency
       desc: '''Verify the countermeasure(s) PHY_ACK.CTRL.CONSISTENCY.
-      fault_status.spurious_ack:
-      tb.dut.u_eflash.gen_flash_cores[0].u_core.spurious_ack_o
+
+      Triiger tb.dut.u_eflash.gen_flash_cores[0].u_core.spurious_ack_o as follows:
+      @ tb.dut.u_eflash.gen_flash_cores[0].u_core.ctrl_fsm_idle
+      force tb.dut.u_eflash.gen_flash_cores[0].u_core.ctrl_rsp_vld = 1 or
+      @ tb.dut.u_eflash.gen_flash_cores[0].u_core.host_outstanding[1:0] == 0
+      force tb.dut.u_eflash.gen_flash_cores[0].u_core.host_req_done_o = 1
+      Check fault_status.spurious_ack
       '''
       stage: V2S
-      tests: []
+      tests: ["flash_ctrl_phy_ack_consistency"]
     }
     {
       name: sec_cm_fifo_ctr_redun


### PR DESCRIPTION
Follwoing v2s test items has been implemented here.
 - sec_cm_phy_arbiter_ctrl_redun
 - sec_cm_phy_host_grant_ctrl_consistency
 - sec_cm_phy_ack_ctrl_consistency

Signed-off-by: Jaedon Kim <jdonjdon@google.com>