### PR TITLE
[test] Add rom_e2e_shutdown_output_rma

### DIFF
--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -23,7 +23,7 @@
       desc: '''Verify that ROM can properly report errors over UART.
 
             - Attempt to boot without a valid ROM_EXT.
-            - Verify that we can receive the 28 character long (`LCV:xxxxxxxx\r\nBFV:xxxxxxxx\r\n`) error
+            - Verify that we can receive the 28 character long (`BFV:xxxxxxxx\r\nLCV:xxxxxxxx\r\n`) error
               output in all life cycle states where Ibex is enabled, i.e. TEST_UNLOCKED*, PROD,
               PROD_END, DEV, and RMA.
                 - BFV should be 0142500d for all life cycle states.

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -15,6 +15,11 @@ load(
     "//rules:opentitan.bzl",
     "opentitan_multislot_flash_binary",
 )
+load(
+    "//rules:manifest.bzl",
+    "CONST",
+    "manifest",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -364,4 +369,42 @@ opentitan_functest(
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
+)
+
+MSG_SHUTDOWN = {
+    "test": "BFV:0142500d\r\nLCV:02108421\r\n",
+    "dev": "BFV:0142500d\r\nLCV:21084210\r\n",
+    "prod": "BFV:0142500d\r\nLCV:2318c631\r\n",
+    "prod_end": "BFV:0142500d\r\nLCV:25294a52\r\n",
+    "rma": "BFV:0142500d\r\nLCV:2739ce73\r\n",
+}
+
+LC_STATES = ["rma"]
+
+manifest(
+    name = "manifest_bad_identifier",
+    address_translation = CONST.FALSE,
+    identifier = 0,
+)
+
+# TODO(#14270): Add remaining lifecycle states.
+[opentitan_functest(
+    name = "shutdown_output_{}".format(lc_state),
+    srcs = ["empty_test.c"],
+    cw310 = cw310_params(
+        bitstream = "@//hw/bitstream:rom",
+        exit_failure = MSG_PASS,
+        exit_success = MSG_SHUTDOWN[lc_state],
+    ),
+    manifest = ":manifest_bad_identifier",
+    signed = False,
+    targets = ["cw310_rom"],
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+) for lc_state in LC_STATES]
+
+test_suite(
+    name = "shutdown_output",
+    tests = ["shutdown_output_{}".format(lc_state) for lc_state in LC_STATES],
 )


### PR DESCRIPTION
This PR adds the shutdown_output test for the RMA life cycle state. See #14270 for details.