### PR TITLE
refactor(spid): Remove unused mailbox_hit port

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1790,8 +1790,6 @@ module spi_device
     .passthrough_o,
     .passthrough_i,
 
-    .mailbox_hit_i (1'b 0),
-
     .event_cmd_filtered_o ()
   );
 


### PR DESCRIPTION
Passthrough logic has `mailbox_hit_i` port to filter the read command hitting the mailbox space. However, that function is deprecated and the HW allows a Read command to cross the mailbox region and the passthrough.

So, `intercept` data structure has `mbx` field to change the mux from Passthrough to internal datapath. While implementing the intercept, the `mailbox_hit_i` port supposes to be removed but tied.

Issue has been reported by @weicaiyang