### PR TITLE
[dv/kmac] Fix kmac regression error

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -399,12 +399,14 @@ class kmac_base_vseq extends cip_base_vseq #(
                               kmac_pkg::ErrWaitTimerExpired}) begin
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 50));
       ral.cfg_shadowed.err_processed.set(1);
+      // After entropy related errors, cannot set `err_processed` and `entropy_ready` together.
+      // Otherwise design will ignore the `entropy_ready` field.
+      csr_update(.csr(ral.cfg_shadowed));
       if (kmac_err_type == kmac_pkg::ErrIncorrectEntropyMode) begin
         `DV_CHECK_MEMBER_RANDOMIZE_FATAL(entropy_mode)
         ral.cfg_shadowed.entropy_mode.set(entropy_mode);
         // Need to pulse `entropy_ready` once we signal that SW has finished processing
         // the entropy-related errors, otherwise FSM will be infinitely looping in Reset state
-        // csr_wr(.ptr(ral.cfg_shadowed.entropy_ready), .value(1'b1));
         ral.cfg_shadowed.entropy_ready.set(1);
       end
       csr_update(.csr(ral.cfg_shadowed));


### PR DESCRIPTION
Cannot set kmac cfg_shadowed's `err_processed` and `entropy_ready` fields together after an entropy error, otherwise design will ignore the entropy_ready field.
Designer will clarify that on the spec.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>