### PR TITLE
[chip, dv] Increase reseed for chip_tl_errors

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1195,7 +1195,7 @@
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_tl_errors"]
       en_run_modes: ["stub_cpu_mode"]
-      reseed: 20
+      reseed: 30
     }
     {
       name: chip_prim_tl_access


### PR DESCRIPTION
The Tl_errors_cgs_wrap occasionally dropped below 100% in nightly.
Increasing reseed should solve it.

Signed-off-by: Weicai Yang <weicai@google.com>