### PR TITLE
[spi_device/dv] Re-construct init tasks

### DIFF
--- a/hw/ip/spi_device/doc/dv/index.md
+++ b/hw/ip/spi_device/doc/dv/index.md
@@ -70,7 +70,7 @@ The `spi_device_base_vseq` virtual sequence is extended from `cip_base_vseq` and
 All test sequences are extended from `spi_device_base_vseq`.
 It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
 Some of the most commonly used tasks / functions are as follows:
-* spi_device_init:            Fully randomize SPI Device control following CSRs and configure TX/RX SRAM FIFO size as following
+* spi_device_fw_init:         Fully randomize SPI Device control following CSRs and configure TX/RX SRAM FIFO size for FW mode as following
   * clock polarity/phase(CPOL, CPHA), bit direction(tx/rx_order), mode, fifo interrupt level(txlvl, rxlvl)
   * TX/RX SRAM FIFO size: from 100 to 1900 and higher distribute for TX size / RX size = 1, 1/2 or 2/1
 * spi_host_xfer_bytes:        Send bytes of data to DUT (SPI Device) through spi_host_driver

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_abort_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_abort_vseq.sv
@@ -12,7 +12,7 @@ class spi_device_abort_vseq extends spi_device_base_vseq;
     bit        tx_fifo_full = 0;
     bit            abort_done = 0;
 
-    spi_device_init();
+    spi_device_fw_init();
     `DV_CHECK_RANDOMIZE_FATAL(this)
     `DV_CHECK_STD_RANDOMIZE_FATAL(device_data)
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -124,13 +124,20 @@ class spi_device_base_vseq extends cip_base_vseq #(
     csr_rd_check(.ptr(ral.async_fifo_level.rxlvl), .compare_value(0));
   endtask
 
-  virtual task spi_device_init();
-    // set clk period
-    if (spi_freq_faster) begin
-      cfg.spi_host_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps / core_spi_freq_ratio;
-    end else begin
-      cfg.spi_host_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps * core_spi_freq_ratio;
+  // configure the clock frequence
+  virtual task spi_clk_init();
+    if (!cfg.spi_clk_configured) begin
+      if (spi_freq_faster) begin
+        cfg.spi_host_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps / core_spi_freq_ratio;
+      end else begin
+        cfg.spi_host_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps * core_spi_freq_ratio;
+      end
+      cfg.spi_clk_configured = 1;
     end
+  endtask
+
+  virtual task spi_device_fw_init();
+    spi_clk_init();
     // update host agent
     cfg.spi_host_agent_cfg.sck_polarity[0] = sck_polarity;
     cfg.spi_host_agent_cfg.sck_phase[0] = sck_phase;

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_bit_transfer_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_bit_transfer_vseq.sv
@@ -24,7 +24,7 @@ class spi_device_bit_transfer_vseq extends spi_device_base_vseq;
     for (int i = 1; i <= num_trans; i++) begin
       `uvm_info(`gfn, $sformatf("starting sequence %0d/%0d", i, num_trans), UVM_LOW)
       `DV_CHECK_RANDOMIZE_FATAL(this)
-      spi_device_init();
+      spi_device_fw_init();
       repeat ($urandom_range(8)) begin
         bit [31:0] host_data_exp_q[$];
         `DV_CHECK_STD_RANDOMIZE_FATAL(host_data)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_dummy_item_extra_dly_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_dummy_item_extra_dly_vseq.sv
@@ -15,8 +15,8 @@ class spi_device_dummy_item_extra_dly_vseq extends spi_device_txrx_vseq;
     en_extra_dly == 1;
   }
 
-  virtual task spi_device_init();
-    super.spi_device_init();
+  virtual task spi_device_fw_init();
+    super.spi_device_fw_init();
     // use more aggressive delay, but if higher than below values, timeout may happen
     randcase
       1: begin

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_intr_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_intr_vseq.sv
@@ -13,7 +13,7 @@ class spi_device_intr_vseq extends spi_device_txrx_vseq;
 
     for (int i = 1; i <= num_trans; i++) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
-      spi_device_init();
+      spi_device_fw_init();
 
       // fill tx async fifo to avoid sending out unknown data
       if (!is_tx_async_fifo_filled) begin

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -299,7 +299,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
 
   // Task for flash or pass init
   virtual task spi_device_flash_pass_init();
-    spi_device_init();
+    spi_clk_init();
     `uvm_info(`gfn, "Initialize flash/passthrough mode", UVM_MEDIUM)
 
     // TODO, #14940. EN4B/EX4B may fail if the next item comes very shortly

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_rx_async_fifo_reset_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_rx_async_fifo_reset_vseq.sv
@@ -25,7 +25,7 @@ class spi_device_rx_async_fifo_reset_vseq extends spi_device_txrx_vseq;
     uint       avail_data;
     bit [31:0] host_data_exp_q[$];
 
-    spi_device_init();
+    spi_device_fw_init();
     `DV_CHECK_STD_RANDOMIZE_FATAL(host_data)
     `DV_CHECK_STD_RANDOMIZE_FATAL(device_data)
     wait_for_tx_avail_bytes(SRAM_WORD_SIZE, SramSpaceAvail, avail_bytes);

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_rx_timeout_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_rx_timeout_vseq.sv
@@ -42,7 +42,7 @@ class spi_device_rx_timeout_vseq extends spi_device_base_vseq;
     uint       avail_bytes;
     uint       avail_data;
 
-    spi_device_init();
+    spi_device_fw_init();
 
     for (int i = 1; i <= num_trans; i++) begin
       `uvm_info(`gfn, $sformatf("starting sequence %0d/%0d", i, num_trans), UVM_LOW)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_smoke_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_smoke_vseq.sv
@@ -21,7 +21,7 @@ class spi_device_smoke_vseq extends spi_device_base_vseq;
     for (int i = 1; i <= num_trans; i++) begin
       `uvm_info(`gfn, $sformatf("starting sequence %0d/%0d", i, num_trans), UVM_LOW)
       `DV_CHECK_RANDOMIZE_FATAL(this)
-      spi_device_init();
+      spi_device_fw_init();
       repeat ($urandom_range(2, 10)) begin
         bit [31:0] host_data_exp_q[$];
         `DV_CHECK_STD_RANDOMIZE_FATAL(host_data)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
@@ -48,6 +48,7 @@ class spi_device_tpm_base_vseq extends spi_device_base_vseq;
   endfunction
   // Configure clocks and tpm, generate a word.
   virtual task tpm_init(tpm_cfg_mode_e mode, bit is_hw_return = $random);
+    spi_clk_init();
     cfg.spi_host_agent_cfg.csid = TPM_CSB_ID;
     // Only SPI mode 0 is supported (CPHA=0, CPOL=0).
     cfg.spi_host_agent_cfg.sck_polarity[TPM_CSB_ID] = 0;

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_rw_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_rw_vseq.sv
@@ -10,7 +10,7 @@ class spi_device_tpm_rw_vseq extends spi_device_tpm_base_vseq;
   virtual task body();
     bit [7:0] spi_byte_q[$];
     bit [7:0] sw_byte_q[$];
-    spi_device_init();
+    spi_device_fw_init();
 
     // randomised tpm configuration.
     tpm_init(TpmCrbMode);

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_sts_read_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_sts_read_vseq.sv
@@ -13,8 +13,6 @@ class spi_device_tpm_sts_read_vseq extends spi_device_tpm_base_vseq;
     bit [7:0] returned_bytes[$];
     uint locality_idx;
 
-    spi_device_init();
-
     // randomised tpm configuration.
     tpm_init(.mode(TpmFifoMode), .is_hw_return(1));
     repeat (num_trans) begin

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tx_async_fifo_reset_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tx_async_fifo_reset_vseq.sv
@@ -16,7 +16,7 @@ class spi_device_tx_async_fifo_reset_vseq extends spi_device_base_vseq;
     uint       avail_data;
     bit [31:0] host_data_exp_q[$];
 
-    spi_device_init();
+    spi_device_fw_init();
     `DV_CHECK_STD_RANDOMIZE_FATAL(host_data)
     `DV_CHECK_STD_RANDOMIZE_FATAL(device_data)
     // Fill TX SRAM FIFO with some data, which will be transfered to TX async FIFO

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
@@ -103,8 +103,8 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
       0 :/ 1
     };
   }
-  virtual task spi_device_init();
-    super.spi_device_init();
+  virtual task spi_device_fw_init();
+    super.spi_device_fw_init();
     cfg.spi_host_agent_cfg.en_extra_dly_btw_sck  = en_extra_dly;
     cfg.spi_host_agent_cfg.en_extra_dly_btw_word = en_extra_dly;
   endtask
@@ -116,7 +116,7 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
       bit done_tx_write, done_rx_read, done_xfer;
       `uvm_info(`gfn, $sformatf("starting sequence %0d/%0d", i, num_trans), UVM_LOW)
       `DV_CHECK_RANDOMIZE_FATAL(this)
-      spi_device_init();
+      spi_device_fw_init();
       fork
         begin
           process_tx_write(tx_total_bytes);

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -16,6 +16,10 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
   // read by the SPI host, in order to update the other part
   bit [TL_AW-1:0]     read_buffer_ptr;
 
+  // clock only needs to be configured once. flash and TPM sequences may start in parallel.
+  // This prevents clk from being configured multiple times
+  bit                 spi_clk_configured;
+
   `uvm_object_utils_begin(spi_device_env_cfg)
     `uvm_field_object(spi_host_agent_cfg, UVM_DEFAULT)
     `uvm_field_object(spi_device_agent_cfg, UVM_DEFAULT)


### PR DESCRIPTION
1. Moved clk configure from spi_device_init so that it won't be updated multiple times
2. Renamed spi_device_init -> spi_device_fw_init, as it's configured for FW mode
3. Removed unnecessary spi_device_fw_init in tpm sequences

Signed-off-by: Weicai Yang <weicai@google.com>