### PR TITLE
[dv/sysctrl] Fix CDC assertion failure

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
@@ -82,7 +82,12 @@ class sysrst_ctrl_base_vseq extends cip_base_vseq #(
     if (kind == "HARD") begin
       fork
         super.apply_reset(kind);
-        cfg.clk_aon_rst_vif.apply_reset(0,400,0,1);
+        // Aon domain has very slow clock so uses scheme 0 to make sure the `rst_ni` and
+        // `rst_aon_ni` will be asserted together within one clk_i cycle.
+        cfg.clk_aon_rst_vif.apply_reset(.pre_reset_dly_clks(0),
+                                        .reset_width_clks(400),
+                                        .post_reset_dly_clks(0),
+                                        .rst_n_scheme(0));
       join
     end
   endtask  // apply_reset


### PR DESCRIPTION
The CDC assertion failure is because there are two resets in sysctrl: 1). rst_ni
2). rst_aon_ni
The aon reset is very slow that in current testbench, that with random pre-reset delay, it might be asserted after rst_ni finishes toggling.

So this PR I uses `scheme 0` to avoid this assertion failure.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>