### PR TITLE
refactor(reggen): Add Interrupt class

### DIFF
--- a/util/reggen/BUILD
+++ b/util/reggen/BUILD
@@ -78,6 +78,16 @@ py_library(
 )
 
 py_library(
+    name = "interrupt",
+    srcs = ["interrupt.py"],
+    deps = [
+        ":bits",
+        ":lib",
+        ":signal",
+    ],
+)
+
+py_library(
     name = "html_helpers",
     srcs = ["html_helpers.py"],
 )
@@ -97,6 +107,7 @@ py_library(
         ":clocking",
         ":countermeasure",
         ":inter_signal",
+        ":interrupt",
         ":lib",
         ":params",
         ":reg_block",

--- a/util/reggen/interrupt.py
+++ b/util/reggen/interrupt.py
@@ -1,0 +1,61 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Sequence
+
+from reggen.access import JsonEnum
+from reggen.bits import Bits
+from reggen.lib import check_keys, check_name, check_str, check_int, check_list
+from reggen.signal import Signal
+
+
+class IntrType(JsonEnum):
+    Event = 1
+    Status = 2
+
+
+_intr_type_map = {'event': IntrType.Event, 'status': IntrType.Status}
+
+
+class Interrupt(Signal):
+
+    def __init__(self, name: str, desc: str, bits: Bits, intr_type: IntrType):
+        super().__init__(name, desc, bits)
+        self.intr_type = intr_type
+
+    @staticmethod
+    def from_raw(what: str, lsb: int, raw: object) -> 'Interrupt':
+        rd = check_keys(raw, what, ['name', 'desc'], ['width', 'type'])
+
+        name = check_name(rd['name'], 'name field of ' + what)
+        desc = check_str(rd['desc'], 'desc field of ' + what)
+        width = check_int(rd.get('width', 1), 'width field of ' + what)
+        if width <= 0:
+            raise ValueError('The width field of signal {} ({}) '
+                             'has value {}, but should be positive.'.format(
+                                 name, what, width))
+        bits = Bits(lsb + width - 1, lsb)
+        intr_type_str = check_str(rd.get('type', 'event'),
+                                  'intr_type field of ' + what)
+
+        try:
+            intr_type = _intr_type_map[intr_type_str.lower()]
+        except KeyError:
+            raise ValueError(
+                'The intr_type field of signal {} ({}) '
+                'has value {}, but should be either event or status.'.format(
+                    name, what, intr_type_str))
+
+        return Interrupt(name, desc, bits, intr_type)
+
+    @staticmethod
+    def from_raw_list(what: str, raw: object) -> Sequence['Interrupt']:
+        lsb = 0
+        ret = []
+        for idx, entry in enumerate(check_list(raw, what)):
+            entry_what = 'entry {} of {}'.format(idx, what)
+            interrupt = Interrupt.from_raw(entry_what, lsb, entry)
+            ret.append(interrupt)
+            lsb += interrupt.bits.width()
+        return ret

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -11,6 +11,7 @@ import hjson  # type: ignore
 from reggen.alert import Alert
 from reggen.bus_interfaces import BusInterfaces
 from reggen.clocking import Clocking, ClockingItem
+from reggen.interrupt import Interrupt
 from reggen.inter_signal import InterSignal
 from reggen.lib import (check_keys, check_name, check_int, check_bool, check_list)
 from reggen.params import ReggenParams, LocalParam
@@ -98,7 +99,7 @@ class IpBlock:
                  params: ReggenParams,
                  reg_blocks: Dict[Optional[str], RegBlock],
                  alias_impl: Optional[str],
-                 interrupts: Sequence[Signal],
+                 interrupts: Sequence[Interrupt],
                  no_auto_intr: bool,
                  alerts: List[Alert],
                  no_auto_alert: bool,
@@ -179,9 +180,9 @@ class IpBlock:
 
         init_block = RegBlock(regwidth, params)
 
-        interrupts = Signal.from_raw_list('interrupt_list for block {}'
-                                          .format(name),
-                                          rd.get('interrupt_list', []))
+        interrupts = Interrupt.from_raw_list('interrupt_list for block {}'
+                                             .format(name),
+                                             rd.get('interrupt_list', []))
         alerts = Alert.from_raw_list('alert_list for block {}'
                                      .format(name),
                                      rd.get('alert_list', []))

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -12,6 +12,7 @@ from reggen.access import SWAccess, HWAccess
 from reggen.bus_interfaces import BusInterfaces
 from reggen.clocking import Clocking, ClockingItem
 from reggen.field import Field
+from reggen.interrupt import Interrupt
 from reggen.signal import Signal
 from reggen.lib import check_int, check_list, check_str_dict, check_str
 from reggen.multi_register import MultiRegister
@@ -503,7 +504,7 @@ class RegBlock:
                        storage_err_alert=None)
         self.add_register(reg)
 
-    def make_intr_regs(self, interrupts: Sequence[Signal]) -> None:
+    def make_intr_regs(self, interrupts: Sequence[Interrupt]) -> None:
         assert interrupts
         assert interrupts[-1].bits.msb < self._reg_width
 


### PR DESCRIPTION
Interrupt class is derived from Signal class. It defines `intr_type` on top of Signal class. The `intr_type` provides the way reggen distinguishes between event and status types. Each type creates their own access type for `INTR_STATE` and `INTR_TEST`.

_Related PR: https://github.com/lowRISC/opentitan/pull/15476_
