### PR TITLE
[entropy_src/rtl] Minor predictability fix

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -2396,7 +2396,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   // as the reset is only important for clearing 32-bit half-SHA-words.
   assign pfifo_precon_clr = fw_ov_mode_entropy_insert ?
                             !es_enable_fo[9] & !pfifo_precon_not_empty :
-                            module_en_pulse_fo[5];
+                            module_en_pulse_fo[5] & !pfifo_precon_not_empty;
 
   assign pfifo_precon_pop = (pfifo_cond_push && sha3_msgfifo_ready);
 


### PR DESCRIPTION
This commit fixes a minor timing hiccup that was previously missed when in RNG-mode.

The precon packer FIFO should not be cleared on disable if it has a full 64-bit data word. This is because once a word is completed and presented to the condititioner input, our scoreboarding assumes that it has been added to the SHA internal state.  However backpressure delays (which are undetectable by DV) can cause inputs to linger.   Not clearing this FIFO allows the conditioner to absorb the word later once the module is re-enabled.

This subtlety has previously been properly applied in FW_OV mode. This commit also applies it in RNG mode as well.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>