### PR TITLE
[spi_device/dv] Update coverage plan and implement covergroup

### DIFF
--- a/hw/ip/spi_device/data/spi_device_sec_cm_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_sec_cm_testplan.hjson
@@ -27,7 +27,7 @@
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
       stage: V2S
-      tests: []
+      tests: ["spi_device_tl_intg_err"]
     }
   ]
 }

--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -453,70 +453,94 @@
       stage: V2
       tests: ["spi_device_flash_and_tpm"]
     }
+    {
+      name: tpm_and_flash_trans_with_min_inactive_time
+      desc: '''
+            Issue these transactions with 2 sys_clk inactive time in between.
+            - 2 tpm transactions.
+            - 2 flash transactions.
+            - a tpm transaction and a flash transaction.'''
+      stage: V2
+      tests: []
+    }
+    {
+      name: stress_all
+      desc: '''
+            - Combine above sequences in one test to run sequentially, except csr sequences.
+            - Test modes switch among FW, flash, passthrough and tpm.
+            - Randomly add reset between each sequence'''
+      stage: V2
+      tests: []
+    }
   ]
   covergroups: [
     {
-      name: spi_device_tpm_all_modes_cg
+      name: all_modes_cg
       desc: '''
             Cover every combination of all possible modes:
-            - All modes perform tx/rx interleaved tpm tx/rx.'''
+            - FW mode, passthrough mode and flash mode.
+            Cover passthrough mode and flash mode with TPM mode enabled.'''
     }
+    // FW mode
     {
-      name: spi_device_tpm_states_cg
+      name: bit_order_clk_cfg_cg
       desc: '''
-            Cover all tpm states on the SPI bus (WAIT, INVALID, ETC).'''
-    }
-    {
-      name: spi_device_fifo_fsm_cg
-      desc: '''
-            Cover all fsm states for RX/TX FIFO.'''
-    }
-    {
-      name: spi_device_abort_all_cg
-      desc: '''
-            Cover the correct abort functionality for all modes.
+            Cover all configurations of rx/tx order in SPI_DEVICE.CFG for FW mode.
+            Note: Flash or TPM mode always use the fixed bit order.
 
-            TODO: Functionality of abort to be clarified.'''
-    }
-    {
-      name: spi_device_txrx_order_cg
-      desc: '''
-            Verify that data being tx/rx is valid regardless of bit order and that the functionality behaves as expected:
-
-            Cover all configurations of rx/tx order in SPI_DEVICE.CFG for all valid modes.'''
-    }
-    {
-      name: spi_device_sram_size_cg
-      desc: '''
-            Cover the SramAw local parameter to confirm all sizes 1 - 32kB.'''
-    }
-    {
-      name: spi_device_sck_config_cg
-      desc: '''
             Cover all combinations of SPI_DEVICE.CFG.CPOL and SPI_DEVICE.CFG.CPHA.
+            Cross both bit order and clock configure.'''
+    }
+    {
+      name: fw_tx_fifo_size_cg
+      desc: '''
+            Cover these values are used to configure TX fifo size for FW mode.
+            - min(1 word), typical(half of SRAM size), max(SRAM size - 1 word)
+            Sample this when fifo is full.'''
+    }
+    {
+      name: fw_rx_fifo_size_cg
+      desc: '''
+            The same CG as `fw_tx_fifo_size_cg` for RX.'''
+    }
+    // TPM mode
+    {
+      name: tpm_cfg_cg
+      desc: '''
+            Cover all combinations of these configurations in CSR `tpm_cfg`:
+              - tpm_mode, hw_reg_dis, tpm_reg_chk_dis, invalid_locality.
+            Cover these address mode:
+             - TPM address in both valid and invalid locality.
+             - TPM address in/outside TPM address region ('hd4_xxxx).
+             - TPM offset matching to any HW return register.
+             - Both word aligned and unaligned.
+            Cross above with TPM read and write transactions.
 
-            Cover valid combinations for each mode.'''
+            This CG is sampled when receiving a TPM request.'''
     }
     {
-      name: spi_device_pass_addr_swap_cg
+      name: tpm_read_hw_reg_cg
       desc: '''
-            Cover all bits enable for address translation.
-            Cover all bits values for address translation.'''
+            Cover TPM read on all HW returned registered.'''
     }
     {
-      name: spi_device_pass_payload_swap_cg
+      name: tpm_transfer_size_cg
       desc: '''
-            Cover all bits enable for payload translation.
-            Cover all bits values for payload translation.'''
+            Cover both TPM read and write.
+            Cover request HW returned and SW handled.
+            Cross above with various payload size.
+              - min (1B), typical (4B), max (64B).'''
     }
     {
-      name: spi_device_pass_cmd_filter_cg
+      name: tpm_sts_cg
       desc: '''
-            Cover all possible bits for command filter.
-            Every opcode should be enabled and filtering checked.'''
+            Cover `tpm_sts` read and write on an active/inactive tpm access.
+            Cover `tpm_sts` read with HW returned and SW handled.
+            Cross above with all locality.'''
     }
+    // flash/passthrough mode
     {
-      name: spi_device_cmd_info_cg
+      name: flash_cmd_info_cg
       desc: '''
             Cover all opcode enabled in cmd info.
             Cover all payload direction.
@@ -527,13 +551,40 @@
             Cover busy enable.
             Cover all dummy sizes.
             Cover all payload enables.
-            This is not configuration coverage, cover only if we have relevant
-            transaction with opcode configured and enabled in cmd_info slot.
 
-            TODO: Consider relevant crosses between opcode and other items.'''
+            cross payload directions, address modes, addr/payload swap enable.
+            cross payload directions, address modes, payload enables.
+            '''
     }
     {
-      name: spi_device_payload_size_cg
+      name: passthrough_addr_swap_cg
+      desc: '''
+            Cover address swap on a transaction with both payload direction (read and program).
+            Cover all bits toggled on the swap address and mask.
+            Cross with filter enabled and disabled.'''
+    }
+    {
+      name: passthrough_payload_swap_cg
+      desc: '''
+            Cover payload swap on a transaction with both payload direction (read and program).
+            Cover all bits toggled on the swap payload and mask.
+            Cross with filter enabled and disabled.'''
+    }
+    {
+      name: passthrough_cmd_filter_cg
+      desc: '''
+            Cover all possible bits for command filter.
+            Every opcode should be enabled and filtering checked.'''
+    }
+    {
+      name: flash_status_cg
+      desc: '''
+            Cover all status bits toggled.
+            Cross above with host reading status and SW reading status.
+            Cover SW updating flash_status while CSB is active.'''
+    }
+    {
+      name: flash_upload_payload_size_cg
       desc: '''
             Cover supported payload sizes for IN transactions.
             Cover supported payload sizes for OUT transactions.
@@ -541,19 +592,27 @@
             Cover payload size of upload transaction exceeds 256B limit (wrap around).'''
     }
     {
-      name: spi_device_read_commands_cg
+      name: flash_busy_bit_cg
       desc: '''
-            Cover read status commands.
-            Cover read JEDEC command.
-            Cover read SFDP command.
-            Cover all other read commands configurable in slots up to 10.
-            Cover dummy cycle for all read commands.
-            Cover INTERCEPT_EN with all applicable read commands.'''
+            Cover host sends flash commands while busy bit is set.
+            Cover above with filter enabled/disabled on that command.
+            '''
     }
     {
-      name: spi_device_mailbox_cg
+      name: flash_read_commands_cg
       desc: '''
-            Cover commands targeting inside mailbox space.
+            Cover read status/read JEDEC/read SFDP and all other read commands configurable in the
+              first 10 slots.
+            Cover dummy cycle.
+            Cover filter enabled/disabled.
+            Cover various payload size
+            Cover INTERCEPT_EN.
+            Cross all above items.'''
+    }
+    {
+      name: passthrough_mailbox_cg
+      desc: '''
+            Cover read commands targeting inside mailbox space.
             Cover command starting outside mailbox and crossing into mailbox space.
             Cover command starting in mailbox comming outside mailbox space.
             Cover command starting outside mailbox and crossing the entire mailbox space and coming
@@ -561,15 +620,21 @@
             Cross above with filter on and off.'''
     }
     {
-      name: spi_device_4B_address_management_cg
+      name: flash_mailbox_cg
       desc: '''
-            Cover all possible combinations of EN4B and EX4B.
-            Cross with various read commands.'''
+            Cover read commands targeting inside mailbox space in the flash mode.'''
+    }
+    {
+      name: spi_device_4B_enter_exit_command_cg
+      desc: '''
+            Cover both EN4B and EX4B commands.
+            Cross this with the previous `cfg_addr_4b_en` value.
+            '''
     }
     {
       name: spi_device_buffer_boundary_cg
       desc: '''
-            Cover buffer boundary crossing (buffer flip).'''
+            Cover buffer boundary crossing (2 buffer flips).'''
     }
     {
       name: spi_device_lanes_cg
@@ -585,10 +650,9 @@
             Cross this with the previous flash_status.wel value.'''
     }
     {
-      name: TPM_with_flash_or_passthrough_mode_cg
+      name: tpm_interleave_with_flash_item_cg
       desc: '''
-            Cover TPM read/write with flash_mode enabled.
-            Cover TPM read/write with passthrough enabled.'''
+            Cover TPM transactions interleaving with flash transactions.'''
     }
   ]
 }

--- a/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
@@ -2,12 +2,134 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+class tpm_read_hw_reg_cg_wrap;
+  covergroup tpm_read_hw_reg_cg (string name) with function sample(
+      bit hit);
+    option.per_instance = 1;
+    option.name = name;
+
+    cp_hit: coverpoint hit {
+      bins done = {1};
+    }
+  endgroup
+
+  function new(string name);
+    tpm_read_hw_reg_cg = new(name);
+  endfunction : new
+
+  function void sample();
+    tpm_read_hw_reg_cg.sample(1);
+  endfunction : sample
+endclass
+
 class spi_device_env_cov extends cip_base_env_cov #(.CFG_T(spi_device_env_cfg));
   `uvm_component_utils(spi_device_env_cov)
+  tpm_read_hw_reg_cg_wrap tpm_read_hw_reg_cg_wraps[string];
+
+  // sample this spi mode when receive a transaction to ensure the mode is actually used.
+  covergroup all_modes_cg with function sample(device_mode_e mode, bit tpm_enabled);
+    cp_mode: coverpoint mode;
+    cp_tpm_enabled: coverpoint tpm_enabled;
+    cr_all: cross cp_mode, cp_tpm_enabled {
+      // FW mode can't run with TPM enabled
+      illegal_bins invalid = binsof(cp_mode) intersect { GenericMode } &&
+                             binsof(cp_tpm_enabled) intersect { 1 };
+    }
+  endgroup
+
+  covergroup bit_order_clk_cfg_cg with function sample(bit tx_order, bit rx_order,
+                                                       bit cpol, bit cpha);
+    cp_bit_order: coverpoint tx_order;
+    cp_rx_order: coverpoint rx_order;
+    cp_cpol: coverpoint cpol;
+    cp_cpha: coverpoint cpha;
+    cr_all: cross tx_order, rx_order, cp_cpol, cp_cpha;
+  endgroup
+
+  covergroup fw_tx_fifo_size_cg with function sample(int tx_size);
+    cp_tx_size: coverpoint tx_size {
+      bins sizes[5] = {[0:SRAM_SIZE]};
+      bins specific_sizes[] = {SRAM_WORD_SIZE, SRAM_SIZE / 2, SRAM_SIZE - SRAM_WORD_SIZE};
+    }
+  endgroup
+
+  covergroup fw_rx_fifo_size_cg with function sample(int rx_size);
+    cp_rx_size: coverpoint rx_size {
+      bins sizes[5] = {[0:SRAM_SIZE]};
+      bins specific_sizes[] = {SRAM_WORD_SIZE, SRAM_SIZE / 2, SRAM_SIZE - SRAM_WORD_SIZE};
+    }
+  endgroup
+
+  covergroup tpm_cfg_cg with function sample(
+      // CSR cfg
+      tpm_cfg_mode_e tpm_mode, bit hw_reg_dis, bit tpm_reg_chk_dis, bit invalid_locality,
+      // transaction related info
+      bit is_write, bit is_in_tpm_region, bit is_valid_locality, bit is_hw_reg_offset,
+      bit is_word_aligned);
+    cp_tpm_mode:          coverpoint tpm_mode;
+    cp_hw_reg_dis:        coverpoint hw_reg_dis;
+    cp_tpm_reg_chk_dis:   coverpoint tpm_reg_chk_dis;
+    cp_invalid_locality:  coverpoint invalid_locality;
+    cp_is_write:          coverpoint is_write;
+    cp_is_in_tpm_region:  coverpoint is_in_tpm_region;
+    cp_is_valid_locality: coverpoint is_valid_locality;
+    cp_is_hw_reg_offset:  coverpoint is_hw_reg_offset;
+    cp_is_word_aligned:   coverpoint is_word_aligned;
+
+    cr_all: cross cp_tpm_mode, cp_hw_reg_dis, cp_tpm_reg_chk_dis, cp_invalid_locality, cp_is_write,
+        cp_is_in_tpm_region, cp_is_valid_locality, cp_is_hw_reg_offset, cp_is_word_aligned;
+  endgroup
+
+  covergroup tpm_transfer_size_cg with function sample(
+      bit is_write, bit is_hw_return, int transfer_size);
+    cp_is_write:      coverpoint is_write;
+    cp_is_hw_return:  coverpoint is_hw_return;
+    cp_transfer_size: coverpoint transfer_size {
+      bins interest[] = {1, 4, MAX_SUPPORT_TPM_SIZE};
+      bins others[4] = {[2:MAX_SUPPORT_TPM_SIZE-1]};
+    }
+    cr_all: cross cp_is_write, cp_is_hw_return, cp_transfer_size {
+      illegal_bins invalid = binsof(cp_is_write) intersect { 1 } &&
+                             binsof(cp_is_hw_return) intersect { 1 };
+    }
+  endgroup
+
+  covergroup tpm_sts_cg with function sample(bit is_write, bit active, bit is_hw_return,
+                                             int locality);
+    cp_is_write: coverpoint is_write;
+    cp_active:   coverpoint active;
+    cp_locality: coverpoint locality {
+      bins valid[] = {[0:MAX_TPM_LOCALITY-1]};
+    }
+    cp_is_hw_return: coverpoint is_hw_return;
+    cr_all: cross cp_is_write, cp_active, cp_locality, cp_is_hw_return {
+      illegal_bins invalid = binsof(cp_is_write) intersect { 1 } &&
+                             binsof(cp_is_hw_return) intersect { 1 };
+    }
+  endgroup
+
+  covergroup tpm_interleave_with_flash_item_cg with function sample(
+      bit is_tpm_item, bit is_flash_item);
+    cp_interleave: coverpoint {is_tpm_item, is_flash_item} {
+      bins tpm_flash_tpm   = (2'b10 => 2'b01 => 2'b10);
+      bins flash_tpm_flash = (2'b01 => 2'b10 => 2'b01);
+    }
+  endgroup
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
     // add more covergroup here
+    foreach (ALL_TPM_HW_REG_NAMES[i]) begin
+      tpm_read_hw_reg_cg_wraps[ALL_TPM_HW_REG_NAMES[i]] = new(ALL_TPM_HW_REG_NAMES[i]);
+    end
+    all_modes_cg = new();
+    bit_order_clk_cfg_cg = new();
+    fw_tx_fifo_size_cg = new();
+    fw_rx_fifo_size_cg = new();
+    tpm_cfg_cg = new();
+    tpm_transfer_size_cg = new();
+    tpm_sts_cg = new();
+    tpm_interleave_with_flash_item_cg = new();
   endfunction : new
 
 endclass

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -133,6 +133,10 @@ package spi_device_env_pkg;
       TPM_ACCESS_OFFSET, TPM_INT_ENABLE_OFFSET, TPM_INT_VECTOR_OFFSET,
       TPM_INT_STATUS_OFFSET, TPM_INT_STATUS_OFFSET, TPM_STS_OFFSET,
       TPM_HASH_START_OFFSET, TPM_DID_VID_OFFSET, TPM_RID_OFFSET};
+  parameter string ALL_TPM_HW_REG_NAMES[] = {
+      "tpm_access_0", "tpm_access_1", "tpm_access_2", "tpm_access_3", "tpm_access_4",
+      "tpm_sts", "tpm_intf_capability", "tpm_int_enable", "tpm_int_status", "tpm_int_vector",
+      "tpm_did_vid", "tpm_rid", "tpm_hash_start"};
 
   parameter uint     NUM_INTERNAL_PROCESSED_CMD  = 11; // exclude WREN, WRDI, EN4B, EX4B
   parameter bit[7:0] READ_JEDEC                  = 8'h9F;


### PR DESCRIPTION
1. Largely updated the coverage plan
2. Implemented covergroup for fw and tpm mode. Will add for flash mode in the next PR
3. Add 2 more tests in testplan - stress all and tpm_and_flash_trans_with_min_inactive_time

Signed-off-by: Weicai Yang <weicai@google.com>