### PR TITLE
[crypto] Adjust P-256 implementations to handle masked values.

### DIFF
--- a/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.c
+++ b/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.c
@@ -17,8 +17,11 @@ OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, r);     // The signature scalar R.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, s);     // The signature scalar S.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x);     // The public key x-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, y);     // The public key y-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, d);     // The private key scalar d.
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x_r);   // Verification result.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa,
+                         d0);  // The private key scalar d (share 0).
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa,
+                         d1);  // The private key scalar d (share 1).
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x_r);  // Verification result.
 
 static const otbn_app_t kOtbnAppEcdsa = OTBN_APP_T_INIT(p256_ecdsa);
 static const otbn_addr_t kOtbnVarEcdsaMode = OTBN_ADDR_T_INIT(p256_ecdsa, mode);
@@ -27,7 +30,8 @@ static const otbn_addr_t kOtbnVarEcdsaR = OTBN_ADDR_T_INIT(p256_ecdsa, r);
 static const otbn_addr_t kOtbnVarEcdsaS = OTBN_ADDR_T_INIT(p256_ecdsa, s);
 static const otbn_addr_t kOtbnVarEcdsaX = OTBN_ADDR_T_INIT(p256_ecdsa, x);
 static const otbn_addr_t kOtbnVarEcdsaY = OTBN_ADDR_T_INIT(p256_ecdsa, y);
-static const otbn_addr_t kOtbnVarEcdsaD = OTBN_ADDR_T_INIT(p256_ecdsa, d);
+static const otbn_addr_t kOtbnVarEcdsaD0 = OTBN_ADDR_T_INIT(p256_ecdsa, d0);
+static const otbn_addr_t kOtbnVarEcdsaD1 = OTBN_ADDR_T_INIT(p256_ecdsa, d1);
 static const otbn_addr_t kOtbnVarEcdsaXr = OTBN_ADDR_T_INIT(p256_ecdsa, x_r);
 
 /* Mode is represented by a single word, 1 for sign and 2 for verify */
@@ -57,9 +61,11 @@ otbn_error_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
   OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(&otbn, kP256ScalarNumWords,
                                               digest->h, kOtbnVarEcdsaMsg));
 
-  // Set the private key.
-  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(&otbn, kP256ScalarNumWords,
-                                              private_key->d, kOtbnVarEcdsaD));
+  // Set the private key shares.
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(
+      &otbn, kP256ScalarNumWords, private_key->d0, kOtbnVarEcdsaD0));
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(
+      &otbn, kP256ScalarNumWords, private_key->d1, kOtbnVarEcdsaD1));
 
   // Start the OTBN routine.
   OTBN_RETURN_IF_ERROR(otbn_execute_app(&otbn));

--- a/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.h
+++ b/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.h
@@ -47,10 +47,13 @@ typedef struct ecdsa_p256_signature_t {
 /**
  * A type that holds an ECDSA/P-256 private key.
  *
- * The private key consists of a single integer d, computed modulo n.
+ * The private key consists of a single integer d, computed modulo n. The key
+ * is represented in two shares, d0 and d1, such that d = (d0 + d1) mod n. The
+ * shares d0 and d1 are also both computed modulo n.
  */
 typedef struct ecdsa_p256_private_key_t {
-  uint32_t d[kP256ScalarNumWords];
+  uint32_t d0[kP256ScalarNumWords];
+  uint32_t d1[kP256ScalarNumWords];
 } ecdsa_p256_private_key_t;
 
 /**

--- a/sw/device/sca/ecc_serial.c
+++ b/sw/device/sca/ecc_serial.c
@@ -73,8 +73,10 @@ OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, r);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, s);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, x);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, y);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, d);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, k);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, d0);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, d1);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, k0);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, k1);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa_sca, x_r);
 
 static const otbn_app_t kOtbnAppP256Ecdsa = OTBN_APP_T_INIT(p256_ecdsa_sca);
@@ -85,9 +87,11 @@ static const otbn_addr_t kOtbnVarR = OTBN_ADDR_T_INIT(p256_ecdsa_sca, r);
 static const otbn_addr_t kOtbnVarS = OTBN_ADDR_T_INIT(p256_ecdsa_sca, s);
 static const otbn_addr_t kOtbnVarX = OTBN_ADDR_T_INIT(p256_ecdsa_sca, x);
 static const otbn_addr_t kOtbnVarY = OTBN_ADDR_T_INIT(p256_ecdsa_sca, y);
-static const otbn_addr_t kOtbnVarD = OTBN_ADDR_T_INIT(p256_ecdsa_sca, d);
+static const otbn_addr_t kOtbnVarD0 = OTBN_ADDR_T_INIT(p256_ecdsa_sca, d0);
+static const otbn_addr_t kOtbnVarD1 = OTBN_ADDR_T_INIT(p256_ecdsa_sca, d1);
 static const otbn_addr_t kOtbnVarXR = OTBN_ADDR_T_INIT(p256_ecdsa_sca, x_r);
-static const otbn_addr_t kOtbnVarK = OTBN_ADDR_T_INIT(p256_ecdsa_sca, k);
+static const otbn_addr_t kOtbnVarK0 = OTBN_ADDR_T_INIT(p256_ecdsa_sca, k0);
+static const otbn_addr_t kOtbnVarK1 = OTBN_ADDR_T_INIT(p256_ecdsa_sca, k1);
 
 /**
  * Simple serial 'd' (set private key) command handler.
@@ -149,10 +153,16 @@ static void p256_ecdsa_sign(otbn_t *otbn_ctx, const uint8_t *msg,
   SS_CHECK(otbn_copy_data_to_otbn(otbn_ctx, /*len_bytes=*/32, msg,
                                   kOtbnVarMsg) == kOtbnOk);
   SS_CHECK(otbn_copy_data_to_otbn(otbn_ctx, /*len_bytes=*/32, private_key_d,
-                                  kOtbnVarD) == kOtbnOk);
-
-  SS_CHECK(otbn_copy_data_to_otbn(otbn_ctx, /*len_bytes=*/32, k, kOtbnVarK) ==
+                                  kOtbnVarD0) == kOtbnOk);
+  SS_CHECK(otbn_copy_data_to_otbn(otbn_ctx, /*len_bytes=*/32, k, kOtbnVarK0) ==
            kOtbnOk);
+
+  // Write all-zero values for second shares of d and k.
+  uint8_t zero[32] = {0};
+  SS_CHECK(otbn_copy_data_to_otbn(otbn_ctx, /*len_bytes=*/32, zero,
+                                  kOtbnVarD1) == kOtbnOk);
+  SS_CHECK(otbn_copy_data_to_otbn(otbn_ctx, /*len_bytes=*/32, zero,
+                                  kOtbnVarK1) == kOtbnOk);
 
   // Call OTBN to perform operation, and wait for it to complete.
   LOG_INFO("Execute");

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -26,10 +26,13 @@ static const ecdsa_p256_public_key_t kPublicKey = {
           0x5954f0a4, 0x155f3e00, 0x874bc63c},
 };
 
-// Private key (d)
+// Private key (d) in two shares
 static const ecdsa_p256_private_key_t kPrivateKey = {
-    .d = {0xaf57b4cd, 0x744c9f1c, 0x8b7e0c02, 0x283e93e9, 0x0d18f00c,
-          0xda0b6cf4, 0x8fe6bb7a, 0x5545a0b7},
+    .d0 = {0xaf57b4cd, 0x744c9f1c, 0x8b7e0c02, 0x283e93e9, 0x0d18f00c,
+           0xda0b6cf4, 0x8fe6bb7a, 0x5545a0b7},
+    // TODO(#15409): add real data here to ensure the second share is
+    // incorporated.
+    .d1 = {0},
 };
 
 hmac_error_t compute_digest(void) {

--- a/sw/device/tests/otbn_ecdsa_op_irq_test.c
+++ b/sw/device/tests/otbn_ecdsa_op_irq_test.c
@@ -42,7 +42,8 @@ OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, r);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, s);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, y);
-OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, d);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, d0);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, d1);
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x_r);
 
 static const otbn_app_t kOtbnAppP256Ecdsa = OTBN_APP_T_INIT(p256_ecdsa);
@@ -53,7 +54,8 @@ static const otbn_addr_t kOtbnVarR = OTBN_ADDR_T_INIT(p256_ecdsa, r);
 static const otbn_addr_t kOtbnVarS = OTBN_ADDR_T_INIT(p256_ecdsa, s);
 static const otbn_addr_t kOtbnVarX = OTBN_ADDR_T_INIT(p256_ecdsa, x);
 static const otbn_addr_t kOtbnVarY = OTBN_ADDR_T_INIT(p256_ecdsa, y);
-static const otbn_addr_t kOtbnVarD = OTBN_ADDR_T_INIT(p256_ecdsa, d);
+static const otbn_addr_t kOtbnVarD0 = OTBN_ADDR_T_INIT(p256_ecdsa, d0);
+static const otbn_addr_t kOtbnVarD1 = OTBN_ADDR_T_INIT(p256_ecdsa, d1);
 static const otbn_addr_t kOtbnVarXR = OTBN_ADDR_T_INIT(p256_ecdsa, x_r);
 
 OTTF_DEFINE_TEST_CONFIG();
@@ -251,7 +253,12 @@ static void p256_ecdsa_sign(otbn_t *otbn_ctx, const uint8_t *msg,
   CHECK(otbn_copy_data_to_otbn(otbn_ctx, /*len_bytes=*/32, msg, kOtbnVarMsg) ==
         kOtbnOk);
   CHECK(otbn_copy_data_to_otbn(otbn_ctx, /*len_bytes=*/32, private_key_d,
-                               kOtbnVarD) == kOtbnOk);
+                               kOtbnVarD0) == kOtbnOk);
+
+  // Write second share of d (all-zero for this test).
+  uint8_t d1[32] = {0};
+  CHECK(otbn_copy_data_to_otbn(otbn_ctx, /*len_bytes=*/32, d1, kOtbnVarD1) ==
+        kOtbnOk);
 
   // Call OTBN to perform operation, and wait for it to complete.
   CHECK(otbn_execute(otbn_ctx) == kOtbnOk);

--- a/sw/otbn/crypto/p256_base_mult_test.s
+++ b/sw/otbn/crypto/p256_base_mult_test.s
@@ -32,9 +32,9 @@ p256_base_mult_test:
 .data
 
 /* scalar d */
-.globl d
+.globl d0
 .balign 32
-d:
+d0:
   .word 0xc7df1a56
   .word 0xfbd94efe
   .word 0xaa847f52
@@ -43,19 +43,10 @@ d:
   .word 0xe5f2cbee
   .word 0x9144233d
   .word 0xc0fbe256
-
-/* blinding parameter rnd */
-.globl rnd
+.globl d1
 .balign 32
-rnd:
-  .word 0x7ab203c3
-  .word 0xd6ee4951
-  .word 0xd5b89b43
-  .word 0x409d2b56
-  .word 0x8e9d2186
-  .word 0x1de0f8ec
-  .word 0x0fa0bf9a
-  .word 0xa21c2147
+d1:
+  .zero 32
 
 /* result buffer x-coordinate */
 .globl x

--- a/sw/otbn/crypto/p256_ecdsa.s
+++ b/sw/otbn/crypto/p256_ecdsa.s
@@ -38,14 +38,14 @@ p256_ecdsa_verify:
  * Populate the variables rnd and k with randomness, and setup data pointers.
  */
 p256_ecdsa_setup_rand:
-  /* Obtain the blinding constant from URND, and write it to `rnd` in DMEM. */
-  bn.wsrr   w0, 0x2 /* URND */
-  la        x10, rnd
-  bn.sid    x0, 0(x10)
-
   /* Obtain the nonce (k) from RND. */
   bn.wsrr   w0, 0x1 /* RND */
-  la        x10, k
+  la        x10, k0
+  bn.sid    x0, 0(x10)
+
+  /* Write all-zero to the second share of k. */
+  bn.xor    w0, w0, w0
+  la        x10, k1
   bn.sid    x0, 0(x10)
 
   ret
@@ -88,10 +88,14 @@ x:
 y:
   .zero 32
 
-/* Private key (d). */
-.globl d
+/* Private key (d) in two shares: d = (d0 + d1) mod n. */
+.globl d0
 .balign 32
-d:
+d0:
+  .zero 32
+.globl d1
+.balign 32
+d1:
   .zero 32
 
 /* Verification result x_r (aka x_1). */
@@ -102,14 +106,13 @@ x_r:
 
 .section .scratchpad
 
-/* Secret scalar k. */
-.globl k
+/* Secret scalar (k) in two shares: k = (k0 + k1) mod n */
+.globl k0
 .balign 32
-k:
+k0:
   .zero 32
 
-/* Random number for blinding. */
-.globl rnd
+.globl k1
 .balign 32
-rnd:
+k1:
   .zero 32

--- a/sw/otbn/crypto/p256_ecdsa_sca.s
+++ b/sw/otbn/crypto/p256_ecdsa_sca.s
@@ -45,16 +45,14 @@ mode:
 
 /* All constants below must be 256b-aligned. */
 
-/* random scalar k */
-.global k
+/* random scalar k (in two shares) */
+.global k0
 .balign 32
-k:
+k0:
   .zero 32
-
-/* randomness for blinding */
+.global k1
 .balign 32
-.global rnd
-rnd:
+k1:
   .zero 32
 
 /* message digest */
@@ -87,10 +85,14 @@ x:
 y:
   .zero 32
 
-/* private key d */
-.globl d
+/* private key d (in two shares) */
+.globl d0
 .balign 32
-d:
+d0:
+  .zero 32
+.globl d1
+.balign 32
+d1:
   .zero 32
 
 /* verification result x_r (aka x_1) */

--- a/sw/otbn/crypto/p256_ecdsa_sign_test.s
+++ b/sw/otbn/crypto/p256_ecdsa_sign_test.s
@@ -36,9 +36,9 @@ ecdsa_sign_test:
 .data
 
 /* nonce k */
-.globl k
+.globl k0
 .balign 32
-k:
+k0:
   .word 0xfe6d1071
   .word 0x21d0a016
   .word 0xb0b2c781
@@ -48,18 +48,11 @@ k:
   .word 0x74210263
   .word 0x1420fc41
 
-/* random number for blinding */
-.globl rnd
+/* second share of k (all-zero)*/
+.globl k1
 .balign 32
-rnd:
-  .word 0x7ab203c3
-  .word 0xd6ee4951
-  .word 0xd5b89b43
-  .word 0x409d2b56
-  .word 0x8e9d2186
-  .word 0x1de0f8ec
-  .word 0x0fa0bf9a
-  .word 0xa21c2147
+k1:
+  .zero 32
 
 /* message digest */
 .globl msg
@@ -75,9 +68,9 @@ msg:
   .word 0x06d71207
 
 /* private key d */
-.globl d
+.globl d0
 .balign 32
-d:
+d0:
   .word 0xc7df1a56
   .word 0xfbd94efe
   .word 0xaa847f52
@@ -86,6 +79,12 @@ d:
   .word 0xe5f2cbee
   .word 0x9144233d
   .word 0xc0fbe256
+
+/* second share of d (all-zero) */
+.globl d1
+.balign 32
+d1:
+  .zero 32
 
 /* signature R */
 .globl r

--- a/sw/otbn/crypto/p256_scalar_mult_test.s
+++ b/sw/otbn/crypto/p256_scalar_mult_test.s
@@ -33,9 +33,9 @@ scalar_mult_test:
 .data
 
 /* scalar k */
-.globl d
+.globl k0
 .balign 32
-d:
+k0:
   .word 0xfe6d1071
   .word 0x21d0a016
   .word 0xb0b2c781
@@ -44,19 +44,10 @@ d:
   .word 0x1b76ebe8
   .word 0x74210263
   .word 0x1420fc41
-
-/* random number for blinding */
-.globl rnd
+.globl k1
 .balign 32
-rnd:
-  .word 0x7ab203c3
-  .word 0xd6ee4951
-  .word 0xd5b89b43
-  .word 0x409d2b56
-  .word 0x8e9d2186
-  .word 0x1de0f8ec
-  .word 0x0fa0bf9a
-  .word 0xa21c2147
+k1:
+  .zero 32
 
 /* example curve point x-coordinate */
 .globl x


### PR DESCRIPTION
Previously, the P-256 implementation on OTBN sometimes handled secret values directly, only masking them within scalar multiplication. Now both the secret scalar k and the private key d are always handled in two shares.

To minimize the size of the change, some tests and the `p256_ecdsa.s` entrypoint still only populate one share; this will be addressed in follow-up PRs.