### PR TITLE
feat(chip): Entering/Exiting sleeps

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_retention_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_retention_vseq.sv
@@ -28,16 +28,25 @@ class chip_sw_sleep_pin_retention_vseq extends chip_sw_base_vseq;
 
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
 
-    for (int unsigned round = 0 ; round < rounds ; round++) begin
+    // Drive GPIO8 (IoA8) to 0
+    cfg.chip_vif.ios_if.drive_pin(IoA8, 1'b 0);
+
+    for (int round = rounds - 1 ; round >= 0 ; round--) begin
         // TODO: Receive values from SW via sw_logger_vif
+        `DV_WAIT(cfg.sw_logger_vif.printed_log == $sformatf("Current Test Round: %1d", round))
 
         // TODO: Check PIN
 
         // TODO: Wait sleep (normal vs deep)
+        wait(cfg.chip_vif.pwrmgr_low_power_if.in_sleep == 1'b 1);
+        repeat (5) @(cfg.chip_vif.pwrmgr_low_power_if.cb);
 
         // TODO: Check PIN value
 
         // TODO: Wake up DUT
+        cfg.chip_vif.ios_if.drive_pin(IoA8, 1'b 1);
+        repeat (3) @(cfg.chip_vif.pwrmgr_low_power_if.cb);
+        cfg.chip_vif.ios_if.drive_pin(IoA8, 1'b 0);
     end
 
   endtask : body

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -661,9 +661,13 @@ opentitan_functest(
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )


### PR DESCRIPTION
This commit implements the test entering and exiting the normal sleeps. DV ENV drives IOA8 PAD to wake up from sleep state. Test code configures the PINMUX to get the interrupt event and enters to sleep by WFI().