### PR TITLE
[chip dv] Fixes for the chip level GPIO tests

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_if.sv
+++ b/hw/dv/sv/jtag_agent/jtag_if.sv
@@ -6,11 +6,13 @@
 interface jtag_if #(time JtagDefaultTckPeriodNs = 20ns) ();
 
   // interface pins
+  // TODO; make these wires and add `_oe` versions to internally control the driving of these
+  // signals.
   logic tck;
   logic trst_n;
-  wire  tms;
-  wire  tdi;
-  wire  tdo;
+  logic tms;
+  logic tdi;
+  logic tdo;
 
   // generate local tck
   bit   tck_en;
@@ -28,7 +30,7 @@ interface jtag_if #(time JtagDefaultTckPeriodNs = 20ns) ();
   clocking device_cb @(posedge tck);
     input  tms;
     input  tdi;
-    output tdo;
+    // output tdo; TODO: add this back later once device mode is supported.
   endclocking
   modport device_mp(clocking device_cb, input trst_n);
 

--- a/hw/top_earlgrey/dv/env/chip_common_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_common_pkg.sv
@@ -8,7 +8,7 @@ package chip_common_pkg;
   import dv_utils_pkg::uint;
 
   // Chip composition (number of hardware resources).
-  parameter dv_utils_pkg::uint NUM_GPIOS = 16;
+  parameter dv_utils_pkg::uint NUM_GPIOS = 32;
   parameter dv_utils_pkg::uint NUM_UARTS = 4;
   parameter dv_utils_pkg::uint NUM_SPI_HOSTS = 2;
   parameter dv_utils_pkg::uint NUM_I2CS = 3;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -49,7 +49,6 @@ class chip_base_vseq #(
     // TODO: Cannot assert different types of resets in parallel; due to randomization
     // resets de-assert at different times. If the main rst_n de-asserts before others,
     // the CPU starts executing right away which can cause breakages.
-    // TODO; Invoke only if JTAG is used.
     cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.do_trst_n();
     super.apply_reset(kind);
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -31,6 +31,11 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
   endtask : body
 
   virtual task pre_start();
+    // CSR tests write to chip CSRs, which includes the pinmux registers. Random writes to the
+    // pinmux may inadvertently connect the chip IOs to peripherals, causing Xs to propagate, if
+    // the chip MIOs are not initialized. Hence, we weakly pull down ALL MIOs for these tests.
+    cfg.chip_vif.ios_if.pins_pd[IoR13:IoA0] = '1;
+
     super.pre_start();
     // Disable assertions failed due to CSR random write value.
     $assertoff(0,
@@ -45,6 +50,7 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
         "tb.dut.top_earlgrey.u_adc_ctrl_aon.u_adc_ctrl_core.u_adc_ctrl_fsm.LpSampleCntCfg_M");
     $asserton(0,
         "tb.dut.top_earlgrey.u_adc_ctrl_aon.u_adc_ctrl_core.u_adc_ctrl_fsm.NpSampleCntCfg_M");
+    cfg.chip_vif.ios_if.pins_pd[IoR13:IoA0] = '0;
   endtask
 
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -45,12 +45,7 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
   endtask
 
   virtual task dut_init(string reset_kind = "HARD");
-    // make sure jtag rst triggers
-    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
     super.dut_init(reset_kind);
-    if (cfg.jtag_riscv_map == null && cfg.use_jtag_dmi == 0) begin
-      cfg.chip_vif.tap_straps_if.drive(JtagTapNone);
-    end
     // Program the AST with the configuration data loaded in OTP creator SW config region.
     if (cfg.use_jtag_dmi == 0) do_ast_cfg();
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
@@ -43,12 +43,9 @@ class chip_sw_gpio_smoke_vseq extends chip_sw_base_vseq;
     // Wait until we reach the SW test state.
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
 
-    // Disable the default pulldown on GPIOs.
-    cfg.chip_vif.gpio_pins_if.set_pulldown_en({NUM_GPIOS{1'b0}});
-
     `uvm_info(`gfn, "Starting GPIO output test", UVM_LOW)
     for (int i = 0; i < num_gpio_vals; i++) begin
-      `DV_SPINWAIT(wait(cfg.chip_vif.gpio_pins_if.pins === gpio_vals[i][NUM_GPIOS-1:0]);,
+      `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === gpio_vals[i][NUM_GPIOS-1:0]);,
                    $sformatf("Timed out waiting for GPIOs == %0h", gpio_vals[i][NUM_GPIOS-1:0]),
                    TIMEOUT_NS,
                   `gfn)
@@ -57,13 +54,13 @@ class chip_sw_gpio_smoke_vseq extends chip_sw_base_vseq;
     // Test walking 1s and 0s.
     for (int i = 0; i < NUM_GPIOS; i++) begin
       logic [NUM_GPIOS-1:0] exp_gpios = (1 << i);
-      `DV_SPINWAIT(wait(cfg.chip_vif.gpio_pins_if.pins === exp_gpios);,
+      `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === exp_gpios);,
                    $sformatf("Timed out waiting for GPIOs == %0h", exp_gpios),
                    TIMEOUT_NS,
                   `gfn)
 
       exp_gpios = ~exp_gpios;
-      `DV_SPINWAIT(wait(cfg.chip_vif.gpio_pins_if.pins === exp_gpios);,
+      `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === exp_gpios);,
                    $sformatf("Timed out waiting for GPIOs == %0h", exp_gpios),
                    TIMEOUT_NS,
                   `gfn)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_vseq.sv
@@ -16,10 +16,6 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
     // Wait until we reach the SW test state.
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
 
-    // Disable pullups and pulldowns on GPIOs.
-    cfg.chip_vif.gpio_pins_if.set_pulldown_en({NUM_GPIOS{1'b0}});
-    cfg.chip_vif.gpio_pins_if.set_pullup_en({NUM_GPIOS{1'b0}});
-
     // Run the GPIO output tests.
     gpio_output_test();
 
@@ -29,27 +25,27 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
 
   virtual task gpio_output_test();
     // Disable GPIOs from being driven as chip inputs.
-    cfg.chip_vif.gpio_pins_if.drive_en({NUM_GPIOS{1'b0}});
+    cfg.chip_vif.gpios_if.drive_en({NUM_GPIOS{1'b0}});
 
     `uvm_info(`gfn, "Starting GPIO output test", UVM_LOW)
 
     // Check for W1 pattern on the GPIO output pins.
     for (int i = 0; i < NUM_GPIOS; i++) begin
       logic [NUM_GPIOS-1:0] exp_gpios = 1 << i;
-      `DV_SPINWAIT(wait(cfg.chip_vif.gpio_pins_if.pins === exp_gpios);,
+      `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === exp_gpios);,
                    $sformatf("Timed out waiting for GPIOs == %0h", exp_gpios),
                    timeout_ns,
                   `gfn)
     end
 
     // Wait and check all 0s.
-    `DV_SPINWAIT(wait(cfg.chip_vif.gpio_pins_if.pins === ~gpios_mask);,
+    `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === ~gpios_mask);,
                  $sformatf("Timed out waiting for GPIOs == %0h", ~gpios_mask),
                  timeout_ns,
                 `gfn)
 
     // Wait and check all 1s.
-    `DV_SPINWAIT(wait(cfg.chip_vif.gpio_pins_if.pins === gpios_mask);,
+    `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === gpios_mask);,
                  $sformatf("Timed out waiting for GPIOs == %0h", gpios_mask),
                  timeout_ns,
                 `gfn)
@@ -57,20 +53,20 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
     // Check for W0 pattern on the GPIO output pins.
     for (int i = 0; i < NUM_GPIOS; i++) begin
       logic [NUM_GPIOS-1:0] exp_gpios = ~(1 << i);
-      `DV_SPINWAIT(wait(cfg.chip_vif.gpio_pins_if.pins === gpios_mask);,
+      `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === gpios_mask);,
                    $sformatf("Timed out waiting for GPIOs == %0h", exp_gpios),
                    timeout_ns,
                   `gfn)
     end
 
     // Wait and check all 1s.
-    `DV_SPINWAIT(wait(cfg.chip_vif.gpio_pins_if.pins === gpios_mask);,
+    `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === gpios_mask);,
                  $sformatf("Timed out waiting for GPIOs == %0h", gpios_mask),
                  timeout_ns,
                 `gfn)
 
     // Wait and check all 0s.
-    `DV_SPINWAIT(wait(cfg.chip_vif.gpio_pins_if.pins === ~gpios_mask);,
+    `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === ~gpios_mask);,
                  $sformatf("Timed out waiting for GPIOs == %0h", ~gpios_mask),
                  timeout_ns,
                 `gfn)
@@ -78,14 +74,14 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
 
   virtual task gpio_input_test();
     // Wait and check all zs - this indicates it is safe to drive GPIOs as inputs.
-    `DV_SPINWAIT(wait(cfg.chip_vif.gpio_pins_if.pins === {NUM_GPIOS{1'bz}});,
+    `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === {NUM_GPIOS{1'bz}});,
                  $sformatf("Timed out waiting for GPIOs == %0h", {NUM_GPIOS{1'bz}}),
                  timeout_ns,
                 `gfn)
 
     // Enable GPIO in input mode.
-    cfg.chip_vif.gpio_pins_if.drive_en(gpios_mask);
-    cfg.chip_vif.gpio_pins_if.drive(~gpios_mask);
+    cfg.chip_vif.gpios_if.drive_en(gpios_mask);
+    cfg.chip_vif.gpios_if.drive(~gpios_mask);
 
     `uvm_info(`gfn, "Starting GPIO input test", UVM_LOW)
 
@@ -96,13 +92,13 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
     // Drive T1 pattern.
     for (int i = 0; i < NUM_GPIOS; i++) begin
       cfg.chip_vif.cpu_clk_rst_if.wait_clks($urandom_range(1000, 2000));
-      cfg.chip_vif.gpio_pins_if.drive_pin(i, 1'b1);
+      cfg.chip_vif.gpios_if.drive_pin(i, 1'b1);
     end
 
     // Drive T0 pattern.
     for (int i = 0; i < NUM_GPIOS; i++) begin
       cfg.chip_vif.cpu_clk_rst_if.wait_clks($urandom_range(1000, 2000));
-      cfg.chip_vif.gpio_pins_if.drive_pin(i, 1'b0);
+      cfg.chip_vif.gpios_if.drive_pin(i, 1'b0);
     end
 
   endtask

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -228,7 +228,9 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
         "//sw/device/lib/dif:base",
+        "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/lib/testing/pinmux_testutils.c
+++ b/sw/device/lib/testing/pinmux_testutils.c
@@ -4,8 +4,10 @@
 
 #include "sw/device/lib/testing/pinmux_testutils.h"
 
+#include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/dif/dif_pinmux.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/testing/test_framework/check.h"
@@ -55,4 +57,59 @@ void pinmux_testutils_init(dif_pinmux_t *pinmux) {
   // Configure USBDEV SENSE outputs to be high-Z (IOC7)
   CHECK_DIF_OK(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoc7,
                                         kTopEarlgreyPinmuxOutselConstantHighZ));
+}
+
+// Mapping of Chip IOs to the GPIO peripheral.
+//
+// Depending on the simulation platform, there may be a limitation to how chip
+// IOs are allocated to the GPIO peripheral, even for testing. The DV testbench
+// does not have this limitation, and is able to allocate as many chip IOs as
+// the number of GPIOs supported by the peripheral. At this time, these pin
+// assignments matches DV (see `hw/top_earlgrey/dv/env/chip_if.sv`).
+//
+// The pinout spreadsheet allocates fewer pins to GPIOs than what the GPIO IP
+// supports. This oversubscription is intentional to maximize testing.
+const dif_pinmux_index_t kPinmuxTestutilsGpioInselPins[kDifGpioNumPins] = {
+    kTopEarlgreyPinmuxInselIoa0,  kTopEarlgreyPinmuxInselIoa1,
+    kTopEarlgreyPinmuxInselIoa2,  kTopEarlgreyPinmuxInselIoa3,
+    kTopEarlgreyPinmuxInselIoa4,  kTopEarlgreyPinmuxInselIoa5,
+    kTopEarlgreyPinmuxInselIoa6,  kTopEarlgreyPinmuxInselIoa7,
+    kTopEarlgreyPinmuxInselIoa8,  kTopEarlgreyPinmuxInselIob6,
+    kTopEarlgreyPinmuxInselIob7,  kTopEarlgreyPinmuxInselIob8,
+    kTopEarlgreyPinmuxInselIob9,  kTopEarlgreyPinmuxInselIob10,
+    kTopEarlgreyPinmuxInselIob11, kTopEarlgreyPinmuxInselIob12,
+    kTopEarlgreyPinmuxInselIoc9,  kTopEarlgreyPinmuxInselIoc10,
+    kTopEarlgreyPinmuxInselIoc11, kTopEarlgreyPinmuxInselIoc12,
+    kTopEarlgreyPinmuxInselIor0,  kTopEarlgreyPinmuxInselIor1,
+    kTopEarlgreyPinmuxInselIor2,  kTopEarlgreyPinmuxInselIor3,
+    kTopEarlgreyPinmuxInselIor4,  kTopEarlgreyPinmuxInselIor5,
+    kTopEarlgreyPinmuxInselIor6,  kTopEarlgreyPinmuxInselIor7,
+    kTopEarlgreyPinmuxInselIor10, kTopEarlgreyPinmuxInselIor11,
+    kTopEarlgreyPinmuxInselIor12, kTopEarlgreyPinmuxInselIor13};
+
+const dif_pinmux_index_t kPinmuxTestutilsGpioMioOutPins[kDifGpioNumPins] = {
+    kTopEarlgreyPinmuxMioOutIoa0,  kTopEarlgreyPinmuxMioOutIoa1,
+    kTopEarlgreyPinmuxMioOutIoa2,  kTopEarlgreyPinmuxMioOutIoa3,
+    kTopEarlgreyPinmuxMioOutIoa4,  kTopEarlgreyPinmuxMioOutIoa5,
+    kTopEarlgreyPinmuxMioOutIoa6,  kTopEarlgreyPinmuxMioOutIoa7,
+    kTopEarlgreyPinmuxMioOutIoa8,  kTopEarlgreyPinmuxMioOutIob6,
+    kTopEarlgreyPinmuxMioOutIob7,  kTopEarlgreyPinmuxMioOutIob8,
+    kTopEarlgreyPinmuxMioOutIob9,  kTopEarlgreyPinmuxMioOutIob10,
+    kTopEarlgreyPinmuxMioOutIob11, kTopEarlgreyPinmuxMioOutIob12,
+    kTopEarlgreyPinmuxMioOutIoc9,  kTopEarlgreyPinmuxMioOutIoc10,
+    kTopEarlgreyPinmuxMioOutIoc11, kTopEarlgreyPinmuxMioOutIoc12,
+    kTopEarlgreyPinmuxMioOutIor0,  kTopEarlgreyPinmuxMioOutIor1,
+    kTopEarlgreyPinmuxMioOutIor2,  kTopEarlgreyPinmuxMioOutIor3,
+    kTopEarlgreyPinmuxMioOutIor4,  kTopEarlgreyPinmuxMioOutIor5,
+    kTopEarlgreyPinmuxMioOutIor6,  kTopEarlgreyPinmuxMioOutIor7,
+    kTopEarlgreyPinmuxMioOutIor10, kTopEarlgreyPinmuxMioOutIor11,
+    kTopEarlgreyPinmuxMioOutIor12, kTopEarlgreyPinmuxMioOutIor13};
+
+uint32_t pinmux_testutils_get_testable_gpios_mask(void) {
+  if (kDeviceType == kDeviceFpgaCw310) {
+    // Only IOA2 to IOA8 are available for use as GPIOs.
+    return 0x1fc;
+  } else {
+    return 0xffffffff;
+  }
 }

--- a/sw/device/lib/testing/pinmux_testutils.h
+++ b/sw/device/lib/testing/pinmux_testutils.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/dif/dif_pinmux.h"
 
 /**
@@ -21,5 +22,19 @@
  * This function is specific to top_earlgrey and top_englishbreakfast.
  */
 void pinmux_testutils_init(dif_pinmux_t *pinmux);
+
+/**
+ * Maps the chip IOs to the GPIO peripheral in input and output directions.
+ */
+extern const dif_pinmux_index_t kPinmuxTestutilsGpioInselPins[kDifGpioNumPins];
+extern const dif_pinmux_index_t kPinmuxTestutilsGpioMioOutPins[kDifGpioNumPins];
+
+/**
+ * Returns the mask of testable GPIO pins.
+ *
+ * Returns a simulation-device-specific mask that enables testing of only a
+ * subset of GPIOs depending on the IO allocation limitations.
+ */
+uint32_t pinmux_testutils_get_testable_gpios_mask(void);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_PINMUX_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -813,6 +813,7 @@ opentitan_functest(
     deps = [
         "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/gpio_smoketest.c
+++ b/sw/device/tests/gpio_smoketest.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/dif/dif_pinmux.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -28,14 +29,6 @@ static const uint32_t kGpioVals[] = {0xAAAAAAAA, 0x55555555, 0xA5A5A5A5,
                                      0xFFFFFFFF, 0};
 
 /**
- * Pins to be tested.
- *
- * This test only uses pins 2-9 to be compatible with both FPGA and DV.
- * See chip-level testbenches and top-level hjson file for actual configuration.
- */
-static const uint32_t kGpioMask = 0x000001fc;
-
-/**
  * Writes the given value to GPIO pins and compares it against the value read.
  *
  * Masks the bits that correspond to the pins that we cannot test.
@@ -43,15 +36,16 @@ static const uint32_t kGpioMask = 0x000001fc;
  * See also: `kGpioMask`.
  *
  * @param write_val Value to write.
+ * @param compare_mask The GPIOs compared.
  */
-static void test_gpio_write(uint32_t write_val) {
+static void test_gpio_write(uint32_t write_val, uint32_t compare_mask) {
   CHECK_DIF_OK(dif_gpio_write_all(&gpio, write_val));
 
   uint32_t read_val = 0;
   CHECK_DIF_OK(dif_gpio_read_all(&gpio, &read_val));
 
-  uint32_t expected = write_val & kGpioMask;
-  uint32_t actual = read_val & kGpioMask;
+  uint32_t expected = write_val & compare_mask;
+  uint32_t actual = read_val & compare_mask;
   CHECK(expected == actual, "%X != %X", expected, actual);
 }
 
@@ -62,32 +56,33 @@ static void test_gpio_write(uint32_t write_val) {
  * NOTE: This test can currently run only on FPGA and DV.
  */
 bool test_main(void) {
+  uint32_t gpio_mask = pinmux_testutils_get_testable_gpios_mask();
   CHECK_DIF_OK(dif_pinmux_init(
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
   // Assign GPIOs in the pinmux
-  for (size_t i = 0; i < 32; ++i) {
-    if (kGpioMask & (1u << i)) {
-      dif_pinmux_index_t mio = kTopEarlgreyPinmuxMioOutIoa0 + i;
+  for (size_t i = 0; i < kDifGpioNumPins; ++i) {
+    if (gpio_mask & (1u << i)) {
+      dif_pinmux_index_t mio = kPinmuxTestutilsGpioMioOutPins[i];
       dif_pinmux_index_t gpio_out = kTopEarlgreyPinmuxOutselGpioGpio0 + i;
       CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, mio, gpio_out));
-      mio = kTopEarlgreyPinmuxInselIoa0 + i;
+      mio = kPinmuxTestutilsGpioInselPins[i];
       dif_pinmux_index_t gpio_in = kTopEarlgreyPinmuxPeripheralInGpioGpio0 + i;
       CHECK_DIF_OK(dif_pinmux_input_select(&pinmux, gpio_in, mio));
     }
   }
   CHECK_DIF_OK(
       dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
-  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, kGpioMask));
+  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, gpio_mask));
 
   for (uint8_t i = 0; i < ARRAYSIZE(kGpioVals); ++i) {
-    test_gpio_write(kGpioVals[i]);
+    test_gpio_write(kGpioVals[i], gpio_mask);
   }
 
   // Walking 1s and 0s. Iterates over every integer with one bit set and every
   // integer with all but one bit set.
   for (uint32_t i = 1; i > 0; i <<= 1) {
-    test_gpio_write(i);
-    test_gpio_write(~i);
+    test_gpio_write(i, gpio_mask);
+    test_gpio_write(~i, gpio_mask);
   }
 
   return true;

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -161,6 +161,7 @@ opentitan_functest(
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )


### PR DESCRIPTION
The first commit adds logic in pinmux testutils to select 32 chip IOs for the GPIO functionality. The tests can mask some of these IOs from being tested for the GPIO functionality if needed. 

The second commit fixes the GPIO SW tests using these pinmux testutil changes.

The third commit fixes the SV side. 