### PR TITLE
[spi_device] Fix CmdAddrInfo_A assertion

### DIFF
--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -1214,7 +1214,7 @@ module spi_tpm
   // If the command and the address have been shifted, the Locality, command
   // type should be matched with the shifted register.
   `ASSERT(CmdAddrInfo_A,
-          $fell(cmdaddr_shift_en) && !csb_i && sys_clk_tpm_cfg.tpm_en |->
+          $fell(cmdaddr_shift_en) && !csb_i && sys_clk_tpm_cfg.tpm_en && is_tpm_reg |->
             (locality == sck_cmdaddr_wdata_q[15:12]) &&
             (cmd_type == sck_cmdaddr_wdata_q[31]),
           clk_in_i, !rst_n)


### PR DESCRIPTION
Need to add a condition - is_tpm_reg before checking the addr
Without is_tpm_reg, locality won't be latched

Signed-off-by: Weicai Yang <weicai@google.com>