### PR TITLE
[top-test] csrng_lc_hw_debug_en_test

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -16,6 +16,17 @@ autogen_hjson_header(
 )
 
 otp_json(
+    name = "otp_ctrl_dev_json",
+    lc_count = 5,
+    lc_state = "DEV",
+)
+
+otp_image(
+    name = "img_dev",
+    src = ":otp_ctrl_dev_json",
+)
+
+otp_json(
     name = "otp_ctrl_rma_json",
     lc_count = 8,
     lc_state = "RMA",
@@ -27,14 +38,14 @@ otp_image(
 )
 
 otp_json(
-    name = "otp_ctrl_dev_json",
-    lc_count = 5,
-    lc_state = "DEV",
+    name = "otp_ctrl_test_unlocked0_json",
+    lc_count = 1,
+    lc_state = "TEST_UNLOCKED0",
 )
 
 otp_image(
-    name = "img_dev",
-    src = ":otp_ctrl_dev_json",
+    name = "img_test_unlocked0",
+    src = ":otp_ctrl_test_unlocked0_json",
 )
 
 otp_json(

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_test_unlocked0.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_test_unlocked0.hjson
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Use the gen-otp-img.py script to convert this configuration into
+// a MEM file for preloading the OTP in FPGA synthesis or simulation.
+//
+
+{
+    // Seed to be used for generation of partition randomized values.
+    // Can be overridden on the command line with the --seed switch.
+    seed: 01931961561863975174
+
+    // The partition and item names must correspond with the OTP memory map.
+    partitions: [
+        {
+            name:  "CREATOR_SW_CFG",
+            items: [
+                {
+                    name: "CREATOR_SW_CFG_ROM_EXEC_EN",
+                    // ROM execution is enabled if this item is set to a
+                    // non-zero value.
+                    value: "0xffffffff",
+                },
+            ],
+        }
+        {
+            name:  "LIFE_CYCLE",
+            // Can be one of the following strings:
+            // RAW, TEST_UNLOCKED0-3, TEST_LOCKED0-2, DEV, PROD, PROD_END, RMA, SCRAP
+            state: "TEST_UNLOCKED0",
+            // Can range from 0 to 16.
+            // Note that a value of 0 is only permissible in RAW state.
+            count: 1
+        }
+    ]
+}

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -187,6 +187,12 @@
               {gen_otp_images_cmd_opts}
         ''',
         '''{gen_otp_images_cmd} \
+              --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_test_unlocked0.hjson \
+              --add-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_hw_cfg.hjson \
+              --out {run_dir}/otp_ctrl_img_test_unlocked0.vmem \
+              {gen_otp_images_cmd_opts}
+        ''',
+         '''{gen_otp_images_cmd} \
               --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_dev.hjson \
               --add-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_creator_sw_cfg.hjson \
               --add-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_owner_sw_cfg.hjson \
@@ -911,6 +917,15 @@
       sw_images: ["//sw/device/tests:entropy_src_kat_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=18_000_000"]
+    }
+    {
+      name: chip_sw_csrng_lc_hw_debug_en_test
+      uvm_test_seq: chip_sw_csrng_lc_hw_debug_en_vseq
+      sw_images: ["//sw/device/tests/sim_dv:csrng_lc_hw_debug_en_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=15_000_000", "+rng_srate_value_min=15",
+                 "+use_otp_image=LcStTestUnlocked0"]
+      run_timeout_mins: 60
     }
     {
       name: chip_sw_csrng_kat_test

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -98,6 +98,7 @@ filesets:
       - seq_lib/chip_rv_dm_ndm_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_entropy_src_fuse_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_csrng_lc_hw_debug_en_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_usb_ast_clk_calib_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -182,6 +182,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     otp_images[lc_ctrl_state_pkg::LcStDev] = "otp_ctrl_img_dev.vmem";
     otp_images[lc_ctrl_state_pkg::LcStProd] = "otp_ctrl_img_prod.vmem";
     otp_images[lc_ctrl_state_pkg::LcStRma] = "otp_ctrl_img_rma.vmem";
+    otp_images[lc_ctrl_state_pkg::LcStTestUnlocked0] = "otp_ctrl_img_test_unlocked0.vmem";
 
     `DV_CHECK_LE_FATAL(num_ram_main_tiles, 16)
     `DV_CHECK_LE_FATAL(num_ram_ret_tiles, 16)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_csrng_lc_hw_debug_en_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_csrng_lc_hw_debug_en_vseq.sv
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This class is used for the test `chip_sw_csrng_lc_hw_debug_en_vseq_test.
+// Please refer to the testplan for more details regarding the OTP
+// initialization values.
+class chip_sw_csrng_lc_hw_debug_en_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_csrng_lc_hw_debug_en_vseq)
+
+  `uvm_object_new
+
+  localparam string LC_CTRL_TRANS_SUCCESS_PATH =
+    "tb.dut.top_earlgrey.u_lc_ctrl.u_lc_ctrl_fsm.trans_success_o";
+
+  localparam logic [255:0] DEVICE_ID =
+      256'hFA53B8058E157CB69F1F413E87242971B6B52A656A1CAB7FEBF21E5BF1F45EDD;
+  localparam logic [255:0] MANUF_STATE =
+      256'h41389646B3968A3B128F4AF0AFFC1AAC77ADEFF42376E09D523D5C06786AAC34;
+  localparam logic [7:0] MUBI8TRUE = prim_mubi_pkg::MuBi8True;
+  localparam logic [7:0] MUBI8FALSE = prim_mubi_pkg::MuBi8False;
+
+  // When the test exit transition has been completed the CPU will be disabled
+  // and therefore it cannot be detected in SW. Detect this transition here
+  // to allow the CPU to be reset.
+  virtual task wait_for_transition();
+    int retval;
+    int transition_success = 0;
+    time lc_test_exit_timeout_ns = 120_000_000; // 120ms
+    retval = uvm_hdl_check_path(LC_CTRL_TRANS_SUCCESS_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", LC_CTRL_TRANS_SUCCESS_PATH))
+   `DV_SPINWAIT(while (transition_success == 0) begin
+                  retval = uvm_hdl_read(LC_CTRL_TRANS_SUCCESS_PATH, transition_success);
+                  `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", LC_CTRL_TRANS_SUCCESS_PATH))
+                  cfg.clk_rst_vif.wait_clks(1);
+                end,
+                "timeout while wait for test exit complete",
+                lc_test_exit_timeout_ns)
+  endtask
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+    // Make sure entropy_src and csrng fuses are setup correctly independent
+    // of which OTP image was loaded. The C portion of this test checks the
+    // lc states across resets.
+    cfg.mem_bkdr_util_h[Otp].otp_write_hw_cfg_partition(
+      .device_id(DEVICE_ID), .manuf_state(MANUF_STATE),
+      .en_sram_ifetch(MUBI8FALSE), .en_csrng_sw_app_read(MUBI8TRUE),
+      .en_entropy_src_fw_read(MUBI8TRUE),
+      .en_entropy_src_fw_over(MUBI8TRUE));
+  endtask
+
+  virtual task body();
+    super.body();
+
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "LC transition in progress.");
+
+    wait_for_transition();
+    cfg.clk_rst_vif.wait_clks(1000);
+    apply_reset();
+
+  endtask
+endclass : chip_sw_csrng_lc_hw_debug_en_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -58,6 +58,7 @@
 `include "chip_sw_alert_handler_entropy_vseq.sv"
 `include "chip_sw_lc_ctrl_program_error_vseq.sv"
 `include "chip_sw_entropy_src_fuse_vseq.sv"
+`include "chip_sw_csrng_lc_hw_debug_en_vseq.sv"
 `include "chip_sw_usb_ast_clk_calib_vseq.sv"
 `include "chip_sw_i2c_host_tx_rx_vseq.sv"
 `include "chip_sw_inject_scramble_seed_vseq.sv"

--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -63,19 +63,12 @@ dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
   }
 
   // ENTROPY_CONTROL register configuration.
-
-  // Conditioning bypass is hardcoded to disabled. Conditioning bypass is not
-  // intended as a regular mode of operation. If, in the future, we want to
-  // expose the ES_TYPE field in the future, we need to check the ES_ROUTE ==
-  // true if ES_TYPE == true, and FIPS_ENABLE == false if ES_ROUTE and ES_TYPE
-  // are both true.
-  uint32_t es_route_val =
-      config.route_to_firmware ? kMultiBitBool4True : kMultiBitBool4False;
   uint32_t entropy_ctrl_reg = bitfield_field32_write(
-      0, ENTROPY_SRC_ENTROPY_CONTROL_ES_ROUTE_FIELD, es_route_val);
+      0, ENTROPY_SRC_ENTROPY_CONTROL_ES_ROUTE_FIELD,
+      config.route_to_firmware ? kMultiBitBool4True : kMultiBitBool4False);
   entropy_ctrl_reg = bitfield_field32_write(
       entropy_ctrl_reg, ENTROPY_SRC_ENTROPY_CONTROL_ES_TYPE_FIELD,
-      kMultiBitBool4False);
+      config.bypass_conditioner ? kMultiBitBool4True : kMultiBitBool4False);
   mmio_region_write32(entropy_src->base_addr,
                       ENTROPY_SRC_ENTROPY_CONTROL_REG_OFFSET, entropy_ctrl_reg);
 

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -118,6 +118,13 @@ typedef struct dif_entropy_src_config {
    */
   bool route_to_firmware;
   /**
+   * If set, raw entropy will be sent to CSRNG, bypassing the conditioner block
+   * and disabling the FIPS flag. Note that the FIPS flag is different from
+   * running the block in FIPS mode. FIPS mode refers to running the entropy_src
+   * in continuous mode.
+   */
+  bool bypass_conditioner;
+  /**
    * Specifies which single-bit-mode to use, if any at all.
    */
   dif_entropy_src_single_bit_mode_t single_bit_mode;

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -20,6 +20,7 @@ dif_entropy_src_config_t entropy_testutils_config_default(void) {
   return (dif_entropy_src_config_t){
       .fips_enable = true,
       .route_to_firmware = false,
+      .bypass_conditioner = false,
       .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
       .health_test_window_size = 0x0200,
       .alert_threshold = 2,
@@ -95,6 +96,30 @@ void entropy_testutils_boot_mode_init(void) {
   CHECK_DIF_OK(dif_edn_set_boot_mode(&edn1));
   CHECK_DIF_OK(dif_edn_configure(&edn0));
   CHECK_DIF_OK(dif_edn_configure(&edn1));
+}
+
+void entropy_testutils_fw_override_enable(dif_entropy_src_t *entropy_src,
+                                          uint8_t buffer_threshold,
+                                          bool route_to_firmware,
+                                          bool bypass_conditioner) {
+  const dif_entropy_src_fw_override_config_t fw_override_config = {
+      .entropy_insert_enable = true,
+      .buffer_threshold = buffer_threshold,
+  };
+  CHECK_DIF_OK(dif_entropy_src_fw_override_configure(
+      entropy_src, fw_override_config, kDifToggleEnabled));
+
+  const dif_entropy_src_config_t config = {
+      .fips_enable = true,
+      .route_to_firmware = route_to_firmware,
+      .bypass_conditioner = bypass_conditioner,
+      .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+      .health_test_threshold_scope = false,
+      .health_test_window_size = 0x0200,
+      .alert_threshold = 2,
+  };
+  CHECK_DIF_OK(
+      dif_entropy_src_configure(entropy_src, config, kDifToggleEnabled));
 }
 
 void entropy_testutils_wait_for_state(const dif_entropy_src_t *entropy_src,

--- a/sw/device/lib/testing/entropy_testutils.h
+++ b/sw/device/lib/testing/entropy_testutils.h
@@ -13,7 +13,7 @@
 dif_entropy_src_config_t entropy_testutils_config_default(void);
 
 /**
- * Initialize the entropy complex in auto-request mode.
+ * Initializes the entropy complex in auto-request mode.
  *
  * Initializes the CSRNG, EDN0, and EDN1 in automatic request mode, with EDN1
  * providing highest-quality entropy and EDN0 providing lower-quality entropy.
@@ -31,7 +31,27 @@ void entropy_testutils_auto_mode_init(void);
 void entropy_testutils_boot_mode_init(void);
 
 /**
- * Wait for the entropy_src to reach a certain state.
+ * Initializes the entropy_src in firmware override mode.
+ *
+ * CSRNG and EDN instances are not initialized by calling this function compared
+ * to the other test init functions.
+ *
+ * @param entropy_src Entropy source handle.
+ * @param buffer_threshold Firmware override buffer threshold.
+ * @param firmware_override_enable Set to true to output entropy data to
+ * registers instead of the CSRNG block.
+ * @param bypass_conditioner Set to true to bypass the entropy_src conditioner.
+ */
+void entropy_testutils_fw_override_enable(dif_entropy_src_t *entropy_src,
+                                          uint8_t buffer_threshold,
+                                          bool firmware_override_enable,
+                                          bool bypass_conditioner);
+
+/**
+ * Waits for the entropy_src to reach a certain state.
+ *
+ * @param entropy_src Entropy source handle.
+ * @param state Entropy source target FSM state.
  */
 void entropy_testutils_wait_for_state(const dif_entropy_src_t *entropy_src,
                                       dif_entropy_src_main_fsm_t state);

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -564,6 +564,7 @@ opentitan_functest(
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:entropy_src",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -578,6 +579,7 @@ opentitan_functest(
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:entropy_src",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/csrng_kat_test.c
+++ b/sw/device/tests/csrng_kat_test.c
@@ -14,36 +14,6 @@
 
 OTTF_DEFINE_TEST_CONFIG();
 
-/**
- * Run CTR DRBG Known-Answer-Tests (KATs).
- *
- * Test vector sourced from NIST's CAVP website:
- * https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/random-number-generators
- *
- * The number format in this docstring follows the CAVP format to simplify
- * auditing of this test case.
- *
- * Test vector: CTR_DRBG AES-256 no DF.
- *
- * - EntropyInput =
- * df5d73faa468649edda33b5cca79b0b05600419ccb7a879ddfec9db32ee494e5531b51de16a30f769262474c73bec010
- * - Nonce = EMPTY
- * - PersonalizationString = EMPTY
- *
- * Command: Instantiate
- * - Key = 8c52f901632d522774c08fad0eb2c33b98a701a1861aecf3d8a25860941709fd
- * - V   = 217b52142105250243c0b2c206b8f59e
- *
- * Command: Generate (first call):
- * - Key = 72f4af5c93258eb3eeec8c0cacea6c1d1978a4fad44312725f1ac43b167f2d52
- * - V   = e86f6d07dfb551cebad80e6bf6830ac4
- *
- * Command: Generate (second call):
- * - Key = 1a1c6e5f1cccc6974436e5fd3f015bc8e9dc0f90053b73e3c19d4dfd66d1b85a
- * - V   = 53c78ac61a0bac9d7d2e92b1e73e3392
- * - ReturnedBits =
- * d1c07cd95af8a7f11012c84ce48bb8cb87189e99d40fccb1771c619bdf82ab2280b1dc2f2581f39164f7ac0c510494b3a43c41b7db17514c87b107ae793e01c5
- */
 void test_ctr_drbg_ctr0(const dif_csrng_t *csrng) {
   CHECK_DIF_OK(dif_csrng_uninstantiate(csrng));
   csrng_testutils_fips_instantiate_kat(csrng, /*fail_expected=*/false);

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -1039,6 +1039,31 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "csrng_lc_hw_debug_en_test",
+    srcs = ["csrng_lc_hw_debug_en_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:kmac",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:csrng_testutils",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "inject_scramble_seed",
     srcs = ["inject_scramble_seed.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
+++ b/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
@@ -1,0 +1,359 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/csrng_testutils.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  /**
+   * The size of the buffer used in firmware to process the entropy bits in
+   * firmware override mode.
+   */
+  kEntropyFifoBufferSize = 12,
+  /**
+   * Maximum number of attempts of entropy_src operations that may stall due
+   * to FIFO operations.
+   */
+  kTestParamEntropySrcMaxAttempts = 256,
+  /**
+   * The size of the exit token in bytes or words.
+   */
+  kExitTokenSizeInBytes = 16,
+  kExitTokenSizeInWords = kExitTokenSizeInBytes / sizeof(uint32_t),
+};
+
+// Store CSRNG output in flash to compare results across life cycle stages.
+OT_SECTION(".non_volatile_scratch")
+uint32_t nv_csrng_output[kEntropyFifoBufferSize];
+
+static dif_lc_ctrl_t lc_ctrl;
+static dif_otp_ctrl_t otp_ctrl;
+static dif_csrng_t csrng;
+static dif_entropy_src_t entropy_src;
+static dif_flash_ctrl_state_t flash_ctrl_state;
+static dif_kmac_t kmac;
+static dif_rstmgr_t rstmgr;
+
+// LC exit token value for LC state transition.
+static const dif_lc_ctrl_token_t kLcExitToken = {
+    .data =
+        {
+            0x00,
+            0x01,
+            0x02,
+            0x03,
+            0x04,
+            0x05,
+            0x06,
+            0x07,
+            0x08,
+            0x09,
+            0x0a,
+            0x0b,
+            0x0c,
+            0x0d,
+            0x0e,
+            0x0f,
+        },
+};
+static_assert(kExitTokenSizeInBytes == ARRAYSIZE(kLcExitToken.data),
+              "Invalid exit token size.");
+
+/**
+ * Initializes KMAC with software provided entropy to avoid sending requests to
+ * EDN0.
+ */
+static void kmac_init(void) {
+  CHECK_DIF_OK(
+      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+
+  // Configure KMAC hardware using software entropy.
+  dif_kmac_config_t config = (dif_kmac_config_t){
+      .entropy_mode = kDifKmacEntropyModeSoftware,
+      .entropy_seed = {0xaa25b4bf, 0x48ce8fff, 0x5a78282a, 0x48465647,
+                       0x70410fef},
+      .entropy_fast_process = kDifToggleEnabled,
+  };
+  CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
+}
+
+/**
+ * Initializes the peripherals used in this test.
+ */
+static void peripherals_init(void) {
+  CHECK_DIF_OK(dif_csrng_init(
+      mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
+  CHECK_DIF_OK(dif_lc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc_ctrl));
+  CHECK_DIF_OK(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash_ctrl_state,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+
+  kmac_init();
+}
+
+/**
+ * Calculates the cShake128 of the test exit token and returns its
+ * representation in two 64bit halves.
+ *
+ * @param[out] otp_token_l Lower half of the text exit token.
+ * @param[out] otp_token_h Higher half of the text exit token.
+ */
+static void exit_token_cshake_hash(uint64_t *otp_token_l,
+                                   uint64_t *otp_token_h) {
+  dif_kmac_customization_string_t s;
+  CHECK_DIF_OK(
+      dif_kmac_customization_string_init(/*data=*/"LC_CTRL", /*len=*/7, &s));
+
+  dif_kmac_operation_state_t op_state;
+  CHECK_DIF_OK(dif_kmac_mode_cshake_start(
+      &kmac, &op_state, kDifKmacModeCshakeLen128, /*n=*/NULL, &s));
+  CHECK_DIF_OK(dif_kmac_absorb(&kmac, &op_state, kLcExitToken.data,
+                               ARRAYSIZE(kLcExitToken.data),
+                               /*processed=*/NULL));
+
+  uint32_t token_hash[kExitTokenSizeInWords];
+  CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &op_state, token_hash,
+                                kExitTokenSizeInWords, /*processed=*/NULL));
+  CHECK_DIF_OK(dif_kmac_end(&kmac, &op_state));
+
+  *otp_token_l = 0;
+  *otp_token_h = 0;
+  uint8_t *p_token = (uint8_t *)token_hash;
+  for (size_t i = 0; i < kExitTokenSizeInBytes; i++) {
+    if (i < kExitTokenSizeInBytes / 2) {
+      *otp_token_l |= (uint64_t)p_token[i] << (i * 8);
+    } else {
+      *otp_token_h |= (uint64_t)p_token[i]
+                      << ((i - kExitTokenSizeInBytes / 2) * 8);
+    }
+  }
+}
+
+/**
+ * Configures the test exit token and locks down the secret0 partition.
+ */
+static void lock_otp_secret0_partition(void) {
+  uint64_t otp_token_l;
+  uint64_t opt_token_h;
+  exit_token_cshake_hash(&otp_token_l, &opt_token_h);
+
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl,
+                                          kDifOtpCtrlPartitionSecret0,
+                                          /*address=*/0x10,
+                                          /*value=*/otp_token_l));
+  otp_ctrl_testutils_wait_for_dai(&otp_ctrl);
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl,
+                                          kDifOtpCtrlPartitionSecret0,
+                                          /*address=*/0x18,
+                                          /*value=*/opt_token_h));
+  otp_ctrl_testutils_wait_for_dai(&otp_ctrl);
+
+  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp_ctrl, kDifOtpCtrlPartitionSecret0,
+                                       /*digest=*/0));
+  otp_ctrl_testutils_wait_for_dai(&otp_ctrl);
+}
+
+/**
+ * Retuns a random pick one DEV, PROD or PROD_END lc state.
+ */
+static dif_lc_ctrl_state_t lc_next_state(void) {
+  uint32_t index = rand_testutils_gen32_range(/*min=*/0, /*max=*/2);
+  dif_lc_ctrl_state_t next_state;
+  switch (index) {
+    case 0:
+      next_state = kDifLcCtrlStateDev;
+      break;
+    case 1:
+      next_state = kDifLcCtrlStateProd;
+      break;
+    case 2:
+      next_state = kDifLcCtrlStateProdEnd;
+      break;
+    default:
+      CHECK(false, "Unexpected case index: %d", index);
+      break;
+  }
+  return next_state;
+}
+
+/**
+ * Stops the entropy_src conditioner.
+ *
+ * @param entropy_src A entropy source handle.
+ */
+static void entropy_conditioner_stop(const dif_entropy_src_t *entropy_src) {
+  uint32_t fail_count = 0;
+  dif_result_t op_result;
+  do {
+    op_result = dif_entropy_src_conditioner_stop(entropy_src);
+    if (op_result == kDifIpFifoFull) {
+      CHECK(fail_count++ < kTestParamEntropySrcMaxAttempts);
+    } else {
+      CHECK_DIF_OK(op_result);
+    }
+  } while (op_result == kDifIpFifoFull);
+}
+
+/**
+ * Writes data to the entropy source firmware override buffer.
+ *
+ * @param entropy_src A entropy source handle.
+ */
+static void fw_override_conditioner_write(
+    const dif_entropy_src_t *entropy_src) {
+  CHECK_DIF_OK(dif_entropy_src_conditioner_start(entropy_src));
+
+  const uint32_t kInputMsg[kEntropyFifoBufferSize] = {
+      0xa52a0da9, 0xcae141b2, 0x6d5bab9d, 0x2c3e5cc0, 0x225afc93, 0x5d31a610,
+      0x91b7f960, 0x0d566bb3, 0xef35e170, 0x94ba7d8e, 0x534eb741, 0x6b60b0da,
+  };
+
+  uint32_t fail_count = 0;
+  uint32_t total = 0;
+  do {
+    uint32_t count;
+    dif_result_t op_result = dif_entropy_src_observe_fifo_write(
+        entropy_src, kInputMsg + total, ARRAYSIZE(kInputMsg) - total, &count);
+    total += count;
+    if (op_result == kDifIpFifoFull) {
+      CHECK(fail_count++ < kTestParamEntropySrcMaxAttempts);
+    } else {
+      fail_count = 0;
+      CHECK_DIF_OK(op_result);
+    }
+  } while (total < ARRAYSIZE(kInputMsg));
+  entropy_conditioner_stop(entropy_src);
+}
+
+/**
+ * Issues CSRNG instantiate and generate command.
+ *
+ * @param[out] output Output buffer.
+ * @param output_len Requested number of entropy words. It must be at least the
+ * size of the `output` buffer.
+ */
+static void csrng_static_generate_run(uint32_t *output, size_t output_len) {
+  entropy_testutils_stop_all();
+  // TODO: May need to flush the output buffers before enabling enabling
+  // firmware override connected to csrng.
+  entropy_testutils_fw_override_enable(&entropy_src, kEntropyFifoBufferSize,
+                                       /*firmware_override_enable=*/false,
+                                       /*bypass_conditioner=*/false);
+  CHECK_DIF_OK(dif_csrng_configure(&csrng));
+  fw_override_conditioner_write(&entropy_src);
+
+  const dif_csrng_seed_material_t kEmptySeedMaterial = {0};
+  CHECK_DIF_OK(dif_csrng_instantiate(&csrng, kDifCsrngEntropySrcToggleEnable,
+                                     &kEmptySeedMaterial));
+
+  csrng_testutils_cmd_generate_run(&csrng, output, output_len);
+  uint32_t prev_word = 0;
+  for (size_t i = 0; i < output_len; ++i) {
+    CHECK(prev_word != output[i],
+          "Unexpected duplicate value at index: %d value: 0x%x", i, prev_word);
+    prev_word = output[i];
+  }
+}
+
+bool test_main(void) {
+  peripherals_init();
+  flash_ctrl_testutils_default_region_access(&flash_ctrl_state,
+                                             /*rd_en=*/true,
+                                             /*prog_en=*/true,
+                                             /*erase_en=*/true,
+                                             /*scramble_en=*/false,
+                                             /*ecc_en=*/false,
+                                             /*he_en=*/false);
+
+  dif_rstmgr_reset_info_bitfield_t rst_info = rstmgr_testutils_reason_get();
+  rstmgr_testutils_reason_clear();
+
+  dif_lc_ctrl_state_t lc_state;
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc_ctrl, &lc_state));
+  LOG_INFO("lc state: %d", lc_state);
+
+  if (rst_info == kDifRstmgrResetInfoPor &&
+      lc_state == kDifLcCtrlStateTestUnlocked0) {
+    enum {
+      kPartitionId = 0,
+    };
+    uint32_t address =
+        (uint32_t)(nv_csrng_output)-TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR;
+    uint32_t expected[kEntropyFifoBufferSize];
+    csrng_static_generate_run(expected, ARRAYSIZE(expected));
+    CHECK(flash_ctrl_testutils_write(&flash_ctrl_state, address,
+                                     /*partition_id=*/0, expected,
+                                     kDifFlashCtrlPartitionTypeData,
+                                     ARRAYSIZE(expected)));
+    CHECK_ARRAYS_EQ(nv_csrng_output, expected, ARRAYSIZE(expected));
+
+    lock_otp_secret0_partition();
+    CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+
+    // The CPU may be able to continue execution before the reset takes effect.
+    wait_for_interrupt();
+    CHECK(false, "Unexpected wakeup.");
+  } else if (rst_info == kDifRstmgrResetInfoSw &&
+             lc_state == kDifLcCtrlStateTestUnlocked0) {
+    uint32_t got[kEntropyFifoBufferSize];
+    csrng_static_generate_run(got, ARRAYSIZE(got));
+    static_assert(ARRAYSIZE(got) == ARRAYSIZE(nv_csrng_output),
+                  "Array size mismatch.");
+    CHECK_ARRAYS_EQ(got, nv_csrng_output, ARRAYSIZE(got));
+
+    CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc_ctrl));
+    CHECK_DIF_OK(dif_lc_ctrl_configure(&lc_ctrl, lc_next_state(),
+                                       /*use_ext_clock=*/false, &kLcExitToken),
+                 "LC transition configuration failed!");
+
+    CHECK_DIF_OK(dif_lc_ctrl_transition(&lc_ctrl), "LC transition failed!");
+
+    // SV testbench waits for this message.
+    LOG_INFO("LC transition in progress.");
+    wait_for_interrupt();
+    CHECK(false, "Unexpected wakeup.");
+  } else {
+    CHECK(lc_state == kDifLcCtrlStateDev || lc_state == kDifLcCtrlStateProd ||
+              lc_state == kDifLcCtrlStateProdEnd,
+          "Unexpected LC state: %d", lc_state);
+    uint32_t got[kEntropyFifoBufferSize];
+    csrng_static_generate_run(got, ARRAYSIZE(got));
+    static_assert(ARRAYSIZE(got) == ARRAYSIZE(nv_csrng_output),
+                  "Array size mismatch.");
+    for (size_t i = 0; i < ARRAYSIZE(got); ++i) {
+      CHECK(got[i] != nv_csrng_output[i], "Unexpected word match.");
+    }
+    return true;
+  }
+  CHECK(false, "Invalid reset: %d, or LC state: %d", rst_info, lc_state);
+  return false;
+}


### PR DESCRIPTION
This commits adds a default OTP image for unlocked_test0 LC state, and
implements the csrng_lc_hw_debug_en_test as a sim_dv target.

There are additional changes made to the entropy_src firmware override
interface to enable conditioner bypass mode. An additional test case
will be added later to cover that functionality.

Fixes [#13222](https://github.com/lowRISC/opentitan/issues/13222)
