### PR TITLE
[dv/prim] Disable coverage for unused logic

### DIFF
--- a/hw/ip/prim/rtl/prim_mubi12_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi12_sync.sv
@@ -137,6 +137,9 @@ module prim_mubi12_sync
     end
   end else begin : gen_no_flops
 
+    //VCS coverage off
+    // pragma coverage off
+
     // This unused companion logic helps remove lint errors
     // for modules where clock and reset are used for assertions only
     // This logic will be removed for synthesis since it is unloaded.
@@ -148,6 +151,9 @@ module prim_mubi12_sync
          unused_logic <= mubi_i;
       end
     end
+
+    //VCS coverage on
+    // pragma coverage on
 
     assign mubi = MuBi12Width'(mubi_i);
 

--- a/hw/ip/prim/rtl/prim_mubi16_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi16_sync.sv
@@ -137,6 +137,9 @@ module prim_mubi16_sync
     end
   end else begin : gen_no_flops
 
+    //VCS coverage off
+    // pragma coverage off
+
     // This unused companion logic helps remove lint errors
     // for modules where clock and reset are used for assertions only
     // This logic will be removed for synthesis since it is unloaded.
@@ -148,6 +151,9 @@ module prim_mubi16_sync
          unused_logic <= mubi_i;
       end
     end
+
+    //VCS coverage on
+    // pragma coverage on
 
     assign mubi = MuBi16Width'(mubi_i);
 

--- a/hw/ip/prim/rtl/prim_mubi4_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi4_sync.sv
@@ -137,6 +137,9 @@ module prim_mubi4_sync
     end
   end else begin : gen_no_flops
 
+    //VCS coverage off
+    // pragma coverage off
+
     // This unused companion logic helps remove lint errors
     // for modules where clock and reset are used for assertions only
     // This logic will be removed for synthesis since it is unloaded.
@@ -148,6 +151,9 @@ module prim_mubi4_sync
          unused_logic <= mubi_i;
       end
     end
+
+    //VCS coverage on
+    // pragma coverage on
 
     assign mubi = MuBi4Width'(mubi_i);
 

--- a/hw/ip/prim/rtl/prim_mubi8_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi8_sync.sv
@@ -137,6 +137,9 @@ module prim_mubi8_sync
     end
   end else begin : gen_no_flops
 
+    //VCS coverage off
+    // pragma coverage off
+
     // This unused companion logic helps remove lint errors
     // for modules where clock and reset are used for assertions only
     // This logic will be removed for synthesis since it is unloaded.
@@ -148,6 +151,9 @@ module prim_mubi8_sync
          unused_logic <= mubi_i;
       end
     end
+
+    //VCS coverage on
+    // pragma coverage on
 
     assign mubi = MuBi8Width'(mubi_i);
 

--- a/util/design/data/prim_mubi_sync.sv.tpl
+++ b/util/design/data/prim_mubi_sync.sv.tpl
@@ -137,6 +137,9 @@ module prim_mubi${n_bits}_sync
     end
   end else begin : gen_no_flops
 
+    //VCS coverage off
+    // pragma coverage off
+
     // This unused companion logic helps remove lint errors
     // for modules where clock and reset are used for assertions only
     // This logic will be removed for synthesis since it is unloaded.
@@ -148,6 +151,9 @@ module prim_mubi${n_bits}_sync
          unused_logic <= mubi_i;
       end
     end
+
+    //VCS coverage on
+    // pragma coverage on
 
     assign mubi = MuBi${n_bits}Width'(mubi_i);
 


### PR DESCRIPTION
The prim_mubi*sync modules have some logic inserted for linters only, and doesn't get synthesized, so coverage is unnecessary.

Signed-off-by: Guillermo Maturana <maturana@google.com>