### PR TITLE
[ujson] Fixes and enhancements

### DIFF
--- a/rules/ujson.bzl
+++ b/rules/ujson.bzl
@@ -12,8 +12,10 @@ def _ujson_rust(ctx):
     ujson_lib = ctx.attr.ujson_lib[CcInfo].compilation_context.headers.to_list()
 
     srcs = []
+    includes = []
     for src in ctx.attr.srcs:
         srcs.extend(src[CcInfo].compilation_context.direct_public_headers)
+        includes.extend(src[CcInfo].compilation_context.headers.to_list())
 
     # TODO(cfrantz): Is there a better way to find the `rustfmt` binary?
     rustfmt_files = ctx.attr._rustfmt.data_runfiles.files.to_list()
@@ -39,7 +41,7 @@ def _ujson_rust(ctx):
 
     ctx.actions.run_shell(
         outputs = [module],
-        inputs = ujson_lib + srcs,
+        inputs = ujson_lib + srcs + includes,
         tools = cc_toolchain.all_files.to_list() + rustfmt_files,
         arguments = [src.path for src in srcs],
         command = command,

--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -292,14 +292,17 @@ static size_t write_status(buffer_sink_t out, status_t value, bool as_json) {
   len += out.sink(out.data, start, end - start);
   len += out.sink(out.data, "\"", as_json ? 1 : 0);
 
-  // print the module id and arg.
-  len += out.sink(out.data, ":[", 2);
+  len += out.sink(out.data, ":", 1);
   if (err) {
     // All error codes include the module identifier.
+    len += out.sink(out.data, "[", 1);
     len += out.sink(out.data, mod, sizeof(mod));
+    len += write_digits(out, arg, 0, 0, 10, kDigitsLow);
+    len += out.sink(out.data, "]", 1);
+  } else {
+    // Ok codes include only the arg
+    len += write_digits(out, arg, 0, 0, 10, kDigitsLow);
   }
-  len += write_digits(out, arg, 0, 0, 10, kDigitsLow);
-  len += out.sink(out.data, "]", 1);
   len += out.sink(out.data, "}", as_json ? 1 : 0);
   return len;
 }

--- a/sw/device/lib/runtime/print_unittest.cc
+++ b/sw/device/lib/runtime/print_unittest.cc
@@ -278,14 +278,14 @@ TEST_F(PrintfTest, BinaryWithWidth) {
 
 TEST_F(PrintfTest, StatusOk) {
   status_t value = OK_STATUS();
-  EXPECT_EQ(base_printf("Hello, %r\n", value), 14);
-  EXPECT_EQ(buf_, "Hello, Ok:[0]\n");
+  EXPECT_EQ(base_printf("Hello, %r\n", value), 12);
+  EXPECT_EQ(buf_, "Hello, Ok:0\n");
 }
 
 TEST_F(PrintfTest, StatusOkWithArg) {
   status_t value = OK_STATUS(12345);
-  EXPECT_EQ(base_printf("Hello, %r\n", value), 18);
-  EXPECT_EQ(buf_, "Hello, Ok:[12345]\n");
+  EXPECT_EQ(base_printf("Hello, %r\n", value), 16);
+  EXPECT_EQ(buf_, "Hello, Ok:12345\n");
 }
 
 TEST_F(PrintfTest, StatusError) {

--- a/sw/device/lib/ujson/example.c
+++ b/sw/device/lib/ujson/example.c
@@ -4,8 +4,8 @@
 
 /////////////////////////////////////////////////////////////////////////////
 // The corresponding C file to a `ujson` header file should simply define
-// the preprocessor token `UJSON_SERDE_IMPL` and then include the header
+// the preprocessor token `UJSON_SERDE_IMPL` to 1 and then include the header
 // file.  This will cause the preprocessor to emit the `serialize` and
 // `deserialize` implementations for the data structures.
-#define UJSON_SERDE_IMPL
+#define UJSON_SERDE_IMPL 1
 #include "sw/device/lib/ujson/example.h"

--- a/sw/device/lib/ujson/example.h
+++ b/sw/device/lib/ujson/example.h
@@ -80,6 +80,20 @@ UJSON_SERDE_STRUCT(Matrix, matrix, STRUCT_MATRIX);
     value(_, West)
 UJSON_SERDE_ENUM(Direction, direction, ENUM_DIRECTION);
 
+/////////////////////////////////////////////////////////////////////////////
+// Automatic generation of C enums corresponding to rust `with_unknown!` enums
+//
+// The following creates an `enum FuzzyBool`:
+// typedef enum FuzzyBool {
+//     kFuzzyBoolFalse = 0,
+//     FuzzyBoolTrue = 100,
+// } fuzzy_bool;
+// status_t ujson_serialize_fuzzy_bool(ujson_t *context, const fuzzy_bool *self);
+// status_t ujson_deserialize_fuzzy_bool(ujson_t *context, fuzzy_bool *self);
+#define ENUM_FUZZY_BOOL(_, value) \
+    value(_, False, 0) \
+    value(_, True, 100)
+C_ONLY(UJSON_SERDE_ENUM(FuzzyBool, fuzzy_bool, ENUM_FUZZY_BOOL, WITH_UNKNOWN));
 
 /////////////////////////////////////////////////////////////////////////////
 // Other miscellaneous supported types: bool and status_t

--- a/sw/device/lib/ujson/example_roundtrip.c
+++ b/sw/device/lib/ujson/example_roundtrip.c
@@ -37,6 +37,13 @@ status_t roundtrip(const char *name) {
     direction x = {0};
     TRY(ujson_deserialize_direction(&uj, &x));
     TRY(ujson_serialize_direction(&uj, &x));
+  } else if (!strcmp(name, "fuzzy_bool")) {
+    fuzzy_bool x = {0};
+    fprintf(stderr, "-- fuzzy_bool\n");
+    TRY(ujson_deserialize_fuzzy_bool(&uj, &x));
+    fprintf(stderr, "-- %d\n", (int)x);
+    TRY(ujson_serialize_fuzzy_bool(&uj, &x));
+    fprintf(stderr, "-- done\n");
   } else if (!strcmp(name, "misc")) {
     misc_t x = {0};
     TRY(ujson_deserialize_misc_t(&uj, &x));

--- a/sw/device/lib/ujson/example_test.cc
+++ b/sw/device/lib/ujson/example_test.cc
@@ -150,4 +150,38 @@ TEST(Derive, DirectionDeserialize) {
   EXPECT_EQ(d, static_cast<direction>(35));
 }
 
+TEST(Derive, FuzzyBoolSerialize) {
+  fuzzy_bool d = kFuzzyBoolTrue;
+  SourceSink ss;
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_serialize_fuzzy_bool(&uj, &d)));
+  EXPECT_EQ(ss.Sink(), R"json("True")json");
+
+  ss.Reset();
+  d = kFuzzyBoolFalse;
+  EXPECT_TRUE(status_ok(ujson_serialize_fuzzy_bool(&uj, &d)));
+  EXPECT_EQ(ss.Sink(), R"json("False")json");
+
+  ss.Reset();
+  d = static_cast<fuzzy_bool>(75);
+  EXPECT_TRUE(status_ok(ujson_serialize_fuzzy_bool(&uj, &d)));
+  EXPECT_EQ(ss.Sink(), R"json(75)json");
+}
+
+TEST(Derive, FuzzyBoolDeserialize) {
+  fuzzy_bool d;
+  SourceSink ss(R"json("False")json");
+  ujson_t uj = ss.UJson();
+  EXPECT_TRUE(status_ok(ujson_deserialize_fuzzy_bool(&uj, &d)));
+  EXPECT_EQ(d, kFuzzyBoolFalse);
+
+  ss.Reset(R"json("True")json");
+  EXPECT_TRUE(status_ok(ujson_deserialize_fuzzy_bool(&uj, &d)));
+  EXPECT_EQ(d, kFuzzyBoolTrue);
+
+  ss.Reset(R"json(35)json");
+  EXPECT_TRUE(status_ok(ujson_deserialize_fuzzy_bool(&uj, &d)));
+  EXPECT_EQ(d, static_cast<fuzzy_bool>(35));
+}
+
 }  // namespace

--- a/sw/device/lib/ujson/private_status.c
+++ b/sw/device/lib/ujson/private_status.c
@@ -2,5 +2,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#define UJSON_SERDE_IMPL
+#define UJSON_SERDE_IMPL 1
 #include "sw/device/lib/ujson/private_status.h"

--- a/sw/device/lib/ujson/ujson_rust.h
+++ b/sw/device/lib/ujson/ujson_rust.h
@@ -107,4 +107,6 @@ use opentitanlib::test_utils::status::status_t;
 #define UJSON_SERDE_ENUM(formal_name_, name_, decl_, ...) \
   UJSON_DECLARE_ENUM(formal_name_, name_, decl_, ##__VA_ARGS__)
 
+#define C_ONLY(x) const _ : () = {/* eat a semicolon */}
+#define RUST_ONLY(x) x
 #endif  // OPENTITAN_SW_DEVICE_LIB_UJSON_UJSON_RUST_H_

--- a/sw/device/lib/ujson/ujson_test.cc
+++ b/sw/device/lib/ujson/ujson_test.cc
@@ -145,6 +145,22 @@ TEST(UJson, ParseInteger) {
 #undef INT
 #undef SIMPLE_INT
 
+TEST(UJson, ParseIntegerError) {
+  SourceSink ss;
+  ujson uj = ss.UJson();
+  uint32_t t;
+  status_t s;
+
+  // Empty string.
+  s = ujson_parse_integer(&uj, (void *)&t, sizeof(t));
+  EXPECT_EQ(status_err(s), kResourceExhausted);
+
+  // Non integer character.
+  ss.Reset("q");
+  s = ujson_parse_integer(&uj, (void *)&t, sizeof(t));
+  EXPECT_EQ(status_err(s), kNotFound);
+}
+
 TEST(UJson, SerializeString) {
   SourceSink ss;
   ujson uj = ss.UJson();
@@ -205,11 +221,11 @@ TEST(UJson, SerializeStatus) {
 
   val = OK_STATUS(1234);
   EXPECT_TRUE(status_ok(ujson_serialize_status_t(&uj, &val)));
-  EXPECT_EQ(ss.Sink(), R"json({"Ok":[1234]})json");
+  EXPECT_EQ(ss.Sink(), R"json({"Ok":1234})json");
 }
 
 TEST(UJson, DeerializeStatus) {
-  SourceSink ss(R"json({"Ok":[1234]})json");
+  SourceSink ss(R"json({"Ok":1234})json");
   ujson uj = ss.UJson();
   status_t val;
   const char *code;

--- a/sw/device/silicon_creator/rom/e2e/json/chip_specific_startup.c
+++ b/sw/device/silicon_creator/rom/e2e/json/chip_specific_startup.c
@@ -2,5 +2,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#define UJSON_SERDE_IMPL
+#define UJSON_SERDE_IMPL 1
 #include "sw/device/silicon_creator/rom/e2e/json/chip_specific_startup.h"

--- a/sw/device/silicon_creator/rom/e2e/json/command.c
+++ b/sw/device/silicon_creator/rom/e2e/json/command.c
@@ -2,5 +2,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#define UJSON_SERDE_IMPL
+#define UJSON_SERDE_IMPL 1
 #include "sw/device/silicon_creator/rom/e2e/json/command.h"


### PR DESCRIPTION
1. In opentitanlib, we use `bindgen` to bring in a lot of chip-specific constants and encode them as `with_unknown!`-style enums.  We also want to define ujson enums for these constants so that C code can exchange these values with test harnesses.
2. Refactor ujson to allow ujson headers to include other ujson headers.
3. Fix ujson's handling of `status_t` to be compatible with `opentitanlib::test_harness::status::Status` (this was always the intention, but there was an error in the C code's encode/decode routines).