### PR TITLE
[sw/silicon_creeator] Remove volatile qualifier from kManifest

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -132,7 +132,7 @@ cc_library(
         "//sw/device/lib/testing/test_rom:english_breakfast_test_rom_manifest",
     ],
     # The manifest section should be populated anytime this is added as a
-    # dependency, even if kManifest is not referenced by software.
+    # dependency, even if the manifest is not referenced by software.
     alwayslink = True,
 )
 

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -232,7 +232,7 @@ dual_cc_library(
         "//sw/device/lib/base:macros",
     ],
     # The manifest section should be populated anytime this is added as a
-    # dependency, even if kManifest is not referenced by software.
+    # dependency, even if the manifest is not referenced by software.
     alwayslink = True,
 )
 

--- a/sw/device/silicon_creator/lib/manifest_def.c
+++ b/sw/device/silicon_creator/lib/manifest_def.c
@@ -9,14 +9,24 @@
 /*
  * Declarations for the manifest fields populdated by the linker script.
  */
-extern const uint32_t _manifest_code_start[];
-extern const uint32_t _manifest_code_end[];
-extern const uint32_t _manifest_entry_point[];
+extern char _manifest_code_start[];
+extern char _manifest_code_end[];
+extern char _manifest_entry_point[];
 
-static_assert(sizeof(uint32_t) == sizeof(uintptr_t), "Pointer is not 32-bits.");
-
-const volatile manifest_t kManifest = {
+/**
+ * Manifest definition.
+ *
+ * Definition of the manifest that resides in the `.manifest` section. The
+ * initializer should explicitly specify the initial values of the members whose
+ * values are known a compilation time, such as `code_start`, `code_end`, and
+ * `entry_point`. The remaining fields will be updated in the binary by
+ * `opentitantool` (overriding the implicitly specified initial value of zero).
+ */
+OT_SECTION(".manifest")
+static manifest_t kManifest_ = {
     .code_start = (uint32_t)_manifest_code_start,
     .code_end = (uint32_t)_manifest_code_end,
     .entry_point = (uint32_t)_manifest_entry_point,
 };
+
+const manifest_t *manifest_def_get(void) { return &kManifest_; }

--- a/sw/device/silicon_creator/lib/manifest_def.h
+++ b/sw/device/silicon_creator/lib/manifest_def.h
@@ -11,13 +11,8 @@
 #include "sw/device/silicon_creator/lib/manifest.h"
 
 /**
- * Manifest definition.
- *
- * Declaration of the manifest that resides in the .manifest section. This
- * should be defined with known values, such as `code_start`, `code_end`, and
- * `entry_point`, populated. The remaining fields will be updated in the binary
- * by the signer tool.
+ * Gets the manifest of the current boot stage.
  */
-extern const volatile manifest_t kManifest OT_SECTION(".manifest");
+const manifest_t *manifest_def_get(void);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MANIFEST_DEF_H_

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
@@ -26,7 +26,6 @@ static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
  * @return Pointer to the manifest of the first owner boot stage image in slot
  * A.
  */
-// TODO(#7893): Should these be volatile?
 inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
   return (const manifest_t *)(TOP_EARLGREY_EFLASH_BASE_ADDR +
                               CHIP_ROM_EXT_SIZE_MAX);


### PR DESCRIPTION
This PR also adds a getter that returns a `const manifest_t *` to enable compiler diagnostics and removes a stale TODO.