### PR TITLE
[otbn,dv] Introduce error signals as resets in OTBN V2S Assertions

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -190,16 +190,10 @@ class otbn_common_vseq extends otbn_base_vseq;
   virtual task pre_run_sec_cm_fi_vseq();
     sb_setting = cfg.en_scb;
     cfg.en_scb = 1;
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 0)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 0)
-    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 0)
   endtask : pre_run_sec_cm_fi_vseq
 
   virtual task post_run_sec_cm_fi_vseq();
     cfg.en_scb = sb_setting;
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 1)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 1)
-    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 1)
   endtask : post_run_sec_cm_fi_vseq
 
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -28,9 +28,6 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
     bit [3:0] mask;
     bit [31:0] err_val = 32'd1 << 20;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(err_type, err_type inside {[0:6]};)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 0)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 0)
-    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 0)
     case(err_type)
       // Injecting error on ispr_addr during a write
       0: begin
@@ -255,9 +252,6 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
     `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked)
     `DV_CHECK_FATAL(uvm_hdl_release(err_path) == 1);
     reset_if_locked();
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 1)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 1)
-    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 1)
   endtask
 
 endclass : otbn_ctrl_redun_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
@@ -18,10 +18,6 @@ class otbn_dmem_err_vseq extends otbn_base_vseq;
     logic [127:0]    key;
     logic [63:0]     nonce;
 
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 0)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 0)
-    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 0)
-
     elf_path = pick_elf_path();
     `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
     load_elf(elf_path, 1'b1);
@@ -54,9 +50,6 @@ class otbn_dmem_err_vseq extends otbn_base_vseq;
     // sure that it has gone out in at most 100 cycles.
     reset_if_locked();
 
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 1)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 1)
-    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 1)
   endtask
 
 endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
@@ -18,10 +18,6 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
     logic [127:0]    key;
     logic [63:0]     nonce;
 
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 0)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 0)
-    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 0)
-
     elf_path = pick_elf_path();
     `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
     load_elf(elf_path, 1'b1);
@@ -63,9 +59,6 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
     // locked state.
     reset_if_locked();
 
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 1)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 1)
-    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 1)
   endtask
 
 endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
@@ -8,9 +8,6 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
 
   task body();
     do_end_addr_check = 0;
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 0)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 0)
-    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 0)
     fork
       begin
         super.body();
@@ -32,9 +29,6 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
       end
     join
 
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsALU", 1)
-    `DV_ASSERT_CTRL_REQ("BlankingAssertsRF", 1)
-    `DV_ASSERT_CTRL_REQ("SecWipeAsserts", 1)
   endtask : body
 
 endclass : otbn_zero_state_err_urnd_vseq

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -344,54 +344,9 @@ module tb;
   // needed for sequences that trigger alerts (locking OTBN) without telling the model.
   `DV_ASSERT_CTRL("otbn_status_assert_en", tb.MatchingStatus_A)
 
-  // We need to turn off blanking related assertions in redundancy related fault injection tests.
-  `DV_ASSERT_CTRL("BlankingAssertsALU", tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluXOp_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU",
-                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluYOpA_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU",
-                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluYOpShft_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU",
-                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluYResUsed_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU",
-                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluShftA_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU",
-                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluShftB_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU",
-                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluShftRes_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU",
-                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluLogicOpA_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU",
-                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluLogicShft_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU",
-                  tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingBignumAluLogicRes_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU", tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingIsprMod_A)
-  `DV_ASSERT_CTRL("BlankingAssertsALU", tb.dut.u_otbn_core.u_otbn_alu_bignum.BlankingIsprACC_A)
-  `DV_ASSERT_CTRL("BlankingAssertsRF", tb.dut.u_otbn_core.u_otbn_rf_bignum.BlankingBignumRegReadA_A)
-  `DV_ASSERT_CTRL("BlankingAssertsRF", tb.dut.u_otbn_core.u_otbn_rf_bignum.BlankingBignumRegReadB_A)
-
   // We need to turn off DMEM related assertions in the tests where we force internals of DMEM to generate errors
   `DV_ASSERT_CTRL("DMemAsserts", tb.dut.u_otbn_core.u_otbn_lsu.DMemRValidAfterReq)
   `DV_ASSERT_CTRL("DMemAsserts", tb.dut.u_otbn_core.OnlyWriteLoadDataBaseWhenDMemValid_A)
   `DV_ASSERT_CTRL("DMemAsserts", tb.dut.u_otbn_core.OnlyWriteLoadDataBignumWhenDMemValid_A)
-
-  // GPR assertions for secure wipe
-  for (genvar i = 2; i < NGpr; ++i) begin : gen_sec_wipe_gpr_asserts
-    `DV_ASSERT_CTRL("SecWipeAsserts",
-                    tb.dut.gen_sec_wipe_gpr_asserts[i].InitSecWipeNonZeroBaseRegs_A)
-    `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.gen_sec_wipe_gpr_asserts[i].SecWipeChangedBaseRegs_A)
-  end
-
-  // WDR assertions for secure wipe
-  for (genvar i = 0; i < NWdr; ++i) begin : gen_sec_wipe_wdr_asserts
-    `DV_ASSERT_CTRL("SecWipeAsserts",
-                    tb.dut.gen_sec_wipe_wdr_asserts[i].InitSecWipeNonZeroWideRegs_A)
-    `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.gen_sec_wipe_wdr_asserts[i].SecWipeChangedWideRegs_A)
-  end
-
-  `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.SecWipeNonZeroMod_A)
-  `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.SecWipeNonZeroACC_A)
-  `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.SecWipeNonZeroFlags_A)
-  `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.SecWipeInvalidCallStack_A)
-  `DV_ASSERT_CTRL("SecWipeAsserts", tb.dut.SecWipeInvalidLoopStack_A)
 
 endmodule

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -845,18 +845,22 @@ module otbn_alu_bignum
   `ASSERT_KNOWN(RegIntgErrKnown_A, reg_intg_violation_err_o)
 
   // Blanking Assertions
+  // All blanking assertions are reset with predec_error or overall error in the whole system
+  // -indicated by operation_commit_i port- as OTBN does not guarantee blanking in the case
+  // of an error.
+
   // adder_x_res related blanking
   `ASSERT(BlankingBignumAluXOp_A,
           !expected_adder_x_en |-> {adder_x_op_a_blanked, adder_x_op_b_blanked,adder_x_res} == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
 
   // adder_y_res related blanking
   `ASSERT(BlankingBignumAluYOpA_A,
           !expected_adder_y_op_a_en |-> adder_y_op_a_blanked == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
   `ASSERT(BlankingBignumAluYOpShft_A,
           !expected_adder_y_op_shifter_en |-> adder_y_op_shifter_res_blanked == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
 
   // Adder Y must be blanked when its result is not used, with one exception: For `BN.SUBM` with
   // `a >= b` (thus the result of Adder X has the carry bit set), the result of Adder Y is not used
@@ -864,44 +868,44 @@ module otbn_alu_bignum
   `ASSERT(BlankingBignumAluYResUsed_A,
           !adder_y_res_used && !(operation_i.op == AluOpBignumSubm && adder_x_res[WLEN+1])
           |-> {x_res_operand_a_mux_out, adder_y_op_b} == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
 
   // shifter_res related blanking
   `ASSERT(BlankingBignumAluShftA_A,
           !expected_shifter_a_en |-> shifter_operand_a_blanked == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
 
   `ASSERT(BlankingBignumAluShftB_A,
           !expected_shifter_b_en |-> shifter_operand_b_blanked == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
 
   `ASSERT(BlankingBignumAluShftRes_A,
           !(expected_shifter_a_en || expected_shifter_b_en) |-> shifter_res == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
 
   // logical_res related blanking
   `ASSERT(BlankingBignumAluLogicOpA_A,
           !expected_logic_a_en |-> logical_op_a_blanked == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || alu_predec_error_o  || !operation_commit_i)
 
   `ASSERT(BlankingBignumAluLogicShft_A,
           !expected_logic_shifter_en |-> logical_op_shifter_res_blanked == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
 
   `ASSERT(BlankingBignumAluLogicRes_A,
           !(expected_logic_a_en || expected_logic_shifter_en) |-> logical_res == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
 
 
   // MOD ISPR Blanking
   `ASSERT(BlankingIsprMod_A,
           !(|mod_wr_en) |-> ispr_mod_bignum_wdata_intg_blanked == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || ispr_predec_error_o || alu_predec_error_o || !operation_commit_i)
 
   // ACC ISPR Blanking
   `ASSERT(BlankingIsprACC_A,
           !(|ispr_acc_wr_en_o) |-> ispr_acc_bignum_wdata_intg_blanked == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || ispr_predec_error_o || alu_predec_error_o || !operation_commit_i)
 
 
 endmodule

--- a/hw/ip/otbn/rtl/otbn_rf_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum.sv
@@ -165,11 +165,11 @@ module otbn_rf_bignum
 
   `ASSERT(BlankingBignumRegReadA_A,
           !rd_en_a_i |->  rd_data_a_intg_o == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || predec_error_o || !wr_commit_i)
 
   `ASSERT(BlankingBignumRegReadB_A,
           !rd_en_b_i |->  rd_data_b_intg_o == '0,
-          clk_i, !rst_ni)
+          clk_i, !rst_ni || predec_error_o || !wr_commit_i)
 
   // Make sure we're not outputting X. This indicates that something went wrong during the initial
   // secure wipe.


### PR DESCRIPTION
Following up PR for https://github.com/lowRISC/opentitan/pull/15197#issuecomment-1263303976. Basically a cleanup and more elegant solution to dealing with V2S assertions in OTBN.

`util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i ci --reseed=2 --tool=xcelium ` reports 57/58 passing rate.