### PR TITLE
[dv/chip] Enhance lc_ctrl_program_err toggle coverage

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2511,7 +2511,8 @@
       name: chip_sw_otp_ctrl_program_error
       desc: '''Verify the otp program error.
 
-            - Initiate an illegal program request from LC ctrl to OTP ctrl.
+            - Initiate an illegal program request from LC ctrl to OTP ctrl by forcing the
+              `lc_otp_program_i`.
             - Verify that the LC ctrl triggers an alert when the OTP ctrl responds back with a
               program error.
             '''

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv
@@ -33,11 +33,16 @@ class chip_sw_lc_ctrl_program_error_vseq extends chip_sw_base_vseq;
 
     `uvm_info(`gfn, $sformatf("post trans observed"), UVM_LOW)
 
+    // This is used for toggle coverage collection purpose to cover the `lc_err_o` transition from
+    // 1 to 0.
+    void'(cfg.chip_vif.signal_probe_otp_ctrl_lc_err_o(SignalProbeRelease));
+
     // check to ensure that we see an otp error
     jtag_read_csr(ral.lc_ctrl.status.get_offset(),
       p_sequencer.jtag_sequencer_h,
       status_val);
 
     `DV_CHECK_FATAL(status_val & (1 << LcOtpError));
+
   endtask
 endclass


### PR DESCRIPTION
This PR adds small enhancement in `chip_sw_lc_ctrl_program_error` test to cover the toggle coverage case where we miss the transition from 1 to 0.
This PR solves part of issue #15481 

Signed-off-by: Cindy Chen <chencindy@opentitan.org>