### PR TITLE
[flash_ctrl] Fixes to host_gnt_err handling for more graceful handling

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -1450,6 +1450,9 @@ module flash_ctrl
      `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdDataFifoRPtr_A,
        `PHY_CORE.u_rd.u_rd_storage.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
        alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyHostCnt_A,
+       `PHY_CORE.u_host_outstanding_cnt, alert_tx_o[1])
    end
    `endif
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -1451,6 +1451,9 @@ module flash_ctrl
      `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdDataFifoRPtr_A,
        `PHY_CORE.u_rd.u_rd_storage.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
        alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyHostCnt_A,
+       `PHY_CORE.u_host_outstanding_cnt, alert_tx_o[1])
    end
    `endif
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -110,6 +110,9 @@ module flash_phy
   logic [NumBanks-1:0]     rsp_fifo_err;
   logic [NumBanks-1:0]     core_fifo_err;
 
+  // outstanding count error per bank
+  logic [NumBanks-1:0]     cnt_err;
+
   // select which bank each is operating on
   assign host_bank_sel = host_req_i ? host_addr_i[BusAddrW-1 -: BankW] : '0;
   assign ctrl_bank_sel = flash_ctrl_i.addr[BusAddrW-1 -: BankW];
@@ -136,8 +139,9 @@ module flash_phy
   assign flash_ctrl_o.fsm_err = |fsm_err;
   assign flash_ctrl_o.spurious_ack = |spurious_acks;
   assign flash_ctrl_o.arb_err = |arb_err;
-  assign flash_ctrl_o.host_gnt_err = |host_gnt_err;
+  assign flash_ctrl_o.host_gnt_err = |{host_gnt_err, cnt_err} ;
   assign flash_ctrl_o.fifo_err = |{rsp_fifo_err, core_fifo_err};
+
 
   // This fifo holds the expected return order
   prim_fifo_sync #(
@@ -295,7 +299,8 @@ module flash_phy
       .spurious_ack_o(spurious_acks[bank]),
       .arb_err_o(arb_err[bank]),
       .host_gnt_err_o(host_gnt_err[bank]),
-      .fifo_err_o(core_fifo_err[bank])
+      .fifo_err_o(core_fifo_err[bank]),
+      .cnt_err_o(cnt_err[bank])
     );
   end // block: gen_flash_banks
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -1457,6 +1457,9 @@ module flash_ctrl
      `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdDataFifoRPtr_A,
        `PHY_CORE.u_rd.u_rd_storage.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
        alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyHostCnt_A,
+       `PHY_CORE.u_host_outstanding_cnt, alert_tx_o[1])
    end
    `endif
 


### PR DESCRIPTION
fixes #15155
- currently if the conditions to host_gnt_err trigger, the flash controller will most definitely lock-up.  While this is somewhat acceptable behvaior since thse conditions occur only when attacked, it is still a little difficult for software to use.

- This commit massages the logic around host_gnt_err to make it slightly more recoverable.  It is not 100% proof, since fault attacks in certain parts of the logic will just be unrecoverable.

- Specifically, do not use ctrl_fsm_idle to qualify host returns, instead use host_outstanding.  This eliminates a single point of failure that could lead to lock-ups.

- Better handling for host grants to info partitions.  When such an error occurs, future host transactions are not accepted until the existing pipeline of reads are fully flushed.  This ensures we get back to a clean state.

Signed-off-by: Timothy Chen <timothytim@google.com>