### PR TITLE
[dv/chip] Remove uart agent coverage in chip level

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -135,6 +135,8 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     // create uart agent config obj
     foreach (m_uart_agent_cfgs[i]) begin
       m_uart_agent_cfgs[i] = uart_agent_cfg::type_id::create($sformatf("m_uart_agent_cfg%0d", i));
+      // Do not create uart agent fcov in chip level test.
+      m_uart_agent_cfgs[i].en_cov = 0;
     end
 
     // create spi device agent config obj


### PR DESCRIPTION
Branch from PR #15325, this PR skips creating the uart agent functional coverage for chip level testing.
Thanks @sriyerg  and @weicaiyang  for the suggetions!

Signed-off-by: Cindy Chen <chencindy@opentitan.org>