### PR TITLE
[flash_ctrl,dv] Add clocking block and input output slack

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // interface for OTP, Life cycle, RMA, PWRMGR and KEYMGR
-interface flash_ctrl_if ();
+interface flash_ctrl_if (
+  input logic clk,
+  input logic rst_n
+);
 
   import lc_ctrl_pkg::*;
   import pwrmgr_pkg::*;
@@ -26,8 +29,8 @@ interface flash_ctrl_if ();
 
   keymgr_flash_t                    keymgr;
 
-  lc_tx_t                           rma_req = lc_ctrl_pkg::Off;
-  lc_flash_rma_seed_t               rma_seed = LC_FLASH_RMA_SEED_DEFAULT;
+  lc_tx_t                           rma_req;
+  lc_flash_rma_seed_t               rma_seed;
   lc_tx_t                           rma_ack;
 
   otp_ctrl_pkg::flash_otp_key_req_t otp_req;
@@ -62,4 +65,10 @@ interface flash_ctrl_if ();
   logic        host_gnt;
   logic ctrl_fsm_idle;
   logic [1:0] host_outstanding;
+
+  clocking cb @(posedge clk);
+    default input #1step output #2;
+    output    rma_req, rma_seed;
+    input     rma_ack;
+  endclocking
 endinterface : flash_ctrl_if

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -87,6 +87,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task pre_start();
     `uvm_create_on(callback_vseq, p_sequencer);
+    cfg.flash_ctrl_vif.rma_req <= lc_ctrl_pkg::Off;
+    cfg.flash_ctrl_vif.rma_seed <= LC_FLASH_RMA_SEED_DEFAULT;
     otp_model();  // Start OTP Model
     super.pre_start();
     cfg.alert_max_delay_in_ns = cfg.alert_max_delay * (cfg.clk_rst_vif.clk_period_ps / 1000.0);
@@ -1082,9 +1084,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, $sformatf("RMA Seed : 0x%08x", rma_seed), UVM_LOW)
 
     // Set Seed and Send Req
-    @(posedge cfg.clk_rst_vif.clk);
-    cfg.flash_ctrl_vif.rma_seed = rma_seed;
-    cfg.flash_ctrl_vif.rma_req = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.rma_seed <= rma_seed;
+    cfg.flash_ctrl_vif.rma_req <= lc_ctrl_pkg::On;
 
     // RMA Start Time
     start_time = $time();

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
@@ -53,7 +53,8 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
             rma_seed = $urandom;  // Random RMA Seed
             send_rma_req(rma_seed);
             `uvm_info("Test", "RMA REQUEST DONE", UVM_LOW)
-            cfg.flash_ctrl_vif.rma_req = lc_ctrl_pkg::Off;
+
+            cfg.flash_ctrl_vif.rma_req <= lc_ctrl_pkg::Off;
           end
           begin
             // exceptions
@@ -103,9 +104,9 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
                 end
                 2'b10: begin
                   if (reset_index inside {DVWaitAddrKey, DVWaitDataKey}) begin
-                    cfg.flash_ctrl_vif.rma_req = lc_ctrl_pkg::On;
+                    cfg.flash_ctrl_vif.rma_req <= lc_ctrl_pkg::On;
                     cfg.clk_rst_vif.wait_clks(2);
-                    cfg.flash_ctrl_vif.rma_req = lc_ctrl_pkg::Off;
+                    cfg.flash_ctrl_vif.rma_req <= lc_ctrl_pkg::Off;
                   end
                 end
                 2'b11: begin

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -64,7 +64,10 @@ module tb;
     .clk  (clk),
     .rst_n(rst_n)
   );
-  flash_ctrl_if flash_ctrl_if ();
+  flash_ctrl_if flash_ctrl_if (
+    .clk  (clk),
+    .rst_n(rst_n)
+  );
   flash_phy_prim_if fpp_if (
     .clk  (clk),
     .rst_n(rst_n)


### PR DESCRIPTION
This PR addresses race between clock and rma_* input / output.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>