### PR TITLE
[dv/otp] Fix stress_all_with_rand_reset nightly failure

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -60,6 +60,8 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     if (common_seq_type == "stress_all_with_rand_reset") begin
       cfg.otp_ctrl_vif.release_part_access_mubi();
       cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
+      // Set dft_en to On to allow the csr_test to check all registers' default value after reset.
+      cfg.otp_ctrl_vif.drive_lc_dft_en(lc_ctrl_pkg::On);
       otp_ctrl_init();
       otp_pwr_init();
       super.apply_resets_concurrently(reset_duration_ps);


### PR DESCRIPTION
This PR fixes the stress_all_with_rand_reset test failure when the base sequence access all CSRs to check their default values after reset. The current testbench did not enable `dft_en`, so the test failed due to illegal access.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>