### PR TITLE
[dv/pwrmgr] Fixes for recent RTL changes

### DIFF
--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_monitor.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_monitor.sv
@@ -31,6 +31,7 @@ class pwrmgr_clk_ctrl_monitor extends dv_base_monitor #(
 
   // collect transactions forever - already forked in dv_base_monitor::run_phase
   virtual protected task collect_trans(uvm_phase phase);
+    cfg.clk_ctrl_en = 0;
     cfg.vif.wait_for_reset();
 
     `uvm_info(`gfn, $sformatf("clk_ctrl %s", (cfg.clk_ctrl_en)? "enabled" :

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_aborted_low_power_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_aborted_low_power_vseq.sv
@@ -16,9 +16,9 @@ class pwrmgr_aborted_low_power_vseq extends pwrmgr_base_vseq;
 
   constraint cpu_interrupt_c {
     cpu_interrupt dist {
-                        1 := 2,
-                        0 := 6
-                        };
+      1 := 2,
+      0 := 6
+    };
   }
 
   rand bit flash_idle;
@@ -53,11 +53,11 @@ class pwrmgr_aborted_low_power_vseq extends pwrmgr_base_vseq;
       setup_interrupt(.enable(en_intr));
       // Enable wakeups.
       enabled_wakeups = wakeups_en & wakeups;
-      `DV_CHECK(enabled_wakeups,
-                $sformatf("Some wakeup must be enabled: wkups=%b, wkup_en=%b",
-                          wakeups, wakeups_en))
-      `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x (wkups=%x  wkup_en=%x)",
-                                enabled_wakeups, wakeups, wakeups_en), UVM_MEDIUM)
+      `DV_CHECK(enabled_wakeups, $sformatf(
+                "Some wakeup must be enabled: wkups=%b, wkup_en=%b", wakeups, wakeups_en))
+      `uvm_info(`gfn, $sformatf(
+                "Enabled wakeups=0x%x (wkups=%x  wkup_en=%x)", enabled_wakeups, wakeups, wakeups_en
+                ), UVM_MEDIUM)
       csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeups_en));
       `uvm_info(`gfn, $sformatf("%0sabling wakeup capture", disable_wakeup_capture ? "Dis" : "En"),
                 UVM_MEDIUM)

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
@@ -66,15 +66,10 @@ class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
       if (escalation_reset) send_escalation_reset();
       cfg.pwrmgr_vif.update_sw_rst_req(sw_rst_from_rstmgr);
 
-      cfg.slow_clk_rst_vif.wait_clks(2);
-      // Wait until fast clock comes back
-      repeat(4) @cfg.clk_rst_vif.cb;
-
-      // This read is not always possible since the CPU may be off.
-      check_reset_status(enabled_resets);
+      `uvm_info(`gfn, "Wait for Fast State NE FastPwrStateActive", UVM_MEDIUM)
+      `DV_WAIT(cfg.pwrmgr_vif.fast_state != pwrmgr_pkg::FastPwrStateActive)
 
       // Check fast state is not FastPwrStateActive for a while
-      `uvm_info(`gfn, "Check Fast State NE FastPwrStateActive", UVM_MEDIUM)
       repeat(20) begin
         @cfg.slow_clk_rst_vif.cb;
         `DV_CHECK_NE(cfg.pwrmgr_vif.fast_state, pwrmgr_pkg::FastPwrStateActive)

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
@@ -1,11 +1,13 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+
 // Description:
 // This sequence creates escalation clock and reset malfunction at FastPwrStateActive state.
 // This event will trigger timeout counter and assert timeout signal
 // when timeout counter reaches EscTimeOutCnt value.
 // Once the timeout occurs, it will create fatal alert and alert agent(tb) will set esc rst.
+// The pass or failure status is determined in the cip scoreboard.
 class pwrmgr_esc_clk_rst_malfunc_vseq extends pwrmgr_base_vseq;
   `uvm_object_utils(pwrmgr_esc_clk_rst_malfunc_vseq)
 
@@ -13,10 +15,7 @@ class pwrmgr_esc_clk_rst_malfunc_vseq extends pwrmgr_base_vseq;
   constraint num_trans_c {num_trans inside {[1 : 3]};}
 
   virtual task body();
-    int margin = $urandom_range(0, 10);
-    // before body, fast state become active state
-    // Add some time margin after fsm become active state.
-    #(margin * 1ns);
+    wait_for_fast_fsm_active();
 
     // send a expected alert to the scoreboard
     expect_fatal_alerts = 1;
@@ -36,18 +35,19 @@ class pwrmgr_esc_clk_rst_malfunc_vseq extends pwrmgr_base_vseq;
       1: path = "tb.dut.rst_esc_ni";
       1: path = "tb.dut.clk_esc_i";
     endcase // randcase
-
+    `uvm_info(`gfn, $sformatf("Sending noise via %s", path), UVM_MEDIUM)
     `DV_CHECK(uvm_hdl_force(path, 0))
     #(delay * 1us);
-  endtask // add_noise
+  endtask : add_noise
 
   task clear_noise();
     int delay = $urandom_range(1, 5);
     string path;
+    `uvm_info(`gfn, "Releasing noise", UVM_MEDIUM)
     path = "tb.dut.rst_esc_ni";
     `DV_CHECK(uvm_hdl_release(path))
     path = "tb.dut.clk_esc_i";
     `DV_CHECK(uvm_hdl_release(path))
     #(delay * 100ns);
-  endtask // clear_noise
+  endtask : clear_noise
 endclass

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
@@ -14,7 +14,7 @@ class pwrmgr_sec_cm_ctrl_config_regwen_vseq extends pwrmgr_wakeup_vseq;
   virtual task pre_start();
     super.pre_start();
     cfg.disable_csr_rd_chk = 1;
-  endtask // pre_start
+  endtask : pre_start
 
   task proc_illegal_ctrl_access();
     uvm_reg_data_t wdata, expdata;
@@ -24,12 +24,12 @@ class pwrmgr_sec_cm_ctrl_config_regwen_vseq extends pwrmgr_wakeup_vseq;
     repeat($urandom_range(1, 5)) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
       expdata = ral.control.get();
-      `uvm_info(`gfn, $sformatf("csr start %x",ral.control.get()), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("csr start %x", ral.control.get()), UVM_HIGH)
       csr_wr(.ptr(ral.control), .value(wdata));
       csr_rd_check(.ptr(ral.control), .compare_value(expdata));
       `uvm_info(`gfn, "csr done", UVM_HIGH)
     end
-  endtask // proc_illegal_ctrl_access
+  endtask : proc_illegal_ctrl_access
 
   virtual task wait_for_csr_to_propagate_to_slow_domain();
     proc_illegal_ctrl_access();

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv
@@ -22,7 +22,7 @@ interface pwrmgr_ast_sva_if (
   // not more than 2 cycles.
   localparam int MIN_CLK_WAIT_CYCLES = 0;
   localparam int MIN_PDN_WAIT_CYCLES = 0;
-  localparam int MAX_CLK_WAIT_CYCLES = 10;
+  localparam int MAX_CLK_WAIT_CYCLES = 20;
   localparam int MAX_PDN_WAIT_CYCLES = 110;
 
   bit disable_sva;

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
@@ -33,7 +33,7 @@ interface pwrmgr_rstmgr_sva_if
 
   // Number of cycles for the LC/SYS reset handshake.
   localparam int MIN_LC_SYS_CYCLES = 0;
-  localparam int MAX_LC_SYS_CYCLES = 24;
+  localparam int MAX_LC_SYS_CYCLES = 30;
   `define LC_SYS_CYCLES ##[MIN_LC_SYS_CYCLES:MAX_LC_SYS_CYCLES]
 
   // Number of cycles for the output resets.

--- a/hw/ip/pwrmgr/dv/tb.sv
+++ b/hw/ip/pwrmgr/dv/tb.sv
@@ -69,10 +69,6 @@ module tb;
     .rst_slow_n
   );
 
-  assign pcc_if.pwr_ast_req = pwrmgr_if.pwr_ast_req;
-  assign pcc_if.pwr_clk_req = pwrmgr_if.pwr_clk_req;
-  assign pcc_if.pwr_rst_req = pwrmgr_if.pwr_rst_req;
-
   `DV_ALERT_IF_CONNECT
 
   // dut


### PR DESCRIPTION
The change in handling of reset had a big impact on DV. Some test sequences need to be adjusted to stop during lc reset or clock stops, and reset handling needs to change.
The pwrmgr_clk_ctrl_agent was out of sync with the counterpart in pwrmgr_base_vseq, so we are moving all functionality to the latter. This PR disables that agent and a subsequent one will remove it. Add some manual exclusions that the UNR tool should have detected.

Signed-off-by: Guillermo Maturana <maturana@google.com>