### PR TITLE
[flash_ctrl,dv] hw fault_status coverage

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -91,6 +91,9 @@ filesets:
       - seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_config_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_hw_rma_err_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_lcmgr_intg_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_hw_read_seed_err_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_hw_prog_rma_wipe_err_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -30,6 +30,22 @@ package flash_ctrl_env_pkg;
   parameter string LIST_OF_ALERTS[] = {"recov_err", "fatal_std_err", "fatal_err",
                                        "fatal_prim_flash_alert", "recov_prim_flash_alert"};
 
+  // Some paths are added multiple times to accomodate
+  // indexing in the loop
+  parameter string LIST_OF_READ_SEED_FORCE_PATHS[] = {
+    "tb.dut.u_flash_hw_if.op",
+    "tb.dut.u_flash_hw_if.op",
+    "tb.dut.u_flash_hw_if.part_sel",
+    "tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd.data_i[31:0]",
+    "tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd.data_i[31:0]"
+  };
+
+  parameter string LIST_OF_PROG_RMA_WIPE_FORCE_PATHS[] = {
+    "tb.dut.u_eflash.gen_flash_cores[0].u_core.gen_prog_data.u_prog.data_i[31:0]",
+    "tb.dut.u_eflash.gen_flash_cores[0].u_core.gen_prog_data.u_prog.data_i[31:0]",
+    "tb.dut.u_flash_hw_if.rma_num_words"
+  };
+
   parameter uint NUM_ALERTS = 5;
   parameter uint FlashNumPages = flash_ctrl_pkg::NumBanks * flash_ctrl_pkg::PagesPerBank;
   parameter uint FlashSizeBytes = FlashNumPages * flash_ctrl_pkg::WordsPerPage *
@@ -305,6 +321,7 @@ package flash_ctrl_env_pkg;
 
   // Parameter for Probing into the DUT RMA FSM
   parameter string PRB_RMA_FSM = "tb.dut.u_flash_hw_if.state_q";
+
   // Taken from enum type lcmgr_state_e in flash_ctrl_lcmgr.sv
   parameter uint RMA_FSM_STATE_ST_RMA_RSP = 11'b10110001010;
 

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
@@ -60,6 +60,7 @@ interface flash_ctrl_if (
   logic [10:0] prog_state1;
   logic [10:0] lcmgr_state;
   logic        init;
+  logic        hw_rvalid;
 
   // v2s error injection
   logic        host_gnt;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_err_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_err_base_vseq.sv
@@ -8,27 +8,21 @@ class flash_ctrl_err_base_vseq extends flash_ctrl_rw_vseq;
   `uvm_object_new
 
   task body();
-    int    state_timeout_ns = 100000; // 100us
     fork
       begin
-        super.body();
+        run_main_event();
       end
       begin
         run_error_event();
       end
     join
-    cfg.seq_cfg.disable_flash_init = 1;
-    cfg.seq_cfg.en_init_keys_seeds = 0;
-    apply_reset();
-    csr_wr(.ptr(ral.init), .value(1));
-    `uvm_info(`gfn,"Test: OTP",UVM_LOW)
-    otp_model();
-    `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rd_buf_en == 1);,
-                 "Timed out waiting for rd_buf_en",
-                 state_timeout_ns)
-    cfg.clk_rst_vif.wait_clks(10);
+    clean_up();
+
   endtask
 
+  virtual task run_main_event();
+    super.body();
+  endtask
   virtual task run_error_event(); endtask
 
   task check_fault(input uvm_object ptr,
@@ -38,4 +32,13 @@ class flash_ctrl_err_base_vseq extends flash_ctrl_rw_vseq;
     `uvm_info(`gfn, "csr wait is done is done", UVM_MEDIUM)
   endtask
 
+  // After fatal error event, we need to reset dut
+  // for clean finish.
+  // This task assert reset and wait for buffer enable comes back.
+  virtual task clean_up();
+    cfg.seq_cfg.disable_flash_init = 1;
+    cfg.seq_cfg.en_init_keys_seeds = 0;
+    apply_reset();
+    init_controller();
+  endtask // clean_up
 endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_prog_rma_wipe_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_prog_rma_wipe_err_vseq.sv
@@ -1,0 +1,91 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence assert erros during rma wipe stage targeting
+// hit a couple of hw oriented fault_status errors.
+// See 'check_status' tasks for what status errors are covered.
+class flash_ctrl_hw_prog_rma_wipe_err_vseq extends flash_ctrl_err_base_vseq;
+  `uvm_object_utils(flash_ctrl_hw_prog_rma_wipe_err_vseq)
+  `uvm_object_new
+
+  task run_main_event();
+    logic [RmaSeedWidth-1:0] rma_seed = $urandom;
+    send_rma_req(rma_seed);
+    cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+  endtask // run_main_event
+
+  // fatal_std_err
+  task run_error_event();
+     int state_wait_timeout_ns = 500_000; // 500 us
+     int event_idx = $urandom_range(0, 3);
+
+    `uvm_info(`gfn, $sformatf("event_idx :%0d", event_idx), UVM_MEDIUM)
+     `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rma_state == StRmaWordSel);,
+                  , state_wait_timeout_ns)
+    cfg.scb_h.exp_alert["fatal_err"] = 1;
+    cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+    cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
+
+    add_glitch(event_idx);
+    collect_err_cov_status(ral.fault_status);
+    check_status(event_idx);
+    cfg.scb_h.do_alert_check = 0;
+    cfg.rma_ack_polling_stop = 1;
+  endtask // run_error_event
+
+  task add_glitch(int idx);
+    string path = LIST_OF_PROG_RMA_WIPE_FORCE_PATHS[idx];
+    case (idx)
+      0, 1: begin
+        // This will trigger std_fault_status.prog_intg_err
+        // but it will be captured in the other test.
+        cfg.scb_h.exp_alert["fatal_std_err"] = 1;
+        cfg.scb_h.alert_chk_max_delay["fatal_std_err"] = 2000;
+        cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
+        $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
+        flip_2bits(path);
+      end
+      2: begin
+        `DV_CHECK(uvm_hdl_force(path, 100));
+      end
+      3: begin
+        $assertoff(0, "tb.dut.u_flash_hw_if.ProgRdVerify_A");
+        csr_wr(.ptr(ral.prog_type_en.normal), .value(0));
+      end
+      default: `uvm_error(`gfn, $sformatf("unsupported index %0d", idx))
+    endcase // case (idx)
+    cfg.clk_rst_vif.wait_clks(10);
+
+    // Since idx = 3 doesn't use force, exclude it from release.
+    if (idx != 3) begin
+      `DV_CHECK(uvm_hdl_release(path));
+    end
+  endtask
+
+  task check_status(int idx);
+    uvm_object fld;
+    case (idx)
+      0: begin
+        fld = ral.fault_status.prog_err;
+      end
+      1: begin
+        fld = ral.fault_status.mp_err;
+      end
+      2: begin
+        fld = ral.fault_status.prog_win_err;
+      end
+      3: begin
+        fld = ral.fault_status.prog_type_err;
+      end
+      default: `uvm_error(`gfn, $sformatf("unsupported index %0d", idx))
+    endcase
+    csr_rd_check(.ptr(ral.err_code), .compare_value(0));
+    csr_rd_check(.ptr(fld), .compare_value(1));
+  endtask // check_status
+
+  task clean_up();
+    apply_reset();
+  endtask // clean_up
+endclass // flash_ctrl_hw_prog_rma_wipe_err_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_read_seed_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_read_seed_err_vseq.sv
@@ -1,0 +1,80 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence assert errors duing seed-reading process targeting
+// some hw oriented fault status errors.
+// See 'check_status' tasks for what status errors are covered.
+class flash_ctrl_hw_read_seed_err_vseq extends flash_ctrl_err_base_vseq;
+  `uvm_object_utils(flash_ctrl_hw_read_seed_err_vseq)
+  `uvm_object_new
+
+  task run_main_event();
+    cfg.seq_cfg.disable_flash_init = 1;
+    cfg.seq_cfg.en_init_keys_seeds = 0;
+    apply_reset();
+     // Enable ecc for all regions
+    init_controller(.non_blocking(1));
+  endtask // run_main_event
+
+  // fatal_std_err
+  task run_error_event();
+    int wait_timeout_ns = 50_000;
+    int event_idx = $urandom_range(0, 4);
+
+    `uvm_info(`gfn, $sformatf("event_idx :%0d", event_idx), UVM_MEDIUM)
+    `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.hw_rvalid == 1);,
+                 , wait_timeout_ns)
+    cfg.scb_h.exp_alert["fatal_err"] = 1;
+    cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+    cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
+
+    add_glitch(event_idx);
+    collect_err_cov_status(ral.fault_status);
+    check_status(event_idx);
+  endtask
+
+  task add_glitch(int idx);
+    string path = LIST_OF_READ_SEED_FORCE_PATHS[idx];
+    case (idx)
+      0, 1: begin
+        `DV_CHECK(uvm_hdl_force(path, FlashOpInvalid));
+      end
+      2: begin
+        `DV_CHECK(uvm_hdl_force(path, 0));
+      end
+      3, 4: begin
+         flip_2bits(path);
+      end
+      default: `uvm_error(`gfn, $sformatf("unsupported index %0d", idx))
+    endcase // case (idx)
+    cfg.clk_rst_vif.wait_clks(10);
+    `DV_CHECK(uvm_hdl_release(path));
+  endtask
+
+  task check_status(int idx);
+    uvm_object fld;
+
+    case (idx)
+      0: begin
+        fld = ral.fault_status.op_err;
+      end
+      1: begin
+        fld = ral.fault_status.seed_err;
+      end
+      2: begin
+        fld = ral.fault_status.mp_err;
+      end
+      3: begin
+        fld = ral.fault_status.rd_err;
+      end
+      4: begin
+        fld = ral.fault_status.phy_relbl_err;
+      end
+      default: `uvm_error(`gfn, $sformatf("unsupported index %0d", idx))
+    endcase // case (idx)
+    csr_rd_check(.ptr(ral.err_code), .compare_value(0));
+    csr_rd_check(.ptr(fld), .compare_value(1));
+  endtask // check_status
+
+endclass // flash_ctrl_hw_read_seed_err_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
@@ -75,6 +75,7 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
                          .timeout_ns(100_000_000));
             cfg.clk_rst_vif.wait_clks(3);
             `uvm_info(`gfn, "RMA FAIL DUE TO Wipe out write data failure (expected)", UVM_LOW)
+            collect_err_cov_status(ral.std_fault_status);
             csr_rd_check(.ptr(ral.std_fault_status.lcmgr_err), .compare_value(1));
           end
         join_any
@@ -100,7 +101,7 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
 
         `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rma_state == StRmaEraseWait);,
                      , state_wait_timeout_ns)
-        `DV_CHECK(uvm_hdl_force(path, $urandom))
+        flip_2bits(path);
         cfg.clk_rst_vif.wait_clks(10);
         `DV_CHECK(uvm_hdl_release(path))
         // Fatal alert (std_fault_status.lcmgr_err) is checked in the other thread by

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence triggers std_fault_status.lcmgr_intg_err by force
+class flash_ctrl_lcmgr_intg_vseq extends flash_ctrl_err_base_vseq;
+  `uvm_object_utils(flash_ctrl_lcmgr_intg_vseq)
+  `uvm_object_new
+
+  task run_main_event;
+    cfg.seq_cfg.disable_flash_init = 1;
+    cfg.seq_cfg.en_init_keys_seeds = 0;
+    apply_reset();
+    init_controller(.non_blocking(1));
+  endtask // init_controller
+
+   // fatal_std_err
+   task run_error_event();
+      int wait_timeout_ns = 50_000;
+      string path = "tb.dut.u_flash_hw_if.rdata_i[38:32]";
+
+      `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.hw_rvalid == 1);,
+                   , wait_timeout_ns)
+      cfg.scb_h.exp_alert["fatal_std_err"] = 1;
+      cfg.scb_h.alert_chk_max_delay["fatal_std_err"] = 2000;
+      cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
+
+      $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
+      `DV_CHECK(uvm_hdl_force(path, $urandom))
+      cfg.clk_rst_vif.wait_clks(10);
+      `DV_CHECK(uvm_hdl_release(path))
+      collect_err_cov_status(ral.std_fault_status);
+      csr_rd_check(.ptr(ral.std_fault_status.lcmgr_intg_err), .compare_value(1));
+   endtask
+endclass // flash_ctrl_lcmgr_intg_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv
@@ -10,54 +10,34 @@ class flash_ctrl_phy_host_grant_err_vseq extends flash_ctrl_err_base_vseq;
 
   task run_error_event();
     int delay;
-    bit add_err;
     string path = "tb.dut.u_eflash.gen_flash_cores[0].u_core.muxed_part";
 
     cfg.scb_h.exp_alert["fatal_err"] = 1;
     cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
-    repeat (2) begin
-      // unit 100 ns;
-      delay = $urandom_range(1, 10);
-      #(delay * 100ns);
+     // unit 100 ns;
+     delay = $urandom_range(1, 10);
+     #(delay * 100ns);
 
-      if (add_err) begin
-        `DV_CHECK(uvm_hdl_release(path))
-      end else begin
-        // This can haapen when host_read is sent to info partition (by force).
-        // After that, fatal error happen. So turning off these assertion
-        // just to make sure test run to complete.
-        $assertoff(0, "tb.dut.u_sw_rd_fifo.DataKnown_A");
-        $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[0].u_core.u_rd.u_rd_storage.DataKnown_A");
-        $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd.u_rd_storage.DataKnown_A");
-        $assertoff(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
-        $assertoff(0, "tb.dut.RspPayLoad_A");
-        $assertoff(0, "tb.dut.u_reg_core.u_socket.gen_dfifo[0].fifo_d.rspfifo.DataKnown_A");
-        $assertoff(0, "tb.dut.u_reg_core.u_socket.gen_dfifo[1].fifo_d.rspfifo.DataKnown_A");
-        $assertoff(0, "tb.dut.u_reg_core.u_socket.fifo_h.rspfifo.DataKnown_A");
-        $assertoff(0, "tb.dut.u_to_rd_fifo.TlOutPayloadKnown_A");
-        $assertoff(0, "tb.dut.u_to_rd_fifo.u_rspfifo.DataKnown_A");
-        $assertoff(0, "tb.dut.tlul_assert_device.dKnown_A");
-        $assertoff(0, "tb.dut.MemRspPayLoad_A");
-        $assertoff(0, "tb.dut.u_tl_adapter_eflash.TlOutPayloadKnown_A");
-        $assertoff(0, "tb.dut.u_tl_adapter_eflash.u_rspfifo.DataKnown_A");
-        $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[0].u_host_rsp_fifo.DataKnown_A");
-        $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[1].u_host_rsp_fifo.DataKnown_A");
-        // set error counter high number to skip unpredictable error
-        cfg.scb_h.exp_tl_rsp_intg_err = 1;
-        cfg.tlul_eflash_exp_cnt = 1;
-        cfg.tlul_core_exp_cnt = 1;
-        cfg.otf_scb_h.comp_off = 1;
+     // This can happen when host_read is sent to info partition (by force).
+     // After that, fatal error happen. So turning off these assertion
+     // just to make sure test run to complete.
+     $assertoff(0, "tb.dut");
 
-        add_err = 1;
-        @(posedge cfg.flash_ctrl_vif.host_gnt);
-        `DV_CHECK(uvm_hdl_force(path, 1))
+     // set error counter high number to skip unpredictable error
+     cfg.scb_h.exp_tl_rsp_intg_err = 1;
+     cfg.tlul_eflash_exp_cnt = 1;
+     cfg.tlul_core_exp_cnt = 1;
+     cfg.otf_scb_h.comp_off = 1;
+     cfg.otf_scb_h.mem_mon_off = 1;
 
-      end
-    end // repeat (2)
+     @(posedge cfg.flash_ctrl_vif.host_gnt);
+     `DV_CHECK(uvm_hdl_force(path, 1))
 
     check_fault(ral.fault_status.host_gnt_err);
+    `DV_CHECK(uvm_hdl_release(path))
+
     collect_err_cov_status(ral.fault_status);
     csr_rd_check(.ptr(ral.err_code), .compare_value(0));
     cfg.tlul_core_exp_cnt = cfg.tlul_core_obs_cnt;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -60,3 +60,6 @@
 `include "flash_ctrl_phy_ack_consistency_vseq.sv"
 `include "flash_ctrl_config_regwen_vseq.sv"
 `include "flash_ctrl_hw_rma_err_vseq.sv"
+`include "flash_ctrl_lcmgr_intg_vseq.sv"
+`include "flash_ctrl_hw_read_seed_err_vseq.sv"
+`include "flash_ctrl_hw_prog_rma_wipe_err_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -425,6 +425,27 @@
       run_opts: ["+flash_program_latency=5", "+test_timeout_ns=300_000_000_000"]
       reseed: 3
     }
+    {
+      name: flash_ctrl_lcmgr_intg
+      uvm_test_seq: flash_ctrl_lcmgr_intg_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1",
+                 "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
+      reseed: 3
+    }
+    {
+      name: flash_ctrl_hw_read_seed_err
+      uvm_test_seq: flash_ctrl_hw_read_seed_err_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1",
+                 "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
+      reseed: 20
+    }
+    {
+      name: flash_ctrl_hw_prog_rma_wipe_err
+      uvm_test_seq: flash_ctrl_hw_prog_rma_wipe_err_vseq
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+flash_program_latency=5",
+                 "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
+      reseed: 20
+    }
  ]
 
   // List of regressions.

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -123,6 +123,8 @@ module tb;
   assign flash_ctrl_if.host_outstanding =
                tb.dut.u_eflash.gen_flash_cores[0].u_core.host_outstanding[1:0];
 
+  assign flash_ctrl_if.hw_rvalid =
+               tb.dut.u_flash_hw_if.rvalid_i;
 
   wire flash_test_v;
   assign (pull1, pull0) flash_test_v = 1'b1;


### PR DESCRIPTION
- Add a few new tests to hit covergropu 'hw_error_cg'
- Add flip_2bits function to accomodate asserting 2 bit error
- Reactor flash_ctrl_err_base_vseq and childrun sequences to be more reusable

Signed-off-by: Jaedon Kim <jdonjdon@google.com>