### PR TITLE
Bazel fusesoc invocation

### DIFF
--- a/hw/BUILD
+++ b/hw/BUILD
@@ -30,7 +30,6 @@ fusesoc_build(
         "//:cores",
     ],
     data = ["//hw/ip/otbn:all_files"],
-    flags = ["--verilator_options=--threads 1"],
     output_groups = {
         "binary": ["sim-verilator/Vchip_sim_tb"],
     },
@@ -47,11 +46,9 @@ filegroup(
 )
 
 # This is used in CI steps that do not want to run Verilator tests, and thus
-# do not want to accidentally build the Verilator model. This causes the
-# //hw:verilator target to not emit any files, which will break any tests that
-# actually rely on this; builds will succeed, tests will fail.
-#
-# FIXME(lowRISC/opentitan#12259): This is a temporary workaround.
+# do not want to build the Verilator model. This causes the //hw:verilator
+# target to not emit any files, which will break any tests that rely on this;
+# builds will succeed, tests will fail.
 config_setting(
     name = "disable_verilator_build",
     values = {"define": "DISABLE_VERILATOR_BUILD=true"},

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -36,6 +36,11 @@ def _fusesoc_build_impl(ctx):
         verilator_options = ctx.attr.verilator_options[BuildSettingInfo].value
         flags.append("--verilator_options={}".format(" ".join(verilator_options)))
 
+    cores_roots = {}
+    for c in ctx.files.cores:
+        if c.dirname not in cores_roots:
+            cores_roots[c.dirname] = True
+
     # Note: the `fileset_top` flag used above is specific to the OpenTitan
     # project to select the correct RTL fileset.
     ctx.actions.run(
@@ -43,8 +48,8 @@ def _fusesoc_build_impl(ctx):
         outputs = outputs,
         inputs = ctx.files.srcs + ctx.files.cores,
         arguments = [
-            "--cores-root={}".format(c.dirname)
-            for c in ctx.files.cores
+            "--cores-root={}".format(c)
+            for c in cores_roots.keys()
         ] + [
             "run",
             "--flag=fileset_top",


### PR DESCRIPTION
Fixes: #15070
by removing two sources of duplicate flags:
* Repeated cores-roots no longer generate duplicate flags.
* We no longer try to compile verilator to use 1 and 4 cores simultaneously.