### PR TITLE
[test] Add test for LC access control signal going to OTP

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__otp.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__otp.sv
@@ -139,3 +139,29 @@ virtual function void otp_write_hw_cfg_partition(
 
   write64(HwCfgDigestOffset, digest);
 endfunction
+
+// Functions that clear the provisioning state of the buffered partitions.
+// This is useful in tests that make front-door accesses for provisioning purposes.
+virtual function void otp_clear_secret0_partition();
+  for (int i = 0; i < Secret0Size; i += 4) begin
+    write32(i + Secret0Offset, 32'h0);
+  end
+endfunction
+
+virtual function void otp_clear_secret1_partition();
+  for (int i = 0; i < Secret1Size; i += 4) begin
+    write32(i + Secret1Offset, 32'h0);
+  end
+endfunction
+
+virtual function void otp_clear_secret2_partition();
+  for (int i = 0; i < Secret2Size; i += 4) begin
+    write32(i + Secret2Offset, 32'h0);
+  end
+endfunction
+
+virtual function void otp_clear_hw_cfg_partition();
+  for (int i = 0; i < HwCfgSize; i += 4) begin
+    write32(i + HwCfgOffset, 32'h0);
+  end
+endfunction

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1623,12 +1623,14 @@
         "chip_sw_sram_ctrl_execution_main",               // lc_hw_debug_en_o: sram_ctrl main
         // TODO: ref chip_sw_rv_dm_lc_disabled (#14147)   // lc_hw_debug_en_o: rv_dm
         "chip_sw_keymgr_key_derivation",                  // lc_keymgr_en_o: keymgr
-        // TODO: add disable test (#15272)                // lc_keymgr_en_o: keymgr
         "chip_sw_clkmgr_external_clk_src_for_lc",         // lc_clk_byp_req_o: clkmgr
         "chip_sw_flash_rma_unlocked",                     // lc_flash_rma_req_o, lc_flash_rma_seed_o: flash_ctrl
-        "chip_sw_otp_ctrl_program",                       // lc_check_byp_en_o: otp_ctrl
+        "chip_sw_lc_ctrl_transition",                     // lc_check_byp_en_o: otp_ctrl
         "chip_sw_flash_ctrl_lc_rw_en",                    // lc_creator*, lc_seed*, lc_owner*, lc_iso*: flash_ctrl
-        // TODO: ref chip_sw_otp_ctrl_lc_signals (#14139) // lc_creator*, lc_seed*: OTP
+        "chip_sw_otp_ctrl_lc_signals_test_unlocked0",     // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i
+        "chip_sw_otp_ctrl_lc_signals_dev",                // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i
+        "chip_sw_otp_ctrl_lc_signals_prod",               // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i
+        "chip_sw_otp_ctrl_lc_signals_rma",                // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i
       ]
     }
 
@@ -2532,7 +2534,7 @@
       name: chip_sw_otp_ctrl_lc_signals
       desc: '''Verify the broadcast signals from LC ctrl.
 
-            - `lc_creator_seed_sw_rw_en_i`: verify that the secret2 partition is locked.
+            - `lc_creator_seed_sw_rw_en_i`: verify that the SECRET2 partition is locked.
             - `lc_seed_hw_rd_en_i`: verify that the keymgr outputs a default value when enabled.
             - `lc_dft_en_i`: verify that the test interface within OTP ctrl is accessible.
             - `lc_check_byp_en_i`: verify that the background check during LC ctrl state
@@ -2540,14 +2542,24 @@
 
             Note that `lc_escalate_en_i` is verified via a connectivity test.
 
+            The `lc_seed_hw_rd_en_i` signal can be tested by attempting a keymgr advance operation
+            into the CreatorRootKey state, which should fail since the root key will be tied off to
+            all-zero when the SECRET2 partition is not locked in OTP.
+
             X-ref'ed with chip_sw_lc_ctrl_broadcast test, which verifies the connectivity of the LC
             decoded outputs to other IPs.
             '''
       stage: V2
       tests: [
-        "chip_prim_tl_access",        // lc_dft_en_i
-        "chip_sw_lc_ctrl_transition", // lc_check_byp_en_i
-        // TODO(#14139): access control signals.
+        // lc_dft_en_i
+        "chip_prim_tl_access",
+        // lc_check_byp_en_i
+        "chip_sw_lc_ctrl_transition",
+        // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, also checks lc_keymgr_en_i since it uses the keymgr.
+        "chip_sw_otp_ctrl_lc_signals_test_unlocked0",
+        "chip_sw_otp_ctrl_lc_signals_dev",
+        "chip_sw_otp_ctrl_lc_signals_prod",
+        "chip_sw_otp_ctrl_lc_signals_rma",
         ]
     }
     {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -560,6 +560,42 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_otp_ctrl_lc_signals_test_unlocked0
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"],
+      // Use the image as basis, but clear provitioning state of the SECRET2
+      // partition so that the test can make front-door accesses to that partition.
+      run_opts: ["+use_otp_image=LcStTestUnlocked0", "+otp_clear_secret2=1"]
+    }
+    {
+      name: chip_sw_otp_ctrl_lc_signals_dev
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"],
+      // Use the image as basis, but clear provitioning state of the SECRET2
+      // partition so that the test can make front-door accesses to that partition.
+      run_opts: ["+use_otp_image=LcStDev", "+otp_clear_secret2=1"]
+    }
+    {
+      name: chip_sw_otp_ctrl_lc_signals_prod
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"],
+      // Use the image as basis, but clear provitioning state of the SECRET2
+      // partition so that the test can make front-door accesses to that partition.
+      run_opts: ["+use_otp_image=LcStProd", "+otp_clear_secret2=1"]
+    }
+    {
+      name: chip_sw_otp_ctrl_lc_signals_rma
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"],
+      // Use the image as basis, but clear provitioning state of the SECRET2
+      // partition so that the test can make front-door accesses to that partition.
+      run_opts: ["+use_otp_image=LcStRma", "+otp_clear_secret2=1"]
+    }
+    {
       // Set higher reseed value to reach all kmac_data to lc_ctrl toggle coverage.
       name: chip_sw_lc_ctrl_transition
       uvm_test_seq: chip_sw_lc_ctrl_transition_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -72,6 +72,7 @@ class chip_base_vseq #(
   // cycle) and  performs immediate post-reset steps to prime the design for stimulus. The
   // base class method invoked by super.dut_init() applies the reset.
   virtual task dut_init(string reset_kind = "HARD");
+    bit otp_clear_hw_cfg, otp_clear_secret0, otp_clear_secret1, otp_clear_secret2;
     // Connect the external clock source if the test needs it.
     //
     // TODO: This is a functional interface which should ideally be connected only in the extended
@@ -95,6 +96,25 @@ class chip_base_vseq #(
     cfg.mem_bkdr_util_h[FlashBank1Info].set_mem();
     // Backdoor load the OTP image.
     cfg.mem_bkdr_util_h[Otp].load_mem_from_file(cfg.otp_images[cfg.use_otp_image]);
+    // Plusargs to selectively clear the provisioning state of some of the OTP partitions.
+    // This is useful in tests that make front-door accesses for provisioning purposes.
+    void'($value$plusargs("otp_clear_hw_cfg=%0d", otp_clear_hw_cfg));
+    void'($value$plusargs("otp_clear_secret0=%0d", otp_clear_secret0));
+    void'($value$plusargs("otp_clear_secret1=%0d", otp_clear_secret1));
+    void'($value$plusargs("otp_clear_secret2=%0d", otp_clear_secret2));
+    if (otp_clear_hw_cfg) begin
+        cfg.mem_bkdr_util_h[Otp].otp_clear_hw_cfg_partition();
+    end
+    if (otp_clear_secret0) begin
+        cfg.mem_bkdr_util_h[Otp].otp_clear_secret0_partition();
+    end
+    if (otp_clear_secret1) begin
+        cfg.mem_bkdr_util_h[Otp].otp_clear_secret1_partition();
+    end
+    if (otp_clear_secret2) begin
+        cfg.mem_bkdr_util_h[Otp].otp_clear_secret2_partition();
+    end
+
     initialize_otp_sig_verify();
     initialize_otp_creator_sw_cfg_ast_cfg();
     callback_vseq.pre_dut_init();

--- a/sw/device/lib/testing/keymgr_testutils.h
+++ b/sw/device/lib/testing/keymgr_testutils.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_TESTUTILS_H_
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_TESTUTILS_H_
 
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_keymgr.h"
 #include "sw/device/lib/dif/dif_kmac.h"
 
@@ -46,6 +47,51 @@ static const dif_keymgr_state_params_t kOwnerIntParams = {
                       0x23fb480c, 0xb012ae5e, 0xf1394d28, 0x1940ceeb},
     .max_key_version = 0xaa,
 };
+
+/**
+ * Struct to hold the creator or owner secrets for the key manager.
+ */
+typedef struct keymgr_testutils_secret {
+  uint32_t value[8];
+} keymgr_testutils_secret_t;
+
+/**
+ * Key manager Creator Secret stored in info flash page.
+ */
+static const keymgr_testutils_secret_t kCreatorSecret = {
+    .value = {0x4e919d54, 0x322288d8, 0x4bd127c7, 0x9f89bc56, 0xb4fb0fdf,
+              0x1ca1567b, 0x13a0e876, 0xa6521d8f}};
+
+/**
+ * Key manager Owner Secret stored in info flash page.
+ */
+static const keymgr_testutils_secret_t kOwnerSecret = {.value = {
+                                                           0xa6521d8f,
+                                                           0x13a0e876,
+                                                           0x1ca1567b,
+                                                           0xb4fb0fdf,
+                                                           0x9f89bc56,
+                                                           0x4bd127c7,
+                                                           0x322288d8,
+                                                           0x4e919d54,
+                                                       }};
+
+/**
+ * Programs flash with secrets so that the keymgr can be advanced to
+ * CreatorRootKey state.
+ *
+ * This is normally a subfunction of keymgr_testutils_startup, but some tests
+ * use the function separately as well.
+ *
+ * @param flash An initialized flash_ctrl handle.
+ * @param creator_secret The creator secret to be programmed to flash.
+ * @param owner_secret The owner secret to be programmed to flash.
+ *
+ */
+void keymgr_testutils_flash_init(
+    dif_flash_ctrl_state_t *flash,
+    const keymgr_testutils_secret_t *creator_secret,
+    const keymgr_testutils_secret_t *owner_secret);
 
 /**
  * Programs flash, restarts, and advances keymgr to CreatorRootKey state.

--- a/sw/device/lib/testing/lc_ctrl_testutils.c
+++ b/sw/device/lib/testing/lc_ctrl_testutils.c
@@ -10,6 +10,51 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+void lc_ctrl_testutils_lc_state_log_or_die(const dif_lc_ctrl_state_t *state) {
+  switch (*state) {
+    case kDifLcCtrlStateTestUnlocked0:
+      LOG_INFO("Life cycle state: TEST_UNLOCKED0");
+      break;
+    case kDifLcCtrlStateTestUnlocked1:
+      LOG_INFO("Life cycle state: TEST_UNLOCKED1");
+      break;
+    case kDifLcCtrlStateTestUnlocked2:
+      LOG_INFO("Life cycle state: TEST_UNLOCKED2");
+      break;
+    case kDifLcCtrlStateTestUnlocked3:
+      LOG_INFO("Life cycle state: TEST_UNLOCKED3");
+      break;
+    case kDifLcCtrlStateTestUnlocked4:
+      LOG_INFO("Life cycle state: TEST_UNLOCKED4");
+      break;
+    case kDifLcCtrlStateTestUnlocked5:
+      LOG_INFO("Life cycle state: TEST_UNLOCKED5");
+      break;
+    case kDifLcCtrlStateTestUnlocked6:
+      LOG_INFO("Life cycle state: TEST_UNLOCKED6");
+      break;
+    case kDifLcCtrlStateTestUnlocked7:
+      LOG_INFO("Life cycle state: TEST_UNLOCKED7");
+      break;
+    case kDifLcCtrlStateDev:
+      LOG_INFO("Life cycle state: DEV");
+      break;
+    case kDifLcCtrlStateProd:
+      LOG_INFO("Life cycle state: PROD");
+      break;
+    case kDifLcCtrlStateProdEnd:
+      LOG_INFO("Life cycle state: PROD_END");
+      break;
+    case kDifLcCtrlStateRma:
+      LOG_INFO("Life cycle state: RMA");
+      break;
+    default:
+      CHECK(false, "CPU is executing in locked/invalid life cycle state: %d",
+            (uint32_t)state);
+      break;
+  }
+}
+
 bool lc_ctrl_testutils_debug_func_enabled(const dif_lc_ctrl_t *lc_ctrl) {
   dif_lc_ctrl_state_t state;
   CHECK_DIF_OK(dif_lc_ctrl_get_state(lc_ctrl, &state));

--- a/sw/device/lib/testing/lc_ctrl_testutils.h
+++ b/sw/device/lib/testing/lc_ctrl_testutils.h
@@ -10,6 +10,15 @@
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
 
 /**
+ * Print current life cycle state to the console.
+ *
+ * Reads the life cycle state register and prints the life cycle state as a
+ * human readable string. The function errors out in locked/invalid life
+ * cycle states where the CPU should not be executing code.
+ */
+void lc_ctrl_testutils_lc_state_log_or_die(const dif_lc_ctrl_state_t *state);
+
+/**
  * Checks whether Lifecycle Controller state has debug functions enabled.
  *
  * There could be implications for tests with debug functions enabled. For

--- a/sw/device/lib/testing/otp_ctrl_testutils.h
+++ b/sw/device/lib/testing/otp_ctrl_testutils.h
@@ -8,6 +8,22 @@
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 
 /**
+ * Enum that encodes the expectation for the check_dai_access_error function.
+ */
+typedef enum { kExpectPassed, kExpectFailed } exp_test_result_t;
+
+/**
+ * Check whether we got an access error in the DAI.
+ *
+ * The test passes depending on the expectation argument.
+ * I.e., if the expectation is that we get an access error (exp_result ==
+ * kExpectFailed), but the DAI does not report any error, the test will fail.
+ */
+void otp_ctrl_testutils_dai_access_error_check(const dif_otp_ctrl_t *otp_ctrl,
+                                               exp_test_result_t exp_result,
+                                               int32_t address);
+
+/**
  * Waits for the DAI operation to finish (busy wait).
  */
 void otp_ctrl_testutils_wait_for_dai(const dif_otp_ctrl_t *otp_ctrl);

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -1151,3 +1151,31 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "otp_ctrl_lc_signals_test",
+    srcs = ["otp_ctrl_lc_signals_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/dif:kmac",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:keymgr_testutils",
+        "//sw/device/lib/testing:kmac_testutils",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_test_config",
+        "//sw/device/silicon_creator/lib/base:chip",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)

--- a/sw/device/tests/sim_dv/otp_ctrl_lc_signals_test.c
+++ b/sw/device/tests/sim_dv/otp_ctrl_lc_signals_test.c
@@ -1,0 +1,350 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_keymgr.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/keymgr_testutils.h"
+#include "sw/device/lib/testing/kmac_testutils.h"
+#include "sw/device/lib/testing/lc_ctrl_testutils.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
+
+static dif_lc_ctrl_t lc;
+static dif_otp_ctrl_t otp;
+static dif_rstmgr_t rstmgr;
+static dif_keymgr_t keymgr;
+static dif_kmac_t kmac;
+static dif_flash_ctrl_state_t flash;
+
+// LC RMA token value in OTP SECRET2 partition.
+static const uint8_t kOtpRmaToken[OTP_CTRL_PARAM_RMA_TOKEN_SIZE] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+};
+
+// Root key share 0 in OTP SECRET2 partition.
+static const uint8_t
+    kOtpRootKeyShare0[OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE0_SIZE] = {
+        0x6e, 0x70, 0x48, 0x68, 0xa3, 0x2f, 0xfa, 0x1b, 0xd8, 0x36, 0x4d,
+        0x00, 0x79, 0xbd, 0x04, 0xe6, 0x53, 0x18, 0xfc, 0xc3, 0xc9, 0xdd,
+        0x39, 0xfa, 0xe0, 0x18, 0x49, 0x69, 0xc9, 0x81, 0x05, 0x17,
+};
+
+// Root key share 1 in OTP SECRET2 partition.
+static const uint8_t
+    kOtpRootKeyShare1[OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE1_SIZE] = {
+        0x2f, 0x78, 0x6f, 0x93, 0x9a, 0xc4, 0xcf, 0x95, 0xb6, 0xec, 0x61,
+        0x76, 0xbd, 0x08, 0x05, 0x0c, 0x09, 0x89, 0xe1, 0x73, 0x4b, 0x0a,
+        0x59, 0x1b, 0xdd, 0x34, 0x84, 0x82, 0x32, 0x9a, 0x93, 0x31};
+
+// Enum that encodes the possible test modes.
+typedef enum { kWriteMode, kReadMode, kWriteReadMode } test_mode_t;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+/**
+ * Initialize the peripherals used in this test.
+ */
+static void init_peripherals(void) {
+  dif_otp_ctrl_config_t config = {
+      .check_timeout = 100000,
+      .integrity_period_mask = 0x3ffff,
+      .consistency_period_mask = 0x3ffffff,
+  };
+  // Life cycle
+  CHECK_DIF_OK(dif_lc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc));
+  // OTP
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_configure(&otp, config));
+  // Rstmgr
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  // KMAC (init for Keymgr use)
+  CHECK_DIF_OK(
+      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  kmac_testutils_config(&kmac, true);
+  // Keymgr
+  CHECK_DIF_OK(dif_keymgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_KEYMGR_BASE_ADDR), &keymgr));
+  // Flash
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash, mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+}
+
+/**
+ * Attempt to write the buffer to the specified address within the SECRET2
+ * partition. If exp_result is set to kExpectFailed, the test expects the
+ * access to fail with a DAI access error. If exp_result is set to
+ * kExpectPassed, the test expects the test to pass without errors.
+ */
+static void otp_write_test(int32_t address, const uint8_t *buffer,
+                           uint32_t size, exp_test_result_t exp_result) {
+  otp_ctrl_testutils_wait_for_dai(&otp);
+  for (int i = address; i < address + size; i += sizeof(uint64_t)) {
+    uint64_t word;
+    memcpy(&word, &buffer[i], sizeof(word));
+    CHECK_DIF_OK(
+        dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret2, i, word));
+    otp_ctrl_testutils_wait_for_dai(&otp);
+    otp_ctrl_testutils_dai_access_error_check(&otp, exp_result, address);
+  }
+}
+
+/**
+ * Attempt to read the OTP contents at the specified address within the SECRET2
+ * partition, and compares the read data to the data in the buffer. If
+ * exp_result is set to kExpectFailed, the test expects the access to fail
+ * with a DAI access error, and it also expects the read data to NOT match with
+ * the data in the buffer. If exp_result is set to kExpectPassed, the test
+ * expects the test to pass without errors and the read data to match with the
+ * data in the buffer.
+ */
+static void otp_read_test(int32_t address, const uint8_t *buffer, uint32_t size,
+                          exp_test_result_t exp_result) {
+  otp_ctrl_testutils_wait_for_dai(&otp);
+  for (int i = address; i < address + size; i += sizeof(uint64_t)) {
+    uint64_t got, exp;
+    CHECK_DIF_OK(
+        dif_otp_ctrl_dai_read_start(&otp, kDifOtpCtrlPartitionSecret2, i));
+    otp_ctrl_testutils_wait_for_dai(&otp);
+    otp_ctrl_testutils_dai_access_error_check(&otp, exp_result, address);
+
+    // Check whether the read data matches.
+    memcpy(&exp, &buffer[i], sizeof(exp));
+    CHECK_DIF_OK(dif_otp_ctrl_dai_read64_end(&otp, &got));
+    if (exp_result == kExpectFailed) {
+      CHECK(got != exp,
+            "0x%x == 0x%x (got == exp) is not expected at address 0x%x", got,
+            exp, address);
+    } else {
+      CHECK(got == exp,
+            "0x%x != 0x%x (got != exp) is not expected at address 0x%x", got,
+            exp, address);
+    }
+  }
+}
+
+/**
+ * Test wrapper function that first calls the write and then the read test.
+ */
+static void otp_write_read_test(test_mode_t test_mode, int32_t address,
+                                const uint8_t *buffer, uint32_t size,
+                                exp_test_result_t exp_result) {
+  if (test_mode == kWriteMode || test_mode == kWriteReadMode) {
+    LOG_INFO("Write test at 0x%x...", address);
+    otp_write_test(address, buffer, size, exp_result);
+  }
+  if (test_mode == kReadMode || test_mode == kWriteReadMode) {
+    LOG_INFO("Read test at 0x%x...", address);
+    otp_read_test(address, buffer, size, exp_result);
+  }
+}
+
+/**
+ * Test wrapper function that calls the write and read tests above for all
+ * objects within the SECRET2 partition.
+ */
+static void run_otp_access_tests(test_mode_t test_mode,
+                                 exp_test_result_t exp_result) {
+  otp_write_read_test(
+      test_mode,
+      OTP_CTRL_PARAM_RMA_TOKEN_OFFSET - OTP_CTRL_PARAM_SECRET2_OFFSET,
+      (uint8_t *)kOtpRmaToken, OTP_CTRL_PARAM_RMA_TOKEN_SIZE, exp_result);
+  otp_write_read_test(test_mode,
+                      OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE0_OFFSET -
+                          OTP_CTRL_PARAM_SECRET2_OFFSET,
+                      (uint8_t *)kOtpRootKeyShare0,
+                      OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE0_SIZE, exp_result);
+  otp_write_read_test(test_mode,
+                      OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE1_OFFSET -
+                          OTP_CTRL_PARAM_SECRET2_OFFSET,
+                      (uint8_t *)kOtpRootKeyShare1,
+                      OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE1_SIZE, exp_result);
+}
+
+/**
+ * Initialize and advance to kDifKeymgrStateCreatorRootKey state.
+ */
+static void keymgr_advance_to_creator_root_key(void) {
+  // Check the last word of the retention SRAM creator area to determine the
+  // type of the ROM.
+  bool is_using_test_rom =
+      retention_sram_get()
+          ->reserved_creator[ARRAYSIZE((retention_sram_t){0}.reserved_creator) -
+                             1] == TEST_ROM_IDENTIFIER;
+  keymgr_testutils_check_state(&keymgr, kDifKeymgrStateReset);
+  keymgr_testutils_advance_state(&keymgr, NULL);
+  keymgr_testutils_check_state(&keymgr, kDifKeymgrStateInitialized);
+  // Advance to kDifKeymgrStateCreatorRootKey state.
+  if (is_using_test_rom) {
+    LOG_INFO("Using test_rom, setting inputs and advancing state...");
+    CHECK_DIF_OK(dif_keymgr_advance_state(&keymgr, &kCreatorParams));
+  } else {
+    LOG_INFO("Using rom, only advancing state...");
+    CHECK_DIF_OK(dif_keymgr_advance_state_raw(&keymgr));
+  }
+}
+
+/**
+ * Checks that the first advance command does not complete.
+ */
+static void keymgr_check_cannot_advance(void) {
+  LOG_INFO("Check that the Keymgr cannot advance...");
+  keymgr_testutils_check_state(&keymgr, kDifKeymgrStateReset);
+  // Try to initialize the key manager. We expect this call to fail with
+  // a "kDifLocked" code, since the key manager is not enabled.
+  CHECK(kDifLocked == dif_keymgr_advance_state(&keymgr, NULL),
+        "Keymgr is not expected to be available in this LC state.");
+}
+
+/**
+ * Check that the key manager flags the KMAC inputs as invalid. This happens
+ * when the root keys are not valid and hence tied to all-zero inside the key
+ * manager.
+ */
+static void keymgr_check_root_key_is_invalid(void) {
+  dif_keymgr_status_codes_t status;
+  keymgr_advance_to_creator_root_key();
+  LOG_INFO("Check that the Keymgr root key is invalid...");
+  do {
+    CHECK_DIF_OK(dif_keymgr_get_status_codes(&keymgr, &status));
+  } while (status == 0);
+  CHECK(status ==
+            (kDifKeymgrStatusCodeIdle | kDifKeymgrStatusCodeInvalidKmacInput),
+        "Unexpected status: %x", status);
+}
+
+/**
+ * Generate a SW key and store it within the retention SRAM.
+ */
+static void keymgr_check_can_generate_key(void) {
+  keymgr_advance_to_creator_root_key();
+  LOG_INFO("Check that the Keymgr can generate a key...");
+  keymgr_testutils_wait_for_operation_done(&keymgr);
+  keymgr_testutils_check_state(&keymgr, kDifKeymgrStateCreatorRootKey);
+  keymgr_testutils_generate_versioned_key(&keymgr, kKeyVersionedParams);
+}
+
+/**
+ * Resets the chip.
+ */
+static void reset_chip(void) {
+  CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+  busy_spin_micros(100);
+  CHECK(false, "Should have reset before this line");
+}
+
+/**
+ * This tests the impact of the lc_creator_seed_sw_rw_en and lc_seed_hw_rd_en
+ * life cycle access control signals on the SECRET2 partition. Since it uses
+ * the key manager to perform some of the testing, this test also checks the
+ * impact of lc_keymgr_en on the key manager.
+ *
+ * The SECRETT2 partition should only be readable/writable by SW in
+ * PROD/RMA/DEV. Once it is locked, the partition is not accessible by SW
+ * anymore, but becomes accessible to HW (key manager).
+ *
+ * The test can be run in different life cycle states and figure out what to
+ * check based on the state exposed in the life cycle controller.
+ *
+ * PROD/DEV/RMA:
+ * 1)  Provision non-constant creator/owner secrets to flash
+ * 2)  Program SECRET2 partition and read it back
+ * 3)  Check that the key manager advance errors out due to all-zero root key
+ * 4)  Reset the chip
+ * 5)  Check that the SECRET2 partition can still be read
+ * 6)  Check that the key manager advance errors out due to all-zero root key
+ * 7)  Lock the SECRET2 partition
+ * 8)  Reset the chip
+ * 9)  Check that the SECRET2 partition is not accessible anymore
+ * 10) Check that the key manager can generate a SW key without errors
+ *
+ * All other life cycle states:
+ * 1) Check that key manager cannot be initialized because it is disabled
+ * 2) Check the SECRET2 partition is not accessible
+ *
+ */
+bool test_main(void) {
+  bool is_computed;
+  dif_lc_ctrl_state_t state;
+  dif_rstmgr_reset_info_bitfield_t rst_info;
+  init_peripherals();
+
+  rst_info = rstmgr_testutils_reason_get();
+  rstmgr_testutils_reason_clear();
+
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc, &state));
+  lc_ctrl_testutils_lc_state_log_or_die(&state);
+
+  switch (state) {
+    case kDifLcCtrlStateDev:
+    case kDifLcCtrlStateProd:
+    case kDifLcCtrlStateProdEnd:
+    case kDifLcCtrlStateRma:
+      if (rst_info & kDifRstmgrResetInfoPor) {
+        LOG_INFO("First access test iteration...");
+        // Make sure the secrets in flash are non-zero.
+        keymgr_testutils_flash_init(&flash, &kCreatorSecret, &kOwnerSecret);
+        // Program the SECRET2 partition and perform read back test.
+        run_otp_access_tests(kWriteReadMode, kExpectPassed);
+        // We expect the root key to be invalid at this point.
+        keymgr_check_root_key_is_invalid();
+        reset_chip();
+
+      } else if (rst_info == kDifRstmgrResetInfoSw) {
+        CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(
+            &otp, kDifOtpCtrlPartitionSecret2, &is_computed));
+
+        if (!is_computed) {
+          LOG_INFO("Second access test iteration...");
+          // SECRET2 partition should still be readable.
+          run_otp_access_tests(kReadMode, kExpectPassed);
+          // We expect the root key to still be invalid at this point, since
+          // SECRET2 has not been locked yet.
+          keymgr_check_root_key_is_invalid();
+          // Lock the SECRET2 partition.
+          otp_ctrl_testutils_lock_partition(&otp, kDifOtpCtrlPartitionSecret2,
+                                            0);
+          reset_chip();
+        } else {
+          LOG_INFO("Third access test iteration...");
+          // All accesses are disallowed.
+          run_otp_access_tests(kWriteReadMode, kExpectFailed);
+          // At this point we expect that the key manager can generate keys
+          // without errors.
+          keymgr_check_can_generate_key();
+          // Test passed.
+          return true;
+        }
+      } else {
+        LOG_ERROR("Unexpected reset info 0x%02X", rst_info);
+      }
+
+      break;
+    default:  // this covers all TEST_UNLOCKED* states.
+      // Accesses to the SECRET2 partition should error out.
+      run_otp_access_tests(kWriteReadMode, kExpectFailed);
+      // Keymgr initialization should not work in this state.
+      keymgr_check_cannot_advance();
+      // Test passed.
+      return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
This addresses both https://github.com/lowRISC/opentitan/issues/15272 and https://github.com/lowRISC/opentitan/issues/14139. It also implicitly addresses the overarching LC signal broadcast test https://github.com/lowRISC/opentitan/issues/14169.

~~Note that this test is not entirely complete yet and there remain two more action items:~~

- [x] ~~Enable the test in TEST_UNLOCKED mode once #15293 has been merged (that PR adds that OTP image)~~
- [x] ~~Add a key manager SW key derivation step to check the effect of `lc_seed_hw_rd_en`~~

Signed-off-by: Michael Schaffner <msf@google.com>