### PR TITLE
[cleanup] Speed up ECC encoding with memoization

### DIFF
--- a/util/design/secded_gen.py
+++ b/util/design/secded_gen.py
@@ -12,6 +12,7 @@ Hsiao SECDED codes, refer to https://ieeexplore.ieee.org/document/8110065.g
 """
 
 import argparse
+import functools
 import itertools
 import logging as log
 import math
@@ -402,6 +403,7 @@ def _ecc_encode(k: int,
     return codeword
 
 
+@functools.lru_cache(maxsize = 1024)
 def ecc_encode(codetype: str, k: int, dataword: int) -> Tuple[int, int]:
     log.info(f"Encoding ECC for {hex(dataword)}")
 


### PR DESCRIPTION
It currently takes minutes to build 1MB vmem files for backdoor flash loading.  By memoizing the `ecc_encode` function, we can generate the vmem files in seconds.

Signed-off-by: Chris Frantz <cfrantz@google.com>