### PR TITLE
[usbdev] Stub out logic in top_englishbreakfast

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -132,6 +132,13 @@
     }
   ]
   param_list: [
+    { name:    "Stub",
+      type:    "bit",
+      default: "0",
+      desc:    "Stub out the core of entropy_src logic"
+      local:   "false",
+      expose:  "true"
+    },
     { name:    "NEndpoints",
       type:    "int",
       default: "12",

--- a/hw/ip/usbdev/usbdev.core
+++ b/hw/ip/usbdev/usbdev.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
+      - lowrisc:tlul:socket_1n
       - lowrisc:prim:edge_detector
       - lowrisc:prim:ram_2p_adv
       - lowrisc:ip:usb_fs_nb_pe

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2381,6 +2381,14 @@
       param_list:
       [
         {
+          name: Stub
+          desc: Stub out the core of entropy_src logic
+          type: bit
+          default: "0"
+          expose: "true"
+          name_top: UsbdevStub
+        }
+        {
           name: RcvrWakeTimeUs
           desc: Maximum number of microseconds for the differential receiver to become operational
           type: int

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -35,6 +35,7 @@ module top_earlgrey #(
   // parameters for spi_host0
   // parameters for spi_host1
   // parameters for usbdev
+  parameter bit UsbdevStub = 0,
   parameter int UsbdevRcvrWakeTimeUs = 100,
   // parameters for pwrmgr_aon
   // parameters for rstmgr_aon
@@ -1611,6 +1612,7 @@ module top_earlgrey #(
   );
   usbdev #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[21:21]),
+    .Stub(UsbdevStub),
     .RcvrWakeTimeUs(UsbdevRcvrWakeTimeUs)
   ) u_usbdev (
 

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1070,6 +1070,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .SecAesStartTriggerDelay(40),
     .SecAesAllowForcingMasks(1'b1),
     .SecAesSkipPRNGReseeding(1'b1),
+    .UsbdevStub(1'b1),
 % else:
     .SecAesMasking(1'b0),
     .SecAesSBoxImpl(aes_pkg::SBoxImplLut),


### PR DESCRIPTION
This is done due to resource constraints and since it is easier to do than to omit the USB instance and disentangle with pinmux.

It should unblock PR CI since the CW305 build is currently failing due to timing violations.

Signed-off-by: Michael Schaffner <msf@google.com>