### PR TITLE
feat(kmac): Error Check for Entropy Ready

### DIFF
--- a/hw/ip/kmac/doc/_index.md
+++ b/hw/ip/kmac/doc/_index.md
@@ -307,6 +307,7 @@ Value | Error Code | Description
 0x06  | UnexpectedModeStrength | SHA3 mode and Keccak Strength combination is not expected.
 0x07  | IncorrectFunctionName | In KMAC mode, the PREFIX has the value other than `encoded_string("KMAC")`
 0x08  | SwCmdSequence | SW does not follow the guided sequence, `start` -> `process` -> {`run` ->} `done`
+0x09  | SwHashingWithoutEntropyReady | SW requests KMAC op without proper config of Entropy in KMAC. This error occurs if KMAC IP masking feature is enabled.
 0x80  | Sha3Control | SW may receive Sha3Control error along with `SwCmdSequence` error. Can be ignored.
 
 #### KeyNotValid (0x01)

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -1092,7 +1092,9 @@ module kmac
   );
 
   // Error checker
-  kmac_errchk u_errchk (
+  kmac_errchk #(
+    .EnMasking (EnMasking)
+  ) u_errchk (
     .clk_i,
     .rst_ni,
 
@@ -1104,6 +1106,8 @@ module kmac
     .cfg_prefix_6B_i(reg_ns_prefix[47:0]), // first 6B of PREFIX
 
     .cfg_en_unsupported_modestrength_i (cfg_en_unsupported_modestrength),
+
+    .entropy_ready_pulse_i (entropy_ready),
 
     // SW commands
     .sw_cmd_i(sw_cmd),
@@ -1118,6 +1122,8 @@ module kmac
 
     // LC escalation
     .lc_escalate_en_i (lc_escalate_en[4]),
+
+    .err_processed_i (err_processed),
 
     .error_o            (errchecker_err),
     .sparse_fsm_error_o (kmac_errchk_state_error)

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -380,6 +380,10 @@ package kmac_pkg;
     // ErrSwCmdSequence
     ErrSwCmdSequence = 8'h 08,
 
+    // ErrSwHashingWithoutEntropyReady
+    //  - Sw issues KMAC op without Entropy setting.
+    ErrSwHashingWithoutEntropyReady = 8'h 09,
+
     // Error Shadow register update
     ErrShadowRegUpdate = 8'h C0,
 


### PR DESCRIPTION
_Related Issue: https://github.com/lowRISC/opentitan/issues/15140 _

This commit adds logic inside `kmac_errchk` module. It checks if SW requests a KMAC op. without configuring the entropy.

The error is reported as `ErrSwHashingWithoutEntropyReady (0x09)` error code. The internal error status is cleared by `err_process`.
