### PR TITLE
[util] Add riscv32 commands to compile_commands.json

### DIFF
--- a/util/generate_compilation_db.py
+++ b/util/generate_compilation_db.py
@@ -69,7 +69,9 @@ class BazelAqueryResults:
                 break
             id = path_fragment['parentId']
 
-        return os.path.join(*reversed(labels))
+        # For our purposes, `os.sep.join()` should be equivalent to
+        # `os.path.join()`, but without the additional overhead.
+        return os.sep.join(reversed(labels))
 
     def iter_artifacts_for_dep_sets(self, dep_set_ids: List[int]):
         """Iterate the reconstructed paths of all artifacts related to `dep_set_ids`."""

--- a/util/generate_compilation_db.py
+++ b/util/generate_compilation_db.py
@@ -149,7 +149,7 @@ def build_compile_commands(
     ]
     if device_build:
         bazel_aquery_command.append('--config=riscv32')
-    bazel_aquery_command.append(args.target)
+    bazel_aquery_command.append(f'mnemonic("CppCompile", {args.target})')
 
     logger.info("Running bazel command: %s", bazel_aquery_command)
     try:
@@ -170,8 +170,8 @@ def build_compile_commands(
     compile_commands = []
     unittest_compile_commands = []
     for action in aquery_results.actions:
-        if action.mnemonic != 'CppCompile' or action.arguments == []:
-            continue
+        assert action.mnemonic == 'CppCompile'
+        assert action.arguments != []
 
         arguments = action.transform_arguments_for_clangd()
 


### PR DESCRIPTION
This commit adds a new `bazel aquery` step to generate_compilation_db.py to construct riscv32-specific compile commands.

I observed some sources missing from compile_commands.json, such as sw/device/examples/sram_program/sram_program.c. I think the problem is that, by default, a wildcard target like "//sw/..." only finds targets buildable on the host platform. This probably didn't come up earlier because I only looked at sources that could be compiled on the host via a `cc_test` rule.

I still had a few problems getting Clangd to work with sram_program.c. When I peeked at the Clangd output in VSCode, I realized a few compiler flags were causing issues. The script now strips these troublemakers in `BazelAqueryAction.filter_arguments_for_clangd()`.

Further, I also realized that concatenating the host-specific and device-specific commands was not right. Clangd seems to pick the first matching command it sees in compile_commands.json. When editing unittest sources, we generally want the host-specific rule. When editing other sources, we generally want the device-specific rule.

Signed-off-by: Dan McArdle <dmcardle@google.com>