### PR TITLE
[chip,pattgen,dv] Add pattgen io test

### DIFF
--- a/hw/dv/sv/pattgen_agent/pattgen_agent_cfg.sv
+++ b/hw/dv/sv/pattgen_agent/pattgen_agent_cfg.sv
@@ -14,6 +14,13 @@ class pattgen_agent_cfg extends dv_base_agent_cfg;
 
   uint length[NUM_PATTGEN_CHANNELS-1:0];
 
+  // pre-divider check enable
+  bit [NUM_PATTGEN_CHANNELS-1:0] chk_prediv;
+
+  // expected clk_cnt value
+  // calculated by 2 * (pattgen.PREDIV_CH + 1)
+  uint div[NUM_PATTGEN_CHANNELS];
+
   `uvm_object_utils_begin(pattgen_agent_cfg)
     `uvm_field_int(error_injected,  UVM_DEFAULT)
     `uvm_field_sarray_int(polarity, UVM_DEFAULT)

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -462,7 +462,7 @@
             - Verify both pattgen channels independently.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_pattgen_ios"]
     }
 
     // PWM (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -356,6 +356,13 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_pattgen_ios
+      uvm_test_seq: chip_sw_patt_ios_vseq
+      sw_images: ["//sw/device/tests/sim_dv:pattgen_ios_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=5_000_000"]
+    }
+    {
       name: chip_sw_uart_tx_rx
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
       sw_images: ["//sw/device/tests/sim_dv:uart_tx_rx_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_common_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_common_pkg.sv
@@ -13,6 +13,7 @@ package chip_common_pkg;
   parameter dv_utils_pkg::uint NUM_SPI_HOSTS = 2;
   parameter dv_utils_pkg::uint NUM_I2CS = 3;
   parameter dv_utils_pkg::uint NUM_PWM_CHANNELS = pwm_reg_pkg::NOutputs;
+  parameter dv_utils_pkg::uint NUM_PATTGEN_CH = pattgen_agent_pkg::NUM_PATTGEN_CHANNELS;
 
   // Buffer is half of SPI_DEVICE Dual Port SRAM
   parameter dv_utils_pkg::uint SPI_FRAME_BYTE_SIZE = spi_device_reg_pkg::SPI_DEVICE_BUFFER_SIZE/2;

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -26,6 +26,7 @@ filesets:
       - lowrisc:dv:uart_agent
       - lowrisc:dv:pwm_monitor
       - lowrisc:dv:i2c_agent
+      - lowrisc:dv:pattgen_agent
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:pwrmgr_pkg
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
@@ -100,6 +101,7 @@ filesets:
       - seq_lib/chip_sw_entropy_src_fuse_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_usb_ast_clk_calib_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_patt_ios_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - alerts_if.sv
       - ast_ext_clk_if.sv

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -19,6 +19,7 @@ class chip_env extends cip_base_env #(
   // spi host agent that transmits trasnactions to dut spi device
   spi_agent              m_spi_agent;
   pwm_monitor            m_pwm_monitor[NUM_PWM_CHANNELS];
+  pattgen_agent          m_pattgen_agent;
 
   `uvm_component_new
 
@@ -117,6 +118,11 @@ class chip_env extends cip_base_env #(
                                            cfg.m_pwm_monitor_cfg[i]);
     end
 
+    // Instantiate pattgen agent
+    m_pattgen_agent = pattgen_agent::type_id::create("m_pattgen_agent", this);
+    uvm_config_db#(pattgen_agent_cfg)::set(this, "m_pattgen_agent*", "cfg",
+                                           cfg.m_pattgen_agent_cfg);
+
     // disable alert_esc_agent's driver and only use its monitor
     foreach (LIST_OF_ALERTS[i]) begin
       cfg.m_alert_agent_cfg[LIST_OF_ALERTS[i]].is_active = 0;
@@ -164,6 +170,10 @@ class chip_env extends cip_base_env #(
 
     foreach (m_pwm_monitor[i]) begin
       m_pwm_monitor[i].analysis_port.connect(virtual_sequencer.pwm_rx_fifo[i].analysis_export);
+    end
+    for (int i = 0; i < NUM_PATTGEN_CH; i++) begin
+      m_pattgen_agent.monitor.item_port[i].connect(
+                                          virtual_sequencer.pattgen_rx_fifo[i].analysis_export);
     end
   endfunction
 

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -87,6 +87,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   rand spi_agent_cfg        m_spi_agent_cfg;
   pwm_monitor_cfg           m_pwm_monitor_cfg[NUM_PWM_CHANNELS];
   rand i2c_agent_cfg        m_i2c_agent_cfgs[NUM_I2CS];
+  rand pattgen_agent_cfg    m_pattgen_agent_cfg;
 
   // JTAG DMI register model
   rand jtag_dmi_reg_block jtag_dmi_ral;
@@ -149,6 +150,10 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     foreach (m_i2c_agent_cfgs[i]) begin
       m_i2c_agent_cfgs[i] = i2c_agent_cfg::type_id::create($sformatf("m_i2c_agent_cfg%0d", i));
     end
+
+    // create pattgen agent config obj
+    m_pattgen_agent_cfg = pattgen_agent_cfg::type_id::create("m_pattgen_agent_cfg");
+    m_pattgen_agent_cfg.if_mode = Device;
 
     // create jtag agent config obj
     m_jtag_riscv_agent_cfg = jtag_riscv_agent_cfg::type_id::create("m_jtag_riscv_agent_cfg");

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -46,6 +46,7 @@ package chip_env_pkg;
   import tl_main_pkg::ADDR_SPACE_RV_CORE_IBEX__CFG;
   import rv_core_ibex_reg_pkg::RV_CORE_IBEX_DV_SIM_WINDOW_OFFSET;
   import i2c_agent_pkg::*;
+  import pattgen_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -481,6 +481,24 @@ interface chip_if;
     end
   end : gen_pwm_if_conn
 
+  // Functional (muxed) interface: PATTGEN
+  // each channel has pda, pcl
+
+  bit __enable_pattgen = 0;
+
+  pattgen_if #(NUM_PATTGEN_CH) pattgen_if();
+  assign pattgen_if.rst_ni = `PATTGEN_HIER.rst_ni;
+  assign pattgen_if.clk_i  = `PATTGEN_HIER.clk_i;
+  assign pattgen_if.pda_tx = !__enable_pattgen ? {NUM_PATTGEN_CH{1'bz}} : {ios[IoB11], ios[IoB9]};
+  assign pattgen_if.pcl_tx = !__enable_pattgen ? {NUM_PATTGEN_CH{1'bz}} : {ios[IoB12], ios[IoB10]};
+
+  initial begin
+    uvm_config_db#(virtual pattgen_if)::set(null, "*.env.m_pattgen_agent*", "vif", pattgen_if);
+  end
+  function automatic void enable_pattgen(bit enable);
+    __enable_pattgen = enable;
+  endfunction
+
   // Functional (muxed) interface: external clock source.
   //
   // The reset port is passive only.

--- a/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
+++ b/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
@@ -19,13 +19,14 @@ class chip_virtual_sequencer extends cip_base_virtual_sequencer #(
 
   // Collect pkts from pwm monitor
   uvm_tlm_analysis_fifo #(pwm_item) pwm_rx_fifo[NUM_PWM_CHANNELS];
-
+  uvm_tlm_analysis_fifo #(pattgen_item) pattgen_rx_fifo[NUM_PATTGEN_CHANNELS];
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     foreach (uart_tx_fifos[i]) uart_tx_fifos[i] = new($sformatf("uart_tx_fifo%0d", i), this);
     foreach (pwm_rx_fifo[i]) pwm_rx_fifo[i] = new($sformatf("pwm_rx_fifo%0d", i), this);
+    foreach (pattgen_rx_fifo[i]) pattgen_rx_fifo[i] = new($sformatf("pattgen_rx_fifo%0d", i), this);
   endfunction
 
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_patt_ios_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_patt_ios_vseq.sv
@@ -1,0 +1,156 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_patt_ios_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_patt_ios_vseq)
+  `uvm_object_new
+
+  typedef struct packed {
+    // polarity:
+    //    0 : sample rising edge
+    //    1 : sample falling edge
+    bit          polarity;
+    bit [31:0]   clk_div;
+    bit [31:0]   patt_lower;
+    bit [31:0]   patt_upper;
+    // range has +1 value of register
+    // to match dif implementation
+
+    // range : [1:64]
+    bit [7:0]    len;
+    // range : [1, 1024]
+    bit [15:0]   rep;
+  } pattgen_chan_cfg_t;
+
+  // expected channel config
+  pattgen_chan_cfg_t exp_cfg[NUM_PATTGEN_CH];
+
+  // expected 64bit pattern
+  bit [63:0]     exp_pat[NUM_PATTGEN_CH];
+
+  rand pattgen_chan_cfg_t rand_chan_cfg;
+  rand bit[1:0] chan_en;
+
+  constraint chan_cfg_c {
+    // Cover limited sets of divsor in full chip test.
+    rand_chan_cfg.clk_div dist { 0 := 4, [1:15] := 1};
+    rand_chan_cfg.len inside {[1:64]};
+    rand_chan_cfg.rep inside {[1:5]};
+  }
+
+  constraint chan_en_c {
+    // At least one channel should be enabled.
+    chan_en != 2'b0;
+  }
+
+  virtual task cpu_init();
+    bit[7:0] byte_arr[];
+    super.cpu_init();
+
+    cfg.m_pattgen_agent_cfg.en_monitor = 0;
+
+    byte_arr = {chan_en};
+    sw_symbol_backdoor_overwrite("kChannelEnable", byte_arr);
+    `uvm_info(`gfn, $sformatf("PATT_IOS CHAN_EN: %2b", chan_en), UVM_MEDIUM)
+
+    for (int i = 0; i < NUM_PATTGEN_CH; i++) begin
+      exp_cfg[i] = rand_chan_cfg;
+      cfg.m_pattgen_agent_cfg.polarity[i] = exp_cfg[i].polarity;
+      cfg.m_pattgen_agent_cfg.length[i] = exp_cfg[i].len * exp_cfg[i].rep;
+      cfg.m_pattgen_agent_cfg.div[i] = 2 * (exp_cfg[i].clk_div + 1);
+      exp_pat[i] = {exp_cfg[i].patt_upper, exp_cfg[i].patt_lower};
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_chan_cfg)
+    end
+
+
+    byte_arr = {exp_cfg[0].polarity};
+    sw_symbol_backdoor_overwrite("kPattPol0", byte_arr);
+    byte_arr = {<<8{{<<32{exp_cfg[0].clk_div}}}};
+    sw_symbol_backdoor_overwrite("kPattDiv0", byte_arr);
+    byte_arr = {<<8{{<<32{exp_cfg[0].patt_lower}}}};
+    sw_symbol_backdoor_overwrite("kPattLower0", byte_arr);
+    byte_arr = {<<8{{<<32{exp_cfg[0].patt_upper}}}};
+    sw_symbol_backdoor_overwrite("kPattUpper0", byte_arr);
+    byte_arr = {exp_cfg[0].len};
+    sw_symbol_backdoor_overwrite("kPattLen0", byte_arr);
+    byte_arr = {<<8{{<<16{exp_cfg[0].rep}}}};
+    sw_symbol_backdoor_overwrite("kPattRep0", byte_arr);
+
+    if (chan_en[0]) begin
+      `uvm_info(`gfn, $sformatf("PATT_IOS CH0: cfg %p", exp_cfg[0]), UVM_MEDIUM)
+    end
+
+    byte_arr = {exp_cfg[1].polarity};
+    sw_symbol_backdoor_overwrite("kPattPol1", byte_arr);
+    byte_arr = {<<8{{<<32{exp_cfg[1].clk_div}}}};
+    sw_symbol_backdoor_overwrite("kPattDiv1", byte_arr);
+    byte_arr = {<<8{{<<32{exp_cfg[1].patt_lower}}}};
+    sw_symbol_backdoor_overwrite("kPattLower1", byte_arr);
+    byte_arr = {<<8{{<<32{exp_cfg[1].patt_upper}}}};
+    sw_symbol_backdoor_overwrite("kPattUpper1", byte_arr);
+    byte_arr = {exp_cfg[1].len};
+    sw_symbol_backdoor_overwrite("kPattLen1", byte_arr);
+    byte_arr = {<<8{{<<16{exp_cfg[1].rep}}}};
+    sw_symbol_backdoor_overwrite("kPattRep1", byte_arr);
+    if (chan_en[1]) begin
+      `uvm_info(`gfn, $sformatf("PATT_IOS CH1: cfg %p", exp_cfg[1]), UVM_MEDIUM)
+    end
+  endtask // cpu_init
+
+  virtual task body();
+    super.body();
+    `uvm_info(`gfn, $sformatf("TEST: wait for pinmux init"), UVM_MEDIUM)
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "pinmux_init end")
+    `uvm_info(`gfn, $sformatf("TEST: pattgen if enable"), UVM_MEDIUM)
+    cfg.chip_vif.enable_pattgen(.enable(1));
+
+    // Avoid false trigger when pad is enabled
+    @(cfg.m_pattgen_agent_cfg.vif.pcl_tx);
+    // Pattgen needs div4 scale
+    cfg.clk_rst_vif.wait_clks(40);
+    cfg.m_pattgen_agent_cfg.en_monitor = 1;
+    cfg.m_pattgen_agent_cfg.chk_prediv = chan_en;
+
+    fork
+      begin
+        `DV_WAIT(cfg.sw_logger_vif.printed_log == "TEST DONE")
+        cfg.m_pattgen_agent_cfg.channel_done = chan_en;
+      end
+      collect_pattgen_data();
+    join_any
+
+    `uvm_info(`gfn, "TEST: body done", UVM_HIGH)
+  endtask
+
+  virtual task collect_pattgen_data();
+    foreach (p_sequencer.pattgen_rx_fifo[i]) begin
+      automatic int j = i;
+      fork begin
+        forever process_pattgen_data(j);
+      end join_none
+    end
+  endtask
+
+  // Collect pattgen_item from pattgen agent and check with expected pattern.
+  // expected channel config length 'exp_cfg[].len' and repeat value 'exp_cfg[].rep' are used
+  // to compare proper size of pattern.
+  virtual task process_pattgen_data(int channel);
+    pattgen_item item;
+    int iter;
+
+    p_sequencer.pattgen_rx_fifo[channel].get(item);
+
+    `uvm_info(`gfn, $sformatf("PATTGEN_CH%0d: got pktlen:%0d",
+                              channel, item.data_q.size()), UVM_LOW)
+    repeat (exp_cfg[channel].rep) begin
+      int bit_cnt = 0;
+      while (bit_cnt < exp_cfg[channel].len) begin
+        `DV_CHECK_EQ(item.data_q[bit_cnt], exp_pat[channel][bit_cnt],
+                     $sformatf("Rep %0d bit_cnt:%0d mismatch", iter, bit_cnt))
+        bit_cnt++;
+      end
+      iter++;
+    end
+  endtask
+endclass // chip_sw_patt_ios_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -62,3 +62,4 @@
 `include "chip_sw_i2c_host_tx_rx_vseq.sv"
 `include "chip_sw_inject_scramble_seed_vseq.sv"
 `include "chip_sw_exit_test_unlocked_bootstrap_vseq.sv"
+`include "chip_sw_patt_ios_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -1077,3 +1077,22 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "pattgen_ios_test",
+    srcs = ["pattgen_ios_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pattgen",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/sim_dv/pattgen_ios_test.c
+++ b/sw/device/tests/sim_dv/pattgen_ios_test.c
@@ -1,0 +1,191 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pattgen.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/**
+   PATTGEN IOS test
+   The test programs both channels of the pattgen to random patterns.
+   Pattgen ios are connected as follows:
+   pda_tx[0] - IOB9
+   pcl_tx[0] - IOB10
+   pda_tx[1] - IOB11
+   pcl_tx[1] - IOB12
+
+   The random pattern programmed by 'chip_sw_patt_ios_vseq.sv'
+   and output will be collected at the PADS and compared in SV test bench.
+ */
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Following volatile const will be overwritten by
+// SV testbench with random values.
+// 1: channel 0, 2: channel 1, 3: Both channels
+static volatile const uint8_t kChannelEnable = 3;
+
+static volatile const uint8_t kPattPol0 = kDifPattgenPolarityLow;
+static volatile const uint32_t kPattDiv0 = 0;
+static volatile const uint32_t kPattLower0 = 0x76543210;
+static volatile const uint32_t kPattUpper0 = 0x76543210;
+static volatile const uint8_t kPattLen0 = 40;
+static volatile const uint16_t kPattRep0 = 3;
+
+static volatile const uint8_t kPattPol1 = kDifPattgenPolarityLow;
+static volatile const uint32_t kPattDiv1 = 0;
+static volatile const uint32_t kPattLower1 = 0x76543210;
+static volatile const uint32_t kPattUpper1 = 0x76543210;
+static volatile const uint8_t kPattLen1 = 40;
+static volatile const uint16_t kPattRep1 = 3;
+
+static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
+static const uint8_t kPattOuts = 4;
+
+static const dif_pinmux_index_t kPinmuxOutsel[] = {
+    kTopEarlgreyPinmuxOutselPattgenPda0Tx, /**< = 49: Peripheral Output 46 */
+    kTopEarlgreyPinmuxOutselPattgenPcl0Tx, /**< = 50: Peripheral Output 47 */
+    kTopEarlgreyPinmuxOutselPattgenPda1Tx, /**< = 51: Peripheral Output 48 */
+    kTopEarlgreyPinmuxOutselPattgenPcl1Tx, /**< = 52: Peripheral Output 49 */
+};
+static const dif_pinmux_index_t kPinmuxMioOut[] = {
+    kTopEarlgreyPinmuxMioOutIob9,   // pda0_tx
+    kTopEarlgreyPinmuxMioOutIob10,  // pcl0_tx
+    kTopEarlgreyPinmuxMioOutIob11,  // pda1_tx
+    kTopEarlgreyPinmuxMioOutIob12,  // pcl1_tx
+};
+
+static dif_rv_plic_t plic;
+static dif_pattgen_t pattgen;
+
+/**
+ * External interrupt handler.
+ */
+void ottf_external_isr(void) {
+  dif_rv_plic_irq_id_t irq_id;
+
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));
+  LOG_INFO("IRQ detected %0d", irq_id);
+
+  switch (irq_id) {
+    case kTopEarlgreyPlicIrqIdPattgenDoneCh0:
+      LOG_INFO("Channel 0");
+      break;
+    case kTopEarlgreyPlicIrqIdPattgenDoneCh1:
+      LOG_INFO("Channel 1");
+      break;
+    default:
+      LOG_FATAL("IRQ: unknown irq %d", irq_id);
+      break;
+  }
+}
+
+bool test_main(void) {
+  dif_pinmux_t pinmux;
+
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  CHECK_DIF_OK(dif_pattgen_init(
+      mmio_region_from_addr(TOP_EARLGREY_PATTGEN_BASE_ADDR), &pattgen));
+  CHECK_DIF_OK(dif_pattgen_channel_set_enabled(&pattgen, kDifPattgenChannel0,
+                                               kDifToggleDisabled));
+  CHECK_DIF_OK(dif_pattgen_channel_set_enabled(&pattgen, kDifPattgenChannel1,
+                                               kDifToggleDisabled));
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
+  rv_plic_testutils_irq_range_enable(&plic, kPlicTarget,
+                                     kTopEarlgreyPlicIrqIdPattgenDoneCh0,
+                                     kTopEarlgreyPlicIrqIdPattgenDoneCh1);
+
+  // Initialize pinmux
+  // Assign PattgenOutput to IOB9..12
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+
+  LOG_INFO("pinmux_init begin");
+  for (int i = 0; i < kPattOuts; ++i) {
+    CHECK_DIF_OK(
+        dif_pinmux_output_select(&pinmux, kPinmuxMioOut[i], kPinmuxOutsel[i]));
+  }
+  // Do not remove below msg.
+  LOG_INFO("pinmux_init end");
+
+  // Enable pattgen interrupt at plic
+  CHECK_DIF_OK(dif_pattgen_irq_set_enabled(&pattgen, kDifPattgenIrqDoneCh0,
+                                           kDifToggleEnabled));
+  CHECK_DIF_OK(dif_pattgen_irq_set_enabled(&pattgen, kDifPattgenIrqDoneCh1,
+                                           kDifToggleEnabled));
+
+  // Program pattgen if the channel is enabled.
+  dif_pattgen_channel_config_t patt_cfg;
+  if (kChannelEnable & 0x1) {
+    patt_cfg.polarity = kPattPol0;
+    patt_cfg.clock_divisor = kPattDiv0;
+    patt_cfg.seed_pattern_lower_word = kPattLower0;
+    patt_cfg.seed_pattern_upper_word = kPattUpper0;
+    patt_cfg.seed_pattern_length = kPattLen0;
+    patt_cfg.num_pattern_repetitions = kPattRep0;
+    CHECK_DIF_OK(
+        dif_pattgen_configure_channel(&pattgen, kDifPattgenChannel0, patt_cfg));
+
+    LOG_INFO("TEST CH0 Enable");
+    CHECK_DIF_OK(dif_pattgen_channel_set_enabled(&pattgen, kDifPattgenChannel0,
+                                                 kDifToggleEnabled));
+  }
+
+  if (kChannelEnable & 0x2) {
+    patt_cfg.polarity = kPattPol1;
+    patt_cfg.clock_divisor = kPattDiv1;
+    patt_cfg.seed_pattern_lower_word = kPattLower1;
+    patt_cfg.seed_pattern_upper_word = kPattUpper1;
+    patt_cfg.seed_pattern_length = kPattLen1;
+    patt_cfg.num_pattern_repetitions = kPattRep1;
+    CHECK_DIF_OK(
+        dif_pattgen_configure_channel(&pattgen, kDifPattgenChannel1, patt_cfg));
+
+    LOG_INFO("TEST CH1 Enable");
+    CHECK_DIF_OK(dif_pattgen_channel_set_enabled(&pattgen, kDifPattgenChannel1,
+                                                 kDifToggleEnabled));
+  }
+
+  LOG_INFO("Wait for interrupt");
+  wait_for_interrupt();
+
+  // Make sure both interrupts are triggered when both channels are enabled.
+  // Because interrupt from each channel can be triggered at different time,
+  // 'wait_for_interrupt' is not sufficient
+  uint32_t state;
+  while (state != kChannelEnable) {
+    CHECK_DIF_OK(dif_pattgen_irq_get_state(&pattgen, &state));
+  }
+
+  // Check the expected interrupt is triggered.
+  bool is_pending;
+  if (kChannelEnable & 0x1) {
+    CHECK_DIF_OK(dif_pattgen_irq_is_pending(&pattgen, kDifPattgenIrqDoneCh0,
+                                            &is_pending));
+    CHECK(is_pending == true);
+    CHECK_DIF_OK(dif_pattgen_irq_acknowledge(&pattgen, kDifPattgenIrqDoneCh0));
+  }
+
+  if (kChannelEnable & 0x2) {
+    CHECK_DIF_OK(dif_pattgen_irq_is_pending(&pattgen, kDifPattgenIrqDoneCh1,
+                                            &is_pending));
+    CHECK(is_pending == true);
+    CHECK_DIF_OK(dif_pattgen_irq_acknowledge(&pattgen, kDifPattgenIrqDoneCh1));
+  }
+
+  // Do not remove the below message
+  LOG_INFO("TEST DONE");
+  return true;
+}


### PR DESCRIPTION
This PR has following updates
 - Add a new pattgen io test (#14135)
 - Add block tb pattgen agent to chip tb
 - Update the pattgen agent to check 'pcl'
 - Add a new sequence to randomize pattgen config and check outputs

Signed-off-by: Jaedon Kim <jdonjdon@google.com>