### PR TITLE
[sw/silicon_creator] Remove volatile qualifier from boot_measurements

### DIFF
--- a/sw/device/silicon_creator/lib/base/boot_measurements.c
+++ b/sw/device/silicon_creator/lib/base/boot_measurements.c
@@ -8,4 +8,4 @@
 
 // This symbol is declared as weak so that the ROM and ROM_EXT may
 // override its location.
-OT_WEAK volatile boot_measurements_t boot_measurements;
+OT_WEAK boot_measurements_t boot_measurements;

--- a/sw/device/silicon_creator/lib/base/boot_measurements.h
+++ b/sw/device/silicon_creator/lib/base/boot_measurements.h
@@ -33,7 +33,7 @@ typedef struct boot_measurements {
 OT_ASSERT_MEMBER_OFFSET(boot_measurements_t, rom_ext, 0);
 OT_ASSERT_SIZE(boot_measurements_t, 32);
 
-extern volatile boot_measurements_t boot_measurements;
+extern boot_measurements_t boot_measurements;
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/base/static_critical_boot_measurements.c
+++ b/sw/device/silicon_creator/lib/base/static_critical_boot_measurements.c
@@ -10,4 +10,4 @@
 // This is placed at a fixed location in memory within the .static_critical
 // section. It will be populated by the ROM before the jump to ROM_EXT.
 OT_SECTION(".static_critical.boot_measurements")
-volatile boot_measurements_t boot_measurements;
+boot_measurements_t boot_measurements;

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -102,6 +102,7 @@ opentitan_rom_binary(
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/base:stdasm",
         "//sw/device/lib/crt",


### PR DESCRIPTION
This PR removes the `volatile` qualifier from `boot_measurements`. As a result, the `.text` section shrinks by 24 bytes because `rom_verify()` shrinks by 24 bytes.

[Partial disassemblies](https://gist.github.com/c1dbfec20c1cc5ee6caecd070d66d671) of `rom_verify()` before and after this PR.
[Full disassembly](https://gist.github.com/7d4e6842466b26567fed4ff6a31e05dc) of ROM before and after this PR.

_Note: Both gists have two files: see `volatile_boot_measurements.dis` for before, and `non_volatile_boot_measurements.dis` for after._

Signed-off-by: Alphan Ulusoy <alphan@google.com>