### PR TITLE
Sungrid input from command file instead of command line

### DIFF
--- a/util/dvsim/SgeLauncher.py
+++ b/util/dvsim/SgeLauncher.py
@@ -80,6 +80,7 @@ class SgeLauncher(Launcher):
             sgeJob.args.b = 'y'  # This is a binary file
             sgeJob.args.o = self.deploy.get_log_path() + '.sge'
             cmd = str(sgeJob.execute(mode='echo'))
+            print('INFO: SGE command line : "' + str(cmd) + '"')
             # ---------------
             self.process = subprocess.Popen(shlex.split(cmd),
                                             bufsize=4096,

--- a/util/dvsim/SgeLauncher.py
+++ b/util/dvsim/SgeLauncher.py
@@ -115,7 +115,7 @@ class SgeLauncher(Launcher):
         # copy SGE jobb results to log file
         if os.path.exists(self.deploy.get_log_path() + '.sge'):
 
-            file1 = open(self.deploy.get_log_path() + '.sge', 'r')
+            file1 = open(self.deploy.get_log_path() + '.sge', 'r', errors='replace')
             Lines = file1.readlines()
             file1.close()
             f = open(self.deploy.get_log_path(),

--- a/util/dvsim/qsubopts.py
+++ b/util/dvsim/qsubopts.py
@@ -1818,19 +1818,31 @@ class qsubOptions():
 
         args = getattr(self.args, 'command_args', [])
         args = getattr(self.args, 'xterm_args', args)
+        # ---------------- command file -------------
+        cwd = os.getcwd()
+        command_file = cwd + '/command_file_' + str(os.getpid())
+        try:
+            with open(command_file, 'w') as f_command:
+                command_temp = str(self.args.command)
+                command_temp = command_temp.replace('"', '')
+                f_command.write(command_temp)
+        except IOError:
+            error_msg = 'Error: problem with open File: ' + str(f_command)
+            raise IOError(error_msg)
 
-        exestring = ' '.join([program] + options + [self.args.command] + args)
+        os.chmod(command_file, 0o0777)
+        exestring = ' '.join([program] + options + [command_file] + args)
         exestring = exestring.replace('-pe lammpi 1', '')
         exestring = exestring.replace('-slot', '-pe make')
         exestring = exestring.replace('-ll ', '-l ')
         exestring = exestring.replace('-t 0', '')
         #        exestring = exestring.replace('-j y','')
-
+        print('INFO: sge command file = ' + command_file)
         if mode == 'echo':
             return (exestring)
         elif mode == 'local':
             import subprocess
-            p = subprocess.Popen(exestring,
+            p = subprocess.Popen(command_file,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT,
                                  shell=True)


### PR DESCRIPTION
Signed-off-by: Sharon Topaz <sharon.topaz@nuvoton.com>

Updating SGE to use a script that contain the execute command lines as input. 
Before SGE (qsub) got directly the execute command line with all the arguments on the same line.
There is a limit of 4096 characters in system buffer size. If the command line contains more than 4096 characters there is an error message:
  Error : Unable to run job: a path or filename may not exceed 4096 characters\nExiting.\n'
Updated the code so all our commands will be passed by script to qsub command.
