### PR TITLE
[spi_device/dv] update scb for TPM HW returned reg

### DIFF
--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -201,7 +201,7 @@
             - Ensure that the data returned is correct for the given locality.
             - Randomise TPM_CFG.invalid_locality and confirm response.'''
       stage: V2
-      tests: ["spi_device_tpm_locality"]
+      tests: ["spi_device_tpm_sts_read"]
     }
     {
       name: pass_cmd_filtering

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_sts_read_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_sts_read_vseq.sv
@@ -4,8 +4,8 @@
 
 // TPM Locality test, making transactions of various locality
 // Targeting HW sts register, randomizing it and checking data returned to host
-class spi_device_tpm_locality_vseq extends spi_device_tpm_base_vseq;
-  `uvm_object_utils(spi_device_tpm_locality_vseq)
+class spi_device_tpm_sts_read_vseq extends spi_device_tpm_base_vseq;
+  `uvm_object_utils(spi_device_tpm_sts_read_vseq)
   `uvm_object_new
 
   virtual task body();
@@ -28,7 +28,7 @@ class spi_device_tpm_locality_vseq extends spi_device_tpm_base_vseq;
       cfg.clk_rst_vif.wait_clks(100);
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(locality_idx, locality_idx < MAX_TPM_LOCALITY;)
 
-      tpm_addr = get_tpm_addr(locality_idx);
+      tpm_addr = get_tpm_addr(locality_idx, TPM_STS_OFFSET);
 
       spi_host_xfer_tpm_item(.write(0), .tpm_size(4), .addr(tpm_addr),
                               .payload_q(returned_bytes));
@@ -42,4 +42,4 @@ class spi_device_tpm_locality_vseq extends spi_device_tpm_base_vseq;
     end
   endtask : body
 
-endclass : spi_device_tpm_locality_vseq
+endclass : spi_device_tpm_sts_read_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -20,7 +20,7 @@
 `include "spi_device_tx_async_fifo_reset_vseq.sv"
 `include "spi_device_rx_async_fifo_reset_vseq.sv"
 `include "spi_device_abort_vseq.sv"
-`include "spi_device_tpm_locality_vseq.sv"
+`include "spi_device_tpm_sts_read_vseq.sv"
 `include "spi_device_tpm_rw_vseq.sv"
 `include "spi_device_pass_base_vseq.sv"
 `include "spi_device_pass_cmd_filtering_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -36,7 +36,7 @@ filesets:
       - seq_lib/spi_device_tx_async_fifo_reset_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_rx_async_fifo_reset_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_abort_vseq.sv: {is_include_file: true}
-      - seq_lib/spi_device_tpm_locality_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_tpm_sts_read_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_tpm_rw_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_pass_base_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_pass_cmd_filtering_vseq.sv: {is_include_file: true}

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -131,8 +131,8 @@
     }
 
     {
-      name: spi_device_tpm_locality
-      uvm_test_seq: spi_device_tpm_locality_vseq
+      name: spi_device_tpm_sts_read
+      uvm_test_seq: spi_device_tpm_sts_read_vseq
     }
 
     {


### PR DESCRIPTION
1. predict and compare HW returned reg in scb
2. renamed tpm_locality_vseq -> tpm_sts_read_vseq
3. Removed some unused parameters

Signed-off-by: Weicai Yang <weicai@google.com>