### PR TITLE
[top/dv] Add exit_test_unlock test.

### DIFF
--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_csr_seq.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_csr_seq.sv
@@ -7,8 +7,8 @@ class jtag_riscv_csr_seq extends jtag_riscv_base_seq;
 
   rand bit [  DMI_OPW-1:0] op;
   rand bit [DMI_DATAW-1:0] data;
-  // Need to convert from csr(byte) address to word address if not in rv_dm mode.
-  rand bit [DMI_ADDRW+1:0] addr;
+  // This is not DTM address, but address for the CSR registers
+  rand bit [DMI_DATAW+1:0] addr;
   rand bit                 do_write;
 
   constraint op_c {

--- a/hw/dv/sv/sw_test_status/sw_test_status_pkg.sv
+++ b/hw/dv/sv/sw_test_status/sw_test_status_pkg.sv
@@ -6,13 +6,14 @@ package sw_test_status_pkg;
 
   // Enum to indicate the SW test status.
   typedef enum bit [15:0] {
-    SwTestStatusUnderReset  = 16'h0000, // 'boot', CPU is under reset.
-    SwTestStatusBooted      = 16'hb004, // 'boot', CPU has booted.
-    SwTestStatusInBootRom   = 16'hb090, // 'bogo', BOotrom GO, SW has entered the boot rom code.
-    SwTestStatusInTest      = 16'h4354, // 'test', SW has entered the test code.
-    SwTestStatusInWfi       = 16'h1d1e, // 'idle', CPU has entered WFI state.
-    SwTestStatusPassed      = 16'h900d, // 'good', SW test has passed.
-    SwTestStatusFailed      = 16'hbaad  // 'baad', SW test has failed.
+    SwTestStatusUnderReset    = 16'h0000, // 'boot', CPU is under reset.
+    SwTestStatusBooted        = 16'hb004, // 'boot', CPU has booted.
+    SwTestStatusInBootRom     = 16'hb090, // 'bogo', BOotrom GO, SW has entered the boot rom code.
+    SwTestStatusInBootRomHalt = 16'hb057, // 'bost', BOotrom STop, ROM_EXEC_EN=0.
+    SwTestStatusInTest        = 16'h4354, // 'test', SW has entered the test code.
+    SwTestStatusInWfi         = 16'h1d1e, // 'idle', CPU has entered WFI state.
+    SwTestStatusPassed        = 16'h900d, // 'good', SW test has passed.
+    SwTestStatusFailed        = 16'hbaad  // 'baad', SW test has failed.
   } sw_test_status_e;
 
 endpackage

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -3229,9 +3229,9 @@
     }
 
     {
-      name: chip_sw_exit_test_locked
+      name: chip_sw_exit_test_unlocked_bootstrap
       desc: '''End to end test to ensure rom boot strap can be performed after
-      exiting TEST_LOCKED.
+      transitioning from TEST states to PROD staets. .
 
       - Pre-load the device into TEST_UNLOCKED state and ROM_EXEC_EN = 0.
       - In the same power cycle, advance device to PROD, PROD_END or DEV through LC JTAG request and
@@ -3242,7 +3242,7 @@
       X-ref'ed with manuf_ft_exit_token from manufacturing test plan.
       '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_exit_test_unlocked_bootstrap"]
     }
 
     {
@@ -3266,7 +3266,7 @@
       X-ref'ed with manuf_ft_sku_individualization from manufacturing test plan.
       '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_inject_scramble_seed"]
     }
   ]
 }

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -405,6 +405,14 @@
       run_timeout_mins: 180
     }
     {
+      name: chip_sw_exit_test_unlocked_bootstrap
+      uvm_test_seq: chip_sw_exit_test_unlocked_bootstrap_vseq
+      sw_images: ["//sw/device/tests/sim_dv:exit_test_unlocked_bootstrap:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+flash_program_latency=5", "+sw_test_timeout_ns=150_000_000"]
+      run_timeout_mins: 180
+    }
+    {
       name: chip_sw_uart_rand_baudrate
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["//sw/device/tests/sim_dv:uart_tx_rx_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -77,6 +77,7 @@ filesets:
       - seq_lib/chip_sw_flash_init_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_flash_rma_unlocked_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_inject_scramble_seed_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_exit_test_unlocked_bootstrap_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_kmac_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_exit_test_unlocked_bootstrap_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_exit_test_unlocked_bootstrap_vseq.sv
@@ -1,0 +1,145 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_exit_test_unlocked_bootstrap_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_exit_test_unlocked_bootstrap_vseq)
+
+  `uvm_object_new
+
+  rand int unlocked_idx;
+  constraint idx_c {
+    unlocked_idx inside {[0:7]};
+  }
+
+  rand bit [7:0] lc_exit_token[TokenWidthByte];
+
+  typedef struct packed {
+    lc_ctrl_state_pkg::lc_state_e lc_state;
+    lc_ctrl_state_pkg::dec_lc_state_e dec_lc_state;
+  } lc_state_t;
+
+  lc_state_t unlocked_states[8] = '{
+    '{
+      lc_state: LcStTestUnlocked0,
+      dec_lc_state: DecLcStTestUnlocked0
+     },
+    '{
+      lc_state: LcStTestUnlocked1,
+      dec_lc_state: DecLcStTestUnlocked1
+     },
+    '{
+      lc_state: LcStTestUnlocked2,
+      dec_lc_state: DecLcStTestUnlocked2
+     },
+    '{
+      lc_state: LcStTestUnlocked3,
+      dec_lc_state: DecLcStTestUnlocked3
+     },
+    '{
+      lc_state: LcStTestUnlocked4,
+      dec_lc_state: DecLcStTestUnlocked4
+     },
+    '{
+      lc_state: LcStTestUnlocked5,
+      dec_lc_state: DecLcStTestUnlocked5
+     },
+    '{
+      lc_state: LcStTestUnlocked6,
+      dec_lc_state: DecLcStTestUnlocked6
+     },
+    '{
+      lc_state: LcStTestUnlocked7,
+      dec_lc_state: DecLcStTestUnlocked7
+     }
+  };
+
+  virtual task dut_init(string reset_kind = "HARD");
+    bit [TokenWidthBit-1:0] otp_exit_token_bits;
+    lc_state_t temp;
+    super.dut_init(reset_kind);
+
+    // make sure we are in one of the unlocked states
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(unlocked_states[unlocked_idx].lc_state);
+
+    // backdoorload the otp tokens and associated digest
+    otp_exit_token_bits = dec_otp_token_from_lc_csrs(lc_exit_token);
+    cfg.mem_bkdr_util_h[Otp].otp_write_secret0_partition(
+      '0, otp_exit_token_bits);
+
+    //ensure rom_exec_en is 0, so that flash is never reached
+    cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgRomExecEnOffset, 0);
+
+  endtask
+
+  // reset jtag interface
+  virtual task reset_jtag_tap();
+    cfg.m_jtag_riscv_agent_cfg.in_reset = 1;
+    #1000ns;
+    cfg.m_jtag_riscv_agent_cfg.in_reset = 0;
+  endtask
+
+  virtual task body();
+    bit err = 0;
+    jtag_riscv_dm_activation_seq jtag_dm_activation_seq =
+        jtag_riscv_dm_activation_seq::type_id::create("jtag_dm_activation_seq");
+
+    super.body();
+
+    // The test sequence needs to ensure rom has halted first.
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRomHalt)
+
+    // Now program ROM_EXEC_EN for next power cycle.
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
+
+    jtag_dm_activation_seq.start(p_sequencer.jtag_sequencer_h);
+    `uvm_info(`gfn, $sformatf("rv_dm_activated: %0d", cfg.m_jtag_riscv_agent_cfg.rv_dm_activated),
+              UVM_LOW)
+    cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
+    jtag_otp_program32(otp_ctrl_reg_pkg::CreatorSwCfgRomExecEnOffset, 1, err);
+    if (err) begin
+      `uvm_error(`gfn, "Otp program failed")
+    end
+
+    // Reset tap interface for switch.
+    reset_jtag_tap();
+
+    // Prepare LC JTAG interface
+    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
+    cfg.clk_rst_vif.wait_clks(10);
+    cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 0;
+
+    for (int i = 0; i < TokenWidthByte; i++) begin
+      `uvm_info(`gfn, $sformatf("LC exit token 0x%x", lc_exit_token[i]), UVM_MEDIUM)
+    end
+
+    // TODO: Should consider applying a random large delay here to simulate different
+    // host side timing.
+    // Transition device into production state.
+    jtag_lc_state_transition(unlocked_states[unlocked_idx].dec_lc_state,
+                             DecLcStProd, {<<8{lc_exit_token}});
+
+    // LC state transition requires a chip reset.
+    `uvm_info(`gfn, "Applying reset after lc transition", UVM_LOW)
+    apply_reset();
+
+    // setup triggers to bootstrap during the second run
+    cfg.chip_vif.sw_straps_if.drive({3{1'b1}});
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
+
+    // bootstrap the same image
+    spi_device_load_bootstrap({cfg.sw_images[SwTypeTest], ".64.vmem"});
+
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log ==
+                      "ROM and flash execution successful");,
+                 "timeout waiting for C side acknowledgement",
+                 cfg.sw_test_timeout_ns)
+
+    `uvm_info(`gfn, "Received C side acknowledgement", UVM_LOW)
+
+
+  endtask
+
+
+
+endclass : chip_sw_exit_test_unlocked_bootstrap_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -61,3 +61,4 @@
 `include "chip_sw_usb_ast_clk_calib_vseq.sv"
 `include "chip_sw_i2c_host_tx_rx_vseq.sv"
 `include "chip_sw_inject_scramble_seed_vseq.sv"
+`include "chip_sw_exit_test_unlocked_bootstrap_vseq.sv"

--- a/sw/device/lib/testing/test_framework/status.h
+++ b/sw/device/lib/testing/test_framework/status.h
@@ -26,6 +26,15 @@ typedef enum test_status {
   kTestStatusInBootRom = 0xb090,  // 'bogo', BOotrom GO
 
   /**
+   * Indicates that the CPU has seen ROM_EXEC_EN = 0 and will now stop
+   * execution.
+   *
+   * Writing this value to #kDeviceTestStatusAddress must not stop simulation of
+   * the current device.
+   */
+  kTestStatusInBootRomHalt = 0xb057,  // 'bost', BOotrom STop
+
+  /**
    * Indicates that the CPU has started executing the test code.
    *
    * Writing this value to #kDeviceTestStatusAddress must not stop simulation of

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -70,6 +70,20 @@ static inline uintptr_t rom_ext_vma_get(const manifest_t *manifest,
 // rom tests. By default, it simply jumps into the OTTF's flash.
 OT_WEAK
 bool rom_test_main(void) {
+#if !OT_IS_ENGLISH_BREAKFAST
+  // Check the otp to see if execute should start
+  uint32_t otp_val = abs_mmio_read32(
+      TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
+      OTP_CTRL_PARAM_CREATOR_SW_CFG_ROM_EXEC_EN_OFFSET);
+
+  if (otp_val == 0) {
+    test_status_set(kTestStatusInBootRomHalt);
+    while (1) {
+      wait_for_interrupt();
+    }
+  }
+#endif
+
   // Initial sec_mmio, required by bootstrap and its dependencies.
   sec_mmio_init();
 
@@ -145,7 +159,6 @@ bool rom_test_main(void) {
 
 #if !OT_IS_ENGLISH_BREAKFAST
   // Check the otp to see if flash scramble should be enabled.
-  uint32_t otp_val;
   otp_val = abs_mmio_read32(
       TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
       OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET);

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -1061,3 +1061,19 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "exit_test_unlocked_bootstrap",
+    srcs = ["exit_test_unlocked_bootstrap.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/sim_dv/exit_test_unlocked_bootstrap.c
+++ b/sw/device/tests/sim_dv/exit_test_unlocked_bootstrap.c
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  dif_lc_ctrl_t lc_ctrl;
+  CHECK_DIF_OK(dif_lc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc_ctrl));
+
+  dif_lc_ctrl_state_t state;
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc_ctrl, &state));
+
+  uint32_t rom_en = abs_mmio_read32(
+      TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
+      OTP_CTRL_PARAM_CREATOR_SW_CFG_ROM_EXEC_EN_OFFSET);
+
+  if (state == kDifLcCtrlStateTestUnlocked0 || (rom_en == 0)) {
+    // The test should never reach here
+    CHECK(false);
+  } else if (state == kDifLcCtrlStateProd && rom_en > 0) {
+    // The test environment is waiting for this message
+    LOG_INFO("ROM and flash execution successful");
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
The primary difference between this test and the existing unlock test is that this sequence tries to simulate the likely system usage.

Specifically, the ROM_EXEC_EN and the advance to PROD are done in the same power cycle.  Upon reboot, an image is then bootstrap into the device to ensure the behavior is correct.

The bootstrap portion for this test is still missing.

Signed-off-by: Timothy Chen <timothytim@google.com>