### PR TITLE
[edn, dif] Rework/enable additional data for INS, RES and GEN commands

### DIFF
--- a/sw/device/lib/dif/dif_edn.h
+++ b/sw/device/lib/dif/dif_edn.h
@@ -52,7 +52,7 @@ enum {
 };
 
 /**
- * CSRNG additional parameters for instantiate and generate commands.
+ * CSRNG seed material for instantiate, reseed and generate commands.
  */
 typedef struct dif_edn_seed_material {
   /**
@@ -63,23 +63,42 @@ typedef struct dif_edn_seed_material {
    */
   size_t len;
   /**
-   * Seed material used in CSRNG instantiate or generate call.
+   * Seed material used in CSRNG instantiate, reseed or generate call.
    */
   uint32_t data[kDifEntropySeedMaterialMaxWordLen];
 } dif_edn_seed_material_t;
+
+/**
+ * CSRNG command parameters for instantiate, reseed and generate commands.
+ */
+typedef struct dif_edn_cmd {
+  /**
+   * The CSRNG application interface command header. For details, refer to the
+   * CSRNG documentation.
+   */
+  uint32_t cmd;
+  /**
+   * Optional seed material.
+   */
+  dif_edn_seed_material_t seed_material;
+} dif_edn_cmd_t;
 
 /**
  * Auto-generate EDN module configuration parameters.
  */
 typedef struct dif_edn_auto_params {
   /**
+   * CSRNG instantiate command material.
+   */
+  dif_edn_cmd_t instantiate_cmd;
+  /**
    * CSRNG reseed command material.
    */
-  dif_edn_seed_material_t reseed_material;
+  dif_edn_cmd_t reseed_cmd;
   /**
    * CSRNG generate command material.
    */
-  dif_edn_seed_material_t generate_material;
+  dif_edn_cmd_t generate_cmd;
   /**
    * Number of generate calls that can be made before a reseed request is made.
    */

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -47,15 +47,32 @@ void entropy_testutils_auto_mode_init(void) {
   const dif_edn_auto_params_t edn0_params = {
       // EDN0 provides lower-quality entropy.  Let one generate command return 8
       // blocks, and reseed every 32 generates.
-      .reseed_material =
+      .instantiate_cmd =
           {
-              .len = 1,
-              .data = {0x00000002 |  // Reseed from entropy source only.
-                       kMultiBitBool4False << 8},
+              .cmd = 0x00000001 |  // Reseed from entropy source only.
+                     kMultiBitBool4False << 8,
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
           },
-      .generate_material =
+      .reseed_cmd =
           {
-              .len = 1, .data = {0x00008003},  // One generate returns 8 blocks.
+              .cmd = 0x00008002 |  // One generate returns 8 blocks, reseed
+                                   // from entropy source only.
+                     kMultiBitBool4False << 8,
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
+          },
+      .generate_cmd =
+          {
+              .cmd = 0x00008003,  // One generate returns 8 blocks.
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
           },
       .reseed_interval = 32,  // Reseed every 32 generates.
   };
@@ -65,15 +82,32 @@ void entropy_testutils_auto_mode_init(void) {
   const dif_edn_auto_params_t edn1_params = {
       // EDN1 provides highest-quality entropy.  Let one generate command
       // return 1 block, and reseed after every generate.
-      .reseed_material =
+      .instantiate_cmd =
           {
-              .len = 1,
-              .data = {0x00000002 |  // Reseed from entropy source only.
-                       kMultiBitBool4False << 8},
+              .cmd = 0x00000001 |  // Reseed from entropy source only.
+                     kMultiBitBool4False << 8,
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
           },
-      .generate_material =
+      .reseed_cmd =
           {
-              .len = 1, .data = {0x00001003},  // One generate returns 1 block.
+              .cmd = 0x00001002 |  // One generate returns 1 block, reseed
+                                   // from entropy source only.
+                     kMultiBitBool4False << 8,
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
+          },
+      .generate_cmd =
+          {
+              .cmd = 0x00001003,  // One generate returns 1 block.
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
           },
       .reseed_interval = 4,  // Reseed after every 4 generates.
   };


### PR DESCRIPTION
Previously, the different commands had varying and at most incomplete support for sending additional data/seed material to CSRNG, which didn't allow making use of many of the features provided by the hardware:
- INS didn't support additional data at all.
- RES and GEN were overloading the seed data structure for storing the actual application interface command header. As a result, they were supporting up to 11 words of additional data/seed material only where the hardware allows up to twelve.

The main change of this PR is to change the dif_edn_seed_material_t data structure to split out the application interface command header from the seed material, and then rework the functions using these structures. This then allows all three commands to take up to 12 words of additional data thereby making full use of the hardware.