### PR TITLE
[spi_device/dv] Fix regression failures

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -317,8 +317,6 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     cfg.spi_device_agent_cfg.host_bit_dir = 0;
     cfg.spi_device_agent_cfg.device_bit_dir = 0;
 
-    cfg.spi_host_agent_cfg.num_bytes_per_trans_in_mon = 1;
-    cfg.spi_device_agent_cfg.num_bytes_per_trans_in_mon = 1;
     ral.cfg.tx_order.set(cfg.spi_host_agent_cfg.host_bit_dir);
     ral.cfg.rx_order.set(cfg.spi_host_agent_cfg.device_bit_dir);
 

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -1042,7 +1042,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
 
   // when receive a spi rx data, save it in rx_fifo and then write to rx_mem
   // when rx_fifo is full (size=2) and no space in sram, drop it
-  virtual function void receive_spi_rx_data(bit [TL_DW:0] data);
+  virtual function void receive_spi_rx_data(bit [TL_DW-1:0] data);
     if (get_rx_sram_space_bytes() >= SRAM_WORD_SIZE || rx_word_q.size < 2) begin
       rx_word_q.push_back(data);
       update_rx_mem_fifo_and_wptr();


### PR DESCRIPTION
1. Fixed spi_monitor to allow it to collect byte data across multiple CSB, which fixed byte/bit transfer related test
2. Fixed a data width in scb
3. Remove unnecessary configure in pass_base_vseq

Signed-off-by: Weicai Yang <weicai@google.com>