### PR TITLE
[cleanup] Fix `bazelisk outquery` to accept all arguments

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -91,8 +91,8 @@ function outquery_starlark_expr() {
 
 function do_outquery() {
     local qexpr="$1"
-    local args="$2"
-    "$file" cquery "$args" \
+    shift
+    "$file" cquery "$@" \
         --output=starlark --starlark:expr="$qexpr" \
         --ui_event_filters=-info --noshow_progress
 }


### PR DESCRIPTION
`bazelisk.sh outquery` should accept all arguments so that things like `--define ...` and `-c opt` are accounted for by the query.

Signed-off-by: Chris Frantz <cfrantz@google.com>