### PR TITLE
[otp] Add prod image and align partition contents with rma/dev

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_prod.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_prod.hjson
@@ -9,7 +9,7 @@
 {
     // Seed to be used for generation of partition randomized values.
     // Can be overridden on the command line with the --seed switch.
-    seed: 94259314771464387
+    seed: 14555711126514784208
 
     // The partition and item names must correspond with the OTP memory map.
     partitions: [
@@ -350,7 +350,7 @@
             name:  "LIFE_CYCLE",
             // Can be one of the following strings:
             // RAW, TEST_UNLOCKED0-3, TEST_LOCKED0-2, DEV, PROD, PROD_END, RMA, SCRAP
-            state: "DEV",
+            state: "PROD",
             // Can range from 0 to 16.
             // Note that a value of 0 is only permissible in RAW state.
             count: "5"

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_raw.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_raw.hjson
@@ -14,16 +14,6 @@
     // The partition and item names must correspond with the OTP memory map.
     partitions: [
         {
-            name:  "SECRET1",
-            lock:  "False",
-            items: [
-                {
-                    name:  "FLASH_DATA_KEY_SEED",
-                    value: "<random>",
-                }
-            ],
-        }
-        {
             name:  "LIFE_CYCLE",
             // Can be one of the following strings:
             // RAW, TEST_UNLOCKED0-3, TEST_LOCKED0-2, DEV, PROD, PROD_END, RMA, SCRAP

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -176,7 +176,7 @@
                                fi ''']
   // Add run modes.
   run_modes: [
-    // Generates OTP images with different LC states with cannonical values,
+    // Generates OTP images with different LC states with canonical values,
     // pseudo-randomized with the same test seed.
     {
       name: gen_otp_images_mode
@@ -186,9 +186,14 @@
               --out {run_dir}/otp_ctrl_img_raw.vmem \
               {gen_otp_images_cmd_opts}
         ''',
-         '''{gen_otp_images_cmd} \
+        '''{gen_otp_images_cmd} \
               --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_dev.hjson \
               --out {run_dir}/otp_ctrl_img_dev.vmem \
+              {gen_otp_images_cmd_opts}
+        ''',
+        '''{gen_otp_images_cmd} \
+              --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_prod.hjson \
+              --out {run_dir}/otp_ctrl_img_prod.vmem \
               {gen_otp_images_cmd_opts}
         ''',
         '''{gen_otp_images_cmd} \
@@ -395,7 +400,8 @@
       uvm_test_seq: chip_sw_inject_scramble_seed_vseq
       sw_images: ["//sw/device/tests/sim_dv:inject_scramble_seed:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+lc_at_prod=1", "+flash_program_latency=5", "+sw_test_timeout_ns=150_000_000"]
+      run_opts: ["+use_otp_image=LcStProd", "+flash_program_latency=5",
+                 "+sw_test_timeout_ns=150_000_000"]
       run_timeout_mins: 180
     }
     {
@@ -959,7 +965,7 @@
       uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
       sw_images: ["//sw/device/tests/sim_dv:keymgr_key_derivation_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+lc_at_prod=1", "+sw_test_timeout_ns=20_000_000"]
+      run_opts: ["+use_otp_image=LcStProd", "+sw_test_timeout_ns=20_000_000"]
     }
     {
       name: chip_sw_keymgr_key_derivation_jitter_en
@@ -1261,7 +1267,7 @@
       name: chip_tap_straps_prod
       uvm_test_seq: chip_tap_straps_vseq
       en_run_modes: ["strap_tests_mode"]
-      run_opts: ["+lc_at_prod=1"]
+      run_opts: ["+use_otp_image=LcStProd"]
       run_timeout_mins: 120
     }
     {

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -178,6 +178,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     // By default, assume these OTP image paths.
     otp_images[lc_ctrl_state_pkg::LcStRaw] = "otp_ctrl_img_raw.vmem";
     otp_images[lc_ctrl_state_pkg::LcStDev] = "otp_ctrl_img_dev.vmem";
+    otp_images[lc_ctrl_state_pkg::LcStProd] = "otp_ctrl_img_prod.vmem";
     otp_images[lc_ctrl_state_pkg::LcStRma] = "otp_ctrl_img_rma.vmem";
 
     `DV_CHECK_LE_FATAL(num_ram_main_tiles, 16)


### PR DESCRIPTION
This adds an additional image to preload OTP in PROD state. It also aligns the configuration contents between RMA/DEV/PROD.

Note that we may want to reduce the duplication here in the future. This can be achieved by splitting out the partitions into separate hjson files and feeding them to the image generation script using the `--add-cfg` switch, see:

https://github.com/lowRISC/opentitan/blob/master/util/design/README.md#otp-preload-image-generator

Signed-off-by: Michael Schaffner <msf@google.com>