### PR TITLE
[rtl/kmac] Change idle state assignment

### DIFF
--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -192,7 +192,7 @@ module keccak_round
   // SEC_CM: FSM.SPARSE
   always_comb begin
     // Default values
-    keccak_st_d = StIdle;
+    keccak_st_d = keccak_st;
 
     xor_message    = 1'b 0;
     update_storage = 1'b 0;

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -693,7 +693,7 @@ module kmac
 
   always_comb begin
     // Default value
-    kmac_st_d = KmacIdle;
+    kmac_st_d = kmac_st;
 
     entropy_in_keyblock = 1'b 0;
     kmac_state_error = 1'b 0;

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -387,7 +387,7 @@ module kmac_app
   // Next State & output logic
   // SEC_CM: FSM.SPARSE
   always_comb begin
-    st_d = StIdle;
+    st_d = st;
 
     mux_sel = SecIdleAcceptSwMsg ? SelSw : SelNone;
 

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -161,7 +161,7 @@ module kmac_core
   // Next state and output logic
   // SEC_CM: FSM.SPARSE
   always_comb begin
-    st_d = StKmacIdle;
+    st_d = st;
 
     en_kmac_datapath = 1'b 0;
     en_key_write = 1'b 0;

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -461,7 +461,7 @@ module kmac_entropy
   // State: Next State and Output Logic
   // SEC_CM: FSM.SPARSE
   always_comb begin
-    st_d = StRandReset;
+    st_d = st;
     sparse_fsm_error_o = 1'b 0;
 
     // Default Timer values

--- a/hw/ip/kmac/rtl/kmac_msgfifo.sv
+++ b/hw/ip/kmac/rtl/kmac_msgfifo.sv
@@ -190,7 +190,7 @@ module kmac_msgfifo
   end
 
   always_comb begin
-    flush_st_d = FlushIdle;
+    flush_st_d = flush_st;
 
     msgfifo_flush_done = 1'b 0;
 

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -201,7 +201,7 @@ module sha3
   // StSqueeze: only run_i, done_i signal is allowed
 
   always_comb begin
-    st_d = StIdle_sparse;
+    st_d = st;
 
     // default output values
     keccak_start = 1'b 0;

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -294,7 +294,7 @@ module sha3pad
   end
 
   always_comb begin
-    st_d = StPadIdle;
+    st_d = st;
 
     // FSM output : default values
     keccak_run_o = 1'b 0;


### PR DESCRIPTION
This PR changes idle state assignment so the VCS tool can automatically exclude any state -> Idle state (if there is no direct logic transaction), which means if the only way to hit this coverage is by issuing random reset.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>