### PR TITLE
[top/dv] Adjust minimum CSB inactive time for sys_clk

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -380,7 +380,8 @@
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
       sw_images: ["//sw/device/tests/sim_dv:uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_spi_load_bootstrap=1", "+calibrate_usb_clk=1"]
+      run_opts: ["+use_spi_load_bootstrap=1", "+calibrate_usb_clk=1",
+                 "+test_timeout_ns=80_000_000"]
       run_timeout_mins: 180
     }
     {

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -336,9 +336,10 @@ class chip_sw_base_vseq extends chip_base_vseq;
     uint byte_cnt = 0;
     uint SPI_FLASH_PAGE_SIZE = 256;
 
-    // Set CSB inactive times to reasonable values.
-    cfg.m_spi_agent_cfg.min_idle_ns_after_csb_drop = 20;
-    cfg.m_spi_agent_cfg.max_idle_ns_after_csb_drop = 100;
+    // Set CSB inactive times to reasonable values. sys_clk is at 24 MHz, and
+    // it needs to capture CSB pulses.
+    cfg.m_spi_agent_cfg.min_idle_ns_after_csb_drop = 50;
+    cfg.m_spi_agent_cfg.max_idle_ns_after_csb_drop = 200;
 
     // Configure the spi_agent for flash mode and add command info.
     spi_host_agent_configure_flash_cmds();


### PR DESCRIPTION
The minimum CSB inactive time was too low for spi_device's sys_clk. It turns out its sys_clk is 24 MHz. Adjust both that time and the max simulation run time.

Resolves #14207