### PR TITLE
[dv/chip] Add flag to skip creating fcov in agents

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -35,6 +35,14 @@ class dv_base_reg extends uvm_reg;
     atomic_en_shadow_wr = new(1);
   endfunction : new
 
+  // Create this register and its fields' IP-specific functional coverage.
+  function void create_cov();
+    dv_base_reg_field fields[$];
+    get_dv_base_reg_fields(fields);
+    foreach(fields[i]) fields[i].create_cov();
+    // Create register-specific covergroups here.
+  endfunction
+
   // this is similar to get_name, but it gets the
   // simple name of the aliased register instead.
   function string get_alias_name ();

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -56,6 +56,10 @@ class dv_base_reg_block extends uvm_reg_block;
   // Custom RAL models may support sub-word CSR writes smaller than CSR width.
   protected bit supports_sub_word_csr_writes = 1'b0;
 
+  // Enables functional coverage of comportable IP-specific specialized registers, such as regwen
+  // and mubi. This flag can only be disabled before invoking `create_dv_reg_cov`.
+  protected bit en_dv_reg_cov = 1;
+
   bit has_unmapped_addrs;
   addr_range_t unmapped_addr_ranges[$];
 
@@ -111,6 +115,20 @@ class dv_base_reg_block extends uvm_reg_block;
   virtual function void build(uvm_reg_addr_t base_addr,
                               csr_excl_item csr_excl = null);
     `uvm_fatal(`gfn, "this method is not supposed to be called directly!")
+  endfunction
+
+  // This function is invoked at the end of `build` method in uvm_reg_base.sv template to create
+  // IP-specific functional coverage for this block and its registers and fields.
+  function void create_cov();
+    dv_base_reg_block blks[$];
+    dv_base_reg regs[$];
+
+    get_dv_base_reg_blocks(blks);
+    foreach (blks[i]) blks[i].create_cov();
+
+    get_dv_base_regs(regs);
+    foreach (regs[i]) regs[i].create_cov();
+    // Create block-specific covergroups here.
   endfunction
 
   function void get_dv_base_reg_blocks(ref dv_base_reg_block blks[$]);
@@ -403,6 +421,18 @@ class dv_base_reg_block extends uvm_reg_block;
       `downcast(retval, super.get_field_by_name(name))
     end
     return retval;
+  endfunction
+
+  function void set_en_dv_reg_cov(bit val);
+    uvm_reg csrs[$];
+    get_registers(csrs);
+    `DV_CHECK_FATAL(!csrs.size(),
+        "Cannot set en_dv_base_reg_cov when covergroups are built already!")
+    en_dv_reg_cov = val;
+  endfunction
+
+  function bit get_en_dv_reg_cov();
+    return en_dv_reg_cov;
   endfunction
 
 endclass

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -222,6 +222,13 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     m_tl_agent_cfg.max_outstanding_req = 8;
   endfunction
 
+  // Disable functional coverage of comportable IP-specific specialized registers.
+  // Chip level testbench does not sample these coverpoints.
+  protected virtual function void pre_build_ral_settings(dv_base_reg_block ral);
+    super.pre_build_ral_settings(ral);
+    ral.set_en_dv_reg_cov(0);
+  endfunction
+
   // Apply RAL fixes before it is locked.
   protected virtual function void post_build_ral_settings(dv_base_reg_block ral);
     RAL_T chip_ral;

--- a/util/reggen/uvm_reg_base.sv.tpl
+++ b/util/reggen/uvm_reg_base.sv.tpl
@@ -196,6 +196,11 @@ ${apply_regwen(rb, reg, inst)}\
   % endif
 % endif
 ${make_ral_pkg_window_instances(reg_width, esc_if_name, rb)}
+
+      // Create functional coverage for comportable IP-specific specialized registers.
+      // This function can only be called if it is a root block to get the correct gating condition
+      // and avoid creating duplicated cov.
+      if (this.get_parent() == null && en_dv_reg_cov) create_cov();
     endfunction : build
   endclass : ${reg_block_name}
 
@@ -445,7 +450,7 @@ reg_field_name, field)">\
 % endif
       ${fname}.set_original_access("${field_access}");
 % if field.mubi:
-      ${fname}.create_mubi_cov(.mubi_width(${field_size}));
+      ${fname}.set_mubi_width(${field_size});
 % endif
 % if field_tags:
       // create field tags


### PR DESCRIPTION
This PR adds the following flag:
In dv_base_reg_block, add a flag to skip creating fcov for mubi and
regwen regs.

This flag is only disabled in chip level because we do not sample these values in chip level env.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>