### PR TITLE
[entropy_src/dv] Close sw_update_cg

### DIFF
--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -769,9 +769,6 @@ interface entropy_src_cov_if
                                               bit module_enable);
     string msg, fmt;
 
-    fmt = "offset: %01d, regupd: %01d, mod_en: %01d";
-    msg = $sformatf(fmt, offset, sw_regupd, module_enable);
-    `uvm_info("", msg, UVM_LOW)
     sw_update_cg_inst.sample(offset, sw_regupd, module_enable);
 
   endfunction

--- a/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
@@ -23,6 +23,11 @@ class entropy_src_dut_cfg extends uvm_object;
   // Constraint knob for module_enable field
   uint          module_enable_pct;
 
+  // Knob to control whether the DUT is disabled before initialization.
+  // Not disabling the device will leave many registers in an unconfigurable state.
+  // This is intentional as it prevents many unpredictable behaviors.
+  uint          preconfig_disable_pct;
+
   // Constraint knob for SW-accessible REGWEN-related fields
   uint          me_regwen_pct, sw_regupd_pct;
 
@@ -63,6 +68,7 @@ class entropy_src_dut_cfg extends uvm_object;
   ///////////////////////
 
   rand bit                      sw_regupd, me_regwen;
+  rand bit                      preconfig_disable;
   rand bit [1:0]                rng_bit_sel;
 
   rand prim_mubi_pkg::mubi4_t   module_enable, fips_enable, route_software, type_bypass,
@@ -97,6 +103,10 @@ class entropy_src_dut_cfg extends uvm_object;
   /////////////////
   // Constraints //
   /////////////////
+
+  constraint preconfig_disable_c { preconfig_disable dist {
+      1 :/ preconfig_disable_pct,
+      0 :/ (100 - preconfig_disable_pct) };}
 
   constraint bypass_window_size_c { bypass_window_size dist {
       384 :/ 1 };}

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -244,7 +244,6 @@ class entropy_src_base_vseq extends cip_base_vseq #(
   // were locked. (Likely intentionally)
   virtual task entropy_src_init(entropy_src_dut_cfg newcfg=cfg.dut_cfg,
                                 realtime pause=default_cfg_pause,
-                                bit do_disable=1'b0,
                                 output bit completed,
                                 output bit regwen);
     completed = 0;
@@ -255,7 +254,7 @@ class entropy_src_base_vseq extends cip_base_vseq #(
       cfg.entropy_src_assert_vif.assert_off_alert();
     end
 
-    if (do_disable) begin
+    if (newcfg.preconfig_disable) begin
       disable_dut();
       `uvm_info(`gfn, "DUT Disabled", UVM_MEDIUM)
     end

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -33,8 +33,11 @@ class entropy_src_base_test extends cip_base_test #(
     cfg.otp_en_es_fw_read_pct          = 100;
     cfg.otp_en_es_fw_over_pct          = 100;
     cfg.dut_cfg.me_regwen_pct          = 100;
+    cfg.dut_cfg.sw_regupd_pct          = 100;
+
     cfg.dut_cfg.module_enable_pct      = 100;
     cfg.dut_cfg.type_bypass_pct        = 100;
+    cfg.dut_cfg.preconfig_disable_pct  = 100;
     // Unless testing bad MuBi's the initial value for fw_ov_insert_start should always be false
     cfg.dut_cfg.fw_ov_insert_start_pct = 0;
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -31,7 +31,8 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.dut_cfg.markov_sigma_min            = 3.0;
     cfg.dut_cfg.markov_sigma_max            = 6.0;
 
-    cfg.dut_cfg.sw_regupd_pct               = 100;
+    cfg.dut_cfg.sw_regupd_pct               = 50;
+    cfg.dut_cfg.preconfig_disable_pct       = 50;
 
     cfg.dut_cfg.entropy_data_reg_enable_pct = 50;
     cfg.dut_cfg.route_software_pct          = 50;


### PR DESCRIPTION
This commit updates the RNG test, dut_cfg structure and RNG vseq to close the sw_update_cg.  This includes:

- Adding randomized config variables to _not_ disable the DUT before reconfiguration
- Randomizing the sw_regupd field
- Forcing the DUT into the enabled state when the disabled state is not requested.
- Forcing an _unlocked_ reconfiguration (and if needed a reset) once a locked reconfiguration has been attempted.
- Only sampling coverage when a new attempted setting is different from the current setting (and thus any lock errors are detectable).

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>