### PR TITLE
[sram_ctrl_ret] Tie off debug enable

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4486,7 +4486,6 @@
           width: 1
           default: lc_ctrl_pkg::Off
           inst_name: sram_ctrl_ret_aon
-          top_signame: lc_ctrl_lc_hw_debug_en
           index: -1
         }
         {
@@ -8023,7 +8022,6 @@
       lc_ctrl.lc_hw_debug_en:
       [
         sram_ctrl_main.lc_hw_debug_en
-        sram_ctrl_ret_aon.lc_hw_debug_en
         pinmux_aon.lc_hw_debug_en
         csrng.lc_hw_debug_en
         rv_dm.lc_hw_debug_en
@@ -17294,7 +17292,6 @@
         width: 1
         default: lc_ctrl_pkg::Off
         inst_name: sram_ctrl_ret_aon
-        top_signame: lc_ctrl_lc_hw_debug_en
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -969,7 +969,6 @@
                                      ],
       'lc_ctrl.lc_nvm_debug_en'    : ['flash_ctrl.lc_nvm_debug_en'],
       'lc_ctrl.lc_hw_debug_en'     : ['sram_ctrl_main.lc_hw_debug_en',
-                                      'sram_ctrl_ret_aon.lc_hw_debug_en',
                                       'pinmux_aon.lc_hw_debug_en',
                                       'csrng.lc_hw_debug_en',
                                       'rv_dm.lc_hw_debug_en',

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2039,7 +2039,7 @@ module top_earlgrey #(
       .sram_otp_key_i(otp_ctrl_sram_otp_key_rsp[1]),
       .cfg_i(ast_ram_1p_cfg),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
-      .lc_hw_debug_en_i(lc_ctrl_lc_hw_debug_en),
+      .lc_hw_debug_en_i(lc_ctrl_pkg::Off),
       .otp_en_sram_ifetch_i(prim_mubi_pkg::MuBi8False),
       .regs_tl_i(sram_ctrl_ret_aon_regs_tl_req),
       .regs_tl_o(sram_ctrl_ret_aon_regs_tl_rsp),


### PR DESCRIPTION
The retention SRAM does not support the execute from SRAM feature, and hence the debug enable can be tied off.

Fixes #15223.

Signed-off-by: Michael Schaffner <msf@google.com>