### PR TITLE
[ottf,tests] add ottf context switching and example concurrency test

### DIFF
--- a/sw/device/lib/testing/test_framework/FreeRTOSConfig.h
+++ b/sw/device/lib/testing/test_framework/FreeRTOSConfig.h
@@ -26,7 +26,7 @@
 #define configCHECK_FOR_STACK_OVERFLOW 1
 #define configMINIMAL_STACK_SIZE 256  // in words
 #define configSTACK_DEPTH_TYPE uint16_t
-#define configTOTAL_HEAP_SIZE ((size_t)0x800u)
+#define configTOTAL_HEAP_SIZE ((size_t)0x8000u)
 #define configUSE_MALLOC_FAILED_HOOK 1
 
 // Other

--- a/sw/device/lib/testing/test_framework/ottf_macros.h
+++ b/sw/device/lib/testing/test_framework/ottf_macros.h
@@ -9,5 +9,9 @@
 #define OTTF_NV_SCRATCH _non_volatile_scratch_start
 #define OTTF_HALF_WORD_SIZE (OTTF_WORD_SIZE / 2)
 #define OTTF_CONTEXT_SIZE (OTTF_WORD_SIZE * 30)
+#define OTTF_TASK_DELETE_SELF_OR_DIE \
+  ottf_task_delete_self();           \
+  abort();                           \
+  CHECK(false);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_MACROS_H_

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -33,11 +33,41 @@
 OT_ASSERT_MEMBER_OFFSET(ottf_test_config_t, enable_concurrency, 0);
 OT_ASSERT_MEMBER_SIZE(ottf_test_config_t, enable_concurrency, 1);
 
+// Pointer to the current FreeRTOS Task Control Block, which should be non-NULL
+// when OTTF concurrency is enabled, and test code is executed within FreeRTOS
+// tasks.
+extern void *pxCurrentTCB;
+
+// `extern` declarations to give the inline functions in the corresponding
+// header a link location.
+extern bool ottf_task_create(TaskFunction_t task_function,
+                             const char *task_name,
+                             configSTACK_DEPTH_TYPE task_stack_depth,
+                             uint32_t task_priority);
+extern void ottf_task_yield(void);
+extern void ottf_task_delete_self(void);
+extern char *ottf_task_get_self_name(void);
+
 // UART for communication with host.
 static dif_uart_t uart0;
 
 // A global random number generator testutil handle.
 rand_testutils_rng_t rand_testutils_rng_ctx;
+
+// The OTTF overrides the default machine ecall exception handler to implement
+// FreeRTOS context switching, required for supporting cooperative scheduling.
+void ottf_machine_ecall_handler(void) {
+  if (pxCurrentTCB != NULL) {
+    // If the pointer to the current TCB is not NULL, we are operating in
+    // concurrency mode. In this case, our default behavior is to assume a
+    // context switch has been requested.
+    vTaskSwitchContext();
+    return;
+  }
+  LOG_ERROR(
+      "OTTF currently only supports use of machine-mode ecall for FreeRTOS "
+      "context switching.");
+}
 
 static void init_uart(void) {
   CHECK_DIF_OK(dif_uart_init(
@@ -98,9 +128,9 @@ void _ottf_main(void) {
   // Run the test.
   if (kOttfTestConfig.enable_concurrency) {
     // Run `test_main()` in a FreeRTOS task, allowing other FreeRTOS tasks to
-    // be spawned, if requested in the main test task.
-    xTaskCreate(test_wrapper, "TestTask", configMINIMAL_STACK_SIZE, NULL,
-                tskIDLE_PRIORITY + 1, NULL);
+    // be spawned, if requested in the main test task. Note, we spawn the main
+    // test task at a priority level of 0.
+    ottf_task_create(test_wrapper, "test_main", kOttfFreeRtosMinStackSize, 0);
     vTaskStartScheduler();
   } else {
     // Otherwise, launch `test_main()` on bare-metal.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -664,6 +664,16 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "example_concurrency_test",
+    srcs = ["example_concurrency_test.c"],
+    deps = [
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "example_test_from_flash",
     srcs = ["example_test_from_flash.c"],
     deps = [

--- a/sw/device/tests/example_concurrency_test.c
+++ b/sw/device/tests/example_concurrency_test.c
@@ -1,0 +1,106 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * This example serves as a starting point for writing software top-level
+ * concurrency tests that use the OpenTitan Test Framework (OTTF), and run at
+ * the flash boot stage. This example is intended to be copied and modified
+ * according to the instructions below.
+ *
+ * This example demonstrates a concurrency test that spawns three FreeRTOS
+ * tasks, in addition to the `test_main` task. Each task is defined using a
+ * separate function that never returns, and deletes itself after executing its
+ * code. Since the priorities of each task are the same, yet higher than the
+ * priority of the "test_main" task, calling `ottf_task_yield()` will switch
+ * control flow between these tasks, until each task deletes itself. Then, the
+ * `test_main` task will continue executing, returning `true` when the overall
+ * test passes, triggering the OTTF to signal test execution has completed.
+ *
+ * Additionally, an example assertion failure is commented out below in `task_3`
+ * to demonstrate how the test will terminate execution immediately upon
+ * encountering said behavior in any task. The test runner (opentitantool) on
+ * Verilator and FPGA platforms is monitoring the UART for a failure message
+ * that gets printed immediately upon an assertion failure. It terminates the
+ * test immediately upon seeing said message. Similarly, in DV, the testbench is
+ * monitoring a specific memory location that gets written to on an assertion
+ * failure.
+ */
+
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_macros.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = true,
+                        .can_clobber_uart = false, );
+
+static void task_1(void *task_parameters) {
+  // ***************************************************************************
+  // Place test code below.
+  // ***************************************************************************
+  LOG_INFO("Executing %s ...", ottf_task_get_self_name());
+  ottf_task_yield();
+  LOG_INFO("Continuing to execute %s ...", ottf_task_get_self_name());
+
+  // ***************************************************************************
+  // Delete the current task and never return.
+  // ***************************************************************************
+  OTTF_TASK_DELETE_SELF_OR_DIE;
+}
+
+static void task_2(void *task_parameters) {
+  // ***************************************************************************
+  // Place test code below.
+  // ***************************************************************************
+  LOG_INFO("Executing %s ...", ottf_task_get_self_name());
+
+  // ***************************************************************************
+  // Delete the current task and never return.
+  // ***************************************************************************
+  OTTF_TASK_DELETE_SELF_OR_DIE;
+}
+
+static void task_3(void *task_parameters) {
+  // ***************************************************************************
+  // Place test code below.
+  // ***************************************************************************
+  LOG_INFO("Executing %s ...", ottf_task_get_self_name());
+
+  // ***************************************************************************
+  // Uncomment to see the effects of a failed assertion. Delete this when
+  // implementing a test.
+  // ***************************************************************************
+  // CHECK(false, "A failed assertion causes immediate test termination.");
+
+  // ***************************************************************************
+  // Delete the current task and never return.
+  // ***************************************************************************
+  OTTF_TASK_DELETE_SELF_OR_DIE;
+}
+
+bool test_main(void) {
+  // ***************************************************************************
+  // Create the FreeRTOS tasks that will comprise this test. Ensure the priority
+  // levels of each task are higher than the priority of the current "test_main"
+  // task, which is 0.
+  // ***************************************************************************
+  LOG_INFO("Starting to execute %s ...", ottf_task_get_self_name());
+  CHECK(ottf_task_create(task_1, "task_1", kOttfFreeRtosMinStackSize, 1));
+  CHECK(ottf_task_create(task_2, "task_2", kOttfFreeRtosMinStackSize, 1));
+  CHECK(ottf_task_create(task_3, "task_3", kOttfFreeRtosMinStackSize, 1));
+
+  // ***************************************************************************
+  // Yield control flow to the highest priority task in the run queue. Since the
+  // tasks created above all have a higher priority level than the current
+  // "test_main" task, execution will not be returned to the current task until
+  // the above tasks have been deleted.
+  // ***************************************************************************
+  LOG_INFO("Yielding execution to another task.");
+  ottf_task_yield();
+
+  // ***************************************************************************
+  // Return true if the test succeeds. Return false if it should fail.
+  // ***************************************************************************
+  return true;
+}

--- a/sw/device/tests/example_test_from_flash.c
+++ b/sw/device/tests/example_test_from_flash.c
@@ -45,6 +45,10 @@ OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
  *
  * See `sw/device/lib/testing/test_framework/ottf_isrs.c` for implementation
  * details of the default OTTF exception handlers.
+ *
+ * Note, the `ottf_machine_ecall_handler` cannot be overridden when using the
+ * full OTTF, as it it used to implement FreeRTOS context switching. See its
+ * implementation in `sw/device/lib/testing/test_framework/ottf_main.c`.
  */
 // void ottf_exception_handler(void) {}
 // void ottf_instr_misaligned_fault_handler(void) {}
@@ -52,7 +56,6 @@ OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
 // void ottf_illegal_instr_fault_handler(void) {}
 // void ottf_breakpoint_handler(void) {}
 // void ottf_load_store_fault_handler(void) {}
-// void ottf_machine_ecall_handler(void) {}
 // void ottf_user_ecall_handler(void) {}
 
 /**

--- a/sw/device/tests/example_test_from_flash.c
+++ b/sw/device/tests/example_test_from_flash.c
@@ -3,18 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * This template serves as a starting point for writing software chip-level
- * tests that use the OpenTitan Test Framework (OTTF). This template is intended
- * to be copied and modified according to the instructions below.
+ * This template serves as a starting point for writing software top-level
+ * tests that use the OpenTitan Test Framework (OTTF), and run at the flash
+ * boot stage. This template is intended to be copied and modified according to
+ * the instructions below.
  *
  * Plese delete all instructional comments after editing this template.
  */
-
-/**
- * Uncomment if you want to initialize the non-volatile scratch region below
- * using UINT32_MAX.
- */
-// #include <stdint.h>
 
 /**
  * Uncomment if you want to log messages with `LOG_{INFO,WARNING,ERROR,FATAL()`.
@@ -32,7 +27,7 @@
  * Set `enable_concurrency` to true if this test should run as a FreeRTOS
  * task (enabling the test to spawn additional concurrent FreeRTOS tasks).
  * When `enable_concurrency` is set to false, this test will run as a
- * bare-metal program. Note, for the majority of chip-level tests, this
+ * bare-metal program. Note, for the majority of top-level tests, this
  * should be set to false.
  *
  * Set `can_clobber_uart` to true if this test will reconfigure the UART in
@@ -73,7 +68,7 @@ OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
 // void ottf_external_isr(void) {}
 
 /**
- * Place data that will need to persist across resets by placing it in the
+ * Save data that will need to persist across resets by placing it in the
  * ".non_volatile_scratch" section. OpenTitan's flash is mapped to its address
  * space for reads. Thus, these variables can be read as usual. Write to this
  * region with the flash controller DIFs, obeying flash constraints. Since the
@@ -81,7 +76,7 @@ OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
  * values of variables in this section are always `0xff`, regardless of any
  * initialization in the source code. In order to avoid confusion, don't
  * initialize or assign to these values. If needed, they can be initialized at
- * runtime during flash controller DIFs.
+ * runtime via flash controller DIFs.
  */
 // OT_SECTION(".non_volatile_scratch") uint32_t non_volatile_data[2];
 


### PR DESCRIPTION
This PR contains several commits that:

- increases the size of the FreeRTOS heap to get concurrency tests working again (the heap was too small causing a malloc error)
- enables (cooperative) context switching between FreeRTOS tasks through the use of the machine-mode ecall
- adds several FreeRTOS wrapper functions to the OTTF API that simplify the FreeRTOS interface by providing functions to:
    - create additional FreeRTOS tasks,
    - delete the currently running task,
    - cooperatively yield control flow between tasks, and
    - get the name of the task that is currently executing.
- adds an example test concurrency to showcase how to use the OTTF to launch, and context switch between several concurrent FreeRTOS tasks.

This partially addresses #8015