### PR TITLE
[top-level] rng srate update to entropy src csrng

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -962,7 +962,8 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_csrng_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18_000_000", "+rng_srate_value_min=15"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000", "+rng_srate_value_min=15",
+                 "+rng_srate_value_max=30"]
       run_timeout_mins: 120
     }
     {


### PR DESCRIPTION
Update rng_srate_value_max test parameter to improve test simulation time.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>