### PR TITLE
[spi_device/dv] Fix flash mode failures

### DIFF
--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -210,7 +210,7 @@ class spi_monitor extends dv_base_monitor#(
     end : loop_forever
   endtask : collect_curr_trans
 
-  virtual protected task collect_flash_trans(spi_item item, output bit flash_opcode_received);
+  virtual protected task collect_flash_trans(spi_item item, ref bit flash_opcode_received);
     int num_addr_bytes;
     flash_opcode_received = 0;
     // for mode 1 and 3, get the leading edges out of the way

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -508,7 +508,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
           byte_addr_q.push_back(addr[31:24]);
         end
         // push the lower 3 bytes address
-        byte_addr_q = {addr[7:0], addr[15:8], addr[23:16], byte_addr_q};
+        byte_addr_q = {byte_addr_q, addr[23:16], addr[15:8], addr[7:0]};
       end
     end
 

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -248,7 +248,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
   // transaction, save to flash_status_q. it's ok that HW update status to any value in both Q.
   virtual task forever_latch_flash_status();
     forever begin
-      @(negedge cfg.spi_host_agent_cfg.vif.csb);
+      @(negedge cfg.spi_host_agent_cfg.vif.csb[FW_FLASH_CSB_ID]);
       if (flash_status_q.size > 0) begin
         flash_status_settle_q.delete();
         flash_status_settle_q.push_back(flash_status_q[$]);


### PR DESCRIPTION
Fixed failures due to recent updates
1. `output` doesn't work for a task if it's killed, changed to `ref`
2. The address order was updated wrongly

Signed-off-by: Weicai Yang <weicai@google.com>