### PR TITLE
[otbn,dv] TP update for unmapped countermeasures

### DIFF
--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -151,7 +151,7 @@
       name: sec_cm_rf_base_data_reg_sw_glitch_detect
       desc: "Verify the countermeasure(s) RF_BASE.DATA_REG_SW.GLITCH_DETECT."
       stage: V2S
-      tests: []
+      tests: ["otbn_sec_cm"]
     }
     {
       name: sec_cm_stack_wr_ptr_ctr_redun
@@ -169,7 +169,7 @@
       name: sec_cm_rf_bignum_data_reg_sw_glitch_detect
       desc: "Verify the countermeasure(s) RF_BIGNUM.DATA_REG_SW.GLITCH_DETECT."
       stage: V2S
-      tests: []
+      tests: ["otbn_sec_cm"]
     }
     {
       name: sec_cm_loop_stack_ctr_redun
@@ -239,15 +239,20 @@
     }
     {
       name: sec_cm_key_sideload
-      desc: "Verify the countermeasure(s) KEY.SIDELOAD."
+      desc: '''Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD.
+
+            Simulation can't really prove that the sideload key is unreachable by SW.
+            However, from defined CSRs and memory returned data, there is no way to read
+            scramble key by SW.
+            '''
       stage: V2S
-      tests: []
+      tests: ["{name}_smoke"]
     }
     {
       name: sec_cm_tlul_fifo_ctr_redun
       desc: "Verify the countermeasure(s) TLUL_FIFO.CTR.REDUN."
       stage: V2S
-      tests: []
+      tests: ["{name}_sec_cm"]
     }
   ]
 }


### PR DESCRIPTION
`otbn_sec_cm` injects faults to `prim_onehot_check` modules that assures `GLITCH_DETECT` countermeasure. Other two points are common with SRAM controller - from which I copied the explanation for why we map the smoke test for `sec_cm_scramble_key_sideload` test.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>