### PR TITLE
[chip dv] Only dump coverage on RV_CORE_IBEX module ports, and other coverage collection updates

### DIFF
--- a/hw/top_earlgrey/dv/cov/chip_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover.cfg
@@ -9,45 +9,45 @@ begin tgl(portsonly)
   +module chip_earlgrey_asic
   +module ast
   +module padring
+  +module rv_core_ibex
   +moduletree top_earlgrey 2
-  +moduletree rv_core_ibex 2
 end
 
-// Enable full coverage collection on these modules to cover the glue logic.
+// Include all coverage metrics in non-preverified modules.
 begin line+cond+fsm+branch+assert
   +module chip_earlgrey_asic
-  +module top_earlgrey
-end
+  +tree tb.dut.u_prim_usb_diff_rx
 
-// Enable full coverage collection on these modules including their
-// sub-hierarchies since they are not pre-verified.
-begin line+cond+fsm+branch+assert
+  +module top_earlgrey
+  +tree tb.dut.top_earlgrey.u_dft_tap_breakout
+
   +moduletree padring
   +moduletree pinmux
   +moduletree rv_core_ibex
-  -tree tb.dut.top_earlgrey.u_rv_core_ibex.u_core
   +moduletree rv_plic
   +moduletree sensor_ctrl
 
-  // Prim_alert/esc pairs are verified in FPV and DV testbenches.
+  // The modules below are preverified in FPV and / or DV testbenches.
+  -moduletree ibex_top
   -moduletree prim_alert_sender
   -moduletree prim_alert_receiver
+  -moduletree prim_cdc_rand_delay  // DV construct.
   -moduletree prim_esc_sender
   -moduletree prim_esc_receiver
-  -moduletree prim_prince // prim_prince is verified in a separate DV environment.
-  -moduletree prim_lfsr // prim_lfsr is verified in FPV.
-  -module prim_cdc_rand_delay  // DV construct.
+  -moduletree prim_lfsr
+  -moduletree prim_prince
 end
 
-// TODO: Re-enable tgl(portsonly) on the the excluded prims above in the non-preverified IPs and
-// glue logic.
+// TODO: Re-enable tgl(portsonly) on the the excluded pre-verified sub-modules above in
+// non-preverified parents.
 begin tgl(portsonly)
+  +tree tb.dut.top_earlgrey.u_pinmux_aon.gen_alert_tx[0].u_prim_alert_sender 1
   +tree tb.dut.top_earlgrey.u_rv_core_ibex.gen_alert_senders[0].u_alert_sender 1
   +tree tb.dut.top_earlgrey.u_rv_core_ibex.gen_alert_senders[1].u_alert_sender 1
   +tree tb.dut.top_earlgrey.u_rv_core_ibex.gen_alert_senders[2].u_alert_sender 1
   +tree tb.dut.top_earlgrey.u_rv_core_ibex.gen_alert_senders[3].u_alert_sender 1
+  +tree tb.dut.top_earlgrey.u_rv_core_ibex.u_core
   +tree tb.dut.top_earlgrey.u_rv_core_ibex.u_prim_esc_receiver 1
-  +tree tb.dut.top_earlgrey.u_pinmux_aon.gen_alert_tx[0].u_prim_alert_sender 1
   +tree tb.dut.top_earlgrey.u_rv_plic.gen_alert_tx[0].u_prim_alert_sender 1
   +tree tb.dut.top_earlgrey.u_sensor_ctrl.u_prim_fatal_alert_sender 1
   +tree tb.dut.top_earlgrey.u_sensor_ctrl.u_prim_recov_alert_sender 1


### PR DESCRIPTION
The existing coverage model dumped port toggle
coverage on the ports of rv_core_ibex and its
immediate sub-modules. It is actually sufficient
to only collect toggle coverage of only the
rv_core_ibex module, because we dump coverage of
all other metrics for the complete tree under
rv_core_ibex (except the ibex_top instance).
Ports that can be covered (and are not yet
covered) will manifest as uncovered holes
in other coverage metrics (line, branch, cond
and fsm). Ports that cannot be covered since
they are unreachable will have to be manually
excluded, which is a tedious process.

This change limits the coverage collection
to only the ports of rv_core_ibex instance. We
employ the same strategy for the block levels -
we only collect port toggles of the DUT module
and not on any of its sub-modules.

Note that the port toggles on ibex_top (a
submodule of rv_core_ibex) will continue to be
dumped, becuase it is a pre-verified IP, and
we dont collect coverage of other metrics within).

The chip_earlgrey_asic and top_earlgrey only
enable coverage of itself - not its submodules.
This enables us to keep the coverage patterning
simple. This also means that any other modules
except for the major ones that we already know
of need to have full coverage enabled under them.

A cosmetic change to keep the paths sorted in
each category in alphabeical order to make
future review easy.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>