### PR TITLE
[spi_device/dv] Add flash and TPM concurrent sequence

### DIFF
--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -280,6 +280,8 @@ class spi_monitor extends dv_base_monitor#(
     `DV_SPINWAIT(
       do begin
         cfg.read_byte(.num_lanes(1), .is_device_rsp(1), .data(tpm_rsp));
+        // current TPM design could only return these values
+        `DV_CHECK_FATAL(tpm_rsp inside {TPM_START, TPM_WAIT, '1})
       end while (tpm_rsp[0] == TPM_WAIT);
       , , TPM_START_MAX_WAIT_TIME_NS)
     `uvm_info(`gfn, "Received TPM START", UVM_MEDIUM)
@@ -291,7 +293,6 @@ class spi_monitor extends dv_base_monitor#(
       `uvm_info(`gfn, $sformatf("collect %s data for TPM, idx %0d: 0x%0x",
                               item.write_command ? "write" : "read", i, item.data[i]), UVM_MEDIUM)
     end
-    item.print();
   endtask
 
   // address is 3 or 4 bytes

--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -442,7 +442,7 @@
             - Configure passthrough or flash mode.
             - Issue TPM read/write interleaving with flash transactions.'''
       stage: V2
-      tests: []
+      tests: ["spi_device_flash_and_tpm"]
     }
   ]
   covergroups: [

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -99,6 +99,8 @@ class spi_device_base_vseq extends cip_base_vseq #(
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
     delay_after_reset_before_access_csr();
+    void'(cfg.spi_cfg_sema.try_get());
+    cfg.spi_cfg_sema.put();
   endtask
 
   virtual task read_and_check_all_csrs_after_reset();

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_and_tpm_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_and_tpm_vseq.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Run both flash_all and tpm_all sequence in parallel to test that spi_device receives
+// flash transactions interleaving with TPM transactions
+class spi_device_flash_and_tpm_vseq extends spi_device_base_vseq;
+  `uvm_object_utils(spi_device_flash_and_tpm_vseq)
+  `uvm_object_new
+
+  task body();
+    spi_device_flash_all_vseq flash_vseq;
+    spi_device_tpm_all_vseq tpm_vseq;
+
+    `uvm_create_on(flash_vseq, p_sequencer)
+    `uvm_create_on(tpm_vseq, p_sequencer)
+
+    // this flash_and_tpm_vseq will do dut_init and clear_all_interrupts
+    // don't do it in sub-vseq, it could affect the other
+    flash_vseq.do_dut_init = 0;
+    tpm_vseq.do_dut_init = 0;
+    flash_vseq.do_clear_all_interrupts = 0;
+    tpm_vseq.do_clear_all_interrupts = 0;
+
+    `DV_CHECK_RANDOMIZE_FATAL(flash_vseq)
+    `DV_CHECK_RANDOMIZE_FATAL(tpm_vseq)
+    fork
+      flash_vseq.start(p_sequencer);
+      tpm_vseq.start(p_sequencer);
+    join
+  endtask : body
+endclass : spi_device_flash_and_tpm_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_all_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_all_vseq.sv
@@ -47,7 +47,7 @@ class spi_device_tpm_all_vseq extends spi_device_tpm_read_hw_reg_vseq;
 
           csr_rd(.ptr(ral.intr_state.tpm_header_not_empty), .value(tpm_intr));
           if (tpm_intr) begin
-            csr_wr(.ptr(ral.intr_state.tpm_header_not_empty), .value(tpm_intr));
+            clear_tpm_interrupt();
             while (1) begin
               csr_rd(.ptr(ral.tpm_status.cmdaddr_notempty), .value(cmdaddr_notempty_val));
               if (!cmdaddr_notempty_val) break;

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_hw_reg_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_hw_reg_vseq.sv
@@ -67,10 +67,10 @@ class spi_device_tpm_read_hw_reg_vseq extends spi_device_tpm_base_vseq;
           `DV_WAIT(cfg.spi_host_agent_cfg.vif.csb[TPM_CSB_ID] == 1)
         end
         begin
-          repeat ($urandom_range(10, 20)) begin
+          repeat ($urandom_range(20, 50)) begin
               randomize_tpm_trans();
               spi_host_xfer_tpm_item(.write(tpm_write), .tpm_size(tpm_size), .addr(tpm_addr),
-                                    .payload_q(returned_bytes));
+                                     .payload_q(returned_bytes));
           end
           upstream_spi_done = 1;
         end

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_rw_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_rw_vseq.sv
@@ -10,7 +10,6 @@ class spi_device_tpm_rw_vseq extends spi_device_tpm_base_vseq;
   virtual task body();
     bit [7:0] spi_byte_q[$];
     bit [7:0] sw_byte_q[$];
-    spi_device_fw_init();
 
     // randomised tpm configuration.
     tpm_init(TpmCrbMode);

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -33,3 +33,4 @@
 `include "spi_device_flash_mode_vseq.sv"
 `include "spi_device_read_buffer_direct_vseq.sv"
 `include "spi_device_flash_all_vseq.sv"
+`include "spi_device_flash_and_tpm_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -49,6 +49,7 @@ filesets:
       - seq_lib/spi_device_flash_mode_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_read_buffer_direct_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_flash_all_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_flash_and_tpm_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -20,6 +20,10 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
   // This prevents clk from being configured multiple times
   bit                 spi_clk_configured;
 
+  // test may have 2 threads to configure spi_device for flash and TPM mode.
+  // both may access the same csr `CFG`, have this to avoid accessing it at the same time.
+  semaphore           spi_cfg_sema = new(1);
+
   `uvm_object_utils_begin(spi_device_env_cfg)
     `uvm_field_object(spi_host_agent_cfg, UVM_DEFAULT)
     `uvm_field_object(spi_device_agent_cfg, UVM_DEFAULT)

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -189,6 +189,11 @@
       name: spi_device_flash_all
       uvm_test_seq: spi_device_flash_all_vseq
     }
+
+    {
+      name: spi_device_flash_and_tpm
+      uvm_test_seq: spi_device_flash_and_tpm_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
1. Run both sequences in parallel
2. update seq/scb to fix a few issues
  - CSB needs to be set via transactions
  - avoid accessing the same CFG csr at the same time
  - In some extrem case, tpm_write_spi_q may contains 2 items

Signed-off-by: Weicai Yang <weicai@google.com>