### PR TITLE
[crypto] Bugfix for RSA-4096 encryption.

### DIFF
--- a/sw/device/tests/otbn_rsa_test.c
+++ b/sw/device/tests/otbn_rsa_test.c
@@ -111,9 +111,9 @@ static void rsa_encrypt(otbn_t *otbn_ctx, const uint8_t *modulus,
 
   // Write input arguments.
   uint32_t mode = 1;  // mode 1 => encrypt
-  CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(mode), &mode,
+  CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(uint32_t), &mode,
                                kOtbnVarRsaMode) == kOtbnOk);
-  CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(n_limbs), &n_limbs,
+  CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(uint32_t), &n_limbs,
                                kOtbnVarRsaNLimbs) == kOtbnOk);
   CHECK(otbn_copy_data_to_otbn(otbn_ctx, size_bytes, modulus,
                                kOtbnVarRsaModulus) == kOtbnOk);

--- a/sw/otbn/crypto/rsa.s
+++ b/sw/otbn/crypto/rsa.s
@@ -47,8 +47,8 @@ rsa_decrypt:
 zero_work_buf:
   la     x3, work_buf
   bn.xor w0, w0, w0
-  /* The buffer is 480 bytes long, which needs fourteen 256b words. */
-  loopi 14, 1
+  /* The buffer is 512 bytes long, which needs sixteen 256b words. */
+  loopi 16, 1
     bn.sid x0, 0(x3++)
   ret
 
@@ -60,9 +60,9 @@ zero_work_buf:
 cp_work_buf:
   la  x3, work_buf
   la  x4, inout
-  /* The buffers are 480 bytes long, which we can load/store with
-     fourteen 256b words. */
-  loopi 14, 2
+  /* The buffers are 512 bytes long, which we can load/store with
+     sixteen 256b words. */
+  loopi 16, 2
     bn.lid x0, 0(x3++)
     bn.sid x0, 0(x4++)
   ret
@@ -109,32 +109,38 @@ dptr_out:
 
 /* (End of fixed-layout section) */
 
-
 /* Modulus (n) */
+.balign 32
 .globl modulus
 modulus:
   .zero 512
 
 /* private exponent (d) */
+.balign 32
 .globl exp
 exp:
   .zero 512
 
 /* input/output data */
+.balign 32
 .globl inout
 inout:
   .zero 512
 
-
-.section .scratchpad
+.balign 32
 m0d:
   /* filled by modload */
+  /* could go in scratchpad if there was space */
   .zero 32
 
+.section .scratchpad
+
+.balign 32
 RR:
   /* filled by modload */
   .zero 512
 
 /* working data */
+.balign 32
 work_buf:
-  .zero 480
+  .zero 512


### PR DESCRIPTION
Fixes #15331

The number of bytes needed for RSA-4096 was miscalculated in rsa.s (it should be 512 bytes, not 480). This fixes the bug and also adds some small cleanups (whole-word writes to DMEM for n_limbs and mode, and .balign directives for the OTBN data).