### PR TITLE
[util] Improve vmem generation performance

### DIFF
--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -13,7 +13,7 @@ import hjson  # type: ignore
 from Crypto.Hash import cSHAKE256
 
 from mem import MemChunk, MemFile
-from util.design.secded_gen import ecc_encode_some  # type: ignore
+from util.design.secded_gen import ecc_encode_some, load_secded_config  # type: ignore
 
 ROM_BASE_WORD = 0x8000 // 4
 ROM_SIZE_WORDS = 8192
@@ -285,6 +285,7 @@ class Scrambler:
         self.nonce = nonce
         self.key = key
         self.rom_size_words = rom_size_words
+        self.config = load_secded_config()
 
         self._addr_width = (rom_size_words - 1).bit_length()
 
@@ -504,7 +505,7 @@ class Scrambler:
                 w39 = w32 | (chk_bits << 32)
                 clr39 = self.unscramble_word(39, log_addr, w39)
                 clr32 = clr39 & mask32
-                exp39 = ecc_encode_some('inv_hsiao', 32, [clr32])[0][0]
+                exp39 = ecc_encode_some(self.config, 'inv_hsiao', 32, [clr32])[0][0]
                 if clr39 != exp39:
                     # The checksum doesn't match. Excellent!
                     found_mismatch = True

--- a/util/design/gen-flash-img.py
+++ b/util/design/gen-flash-img.py
@@ -11,12 +11,13 @@ import argparse
 import math
 import re
 from pathlib import Path
+from typing import Dict, Any
 
 import secded_gen
 
 
-def _add_intg_ecc(in_val: int) -> str:
-    result, m = secded_gen.ecc_encode("hamming", 64, in_val)
+def _add_intg_ecc(config: Dict[str, Any], in_val: int) -> str:
+    result, m = secded_gen.ecc_encode(config, "hamming", 64, in_val)
 
     m_nibbles = math.ceil(m / 4)
     result = format(result, '0' + str(16 + m_nibbles) + 'x')
@@ -25,8 +26,8 @@ def _add_intg_ecc(in_val: int) -> str:
     return result[1:]
 
 
-def _add_reliability_ecc(in_val: int) -> str:
-    result, m = secded_gen.ecc_encode("hamming", 68, in_val)
+def _add_reliability_ecc(config: Dict[str, Any], in_val: int) -> str:
+    result, m = secded_gen.ecc_encode(config, "hamming", 68, in_val)
 
     m_nibbles = math.ceil((68 + m) / 4)
     result = format(result, '0' + str(m_nibbles) + 'x')
@@ -50,6 +51,8 @@ def main():
     # search only for lines that contain data, skip all other comments
     result = re.findall(r"^@.*$", vmem_orig, flags=re.MULTILINE)
 
+    config = secded_gen.load_secded_config()
+
     output = []
     for line in result:
         items = line.split()
@@ -58,8 +61,8 @@ def main():
             if re.match(r"^@", item):
                 result += item
             else:
-                data_w_intg_ecc = _add_intg_ecc(int(item, 16))
-                full_ecc = _add_reliability_ecc(int(data_w_intg_ecc, 16))
+                data_w_intg_ecc = _add_intg_ecc(config, int(item, 16))
+                full_ecc = _add_reliability_ecc(config, int(data_w_intg_ecc, 16))
                 result += f' {full_ecc}'
 
         # add processed element to output

--- a/util/design/secded_gen.py
+++ b/util/design/secded_gen.py
@@ -374,6 +374,7 @@ def _ecc_pick_code(config: Dict[str, Any], codetype: str, k: int) -> Tuple[int, 
     raise Exception(f'ECC for length {k} of type {codetype} unsupported')
 
 
+@functools.lru_cache(maxsize=None)
 def _ecc_encode(k: int,
                 m: int, bitmasks: List[int], invert: int,
                 dataword: int) -> int:
@@ -592,6 +593,7 @@ def _inv_hamming_code(k, m):
 # k = data bits
 # m = parity bits
 # generate hamming code
+@functools.lru_cache(maxsize=None)
 def _hamming_code(k, m):
 
     n = k + m


### PR DESCRIPTION
This PR speeds up vmem generation (mostly ECC encoding) by:
* Moving config HJSON file parsing outside so that it's not loaded repeatedly in tight loops,
* Adding memoization to two functions on the hot path, and
* Rewriting `_hamming_code()` with integer operations and list comprehensions (the original code used floating pointer operations and a more complex nested loop structure).

This speeds up the vmem generation part of `bazel build //sw/device/...`  by ~3x on my machine (~4 mins down from ~11 mins when compared to `master`, which includes the changes in #15387).

```
# upstream/master @ 35b088540
INFO: Elapsed time: 667.718s, Critical Path: 50.85s

# alphan/vmem-speed
INFO: Elapsed time: 236.404s, Critical Path: 25.25s
```

Signed-off-by: Alphan Ulusoy <alphan@google.com>