### PR TITLE
[bazel] update rules_rust to enable bindgen

### DIFF
--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rust_repository_set")
+load("@rules_rust//bindgen:repositories.bzl", "rust_bindgen_dependencies", "rust_bindgen_register_toolchains")
 load("//third_party/rust/crates:crates.bzl", "raze_fetch_remote_crates")
 load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
 load(
@@ -32,6 +33,8 @@ def rust_deps():
         iso_date = "2022-03-22",
         edition = "2021",
     )
+    rust_bindgen_dependencies()
+    rust_bindgen_register_toolchains()
     raze_fetch_remote_crates()
     ftdi_fetch_remote_crates()
     serde_annotate_fetch_remote_crates()

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -11,9 +11,9 @@ def rust_repos(rules_rust = None, safe_ftdi = None, serde_annotate = None):
     http_archive_or_local(
         name = "rules_rust",
         local = rules_rust,
-        sha256 = "408a3ab2816eecabf6caf7b21ec07e0dcfde88a18267a0bc8fbd7d98ec08797d",
-        strip_prefix = "rules_rust-sha-retrieval-bugfix-20221006_01",
-        url = "https://github.com/lowRISC/rules_rust/archive/refs/tags/sha-retrieval-bugfix-20221006_01.tar.gz",
+        sha256 = "f52d8585a797eb2b7af6535457a65f7b1a3548c76fe8e962355dba23186ec9ef",
+        strip_prefix = "rules_rust-configurable-bindgen-libcxx-dir-20221018_01",
+        url = "https://github.com/lowRISC/rules_rust/archive/refs/tags/configurable-bindgen-libcxx-dir-20221018_01.tar.gz",
     )
 
     http_archive_or_local(

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -141,6 +141,8 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   ${BAZELISK} fetch \
     --repository_cache=${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR} \
     //... \
+    @bindgen_clang_linux//... \
+    @rules_rust_bindgen__bindgen-0.60.1//... \
     @go_sdk//... \
     @lowrisc_rv32imcb_files//... \
     @local_config_cc_toolchains//... \


### PR DESCRIPTION
This updates rules_rust to fix #15441 and #15568, and enable using the rust bindgen tool in (older linux) airgapped environments.

Signed-off-by: Timothy Trippel <ttrippel@google.com>