### PR TITLE
refactor(prim): rst_sync to have scanchain

### DIFF
--- a/hw/ip/prim/prim_rst_sync.core
+++ b/hw/ip/prim/prim_rst_sync.core
@@ -12,6 +12,7 @@ filesets:
       # Needed because the generic prim_flop_2sync has a
       # dependency on prim:flop.
       - lowrisc:prim:flop_2sync
+      - lowrisc:prim:mubi
       - lowrisc:prim:cdc_rand_delay
     files:
       - rtl/prim_rst_sync.sv

--- a/hw/ip/prim/rtl/prim_rst_sync.sv
+++ b/hw/ip/prim/rtl/prim_rst_sync.sv
@@ -5,14 +5,15 @@
 // Reset synchronizer
 /** Conventional 2FF async assert sync de-assert reset synchronizer
  *
- *
- * The sync module does not have scan input. Scan mux needs to be added after
- * this sync module.
  */
 
 module prim_rst_sync #(
   // ActiveHigh should be 0 if the input reset is active low reset
   parameter bit ActiveHigh = 1'b 0,
+
+  // In certain case, Scan may be inserted at the following reset chain.
+  // Set SkipScan to 1'b 1 in that case.
+  parameter bit SkipScan   = 1'b 0,
 
   // CDC parameters
   parameter int CdcLatencyPs = 1000,
@@ -20,16 +21,23 @@ module prim_rst_sync #(
 ) (
   input        clk_i,
   input        d_i, // raw reset (not synched to clk_i)
-  output logic q_o  // reset synched to clk_i
+  output logic q_o, // reset synched to clk_i
+
+  // Scan chain
+  input                        scan_rst_ni,
+  input prim_mubi_pkg::mubi4_t scanmode_i
 );
 
-  logic sync_rst_n;
+  logic async_rst_n, scan_rst;
+  logic rst_sync;
 
   // TODO: Check if 2FF set can be used.
   if (ActiveHigh == 1'b 1) begin : g_rst_inv
-    assign sync_rst_n = ~d_i;
+    assign async_rst_n = ~d_i;
+    assign scan_rst    = ~scan_rst_ni;
   end else begin : g_rst_direct
-    assign sync_rst_n = d_i;
+    assign async_rst_n = d_i;
+    assign scan_rst    = scan_rst_ni;
   end
 
   prim_flop_2sync #(
@@ -39,9 +47,25 @@ module prim_rst_sync #(
     .CdcJitterPs  (CdcJitterPs)
   ) u_sync (
     .clk_i,
-    .rst_ni (sync_rst_n ),
+    .rst_ni (async_rst_n),
     .d_i    (!ActiveHigh), // reset release value
-    .q_o
+    .q_o    (rst_sync   )
   );
+
+  if (SkipScan) begin : g_skip_scan
+    logic  unused_scan;
+    assign unused_scan = ^{scan_rst, scanmode_i};
+
+    assign q_o = rst_sync;
+  end else begin : g_scan_mux
+    prim_clock_mux2 #(
+      .NoFpgaBufG(1'b1)
+    ) u_scan_mux (
+      .clk0_i(rst_sync                                         ),
+      .clk1_i(scan_rst                                         ),
+      .sel_i (prim_mubi_pkg::mubi4_test_true_strict(scanmode_i)),
+      .clk_o (q_o                                              )
+    );
+  end
 
 endmodule : prim_rst_sync


### PR DESCRIPTION
Based on the feedback in previous rst_sync PR, `prim_rst_sync` now has scanchain inputs.