### PR TITLE
[top/test] Add chip_rv_dm_lc_disabled test

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -235,10 +235,14 @@
           ]
         }
       },
-      // ROM size (given as `items` below) must be a power of two.
+      // Note that this region starts at `0x800` and contains the HaltAddress,
+      // ResumeAddress and ExceptionAddress locations.
       { window: {
           name: "ROM"
-          items: "512" // 2 KiB
+          // ROM size (given as `items` below) must be a power of two.
+          // The 512 x 4 = 2 KiB are enough to hold the 19 x 8 = 0x98 bytes
+          // currently allocated in the debug ROM.
+          items: "512"
           swaccess: "ro",
           desc: '''Access window into the debug ROM.'''
         }

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -439,6 +439,8 @@
             and RMA, regardless of the value on DFT SW straps.
             '''
       stage: V2
+      // TODO: add chip_tap_straps_test_unlocked0 also (#14147)
+      // TODO: add chip_tap_straps_test_locked0 also (#14147)
       tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
     }
 
@@ -605,7 +607,7 @@
       tests: ["chip_tap_straps_rma"]
     }
     {
-      name: chip_sw_rv_dm_lc_disabled
+      name: chip_rv_dm_lc_disabled
       desc: '''Verify that the debug capabilities are disabled in certain life cycle stages.
 
             - Put life cycle on states other than Test, RMA and DEV.
@@ -616,7 +618,9 @@
             - X-ref'ed with `chip_tap_strap_sampling`
             '''
       stage: V2
-      tests: []
+      tests: [// Checks rv_dm from both JTAG and CPU side in stub CPU mode.
+              "chip_rv_dm_lc_disabled"
+      ]
     }
 
     // RV_TIMER (pre-verified IP) integration tests:
@@ -1501,6 +1505,8 @@
             correctness.
             '''
       stage: V2
+      // TODO: add chip_tap_straps_test_unlocked0 also (#14147)
+      // TODO: add chip_tap_straps_test_locked0 also (#14147)
       tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
     }
     {
@@ -1616,10 +1622,11 @@
         "chip_tap_straps_dev",                            // lc_dft_en_o, lc_hw_debug_en_o: pinmux
         "chip_tap_straps_prod",                           // lc_dft_en_o, lc_hw_debug_en_o: pinmux
         "chip_tap_straps_rma",                            // lc_dft_en_o, lc_hw_debug_en_o: pinmux
+        // TODO: add chip_tap_straps_test_unlocked0 also (#14147)
         "chip_sw_rom_ctrl_integrity_check",               // lc_dft_en_o, lc_hw_debug_en_o: pwrmgr
         "chip_sw_clkmgr_external_clk_src_for_sw",         // lc_hw_debug_en_o: clkmgr
         "chip_sw_sram_ctrl_execution_main",               // lc_hw_debug_en_o: sram_ctrl main
-        // TODO: ref chip_sw_rv_dm_lc_disabled (#14147)   // lc_hw_debug_en_o: rv_dm
+        "chip_rv_dm_lc_disabled"                          // lc_hw_debug_en_o: rv_dm
         "chip_sw_keymgr_key_derivation",                  // lc_keymgr_en_o: keymgr
         "chip_sw_clkmgr_external_clk_src_for_lc",         // lc_clk_byp_req_o: clkmgr
         "chip_sw_flash_rma_unlocked",                     // lc_flash_rma_req_o, lc_flash_rma_seed_o: flash_ctrl

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1376,6 +1376,13 @@
       run_timeout_mins: 120
     }
     {
+      name: chip_rv_dm_lc_disabled
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "chip_rv_dm_lc_disabled_vseq"
+      en_run_modes: ["stub_cpu_mode"]
+      run_opts: ["+en_scb=0", "+en_scb_tl_err_chk=0", "+use_jtag_dmi=1"]
+    }
+    {
       name: chip_sw_rv_core_ibex_address_translation
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests:rv_core_ibex_address_translation_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -98,6 +98,7 @@ filesets:
       - seq_lib/chip_sw_repeat_reset_wkup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rstmgr_alert_info_vseq.sv: {is_include_file: true}
       - seq_lib/chip_rv_dm_ndm_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_rv_dm_lc_disabled_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_entropy_src_fuse_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_csrng_lc_hw_debug_en_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_lc_disabled_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_lc_disabled_vseq.sv
@@ -1,0 +1,117 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence accesses the rv_dm mem interface with randomly backdoor-loaded LC state. If the LC
+// state gates the rv_dm mem interface (via lc_debug_en), we are expecting to see a TLUL d_error.
+class chip_rv_dm_lc_disabled_vseq extends chip_stub_cpu_base_vseq;
+  `uvm_object_utils(chip_rv_dm_lc_disabled_vseq)
+
+  `uvm_object_new
+  jtag_dmi_reg_block jtag_dmi_ral;
+  rand lc_state_e lc_state;
+
+  constraint num_trans_c {
+    num_trans inside {[2:20]};
+  }
+
+  // Add constraint to avoid lc_escalate_en being broadcasted and causes fatal alerts.
+  constraint lc_state_c {
+    lc_state != LcStScrap;
+  }
+
+  virtual function void set_handles();
+    super.set_handles();
+    jtag_dmi_ral = cfg.jtag_dmi_ral;
+  endfunction // set_handles
+
+  virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
+    super.pre_start();
+    max_outstanding_accesses = 1;
+  endtask
+
+  virtual task apply_reset(string kind = "HARD");
+    fork
+      if (kind inside {"HARD", "TRST"}) begin
+        jtag_dmi_ral.reset("HARD");
+      end
+      super.apply_reset(kind);
+    join
+  endtask
+
+  task rv_dm_activate();
+    // "Activate" the DM to so that DM_CSRs can be written to.
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(1), .blocking(1), .predict(1));
+    cfg.clk_rst_vif.wait_clks(5);
+  endtask
+
+  virtual function void backdoor_override_otp();
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(lc_state)
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(lc_state);
+  endfunction
+
+  virtual function void initialize_otp_sig_verify();
+    backdoor_override_otp();
+    super.initialize_otp_sig_verify();
+  endfunction
+
+  virtual function bit allow_rv_dm_access();
+    if (lc_state inside {LcStTestUnlocked0, LcStTestUnlocked1, LcStTestUnlocked2,
+        LcStTestUnlocked3, LcStTestUnlocked4, LcStTestUnlocked5, LcStTestUnlocked6,
+        LcStTestUnlocked7, LcStRma, LcStDev}) begin
+      return 1;
+    end else begin
+      return 0;
+    end
+  endfunction
+
+  // Access check via JTAG.
+  virtual task rv_dm_jtag_access_check(bit gated);
+    uvm_reg_data_t wdata = $urandom();
+    uvm_reg_data_t exp_data, rdata;
+    // Write a random 32bit value to the sbaddress0 register.
+    csr_wr(.ptr(jtag_dmi_ral.sbaddress0), .value(wdata), .blocking(1), .predict(~gated));
+    cfg.clk_rst_vif.wait_clks(5);
+    // Expected readback data is all-zero if the JTAG interface is gated.
+    exp_data = gated ? '0 : wdata;
+    `uvm_info(`gfn, $sformatf("RV_DM sbaddress0 write data %0h, expected readback data %0h",
+              wdata, exp_data), UVM_HIGH)
+    // Read back and compare
+    csr_rd(.ptr(jtag_dmi_ral.sbaddress0), .value(rdata), .blocking(1));
+    `DV_CHECK_EQ(rdata, exp_data, $sformatf(
+                 "RV_DM sbaddress0 read back check failed, got 0x%x, expected 0x%x",
+                 rdata, exp_data))
+    cfg.clk_rst_vif.wait_clks(5);
+  endtask
+
+  // Access check via TL-UL bus.
+  // TODO.
+
+  virtual task body();
+
+    for (int trans_i = 1; trans_i <= num_trans; trans_i++) begin
+      // uvm_reg rv_dm_mem_regs[$];
+
+      if (trans_i > 1 && $urandom_range(0, 4)) dut_init();
+      `uvm_info(`gfn, $sformatf("Run iterations %0d/%0d with lc_state %0s", trans_i, num_trans,
+                lc_state.name), UVM_LOW)
+      rv_dm_activate();
+      // if ($urandom_range(0, 1)) begin
+      // Check the RV_DM gating. Since the serial interface wires
+      // are gated with the lc_dft_en signal, it is sufficient to check an
+      // RW'able register to verify whether the gating works or not.
+      rv_dm_jtag_access_check(~allow_rv_dm_access());
+      // end
+
+
+      // if ($urandom_range(0, 1)) begin
+      // rv_dm_activate
+      //   `uvm_info(`gfn, "Check RV_DM MEM access", UVM_HIGH)
+      //   jtag_dmi_ral.get_registers(rv_dm_mem_regs);
+      //   rand_rw_prim_regs(rv_dm_mem_regs, ~allow_rv_dm_access());
+      // end
+    end
+  endtask : body
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -54,6 +54,7 @@
 `include "chip_sw_repeat_reset_wkup_vseq.sv"
 `include "chip_sw_rstmgr_alert_info_vseq.sv"
 `include "chip_rv_dm_ndm_reset_vseq.sv"
+`include "chip_rv_dm_lc_disabled_vseq.sv"
 `include "chip_sw_alert_handler_escalation_vseq.sv"
 `include "chip_sw_alert_handler_entropy_vseq.sv"
 `include "chip_sw_alert_handler_lpg_clkoff_vseq.sv"


### PR DESCRIPTION
Addresses #14147 and #14169.

This test is similar to `chip_prim_tl_access`, but also does accesses via the JTAG interface.

This PR is dependent on #15626.

Signed-off-by: Michael Schaffner <msf@google.com>