### PR TITLE
[entropy_src/dv] New agent to test external health test interface

### DIFF
--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent.core
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent.core
@@ -1,0 +1,30 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:entropy_src_xht_agent:0.1"
+description: "entropy_src external HT DV UVM agent"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_utils
+      - lowrisc:dv:dv_lib
+      - lowrisc:ip:entropy_src_pkg
+      - lowrisc:dv:digestpp_dpi:0.1
+    files:
+      - entropy_src_xht_if.sv
+      - entropy_src_xht_agent_pkg.sv
+      - entropy_src_xht_item.sv: {is_include_file: true}
+      - entropy_src_xht_agent_cfg.sv: {is_include_file: true}
+      - entropy_src_xht_device_driver.sv: {is_include_file: true}
+      - entropy_src_xht_monitor.sv: {is_include_file: true}
+      - entropy_src_xht_sequencer.sv: {is_include_file: true}
+      - entropy_src_xht_agent.sv: {is_include_file: true}
+      - seq_lib/entropy_src_xht_base_device_seq.sv: {is_include_file: true}
+      - seq_lib/entropy_src_xht_seq_list.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_xht_agent extends dv_base_agent #(
+  .CFG_T       (entropy_src_xht_agent_cfg),
+  .DRIVER_T    (entropy_src_xht_device_driver),
+  .SEQUENCER_T (entropy_src_xht_sequencer),
+  .MONITOR_T   (entropy_src_xht_monitor),
+  .COV_T       (dv_base_agent_cov#(entropy_src_xht_agent_cfg))
+);
+
+  `uvm_component_utils(entropy_src_xht_agent)
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    cfg.has_req_fifo = 1;
+
+    if (!uvm_config_db#(virtual entropy_src_xht_if)::get(
+        this, "", "vif", cfg.vif)) begin
+      `uvm_fatal(`gfn, "failed to get entropy_src_xht_if handle from uvm_config_db")
+    end
+
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    monitor.req_analysis_port.connect(sequencer.req_analysis_fifo.analysis_export);
+  endfunction
+
+  virtual task run_phase(uvm_phase phase);
+    entropy_src_xht_base_device_seq m_seq
+        = entropy_src_xht_base_device_seq::type_id::create("m_seq", this);
+    if (cfg.start_default_seq) begin
+      uvm_config_db#(uvm_object_wrapper)::set(null, {sequencer.get_full_name(), ".run_phase"},
+                                              "default_sequence", m_seq.get_type());
+      sequencer.start_phase_sequence(phase);
+    end
+  endtask
+
+endclass

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent_cfg.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent_cfg.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_xht_agent_cfg extends dv_base_agent_cfg;
+
+  virtual entropy_src_xht_if vif;
+
+  bit     start_default_seq = 1'b0;
+  bit     unfiltered_monitor_traffic = 1'b0;
+
+  `uvm_object_utils_begin(entropy_src_xht_agent_cfg)
+    `uvm_field_int(start_default_seq, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+endclass

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent_pkg.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent_pkg.sv
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package entropy_src_xht_agent_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import dv_lib_pkg::*;
+  import entropy_src_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  `include "entropy_src_xht_item.sv"
+  `include "entropy_src_xht_agent_cfg.sv"
+  `include "entropy_src_xht_device_driver.sv"
+  `include "entropy_src_xht_monitor.sv"
+  `include "entropy_src_xht_sequencer.sv"
+  `include "entropy_src_xht_seq_list.sv"
+  `include "entropy_src_xht_agent.sv"
+
+endpackage : entropy_src_xht_agent_pkg

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_device_driver.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_device_driver.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_xht_device_driver extends dv_base_driver #(
+    .ITEM_T(entropy_src_xht_item),
+    .CFG_T (entropy_src_xht_agent_cfg)
+);
+
+  `uvm_component_utils(entropy_src_xht_device_driver)
+  `uvm_component_new
+
+  virtual task reset_signals();
+    forever begin
+      @(negedge cfg.vif.rst_n);
+      `uvm_info(`gfn, "Driver is under reset", UVM_DEBUG)
+      cfg.vif.xht_cb.rsp <= ENTROPY_SRC_XHT_RSP_DEFAULT;
+      @(posedge cfg.vif.rst_n);
+      `uvm_info(`gfn, "Driver is out of reset", UVM_DEBUG)
+    end
+  endtask
+
+  virtual task get_and_drive();
+    forever begin
+      @(cfg.vif.xht_cb);
+      seq_item_port.try_next_item(req);
+      if (req == null) begin
+        cfg.vif.xht_cb.rsp.test_fail_hi_pulse <= 1'b0;
+        cfg.vif.xht_cb.rsp.test_fail_lo_pulse <= 1'b0;
+      end else begin
+        cfg.vif.xht_cb.rsp <= req.rsp;
+        seq_item_port.item_done(req);
+      end
+    end
+  endtask
+
+endclass

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_if.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_if.sv
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface entropy_src_xht_if import entropy_src_pkg::*;
+(
+  input wire clk,
+  input wire rst_n
+);
+
+  entropy_src_xht_req_t req;
+  entropy_src_xht_rsp_t rsp;
+
+  logic entropy_bit_valid_q;
+
+  always @(posedge clk) begin
+    entropy_bit_valid_q <= req.entropy_bit_valid;
+  end
+
+  clocking xht_cb @(posedge clk);
+    input req;
+    output rsp;
+  endclocking
+
+  clocking mon_cb @(posedge clk);
+    input req;
+    input rsp;
+    input entropy_bit_valid_q;
+  endclocking
+
+endinterface

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_item.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_item.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_xht_item extends uvm_sequence_item;
+
+  entropy_src_xht_req_t req;
+  entropy_src_xht_rsp_t rsp;
+
+  `uvm_object_utils(entropy_src_xht_item)
+  `uvm_object_new
+
+endclass

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_monitor.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_monitor.sv
@@ -1,0 +1,83 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_xht_monitor extends dv_base_monitor #(
+  .ITEM_T (entropy_src_xht_item),
+  .CFG_T  (entropy_src_xht_agent_cfg),
+  .COV_T  (dv_base_agent_cov#(entropy_src_xht_agent_cfg))
+);
+
+  `uvm_component_utils(entropy_src_xht_monitor)
+  `uvm_component_new
+
+  task run_phase(uvm_phase phase);
+    fork
+      monitor_reset();
+      begin
+        @(posedge cfg.vif.rst_n);
+        collect_req(phase);
+      end
+    join
+  endtask
+
+  virtual protected task monitor_reset();
+    forever begin
+      @(negedge cfg.vif.rst_n);
+      `uvm_info(`gfn, "Reset detected!", UVM_DEBUG)
+      cfg.in_reset = 1;
+      @(posedge cfg.vif.rst_n);
+      `uvm_info(`gfn, "Reset release detected!", UVM_DEBUG)
+      cfg.in_reset = 0;
+    end
+  endtask
+
+  // Shorthand for restarting forever loop on reset detection.
+  `define WAIT_FOR_RESET    \
+    if (cfg.in_reset) begin \
+      wait (!cfg.in_reset); \
+      continue;             \
+    end
+
+  virtual protected task collect_req(uvm_phase phase);
+    forever begin
+      @(cfg.vif.mon_cb);
+      `WAIT_FOR_RESET
+      create_and_write_item();
+    end
+  endtask
+
+  virtual protected function void create_and_write_item();
+    entropy_src_xht_item item;
+
+    bit  event_filter;
+
+    // The entropy_src_extht_req_t encodes three types of events that the agent must monitor
+    // - entropy_bit_valid
+    // - clear, and
+    // - window_wrap pulse.
+    // All other req fields are data or parameters (unchanging except with a clear pulse)
+    //
+    // Meanwhile the entropy_src_rsp_t data is continuously monitored.
+    // Creating a new item at every clock however has a noticible performance impact on simulations
+    // therefore we typically assume that the xht_sequence only outputs updates in the cycle after
+    // entropy_bit_valid, and so we add entropy_bit_valid_q to our event filter.
+    //
+    // To get scoreboard access to all bus samples, set cfg.unfiltered_monitor_traffic to 1. This
+    // will allow for simulations in which an xht sequence takes longer than one cycle to respond.
+    event_filter = (cfg.vif.mon_cb.req.entropy_bit_valid ||
+                    cfg.vif.mon_cb.req.clear ||
+                    cfg.vif.mon_cb.req.window_wrap_pulse ||
+                    cfg.vif.mon_cb.entropy_bit_valid_q);
+
+    if (cfg.unfiltered_monitor_traffic || event_filter) begin
+      `uvm_info(`gfn, "Sending item", UVM_DEBUG)
+      item = entropy_src_xht_item::type_id::create("item");
+      item.rsp = cfg.vif.mon_cb.rsp;
+      item.req = cfg.vif.mon_cb.req;
+      analysis_port.write(item);
+      req_analysis_port.write(item);
+    end
+  endfunction
+
+endclass

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_sequencer.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_sequencer.sv
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_xht_sequencer extends dv_base_sequencer #(
+    .ITEM_T (entropy_src_xht_item),
+    .CFG_T  (entropy_src_xht_agent_cfg)
+);
+  `uvm_component_utils(entropy_src_xht_sequencer)
+  `uvm_component_new
+
+endclass

--- a/hw/dv/sv/entropy_src_xht_agent/seq_lib/entropy_src_xht_base_device_seq.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/seq_lib/entropy_src_xht_base_device_seq.sv
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_xht_base_device_seq extends dv_base_seq #(
+  .REQ         (entropy_src_xht_item),
+  .CFG_T       (entropy_src_xht_agent_cfg),
+  .SEQUENCER_T (entropy_src_xht_sequencer)
+);
+
+  bit [RNG_BUS_WIDTH - 1:0] window_data_q[$];
+  bit [15:0]                test_cnt_hi;
+  bit [15:0]                test_cnt_lo;
+
+  `uvm_object_utils(entropy_src_xht_base_device_seq)
+
+  `uvm_object_new
+
+  virtual function void update_item_rsp(entropy_src_xht_item item);
+    if (item.req.clear) begin
+       window_data_q.delete();
+       test_cnt_hi = ENTROPY_SRC_XHT_RSP_DEFAULT.test_cnt_hi;
+       test_cnt_lo = ENTROPY_SRC_XHT_RSP_DEFAULT.test_cnt_lo;
+    end else begin
+      if (item.req.active && item.req.entropy_bit_valid) begin
+        window_data_q.push_back(item.req.entropy_bit);
+        if (window_data_q.size() == item.req.health_test_window) begin
+          // Use a hash function to create output values that cover the
+          // complete range of test_cnt's, but also depend deterministically
+          // on the window data.
+          `uvm_info(`gfn, "Generating SHA3 hash", UVM_FULL)
+          test_cnt_hash(test_cnt_hi, test_cnt_lo);
+        end
+      end
+      if (item.req.active && item.req.window_wrap_pulse) begin
+        window_data_q.delete();
+      end
+    end
+
+    item.rsp.test_cnt_hi = test_cnt_hi;
+    item.rsp.test_cnt_lo = test_cnt_lo;
+    item.rsp.test_fail_hi_pulse = test_cnt_hi > item.req.thresh_hi;
+    item.rsp.test_fail_lo_pulse = test_cnt_lo < item.req.thresh_lo;
+    item.rsp.continuous_test = 1'b0;
+  endfunction
+
+  // For generating hypothetical HT results here we apply three basic requirements
+  // 1. The outputs should be deterministic with respect to the input data
+  // 2. The test outputs should have good coverage over the whole range of test_cnts (16 bits)
+  // 3. The low output should be less than or equal the high output.
+  // Given these three constraints, this function arbitrarily generates a SHA3 hash of the input
+  // data, and extracts the lowest 32 bits of the digest to create two synthetic test_cnt outputs.
+  function void test_cnt_hash(output bit [15:0] hi, output bit [15:0] lo);
+    localparam int ShaWidth = 384;
+    localparam int RngWordsPerByte = 8/RNG_BUS_WIDTH;
+
+    bit [7:0]  sha_msg[];
+    int        msg_size;
+    int        msg_idx = 0;
+    bit [7:0]  sha_digest[ShaWidth / 8];
+    int        rng_cntr = 0;
+    bit        whole_byte;
+    bit [7:0]  sha_byte = '0;
+    bit [15:0] output_a, output_b;
+
+    // The "message" will be equal to the number of bytes in the window
+    // rounding up to include any partial bytes.
+    msg_size = (window_data_q.size() + RngWordsPerByte - 1) / RngWordsPerByte;
+    sha_msg = new[msg_size];
+
+    for (int i = 0; i < window_data_q.size(); i++) begin
+      sha_byte = {sha_byte[(8 - RNG_BUS_WIDTH - 1):0], window_data_q[i]};
+      rng_cntr++;
+      whole_byte = (rng_cntr == RngWordsPerByte);
+      // Add data to the message whenever we have a whole byte,
+      // or if there is ever a dangling nibble.
+      if (whole_byte || (i == (window_data_q.size() - 1)) ) begin
+        sha_msg[msg_idx] = sha_byte;
+        msg_idx++;
+        rng_cntr = 0;
+      end
+    end
+
+    digestpp_dpi_pkg::c_dpi_sha3_384(sha_msg, msg_idx, sha_digest);
+    // Arbitrarily capture the lowest 4 bytes as a pair of outputs.
+    output_a = {sha_digest[3], sha_digest[2]};
+    output_b = {sha_digest[1], sha_digest[0]};
+
+    hi = (output_a < output_b) ? output_b : output_a;
+    lo = (output_a < output_b) ? output_a : output_b;
+
+  endfunction
+
+  virtual task body();
+    entropy_src_xht_item req_q[$];
+    `uvm_info(`gfn, "Starting seq", UVM_HIGH)
+    fork
+      forever begin : get_req
+        p_sequencer.req_analysis_fifo.get(req);
+        req_q.push_back(req);
+      end : get_req
+      forever begin : send_rsp
+        `uvm_info(`gfn, "Waiting for activity", UVM_DEBUG)
+        `DV_SPINWAIT_EXIT(wait(req_q.size());, wait(cfg.in_reset))
+        if (cfg.in_reset) begin
+          `uvm_info(`gfn, "Reset detected!", UVM_DEBUG)
+          test_cnt_hi = ENTROPY_SRC_XHT_RSP_DEFAULT.test_cnt_hi;
+          test_cnt_lo = ENTROPY_SRC_XHT_RSP_DEFAULT.test_cnt_lo;
+          wait (!cfg.in_reset)
+          req_q.delete();
+          window_data_q.delete();
+        end else begin
+          `uvm_info(`gfn, "Got Item!", UVM_DEBUG)
+          rsp = req_q.pop_front();
+          start_item(rsp);
+          update_item_rsp(rsp);
+          finish_item(rsp);
+          get_response(rsp);
+        end
+      end : send_rsp
+    join
+  endtask
+
+endclass

--- a/hw/dv/sv/entropy_src_xht_agent/seq_lib/entropy_src_xht_seq_list.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/seq_lib/entropy_src_xht_seq_list.sv
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "entropy_src_xht_base_device_seq.sv"

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.core
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:cip_lib
       - lowrisc:dv:push_pull_agent
+      - lowrisc:dv:entropy_src_xht_agent
       - lowrisc:dv:entropy_subsys_fifo_exception_if
     files:
       - entropy_src_env_pkg.sv

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -14,6 +14,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
        m_csrng_agent_cfg;
   rand push_pull_agent_cfg#(.HostDataWidth(0))
        m_aes_halt_agent_cfg;
+  entropy_src_xht_agent_cfg m_xht_agent_cfg;
 
   // Additional reset interface for the csrng.
   virtual clk_rst_if    csrng_rst_vif;
@@ -151,6 +152,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
                             type_id::create("m_csrng_agent_cfg");
     m_aes_halt_agent_cfg  = push_pull_agent_cfg#(.HostDataWidth(0))::
                             type_id::create("m_aes_halt_agent_cfg");
+    m_xht_agent_cfg       = entropy_src_xht_agent_cfg::type_id::create("m_xht_agent_cfg");
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -13,6 +13,7 @@ package entropy_src_env_pkg;
   import csr_utils_pkg::*;
   import entropy_src_ral_pkg::*;
   import push_pull_agent_pkg::*;
+  import entropy_src_xht_agent_pkg::*;
   import entropy_src_pkg::*;
   import prim_mubi_pkg::*;
   import entropy_subsys_fifo_exception_pkg::*;

--- a/hw/ip/entropy_src/dv/env/entropy_src_virtual_sequencer.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_virtual_sequencer.sv
@@ -11,6 +11,7 @@ class entropy_src_virtual_sequencer extends cip_base_virtual_sequencer #(
   push_pull_sequencer#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))         rng_sequencer_h;
   push_pull_sequencer#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))  csrng_sequencer_h;
   push_pull_sequencer#(.HostDataWidth(0))                                      aes_halt_sequencer_h;
+  entropy_src_xht_sequencer                                                    xht_sequencer;
 
   `uvm_component_new
 

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -39,9 +39,8 @@ module tb;
       rng_if(.clk(clk), .rst_n(csrng_rst_n));
   push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
       csrng_if(.clk(clk), .rst_n(csrng_rst_n));
-  // Use a push_pull interface to
-  push_pull_if#(.HostDataWidth(0))
-      aes_halt_if(.clk(clk), .rst_n(csrng_rst_n));
+  push_pull_if#(.HostDataWidth(0)) aes_halt_if(.clk(clk), .rst_n(csrng_rst_n));
+  entropy_src_xht_if xht_if(.clk(clk), .rst_n(rst_n));
   entropy_src_path_if entropy_src_path_if (.entropy_src_hw_if_i(entropy_src_hw_if_i));
   entropy_src_assert_if entropy_src_assert_if (.entropy_src_hw_if_i(entropy_src_hw_if_i));
 
@@ -66,8 +65,8 @@ module tb;
     .cs_aes_halt_o                (aes_halt_if.req),
     .cs_aes_halt_i                (aes_halt_if.ack),
 
-    .entropy_src_xht_o            (),
-    .entropy_src_xht_i            ('0),
+    .entropy_src_xht_o            (xht_if.req),
+    .entropy_src_xht_i            (xht_if.rsp),
 
     .entropy_src_rng_o            (rng_if.ready),
     .entropy_src_rng_i            ({rng_if.valid, rng_if.h_data}),
@@ -113,6 +112,7 @@ module tb;
         set(null, "*.env.m_csrng_agent*", "vif", csrng_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(0)))::
         set(null, "*.env.m_aes_halt_agent*", "vif", aes_halt_if);
+    uvm_config_db#(virtual entropy_src_xht_if)::set(null, "*.env.m_xht_agent*", "vif", xht_if);
     uvm_config_db#(virtual entropy_src_assert_if)::set(null, "*.env", "entropy_src_assert_vif",
         entropy_src_assert_if);
     uvm_config_db#(virtual entropy_src_path_if)::set(null, "*.env", "entropy_src_path_vif",


### PR DESCRIPTION
In order to test the ExtHT interface, this commit adds a simple agent to monitor the ExtHT interface, and occassionally signal health test failures back to the DUT.

- Most of the new files are related to this new agent, which is loosely based on the push_pull agent. However this interface has no acknowlegement handshaking, so this agent is much simpler.
- A simple base_sequence is provided which consumes entropy from the DUT and calculates an arbitrary figure of merit, a partial SHA3 digest of the window data.  This figure of merit can later be used to tune the failure rate of the simulated health test.
- An initial attempt is made at incorporating the new agent into the `entropy_src` environment, and to provide some scoreboarding.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>