### PR TITLE
[ci] add Xcelium DV test set 1 to private CI

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1410,21 +1410,16 @@
               "chip_sw_sram_ctrl_main_scrambled_access_jitter_en"]
     }
     {
-      name: xcelium_ci
-      tests: ["chip_plic_all_irqs"]
-      reseed: 1
-    }
-    {
       name: xcelium_ci_0
-      tests: ["chip_plic_all_irqs"]
-              // TODO(#14532): enable these tests slowly to ensure no CI breakages.
-              // "chip_sw_clkmgr_jitter",
-              // "chip_sw_kmac_app_rom",
-              // "chip_sw_rstmgr_sw_rst",
-              // "chip_sw_hmac_enc",
-              // "chip_sw_aes_enc_jitter_en",
-              // "chip_sw_rom_ctrl_integrity_check",
+      tests: ["chip_sw_clkmgr_jitter",
+              "chip_sw_kmac_app_rom",
+              "chip_sw_rstmgr_sw_rst",
+              "chip_sw_hmac_enc",
+              "chip_sw_aes_enc_jitter_en",
+              "chip_sw_rom_ctrl_integrity_check"]
+              // TODO(#15371): this currently failing on nightly regression
               // "chip_sw_lc_walkthrough_testunlocks",
+              // TODO(#15459): chip_prim_tl_access is currently failing on Xcelium
               // "chip_prim_tl_access"]
     }
     {


### PR DESCRIPTION
This increases the number of Xcelium top-level DV tests run in private CI. This partially addresses #14532.

Signed-off-by: Timothy Trippel <ttrippel@google.com>