### PR TITLE
[dv/kmac] Create a function to disable EDN assertions

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_if.sv
@@ -16,7 +16,30 @@ interface kmac_if(input clk_i, input rst_ni);
     lc_escalate_en_i = val;
   endfunction
 
-  `ASSERT(KmacMaskingO_A, `EN_MASKING == en_masking_o)
+  // EDN interface except the handshake to always complete.
+  // But in KMAC, the handshake can be interrupted if there are terminal errors or reset.
+  // So this function disable EDN related assertions.
+  function automatic void disable_edn_asserts();
+    `ifdef EN_MASKING
+      $assertoff(0,
+          dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq);
+      $assertoff(0, edn_if[0].ReqHighUntilAck_A);
+      $assertoff(0, edn_if[0].AckAssertedOnlyWhenReqAsserted_A);
+    `endif
+  endfunction
+
+  // This assertion will not be true if keccak operation is interrupted by lc_escalate_en signal.
+  function automatic void disable_keccak_asserts();
+    `ifdef EN_MASKING
+      $assertoff(0, dut.u_sha3.u_keccak.u_keccak_p.gen_selperiod_chk.SelStayTwoCycleIfTrue_A);
+    `endif
+  endfunction
+
+  `ifdef EN_MASKING
+    `ASSERT(KmacMaskingO_A, en_masking_o == 1)
+  `else
+    `ASSERT(KmacMaskingO_A, en_masking_o == 0)
+  `endif
 
   `ASSERT(AppKeymgrErrOutputZeros_A, app_rsp[AppKeymgr].error |->
           app_rsp[AppKeymgr].digest_share0 == 0 && app_rsp[AppKeymgr].digest_share1 == 0)

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -984,4 +984,9 @@ class kmac_base_vseq extends cip_base_vseq #(
     cfg.clk_rst_vif.wait_clks($urandom_range(100, 2000));
   endtask
 
+  // EDN is only used in kmac masked version.
+  virtual function void disable_edn_asserts();
+    if (cfg.enable_masking) cfg.kmac_vif.disable_edn_asserts();
+  endfunction
+
 endclass : kmac_base_vseq

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
@@ -20,10 +20,9 @@ class kmac_common_vseq extends kmac_base_vseq;
       // Shadow storage fatal error might cause req to drop without ack.
       $assertoff(0,
       "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckHoldReq");
-      $assertoff(0,
-      "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
-      $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
-      $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
+      disable_edn_asserts();
+    end else if (common_seq_type == "stress_all_with_rand_reset") begin
+      disable_edn_asserts();
     end
   endtask
 

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
@@ -29,17 +29,10 @@ class kmac_edn_timeout_error_vseq extends kmac_app_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    if (cfg.enable_masking) disable_asserts();
+    disable_edn_asserts();
     cfg.en_scb = 0;
     check_keymgr_rsp_nonblocking();
   endtask
-
-  virtual function void disable_asserts();
-    $assertoff(0,
-      "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
-    $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
-    $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
-  endfunction
 
   virtual task post_start();
     super.post_start();

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_entropy_mode_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_entropy_mode_error_vseq.sv
@@ -17,9 +17,6 @@ class kmac_entropy_mode_error_vseq extends kmac_edn_timeout_error_vseq;
     kmac_err_type dist {kmac_pkg::ErrIncorrectEntropyMode :/ 4, kmac_pkg::ErrNone :/ 1};
   }
 
-  // No assertions to disable.
-  virtual function void disable_asserts();
-  endfunction
 
   virtual task check_err_code();
     kmac_pkg::err_t kmac_err = '{valid: 1'b1,

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
@@ -7,16 +7,10 @@ class kmac_lc_escalation_vseq extends kmac_app_vseq;
   `uvm_object_utils(kmac_lc_escalation_vseq)
   `uvm_object_new
 
-  virtual function void disable_asserts();
-    $assertoff(0,
-      "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
-    $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
-    $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
-  endfunction
-
   virtual task pre_start();
     super.pre_start();
-    if (cfg.enable_masking) disable_asserts();
+    disable_edn_asserts();
+    disable_keccak_asserts();
   endtask
 
   virtual task body();

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -63,12 +63,11 @@
   build_modes: [
     {
       name: enable_mask_mode
-      build_opts: ["+define+EN_MASKING=1"]
+      build_opts: ["+define+EN_MASKING"]
       run_opts: ["+enable_masking=1"]
     }
     {
       name: disable_mask_mode
-      build_opts: ["+define+EN_MASKING=0"]
       run_opts: ["+enable_masking=0"]
     }
   ]
@@ -188,7 +187,6 @@
     {
       name: "{variant}_lc_escalation"
       uvm_test_seq: kmac_lc_escalation_vseq
-      run_opts: ["+disable_lc_asserts=1"]
     }
     {
       name: kmac_stress_all

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -47,8 +47,11 @@ module tb;
   `DV_ALERT_IF_CONNECT
 
   // dut
-
-  kmac #(.EnMasking(`EN_MASKING)) dut (
+`ifdef EN_MASKING
+  kmac #(.EnMasking(1)) dut (
+`else
+  kmac #(.EnMasking(0)) dut (
+`endif
     .clk_i              (clk            ),
     .rst_ni             (rst_n          ),
     .rst_shadowed_ni    (rst_shadowed_n ),
@@ -115,18 +118,6 @@ module tb;
 
     $timeformat(-12, 0, " ps", 12);
     run_test();
-  end
-
-  // This assertion only exists when en_masking parameter is set.
-  // This assertion will not be true if Kmac is interrupted by lc_escalate_en signal.
-  if (`EN_MASKING) begin : gen_assert_disable_for_masking_mode
-    initial begin
-      bit disable_lc_asserts;
-      void'($value$plusargs("disable_lc_asserts=%0b", disable_lc_asserts));
-      if (disable_lc_asserts) begin
-        $assertoff(0, tb.dut.u_sha3.u_keccak.u_keccak_p.gen_selperiod_chk.SelStayTwoCycleIfTrue_A);
-      end
-    end
   end
 
 endmodule


### PR DESCRIPTION
This PR adds a function in base sequence to disable EDN related assertions.
These assertions are no longer valid if EDN handshake is interrupted by reset or terminal errros.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>