### PR TITLE
[opentitantool] Support multi-layer alias conf

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -123,10 +123,16 @@ impl TransportWrapper {
     /// string as is.
     fn map_name(map: &HashMap<String, String>, name: &str) -> String {
         let name = name.to_uppercase();
-        // TODO(#8769): Support multi-level aliasing, either by
-        // flattening after parsing all files, or by repeated lookup
-        // here.
-        map.get(&name).cloned().unwrap_or(name)
+        match map.get(&name) {
+            Some(v) => {
+                if v.eq(&name) {
+                    name
+                } else {
+                    Self::map_name(map, v)
+                }
+            }
+            None => name,
+        }
     }
 
     /// Apply given configuration to a single pins.


### PR DESCRIPTION
We have an agreed way of connecting HyperDebug to CW310, which should be declared in a JSON conf file, such that opentitan tool understands a name such as A3 to be an alias of the HyperDebug native pin CN7_18.

Separately, the ChromeOS team has a particular idea of how to use the OpenTitan chip pins, and wishes to use the name AP_FLASH_SEL as an alias for A3.  This is mostly independent of CW310 and HyperDebug, and would apply even to future ASIC development board.

Because of the above, I foresee that we would want to simultaneously provide a CW310/HyperDebug configuration file, and a CromeOS/EarlGrey configuration file to OpenTitan tool.

This PR allows the --conf option to take multiple arguments, and it adapts the alias resolution logic to be transitive.

A semi-major inconvenience is the fact that StructOpt allows two way of specifying Vec<String> as command line options, either
```
ott --conf A.json --conf B.json
```
or
```
ott --conf A.json B.json
```

The latter causes an ambiguity, if you write:
```
ott --conf A.json console
```
in that the flags parse believes that `console` is the name of a second configuration file.

A workaround is to "terminate" the list by another option, e.g.:
```
ott --conf A.json --interface hyperdebug console
```

As-is, this PR runs the risk of breaking existing scripts, if they specify --interface before --conf, I do not like that.  I have not been able to find a way of telling StructOpt to require repeating --conf in front of each configuration file name.  I think that would be the ideal way, if it is possible.

Change-Id: I6f8a328f269dfee246a19c4d3bae9fd60f056aec