### PR TITLE
[top/dv] Lengthen the wait time in the test.

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -588,9 +588,9 @@
       uvm_test_seq: chip_sw_rstmgr_alert_info_vseq
       sw_images: ["//sw/device/tests:rstmgr_alert_info_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15_000_000", "+en_scb_tl_err_chk=0",
+      run_opts: ["+sw_test_timeout_ns=15_500_000", "+en_scb_tl_err_chk=0",
                  "+en_scb_ping_chk=0"]
-      run_timeout_mins: 40
+      run_timeout_mins: 60
     }
     {
       name: chip_sw_rstmgr_cpu_info

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -83,7 +83,7 @@ enum {
   kRoundOneDelay = 100,           // us
   kRoundTwoDelay = 100,           // us
   kRoundThreeDelay = 1000,        // us
-  kRoundFourDelay = 2500,         // us
+  kRoundFourDelay = 2800,         // us
 };
 
 static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;


### PR DESCRIPTION
When alerts pings are enabled, the hardware goes through randomized wait time to ensure that alert pings are not always enabled at the same moment every time.

This time maxes out at 2700+ us given our current design, which is just slightly longer than the wait time in the test.  I believe this leads to sporatic failures, this commit lengthens the wait time a bit.

Signed-off-by: Timothy Chen <timothytim@google.com>