### PR TITLE
[rom_e2e] add some ROM E2E to DV

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -22,6 +22,13 @@
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
     }
+    {
+      name: rom_e2e_static_critical
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:1:signed"]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: ["+sw_test_timeout_ns=20000000"]
+    }
 
     // Signed chip-level tests to be run with ROM, instead of test ROM.
     {

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -15,6 +15,13 @@
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
     }
+    {
+      name: rom_e2e_shutdown_exception_c
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_shutdown_exception_c:1:signed"]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: ["+sw_test_timeout_ns=20000000"]
+    }
 
     // Signed chip-level tests to be run with ROM, instead of test ROM.
     {

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -115,7 +115,7 @@
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2
-      tests: []
+      tests: ["rom_e2e_shutdown_exception_c"]
     }
 
     {

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -1125,9 +1125,9 @@
               `sec_mmio_check_counters()`.
             - Verify that a failed sec_mmio check triggers an illegal instruction exception.
             '''
-      tags: ["rom", "no_dv", "fpga", "silicon"]
+      tags: ["rom", "dv", "verilator", "fpga", "silicon"]
       stage: V2
-      tests: []
+      tests: ["rom_e2e_static_critical"]
     }
 
     {

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -74,8 +74,12 @@ opentitan_functest(
 opentitan_functest(
     name = "rom_e2e_static_critical",
     srcs = ["rom_e2e_static_critical_test.c"],
+    dv = dv_params(
+        rom = "//sw/device/silicon_creator/rom",
+    ),
     signed = True,
     targets = [
+        "dv",
         "cw310_rom",
         "verilator",
     ],

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -23,8 +23,12 @@ opentitan_functest(
         exit_failure = "NO_FAILURE_MESSAGE",
         exit_success = "BFV:01495202(?s:.*)BFV:01495202",
     ),
+    dv = dv_params(
+        rom = "//sw/device/silicon_creator/rom",
+    ),
     signed = True,
     targets = [
+        "dv",
         "cw310_rom",
         "verilator",
     ],


### PR DESCRIPTION
This adds the following ROM E2E to run in DV:
- rom_e2e_shutdown_exception_c
- rom_e2e_static_critical

This partially addresses #14634.