### PR TITLE
[dv/kmac] Move to V2S

### DIFF
--- a/hw/ip/kmac/data/kmac.prj.hjson
+++ b/hw/ip/kmac/data/kmac.prj.hjson
@@ -13,9 +13,9 @@
         version:            "1.0",
         life_stage:         "L1",
         design_stage:       "D2S",
-        verification_stage: "V2",
+        verification_stage: "V2S",
         dif_stage:          "S2",
-        commit_id:          "54b949255a8c463ea365126d90c39cd26c462638",
+        commit_id:          "c2a8c64ccbca39707be7883dfd2f8c1100813730",
       }
     ]
 }

--- a/hw/ip/kmac/doc/checklist.md
+++ b/hw/ip/kmac/doc/checklist.md
@@ -222,11 +222,11 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
-Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
-Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
+Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
+Tests         | [FPV_SEC_CM_VERIFIED][]                 | Done        |
+Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
+Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | 09/29/2022
 
 [SEC_CM_TESTPLAN_COMPLETED]:          {{<relref "/doc/project/checklist.md#sec_cm_testplan_completed" >}}
 [FPV_SEC_CM_VERIFIED]:                {{<relref "/doc/project/checklist.md#fpv_sec_cm_verified" >}}


### PR DESCRIPTION
This PR declares V2S for kmac.
All TODO items in issue https://github.com/lowRISC/opentitan/issues/15207 are resolved.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>