### PR TITLE
[entropy_src/dv] Closing some functional coverage gaps

### DIFF
--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -29,12 +29,14 @@ class entropy_src_base_test extends cip_base_test #(
   virtual function void configure_env();
     // seed_cnt only used by smoke test
     // so there is no need to randomize it.
-    cfg.seed_cnt                  = 1;
-    cfg.otp_en_es_fw_read_pct     = 100;
-    cfg.otp_en_es_fw_over_pct     = 100;
-    cfg.dut_cfg.me_regwen_pct     = 100;
-    cfg.dut_cfg.module_enable_pct = 100;
-    cfg.dut_cfg.type_bypass_pct   = 100;
+    cfg.seed_cnt                       = 1;
+    cfg.otp_en_es_fw_read_pct          = 100;
+    cfg.otp_en_es_fw_over_pct          = 100;
+    cfg.dut_cfg.me_regwen_pct          = 100;
+    cfg.dut_cfg.module_enable_pct      = 100;
+    cfg.dut_cfg.type_bypass_pct        = 100;
+    // Unless testing bad MuBi's the initial value for fw_ov_insert_start should always be false
+    cfg.dut_cfg.fw_ov_insert_start_pct = 0;
 
     // Setting the following parameters to less than zero means that random reconfig or random
     // fatal alerts will not be driven by the RNG virtual sequence unless they are overridden

--- a/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
@@ -13,8 +13,6 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
     cfg.en_scb                              = 1;
     cfg.alert_max_delay                     = 5;
 
-    cfg.dut_cfg.fips_window_size            = 2048;
-    cfg.dut_cfg.bypass_window_size          = 384;
     cfg.dut_cfg.boot_mode_retry_limit       = 10;
     cfg.sim_duration                        = 10ms;
     cfg.hard_mtbf                           = 100s;

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -13,8 +13,6 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.en_scb                      = 1;
     cfg.alert_max_delay             = 5;
 
-    cfg.dut_cfg.fips_window_size            = 2048;
-    cfg.dut_cfg.bypass_window_size          = 384;
     cfg.dut_cfg.boot_mode_retry_limit       = 10;
     cfg.sim_duration                = 20ms;
     // On average two hard failures per simulation
@@ -37,10 +35,11 @@ class entropy_src_rng_test extends entropy_src_base_test;
 
     cfg.dut_cfg.entropy_data_reg_enable_pct = 50;
     cfg.dut_cfg.route_software_pct          = 50;
-    cfg.otp_en_es_fw_read_pct       = 50;
-    cfg.otp_en_es_fw_over_pct       = 50;
+    cfg.otp_en_es_fw_read_pct               = 50;
+    cfg.otp_en_es_fw_over_pct               = 50;
 
-    cfg.dut_cfg.type_bypass_pct             = 50;
+    cfg.dut_cfg.type_bypass_pct             = 25;
+    cfg.dut_cfg.ht_threshold_scope_pct      = 50;
     cfg.dut_cfg.default_ht_thresholds_pct   = 0;
 
     // Sometimes read data from the Observe FIFO (but always take entropy from RNG)


### PR DESCRIPTION
This commit changes the entropy_src_base_vseq to update a handful of previously unused registers in order to close some coverpoints

Where needed this commit also includes a number of fixes to previously unseen DV bugs.

Detailed list of changes:
- Randomizes threshold_scope, alert_threshold, and window sizes (for fips windows)
- Updates RNG Vseq to only change threshold_scope & window sizes after a reset.  These registers have a major impact on the output of the health tests.  Meanwhile the health test thresholds can only be adjusted in one direction after reset, so if the average health test output changes, the thresholds cannot be moved to set a meaningful value.
- Changed base vseq to update more registers on initialization, particularly ones that were not being randomized before. Some registers whose usual initialization value is usually fixed are also updated on initialization particularly if the dut_cfg indicates that it is time to stress the bad-mubi detection alerts.
- Modified the coverage sampling for the win_ht_deep_threshold_cg to check the actual DUT register values rather than relying on the dut_cfg. Note that dut_cfg values may not stick due to one-way constraints or write protect issues).  Since the covergroup sampling is done in terms of sigmas instead of actual thresholds, this requires a new function to compute sigma values from the thresholds.
- Vseq's now use the disable_dut() function more frequently (as opposed to simply deasserting `module_enable`).  The has to be done because certain interrupts status registers were not being cleared on disable.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>