### PR TITLE
[spi_device/dv] Enable testing unaligned address when read TPM HW regs

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_hw_reg_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_hw_reg_vseq.sv
@@ -27,9 +27,6 @@ class spi_device_tpm_read_hw_reg_vseq extends spi_device_tpm_base_vseq;
     is_hw_reg_region == 1;
     is_hw_reg_offset == 1;
     tpm_write == 0;
-
-    // TODO
-    is_valid_locality == 1;
   }
 
   virtual task body();

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -215,7 +215,6 @@ package spi_device_env_pkg;
   // return locality index from the addr
   function automatic bit[23:0] get_locality_from_addr(bit[TPM_ADDR_WIDTH-1:0] addr);
     uint loc = addr[TPM_OFFSET_WIDTH + TPM_LOCALITY_WIDTH - 1 : TPM_OFFSET_WIDTH];
-    `DV_CHECK_LE(loc, MAX_TPM_LOCALITY, , , msg_id)
     return loc;
   endfunction
 


### PR DESCRIPTION
1. Enabled testing unaligned address when read TPM HW regs
2. updated scb to support to drop HW reg write when host writes invalid locality

The `spi_device_tpm_read_hw_reg` will fail until #15266 is fixed.

Signed-off-by: Weicai Yang <weicai@google.com>