### PR TITLE
[unr] Use elite license

### DIFF
--- a/hw/dv/tools/vcs/unr.cfg
+++ b/hw/dv/tools/vcs/unr.cfg
@@ -10,6 +10,10 @@
 # Provide the reset specification: signal_name, active_value, num clk cycles reset to be active
 -reset rst_ni 0 20
 
+# Enables the Elite licensing for UNR
+# Adding this switch avoids the compile error saying could not find the `VC-static-cov` license
+-fmlElite
+
 # Black box common security modules
  -blackBoxes -type design prim_count+prim_spare_fsm+prim_double_lfsr
 


### PR DESCRIPTION
It is recommended to use the elite license for UNR.
Adding this switch will help us avoid the error saying "no vc-static-cov license".

Signed-off-by: Cindy Chen <chencindy@opentitan.org>