### PR TITLE
[test] Add rom_e2e_address_translation

### DIFF
--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -787,8 +787,7 @@
             |         Off         |      B     |     A     |  Yes  |
             |         On          |   Virtual  |     A     |  No   |
             |         On          |   Virtual  |     B     |  No   |
-            |         Invalid     |   Virtual  |     A     |  Yes  |
-            |         Invalid     |   Virtual  |     B     |  Yes  |
+            |         Invalid     |      A     |     A     |  Yes  |
             '''
       tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -11,6 +11,10 @@ load(
     "opentitan_functest",
     "verilator_params",
 )
+load(
+    "//rules:opentitan.bzl",
+    "opentitan_multislot_flash_binary",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -195,5 +199,39 @@ opentitan_functest(
         "//sw/device/lib/ujson",
         "//sw/device/silicon_creator/rom/e2e/json:chip_specific_startup",
         "//sw/device/silicon_creator/rom/e2e/json:command",
+    ],
+)
+
+MSG_STARTING_ROM_EXT = "Starting ROM_EXT"
+
+MSG_BOOT_FAULT = "BFV:"
+
+opentitan_functest(
+    name = "rom_ext_a_flash_a",
+    cw310 = cw310_params(
+        exit_failure = MSG_BOOT_FAULT,
+        exit_success = MSG_STARTING_ROM_EXT,
+    ),
+    ot_flash_binary = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+    targets = ["cw310_rom"],
+)
+
+# TODO(#13511): Add a positive test for slot_b.
+
+opentitan_functest(
+    name = "rom_ext_v_flash_a",
+    cw310 = cw310_params(
+        exit_failure = MSG_BOOT_FAULT,
+        exit_success = MSG_STARTING_ROM_EXT,
+    ),
+    ot_flash_binary = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual",
+    targets = ["cw310_rom"],
+)
+
+test_suite(
+    name = "address_translation",
+    tests = [
+        "rom_ext_a_flash_a",
+        "rom_ext_v_flash_a"
     ],
 )

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -206,6 +206,16 @@ MSG_STARTING_ROM_EXT = "Starting ROM_EXT"
 
 MSG_BOOT_FAULT = "BFV:"
 
+MSG_STORE_ACCESS_FAULT = "BFV:07495202(?s:.*)BFV:07495202"
+
+MSG_ILLEGAL_INSTRUCTION_FAULT = "BFV:02495202(?s:.*)BFV:02495202"
+
+SLOT_A_OFFSET = "0x0"
+
+SLOT_B_OFFSET = "0x80000"
+
+FLASH_SIZE = "0x100000"
+
 opentitan_functest(
     name = "rom_ext_a_flash_a",
     cw310 = cw310_params(
@@ -216,7 +226,71 @@ opentitan_functest(
     targets = ["cw310_rom"],
 )
 
-# TODO(#13511): Add a positive test for slot_b.
+opentitan_multislot_flash_binary(
+    name = "rom_ext_b_flash_b_image",
+    srcs = {
+        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": {
+            "key": "test_key_0",
+            "offset": SLOT_B_OFFSET,
+        },
+    },
+    image_size = FLASH_SIZE,
+)
+
+opentitan_functest(
+    name = "rom_ext_b_flash_b",
+    cw310 = cw310_params(
+        exit_failure = MSG_BOOT_FAULT,
+        exit_success = MSG_STARTING_ROM_EXT,
+    ),
+    key = "multislot",
+    ot_flash_binary = ":rom_ext_b_flash_b_image",
+    targets = ["cw310_rom"],
+)
+
+opentitan_multislot_flash_binary(
+    name = "rom_ext_a_flash_b_image",
+    srcs = {
+        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a": {
+            "key": "test_key_0",
+            "offset": SLOT_B_OFFSET,
+        },
+    },
+    image_size = FLASH_SIZE,
+)
+
+opentitan_functest(
+    name = "rom_ext_a_flash_b",
+    cw310 = cw310_params(
+        exit_failure = MSG_STARTING_ROM_EXT,
+        exit_success = MSG_STORE_ACCESS_FAULT,
+    ),
+    key = "multislot",
+    ot_flash_binary = ":rom_ext_a_flash_b_image",
+    targets = ["cw310_rom"],
+)
+
+opentitan_multislot_flash_binary(
+    name = "rom_ext_b_flash_a_image",
+    srcs = {
+        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": {
+            "key": "test_key_0",
+            "offset": SLOT_A_OFFSET,
+        },
+    },
+    image_size = FLASH_SIZE,
+)
+
+opentitan_functest(
+    name = "rom_ext_b_flash_a",
+    cw310 = cw310_params(
+        exit_failure = MSG_STARTING_ROM_EXT,
+        exit_success = MSG_STORE_ACCESS_FAULT,
+    ),
+    key = "multislot",
+    ot_flash_binary = ":rom_ext_b_flash_a_image",
+    targets = ["cw310_rom"],
+)
 
 opentitan_functest(
     name = "rom_ext_v_flash_a",
@@ -228,10 +302,47 @@ opentitan_functest(
     targets = ["cw310_rom"],
 )
 
+opentitan_multislot_flash_binary(
+    name = "rom_ext_v_flash_b_image",
+    srcs = {
+        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": {
+            "key": "test_key_0",
+            "offset": SLOT_B_OFFSET,
+        },
+    },
+    image_size = FLASH_SIZE,
+)
+
+opentitan_functest(
+    name = "rom_ext_v_flash_b",
+    cw310 = cw310_params(
+        exit_failure = MSG_BOOT_FAULT,
+        exit_success = MSG_STARTING_ROM_EXT,
+    ),
+    key = "multislot",
+    ot_flash_binary = ":rom_ext_v_flash_b_image",
+    targets = ["cw310_rom"],
+)
+
+opentitan_functest(
+    name = "rom_ext_a_flash_a_bad_addr_trans",
+    cw310 = cw310_params(
+        exit_failure = MSG_STARTING_ROM_EXT,
+        exit_success = MSG_ILLEGAL_INSTRUCTION_FAULT,
+    ),
+    ot_flash_binary = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a_bad_address_translation",
+    targets = ["cw310_rom"],
+)
+
 test_suite(
     name = "address_translation",
     tests = [
         "rom_ext_a_flash_a",
-        "rom_ext_v_flash_a"
+        "rom_ext_a_flash_a_bad_addr_trans",
+        "rom_ext_a_flash_b",
+        "rom_ext_b_flash_a",
+        "rom_ext_b_flash_b",
+        "rom_ext_v_flash_a",
+        "rom_ext_v_flash_b",
     ],
 )

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -190,3 +190,22 @@ opentitan_flash_binary(
         "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
+
+manifest(
+    name = "manifest_bad_address_translation",
+    address_translation = 0,
+    identifier = CONST.ROM_EXT,
+)
+
+opentitan_flash_binary(
+    name = "rom_ext_slot_a_bad_address_translation",
+    srcs = ["rom_ext_start.S"],
+    manifest = ":manifest_bad_address_translation",
+    signed = True,
+    deps = [
+        ":ld_slot_a",
+        ":rom_ext",
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -190,27 +190,3 @@ opentitan_flash_binary(
         "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
-
-BOOT_SUCCESS_MSG = "Starting ROM_EXT"
-
-opentitan_functest(
-    name = "rom_ext_slot_a_boot_test",
-    cw310 = cw310_params(
-        exit_success = BOOT_SUCCESS_MSG,
-    ),
-    ot_flash_binary = ":rom_ext_slot_a",
-    signed = True,
-    targets = ["cw310_rom"],
-)
-
-# TODO(#13511): Add a positive test for slot_b.
-
-opentitan_functest(
-    name = "rom_ext_slot_virtual_boot_test",
-    cw310 = cw310_params(
-        exit_success = BOOT_SUCCESS_MSG,
-    ),
-    ot_flash_binary = ":rom_ext_slot_virtual",
-    signed = True,
-    targets = ["cw310_rom"],
-)

--- a/sw/device/silicon_creator/rom_ext/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_start.S
@@ -23,7 +23,8 @@
    *
    * Interrupt vectors in Ibex have 32 4-byte entries for 32 possible interrupts.
    * The vector must be 256-byte aligned, as Ibex's vectoring mechanism
-   * requires that.
+   * requires that. This section will be padded with `unimp` (`0xc0001073`) if
+   * needed depending on the alignment of the next section.
    *
    * Only the following will be used by Ibex:
    * - Exception Handler (Entry 0)
@@ -35,54 +36,20 @@
    * More information about Ibex's interrupts can be found here:
    *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
    */
-  .balign 256
+  .balignl 256, 0xc0001073
   .global _rom_ext_interrupt_vector
   .type _rom_ext_interrupt_vector, @function
 _rom_ext_interrupt_vector:
-  // RISC-V Standard (Vectored) Interrupt Handlers:
+  // Entry 0: exception handler.
+  j rom_ext_exception_handler
 
-  // Exception and User Software Interrupt Handler.
-  unimp
-  // Supervisor Software Interrupt Handler.
-  unimp
-  // Reserved.
-  unimp
-  // Machine Software Interrupt Handler.
-  unimp
-
-  // User Timer Interrupt Handler.
-  unimp
-  // Supervisor Timer Interrupt Handler.
-  unimp
-  // Reserved.
-  unimp
-  // Machine Timer Interrupt Handler.
-  unimp
-
-  // User External Interrupt Handler.
-  unimp
-  // Supervisor External Interrupt Handler.
-  unimp
-  // Reserved.
-  unimp
-  // Machine External Interrupt Handler.
-  unimp
-
-  // Reserved.
-  unimp
-  unimp
-  unimp
-  unimp
-
-  // Vendor Interrupt Handlers:
-
-  // On Ibex interrupt ids 16-30 are for "fast" interrupts.
-  .rept 15
-  unimp
+  // Entries 1-30: interrupt handlers.
+  .rept 30
+  j rom_ext_interrupt_handler
   .endr
 
-  // On Ibex interrupt id 31 is for non-maskable interrupts.
-  unimp
+  // Entry 31: non-maskable interrupt handler.
+  j rom_ext_nmi_handler
   .size _rom_ext_interrupt_vector, .-_rom_ext_interrupt_vector
 
   // Re-enable compressed instructions, linker relaxation.
@@ -153,14 +120,6 @@ _rom_ext_start_boot:
   la   sp, (_stack_end - 16)
 
   /**
-   * Set well-defined interrupt/exception handlers
-   *
-   * The lowest two bits should be `0b01` to ensure we use vectored interrupts.
-   */
-  la   t0, (_rom_ext_interrupt_vector + 1)
-  csrw mtvec, t0
-
-  /**
    * Setup C Runtime
    */
 
@@ -200,6 +159,18 @@ _rom_ext_start_boot:
   li a5, 0x0
   li a6, 0x0
   li a7, 0x0
+
+  /**
+   * Set well-defined interrupt/exception handlers
+   *
+   * The lowest two bits should be `0b01` to ensure we use vectored interrupts.
+   * We set the handlers only after making sure that we can execute some code,
+   * i.e. `crt_section_copy` and `crt_section_clear`, to avoid a double-fault
+   * condition. Any exceptions and interrupts occuring before this line will be
+   * handled by the ROM.
+   */
+  la   t0, (_rom_ext_interrupt_vector + 1)
+  csrw mtvec, t0
 
   /**
    * Jump to C Code


### PR DESCRIPTION
This PR

* Modifies `opentitantool`'s `SpiFlash::program_with_progress` to skip chunks with all 1s,
* Fixes ROM_EXT interrupt vector setup, and
* Adds tests for `rom_e2e_address_translation`.

Fixes #14483