### PR TITLE
[opentitantool] Move `update-usr-access` under the `fpga` command group.

### DIFF
--- a/rules/splice.bzl
+++ b/rules/splice.bzl
@@ -68,8 +68,8 @@ def _bitstream_splice_impl(ctx):
             inputs = [spliced],
             arguments = [
                 "--rcfile=",
-                "--logging",
-                "info",
+                "--logging=info",
+                "fpga",
                 "update-usr-access",
                 spliced.path,
                 output.path,

--- a/sw/host/opentitantool/src/command/fpga.rs
+++ b/sw/host/opentitantool/src/command/fpga.rs
@@ -11,4 +11,5 @@ use opentitanlib::app::command::CommandDispatch;
 pub enum FpgaCommand {
     LoadBitstream(crate::command::load_bitstream::LoadBitstream),
     SetPll(crate::command::set_pll::SetPll),
+    UpdateUsrAccess(crate::command::update_usr_access::UpdateUsrAccess),
 }

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -34,7 +34,6 @@ enum RootCommandHierarchy {
     Fpga(command::fpga::FpgaCommand),
     I2c(command::i2c::I2cCommand),
     Image(command::image::Image),
-    UpdateUsrAccess(command::update_usr_access::UpdateUsrAccess),
     NoOp(command::NoOp),
     Rsa(command::rsa::Rsa),
     Spi(command::spi::SpiCommand),


### PR DESCRIPTION
`opentitantool update-usr-access` is now called `opentitantool fpga update-user-access`.

This change was suggested at https://github.com/lowRISC/opentitan/pull/14830#discussion_r971974771. Closes https://github.com/lowRISC/opentitan/issues/14950.

Signed-off-by: Johnathan Van Why <jrvanwhy@google.com>