### PR TITLE
[chip] Scaffold `chip_sw_sleep_pin_retention` test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -344,6 +344,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_sleep_pin_retention
+      uvm_test_seq: chip_sw_sleep_pin_retention_vseq
+      sw_images: ["//sw/device/tests/sim_dv:sleep_pin_retention_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_sleep_pwm_pulses
       uvm_test_seq: chip_sw_pwm_pulses_vseq
       sw_images: ["//sw/device/tests:sleep_pwm_pulses_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -63,6 +63,7 @@ filesets:
       - seq_lib/chip_sw_deep_sleep_all_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sleep_pin_wake_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_sleep_pin_retention_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_pwm_pulses_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_rand_baudrate_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_retention_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_retention_vseq.sv
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_sleep_pin_retention_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_sleep_pin_retention_vseq)
+
+  `uvm_object_new
+
+  import chip_common_pkg::*;
+
+  rand bit [7:0] rounds;
+
+  constraint rounds_c { rounds inside {[8'h 1 : 8'h 7]}; }
+
+  virtual task cpu_init();
+    bit [7:0] byte_arr [];
+    byte_arr = '{rounds};
+
+    super.cpu_init();
+
+    sw_symbol_backdoor_overwrite("kRounds", byte_arr);
+
+  endtask : cpu_init
+
+  virtual task body();
+    super.body();
+
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+
+    for (int unsigned round = 0 ; round < rounds ; round++) begin
+        // TODO: Receive values from SW via sw_logger_vif
+
+        // TODO: Check PIN
+
+        // TODO: Wait sleep (normal vs deep)
+
+        // TODO: Check PIN value
+
+        // TODO: Wake up DUT
+    end
+
+  endtask : body
+
+endclass : chip_sw_sleep_pin_retention_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -43,6 +43,7 @@
 `include "chip_sw_sram_ctrl_scrambled_access_vseq.sv"
 `include "chip_sw_sleep_pin_mio_dio_val_vseq.sv"
 `include "chip_sw_sleep_pin_wake_vseq.sv"
+`include "chip_sw_sleep_pin_retention_vseq.sv"
 `include "chip_sw_pwm_pulses_vseq.sv"
 `include "chip_sw_keymgr_key_derivation_vseq.sv"
 `include "chip_sw_ast_clk_outputs_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -653,6 +653,22 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "sleep_pin_retention_test",
+    srcs = ["sleep_pin_retention_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "spi_tx_rx_test",
     srcs = ["spi_tx_rx_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/sleep_pin_retention_test.c
+++ b/sw/device/tests/sim_dv/sleep_pin_retention_test.c
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_pwrmgr_t pwrmgr;
+static dif_pinmux_t pinmux;
+
+// SV randomizes the round of entering/exiting sleep then set this volatile
+// variable via backdoor_overwrite.
+static volatile const uint8_t kRounds = 2;
+
+// SW testcode randomly chooses the value for 8 GPIO pins (pins are fixed) then
+// invert the value for retention. SW will sends the value to SV testbench via
+// LOG_INFO().
+static const uint8_t kGpioVal = 0x00;
+
+bool test_main(void) {
+  bool result = false;
+
+  LOG_INFO("Num Rounds: %3d", kRounds);
+
+  return result;
+}


### PR DESCRIPTION
This commit defines `sleep_pin_retention` SW test in bazel and chip_sim_cfg.hjson, and creates a SW skeleton code under `sw/device/tests/sim_dv/`.