### PR TITLE
[dv] Properly remove coverage on CDC rand delay module

### DIFF
--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -20,7 +20,7 @@
 // csr_assert_fpv is an auto-generated csr read assertion module. So only assertion coverage is
 // meaningful to collect.
 -moduletree *csr_assert_fpv
--module prim_cdc_rand_delay // DV CDC module
+-module prim_cdc_rand_delay  // DV construct.
 
 begin tgl
   -tree tb

--- a/hw/dv/tools/vcs/cover_reg_top.cfg
+++ b/hw/dv/tools/vcs/cover_reg_top.cfg
@@ -7,11 +7,11 @@
 
 +moduletree *_reg_top
 +node tb.dut tl_*
+-module prim_cdc_rand_delay  // DV construct.
 
 begin assert
   +moduletree *csr_assert_fpv
   +moduletree tlul_assert
-  -moduletree prim_cdc_rand_delay // TODO: CDC not enabled yet
 end
 
 // Remove everything else from toggle coverage except:

--- a/hw/dv/tools/xcelium/cover.ccf
+++ b/hw/dv/tools/xcelium/cover.ccf
@@ -24,6 +24,7 @@ deselect_coverage -betfs -module prim_lfsr...
 
 // Black-box DV CDC module.
 deselect_coverage -betfs -module prim_cdc_rand_delay
+
 // csr_assert_fpv is an auto-generated csr read assertion module. So only assertion coverage is
 // meaningful to collect.
 deselect_coverage -betf -module *csr_assert_fpv...

--- a/hw/top_earlgrey/dv/cov/chip_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover.cfg
@@ -36,6 +36,7 @@ begin line+cond+fsm+branch+assert
   -moduletree prim_esc_receiver
   -moduletree prim_prince // prim_prince is verified in a separate DV environment.
   -moduletree prim_lfsr // prim_lfsr is verified in FPV.
+  -module prim_cdc_rand_delay  // DV construct.
 end
 
 // TODO: Re-enable tgl(portsonly) on the the excluded prims above in the non-preverified IPs and

--- a/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg
@@ -58,4 +58,5 @@ begin line+cond+fsm+branch+assert
   +tree tb.dut.top_earlgrey.u_rv_plic.u_reg
   +tree tb.dut.top_earlgrey.u_sensor_ctrl.u_reg
   +tree tb.dut.top_earlgrey.u_rv_core_ibex.u_reg_cfg
+  -module prim_cdc_rand_delay  // DV construct.
 end


### PR DESCRIPTION
THis commit removes the coverage collection on prim CDC rand delay module, which is a DV construct.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>