### PR TITLE
[top-test] entropy_src_csrng adjust timeout

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -910,7 +910,8 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_csrng_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15_000_000", "+rng_srate_value_min=15"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000", "+rng_srate_value_min=15"]
+      run_timeout_mins: 120
     }
     {
       name: chip_sw_edn_entropy_reqs


### PR DESCRIPTION
Adjust test timeout to fix nightly regression failure.

Fixes [#13227](https://github.com/lowRISC/opentitan/issues/13227)