### PR TITLE
[spi_device/dv] Test async fifo empty/full status

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_full_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_full_vseq.sv
@@ -10,7 +10,7 @@ class spi_device_fifo_full_vseq extends spi_device_txrx_vseq;
 
   // additional constraint for tx_total_bytes to transfer more data
   constraint tx_total_bytes_additional_c {
-    tx_total_bytes inside {[5 * SRAM_SIZE : 10 * SRAM_SIZE]};
+    tx_total_bytes inside {[5 * SRAM_SIZE : 7 * SRAM_SIZE]};
   }
 
   constraint tx_delay_c {
@@ -21,7 +21,7 @@ class spi_device_fifo_full_vseq extends spi_device_txrx_vseq;
     rx_delay dist {
       0              :/ 1,
       [1   : 100]    :/ 1,
-      [101 : 10_000] :/ 8
+      [101 : 2_000]  :/ 8
     };
   }
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
@@ -64,7 +64,7 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
   }
 
   constraint num_trans_c {
-    num_trans inside {[2:5]};
+    num_trans inside {[2:3]};
   }
 
   constraint en_dummy_host_xfer_c {


### PR DESCRIPTION
Added in spi_device_intr to check async fifo empty/full status.
Also adjusted constraint for spi_device_fifo_full, so that it doesn't run more than 1hr

Signed-off-by: Weicai Yang <weicai@google.com>