### PR TITLE
[conn] Remove debug_en check for retention RAM

### DIFF
--- a/hw/top_earlgrey/data/chip_conn_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_conn_testplan.hjson
@@ -784,7 +784,6 @@
       tests: ["lc_hw_debug_en_pwrmgr",
               "lc_hw_debug_en_clkmgr",
               "lc_hw_debug_en_pinmux",
-              "lc_hw_debug_en_sram_ctrl_ret",
               "lc_hw_debug_en_sram_ctrl_main",
               "lc_hw_debug_en_rv_dm",
               "lc_hw_debug_en_csrng"]

--- a/hw/top_earlgrey/formal/conn_csvs/lc_ctrl_broadcast.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/lc_ctrl_broadcast.csv
@@ -31,7 +31,6 @@ CONNECTION, LC_CPU_EN_RV_CORE_IBEX, top_earlgrey.u_lc_ctrl, lc_cpu_en_o, top_ear
 CONNECTION, LC_HW_DEBUG_EN_PWRMGR,         top_earlgrey.u_lc_ctrl, lc_hw_debug_en_o, top_earlgrey.u_pwrmgr_aon,        lc_hw_debug_en_i
 CONNECTION, LC_HW_DEBUG_EN_CLKMGR,         top_earlgrey.u_lc_ctrl, lc_hw_debug_en_o, top_earlgrey.u_clkmgr_aon,        lc_hw_debug_en_i
 CONNECTION, LC_HW_DEBUG_EN_PINMUX,         top_earlgrey.u_lc_ctrl, lc_hw_debug_en_o, top_earlgrey.u_pinmux_aon,        lc_hw_debug_en_i
-CONNECTION, LC_HW_DEBUG_EN_SRAM_CTRL_RET,  top_earlgrey.u_lc_ctrl, lc_hw_debug_en_o, top_earlgrey.u_sram_ctrl_ret_aon, lc_hw_debug_en_i
 CONNECTION, LC_HW_DEBUG_EN_SRAM_CTRL_MAIN, top_earlgrey.u_lc_ctrl, lc_hw_debug_en_o, top_earlgrey.u_sram_ctrl_main,    lc_hw_debug_en_i
 CONNECTION, LC_HW_DEBUG_EN_RV_DM,          top_earlgrey.u_lc_ctrl, lc_hw_debug_en_o, top_earlgrey.u_rv_dm,             lc_hw_debug_en_i
 CONNECTION, LC_HW_DEBUG_EN_CSRNG,          top_earlgrey.u_lc_ctrl, lc_hw_debug_en_o, top_earlgrey.u_csrng,             lc_hw_debug_en_i


### PR DESCRIPTION
This is due to https://github.com/lowRISC/opentitan/pull/15224.

Signed-off-by: Michael Schaffner <msf@google.com>