### PR TITLE
[spi_device] update state default assignment

### DIFF
--- a/hw/ip/spi_device/rtl/spi_fwm_rxf_ctrl.sv
+++ b/hw/ip/spi_device/rtl/spi_fwm_rxf_ctrl.sv
@@ -177,6 +177,8 @@ module spi_fwm_rxf_ctrl #(
 
   // Next State & output logic
   always_comb begin
+    // default output value
+    st_next     = st;
     fifo_ready = 1'b0;
     update_wdata = 1'b0;
     clr_byte_enable = 1'b0;

--- a/hw/ip/spi_device/rtl/spi_fwm_txf_ctrl.sv
+++ b/hw/ip/spi_device/rtl/spi_fwm_txf_ctrl.sv
@@ -90,7 +90,7 @@ module spi_fwm_txf_ctrl #(
   // State Machine next , output logic
   always_comb begin
     // default output value
-    st_next     = StIdle;
+    st_next     = st;
     sram_req_d  = 1'b0;
     update_rptr = 1'b0;
     latch_wptr  = 1'b0;

--- a/hw/ip/spi_device/rtl/spid_readsram.sv
+++ b/hw/ip/spi_device/rtl/spid_readsram.sv
@@ -227,7 +227,7 @@ module spid_readsram
   end
 
   always_comb begin
-    st_d = StIdle;
+    st_d = st_q;
 
     fifo_wvalid = 1'b 0;
 


### PR DESCRIPTION
Same as #15225, changed to `st_d = st_q`, so that VCS can automatically exclude any state -> idle state transition coverage.
Related to a tool issue #15236

Signed-off-by: Weicai Yang <weicai@google.com>