### PR TITLE
[ottool] Add some simple `serde-annotate` annotations 

### DIFF
--- a/sw/host/opentitanlib/opentitantool_derive/src/lib.rs
+++ b/sw/host/opentitanlib/opentitantool_derive/src/lib.rs
@@ -32,7 +32,7 @@ use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Fields, Ident, Variant
 ///         &self,
 ///         context: &dyn std::any::Any,
 ///         backend: &mut dyn opentitanlib::transport::Transport
-///     ) -> anyhow::Result<Option<Box<dyn erased_serde::Serialize>>> {
+///     ) -> anyhow::Result<Option<Box<dyn serde_annotate::Annotate>>> {
 ///         match self {
 ///             Hello::World(ref __field) => __field.run(context, backend),
 ///             Hello::People(ref __field) => __field.run(context, backend),
@@ -75,7 +75,7 @@ fn dispatch_enum(name: &Ident, e: &DataEnum) -> TokenStream {
                     &self,
                     context: &dyn std::any::Any,
                     backend: &opentitanlib::app::TransportWrapper,
-                ) -> anyhow::Result<Option<Box<dyn erased_serde::Serialize>>> {
+                ) -> anyhow::Result<Option<Box<dyn serde_annotate::Annotate>>> {
                     match self {
                         #(#arms),*
                     }

--- a/sw/host/opentitanlib/src/app/command.rs
+++ b/sw/host/opentitanlib/src/app/command.rs
@@ -4,8 +4,8 @@
 
 use crate::app::TransportWrapper;
 use anyhow::Result;
-use erased_serde::Serialize;
 pub use opentitantool_derive::*;
+use serde_annotate::Annotate;
 use std::any::Any;
 
 /// The `CommandDispatch` trait should be implemented for all leaf structures
@@ -21,5 +21,5 @@ pub trait CommandDispatch {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>>;
+    ) -> Result<Option<Box<dyn Annotate>>>;
 }

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -15,8 +15,8 @@ use crate::transport::{ProxyOps, Transport, TransportError};
 use anyhow::Result;
 use std::time::Duration;
 
-use erased_serde::Serialize;
 use indicatif::{ProgressBar, ProgressStyle};
+use serde_annotate::Annotate;
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -114,7 +114,7 @@ impl TransportWrapper {
     }
 
     /// Invoke non-standard functionality of some Transport implementations.
-    pub fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Serialize>>> {
+    pub fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Annotate>>> {
         self.transport.borrow().dispatch(action)
     }
 

--- a/sw/host/opentitanlib/src/lib.rs
+++ b/sw/host/opentitanlib/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#![feature(min_specialization)]
 pub mod app;
 pub mod backend;
 pub mod bootstrap;

--- a/sw/host/opentitanlib/src/test_utils/bootstrap.rs
+++ b/sw/host/opentitanlib/src/test_utils/bootstrap.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
@@ -21,7 +21,7 @@ pub struct Bootstrap {
 }
 
 impl Bootstrap {
-    pub fn init(&self, transport: &TransportWrapper) -> Result<Option<Box<dyn Serialize>>> {
+    pub fn init(&self, transport: &TransportWrapper) -> Result<Option<Box<dyn Annotate>>> {
         if let Some(bootstrap) = &self.bootstrap {
             self.load(transport, bootstrap)?;
         }

--- a/sw/host/opentitanlib/src/test_utils/init.rs
+++ b/sw/host/opentitanlib/src/test_utils/init.rs
@@ -4,8 +4,8 @@
 
 use anyhow::Result;
 use directories::ProjectDirs;
-use erased_serde::Serialize;
 use log::LevelFilter;
+use serde_annotate::Annotate;
 use std::env::ArgsOs;
 use std::ffi::OsString;
 use std::io::ErrorKind;
@@ -100,7 +100,7 @@ impl InitializeTest {
 
     // Print the result of a command.
     // If there is an error and `RUST_BACKTRACE=1`, print a backtrace.
-    pub fn print_result(operation: &str, result: Result<Option<Box<dyn Serialize>>>) -> Result<()> {
+    pub fn print_result(operation: &str, result: Result<Option<Box<dyn Annotate>>>) -> Result<()> {
         match result {
             Ok(Some(value)) => {
                 log::info!("{}: success.", operation);

--- a/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use structopt::StructOpt;
@@ -32,7 +32,7 @@ pub struct LoadBitstream {
 }
 
 impl LoadBitstream {
-    pub fn init(&self, transport: &TransportWrapper) -> Result<Option<Box<dyn Serialize>>> {
+    pub fn init(&self, transport: &TransportWrapper) -> Result<Option<Box<dyn Annotate>>> {
         if let Some(bitstream) = &self.bitstream {
             self.load(transport, bitstream)
         } else {
@@ -44,7 +44,7 @@ impl LoadBitstream {
         &self,
         transport: &TransportWrapper,
         file: &Path,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         log::info!("Loading bitstream: {:?}", file);
         let payload = std::fs::read(file)?;
         let progress = app::progress_bar(payload.len() as u64);

--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{ensure, Result};
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use serialport::SerialPortType;
 use std::any::Any;
 use std::cell::RefCell;
@@ -180,7 +180,7 @@ impl Transport for CW310 {
         Ok(Rc::clone(inner.spi.as_ref().unwrap()))
     }
 
-    fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Serialize>>> {
+    fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Annotate>>> {
         if let Some(fpga_program) = action.downcast_ref::<FpgaProgram>() {
             // Open the console UART.  We do this first so we get the receiver
             // started and the uart buffering data for us.

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -121,7 +121,7 @@ pub trait Transport {
     }
 
     /// Invoke non-standard functionality of some Transport implementations.
-    fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
+    fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn serde_annotate::Annotate>>> {
         Err(TransportError::UnsupportedOperation.into())
     }
 }

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -46,7 +46,6 @@ rust_binary(
         "//third_party/rust/crates:raw_tty",
         "//third_party/rust/crates:regex",
         "//third_party/rust/crates:serde",
-        #"//third_party/rust/crates:serde_annotate",
         "//third_party/rust/crates:serde_json",
         "//third_party/rust/crates:shellwords",
         "//third_party/rust/crates:structopt",

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -46,6 +46,7 @@ rust_binary(
         "//third_party/rust/crates:raw_tty",
         "//third_party/rust/crates:regex",
         "//third_party/rust/crates:serde",
+        "//third_party/rust/crates:serde_bytes",
         "//third_party/rust/crates:serde_json",
         "//third_party/rust/crates:shellwords",
         "//third_party/rust/crates:structopt",

--- a/sw/host/opentitantool/src/command/bootstrap.rs
+++ b/sw/host/opentitantool/src/command/bootstrap.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{ensure, Result};
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -46,7 +46,7 @@ impl BootstrapCommand {
     fn bootstrap_using_direct_emulator_integration(
         &self,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         ensure!(
             !(self.filename.len() > 1 || self.filename[0].contains('@')),
             "The `emulator` protocol does not support image assembly"
@@ -72,7 +72,7 @@ impl CommandDispatch for BootstrapCommand {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         // The `min_values` structopt attribute should take care of this, but it doesn't.
         ensure!(
             !self.filename.is_empty(),

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Result};
-use erased_serde::Serialize;
 use nix::unistd::isatty;
 use raw_tty::TtyModeGuard;
 use regex::Regex;
+use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
@@ -52,7 +52,7 @@ impl CommandDispatch for Console {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         // We need the UART for the console command to operate.
         transport.capabilities()?.request(Capability::UART).ok()?;
         let mut stdout = std::io::stdout();

--- a/sw/host/opentitantool/src/command/emulator.rs
+++ b/sw/host/opentitantool/src/command/emulator.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ impl CommandDispatch for EmuGetState {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport
             .capabilities()?
             .request(Capability::EMULATOR)
@@ -89,7 +89,7 @@ impl CommandDispatch for EmuStart {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport
             .capabilities()?
             .request(Capability::EMULATOR)
@@ -115,7 +115,7 @@ impl CommandDispatch for EmuStop {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport
             .capabilities()?
             .request(Capability::EMULATOR)

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use structopt::StructOpt;
 
@@ -30,7 +30,7 @@ impl CommandDispatch for GpioRead {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
         let value = gpio_pin.read()?;
@@ -59,7 +59,7 @@ impl CommandDispatch for GpioWrite {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
 
@@ -87,7 +87,7 @@ impl CommandDispatch for GpioSetMode {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
         gpio_pin.set_mode(self.mode)?;
@@ -114,7 +114,7 @@ impl CommandDispatch for GpioSetPullMode {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
         gpio_pin.set_pull_mode(self.pull_mode)?;
@@ -134,7 +134,7 @@ impl CommandDispatch for GpioApplyStrapping {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         transport.apply_pin_strapping(&self.name)?;
         Ok(None)
@@ -153,7 +153,7 @@ impl CommandDispatch for GpioRemoveStrapping {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         transport.remove_pin_strapping(&self.name)?;
         Ok(None)

--- a/sw/host/opentitantool/src/command/hello.rs
+++ b/sw/host/opentitantool/src/command/hello.rs
@@ -8,7 +8,7 @@
 //! the command framework for opentitantool.
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use structopt::StructOpt;
 
@@ -33,7 +33,7 @@ impl CommandDispatch for HelloWorld {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         // Is the world cruel or not?
         let msg = if self.cruel {
             "Hello cruel World!"
@@ -57,7 +57,7 @@ impl CommandDispatch for HelloPeople {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         // The `hello people` command produces no result.
         Ok(None)
     }
@@ -88,7 +88,7 @@ impl CommandDispatch for GoodbyeCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         Ok(Some(Box::new(GoodbyeMessage {
             message: "Goodbye!".to_owned(),
         })))

--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use structopt::StructOpt;
 
@@ -29,7 +29,7 @@ impl CommandDispatch for I2cRawRead {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport)?;
@@ -53,7 +53,7 @@ impl CommandDispatch for I2cRawWrite {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport)?;
@@ -89,7 +89,7 @@ impl CommandDispatch for I2cCommand {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         // None of the I2C commands care about the prior context, but they do
         // care about the `bus` parameter in the current node.
         self.command.run(self, transport)

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -204,9 +204,11 @@ pub struct DigestCommand {
 }
 
 /// Response format for the digest command.
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Annotate)]
 pub struct DigestResponse {
-    pub digest: String,
+    #[serde(with = "serde_bytes")]
+    #[annotate(comment = "SHA256 Digest excluding the image signature bytes", format = hexstr)]
+    pub digest: Vec<u8>,
 }
 
 impl CommandDispatch for DigestCommand {
@@ -222,7 +224,7 @@ impl CommandDispatch for DigestCommand {
             file.write(&digest.to_le_bytes())?;
         }
         Ok(Some(Box::new(DigestResponse {
-            digest: format!("0x{}", hex::encode(&digest.to_be_bytes())),
+            digest: digest.to_be_bytes(),
         })))
     }
 }

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, ensure, Result};
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use std::convert::TryInto;
 use std::fs::File;
@@ -54,7 +54,7 @@ impl CommandDispatch for AssembleCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         // The `min_values` structopt attribute should take care of this, but it doesn't.
         ensure!(
             !self.filename.is_empty(),
@@ -80,7 +80,7 @@ impl CommandDispatch for ManifestShowCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         let image = image::Image::read_from_file(&self.image)?;
         let manifest_def: ManifestSpec = image.borrow_manifest()?.try_into()?;
         Ok(Some(Box::new(manifest_def)))
@@ -132,7 +132,7 @@ impl CommandDispatch for ManifestUpdateCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         let mut image = image::Image::read_from_file(&self.image)?;
 
         // Update the size field in the manifest to reflect the actual size of the image.
@@ -178,7 +178,7 @@ impl CommandDispatch for ManifestVerifyCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         let image = image::Image::read_from_file(&self.image)?;
         let manifest: ManifestSpec = image.borrow_manifest()?.try_into()?;
         let modulus = manifest.modulus().ok_or(anyhow!("Invalid modulus"))?;
@@ -214,7 +214,7 @@ impl CommandDispatch for DigestCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         let image = image::Image::read_from_file(&self.image)?;
         let digest = image.compute_digest();
         if let Some(bin) = &self.bin {

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs;
 use std::path::PathBuf;
@@ -39,7 +39,7 @@ impl CommandDispatch for LoadBitstream {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         log::info!("Loading bitstream: {:?}", self.filename);
         let bitstream = fs::read(&self.filename)?;
         let progress = app::progress_bar(bitstream.len() as u64);

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -19,7 +19,7 @@ pub mod update_usr_access;
 pub mod version;
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use structopt::StructOpt;
 
@@ -35,7 +35,7 @@ impl CommandDispatch for NoOp {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         Ok(None)
     }
 }

--- a/sw/host/opentitantool/src/command/rsa.rs
+++ b/sw/host/opentitantool/src/command/rsa.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -49,7 +49,7 @@ impl CommandDispatch for RsaKeyShowCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         let key = match RsaPublicKey::from_pkcs1_der_file(&self.der_file) {
             Ok(key) => Ok(key),
             Err(_) => match RsaPrivateKey::from_pkcs8_der_file(&self.der_file) {
@@ -84,7 +84,7 @@ impl CommandDispatch for RsaKeyGenerateCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         let private_key = RsaPrivateKey::new()?;
         let mut der_file = self.output_dir.to_owned();
         der_file.push(&self.basename);
@@ -138,7 +138,7 @@ impl CommandDispatch for RsaSignCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         let signature = self.private_key.sign(&self.digest)?;
         if let Some(output) = &self.output {
             signature.write_to_file(output)?;
@@ -171,7 +171,7 @@ impl CommandDispatch for RsaVerifyCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         let key = RsaPublicKey::from_pkcs1_der_file(&self.der_file)?;
         let digest = Sha256Digest::from_str(&self.digest)?;
         let signature = Signature::from_str(&self.signature)?;

--- a/sw/host/opentitantool/src/command/set_pll.rs
+++ b/sw/host/opentitantool/src/command/set_pll.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use structopt::StructOpt;
 
@@ -20,7 +20,7 @@ impl CommandDispatch for SetPll {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         log::info!("Programming the CDCE906 PLL chip with defaults");
         Ok(transport.dispatch(&cw310::SetPll {})?)
     }

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs::{self, File};
 use std::io::{self, Write};
@@ -63,7 +63,7 @@ impl CommandDispatch for SpiSfdp {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport)?;
@@ -105,7 +105,7 @@ impl CommandDispatch for SpiReadId {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport)?;
@@ -154,7 +154,7 @@ impl CommandDispatch for SpiRead {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport)?;
@@ -204,7 +204,7 @@ impl CommandDispatch for SpiErase {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport)?;
@@ -246,7 +246,7 @@ impl CommandDispatch for SpiProgram {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport)?;
@@ -293,7 +293,7 @@ impl CommandDispatch for SpiCommand {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         // None of the SPI commands care about the prior context, but they do
         // care about the `bus` parameter in the current node.
         self.command.run(self, transport)

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -95,8 +95,9 @@ pub struct SpiReadId {
     length: usize,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, Annotate)]
 pub struct SpiReadIdResponse {
+    #[annotate(format = hex)]
     jedec_id: Vec<u8>,
 }
 

--- a/sw/host/opentitantool/src/command/transport.rs
+++ b/sw/host/opentitantool/src/command/transport.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use structopt::StructOpt;
 
@@ -21,7 +21,7 @@ impl CommandDispatch for TransportInit {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         // Configure all GPIO pins to default direction and level, according to
         // configuration files provided.
         transport.apply_default_pin_configurations()?;

--- a/sw/host/opentitantool/src/command/update_usr_access.rs
+++ b/sw/host/opentitantool/src/command/update_usr_access.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
+use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs;
 use std::path::PathBuf;
@@ -34,7 +34,7 @@ impl CommandDispatch for UpdateUsrAccess {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         let mut bs = fs::read(&self.input)?;
         usr_access_set(
             &mut bs,

--- a/sw/host/opentitantool/src/command/version.rs
+++ b/sw/host/opentitantool/src/command/version.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use erased_serde::Serialize;
 use regex::Regex;
+use serde_annotate::Annotate;
 use std::any::Any;
 use std::collections::BTreeMap;
 use structopt::StructOpt;
@@ -44,7 +44,7 @@ impl CommandDispatch for Version {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Serialize>>> {
+    ) -> Result<Option<Box<dyn Annotate>>> {
         let properties = get_volatile_status();
         Ok(Some(Box::new(VersionResponse {
             version: properties.get("BUILD_GIT_VERSION").unwrap().to_string(),

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#![feature(min_specialization)]
 use anyhow::Result;
 use atty::Stream;
 use directories::ProjectDirs;
-use erased_serde::Serialize;
 use log::LevelFilter;
+use serde_annotate::Annotate;
 use serde_annotate::ColorProfile;
 use std::env::{args_os, ArgsOs};
 use std::ffi::OsString;
@@ -157,7 +158,7 @@ fn parse_command_line(opts: Opts, mut args: ArgsOs) -> Result<Opts> {
 
 // Print the result of a command.
 // If there is an error and `RUST_BACKTRACE=1`, print a backtrace.
-fn print_command_result(opts: &Opts, result: Result<Option<Box<dyn Serialize>>>) -> Result<()> {
+fn print_command_result(opts: &Opts, result: Result<Option<Box<dyn Annotate>>>) -> Result<()> {
     match result {
         Ok(Some(value)) => {
             log::info!("Command result: success.");
@@ -166,7 +167,7 @@ fn print_command_result(opts: &Opts, result: Result<Option<Box<dyn Serialize>>>)
             } else {
                 ColorProfile::default()
             };
-            let doc = serde_annotate::serialize(&value)?;
+            let doc = serde_annotate::serialize(value.as_ref())?;
             let string = match opts.format {
                 Format::Json => doc.to_json().color(profile).to_string(),
                 Format::Json5 => doc.to_json5().color(profile).to_string(),

--- a/third_party/rust/crates/BUILD.bazel
+++ b/third_party/rust/crates/BUILD.bazel
@@ -230,7 +230,7 @@ alias(
 
 alias(
     name = "proc_macro2",
-    actual = "@raze__proc_macro2__1_0_43//:proc_macro2",
+    actual = "@raze__proc_macro2__1_0_45//:proc_macro2",
     tags = [
         "cargo-raze",
         "manual",
@@ -302,7 +302,16 @@ alias(
 
 alias(
     name = "serde",
-    actual = "@raze__serde__1_0_144//:serde",
+    actual = "@raze__serde__1_0_145//:serde",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "serde_bytes",
+    actual = "@raze__serde_bytes__0_11_7//:serde_bytes",
     tags = [
         "cargo-raze",
         "manual",
@@ -356,7 +365,7 @@ alias(
 
 alias(
     name = "syn",
-    actual = "@raze__syn__1_0_100//:syn",
+    actual = "@raze__syn__1_0_101//:syn",
     tags = [
         "cargo-raze",
         "manual",
@@ -374,7 +383,7 @@ alias(
 
 alias(
     name = "thiserror",
-    actual = "@raze__thiserror__1_0_35//:thiserror",
+    actual = "@raze__thiserror__1_0_37//:thiserror",
     tags = [
         "cargo-raze",
         "manual",

--- a/third_party/rust/crates/Cargo.raze.lock
+++ b/third_party/rust/crates/Cargo.raze.lock
@@ -187,7 +187,7 @@ dependencies = [
  "num_enum",
  "object 0.25.3",
  "proc-macro-error",
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
  "rand",
  "raw_tty",
@@ -195,12 +195,13 @@ dependencies = [
  "rsa",
  "rusb",
  "serde",
+ "serde_bytes",
  "serde_json",
  "serialport",
  "sha2",
  "shellwords",
  "structopt",
- "syn 1.0.100",
+ "syn 1.0.101",
  "tempfile",
  "thiserror",
  "typetag",
@@ -257,13 +258,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
  "winapi",
 ]
@@ -341,7 +342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -494,9 +495,9 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb19fe8de3ea0920d282f7b77dd4227aea6b8b999b42cdf0ca41b2472b14443a"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -537,14 +538,13 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a0714f28b1ee39ccec0770ccb544eb02c9ef2c82bb096230eefcffa6468b0"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "winapi",
 ]
@@ -831,9 +831,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "pem-rfc7468"
@@ -930,9 +930,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
  "version_check",
 ]
 
@@ -942,7 +942,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
  "version_check",
 ]
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "3edcd08cf4fea98d1ae6c9ddd3b8ccb1acac7c3693d62625969a7daa04a2ae36"
 dependencies = [
  "unicode-ident",
 ]
@@ -980,7 +980,7 @@ version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
 ]
 
 [[package]]
@@ -1143,22 +1143,31 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.144"
+name = "serde_bytes"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
 dependencies = [
- "proc-macro2 1.0.43",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+dependencies = [
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1256,9 +1265,9 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1280,11 +1289,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
  "unicode-ident",
 ]
@@ -1295,9 +1304,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
  "unicode-xid 0.2.4",
 ]
 
@@ -1351,22 +1360,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1414,9 +1423,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e60147782cc30833c05fba3bab1d9b5771b2685a2557672ac96fa5d154099c0e"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1504,9 +1513,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1526,9 +1535,9 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1595,8 +1604,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
 dependencies = [
- "proc-macro2 1.0.43",
- "syn 1.0.100",
+ "proc-macro2 1.0.45",
+ "syn 1.0.101",
  "synstructure",
 ]
 
@@ -1615,8 +1624,8 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.45",
  "quote 1.0.21",
- "syn 1.0.100",
+ "syn 1.0.101",
  "synstructure",
 ]

--- a/third_party/rust/crates/Cargo.toml
+++ b/third_party/rust/crates/Cargo.toml
@@ -46,6 +46,7 @@ regex = "1.5.4"
 rsa = "0.5.0"
 rusb = "0.8.1"
 serde = { version="1.0.130", features=["serde_derive"] }
+serde_bytes = "0.11"
 serde_json = "1.0.69"
 serialport = "4.0.1"
 sha2 = "0.10.1"

--- a/third_party/rust/crates/crates.bzl
+++ b/third_party/rust/crates/crates.bzl
@@ -37,22 +37,23 @@ _DEPENDENCIES = {
         "num_enum": "@raze__num_enum__0_5_7//:num_enum",
         "object": "@raze__object__0_25_3//:object",
         "proc-macro-error": "@raze__proc_macro_error__1_0_4//:proc_macro_error",
-        "proc-macro2": "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "proc-macro2": "@raze__proc_macro2__1_0_45//:proc_macro2",
         "quote": "@raze__quote__1_0_21//:quote",
         "rand": "@raze__rand__0_8_5//:rand",
         "raw_tty": "@raze__raw_tty__0_1_0//:raw_tty",
         "regex": "@raze__regex__1_6_0//:regex",
         "rsa": "@raze__rsa__0_5_0//:rsa",
         "rusb": "@raze__rusb__0_8_1//:rusb",
-        "serde": "@raze__serde__1_0_144//:serde",
+        "serde": "@raze__serde__1_0_145//:serde",
+        "serde_bytes": "@raze__serde_bytes__0_11_7//:serde_bytes",
         "serde_json": "@raze__serde_json__1_0_85//:serde_json",
         "serialport": "@raze__serialport__4_2_0//:serialport",
         "sha2": "@raze__sha2__0_10_6//:sha2",
         "shellwords": "@raze__shellwords__1_1_0//:shellwords",
         "structopt": "@raze__structopt__0_3_26//:structopt",
-        "syn": "@raze__syn__1_0_100//:syn",
+        "syn": "@raze__syn__1_0_101//:syn",
         "tempfile": "@raze__tempfile__3_3_0//:tempfile",
-        "thiserror": "@raze__thiserror__1_0_35//:thiserror",
+        "thiserror": "@raze__thiserror__1_0_37//:thiserror",
         "typetag": "@raze__typetag__0_1_8//:typetag",
         "zerocopy": "@raze__zerocopy__0_5_0//:zerocopy",
     },
@@ -259,7 +260,7 @@ def raze_fetch_remote_crates(
 
         clap__2_34_0=None,
 
-        console__0_15_1=None,
+        console__0_15_2=None,
 
         const_oid__0_6_2=None,
 
@@ -321,7 +322,7 @@ def raze_fetch_remote_crates(
 
         humantime__2_1_0=None,
 
-        iana_time_zone__0_1_48=None,
+        iana_time_zone__0_1_50=None,
 
         indicatif__0_16_2=None,
 
@@ -387,7 +388,7 @@ def raze_fetch_remote_crates(
 
         object__0_29_0=None,
 
-        once_cell__1_14_0=None,
+        once_cell__1_15_0=None,
 
         pem_rfc7468__0_2_4=None,
 
@@ -407,7 +408,7 @@ def raze_fetch_remote_crates(
 
         proc_macro2__0_4_30=None,
 
-        proc_macro2__1_0_43=None,
+        proc_macro2__1_0_45=None,
 
         quote__0_6_13=None,
 
@@ -447,9 +448,11 @@ def raze_fetch_remote_crates(
 
         semver_parser__0_7_0=None,
 
-        serde__1_0_144=None,
+        serde__1_0_145=None,
 
-        serde_derive__1_0_144=None,
+        serde_bytes__0_11_7=None,
+
+        serde_derive__1_0_145=None,
 
         serde_json__1_0_85=None,
 
@@ -475,7 +478,7 @@ def raze_fetch_remote_crates(
 
         syn__0_15_44=None,
 
-        syn__1_0_100=None,
+        syn__1_0_101=None,
 
         synstructure__0_12_6=None,
 
@@ -489,9 +492,9 @@ def raze_fetch_remote_crates(
 
         textwrap__0_11_0=None,
 
-        thiserror__1_0_35=None,
+        thiserror__1_0_37=None,
 
-        thiserror_impl__1_0_35=None,
+        thiserror_impl__1_0_37=None,
 
         time__0_1_44=None,
 
@@ -969,22 +972,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.clap-2.34.0.bazel"),
         )
 
-    if console__0_15_1:
+    if console__0_15_2:
         maybe(
             native.new_local_repository,
-            name = "raze__console__0_15_1",
-            path = console__0_15_1,
-            build_file = "//third_party/rust/crates/remote:BUILD.console-0.15.1.bazel",
+            name = "raze__console__0_15_2",
+            path = console__0_15_2,
+            build_file = "//third_party/rust/crates/remote:BUILD.console-0.15.2.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__console__0_15_1",
-            url = "https://crates.io/api/v1/crates/console/0.15.1/download",
+            name = "raze__console__0_15_2",
+            url = "https://crates.io/api/v1/crates/console/0.15.2/download",
             type = "tar.gz",
-            sha256 = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847",
-            strip_prefix = "console-0.15.1",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.console-0.15.1.bazel"),
+            sha256 = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c",
+            strip_prefix = "console-0.15.2",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.console-0.15.2.bazel"),
         )
 
     if const_oid__0_6_2:
@@ -1527,22 +1530,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.humantime-2.1.0.bazel"),
         )
 
-    if iana_time_zone__0_1_48:
+    if iana_time_zone__0_1_50:
         maybe(
             native.new_local_repository,
-            name = "raze__iana_time_zone__0_1_48",
-            path = iana_time_zone__0_1_48,
-            build_file = "//third_party/rust/crates/remote:BUILD.iana-time-zone-0.1.48.bazel",
+            name = "raze__iana_time_zone__0_1_50",
+            path = iana_time_zone__0_1_50,
+            build_file = "//third_party/rust/crates/remote:BUILD.iana-time-zone-0.1.50.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__iana_time_zone__0_1_48",
-            url = "https://crates.io/api/v1/crates/iana-time-zone/0.1.48/download",
+            name = "raze__iana_time_zone__0_1_50",
+            url = "https://crates.io/api/v1/crates/iana-time-zone/0.1.50/download",
             type = "tar.gz",
-            sha256 = "237a0714f28b1ee39ccec0770ccb544eb02c9ef2c82bb096230eefcffa6468b0",
-            strip_prefix = "iana-time-zone-0.1.48",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.iana-time-zone-0.1.48.bazel"),
+            sha256 = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0",
+            strip_prefix = "iana-time-zone-0.1.50",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.iana-time-zone-0.1.50.bazel"),
         )
 
     if indicatif__0_16_2:
@@ -2127,22 +2130,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.object-0.29.0.bazel"),
         )
 
-    if once_cell__1_14_0:
+    if once_cell__1_15_0:
         maybe(
             native.new_local_repository,
-            name = "raze__once_cell__1_14_0",
-            path = once_cell__1_14_0,
-            build_file = "//third_party/rust/crates/remote:BUILD.once_cell-1.14.0.bazel",
+            name = "raze__once_cell__1_15_0",
+            path = once_cell__1_15_0,
+            build_file = "//third_party/rust/crates/remote:BUILD.once_cell-1.15.0.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__once_cell__1_14_0",
-            url = "https://crates.io/api/v1/crates/once_cell/1.14.0/download",
+            name = "raze__once_cell__1_15_0",
+            url = "https://crates.io/api/v1/crates/once_cell/1.15.0/download",
             type = "tar.gz",
-            sha256 = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0",
-            strip_prefix = "once_cell-1.14.0",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.once_cell-1.14.0.bazel"),
+            sha256 = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1",
+            strip_prefix = "once_cell-1.15.0",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.once_cell-1.15.0.bazel"),
         )
 
     if pem_rfc7468__0_2_4:
@@ -2307,22 +2310,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.proc-macro2-0.4.30.bazel"),
         )
 
-    if proc_macro2__1_0_43:
+    if proc_macro2__1_0_45:
         maybe(
             native.new_local_repository,
-            name = "raze__proc_macro2__1_0_43",
-            path = proc_macro2__1_0_43,
-            build_file = "//third_party/rust/crates/remote:BUILD.proc-macro2-1.0.43.bazel",
+            name = "raze__proc_macro2__1_0_45",
+            path = proc_macro2__1_0_45,
+            build_file = "//third_party/rust/crates/remote:BUILD.proc-macro2-1.0.45.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__proc_macro2__1_0_43",
-            url = "https://crates.io/api/v1/crates/proc-macro2/1.0.43/download",
+            name = "raze__proc_macro2__1_0_45",
+            url = "https://crates.io/api/v1/crates/proc-macro2/1.0.45/download",
             type = "tar.gz",
-            sha256 = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab",
-            strip_prefix = "proc-macro2-1.0.43",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.proc-macro2-1.0.43.bazel"),
+            sha256 = "3edcd08cf4fea98d1ae6c9ddd3b8ccb1acac7c3693d62625969a7daa04a2ae36",
+            strip_prefix = "proc-macro2-1.0.45",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.proc-macro2-1.0.45.bazel"),
         )
 
     if quote__0_6_13:
@@ -2667,40 +2670,58 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.semver-parser-0.7.0.bazel"),
         )
 
-    if serde__1_0_144:
+    if serde__1_0_145:
         maybe(
             native.new_local_repository,
-            name = "raze__serde__1_0_144",
-            path = serde__1_0_144,
-            build_file = "//third_party/rust/crates/remote:BUILD.serde-1.0.144.bazel",
+            name = "raze__serde__1_0_145",
+            path = serde__1_0_145,
+            build_file = "//third_party/rust/crates/remote:BUILD.serde-1.0.145.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__serde__1_0_144",
-            url = "https://crates.io/api/v1/crates/serde/1.0.144/download",
+            name = "raze__serde__1_0_145",
+            url = "https://crates.io/api/v1/crates/serde/1.0.145/download",
             type = "tar.gz",
-            sha256 = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860",
-            strip_prefix = "serde-1.0.144",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.serde-1.0.144.bazel"),
+            sha256 = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b",
+            strip_prefix = "serde-1.0.145",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.serde-1.0.145.bazel"),
         )
 
-    if serde_derive__1_0_144:
+    if serde_bytes__0_11_7:
         maybe(
             native.new_local_repository,
-            name = "raze__serde_derive__1_0_144",
-            path = serde_derive__1_0_144,
-            build_file = "//third_party/rust/crates/remote:BUILD.serde_derive-1.0.144.bazel",
+            name = "raze__serde_bytes__0_11_7",
+            path = serde_bytes__0_11_7,
+            build_file = "//third_party/rust/crates/remote:BUILD.serde_bytes-0.11.7.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__serde_derive__1_0_144",
-            url = "https://crates.io/api/v1/crates/serde_derive/1.0.144/download",
+            name = "raze__serde_bytes__0_11_7",
+            url = "https://crates.io/api/v1/crates/serde_bytes/0.11.7/download",
             type = "tar.gz",
-            sha256 = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00",
-            strip_prefix = "serde_derive-1.0.144",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.serde_derive-1.0.144.bazel"),
+            sha256 = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b",
+            strip_prefix = "serde_bytes-0.11.7",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.serde_bytes-0.11.7.bazel"),
+        )
+
+    if serde_derive__1_0_145:
+        maybe(
+            native.new_local_repository,
+            name = "raze__serde_derive__1_0_145",
+            path = serde_derive__1_0_145,
+            build_file = "//third_party/rust/crates/remote:BUILD.serde_derive-1.0.145.bazel",
+        )
+    else:
+        maybe(
+            http_archive,
+            name = "raze__serde_derive__1_0_145",
+            url = "https://crates.io/api/v1/crates/serde_derive/1.0.145/download",
+            type = "tar.gz",
+            sha256 = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c",
+            strip_prefix = "serde_derive-1.0.145",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.serde_derive-1.0.145.bazel"),
         )
 
     if serde_json__1_0_85:
@@ -2919,22 +2940,22 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.syn-0.15.44.bazel"),
         )
 
-    if syn__1_0_100:
+    if syn__1_0_101:
         maybe(
             native.new_local_repository,
-            name = "raze__syn__1_0_100",
-            path = syn__1_0_100,
-            build_file = "//third_party/rust/crates/remote:BUILD.syn-1.0.100.bazel",
+            name = "raze__syn__1_0_101",
+            path = syn__1_0_101,
+            build_file = "//third_party/rust/crates/remote:BUILD.syn-1.0.101.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__syn__1_0_100",
-            url = "https://crates.io/api/v1/crates/syn/1.0.100/download",
+            name = "raze__syn__1_0_101",
+            url = "https://crates.io/api/v1/crates/syn/1.0.101/download",
             type = "tar.gz",
-            sha256 = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e",
-            strip_prefix = "syn-1.0.100",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.syn-1.0.100.bazel"),
+            sha256 = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2",
+            strip_prefix = "syn-1.0.101",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.syn-1.0.101.bazel"),
         )
 
     if synstructure__0_12_6:
@@ -3045,40 +3066,40 @@ def raze_fetch_remote_crates(
             build_file = Label("//third_party/rust/crates/remote:BUILD.textwrap-0.11.0.bazel"),
         )
 
-    if thiserror__1_0_35:
+    if thiserror__1_0_37:
         maybe(
             native.new_local_repository,
-            name = "raze__thiserror__1_0_35",
-            path = thiserror__1_0_35,
-            build_file = "//third_party/rust/crates/remote:BUILD.thiserror-1.0.35.bazel",
+            name = "raze__thiserror__1_0_37",
+            path = thiserror__1_0_37,
+            build_file = "//third_party/rust/crates/remote:BUILD.thiserror-1.0.37.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__thiserror__1_0_35",
-            url = "https://crates.io/api/v1/crates/thiserror/1.0.35/download",
+            name = "raze__thiserror__1_0_37",
+            url = "https://crates.io/api/v1/crates/thiserror/1.0.37/download",
             type = "tar.gz",
-            sha256 = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85",
-            strip_prefix = "thiserror-1.0.35",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.thiserror-1.0.35.bazel"),
+            sha256 = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e",
+            strip_prefix = "thiserror-1.0.37",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.thiserror-1.0.37.bazel"),
         )
 
-    if thiserror_impl__1_0_35:
+    if thiserror_impl__1_0_37:
         maybe(
             native.new_local_repository,
-            name = "raze__thiserror_impl__1_0_35",
-            path = thiserror_impl__1_0_35,
-            build_file = "//third_party/rust/crates/remote:BUILD.thiserror-impl-1.0.35.bazel",
+            name = "raze__thiserror_impl__1_0_37",
+            path = thiserror_impl__1_0_37,
+            build_file = "//third_party/rust/crates/remote:BUILD.thiserror-impl-1.0.37.bazel",
         )
     else:
         maybe(
             http_archive,
-            name = "raze__thiserror_impl__1_0_35",
-            url = "https://crates.io/api/v1/crates/thiserror-impl/1.0.35/download",
+            name = "raze__thiserror_impl__1_0_37",
+            url = "https://crates.io/api/v1/crates/thiserror-impl/1.0.37/download",
             type = "tar.gz",
-            sha256 = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783",
-            strip_prefix = "thiserror-impl-1.0.35",
-            build_file = Label("//third_party/rust/crates/remote:BUILD.thiserror-impl-1.0.35.bazel"),
+            sha256 = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb",
+            strip_prefix = "thiserror-impl-1.0.37",
+            build_file = Label("//third_party/rust/crates/remote:BUILD.thiserror-impl-1.0.37.bazel"),
         )
 
     if time__0_1_44:

--- a/third_party/rust/crates/remote/BUILD.chrono-0.4.22.bazel
+++ b/third_party/rust/crates/remote/BUILD.chrono-0.4.22.bazel
@@ -64,7 +64,7 @@ rust_library(
     version = "0.4.22",
     # buildifier: leave-alone
     deps = [
-        "@raze__iana_time_zone__0_1_48//:iana_time_zone",
+        "@raze__iana_time_zone__0_1_50//:iana_time_zone",
         "@raze__num_integer__0_1_45//:num_integer",
         "@raze__num_traits__0_2_15//:num_traits",
         "@raze__time__0_1_44//:time",

--- a/third_party/rust/crates/remote/BUILD.console-0.15.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.console-0.15.2.bazel
@@ -57,11 +57,11 @@ rust_library(
         "crate-name=console",
         "manual",
     ],
-    version = "0.15.1",
+    version = "0.15.2",
     # buildifier: leave-alone
     deps = [
+        "@raze__lazy_static__1_4_0//:lazy_static",
         "@raze__libc__0_2_133//:libc",
-        "@raze__once_cell__1_14_0//:once_cell",
         "@raze__terminal_size__0_1_17//:terminal_size",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.ctor-0.1.23.bazel
+++ b/third_party/rust/crates/remote/BUILD.ctor-0.1.23.bazel
@@ -53,6 +53,6 @@ rust_proc_macro(
     # buildifier: leave-alone
     deps = [
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
+        "@raze__syn__1_0_101//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.deser-hjson-1.0.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.deser-hjson-1.0.2.bazel
@@ -52,7 +52,7 @@ rust_library(
     version = "1.0.2",
     # buildifier: leave-alone
     deps = [
-        "@raze__serde__1_0_144//:serde",
+        "@raze__serde__1_0_145//:serde",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.erased-serde-0.3.23.bazel
+++ b/third_party/rust/crates/remote/BUILD.erased-serde-0.3.23.bazel
@@ -84,7 +84,7 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":erased_serde_build_script",
-        "@raze__serde__1_0_144//:serde",
+        "@raze__serde__1_0_145//:serde",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.iana-time-zone-0.1.50.bazel
+++ b/third_party/rust/crates/remote/BUILD.iana-time-zone-0.1.50.bazel
@@ -52,7 +52,7 @@ rust_library(
         "crate-name=iana-time-zone",
         "manual",
     ],
-    version = "0.1.48",
+    version = "0.1.50",
     # buildifier: leave-alone
     deps = [
     ],

--- a/third_party/rust/crates/remote/BUILD.indicatif-0.16.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.indicatif-0.16.2.bazel
@@ -85,7 +85,7 @@ rust_library(
     version = "0.16.2",
     # buildifier: leave-alone
     deps = [
-        "@raze__console__0_15_1//:console",
+        "@raze__console__0_15_2//:console",
         "@raze__lazy_static__1_4_0//:lazy_static",
         "@raze__number_prefix__0_4_0//:number_prefix",
         "@raze__regex__1_6_0//:regex",

--- a/third_party/rust/crates/remote/BUILD.num-bigint-dig-0.7.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.num-bigint-dig-0.7.0.bazel
@@ -104,7 +104,7 @@ rust_library(
         "@raze__num_iter__0_1_43//:num_iter",
         "@raze__num_traits__0_2_15//:num_traits",
         "@raze__rand__0_8_5//:rand",
-        "@raze__serde__1_0_144//:serde",
+        "@raze__serde__1_0_145//:serde",
         "@raze__smallvec__1_9_0//:smallvec",
         "@raze__zeroize__1_4_3//:zeroize",
     ],

--- a/third_party/rust/crates/remote/BUILD.num_enum_derive-0.5.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.num_enum_derive-0.5.7.bazel
@@ -52,9 +52,9 @@ rust_proc_macro(
     version = "0.5.7",
     # buildifier: leave-alone
     deps = [
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
         "@raze__proc_macro_crate__1_2_1//:proc_macro_crate",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
+        "@raze__syn__1_0_101//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.once_cell-1.15.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.once_cell-1.15.0.bazel
@@ -31,27 +31,44 @@ licenses([
 
 # Generated Targets
 
-rust_proc_macro(
-    name = "thiserror_impl",
+# Unsupported target "bench" with type "example" omitted
+
+# Unsupported target "bench_acquire" with type "example" omitted
+
+# Unsupported target "bench_vs_lazy_static" with type "example" omitted
+
+# Unsupported target "lazy_static" with type "example" omitted
+
+# Unsupported target "reentrant_init_deadlocks" with type "example" omitted
+
+# Unsupported target "regex" with type "example" omitted
+
+# Unsupported target "test_synchronization" with type "example" omitted
+
+rust_library(
+    name = "once_cell",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "alloc",
+        "default",
+        "race",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2018",
+    edition = "2021",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=thiserror-impl",
+        "crate-name=once_cell",
         "manual",
     ],
-    version = "1.0.35",
+    version = "1.15.0",
     # buildifier: leave-alone
     deps = [
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
-        "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
     ],
 )
+
+# Unsupported target "it" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.proc-macro-crate-1.2.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro-crate-1.2.1.bazel
@@ -50,8 +50,8 @@ rust_library(
     version = "1.2.1",
     # buildifier: leave-alone
     deps = [
-        "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__thiserror__1_0_35//:thiserror",
+        "@raze__once_cell__1_15_0//:once_cell",
+        "@raze__thiserror__1_0_37//:thiserror",
         "@raze__toml__0_5_9//:toml",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.proc-macro-error-1.0.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro-error-1.0.4.bazel
@@ -90,9 +90,9 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":proc_macro_error_build_script",
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
+        "@raze__syn__1_0_101//:syn",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -81,7 +81,7 @@ rust_proc_macro(
     # buildifier: leave-alone
     deps = [
         ":proc_macro_error_attr_build_script",
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.proc-macro2-1.0.45.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro2-1.0.45.bazel
@@ -38,16 +38,17 @@ load(
 )
 
 cargo_build_script(
-    name = "serde_derive_build_script",
+    name = "proc_macro2_build_script",
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
     crate_features = [
         "default",
+        "proc-macro",
     ],
     crate_root = "build.rs",
     data = glob(["**"]),
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -55,35 +56,44 @@ cargo_build_script(
         "cargo-raze",
         "manual",
     ],
-    version = "1.0.144",
+    version = "1.0.45",
     visibility = ["//visibility:private"],
     deps = [
     ],
 )
 
-rust_proc_macro(
-    name = "serde_derive",
+rust_library(
+    name = "proc_macro2",
     srcs = glob(["**/*.rs"]),
     crate_features = [
         "default",
+        "proc-macro",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=serde_derive",
+        "crate-name=proc-macro2",
         "manual",
     ],
-    version = "1.0.144",
+    version = "1.0.45",
     # buildifier: leave-alone
     deps = [
-        ":serde_derive_build_script",
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
-        "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
+        ":proc_macro2_build_script",
+        "@raze__unicode_ident__1_0_4//:unicode_ident",
     ],
 )
+
+# Unsupported target "comments" with type "test" omitted
+
+# Unsupported target "features" with type "test" omitted
+
+# Unsupported target "marker" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted
+
+# Unsupported target "test_fmt" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.quote-1.0.21.bazel
+++ b/third_party/rust/crates/remote/BUILD.quote-1.0.21.bazel
@@ -84,7 +84,7 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":quote_build_script",
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.redox_users-0.4.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.redox_users-0.4.3.bazel
@@ -52,6 +52,6 @@ rust_library(
     deps = [
         "@raze__getrandom__0_2_7//:getrandom",
         "@raze__redox_syscall__0_2_16//:redox_syscall",
-        "@raze__thiserror__1_0_35//:thiserror",
+        "@raze__thiserror__1_0_37//:thiserror",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.serde-1.0.145.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde-1.0.145.bazel
@@ -30,45 +30,66 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
 
-# Unsupported target "bench" with type "example" omitted
-
-# Unsupported target "bench_acquire" with type "example" omitted
-
-# Unsupported target "bench_vs_lazy_static" with type "example" omitted
-
-# Unsupported target "lazy_static" with type "example" omitted
-
-# Unsupported target "reentrant_init_deadlocks" with type "example" omitted
-
-# Unsupported target "regex" with type "example" omitted
-
-# Unsupported target "test_synchronization" with type "example" omitted
-
-rust_library(
-    name = "once_cell",
+cargo_build_script(
+    name = "serde_build_script",
     srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
     crate_features = [
-        "alloc",
         "default",
-        "race",
+        "derive",
+        "serde_derive",
         "std",
     ],
-    crate_root = "src/lib.rs",
-    data = [],
-    edition = "2018",
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=once_cell",
         "manual",
     ],
-    version = "1.14.0",
-    # buildifier: leave-alone
+    version = "1.0.145",
+    visibility = ["//visibility:private"],
     deps = [
     ],
 )
 
-# Unsupported target "it" with type "test" omitted
+rust_library(
+    name = "serde",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "derive",
+        "serde_derive",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    proc_macro_deps = [
+        "@raze__serde_derive__1_0_145//:serde_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=serde",
+        "manual",
+    ],
+    version = "1.0.145",
+    # buildifier: leave-alone
+    deps = [
+        ":serde_build_script",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.serde_bytes-0.11.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_bytes-0.11.7.bazel
@@ -30,66 +30,34 @@ licenses([
 ])
 
 # Generated Targets
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load-on-top
-load(
-    "@rules_rust//cargo:cargo_build_script.bzl",
-    "cargo_build_script",
-)
-
-cargo_build_script(
-    name = "serde_build_script",
-    srcs = glob(["**/*.rs"]),
-    build_script_env = {
-    },
-    crate_features = [
-        "default",
-        "derive",
-        "serde_derive",
-        "std",
-    ],
-    crate_root = "build.rs",
-    data = glob(["**"]),
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    version = "1.0.144",
-    visibility = ["//visibility:private"],
-    deps = [
-    ],
-)
 
 rust_library(
-    name = "serde",
+    name = "serde_bytes",
     srcs = glob(["**/*.rs"]),
     crate_features = [
         "default",
-        "derive",
-        "serde_derive",
         "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
-    proc_macro_deps = [
-        "@raze__serde_derive__1_0_144//:serde_derive",
-    ],
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=serde",
+        "crate-name=serde_bytes",
         "manual",
     ],
-    version = "1.0.144",
+    version = "0.11.7",
     # buildifier: leave-alone
     deps = [
-        ":serde_build_script",
+        "@raze__serde__1_0_145//:serde",
     ],
 )
+
+# Unsupported target "test_derive" with type "test" omitted
+
+# Unsupported target "test_partialeq" with type "test" omitted
+
+# Unsupported target "test_serde" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.serde_derive-1.0.145.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_derive-1.0.145.bazel
@@ -38,17 +38,16 @@ load(
 )
 
 cargo_build_script(
-    name = "proc_macro2_build_script",
+    name = "serde_derive_build_script",
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
     crate_features = [
         "default",
-        "proc-macro",
     ],
     crate_root = "build.rs",
     data = glob(["**"]),
-    edition = "2018",
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -56,44 +55,35 @@ cargo_build_script(
         "cargo-raze",
         "manual",
     ],
-    version = "1.0.43",
+    version = "1.0.145",
     visibility = ["//visibility:private"],
     deps = [
     ],
 )
 
-rust_library(
-    name = "proc_macro2",
+rust_proc_macro(
+    name = "serde_derive",
     srcs = glob(["**/*.rs"]),
     crate_features = [
         "default",
-        "proc-macro",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2018",
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=proc-macro2",
+        "crate-name=serde_derive",
         "manual",
     ],
-    version = "1.0.43",
+    version = "1.0.145",
     # buildifier: leave-alone
     deps = [
-        ":proc_macro2_build_script",
-        "@raze__unicode_ident__1_0_4//:unicode_ident",
+        ":serde_derive_build_script",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_101//:syn",
     ],
 )
-
-# Unsupported target "comments" with type "test" omitted
-
-# Unsupported target "features" with type "test" omitted
-
-# Unsupported target "marker" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted
-
-# Unsupported target "test_fmt" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.serde_json-1.0.85.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_json-1.0.85.bazel
@@ -86,7 +86,7 @@ rust_library(
         ":serde_json_build_script",
         "@raze__itoa__1_0_3//:itoa",
         "@raze__ryu__1_0_11//:ryu",
-        "@raze__serde__1_0_144//:serde",
+        "@raze__serde__1_0_145//:serde",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.structopt-derive-0.4.18.bazel
+++ b/third_party/rust/crates/remote/BUILD.structopt-derive-0.4.18.bazel
@@ -51,9 +51,9 @@ rust_proc_macro(
     # buildifier: leave-alone
     deps = [
         "@raze__heck__0_3_3//:heck",
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
         "@raze__proc_macro_error__1_0_4//:proc_macro_error",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
+        "@raze__syn__1_0_101//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.syn-1.0.101.bazel
+++ b/third_party/rust/crates/remote/BUILD.syn-1.0.101.bazel
@@ -64,7 +64,7 @@ cargo_build_script(
         "cargo-raze",
         "manual",
     ],
-    version = "1.0.100",
+    version = "1.0.101",
     visibility = ["//visibility:private"],
     deps = [
     ],
@@ -100,11 +100,11 @@ rust_library(
         "crate-name=syn",
         "manual",
     ],
-    version = "1.0.100",
+    version = "1.0.101",
     # buildifier: leave-alone
     deps = [
         ":syn_build_script",
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
         "@raze__unicode_ident__1_0_4//:unicode_ident",
     ],

--- a/third_party/rust/crates/remote/BUILD.synstructure-0.12.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.synstructure-0.12.6.bazel
@@ -52,9 +52,9 @@ rust_library(
     version = "0.12.6",
     # buildifier: leave-alone
     deps = [
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
+        "@raze__syn__1_0_101//:syn",
         "@raze__unicode_xid__0_2_4//:unicode_xid",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.thiserror-1.0.37.bazel
+++ b/third_party/rust/crates/remote/BUILD.thiserror-1.0.37.bazel
@@ -54,7 +54,7 @@ cargo_build_script(
         "cargo-raze",
         "manual",
     ],
-    version = "1.0.35",
+    version = "1.0.37",
     visibility = ["//visibility:private"],
     deps = [
     ],
@@ -69,7 +69,7 @@ rust_library(
     data = [],
     edition = "2018",
     proc_macro_deps = [
-        "@raze__thiserror_impl__1_0_35//:thiserror_impl",
+        "@raze__thiserror_impl__1_0_37//:thiserror_impl",
     ],
     rustc_flags = [
         "--cap-lints=allow",
@@ -79,7 +79,7 @@ rust_library(
         "crate-name=thiserror",
         "manual",
     ],
-    version = "1.0.35",
+    version = "1.0.37",
     # buildifier: leave-alone
     deps = [
         ":thiserror_build_script",

--- a/third_party/rust/crates/remote/BUILD.thiserror-impl-1.0.37.bazel
+++ b/third_party/rust/crates/remote/BUILD.thiserror-impl-1.0.37.bazel
@@ -32,7 +32,7 @@ licenses([
 # Generated Targets
 
 rust_proc_macro(
-    name = "ghost",
+    name = "thiserror_impl",
     srcs = glob(["**/*.rs"]),
     crate_features = [
     ],
@@ -44,10 +44,10 @@ rust_proc_macro(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=ghost",
+        "crate-name=thiserror-impl",
         "manual",
     ],
-    version = "0.1.6",
+    version = "1.0.37",
     # buildifier: leave-alone
     deps = [
         "@raze__proc_macro2__1_0_45//:proc_macro2",
@@ -55,9 +55,3 @@ rust_proc_macro(
         "@raze__syn__1_0_101//:syn",
     ],
 )
-
-# Unsupported target "autotraits" with type "test" omitted
-
-# Unsupported target "compiletest" with type "test" omitted
-
-# Unsupported target "readme" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.toml-0.5.9.bazel
+++ b/third_party/rust/crates/remote/BUILD.toml-0.5.9.bazel
@@ -57,7 +57,7 @@ rust_library(
     version = "0.5.9",
     # buildifier: leave-alone
     deps = [
-        "@raze__serde__1_0_144//:serde",
+        "@raze__serde__1_0_145//:serde",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.typetag-0.1.8.bazel
+++ b/third_party/rust/crates/remote/BUILD.typetag-0.1.8.bazel
@@ -57,8 +57,8 @@ rust_library(
     deps = [
         "@raze__erased_serde__0_3_23//:erased_serde",
         "@raze__inventory__0_2_3//:inventory",
-        "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__serde__1_0_144//:serde",
+        "@raze__once_cell__1_15_0//:once_cell",
+        "@raze__serde__1_0_145//:serde",
     ],
 )
 

--- a/third_party/rust/crates/remote/BUILD.typetag-impl-0.1.8.bazel
+++ b/third_party/rust/crates/remote/BUILD.typetag-impl-0.1.8.bazel
@@ -50,8 +50,8 @@ rust_proc_macro(
     version = "0.1.8",
     # buildifier: leave-alone
     deps = [
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
+        "@raze__syn__1_0_101//:syn",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.wasm-bindgen-backend-0.2.83.bazel
+++ b/third_party/rust/crates/remote/BUILD.wasm-bindgen-backend-0.2.83.bazel
@@ -53,10 +53,10 @@ rust_library(
     deps = [
         "@raze__bumpalo__3_11_0//:bumpalo",
         "@raze__log__0_4_17//:log",
-        "@raze__once_cell__1_14_0//:once_cell",
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__once_cell__1_15_0//:once_cell",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
+        "@raze__syn__1_0_101//:syn",
         "@raze__wasm_bindgen_shared__0_2_83//:wasm_bindgen_shared",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.wasm-bindgen-macro-support-0.2.83.bazel
+++ b/third_party/rust/crates/remote/BUILD.wasm-bindgen-macro-support-0.2.83.bazel
@@ -51,9 +51,9 @@ rust_library(
     version = "0.2.83",
     # buildifier: leave-alone
     deps = [
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
+        "@raze__syn__1_0_101//:syn",
         "@raze__wasm_bindgen_backend__0_2_83//:wasm_bindgen_backend",
         "@raze__wasm_bindgen_shared__0_2_83//:wasm_bindgen_shared",
     ],

--- a/third_party/rust/crates/remote/BUILD.zerocopy-derive-0.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.zerocopy-derive-0.3.1.bazel
@@ -50,8 +50,8 @@ rust_proc_macro(
     version = "0.3.1",
     # buildifier: leave-alone
     deps = [
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
-        "@raze__syn__1_0_100//:syn",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
+        "@raze__syn__1_0_101//:syn",
         "@raze__synstructure__0_12_6//:synstructure",
     ],
 )

--- a/third_party/rust/crates/remote/BUILD.zeroize_derive-1.3.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.zeroize_derive-1.3.2.bazel
@@ -50,9 +50,9 @@ rust_proc_macro(
     version = "1.3.2",
     # buildifier: leave-alone
     deps = [
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro2__1_0_45//:proc_macro2",
         "@raze__quote__1_0_21//:quote",
-        "@raze__syn__1_0_100//:syn",
+        "@raze__syn__1_0_101//:syn",
         "@raze__synstructure__0_12_6//:synstructure",
     ],
 )

--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -19,7 +19,8 @@ def rust_deps():
     rust_register_toolchains(
         include_rustc_srcs = True,
         edition = "2018",
-        version = "1.60.0",
+        version = "nightly",
+        iso_date = "2022-09-28",
     )
     rust_repository_set(
         name = "rust_opentitan_rv32imc",

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -28,7 +28,7 @@ def rust_repos(rules_rust = None, safe_ftdi = None, serde_annotate = None):
     http_archive_or_local(
         name = "serde_annotate",
         local = serde_annotate,
-        sha256 = "48775889028e42dbb684b6f5442a6e3cea8bee206be7e1eb46ec0a0fce79e6c4",
-        strip_prefix = "serde-annotate-0.0.2",
-        url = "https://github.com/lowRISC/serde-annotate/archive/refs/tags/v0.0.2.tar.gz",
+        sha256 = "e5d82f7519eac85daa5b52d85c597285ba761cad7138694c222be102346421ae",
+        strip_prefix = "serde-annotate-0.0.3",
+        url = "https://github.com/lowRISC/serde-annotate/archive/refs/tags/v0.0.3.tar.gz",
     )


### PR DESCRIPTION
This change updated opentitantool to use serde-annotate to provide annotations.

1. Update rust to use the `nightly 2022-09-28` toolchain.  This is required because `serde-annotate` uses the nightly feature `min_specialization`.
2. Convert from `erased-serde` to `serde-annotate`: We were using erased-serde to return trait-objects for all command results.  Annotations are currently not compatible with erased-serde; serde-annotate implements its own form of type-erasure.
3. Add some simple annotations to the `image digest` and `spi read-id` commands.
3a. `image digest` response structure now represents the digest as its natural form: a `Vec<u8>`.  The serializer is instructed to encode this bytes object as a `hexstr`.  A comment is added to remind the reader that the digest does not cover the signature bytes.
3b. `spi read-id` encodes the response in hex when the `--format` supports hex (json5 and yaml).