### PR TITLE
[dv, e2e] keymgr_init test

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -48,6 +48,13 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=10000000"]
     }
+    {
+      name: rom_keymgr_init
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/silicon_creator/rom/e2e:e2e_keymgr_init:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=10000000"]
+    }
   ]
 
   regressions: [

--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -574,3 +574,19 @@ dif_result_t dif_keymgr_read_binding(const dif_keymgr_t *keymgr,
 
   return kDifOk;
 }
+
+dif_result_t dif_keymgr_read_max_key_version(
+    const dif_keymgr_t *keymgr, dif_keymgr_max_key_version_t *versions) {
+  if (keymgr == NULL || versions == NULL) {
+    return kDifBadArg;
+  }
+
+  versions->creator_max_key_version = mmio_region_read32(
+      keymgr->base_addr, KEYMGR_MAX_CREATOR_KEY_VER_SHADOWED_REG_OFFSET);
+  versions->owner_int_max_key_version = mmio_region_read32(
+      keymgr->base_addr, KEYMGR_MAX_OWNER_INT_KEY_VER_SHADOWED_REG_OFFSET);
+  versions->owner_max_key_version = mmio_region_read32(
+      keymgr->base_addr, KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -557,3 +557,20 @@ dif_result_t dif_keymgr_read_output(const dif_keymgr_t *keymgr,
 
   return kDifOk;
 }
+
+dif_result_t dif_keymgr_read_binding(const dif_keymgr_t *keymgr,
+                                     dif_keymgr_binding_value_t *output) {
+  if (keymgr == NULL || output == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_memcpy_from_mmio32(keymgr->base_addr,
+                                 KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET,
+                                 output->sealing, sizeof(output->sealing));
+
+  mmio_region_memcpy_from_mmio32(
+      keymgr->base_addr, KEYMGR_ATTEST_SW_BINDING_0_REG_OFFSET,
+      output->attestation, sizeof(output->attestation));
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_keymgr.h
+++ b/sw/device/lib/dif/dif_keymgr.h
@@ -480,7 +480,30 @@ typedef struct dif_keymgr_output {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_keymgr_read_output(const dif_keymgr_t *keymgr,
                                     dif_keymgr_output_t *output);
+/**
+ * Attestation and sealing binding value.
+ */
+typedef struct dif_keymgr_binding_value {
+  /**
+   * Sealing binding value.
+   */
+  uint32_t sealing[8];
+  /**
+   * Attestation binding value.
+   */
+  uint32_t attestation[8];
+} dif_keymgr_binding_value_t;
 
+/**
+ * Reads both the attestation or the binding value set.
+ *
+ * @param keymgr A key manager handle.
+ * @param[out] output Value read.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_read_binding(const dif_keymgr_t *keymgr,
+                                     dif_keymgr_binding_value_t *output);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_keymgr.h
+++ b/sw/device/lib/dif/dif_keymgr.h
@@ -504,6 +504,31 @@ typedef struct dif_keymgr_binding_value {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_keymgr_read_binding(const dif_keymgr_t *keymgr,
                                      dif_keymgr_binding_value_t *output);
+
+typedef struct dif_keymgr_max_key_version {
+  /**
+   * Max creator key version.
+   */
+  uint32_t creator_max_key_version;
+  /**
+   * Max owner intermediate key version.
+   */
+  uint32_t owner_int_max_key_version;
+  /**
+   * Max owner key version.
+   */
+  uint32_t owner_max_key_version;
+} dif_keymgr_max_key_version_t;
+
+/**
+ * Reads the max key version of each stage.
+ *
+ * @param keymgr A key manager handle.
+ * @param version Struct with the max versions set.
+ * @return dif_result_t
+ */
+dif_result_t dif_keymgr_read_max_key_version(
+    const dif_keymgr_t *keymgr, dif_keymgr_max_key_version_t *versions);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_keymgr_unittest.cc
+++ b/sw/device/lib/dif/dif_keymgr_unittest.cc
@@ -834,5 +834,27 @@ TEST_F(ReadBindingTest, Read) {
   EXPECT_THAT(kExpected[0], ::testing::ElementsAreArray(output.sealing));
   EXPECT_THAT(kExpected[1], ::testing::ElementsAreArray(output.attestation));
 }
+
+class ReadMaxKeyVersionTest : public DifKeymgrInitialized {};
+
+TEST_P(BadArgsTwo, ReadMaxKeyVersion) {
+  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
+  auto version =
+      GetGoodBadPtrArg<dif_keymgr_max_key_version_t>(std::get<1>(GetParam()));
+
+  EXPECT_DIF_BADARG(dif_keymgr_read_max_key_version(keymgr, version));
+}
+
+TEST_F(ReadMaxKeyVersionTest, Read) {
+  EXPECT_READ32(KEYMGR_MAX_CREATOR_KEY_VER_SHADOWED_REG_OFFSET, 0xa093ed64);
+  EXPECT_READ32(KEYMGR_MAX_OWNER_INT_KEY_VER_SHADOWED_REG_OFFSET, 0x874d53e);
+  EXPECT_READ32(KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET, 0x874df4a);
+
+  dif_keymgr_max_key_version_t versions;
+  EXPECT_DIF_OK(dif_keymgr_read_max_key_version(&keymgr_, &versions));
+  EXPECT_THAT(0xa093ed64, versions.creator_max_key_version);
+  EXPECT_THAT(0x874d53e, versions.owner_int_max_key_version);
+  EXPECT_THAT(0x874df4a, versions.owner_max_key_version);
+}
 }  // namespace
 }  // namespace dif_keymgr_unittest

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -1105,7 +1105,7 @@
             '''
       tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
-      tests: []
+      tests: ["rom_keymgr_init"]
     }
 
     {

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -138,6 +138,26 @@ opentitan_functest(
     ],
 )
 
+opentitan_functest(
+    name = "e2e_keymgr_init",
+    srcs = ["rom_e2e_keymgr_init_test.c"],
+    signed = True,
+    targets = [
+        "cw310_rom",
+        "verilator",
+    ],
+    verilator = verilator_params(
+        timeout = "eternal",
+        rom = "//sw/device/silicon_creator/rom",
+    ),
+    deps = [
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/testing:keymgr_testutils",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 # Same as `:e2e_bootup_success`, but the Dev OTP image is spliced into the
 # bitstream before it's sent to the CW310 FPGA.
 opentitan_functest(

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_keymgr_init_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_keymgr_init_test.c
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_keymgr.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/keymgr_testutils.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/base/boot_measurements.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/manifest.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"  // Generated
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kRomExtMeasEnOffset =
+      OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN_OFFSET,
+};
+
+static void Initialize_peripherals(dif_keymgr_t *keymgr, dif_otp_ctrl_t *otp) {
+  CHECK_DIF_OK(dif_keymgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_KEYMGR_BASE_ADDR), keymgr));
+
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), otp));
+}
+
+static uint32_t otp_read32(dif_otp_ctrl_t *otp, uint32_t offset) {
+  return mmio_region_read32(otp->base_addr,
+                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET + offset);
+}
+
+bool test_main(void) {
+  dif_keymgr_t keymgr;
+  dif_otp_ctrl_t otp;
+  Initialize_peripherals(&keymgr, &otp);
+
+  keymgr_testutils_check_state(&keymgr, kDifKeymgrStateReset);
+
+  dif_keymgr_binding_value_t bindings;
+  CHECK_DIF_OK(dif_keymgr_read_binding(&keymgr, &bindings));
+
+  const manifest_t *manifest = manifest_def_get();
+
+  if (otp_read32(&otp, kRomExtMeasEnOffset) == kHardenedBoolTrue) {
+    // Check that the attestation is equal to the digest.
+    CHECK(otp_read32(&otp, kRomExtMeasEnOffset) == kHardenedBoolTrue);
+    CHECK_ARRAYS_EQ(bindings.attestation, boot_measurements.rom_ext.data,
+                    ARRAYSIZE(bindings.attestation));
+  } else {
+    // Check that the attestation is equal to `binding_value` field of the
+    // manifest.
+    CHECK_ARRAYS_EQ(bindings.attestation, manifest->binding_value.data,
+                    ARRAYSIZE(bindings.attestation));
+  }
+
+  // Check that the sealing is equal to `binding_value` field of the
+  // manifest.
+  CHECK_ARRAYS_EQ(bindings.sealing, manifest->binding_value.data,
+                  ARRAYSIZE(bindings.sealing));
+
+  // Check that the creator max version is equal to `max_key_version` field of
+  // the manifest.
+  dif_keymgr_max_key_version_t versions;
+  CHECK_DIF_OK(dif_keymgr_read_max_key_version(&keymgr, &versions));
+  CHECK(versions.creator_max_key_version == manifest->max_key_version);
+  return true;
+}


### PR DESCRIPTION
This PR adds the e2e test  `rom_e2e_keymgr_init`.