### PR TITLE
[crypto] Fix bug in ECDSA-P256 scalar inversion.

### DIFF
--- a/sw/otbn/crypto/p256.s
+++ b/sw/otbn/crypto/p256.s
@@ -736,8 +736,9 @@ proj_to_affine:
  * the field GF(m).
  * For inverse computation Fermat's little theorem is used, i.e.
  * we compute x^-1 = x^(m-2) mod m.
- * For exponentiation we use a standard, variable time (!) square and multiply
- * algorithm.
+ * For exponentiation we use a standard, variable time square and multiply
+ * algorithm. (The timing varies based on the modulus alone, not the input x,
+ * so it is safe to use for a non-secret modulus and a secret operand).
  *
  * @param[in]  w0: x, a 256 bit operand with x < m
  * @param[in]  w29: m, modulus, 2^256 > m > 2^255.
@@ -1143,6 +1144,11 @@ p256_sign:
   la        x16, k1
   li        x2, 1
   bn.lid    x2, 0(x16)
+
+  /* Combine the shares of k for inversion.
+     TODO(#15507): modify inversion to handle k in shares.
+       w0 <= (w0 + w1) mod n = k */
+  bn.addm   w0, w0, w1
 
   /* modular multiplicative inverse of k
      w1 <= k^-1 mod n */

--- a/sw/otbn/crypto/p256_ecdsa_sign_test.s
+++ b/sw/otbn/crypto/p256_ecdsa_sign_test.s
@@ -35,7 +35,7 @@ ecdsa_sign_test:
 
 .data
 
-/* nonce k */
+/* first share of nonce k (first 128 bits of k, then 128 0s) */
 .globl k0
 .balign 32
 k0:
@@ -43,16 +43,17 @@ k0:
   .word 0x21d0a016
   .word 0xb0b2c781
   .word 0x9590ef5d
+  .zero 16
+
+/* second share of nonce k (128 0s, then last 128 bits of k) */
+.globl k1
+.balign 32
+k1:
+  .zero 16
   .word 0x3fdfa379
   .word 0x1b76ebe8
   .word 0x74210263
   .word 0x1420fc41
-
-/* second share of k (all-zero)*/
-.globl k1
-.balign 32
-k1:
-  .zero 32
 
 /* message digest */
 .globl msg


### PR DESCRIPTION
Related to https://github.com/lowRISC/opentitan/pull/15439

Fixes a recently introduced bug in ECDSA-P256 signatures; the scalar inversion routine handles scalars in plaintext, so the shares need to be combined in order to use it. Eventually we should use a more heavily protected implementation (see #15507) but for now this just fixes the bug by combining shares.

This commit also updates the p256 signature test  on the OTBN simulator to use both shares, so that this type of bug will be caught faster in the future.