### PR TITLE
[chip testplan] Clarified normal sleep for dm wake

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -588,7 +588,7 @@
       name: chip_rv_dm_access_after_wakeup
       desc: '''Verify RV_DM works after wakes up from sleep.
 
-            - Put the chip into sleep mode and then wake up.
+            - Put the chip into normal sleep mode and then wake up.
             - Access some RV_DM CSRs to ensure that RV_DM doesn't need a full reset to work.
             '''
       stage: V2


### PR DESCRIPTION
Waking up after a deep sleep is more similar to a start-up after a reset with, for example, execution starting in the ROM.

This pull request is to clarify my assumption that `chip_rv_dm_access_after_wakeup` wants to test the DM works after a normal sleep specifically.