### PR TITLE
[tests] Update life-cycle broadcast testpoint

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1587,30 +1587,49 @@
       name: chip_sw_lc_ctrl_broadcast
       desc: '''Verify broadcast signals from lc_ctrl.
 
-            - Preload the LC partition in the OTP ctrl with the following states: RMA, DEV,
-              TEST_LOCKED[N] & SCRAP (tested in chip_lc_ctrl_escalation).
+            - Preload the LC partition in the otp_ctrl with the following states: RMA, DEV,
+              TEST_LOCKED[N] & SCRAP.
             - Verify that the following broadcast signals are having the right effect in the
               respective IPs that consume them:
-              - lc_dft_en_o: impacts clkmgr, pinmux, OTP ctrl & AST
-              - lc_nvm_debug_en_o: impacts flash ctrl
-              - lc_hw_debug_en_o: impacts pinmux, SRAM ctrl (main and ret) & the debug module
-              - lc_cpu_en_o: impacts the CPU
-              - lc_keymgr_en: impacts keymgr
-              - lc_escalate_en_o: impacts SRAM ctrl, AES & OTP ctrl
+              - lc_dft_en_o: impacts pinmux, pwrmgr, otp_ctrl, AST
+              - lc_hw_debug_en_o: impacts pinmux, pwrmgr, sram_ctrl (main and ret) & the rv_dm
+              - lc_keymgr_en_o: impacts keymgr
               - lc_clk_byp_req_o: impacts clkmgr (handshake with lc_clk_byp_ack_i)
-              - lc_flash_rma_req_o: impacts flash ctrl (handshake with lc_flash_ram_ack_i)
-              - lc_flash_rma_seed_o: impacts flash ctrl
-              - lc_check_byp_en_o: impacts OTP ctrl
-              - lc_creator_seed_sw_rw_en_o: impacts flash ctrl & OTP ctrl
-              - lc_owner_seed_sw_rw_en_o: impacts flash ctrl
-              - lc_iso_part_sw_rd_en_o: impacts flash ctrl
-              - lc_iso_part_sw_wr_en_o: impacts flash ctrl
-              - lc_seed_hw_rd_en_o: impacts flash ctrl & OTP ctrl
+              - lc_flash_rma_req_o: impacts flash_ctrl (handshake with lc_flash_ram_ack_i)
+              - lc_flash_rma_seed_o: impacts flash_ctrl
+              - lc_check_byp_en_o: impacts otp_ctrl
+              - lc_creator_seed_sw_rw_en_o: impacts flash_ctrl & otp_ctrl
+              - lc_owner_seed_sw_rw_en_o: impacts flash_ctrl
+              - lc_iso_part_sw_rd_en_o: impacts flash_ctrl
+              - lc_iso_part_sw_wr_en_o: impacts flash_ctrl
+              - lc_seed_hw_rd_en_o: impacts flash_ctrl & otp_ctrl
             - These outputs are enabled per the [life cycle architecture spec]({{< relref "doc/security/specs/device_life_cycle/#architecture" >}}).
             X-ref'ed with the respective IP tests that consume these signals.
+
+            Note that the following signals are already verified with connectivity tests and SVAs:
+              - lc_dft_en_o (AST connection)
+              - lc_cpu_en_o (rv_core_ibex)
+              - lc_nvm_debug_en_o (flash_ctrl)
+              - lc_escalate_en_o (multiple)
             '''
       stage: V2
-      tests: []
+      tests: [
+        "chip_prim_tl_access",                            // lc_dft_en_o: otp_ctrl
+        "chip_tap_straps_dev",                            // lc_dft_en_o, lc_hw_debug_en_o: pinmux
+        "chip_tap_straps_prod",                           // lc_dft_en_o, lc_hw_debug_en_o: pinmux
+        "chip_tap_straps_rma",                            // lc_dft_en_o, lc_hw_debug_en_o: pinmux
+        "chip_sw_rom_ctrl_integrity_check",               // lc_dft_en_o, lc_hw_debug_en_o: pwrmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw",         // lc_hw_debug_en_o: clkmgr
+        "chip_sw_sram_ctrl_execution_main",               // lc_hw_debug_en_o: sram_ctrl main
+        // TODO: ref chip_sw_rv_dm_lc_disabled (#14147)   // lc_hw_debug_en_o: rv_dm
+        "chip_sw_keymgr_key_derivation",                  // lc_keymgr_en_o: keymgr
+        // TODO: add disable test (#15272)                // lc_keymgr_en_o: keymgr
+        "chip_sw_clkmgr_external_clk_src_for_lc",         // lc_clk_byp_req_o: clkmgr
+        "chip_sw_flash_rma_unlocked",                     // lc_flash_rma_req_o, lc_flash_rma_seed_o: flash_ctrl
+        "chip_sw_otp_ctrl_program",                       // lc_check_byp_en_o: otp_ctrl
+        "chip_sw_flash_ctrl_lc_rw_en",                    // lc_creator*, lc_seed*, lc_owner*, lc_iso*: flash_ctrl
+        // TODO: ref chip_sw_otp_ctrl_lc_signals (#14139) // lc_creator*, lc_seed*: OTP
+      ]
     }
 
 
@@ -2513,28 +2532,23 @@
       name: chip_sw_otp_ctrl_lc_signals
       desc: '''Verify the broadcast signals from LC ctrl.
 
-            - `lc_escalate_en_i`: read the error code CSR and verify that it reflects an FSM error
-              state due to the escalation signal triggering.
             - `lc_creator_seed_sw_rw_en_i`: verify that the secret2 partition is locked.
             - `lc_seed_hw_rd_en_i`: verify that the keymgr outputs a default value when enabled.
             - `lc_dft_en_i`: verify that the test interface within OTP ctrl is accessible.
             - `lc_check_byp_en_i`: verify that the background check during LC ctrl state
               programming passes when enabled.
 
+            Note that `lc_escalate_en_i` is verified via a connectivity test.
+
             X-ref'ed with chip_sw_lc_ctrl_broadcast test, which verifies the connectivity of the LC
             decoded outputs to other IPs.
             '''
       stage: V2
-      tests: []
-    }
-    {
-      name: chip_sw_otp_ctrl_ast
-      desc: '''Verify the power sequencing signals to AST, as well as the alert.
-
-            Details TBD.
-            '''
-      stage: V2
-      tests: []
+      tests: [
+        "chip_prim_tl_access",        // lc_dft_en_i
+        "chip_sw_lc_ctrl_transition", // lc_check_byp_en_i
+        // TODO(#14139): access control signals.
+        ]
     }
     {
       name: chip_sw_otp_prim_tl_access


### PR DESCRIPTION
This updates the life-cycle broadcast related testpoint. Several tests already exist, but some need to be updated/developed.

Partially addresses #14139, #14169.

Signed-off-by: Michael Schaffner <msf@google.com>