### PR TITLE
[prim] support two interrupt types (Event, Status)

### DIFF
--- a/hw/ip/prim/rtl/prim_intr_hw.sv
+++ b/hw/ip/prim/rtl/prim_intr_hw.sv
@@ -9,7 +9,19 @@
 
 module prim_intr_hw # (
   parameter int unsigned Width = 1,
-  parameter bit FlopOutput = 1
+  parameter bit FlopOutput = 1,
+
+  // IntrT parameter is to hint the logic for the interrupt type. Module
+  // supports two interrupt types, *Status* and *Event*.
+  //
+  // The differences between those two types are:
+  // - Status is persistent. Until the root cause is alleviated, the interrupt
+  //   keeps asserting.
+  // - Event remains high for a relatively short period time without SW
+  //   intervention. One distinct example is an error (error could be status
+  //   though). If a certain error condition is captured, HW logic may create a
+  //   pulse. In this case the interrupt is assumed as an Event interrupt.
+  parameter IntrT = "Event" // Event or Status
 ) (
   // event
   input  clk_i,
@@ -28,13 +40,34 @@ module prim_intr_hw # (
   output logic [Width-1:0]  intr_o
 );
 
-  logic  [Width-1:0]    new_event;
-  assign new_event =
-             (({Width{reg2hw_intr_test_qe_i}} & reg2hw_intr_test_q_i) | event_intr_i);
-  assign hw2reg_intr_state_de_o = |new_event;
-  // for scalar interrupts, this resolves to '1' with new event
-  // for vector interrupts, new events are OR'd in to existing interrupt state
-  assign hw2reg_intr_state_d_o  =  new_event | reg2hw_intr_state_q_i;
+  logic [Width-1:0] status; // incl. test
+
+  if (IntrT == "Event") begin : g_intr_event
+    logic  [Width-1:0]    new_event;
+    assign new_event =
+               (({Width{reg2hw_intr_test_qe_i}} & reg2hw_intr_test_q_i) | event_intr_i);
+    assign hw2reg_intr_state_de_o = |new_event;
+    // for scalar interrupts, this resolves to '1' with new event
+    // for vector interrupts, new events are OR'd in to existing interrupt state
+    assign hw2reg_intr_state_d_o  =  new_event | reg2hw_intr_state_q_i;
+
+    assign status = reg2hw_intr_state_q_i ;
+  end : g_intr_event
+  else if (IntrT == "Status") begin : g_intr_status
+    logic [Width-1:0] test_q; // Storing test. Cleared by SW
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) test_q <= '0;
+      else if (reg2hw_intr_test_qe_i) test_q <= reg2hw_intr_test_q_i;
+    end
+
+    // TODO: In Status type, INTR_STATE is better to be external type and RO.
+    assign hw2reg_intr_state_de_o = 1'b 1; // always represent the status
+    assign hw2reg_intr_state_d_o  = event_intr_i | test_q;
+
+    assign status = reg2hw_intr_state_q_i;
+  end : g_intr_status
+
 
   if (FlopOutput == 1) begin : gen_flop_intr_output
     // flop the interrupt output
@@ -42,7 +75,7 @@ module prim_intr_hw # (
       if (!rst_ni) begin
         intr_o <= '0;
       end else begin
-        intr_o <= reg2hw_intr_state_q_i & reg2hw_intr_enable_q_i;
+        intr_o <= status & reg2hw_intr_enable_q_i;
       end
     end
 
@@ -54,5 +87,6 @@ module prim_intr_hw # (
     assign intr_o = reg2hw_intr_state_q_i & reg2hw_intr_enable_q_i;
   end
 
+  `ASSERT_INIT(IntrTKind_A, IntrT inside {"Event", "Status"})
 
 endmodule


### PR DESCRIPTION
This PR revises `prim_intr_hw` to support two interrupt types, **Event** and **Status**.
**Event** is the interrupt currently supported. **Status** is a new interrupt type that directly represents its HW status. For example, TxFifoEmpty signal may be a candidate fro the status type interrupt. If the interrupt type is set to **Status**, the `INTR_STATE` of the field becomes `ro` to the SW and the field in `INTR_TEST` is set to `rw`. Current **register generation** tool does not support interrupt type yep.