### PR TITLE
[dv/top] Add option to automatically set rom_exec_en

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__otp.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__otp.sv
@@ -9,7 +9,16 @@ virtual function void otp_write_lc_partition_state(lc_ctrl_state_pkg::lc_state_e
   for (int i = 0; i < LcStateSize; i += 4) begin
     write32(i + LcStateOffset, lc_state[i*8+:32]);
   end
-endfunction
+endfunction : otp_write_lc_partition_state
+
+virtual function lc_ctrl_state_pkg::lc_state_e otp_read_lc_partition_state();
+  lc_ctrl_state_pkg::lc_state_e lc_state;
+  for (int i = 0; i < LcStateSize; i += 4) begin
+    lc_state[i*8 +: 32] = read32(i + LcStateOffset);
+  end
+
+  return lc_state;
+endfunction : otp_read_lc_partition_state
 
 virtual function void otp_write_lc_partition_cnt(lc_ctrl_state_pkg::lc_cnt_e lc_cnt);
   for (int i = 0; i < LcTransitionCntSize; i += 4) begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
@@ -27,6 +27,11 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
     super.pre_start();
   endtask
 
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset();
+    set_otp_creator_sw_cfg_rom_exec_en(1);
+  endtask
+
   virtual task body();
     bit [TokenWidthBit-1:0] otp_exit_token_bits, otp_unlock_token_bits, otp_rma_token_bits;
     bit [7:0] selected_dest_state[];


### PR DESCRIPTION
- addresses #15371
- allows a test to automatically set rom_exec_en when apply_reset is called.

Signed-off-by: Timothy Chen <timothytim@google.com>