### PR TITLE
[entropy_src/rtl] More Ext. HT port updates

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
@@ -65,17 +65,21 @@ package entropy_src_pkg;
     logic active;
     logic [15:0] thresh_hi;
     logic [15:0] thresh_lo;
+    logic [15:0] health_test_window;
     logic window_wrap_pulse;
     logic threshold_scope;
   } entropy_src_xht_req_t;
 
   typedef struct packed {
-    logic[15:0] test_cnt;
+    logic[15:0] test_cnt_hi;
+    logic[15:0] test_cnt_lo;
+    logic continuous_test;
     logic test_fail_hi_pulse;
     logic test_fail_lo_pulse;
   } entropy_src_xht_rsp_t;
 
   parameter entropy_src_xht_req_t ENTROPY_SRC_XHT_REQ_DEFAULT = '{default: '0};
-  parameter entropy_src_xht_rsp_t ENTROPY_SRC_XHT_RSP_DEFAULT = '{default: '0};
+  parameter entropy_src_xht_rsp_t ENTROPY_SRC_XHT_RSP_DEFAULT =
+      '{test_cnt_lo: 16'hffff, default: '0};
 
 endpackage : entropy_src_pkg


### PR DESCRIPTION
This comment makes the following changes that were observed to be needed when implementing the Ext HT agent:

- Adds support for high and low test counts (much like the outputs maintained by the Markov and Adaptp tests).
- Reinstates the window_size field in the entropy_src_xht_req structure. Without this the only way to determine when a window has been completed is to look at the window_wrap_pulse.  However once `window_wrap_pulse` arrives, it is one cycle too late to send the test results.  The window_wrap_pulse is still needed for synchronization, but it is not sufficient to achieve proper timing.
- Adds a continuous_test field in the entropy_src_xht_req structure in order to support the possibility of non-windowed external tests.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>