### PR TITLE
[otp/bazel] Refactor OTP Bazel rules and add overlay support

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:autogen.bzl", "autogen_hjson_header")
-load("//rules:otp.bzl", "otp_image", "otp_json")
+load("//rules:otp.bzl", "otp_image", "otp_json", "otp_partition")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
@@ -11,6 +11,11 @@ package(default_visibility = ["//visibility:public"])
 # This package must be kept in sync with get_otp_images() from //rules:otp.bzl.
 # That is, each OTP image referenced by the macro should have a definition in
 # this BUILD file.
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)
 
 autogen_hjson_header(
     name = "otp_ctrl_regs",
@@ -20,72 +25,364 @@ autogen_hjson_header(
 )
 
 otp_json(
-    name = "otp_ctrl_dev_json",
-    lc_count = 5,
-    lc_state = "DEV",
+    name = "otp_json_creator_sw_cfg",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_DIGEST": "0x0",
+                # Use software mod_exp implementation for signature
+                # verification. See the definition of `hardened_bool_t` in
+                # sw/device/lib/base/hardened.h.
+                "CREATOR_SW_CFG_USE_SW_RSA_VERIFY": "0x739",
+                # Mark the first two keys as valid and remaining as invalid
+                # since we have currently only two keys. See the definition of
+                # `hardened_byte_bool_t` in sw/device/lib/base/hardened.h.
+                "CREATOR_SW_CFG_KEY_IS_VALID": "0x4b4b4b4b4b4ba5a5",
+                # Enable use of entropy for countermeasures. See the definition
+                # of `hardened_bool_t` in sw/device/lib/base/hardened.h.
+                "CREATOR_SW_CFG_RNG_EN": "0x739",
+                # ROM execution is enabled if this item is set to a non-zero
+                # value.
+                "CREATOR_SW_CFG_ROM_EXEC_EN": "0xffffffff",
+                # Value to write to the cpuctrl CSR in `rom_init()`.
+                # See:
+                # https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html#cpu-control-register-cpuctrl
+                "CREATOR_SW_CFG_CPUCTRL": "0x1",
+                "CREATOR_SW_CFG_JITTER_EN": "0x9",
+                # Value of the min_security_version_rom_ext field of the
+                # default boot data.
+                "CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT": "0x0",
+                # Value of the min_security_version_bl0 field of the default
+                # boot data.
+                "CREATOR_SW_CFG_MIN_SEC_VER_BL0": "0x0",
+                # Enable the default boot data in PROD and PROD_END life cycle
+                # states. See the definition of `hardened_bool_t` in
+                # sw/device/lib/base/hardened.h.
+                "CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN": "0x739",
+            },
+        ),
+    ],
+)
+
+otp_json(
+    name = "otp_json_owner_sw_cfg",
+    partitions = [
+        otp_partition(
+            name = "OWNER_SW_CFG",
+            items = {
+                "OWNER_SW_CFG_DIGEST": "0x0",
+                # Enable bootstrap. See `hardened_bool_t` in
+                # sw/device/lib/base/hardened.h.
+                "OWNER_SW_CFG_ROM_BOOTSTRAP_EN": "0x739",
+                # Set to 0x739 to use the ROM_EXT hash measurement as the key
+                # manager attestation binding value.
+                "OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN": "0x0",
+                # Set the enables to kAlertEnableNone.
+                # See `alert_enable_t` in
+                # sw/device/silicon_creator/lib/drivers/alert.h
+                "OWNER_SW_CFG_ROM_ALERT_CLASS_EN": "0xa9a9a9a9",
+                # Set the esclation policies to kAlertEscalateNone.
+                # See `alert_escalate_t` in
+                # sw/device/silicon_creator/lib/drivers/alert.h
+                "OWNER_SW_CFG_ROM_ALERT_ESCALATION": "0xd1d1d1d1",
+                # Set the classifiactions to kAlertClassX.
+                # See `alert_class_t` in
+                # sw/device/silicon_creator/lib/drivers/alert.h
+                "OWNER_SW_CFG_ROM_ALERT_CLASSIFICATION": ["0x94949494"] * 80,
+                # Set the classifiactions to kAlertClassX. See `alert_class_t` in
+                # sw/device/silicon_creator/lib/drivers/alert.h
+                "OWNER_SW_CFG_ROM_LOCAL_ALERT_CLASSIFICATION": ["0x94949494"] * 16,
+                # Set the alert accumulation thresholds to 0 per class.
+                "OWNER_SW_CFG_ROM_ALERT_ACCUM_THRESH": ["0x00000000"] * 4,
+                # Set the alert timeout cycles to 0 per class.
+                "OWNER_SW_CFG_ROM_ALERT_TIMEOUT_CYCLES": ["0x00000000"] * 4,
+                # Set the alert phase cycles to 0,10,10,0xFFFFFFFF for classes
+                # A and B, and to all zeros for classes C and D.
+                "OWNER_SW_CFG_ROM_ALERT_PHASE_CYCLES": [
+                    "0x0",
+                    "0xa",
+                    "0xa",
+                    "0xFFFFFFFF",
+                    "0x0",
+                    "0xa",
+                    "0xa",
+                    "0xFFFFFFFF",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                ],
+                "OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA": "0x36ed9cb0",
+            },
+        ),
+    ],
+)
+
+otp_json(
+    name = "otp_json_hw_cfg",
+    partitions = [
+        otp_partition(
+            name = "HW_CFG",
+            items = {
+                "DEVICE_ID": "<random>",
+                # Cryptolib and chip-level tests require access to the CSRNG
+                # software interfaces.
+                "EN_CSRNG_SW_APP_READ": True,
+                # Cryptolib and chip-level tests require access to the
+                # entropy_src FW data interface.
+                "EN_ENTROPY_SRC_FW_READ": True,
+                # Cryptolib and chip-level tests require access to the
+                # entropy_src FW override interface.
+                "EN_ENTROPY_SRC_FW_OVER": True,
+            },
+            lock = True,
+        ),
+    ],
+)
+
+# OTP LC STATE-SPECIFIC CONFIGS
+otp_json(
+    name = "otp_json_raw",
+    partitions = [
+        otp_partition(
+            name = "SECRET1",
+            items = {
+                "FLASH_DATA_KEY_SEED": "<random>",
+            },
+            lock = False,
+        ),
+        otp_partition(
+            name = "LIFE_CYCLE",
+            count = 0,
+            state = "RAW",
+        ),
+    ],
+    seed = "01931961561863975174",
+)
+
+otp_json(
+    name = "otp_json_test_unlocked0",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                # ROM execution is enabled if this item is set to a non-zero value.
+                "CREATOR_SW_CFG_ROM_EXEC_EN": "0xffffffff",
+            },
+        ),
+        otp_partition(
+            name = "LIFE_CYCLE",
+            count = 0,
+            state = "RAW",
+        ),
+    ],
+    seed = "01931961561863975174",
+)
+
+otp_json(
+    name = "otp_json_dev",
+    partitions = [
+        otp_partition(
+            name = "SECRET0",
+            items = {
+                "TEST_UNLOCK_TOKEN": "<random>",
+                "TEST_EXIT_TOKEN": "<random>",
+            },
+            lock = True,
+        ),
+        otp_partition(
+            name = "SECRET1",
+            items = {
+                "FLASH_ADDR_KEY_SEED": "<random>",
+                "FLASH_DATA_KEY_SEED": "<random>",
+                "SRAM_DATA_KEY_SEED": "<random>",
+            },
+            lock = True,
+        ),
+        otp_partition(
+            name = "SECRET2",
+            items = {
+                "RMA_TOKEN": "<random>",
+                "CREATOR_ROOT_KEY_SHARE0": "<random>",
+                "CREATOR_ROOT_KEY_SHARE1": "<random>",
+            },
+            lock = False,
+        ),
+        otp_partition(
+            name = "LIFE_CYCLE",
+            count = "5",
+            state = "DEV",
+        ),
+    ],
+    seed = "94259314771464387",
+)
+
+otp_json(
+    name = "otp_json_prod",
+    partitions = [
+        otp_partition(
+            name = "SECRET0",
+            items = {
+                "TEST_UNLOCK_TOKEN": "<random>",
+                "TEST_EXIT_TOKEN": "<random>",
+            },
+            lock = True,
+        ),
+        otp_partition(
+            name = "SECRET1",
+            items = {
+                "FLASH_ADDR_KEY_SEED": "<random>",
+                "FLASH_DATA_KEY_SEED": "<random>",
+                "SRAM_DATA_KEY_SEED": "<random>",
+            },
+            lock = True,
+        ),
+        otp_partition(
+            name = "SECRET2",
+            items = {
+                "RMA_TOKEN": "<random>",
+                "CREATOR_ROOT_KEY_SHARE0": "<random>",
+                "CREATOR_ROOT_KEY_SHARE1": "<random>",
+            },
+            lock = False,
+        ),
+        otp_partition(
+            name = "LIFE_CYCLE",
+            count = 5,
+            state = "PROD",
+        ),
+    ],
+    seed = "14555711126514784208",
+)
+
+otp_json(
+    name = "otp_json_rma",
+    partitions = [
+        otp_partition(
+            name = "SECRET0",
+            items = {
+                "TEST_UNLOCK_TOKEN": "<random>",
+                "TEST_EXIT_TOKEN": "<random>",
+            },
+            lock = True,
+        ),
+        otp_partition(
+            name = "SECRET1",
+            items = {
+                "FLASH_ADDR_KEY_SEED": "<random>",
+                "FLASH_DATA_KEY_SEED": "<random>",
+                "SRAM_DATA_KEY_SEED": "<random>",
+            },
+            lock = True,
+        ),
+        otp_partition(
+            name = "SECRET2",
+            items = {
+                "RMA_TOKEN": "<random>",
+                "CREATOR_ROOT_KEY_SHARE0": "<random>",
+                "CREATOR_ROOT_KEY_SHARE1": "<random>",
+            },
+            lock = False,
+        ),
+        otp_partition(
+            name = "LIFE_CYCLE",
+            count = 8,
+            state = "RMA",
+        ),
+    ],
+    seed = "01931961561863975174",
 )
 
 otp_image(
     name = "img_dev",
-    src = ":otp_ctrl_dev_json",
-)
-
-otp_json(
-    name = "otp_ctrl_rma_json",
-    lc_count = 8,
-    lc_state = "RMA",
-)
-
-otp_image(
-    name = "img_rma",
-    src = ":otp_ctrl_rma_json",
-)
-
-otp_json(
-    name = "otp_ctrl_test_unlocked0_json",
-    lc_count = 1,
-    lc_state = "TEST_UNLOCKED0",
-)
-
-otp_image(
-    name = "img_test_unlocked0",
-    src = ":otp_ctrl_test_unlocked0_json",
-)
-
-otp_json(
-    name = "otp_ctrl_prod_json",
-    lc_count = 5,
-    lc_state = "PROD",
+    src = ":otp_json_dev",
+    overlays = [
+        ":otp_json_creator_sw_cfg",
+        ":otp_json_owner_sw_cfg",
+        ":otp_json_hw_cfg",
+    ],
 )
 
 otp_image(
     name = "img_prod",
-    src = ":otp_ctrl_prod_json",
+    src = ":otp_json_prod",
+    overlays = [
+        ":otp_json_creator_sw_cfg",
+        ":otp_json_owner_sw_cfg",
+        ":otp_json_hw_cfg",
+    ],
 )
 
+otp_image(
+    name = "img_raw",
+    src = ":otp_json_raw",
+    overlays = [
+        ":otp_json_creator_sw_cfg",
+        ":otp_json_owner_sw_cfg",
+        ":otp_json_hw_cfg",
+    ],
+)
+
+otp_image(
+    name = "img_rma",
+    src = ":otp_json_rma",
+    overlays = [
+        ":otp_json_creator_sw_cfg",
+        ":otp_json_owner_sw_cfg",
+        ":otp_json_hw_cfg",
+    ],
+)
+
+otp_image(
+    name = "img_test_unlocked0",
+    src = ":otp_json_test_unlocked0",
+    overlays = [
+        ":otp_json_creator_sw_cfg",
+        ":otp_json_owner_sw_cfg",
+        ":otp_json_hw_cfg",
+    ],
+)
+
+# Create an execution-disabling overlay
 otp_json(
-    name = "otp_exec_disabled_json",
-    creator_sw_cfg_rom_exec_en = "0x0",
-    lc_count = 8,
-    lc_state = "RMA",
+    name = "otp_json_exec_disabled",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {"CREATOR_SW_CFG_ROM_EXEC_EN": "0x0"},
+        ),
+    ],
 )
 
 otp_image(
     name = "img_exec_disabled",
-    src = ":otp_exec_disabled_json",
+    src = ":otp_json_rma",
+    overlays = [
+        ":otp_json_creator_sw_cfg",
+        ":otp_json_owner_sw_cfg",
+        ":otp_json_hw_cfg",
+        ":otp_json_exec_disabled",
+    ],
 )
 
 filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
+    name = "otp_imgs",
+    srcs = [
+        ":img_dev",
+        ":img_prod",
+        ":img_raw",
+        ":img_rma",
+        ":img_test_unlocked0",
+    ],
 )
 
 pkg_files(
     name = "package",
-    srcs = [
-        ":img_dev",
-        ":img_prod",
-        ":img_rma",
-    ],
+    srcs = [":otp_imgs"],
     prefix = "earlgrey/otp",
 )

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -4,9 +4,36 @@
 
 """Rules for generating OTP images.
 
-The rules in this file are used to generate a JSON file that describe the OTP
-configuration which is then consumed to produce the OTP VMEM image file for
-preloading the OTP in FPGA synthesis or simulation.
+OTP image generation begins with producing one or more (H)JSON files that
+describe the OTP configuration. These files are then consumed by the OTP image
+generation tool to produce the OTP VMEM image file used to preload the OTP in
+FPGA synthesis or simulation.
+
+The JSON file generation is handled by the otp_json rule, which accepts a list
+of partitions. Due to Bazel's limited datatypes for rule attributes, a helper
+function (otp_partition) is used to serialize the representation of each
+partition to pass it into otp_json as a string.
+
+Usage example:
+otp_json(
+    name = "example_otp_json",
+    partitions = [
+        otp_partition(
+            name = "Partition0",
+            lock = True,
+            items = {
+                "ITEM_1": "abc",
+                "ITEM_2": "<random>",
+            }
+        ),
+        otp_partition(...),
+    ],
+)
+
+Note that the "items" dictionary for each partition should be expressed as
+{"key": "value"} mappings. This will be expanded by the otp_json rule into a
+list of dicts, each of the form {"name": key, "value": value}, which is the
+format expected by the image generation tool.
 """
 
 def get_otp_images():
@@ -35,158 +62,18 @@ def get_otp_images():
         ))
     return out
 
+def otp_partition(name, **kwargs):
+    partition = {
+        "name": name,
+    }
+    partition.update(kwargs)
+    return json.encode(partition)
+
 def _otp_json_impl(ctx):
-    """Bazel rule for generating JSON specifications for OTP configurations."""
-
     otp = {}
-
-    # Seed to be used for generation of partition randomized values.
-    # Can be overridden by the OTP image generation tool.
-    otp["seed"] = "01931961561863975174"
-
-    # Assemble all OTP paritions
-    # The partition and item names must correspond with the OTP memory map.
-    otp["partitions"] = [
-        {
-            "name": "CREATOR_SW_CFG",
-            "items": {
-                "CREATOR_SW_CFG_DIGEST": "0x0",
-                # Use software mod_exp implementation for signature
-                # verification. See the definition of `hardened_bool_t` in
-                # sw/device/lib/base/hardened.h.
-                "CREATOR_SW_CFG_USE_SW_RSA_VERIFY": "0x739",
-                # Mark the first two keys as valid and remaining as invalid
-                # since we have currently only two keys. See the definition of
-                # `hardened_byte_bool_t` in sw/device/lib/base/hardened.h.
-                "CREATOR_SW_CFG_KEY_IS_VALID": "0x4b4b4b4b4b4ba5a5",
-                # Enable use of entropy for countermeasures. See the definition
-                # of `hardened_bool_t` in sw/device/lib/base/hardened.h.
-                "CREATOR_SW_CFG_RNG_EN": "0x739",
-                # ROM execution is enabled if this item is set to a non-zero
-                # value.
-                "CREATOR_SW_CFG_ROM_EXEC_EN": ctx.attr.creator_sw_cfg_rom_exec_en,
-                # Value to write to the cpuctrl CSR in `rom_init()`.
-                # See:
-                # https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html#cpu-control-register-cpuctrl
-                "CREATOR_SW_CFG_CPUCTRL": "0x1",
-                "CREATOR_SW_CFG_JITTER_EN": "0x9",
-                # Value of the min_security_version_rom_ext field of the
-                # default boot data.
-                "CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT": "0x0",
-                # Value of the min_security_version_bl0 field of the default
-                # boot data.
-                "CREATOR_SW_CFG_MIN_SEC_VER_BL0": "0x0",
-                # Enable the default boot data in PROD and PROD_END life cycle
-                # states. See the definition of `hardened_bool_t` in
-                # sw/device/lib/base/hardened.h.
-                "CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN": "0x739",
-            },
-        },
-        {
-            "name": "OWNER_SW_CFG",
-            "items": {
-                "OWNER_SW_CFG_DIGEST": "0x0",
-                # Enable bootstrap. See `hardened_bool_t` in
-                # sw/device/lib/base/hardened.h.
-                "OWNER_SW_CFG_ROM_BOOTSTRAP_EN": "0x739",
-                # Set to 0x739 to use the ROM_EXT hash measurement as the key
-                # manager attestation binding value.
-                "OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN": "0x0",
-                # Set the enables to kAlertEnableNone.
-                # See `alert_enable_t` in
-                # sw/device/silicon_creator/lib/drivers/alert.h
-                "OWNER_SW_CFG_ROM_ALERT_CLASS_EN": "0xa9a9a9a9",
-                # Set the esclation policies to kAlertEscalateNone.
-                # See `alert_escalate_t`
-                # in sw/device/silicon_creator/lib/drivers/alert.h
-                "OWNER_SW_CFG_ROM_ALERT_ESCALATION": "0xd1d1d1d1",
-                # Set the classifiactions to kAlertClassX.
-                # See `alert_class_t` in
-                # sw/device/silicon_creator/lib/drivers/alert.h
-                "OWNER_SW_CFG_ROM_ALERT_CLASSIFICATION": ["0x94949494"] * 80,
-                # Set the classifiactions to kAlertClassX.
-                # See `alert_class_t` in
-                # sw/device/silicon_creator/lib/drivers/alert.h
-                "OWNER_SW_CFG_ROM_LOCAL_ALERT_CLASSIFICATION": ["0x94949494"] * 16,
-                # Set the alert accumulation thresholds to 0 per class.
-                "OWNER_SW_CFG_ROM_ALERT_ACCUM_THRESH": ["0x00000000"] * 4,
-                # Set the alert timeout cycles to 0 per class.
-                "OWNER_SW_CFG_ROM_ALERT_TIMEOUT_CYCLES": ["0x00000000"] * 4,
-                # Set the alert phase cycles to 0,10,10,0xFFFFFFFF for classes
-                # A and B, and to all zeros for classes C and D.
-                "OWNER_SW_CFG_ROM_ALERT_PHASE_CYCLES": [
-                    "0x0",
-                    "0xa",
-                    "0xa",
-                    "0xFFFFFFFF",
-                    "0x0",
-                    "0xa",
-                    "0xa",
-                    "0xFFFFFFFF",
-                    "0x0",
-                    "0x0",
-                    "0x0",
-                    "0x0",
-                    "0x0",
-                    "0x0",
-                    "0x0",
-                    "0x0",
-                ],
-                "OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA": "0x36ed9cb0",
-            },
-        },
-        {
-            "name": "HW_CFG",
-            # If set to true, this computes the HW digest value and locks the
-            # partition.
-            "lock": True,
-            "items": {
-                "DEVICE_ID": "<random>",
-                # Cryptolib and chip-level tests require access to the CSRNG
-                # software interfaces.
-                "EN_CSRNG_SW_APP_READ": True,
-                # Cryptolib and chip-level tests require access to the
-                # entropy_src FW data interface.
-                "EN_ENTROPY_SRC_FW_READ": True,
-                # Cryptolib and chip-level tests require access to the
-                # entropy_src FW override interface.
-                "EN_ENTROPY_SRC_FW_OVER": True,
-            },
-        },
-        {
-            "name": "SECRET0",
-            "lock": True,
-            "items": {
-                "TEST_UNLOCK_TOKEN": "<random>",
-                "TEST_EXIT_TOKEN": "<random>",
-            },
-        },
-        {
-            "name": "SECRET1",
-            "lock": True,
-            "items": {
-                "FLASH_ADDR_KEY_SEED": "<random>",
-                "FLASH_DATA_KEY_SEED": "<random>",
-                "SRAM_DATA_KEY_SEED": "<random>",
-            },
-        },
-        {
-            "name": "SECRET2",
-            "lock": False,
-            "items": {
-                "RMA_TOKEN": "<random>",
-                "CREATOR_ROOT_KEY_SHARE0": "<random>",
-                "CREATOR_ROOT_KEY_SHARE1": "<random>",
-            },
-        },
-        {
-            "name": "LIFE_CYCLE",
-            "state": ctx.attr.lc_state,
-            # Can range from 0 to 16.
-            # Note that a value of 0 is only permissible in RAW state.
-            "count": ctx.attr.lc_count,
-        },
-    ]
+    if ctx.attr.seed != "":
+        otp["seed"] = ctx.attr.seed
+    otp["partitions"] = [json.decode(p) for p in ctx.attr.partitions]
 
     # For every partition with an "items" dictionary, expand the dictionary of
     # key:value pairs into a list of dicts, each of the form
@@ -202,26 +89,27 @@ def _otp_json_impl(ctx):
 
     file = ctx.actions.declare_file("{}.json".format(ctx.attr.name))
     ctx.actions.write(file, json.encode_indent(otp))
-    return DefaultInfo(files = depset([file]))
+    return [DefaultInfo(files = depset([file]))]
 
 otp_json = rule(
     implementation = _otp_json_impl,
     attrs = {
-        # Valid life cycle states can be found in the life cycle state
-        # definition file (default: hw/ip/lc_ctrl/data/lc_ctrl_state.hjson)
-        "lc_state": attr.string(doc = "Life cycle state", default = "RMA"),
-        "lc_count": attr.int(doc = "Life cycle count", default = 8),
-        "creator_sw_cfg_rom_exec_en": attr.string(default = "0xffffffff"),
+        "seed": attr.string(
+            doc = "Seed to be used for generation of partition randomized values. Can be overridden by the OTP image generation tool.",
+        ),
+        "partitions": attr.string_list(doc = "A list of serialized partitions from otp_partition."),
     },
 )
 
 def _otp_image(ctx):
     output = ctx.actions.declare_file(ctx.attr.name + ".24.vmem")
     args = ctx.actions.args()
-    args.add("--quiet")
+    if not ctx.attr.verbose:
+        args.add("--quiet")
     args.add("--lc-state-def", ctx.file.lc_state_def)
     args.add("--mmap-def", ctx.file.mmap_def)
     args.add("--img-cfg", ctx.file.src)
+    args.add_all(ctx.files.overlays, before_each = "--add-cfg")
     args.add("--out", "{}/{}.BITWIDTH.vmem".format(output.dirname, ctx.attr.name))
     ctx.actions.run(
         outputs = [output],
@@ -229,7 +117,7 @@ def _otp_image(ctx):
             ctx.file.src,
             ctx.file.lc_state_def,
             ctx.file.mmap_def,
-        ],
+        ] + ctx.files.overlays,
         arguments = [args],
         executable = ctx.executable._tool,
     )
@@ -238,7 +126,14 @@ def _otp_image(ctx):
 otp_image = rule(
     implementation = _otp_image,
     attrs = {
-        "src": attr.label(allow_single_file = True),
+        "src": attr.label(
+            allow_single_file = [".json", ".hjson"],
+            doc = "Image configuration file in Hjson format.",
+        ),
+        "overlays": attr.label_list(
+            allow_files = [".json", ".hjson"],
+            doc = "Additional image configuration file(s) in Hjson format to override src. Overlays are applied in the order provided.",
+        ),
         "lc_state_def": attr.label(
             allow_single_file = True,
             default = "//hw/ip/lc_ctrl/data:lc_ctrl_state.hjson",
@@ -248,6 +143,10 @@ otp_image = rule(
             allow_single_file = True,
             default = "//hw/ip/otp_ctrl/data:otp_ctrl_mmap.hjson",
             doc = "OTP Controller memory map file in Hjson format.",
+        ),
+        "verbose": attr.bool(
+            default = False,
+            doc = "Display progress messages from image-generation tool.",
         ),
         "_tool": attr.label(
             default = "//util/design:gen-otp-img",


### PR DESCRIPTION
This commit refactors how the json configuration files are generated and adds the ability to provide multiple HJSON files as overlays to the `otp_image` target.

Addresses part of #15337.