### PR TITLE
fix(spid): TPM_HASH_START return value

### DIFF
--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -806,7 +806,7 @@ module spi_tpm
       end
 
       RegHashStart: begin
-        isck_hw_reg_word = 32'h 0000_0000;
+        isck_hw_reg_word = 32'h FFFF_FFFF;
       end
 
       RegId: begin


### PR DESCRIPTION
`TPM_HASH_START` return value should be 0xFF. The HW returned 0x00.

_Related Issue: https://github.com/lowRISC/opentitan/issues/15241_
