### PR TITLE
[flash_ctrl,dv] Coverage update

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -184,15 +184,6 @@
       tests: ["flash_ctrl_error_mp"]
     }
     {
-      name: error_rd
-      desc: '''
-            Perform accesses in order to provoke read data error. Test both, Software interface and
-            Hardware interface. Related covergroup is error_cg.
-            '''
-      stage: V2S
-      tests: []
-    }
-    {
       name: error_prog_win
       desc: '''
             Perform accesses in order to provoke the 'program resolution' error.
@@ -254,15 +245,6 @@
             '''
       stage: V2
       tests: ["flash_ctrl_stress_all"]
-    }
-    {
-      name: error_flash_phy
-      desc: '''
-            Perform accesses in order to provoke native flash error. Test both, Software interface
-            and Hardware interface. Related covergroup is error_cg.
-            '''
-      stage: V2S
-      tests: []
     }
     {
       name: secret_partition

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -64,7 +64,7 @@ class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
   covergroup eviction_cg with function sample (int idx, bit[1:0] op,
                                                bit [1:0] scr_ecc);
     evic_idx_cp : coverpoint idx {
-      bins evic_idx[] = {1, 2, 4, 8};
+      bins evic_idx[] = {[0:3]};
     }
     evic_op_cp : coverpoint op {
       bins evic_op[] = {1, 2};

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -315,13 +315,6 @@ class flash_ctrl_scoreboard #(
                   end
                end
             end
-            "exec": begin
-              bit is_exec_key = `gmv(ral.exec) == CODE_EXEC_KEY;
-              tlul_pkg::tl_a_user_t a_user = item.a_user;
-              if (cfg.en_cov) begin
-                cov.fetch_code_cg.sample(is_exec_key, a_user.instr_type);
-              end
-            end
             default: begin
             // TODO: Uncomment once func cover is implemented
             // `uvm_info(`gfn, $sformatf("Not for func coverage: %0s", csr.get_full_name()))
@@ -833,9 +826,14 @@ class flash_ctrl_scoreboard #(
 
   // Check if the input tl_seq_item has any tl errors.
   virtual function bit get_flash_instr_type_err(tl_seq_item item, tl_channels_e channel);
-
+    bit is_exec_key = `gmv(ral.exec) == CODE_EXEC_KEY;
     // Local Variable
     tlul_pkg::tl_a_user_t a_user = item.a_user;
+    if (cfg.en_cov) begin
+      if (channel == AddrChannel) begin
+        cov.fetch_code_cg.sample(is_exec_key, a_user.instr_type);
+      end
+    end
 
     // If Data Access, or a Write, or the CODE_EXEC_KEY Matches
     if (((a_user.instr_type == MuBi4False) || (item.a_opcode != tlul_pkg::Get)) ||

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
@@ -35,19 +35,21 @@ class flash_ctrl_common_vseq extends flash_ctrl_otf_base_vseq;
   endtask // pre_start
 
   virtual task body();
-    string path;
+    string path[] = {
+      {"tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd",
+              ".u_rd_storage.gen_normal_fifo.storage_rdata[74:0]"},
+      {"tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd",
+              ".u_rd_storage.gen_normal_fifo.storage_rdata[74:0]"},
+      "tb.dut.u_to_rd_fifo.u_rspfifo.gen_normal_fifo.storage_rdata[39:0]"
+    };
     if (common_seq_type == "") void'($value$plusargs("run_%0s", common_seq_type));
     if (common_seq_type == "sec_cm_fi") begin
-      // Prevent 'x' propagate data path while force corrupt fifo ptr.
-      path = {"tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd",
-              ".u_rd_storage.gen_normal_fifo.storage_rdata[74:0]"};
-      `DV_CHECK(uvm_hdl_deposit(path, 0))
-      path = {"tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd",
-              ".u_rd_storage.gen_normal_fifo.storage_rdata[74:0]"};
-      `DV_CHECK(uvm_hdl_deposit(path, 0))
+      for (int i = 0; i < path.size(); i++) begin
+        `DV_CHECK(uvm_hdl_deposit(path[i], 0))
+      end
     // Each run of sec_cm takes about 10 min.
-    // Limit num_trans of sec_cm to 5.
-      run_sec_cm_fi_vseq(5);
+    // Limit num_trans of sec_cm to 10.
+      run_sec_cm_fi_vseq(10);
     end else run_common_vseq_wrapper(num_trans);
   endtask : body
 
@@ -130,6 +132,7 @@ class flash_ctrl_common_vseq extends flash_ctrl_otf_base_vseq;
           $asserton(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
           $asserton(0, "tb.dut.u_eflash.gen_flash_cores[0].u_core.RdTxnCheck_A");
           $asserton(0, "tb.dut.u_eflash.gen_flash_cores[1].u_core.RdTxnCheck_A");
+          $asserton(0, "tb.dut.RspPayLoad_A");
         end else begin
           $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd.u_rd_storage");
           $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd.u_rd_storage");
@@ -142,6 +145,7 @@ class flash_ctrl_common_vseq extends flash_ctrl_otf_base_vseq;
           $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[0].u_core.RdTxnCheck_A");
           $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[1].u_core.RdTxnCheck_A");
           $assertoff(0, "tb.dut.u_to_rd_fifo.rvalidHighWhenRspFifoFull");
+          $assertoff(0, "tb.dut.RspPayLoad_A");
         end
       end
       SecCmPrimSparseFsmFlop: begin

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
@@ -37,13 +37,13 @@ class flash_ctrl_disable_vseq extends flash_ctrl_otf_base_vseq;
       1: begin
         cfg.flash_ctrl_vif.lc_escalate_en =
           get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(4));
-        is_disable = (cfg.flash_ctrl_vif.lc_escalate_en == lc_ctrl_pkg::On);
+        is_disable = (cfg.flash_ctrl_vif.lc_escalate_en != lc_ctrl_pkg::Off);
       end
       1: begin
         mubi4_t dis_val;
         dis_val = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(4));
         csr_wr(.ptr(ral.dis), .value(dis_val));
-        is_disable = (dis_val == MuBi4True);
+        is_disable = (dis_val != MuBi4False);
       end
     endcase // randcase
     exp_err = is_disable;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
@@ -5,7 +5,7 @@
 // This sequence sends read traffic with error injection
 // at the output of read_buffer.
 // Read response will trigger fatal_err.storage_err.
-class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_rw_vseq;
+class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_legacy_base_vseq;
   `uvm_object_utils(flash_ctrl_rd_path_intg_vseq)
   `uvm_object_new
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_evict_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_evict_vseq.sv
@@ -22,7 +22,7 @@ class flash_ctrl_rw_evict_vseq extends flash_ctrl_legacy_base_vseq;
       begin
         rd_cache_t entry;
 
-        while (idx < 30 && cfg.flash_ctrl_vif.fatal_err == 0) begin
+        while (idx < 50 && cfg.flash_ctrl_vif.fatal_err == 0) begin
           `DV_CHECK_RANDOMIZE_FATAL(this)
           rand_op.addr[OTFBankId] = bank;
           ctrl = rand_op;
@@ -71,7 +71,7 @@ class flash_ctrl_rw_evict_vseq extends flash_ctrl_legacy_base_vseq;
                   end
                   readback_flash(ctrl, bank, 1, fractions);
                 end
-                1: begin
+                3: begin
                   addr_q.push_back(entry);
                   if (addr_q.size > 4) begin
                     rd_cache_t old_ent = addr_q.pop_front();
@@ -108,7 +108,7 @@ class flash_ctrl_rw_evict_vseq extends flash_ctrl_legacy_base_vseq;
       end // fork begin
       begin
         time timeout_ns = 100_000_000;
-        evict_trans = $urandom_range(4, 20);
+        evict_trans = $urandom_range(10, 20);
         `uvm_info("seq", $sformatf("wait evict start %0d", evict_trans), UVM_MEDIUM)
         `DV_SPINWAIT( wait(idx == evict_trans);,
                       $sformatf("Timed out waiting for evict trans %0d idx:%0d",

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -329,6 +329,12 @@
       reseed: 40
     }
     {
+      name: flash_ctrl_rw_evict_all_en
+      uvm_test_seq: flash_ctrl_rw_evict_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_read=1", "+en_always_prog=1"]
+      reseed: 40
+    }
+    {
       name: flash_ctrl_re_evict
       uvm_test_seq: flash_ctrl_re_evict_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_read=1"]
@@ -343,7 +349,7 @@
     }
     {
       name: flash_ctrl_sec_cm
-      run_timeout_mins: 120
+      run_timeout_mins: 180
     }
     {
       name: flash_ctrl_sec_info_access
@@ -417,9 +423,10 @@
     }
     {
       // For test clean up run subset of tests
-      name: sub
-      tests: ["flash_ctrl_smoke",
-              "flash_ctrl_smoke_hw"
+      name: evict
+      tests: ["flash_ctrl_rw_evict",
+              "flash_ctrl_re_evict",
+              "flash_ctrl_rw_evict_all_en"
               ]
     }
     {

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -158,7 +158,7 @@
        - Debug state is changed to 'flash_ctrl_env_pkg::FlashLcDisabled' state
       '''
       stage: V2S
-      tests: ["flash_ctrl_rd_path_intg", "flash_ctrl_access_after_disable"]
+      tests: ["flash_ctrl_rd_intg", "flash_ctrl_access_after_disable"]
     }
     {
       name: sec_cm_mem_disable_config_mubi


### PR DESCRIPTION
This PR has following updates
 - Update testplans for v2s
 - Fix eviction cover point from vector to index
 - Move sampling point of fetch code cover group
 - Increase test runs of some tests
 - Update flash_ctrl_disable error condition to '!= true'
 - Add error injection to fetch code test.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>