### PR TITLE
[dv/otp_ctrl] Fix tl_intg_error nightly failure

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
@@ -57,7 +57,7 @@ virtual task test_sec_cm_fi();
     // when a fault occurs at the reg_we_check, it's treated as a TL intg error
     if (if_proxy.sec_cm_type == SecCmPrimOnehot &&
         !uvm_re_match("*u_prim_reg_we_check*", if_proxy.path)) begin
-      check_sec_tl_intg_error_resp(if_proxy.path);
+        check_tl_intg_error_response();
     end else begin
       check_sec_cm_fi_resp(if_proxy);
     end
@@ -67,10 +67,6 @@ virtual task test_sec_cm_fi();
     dut_init("HARD");
   end
 endtask : test_sec_cm_fi
-
-virtual task check_sec_tl_intg_error_resp(string proxy_path);
-  check_tl_intg_error_response();
-endtask
 
 virtual task sec_cm_inject_fault(sec_cm_base_if_proxy if_proxy);
   if_proxy.inject_fault();


### PR DESCRIPTION
This PR fixes the TL_intg_error failure in nightly regression. The issue is that: the prim_otp_tl interface does not set any err_code, only triggers a prim_otp_alert.
And the tl_intg_err task is share for sec_cm one_hot check and tl_intg_error check.

So we need to distinguish which tlul interface has integrity and sec_cm error.
Because these two tests have different input: ral_name and proxy_path, so otp_ctrl_common_vseq create an internal flag to store which tlul interface is used.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>