### PR TITLE
[dv] add several Xcelium regressions to scale up presubmit testing

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1307,13 +1307,77 @@
               "chip_sw_hmac_enc_jitter_en",
               "chip_sw_keymgr_key_derivation_jitter_en",
               "chip_sw_kmac_mode_kmac_jitter_en",
-              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en"
-             ]
+              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en"]
     }
     {
       name: xcelium_ci
       tests: ["chip_plic_all_irqs"]
       reseed: 1
+    }
+    {
+      name: xcelium_ci_0
+      tests: ["chip_plic_all_irqs"]
+              // TODO(#14532): enable these tests slowly to ensure no CI breakages.
+              // "chip_sw_clkmgr_jitter",
+              // "chip_sw_kmac_app_rom",
+              // "chip_sw_rstmgr_sw_rst",
+              // "chip_sw_hmac_enc",
+              // "chip_sw_aes_enc_jitter_en",
+              // "chip_sw_rom_ctrl_integrity_check",
+              // "chip_sw_lc_walkthrough_testunlocks",
+              // "chip_prim_tl_access"]
+    }
+    {
+      name: xcelium_ci_1
+      tests: ["chip_plic_all_irqs"]
+              // TODO(#14532): enable these tests slowly to ensure no CI breakages.
+              // "chip_sw_rv_core_ibex_address_translation",
+              // "chip_sw_rv_timer_irq",
+              // "chip_sw_spi_device_tx_rx",
+              // "chip_sw_usb_ast_clk_calib",
+              // "chip_sw_lc_walkthrough_dev",
+              // "chip_sw_kmac_mode_cshake",
+              // "chip_sw_plic_sw_irq",
+              // "chip_sw_aes_enc"]
+    }
+    {
+      name: xcelium_ci_2
+      tests: ["chip_plic_all_irqs"]
+              // TODO(#14532): enable these tests slowly to ensure no CI breakages.
+              // "chip_sw_pwrmgr_main_power_glitch_reset",
+              // "chip_tap_straps_prod",
+              // "chip_sw_kmac_mode_kmac",
+              // "chip_rv_dm_ndm_reset_req",
+              // "chip_sw_kmac_idle",
+              // "chip_sw_sensor_ctrl_status",
+              // "chip_sw_lc_walkthrough_rma",
+              // "chip_sw_entropy_src_kat_test"]
+    }
+    {
+      name: xcelium_ci_3
+      tests: ["chip_plic_all_irqs"]
+              // TODO(#14532): enable these tests slowly to ensure no CI breakages.
+              // "chip_tap_straps_dev",
+              // "chip_sw_pwrmgr_deep_sleep_power_glitch_reset",
+              // "chip_sw_sram_ctrl_ret_scrambled_access",
+              // "chip_sw_lc_walkthrough_prodend",
+              // "chip_sw_rstmgr_sw_req",
+              // "chip_sw_aes_idle",
+              // "chip_sw_pwrmgr_sleep_power_glitch_reset",
+              // "chip_sw_pwrmgr_sleep_disabled"]
+    }
+    {
+      name: xcelium_ci_4
+      tests: ["chip_plic_all_irqs"]
+              // TODO(#14532): enable these tests slowly to ensure no CI breakages.
+              // "chip_sw_sram_ctrl_main_scrambled_access",
+              // "chip_sw_aes_entropy",
+              // "chip_sw_sleep_pin_mio_dio_val",
+              // "chip_sw_entropy_src_ast_rng_req",
+              // "chip_sw_csrng_kat_test",
+              // "chip_sw_kmac_mode_kmac_jitter_en",
+              // "chip_sw_lc_walkthrough_prod",
+              // "chip_sw_sysrst_ctrl_inputs"]
     }
   ]
 }


### PR DESCRIPTION
This adds several top-level test regression suites to enable scaling up DV presubmit testing in CI using Xcelium.

This partially addresses #14532.

Note, these regressions will not be run in CI until the private CI [job configuration](https://github.com/lowRISC/opentitan-private-ci/blob/master/jobs.yml) has been updated.

These tests were selected automatically using a script I wrote that:
1. parses the last Xcelium nightly regression log file to extract test runtimes, and
2. round-robin assign tests to 5 different regression suites until each regression contains enough tests such that the cumulative test runtime for a given regression suite is < 80mins.

Note, while dvsim can be configured to run multiple tests in parallel on a given private CI VM, this number was chosen as a worst case bound, to aim to keep the total test runtime well under ~2hrs, the current latency for CI.

Below, I show two plots (a plot of all test runtimes on top; a histogram of test runtimes on bottom) that indicate the tests covered by these regressions. Left of the red vertical lines are the tests these regression contain.

![xcelium-test-runtimes](https://user-images.githubusercontent.com/5633066/193962892-20cb233d-e72b-4ce0-93ea-1d565fe0ac3d.png)

![xcelium-test-runtimes-histogram](https://user-images.githubusercontent.com/5633066/193962911-5fe37e2b-5e45-4865-84b3-0d9027363dc6.png)
