### PR TITLE
[otbn,dv] Add test for RF integrity error FIs

### DIFF
--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -145,7 +145,7 @@
       name: sec_cm_rf_base_data_reg_sw_integrity
       desc: "Verify the countermeasure(s) RF_BASE.DATA_REG_SW.INTEGRITY."
       stage: V2S
-      tests: ["otbn_csr_rw"]
+      tests: ["otbn_rf_base_intg_err"]
     }
     {
       name: sec_cm_rf_base_data_reg_sw_glitch_detect
@@ -163,7 +163,7 @@
       name: sec_cm_rf_bignum_data_reg_sw_integrity
       desc: "Verify the countermeasure(s) RF_BIGNUM.DATA_REG_SW.INTEGRITY."
       stage: V2S
-      tests: ["otbn_csr_rw"]
+      tests: ["otbn_rf_bignum_intg_err"]
     }
     {
       name: sec_cm_rf_bignum_data_reg_sw_glitch_detect

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -53,6 +53,8 @@ filesets:
       - seq_lib/otbn_alu_bignum_mod_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_controller_ispr_rdata_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_mac_bignum_acc_err_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_rf_base_intg_err_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_rf_bignum_intg_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_ctrl_redun_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_sec_wipe_err_vseq.sv: {is_include_file: true}

--- a/hw/ip/otbn/dv/uvm/env/otbn_rf_base_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_rf_base_if.sv
@@ -9,11 +9,11 @@ interface otbn_rf_base_if (
   input       rst_ni,
 
   // Signal names from the otbn_rf_base module (where we are bound)
-  input logic pop_stack_a, 
+  input logic pop_stack_a,
   input logic pop_stack_b,
   input logic push_stack_reqd,
   input logic stack_full,
-  input logic stack_data_valid 
+  input logic stack_data_valid
 );
 
   function automatic otbn_env_pkg::call_stack_flags_t get_call_stack_flags();
@@ -32,6 +32,32 @@ interface otbn_rf_base_if (
       return otbn_env_pkg::StackPartial;
     end
     return otbn_env_pkg::StackEmpty;
+  endfunction
+
+  // Force the `rd_data_a_intg_o` signal to `should_val`.  This function needs to be static because
+  // its argument must live as least as long as the `force` statement is in effect.
+  function static void force_rf_base_rd_data_a_intg(
+      input logic [otbn_pkg::BaseIntgWidth-1:0] should_val
+    );
+    force u_otbn_rf_base.rd_data_a_intg_o = should_val;
+  endfunction
+
+  // Force the `rd_data_b_intg_o` signal to `should_val`.  This function needs to be static because
+  // its argument must live as least as long as the `force` statement is in effect.
+  function static void force_rf_base_rd_data_b_intg(
+      input logic [otbn_pkg::BaseIntgWidth-1:0] should_val
+    );
+    force u_otbn_rf_base.rd_data_b_intg_o = should_val;
+  endfunction
+
+  // Release the forcing of the `rd_data_a_intg_o` signal.
+  function automatic void release_rf_base_rd_data_a_intg();
+    release u_otbn_rf_base.rd_data_a_intg_o;
+  endfunction
+
+  // Release the forcing of the `rd_data_b_intg_o` signal.
+  function automatic void release_rf_base_rd_data_b_intg();
+    release u_otbn_rf_base.rd_data_b_intg_o;
   endfunction
 
 endinterface

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_intg_err_vseq.sv
@@ -95,7 +95,7 @@ class otbn_intg_err_vseq extends otbn_base_vseq;
       // OTBN should now do a secure wipe. Give it up to 400 cycles to do so (because it needs to go
       // twice over all registers and reseed URND in between, the time of which depends on the delay
       // configured in the EDN model).
-      repeat (400) @(cfg.clk_rst_vif.cbn);
+      cfg.clk_rst_vif.wait_n_clks(400);
 
       // We should now be in a locked state after the secure wipe.
       `DV_CHECK_FATAL(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
@@ -1,0 +1,110 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence to insert 1 or 2 bit flips to base register file read outputs.
+// Time it so that only when a registers gets used, data corruption happen.
+
+class otbn_rf_base_intg_err_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_rf_base_intg_err_vseq)
+
+  `uvm_object_new
+  rand bit insert_intg_err_to_a;
+
+  task await_use();
+    logic rd_en;
+    `uvm_info(`gfn, "Waiting for selected RF to be used", UVM_LOW)
+    `DV_SPINWAIT_EXIT(
+      do begin
+        @(cfg.clk_rst_vif.cbn);
+        rd_en = insert_intg_err_to_a ? cfg.trace_vif.rf_base_rd_en_a :
+                                       cfg.trace_vif.rf_base_rd_en_b;
+      end while(!rd_en);,
+      cfg.clk_rst_vif.wait_clks(2000);,
+      "Not getting selected rd_en from OTBN for 2000 cycles!"
+    )
+  endtask
+
+  function bit [otbn_pkg::BaseIntgWidth-1:0] corrupt_data(
+      input bit [otbn_pkg::BaseIntgWidth-1:0] orig_data
+    );
+    bit [otbn_pkg::BaseIntgWidth-1:0] mask;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
+    return cfg.fix_integrity_32(orig_data) ^ mask;
+  endfunction
+
+  task inject_errors();
+    logic [otbn_pkg::BaseIntgWidth-1:0] orig_data;
+    bit [otbn_pkg::BaseIntgWidth-1:0] new_data;
+    orig_data = insert_intg_err_to_a ? cfg.trace_vif.rf_base_rd_data_a :
+                                       cfg.trace_vif.rf_base_rd_data_b;
+    new_data = corrupt_data(orig_data);
+    `uvm_info(`gfn, "Injecting errors into Base RF", UVM_LOW)
+    if (insert_intg_err_to_a) begin
+      cfg.rf_base_vif.force_rf_base_rd_data_a_intg(new_data);
+    end else begin
+      cfg.rf_base_vif.force_rf_base_rd_data_b_intg(new_data);
+    end
+  endtask
+
+  task release_force();
+    if (insert_intg_err_to_a) begin
+      cfg.rf_base_vif.release_rf_base_rd_data_a_intg();
+    end else begin
+      cfg.rf_base_vif.release_rf_base_rd_data_b_intg();
+    end
+  endtask
+
+  task body();
+    uvm_reg_data_t             act_val;
+    string                     elf_path;
+    bit [BaseWordsPerWLEN-1:0] corrupted_words;
+    bit [ExtWLEN-1:0]          new_data;
+    otbn_pkg::err_bits_t err_bits;
+
+    elf_path = pick_elf_path();
+    `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
+    load_elf(elf_path, 1'b1);
+
+    // Start running OTBN. When this task returns, we'll be in the middle of a run.
+    start_running_otbn(.check_end_addr(1'b0));
+
+    // Wait until the register containing the integrity-checked value is being used.
+    await_use();
+
+    inject_errors();
+
+    // Notify the model about the integrity violation error.
+    err_bits = '{reg_intg_violation: 1'b1, default: 1'b0};
+    cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
+
+    @(cfg.clk_rst_vif.cbn);
+    release_force();
+
+    // OTBN should now do a secure wipe. Give it up to 400 cycles to do so (because it needs to go
+    // twice over all registers and reseed URND in between, the time of which depends on the delay
+    // configured in the EDN model).
+    cfg.clk_rst_vif.wait_n_clks(400);
+    // We should now be in a locked state after the secure wipe.
+    `DV_CHECK_FATAL(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
+    // The scoreboard will have seen the transition to locked state and inferred that it should
+    // see a fatal alert. However, it doesn't really have a way to ensure that we keep generating
+    // them.  Wait for 3 fatal alerts and also read STATUS, ERR_BITS and FATAL_ALERT_CAUSE in
+    // parallel.
+    fork
+      begin
+        csr_utils_pkg::csr_rd(.ptr(ral.status), .value(act_val));
+        csr_utils_pkg::csr_rd(.ptr(ral.err_bits), .value(act_val));
+        csr_utils_pkg::csr_rd(.ptr(ral.fatal_alert_cause), .value(act_val));
+      end
+      begin
+        repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
+      end
+    join
+
+    // Reset and finish sequence.
+    do_apply_reset = 1'b1;
+    dut_init("HARD");
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_bignum_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_bignum_intg_err_vseq.sv
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence to insert 1 or 2 bit flips per word to bignum register file while
+// OTBN is trying to read from it.
+
+class otbn_rf_bignum_intg_err_vseq extends otbn_intg_err_vseq;
+  `uvm_object_utils(otbn_rf_bignum_intg_err_vseq)
+
+  `uvm_object_new
+  rand bit insert_intg_err_to_a;
+
+  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+    logic rd_en;
+    used_words = '0;
+    `uvm_info(`gfn, "Waiting for selected RF to be used", UVM_LOW)
+    `DV_SPINWAIT_EXIT(
+      do begin
+        @(cfg.clk_rst_vif.cbn);
+        rd_en = insert_intg_err_to_a ? cfg.trace_vif.rf_bignum_rd_en_a :
+                                       cfg.trace_vif.rf_bignum_rd_en_b;
+      end while(!rd_en); used_words = '1;,
+      cfg.clk_rst_vif.wait_clks(2000);,
+      "Not getting selected rd_en from OTBN for 2000 cycles!"
+    )
+  endtask
+
+  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+    logic [otbn_pkg::ExtWLEN-1:0] orig_data;
+    bit   [otbn_pkg::ExtWLEN-1:0] new_data;
+
+    orig_data = insert_intg_err_to_a ? cfg.trace_vif.rf_bignum_rd_data_a_intg :
+                                       cfg.trace_vif.rf_bignum_rd_data_b_intg;
+    new_data = corrupt_data(orig_data, '{default: 100}, corrupted_words);
+
+    if (corrupted_words != '0) begin
+      `uvm_info(`gfn, "Injecting errors into Bignum RF", UVM_LOW)
+      if (insert_intg_err_to_a) begin
+        cfg.trace_vif.force_rf_bignum_rd_data_a_intg(new_data);
+      end else begin
+        cfg.trace_vif.force_rf_bignum_rd_data_b_intg(new_data);
+      end
+    end else begin
+      `uvm_info(`gfn, "Randomization decided to not inject any errors.", UVM_LOW)
+    end
+  endtask
+
+  task release_force();
+    if (insert_intg_err_to_a) begin
+      cfg.trace_vif.release_rf_bignum_rd_data_a_intg();
+    end else begin
+      cfg.trace_vif.release_rf_bignum_rd_data_b_intg();
+    end
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -20,6 +20,8 @@
 `include "otbn_alu_bignum_mod_err_vseq.sv"
 `include "otbn_controller_ispr_rdata_err_vseq.sv"
 `include "otbn_mac_bignum_acc_err_vseq.sv"
+`include "otbn_rf_base_intg_err_vseq.sv"
+`include "otbn_rf_bignum_intg_err_vseq.sv"
 `include "otbn_pc_ctrl_flow_redun_vseq.sv"
 `include "otbn_rnd_sec_cm_vseq.sv"
 `include "otbn_ctrl_redun_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -240,6 +240,20 @@ name:
       reseed: 5
     }
 
+    {
+      name: "otbn_rf_bignum_intg_err"
+      uvm_test_seq: "otbn_rf_bignum_intg_err_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 10
+    }
+
+    {
+      name: "otbn_rf_base_intg_err"
+      uvm_test_seq: "otbn_rf_base_intg_err_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 10
+    }
+
     // This test runs several sequences back-to-back. Unlike otbn_multi, these
     // sequences can include imem or dmem error sequences. We shouldn't need
     // many seeds here because each test runs several operations.
@@ -338,7 +352,7 @@ name:
          "otbn_multi_err", "otbn_imem_err", "otbn_dmem_err",
          "otbn_stress_all", "otbn_escalate", "otbn_illegal_mem_acc",
          "otbn_zero_state_err_urnd", "otbn_sw_errs_fatal_chk",
-         "otbn_rnd_sec_cm", "otbn_mac_bignum_acc_err",
+         "otbn_rnd_sec_cm", "otbn_mac_bignum_acc_err", "otbn_rf_base_intg_err",
          "otbn_controller_ispr_rdata_err", "otbn_alu_bignum_mod_err"
       ]
 
@@ -366,6 +380,7 @@ name:
         "otbn_tl_intg_err", "otbn_sec_cm", "otbn_pc_ctrl_flow_redun",
         "otbn_rnd_sec_cm", "otbn_alu_bignum_mod_err",
         "otbn_controller_ispr_rdata_err", "otbn_mac_bignum_acc_err",
+        "otbn_rf_base_intg_err",
         "otbn_sec_wipe_err", "otbn_urnd_err",
         # V2S but known broken
         # "otbn_passthru_mem_tl_intg_err",


### PR DESCRIPTION
This commit introduces two tests that are used for injecting integrity errors by making bit flips on base register file (rf_intg_err) or bignum register file (rf_bignum_intg_err). Relevant V2S countermeasures are mapped as well. This would more directly check the error response of OTBN in the case of integrity faults rather than having more implicit checking throughout our other tests.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>