### PR TITLE
[flash_ctrl,dv] fix regression fail

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
@@ -53,6 +53,8 @@ class flash_ctrl_derr_detect_vseq extends flash_ctrl_otf_base_vseq;
       end
     join_any
     disable fork;
+    // Add drain time
+    #10us;
     if (cfg.derr_created[0] + cfg.derr_created[1] > 0) begin
       fatal_cnt = cfg.scb_h.alert_count["fatal_err"];
       `DV_CHECK_NE(fatal_cnt, 0, "fatal alert is not detected",

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
@@ -121,9 +121,11 @@ class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
     if (enable) begin
       $asserton(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
       $asserton(0, "tb.dut.u_flash_hw_if.u_addr_sync_reqack.SyncReqAckHoldReq");
+      $asserton(0, "tb.dut.u_flash_hw_if.ProgRdVerify_A");
     end else begin
       $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
       $assertoff(0, "tb.dut.u_flash_hw_if.u_addr_sync_reqack.SyncReqAckHoldReq");
+      $assertoff(0, "tb.dut.u_flash_hw_if.ProgRdVerify_A");
     end
   endfunction // update_assert
 endclass // flash_ctrl_hw_rma_reset_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -138,7 +138,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     void'($value$plusargs("csr_test_mode=%0b", csr_test_mode));
     void'($value$plusargs("run_%0s", run_seq_name));
     if (csr_test_mode == 1 ||
-        run_seq_name inside{"tl_intg_err"}) begin
+        run_seq_name inside{"tl_intg_err", "sec_cm_fi"}) begin
       super.pre_start();
     end else begin
       flash_init_c.constraint_mode(0);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
@@ -43,6 +43,7 @@ class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_
             `DV_CHECK(uvm_hdl_force(path2, 1))
           end
         endcase // randcase
+        cfg.otf_scb_h.comp_off = 1;
       end
     end // repeat (2)
     check_fault(ral.fault_status.spurious_ack);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -8,24 +8,20 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
 
   task run_error_event();
     int delay;
-    bit arb_err;
     string path = {"tb.dut.u_eflash.gen_flash_cores[0].",
                    "u_core.u_host_arb.gen_input_bufs[1].u_req_buf.out_o[1:0]"};
     cfg.scb_h.exp_alert["fatal_err"] = 1;
     cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
-    repeat (2) begin
-      // unit 100 ns;
-      delay = $urandom_range(1, 10);
-      #(delay * 100ns);
-      if (arb_err) begin
-        `DV_CHECK(uvm_hdl_release(path))
-      end else begin
-        arb_err = 1;
-        `DV_CHECK(uvm_hdl_force(path, 2'h0))
-      end
-    end // repeat (2)
+    // unit 100 ns;
+    delay = $urandom_range(1, 10);
+    #(delay * 100ns);
+    `DV_CHECK(uvm_hdl_force(path, 2'h0))
+
+    delay = $urandom_range(1, 10);
+    #(delay * 1us);
+    `DV_CHECK(uvm_hdl_release(path))
     check_fault(ral.fault_status.arb_err);
   endtask
 endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv
@@ -39,7 +39,11 @@ class flash_ctrl_phy_host_grant_err_vseq extends flash_ctrl_err_base_vseq;
         $assertoff(0, "tb.dut.u_to_rd_fifo.TlOutPayloadKnown_A");
         $assertoff(0, "tb.dut.u_to_rd_fifo.u_rspfifo.DataKnown_A");
         $assertoff(0, "tb.dut.tlul_assert_device.dKnown_A");
-
+        $assertoff(0, "tb.dut.MemRspPayLoad_A");
+        $assertoff(0, "tb.dut.u_tl_adapter_eflash.TlOutPayloadKnown_A");
+        $assertoff(0, "tb.dut.u_tl_adapter_eflash.u_rspfifo.DataKnown_A");
+        $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[0].u_host_rsp_fifo.DataKnown_A");
+        $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[1].u_host_rsp_fifo.DataKnown_A");
         // set error counter high number to skip unpredictable error
         cfg.scb_h.exp_tl_rsp_intg_err = 1;
         cfg.tlul_eflash_exp_cnt = 1;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
@@ -29,6 +29,7 @@ class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_rw_vseq;
       path2 = {"tb.dut.u_eflash.gen_flash_cores[1].u_core",
                $sformatf(".u_rd.gen_bufs[0].u_rd_buf.data_i[%0d]", idx2)};
 
+      cfg.clk_rst_vif.wait_clks(10);
       `uvm_info(`gfn, $sformatf("Assert read path err idx1:%0d idx2:%0d", idx1, idx2), UVM_LOW)
       `DV_CHECK(uvm_hdl_force(path1, 1'b0))
       `DV_CHECK(uvm_hdl_force(path2, 1'b0))
@@ -53,14 +54,14 @@ class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_rw_vseq;
         saw_err |= local_saw_err;
 
         if ((i % 2)== 1) tl_addr += 4;
-       end
-       csr_utils_pkg::wait_no_outstanding_access();
-       `DV_CHECK_EQ(saw_err, 1)
+      end
+      csr_utils_pkg::wait_no_outstanding_access();
+      `DV_CHECK_EQ(saw_err, 1)
 
       // Check fault_status register and err_code register to make sure
       // host read only triggers fault_status.phy_storage_err
-       csr_rd_check(.ptr(ral.fault_status.phy_storage_err), .compare_value(1));
-       csr_rd_check(.ptr(ral.err_code), .compare_value(0));
+      csr_rd_check(.ptr(ral.fault_status.phy_storage_err), .compare_value(1));
+      csr_rd_check(.ptr(ral.err_code), .compare_value(0));
 
       `uvm_info(`gfn, "Wait until all drain", UVM_LOW)
       cfg.clk_rst_vif.wait_clks(100);

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -362,21 +362,22 @@
     {
       name: flash_ctrl_rd_intg
       uvm_test_seq: flash_ctrl_rd_path_intg_vseq
-      run_opts: ["+scb_otf_en=1", "+ecc_mode=4",
-                 "+otf_num_hr=40", "+en_always_read=1"]
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1",
+                 "+otf_num_hr=100", "+en_always_read=1"]
       reseed: 3
     }
     {
       name: flash_ctrl_wr_intg
       uvm_test_seq: flash_ctrl_wr_path_intg_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=0",
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=0", "+ecc_mode=1",
                  "+en_always_prog=1", "+otf_rd_pct=0"]
       reseed: 3
     }
     {
       name: flash_ctrl_access_after_disable
       uvm_test_seq: flash_ctrl_access_after_disable_vseq
-      run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+otf_num_rw=5", "+otf_num_hr=0", "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+otf_num_rw=5", "+otf_num_hr=0",
+                 "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
       reseed: 3
     }
     {
@@ -388,21 +389,21 @@
     {
       name: flash_ctrl_phy_arb_redun
       uvm_test_seq: flash_ctrl_phy_arb_redun_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=10",
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=10", "+ecc_mode=1",
                  "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
       reseed: 5
     }
     {
       name: flash_ctrl_phy_host_grant_err
       uvm_test_seq: flash_ctrl_phy_host_grant_err_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=5",
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=50", "+ecc_mode=1",
                  "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
       reseed: 5
     }
     {
       name: flash_ctrl_phy_ack_consistency
       uvm_test_seq: flash_ctrl_phy_ack_consistency_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=5",
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=5", "+ecc_mode=1",
                  "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
       reseed: 5
     }


### PR DESCRIPTION
Adjust error conditions of following error tests
- flash_ctrl_sec_cm
- flash_ctrl_derr_detect
- flash_ctrl_phy_arb_redun
- flash_ctrl_phy_host_grant_err
- flash_ctrl_phy_ack_consistency

Disable irrelevant assert from flash_ctrl_hw_rma_rest Set ecc/scramble randomize for error tests

Signed-off-by: Jaedon Kim <jdonjdon@google.com>