### PR TITLE
[sim_verilator] Initialize the first flash bank before backdoor loading

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -24,6 +24,7 @@ filegroup(
     name = "all_files",
     srcs = glob(["**"]) + [
         "//hw/top_earlgrey/data:all_files",
+        "//hw/top_earlgrey/dv/verilator:all_files",
         "//hw/top_earlgrey/ip:all_files",
         "//hw/top_earlgrey/sw:all_files",
     ],

--- a/hw/top_earlgrey/dv/verilator/BUILD
+++ b/hw/top_earlgrey/dv/verilator/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
@@ -26,11 +26,12 @@ int main(int argc, char **argv) {
               0x4000 / 4, 4);
   MemArea ram(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope, 0x20000 / 4,
               4);
+  // Only handle the lower bank of flash for now.
   MemArea flash(top_scope +
                     ".u_flash_ctrl.u_eflash.u_flash.gen_generic.u_impl_generic."
                     "gen_prim_flash_banks[0].u_prim_flash_bank.u_mem."
                     "gen_generic.u_impl_generic",
-                0x100000 / 8, 8);
+                0x80000 / 8, 8);
   MemArea otp(top_scope + ".u_otp_ctrl.u_otp.gen_generic.u_impl_generic." +
                   ram1p_adv_scope,
               0x4000 / 4, 4);

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "verilated_toplevel.h"
 #include "verilator_memutil.h"
@@ -32,6 +34,11 @@ int main(int argc, char **argv) {
                     "gen_prim_flash_banks[0].u_prim_flash_bank.u_mem."
                     "gen_generic.u_impl_generic",
                 0x80000 / 8, 8);
+  // Start with the flash region erased. Future loads can overwrite.
+  std::vector<uint8_t> all_ones(flash.GetSizeBytes());
+  std::fill(all_ones.begin(), all_ones.end(), 0xffu);
+  flash.Write(/*word_offset=*/0, all_ones);
+
   MemArea otp(top_scope + ".u_otp_ctrl.u_otp.gen_generic.u_impl_generic." +
                   ram1p_adv_scope,
               0x4000 / 4, 4);


### PR DESCRIPTION
Correct the size of the flash bank identified by the "flash" mem area. Ensure it begins with an initial state of being erased before selectively overwriting pieces with backdoor loading.