### PR TITLE
[sw/silicon_creator] Remove volatile qualifier from epmp_state

### DIFF
--- a/sw/device/silicon_creator/lib/base/static_critical_epmp_state.c
+++ b/sw/device/silicon_creator/lib/base/static_critical_epmp_state.c
@@ -10,4 +10,4 @@
 // This is placed at a fixed location in memory within the .static_critical
 // section. It will be populated by the ROM before the jump to ROM_EXT.
 OT_SECTION(".static_critical.epmp_state")
-volatile epmp_state_t epmp_state;
+epmp_state_t epmp_state;

--- a/sw/device/silicon_creator/lib/epmp_state.c
+++ b/sw/device/silicon_creator/lib/epmp_state.c
@@ -9,7 +9,7 @@
 
 // The context is declared as weak so that the ROM and ROM_EXT may
 // override its location.
-OT_WEAK volatile epmp_state_t epmp_state;
+OT_WEAK epmp_state_t epmp_state;
 
 /**
  * Extern declarations of inline functions.
@@ -23,7 +23,7 @@ extern void epmp_state_configure_napot(uint32_t entry, epmp_region_t region,
 
 rom_error_t epmp_state_check(void) {
   uint32_t checks = 0;
-  volatile const epmp_state_t *s = &epmp_state;
+  const epmp_state_t *s = &epmp_state;
 #define CHECK_CSR(reg, value) \
   do {                        \
     uint32_t csr;             \

--- a/sw/device/silicon_creator/lib/epmp_state.h
+++ b/sw/device/silicon_creator/lib/epmp_state.h
@@ -142,7 +142,7 @@ typedef struct epmp_state {
   uint32_t mseccfg;
 } epmp_state_t;
 
-extern volatile epmp_state_t epmp_state;
+extern epmp_state_t epmp_state;
 
 /**
  * Configure the given PMP entry in state using the Top-Of-Range addressing

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -145,6 +145,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:csr",
+        "//sw/device/lib/base:memory",
         "//sw/device/silicon_creator/lib:epmp_state",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
     ],

--- a/sw/device/silicon_creator/rom/rom_epmp.c
+++ b/sw/device/silicon_creator/rom/rom_epmp.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/memory.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -85,7 +86,7 @@ void rom_epmp_state_init(lifecycle_state_t lc_state) {
   // The actual hardware configuration is performed separately, either by reset
   // logic or in assembly. This code must be kept in sync with any changes
   // to the hardware configuration.
-  epmp_state = (epmp_state_t){0};
+  memset(&epmp_state, 0, sizeof(epmp_state));
   epmp_state_configure_tor(1, rom_text, kEpmpPermLockedReadExecute);
   epmp_state_configure_napot(2, rom, kEpmpPermLockedReadOnly);
   epmp_state_configure_napot(5, eflash, kEpmpPermLockedReadOnly);

--- a/sw/device/silicon_creator/rom/rom_epmp_test.c
+++ b/sw/device/silicon_creator/rom/rom_epmp_test.c
@@ -375,7 +375,7 @@ void rom_main(void) {
   LOG_INFO("Starting ROM ePMP functional test.");
 
   // Initialize shadow copy of the ePMP register configuration.
-  epmp_state = (epmp_state_t){0};
+  memset(&epmp_state, 0, sizeof(epmp_state));
   rom_epmp_state_init(kLcStateProd);
   CHECK(epmp_state_check() == kErrorOk);
 


### PR DESCRIPTION
This PR removes the `volatile` qualifier from `epmp_state`. This also allows us to replace the temporary that we use to initiaize `epmp_state` (extra memory + `memset` + `memcpy`) with a single `memset` call. As a result, 
* The `.text` section shrinks by 76 bytes.
  * `rom_epmp_state_init` shrinks by 60 bytes, 
  * `rom_epmp_unlock_rom_ext_rx` shrinks by 8 bytes, and
  * `rom_epmp_unlock_rom_ext_r` shrinks by 6 bytes.
  * _Remaining 2 bytes are padding since `.text` end is word aligned._

[Partial disassemblies](https://gist.github.com/1e796a96b991cbe9c7d1e30003e492a9) of the functions above before and after this PR.
[Full disassembly](https://gist.github.com/469b0e9cd035fd13d64fd8333979b750) of ROM before and after this PR.

_Note: Both gists have two files: see `volatile_epmp_state.dis` for before, and `non_volatile_epmp_state.dis` for after._

Signed-off-by: Alphan Ulusoy <alphan@google.com>