### PR TITLE
[dv, top] Exclude TL integrity error fcov

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -106,6 +106,12 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
     foreach (cfg.m_tl_agent_cfgs[i]) begin
       cfg.m_tl_agent_cfgs[i].synchronise_ports = 1'b1;
     end
+
+    // if en_cov is off, disable all other functional coverage
+    if (!cfg.en_cov) begin
+      cfg.en_tl_err_cov = 0;
+      cfg.en_tl_intg_err_cov = 0;
+    end
   endfunction
 
   virtual function void connect_phase(uvm_phase phase);
@@ -152,4 +158,3 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
   endfunction : end_of_elaboration_phase
 
 endclass
-

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg #(RAL_T);
+  // control knobs to enable/disable covergroups
+  // these are default enabled. If en_cov is off, these will be disabled as well.
+  bit en_tl_err_cov      = 1;
+  bit en_tl_intg_err_cov = 1;
+
   // Downstream agent cfg objects.
 
   // If the block supports only one RAL, just use `m_tl_agent_cfg`.

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -120,6 +120,9 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     has_devmode = 0;
     list_of_alerts = chip_common_pkg::LIST_OF_ALERTS;
 
+    // No need to cover all kinds of interity errors as they are tested in block-level.
+    en_tl_intg_err_cov = 0;
+
     // Set up second RAL model for ROM memory and associated collateral
     if (use_jtag_dmi == 1) begin
       ral_model_names.push_back(rv_dm_mem_ral_name);


### PR DESCRIPTION
Add 2 knobs for enable/disable tl error fcov and integrity fcov
Disable the integrity fcov in chip-level

Signed-off-by: Weicai Yang <weicai@google.com>