### PR TITLE
[dv/kmac] Fix KMAC errors

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -217,6 +217,23 @@
       stage: V2
       tests: ["{variant}_entropy_mode_error"]
    }
+    {
+      name: entropy_ready_error
+      desc: ''' Test kmac responses correctly when entropy_ready field is not set.
+            Based on kmac app sequence, this sequence does not write `1` to
+            `ral.cfg_shadowed.entropy_ready` field before a kmac operation.
+            **Check**:
+            - If masking is enabled and the kmac operation is EDN mode:
+              - If it is a SW operation, check error related registers including `err_code`,
+                `status`, and `interrupt`.
+              - If it is an APP operation, check keymgr interface responses with error bit sets to
+                `1`.
+            - If masking is not enabled or the operation does not require entropy:
+              - Check no error triggered.
+            '''
+      stage: V2
+      tests: ["{variant}_entropy_ready_error"]
+   }
    {
       name: lc_escalation
       desc: '''

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -130,7 +130,10 @@ class kmac_smoke_vseq extends kmac_base_vseq;
       end
 
       if (cfg.enable_masking && kmac_err_type == kmac_pkg::ErrIncorrectEntropyMode) begin
-        if (!entropy_fetched) check_err();
+        if (!entropy_fetched) begin
+          check_err();
+          continue;
+        end
       end else if (cfg.enable_masking) begin
         entropy_fetched = 1;
       end


### PR DESCRIPTION
This PR fixes two KMAC nightly issues:
1). entropy failure: Cannot write `err_process` and `entropy_ready`
  field together after an entropy error.
  Design will clarify that in the design doc.
2). Add a testplan entry for kmac_entropy_ready test.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>