### PR TITLE
[spi_device/dv] Update interrupt fcov and add TPM interrupt checker

### DIFF
--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -276,6 +276,8 @@ class spi_monitor extends dv_base_monitor#(
       end
     join
     `uvm_info(`gfn, $sformatf("Received TPM addr: %p", item.address_q), UVM_MEDIUM)
+    req_analysis_port.write(item);
+
     // poll TPM_START
     `DV_SPINWAIT(
       do begin

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_all_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_all_vseq.sv
@@ -33,6 +33,10 @@ class spi_device_tpm_all_vseq extends spi_device_tpm_read_hw_reg_vseq;
 
   virtual task body();
     bit main_body_done;
+
+    // both SW and HW may want to update this interrupt at the same time,
+    // scb can't predict this interrupt properly.
+    cfg.en_check_tpm_not_empty_intr = 0;
     fork
       begin
         super.body();

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -24,6 +24,10 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
   // both may access the same csr `CFG`, have this to avoid accessing it at the same time.
   semaphore           spi_cfg_sema = new(1);
 
+  // in some sequence, both SW and HW may want to update this interrupt at the same time,
+  // which is hard to handle in scb. In this case, disable the checker.
+  // as long as all TPM requests can be read out and compared correctly, it's sufficient.
+  bit                 en_check_tpm_not_empty_intr = 1;
   `uvm_object_utils_begin(spi_device_env_cfg)
     `uvm_field_object(spi_host_agent_cfg, UVM_DEFAULT)
     `uvm_field_object(spi_device_agent_cfg, UVM_DEFAULT)
@@ -42,6 +46,9 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
 
     sram_start_addr = ral.get_addr_from_offset(SRAM_OFFSET);
     sram_end_addr   = sram_start_addr + SRAM_SIZE - 1;
+
+    // only support 1 outstanding TL item
+    m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 
   function spi_device_reg_cmd_info get_cmd_info_reg_by_opcode(bit [7:0] opcode);


### PR DESCRIPTION
1. Sample interrupt fcov
2. Update scb to check TPM interrupt with an enable knob
3. Disable TPM interrupt checkers for tpm_all test
4. Update TL max_outstanding_num

Signed-off-by: Weicai Yang <weicai@google.com>