### PR TITLE
[edn] Use MuBi4False instead of 4'h0 for flag0 when enabling entropy src

### DIFF
--- a/sw/device/lib/dif/dif_csrng_shared.c
+++ b/sw/device/lib/dif/dif_csrng_shared.c
@@ -38,10 +38,9 @@ dif_result_t csrng_send_app_cmd(mmio_region_t base_addr, ptrdiff_t offset,
   reg = bitfield_field32_write(reg, kAppCmdFieldCmdLen, cmd_len);
   reg = bitfield_field32_write(
       reg, kAppCmdFieldFlag0,
-      // When entropy src is enabled, we just need to program "not true".
       (cmd.entropy_src_enable == kDifCsrngEntropySrcToggleDisable)
           ? kMultiBitBool4True
-          : 0);
+          : kMultiBitBool4False);
   reg = bitfield_field32_write(reg, kAppCmdFieldGlen, cmd.generate_len);
   mmio_region_write32(base_addr, offset, reg);
 

--- a/sw/device/lib/dif/dif_csrng_unittest.cc
+++ b/sw/device/lib/dif/dif_csrng_unittest.cc
@@ -221,13 +221,15 @@ TEST_F(CommandTest, InstantiateOk) {
   EXPECT_DIF_OK(dif_csrng_instantiate(&csrng_, kDifCsrngEntropySrcToggleDisable,
                                       &seed_material_));
 
-  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000001);
+  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
+                 0x00000001 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_instantiate(&csrng_, kDifCsrngEntropySrcToggleEnable,
                                       &seed_material_));
 
   seed_material_.seed_material[0] = 0x5a5a5a5a;
   seed_material_.seed_material_len = 1;
-  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000011);
+  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
+                 0x00000011 | kMultiBitBool4False << 8);
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
   EXPECT_DIF_OK(dif_csrng_instantiate(&csrng_, kDifCsrngEntropySrcToggleEnable,
                                       &seed_material_));
@@ -244,12 +246,14 @@ TEST_F(CommandTest, InstantiateBadArgs) {
 }
 
 TEST_F(CommandTest, ReseedOk) {
-  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000002);
+  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
+                 0x00000002 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_reseed(&csrng_, &seed_material_));
 
   seed_material_.seed_material[0] = 0x5a5a5a5a;
   seed_material_.seed_material_len = 1;
-  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000012);
+  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
+                 0x00000012 | kMultiBitBool4False << 8);
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
   EXPECT_DIF_OK(dif_csrng_reseed(&csrng_, &seed_material_));
 }
@@ -263,12 +267,14 @@ TEST_F(CommandTest, ReseedBadArgs) {
 }
 
 TEST_F(CommandTest, UpdateOk) {
-  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000004);
+  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
+                 0x00000004 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_update(&csrng_, &seed_material_));
 
   seed_material_.seed_material[0] = 0x5a5a5a5a;
   seed_material_.seed_material_len = 1;
-  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000014);
+  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
+                 0x00000014 | kMultiBitBool4False << 8);
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
   EXPECT_DIF_OK(dif_csrng_update(&csrng_, &seed_material_));
 }
@@ -279,11 +285,13 @@ TEST_F(CommandTest, UpdateBadArgs) {
 
 TEST_F(CommandTest, GenerateOk) {
   // 512bits = 16 x 32bit = 4 x 128bit blocks
-  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00004003);
+  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
+                 0x00004003 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_generate_start(&csrng_, /*len=*/16));
 
   // 576bits = 18 x 32bit = 5 x 128bit blocks (rounded up)
-  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00005003);
+  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
+                 0x00005003 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_generate_start(&csrng_, /*len=*/18));
 }
 
@@ -293,7 +301,8 @@ TEST_F(CommandTest, GenerateBadArgs) {
 }
 
 TEST_F(CommandTest, UninstantiateOk) {
-  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000005);
+  EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
+                 0x00000005 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_uninstantiate(&csrng_));
 }
 

--- a/sw/device/lib/dif/dif_edn_unittest.cc
+++ b/sw/device/lib/dif/dif_edn_unittest.cc
@@ -144,7 +144,7 @@ TEST_F(SetModeTest, Auto) {
 
   EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, 1);
 
-  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 1);
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 1 | kMultiBitBool4False << 8);
 
   EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, 1);
 
@@ -275,13 +275,15 @@ TEST_F(CommandTest, InstantiateOk) {
   EXPECT_DIF_OK(dif_edn_instantiate(&edn_, kDifEdnEntropySrcToggleDisable,
                                     &seed_material_));
 
-  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x00000001);
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET,
+                 0x00000001 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_edn_instantiate(&edn_, kDifEdnEntropySrcToggleEnable,
                                     &seed_material_));
 
   seed_material_.data[0] = 0x5a5a5a5a;
   seed_material_.len = 1;
-  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x00000011);
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET,
+                 0x00000011 | kMultiBitBool4False << 8);
   EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
   EXPECT_DIF_OK(dif_edn_instantiate(&edn_, kDifEdnEntropySrcToggleEnable,
                                     &seed_material_));
@@ -305,12 +307,14 @@ TEST_F(CommandTest, InstantiateBadArgs) {
 }
 
 TEST_F(CommandTest, ReseedOk) {
-  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x00000002);
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET,
+                 0x00000002 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_edn_reseed(&edn_, &seed_material_));
 
   seed_material_.data[0] = 0x5a5a5a5a;
   seed_material_.len = 1;
-  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x00000012);
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET,
+                 0x00000012 | kMultiBitBool4False << 8);
   EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
   EXPECT_DIF_OK(dif_edn_reseed(&edn_, &seed_material_));
 }
@@ -324,12 +328,14 @@ TEST_F(CommandTest, ReseedBadArgs) {
 }
 
 TEST_F(CommandTest, UpdateOk) {
-  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x00000004);
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET,
+                 0x00000004 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_edn_update(&edn_, &seed_material_));
 
   seed_material_.data[0] = 0x5a5a5a5a;
   seed_material_.len = 1;
-  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x00000014);
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET,
+                 0x00000014 | kMultiBitBool4False << 8);
   EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
   EXPECT_DIF_OK(dif_edn_update(&edn_, &seed_material_));
 }
@@ -340,11 +346,13 @@ TEST_F(CommandTest, UpdateBadArgs) {
 
 TEST_F(CommandTest, GenerateOk) {
   // 512bits = 16 x 32bit = 4 x 128bit blocks
-  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x00004003);
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET,
+                 0x00004003 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_edn_generate_start(&edn_, /*len=*/16));
 
   // 576bits = 18 x 32bit = 5 x 128bit blocks (rounded up)
-  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x00005003);
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET,
+                 0x00005003 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_edn_generate_start(&edn_, /*len=*/18));
 }
 
@@ -354,7 +362,8 @@ TEST_F(CommandTest, GenerateBadArgs) {
 }
 
 TEST_F(CommandTest, UninstantiateOk) {
-  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET, 0x00000005);
+  EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET,
+                 0x00000005 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_edn_uninstantiate(&edn_));
 }
 

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -50,7 +50,8 @@ void entropy_testutils_auto_mode_init(void) {
       .reseed_material =
           {
               .len = 1,
-              .data = {0x00000002},  // Reseed from entropy source only.
+              .data = {0x00000002 |  // Reseed from entropy source only.
+                       kMultiBitBool4False << 8},
           },
       .generate_material =
           {
@@ -67,7 +68,8 @@ void entropy_testutils_auto_mode_init(void) {
       .reseed_material =
           {
               .len = 1,
-              .data = {0x00000002},  // Reseed from entropy source only.
+              .data = {0x00000002 |  // Reseed from entropy source only.
+                       kMultiBitBool4False << 8},
           },
       .generate_material =
           {


### PR DESCRIPTION
Recently, flag0 got converted from a single bit to a MuBi4 field. When seeing invalid MuBi4 values, the CSRNG hardware triggers a recoverable error and stops giving out entropy. As it turns out, in some places the implementation still assumes 4'h0 was interpreted as a legal MuBi4False, which effectively breaks EDN auto mode and all tests using that such as otbn_randomness_test.

This is related to lowRISC/OpenTitan#15165.