### PR TITLE
[otbn,dv] Fixes for assertion failures in V2S tests + regression failure for sec_cm test

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -190,10 +190,16 @@ class otbn_common_vseq extends otbn_base_vseq;
   virtual task pre_run_sec_cm_fi_vseq();
     sb_setting = cfg.en_scb;
     cfg.en_scb = 1;
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 0)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 0)
+    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 0)
   endtask : pre_run_sec_cm_fi_vseq
 
   virtual task post_run_sec_cm_fi_vseq();
     cfg.en_scb = sb_setting;
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 1)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 1)
+    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 1)
   endtask : post_run_sec_cm_fi_vseq
 
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
@@ -18,6 +18,10 @@ class otbn_dmem_err_vseq extends otbn_base_vseq;
     logic [127:0]    key;
     logic [63:0]     nonce;
 
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 0)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 0)
+    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 0)
+
     elf_path = pick_elf_path();
     `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
     load_elf(elf_path, 1'b1);
@@ -50,6 +54,9 @@ class otbn_dmem_err_vseq extends otbn_base_vseq;
     // sure that it has gone out in at most 100 cycles.
     reset_if_locked();
 
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 1)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 1)
+    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 1)
   endtask
 
 endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
@@ -18,6 +18,10 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
     logic [127:0]    key;
     logic [63:0]     nonce;
 
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 0)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 0)
+    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 0)
+
     elf_path = pick_elf_path();
     `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
     load_elf(elf_path, 1'b1);
@@ -58,6 +62,10 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
     // Looks like the injected error should have some effect. Wait until the ISS and RTL move to a
     // locked state.
     reset_if_locked();
+
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 1)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 1)
+    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 1)
   endtask
 
 endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
@@ -36,7 +36,6 @@ class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
           do begin
             @(cfg.clk_rst_vif.cb);
             uvm_hdl_read("tb.dut.u_dmem.req_i", req);
-    `DV_ASSERT_CTRL_REQ("DMemAsserts", 0)
           end while(!req);
         )
         `DV_CHECK_FATAL(uvm_hdl_force(gnt_path, 0) == 1)

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
@@ -8,6 +8,9 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
 
   task body();
     do_end_addr_check = 0;
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 0)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 0)
+    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 0)
     fork
       begin
         super.body();
@@ -29,6 +32,9 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
       end
     join
 
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 1)
+    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 1)
+    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 1)
   endtask : body
 
 endclass : otbn_zero_state_err_urnd_vseq


### PR DESCRIPTION
Commit number one is a simple fix for preventing disabling the same assertion group twice.

Commit number two is the main change, touches sec_cm test sequence and model. Basically makes model consistent with the described behaviour (going to LOCKED after initial secure wipe is complete in the case of seeing a fatal error while doing initial secure wipe). `SecCmPrimOnehot` now causes a BadInternalState fatal error (with commit 585cbfb85091acccdb115df7c0342448fec2473d) so test sequence is changed to reflect that.

We talked about (https://github.com/lowRISC/opentitan/pull/14951#issuecomment-1255927945) disabling V2S assertions in the case of fault injecting tests. Commit number three in this PR does exactly that.

With this PR we see 20/20 otbn_sec_cm test rate. Haven't ran a full regression to check other tests though.