### PR TITLE
[spi_device/dv] Fix a regression failure

### DIFF
--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -574,7 +574,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
     bit [31:0] payload_start_addr = get_converted_addr(PAYLOAD_FIFO_START_ADDR);
     int payload_depth_exp;
     upload_cmd_q.push_back(item.opcode);
-    intr_trigger_pending[CmdFifoNotEmpty] = 1;
+    update_pending_intr_w_delay(CmdFifoNotEmpty);
 
     if (item.address_q.size > 0) begin
       bit[31:0] addr = convert_addr_from_byte_queue(item.address_q);
@@ -588,7 +588,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
       `uvm_info(`gfn, $sformatf("write upload payload idx %0d, mem addr 0x%0x, val: 0x%0x",
                 i, addr, item.payload_q[i]), UVM_MEDIUM)
     end
-    if (item.payload_q.size > 0) intr_trigger_pending[PayloadNotEmpty] = 1;
+    if (item.payload_q.size > 0) update_pending_intr_w_delay(PayloadNotEmpty);
 
     update_cmdfifo_status();
     update_addrfifo_status();
@@ -751,17 +751,29 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
 
     if (offset >= threshold && threshold > 0 && !read_buffer_watermark_triggered) begin
       read_buffer_watermark_triggered = 1;
-      intr_trigger_pending[ReadbufWatermark] = 1;
+      update_pending_intr_w_delay(ReadbufWatermark);
       `uvm_info(`gfn, $sformatf("read buffer watermark is triggered, addr: 0x%0x", addr),
                 UVM_MEDIUM)
     end
     if (addr % READ_BUFFER_HALF_SIZE == 0) begin
       // after flip, WM can be triggered again
       read_buffer_watermark_triggered = 0;
-      intr_trigger_pending[ReadbufFlip] = 1;
+      update_pending_intr_w_delay(ReadbufFlip);
       `uvm_info(`gfn, $sformatf("read buffer flip is triggered, addr: 0x%0x", addr),
                 UVM_MEDIUM)
     end
+  endfunction
+
+  // flash/tpm interrupt is updated from spi domain to sys clk domain, which takes 2+ cycles.
+  // allow the 1st interrupt read doesn't aligned with the exp value, but if SW issues 2 interrupt
+  // read with no delay, the 2nd one may also doesn't match.
+  // add some cycle delays to make it close to design behavior, so that the 2nd interrupt read
+  // must match.
+  virtual function void update_pending_intr_w_delay(spi_device_intr_e intr, int delay_cyc = 3);
+    fork begin
+      cfg.clk_rst_vif.wait_n_clks(delay_cyc);
+      intr_trigger_pending[intr] = 1;
+    end join_none
   endfunction
 
   // process_tl_access:this task processes incoming access into the IP over tl interface


### PR DESCRIPTION
flash/tpm interrupt is updated from spi domain to sys clk domain, which takes 3+ cycles.
scb allow the 1st interrupt read doesn't aligned with the exp value, but if SW issues 2 interrupt read with no delay, the 2nd one may also doesn't match. add some cycle delays to make it close to design behavior, so that the 2nd interrupt read must match.
This doesn't match scb cycle accurate, but it shortens the uncertain period.

Signed-off-by: Weicai Yang <weicai@google.com>