### PR TITLE
[entropy_src/dv] Adjustments to alert_cnt_cg

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
@@ -209,12 +209,15 @@ class entropy_src_dut_cfg extends uvm_object;
       [6  : 10] :/ 0,
       [11 : 80] :/ 10};}
 
-  // TODO: Update dist to satisfy cover points
   constraint alert_threshold_c {alert_threshold dist {
-      1 :/ 2,
-      2 :/ 5,
-      3 :/ 1,
-      4 :/ 1};}
+      1             :/ 3,
+      2             :/ 5,
+      // This bin should hit the next two higher alert_cnt_cg CPs. All values in this range will
+      //  sometimes get an alert.
+      [3:10]        :/ 3,
+      // All remaining possible values
+      [11:16'hffff] :/ 1
+   };}
 
   constraint default_ht_thresholds_c {default_ht_thresholds dist {
       1 :/ default_ht_thresholds_pct,

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -808,7 +808,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
           set_exp_alert(.alert_name("recov_alert"), .is_fatal(0), .max_delay(cfg.alert_max_delay));
           // The DUT should either set the alert, or crash the sim.
           // If we succeed, sample this alert_threshold as covered successfully.
-          cov_vif.cg_alert_cnt_sample(alert_threshold);
+          cov_vif.cg_alert_cnt_sample(alert_threshold, 1);
         end else if (main_sm_escalates) begin
           fmt = "Main SM in error state, overrides recov alert (Fail cnt: %01d,  thresh: %01d)";
         end else if(threshold_alert_active) begin
@@ -1481,6 +1481,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
                                    invalid_es_type);
             end
             "alert_threshold": begin
+              cov_vif.cg_alert_cnt_sample(item.a_data, 0);
               check_redundancy_val("alert_threshold", "", "es_thresh_cfg_alert",
                                    invalid_alert_threshold);
             end

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -39,7 +39,7 @@ module tb;
       rng_if(.clk(clk), .rst_n(csrng_rst_n));
   push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
       csrng_if(.clk(clk), .rst_n(csrng_rst_n));
-  push_pull_if#(.HostDataWidth(0)) aes_halt_if(.clk(clk), .rst_n(csrng_rst_n));
+  push_pull_if#(.HostDataWidth(0)) aes_halt_if(.clk(clk), .rst_n(csrng_rst_n && rst_n));
   entropy_src_xht_if xht_if(.clk(clk), .rst_n(rst_n));
   entropy_src_path_if entropy_src_path_if (.entropy_src_hw_if_i(entropy_src_hw_if_i));
   entropy_src_assert_if entropy_src_assert_if (.entropy_src_hw_if_i(entropy_src_hw_if_i));


### PR DESCRIPTION
- Expanded to alert_cnt_cg to cover both when a alert threshold is chosen, and when an HT alert is actually fired.
  - Since for the highest possible bins alerts are unlikely to fire, the cross bin corresponding to firing with the highest thresholds is ignored.
- Lined up alert_threshold coverpoints with covergroup
- When using high alert thresholds, the dut may never detect a failure in the RNG stream, therefore the RNG agent is reset whenever the DUT is disabled, to clear any undetected failures.
- Unrelated Minor bugfix in the testbench: the cs_aes_halt if must be reset whenever the DUT is reset otherwise the agent will encounter an handshaking assertion.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>