### PR TITLE
[chip] `sleep_pin_retention` test: SW/DV handshake + GPIO check

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_retention_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_retention_vseq.sv
@@ -23,7 +23,18 @@ class chip_sw_sleep_pin_retention_vseq extends chip_sw_base_vseq;
 
   endtask : cpu_init
 
+  function logic [7:0] sample_gpio();
+    // TODO: After https://github.com/lowRISC/opentitan/pull/15339 is merged,
+    // revise code to get value from gpio_if not from ios_if.
+    logic [7:0] result;
+
+    result = cfg.chip_vif.ios_if.pins_o[IoA7:IoA0];
+
+    return result;
+  endfunction : sample_gpio
+
   virtual task body();
+    string printed_log;
     super.body();
 
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
@@ -31,22 +42,50 @@ class chip_sw_sleep_pin_retention_vseq extends chip_sw_base_vseq;
     // Drive GPIO8 (IoA8) to 0
     cfg.chip_vif.ios_if.drive_pin(IoA8, 1'b 0);
 
+    // GPIO[7:0] to input mode.
+    // TODO: After https://github.com/lowRISC/opentitan/pull/15339 is merged,
+    // revise code to get value from gpio_if not from ios_if.
+    cfg.chip_vif.ios_if.pins_oe[IoA7:IoA0] = '0;
+
     for (int round = rounds - 1 ; round >= 0 ; round--) begin
-        // TODO: Receive values from SW via sw_logger_vif
-        `DV_WAIT(cfg.sw_logger_vif.printed_log == $sformatf("Current Test Round: %1d", round))
+      bit   [7:0] gpio_val;
+      logic [7:0] gpio_sample;
 
-        // TODO: Check PIN
+      string exp_str;
 
-        // TODO: Wait sleep (normal vs deep)
-        wait(cfg.chip_vif.pwrmgr_low_power_if.in_sleep == 1'b 1);
-        repeat (5) @(cfg.chip_vif.pwrmgr_low_power_if.cb);
+      // Init the variables
+      printed_log = "";
 
-        // TODO: Check PIN value
+      // TODO: Receive values from SW via sw_logger_vif
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == $sformatf("Current Test Round: %1d", round))
 
-        // TODO: Wake up DUT
-        cfg.chip_vif.ios_if.drive_pin(IoA8, 1'b 1);
-        repeat (3) @(cfg.chip_vif.pwrmgr_low_power_if.cb);
-        cfg.chip_vif.ios_if.drive_pin(IoA8, 1'b 0);
+      exp_str = "Chosen GPIO value:";
+      while (printed_log.substr(0, exp_str.len()-1) != exp_str) begin
+        @(cfg.sw_logger_vif.printed_log_event);
+        printed_log = cfg.sw_logger_vif.printed_log;
+      end
+
+      assert(cfg.sw_logger_vif.printed_arg[0] inside {[0:255]});
+      gpio_val = cfg.sw_logger_vif.printed_arg[0][7:0];
+
+      `uvm_info(`gfn, $sformatf("Received GPIO value: %2x", gpio_val), UVM_LOW)
+
+      // TODO: Check PIN
+      gpio_sample = sample_gpio();
+      `DV_CHECK(gpio_sample == gpio_val,
+        $sformatf("GPIO value mismatch: Exp[%2x] / Rcv[%2x]",
+                  gpio_val, gpio_sample))
+
+      // TODO: Wait sleep (normal vs deep)
+      wait(cfg.chip_vif.pwrmgr_low_power_if.in_sleep == 1'b 1);
+      repeat (5) @(cfg.chip_vif.pwrmgr_low_power_if.cb);
+
+      // TODO: Check PIN value
+
+      // TODO: Wake up DUT
+      cfg.chip_vif.ios_if.drive_pin(IoA8, 1'b 1);
+      repeat (3) @(cfg.chip_vif.pwrmgr_low_power_if.cb);
+      cfg.chip_vif.ios_if.drive_pin(IoA8, 1'b 0);
     end
 
   endtask : body

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -681,6 +681,7 @@ opentitan_functest(
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rv_plic",


### PR DESCRIPTION
This PR includes #15338 

### Add GPIO/ PINMUX configuration

In this commit, the `sleep_pin_retention` test selects IoA[7:0] PADs for
GPIO[7:0] and drives the PADs (via GPIO) to all zero befor the test
begins.

### Random choice of GPIO value

In this commit, the `chip_sw_sleep_pin_retention` test choses GPIO[7:0]
value randomly per round and drive the PADs.

SV side receives the value and check the PADs