### PR TITLE
[top-level] Fix csrng_lc_hw_debug_en_test

### DIFF
--- a/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
+++ b/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
@@ -349,8 +349,11 @@ bool test_main(void) {
     csrng_static_generate_run(got, ARRAYSIZE(got));
     static_assert(ARRAYSIZE(got) == ARRAYSIZE(nv_csrng_output),
                   "Array size mismatch.");
-    for (size_t i = 0; i < ARRAYSIZE(got); ++i) {
-      CHECK(got[i] != nv_csrng_output[i], "Unexpected word match.");
+
+    if (lc_state == kDifLcCtrlStateDev) {
+      CHECK_ARRAYS_EQ(got, nv_csrng_output, ARRAYSIZE(got));
+    } else {
+      CHECK_ARRAYS_NE(got, nv_csrng_output, ARRAYSIZE(got));
     }
     return true;
   }


### PR DESCRIPTION
The lc_ctrl sets `lc_hw_debug` when the device is in test unlocked, dev or rma mode. The test was previously expecting dev to behave as a prod device by mistake. This change updates the test logic to expect deterministic entropy to match if the lc_state is DEV.
