### PR TITLE
[crypto] Update API header file.

### DIFF
--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -15,39 +15,16 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * DRBG state.
- *
- * Representation is internal to the drbg implementation; initialize
- * with #otcrypto_drbg_instantiate or
- * #otcrypto_drbg_manual_instantiate.
- *
- * Note: The drbg_state_t struct along with V and K, should include:
- * drbg_entropy_mode: To indicate the entropy mode used. Also used to
- * disallow mixing of auto entropy and manual entropy DRBG operations.
- * reseed_counter: To indicate the number of requests for pseudorandom
- * bits since instantiation or reseeding.
- * security_strength: To indicate security strength of the DRBG
- * instantiation.
- * prediction_resistance_flag: To indicate if prediction resistance is
- * required.
- * drbg_mechanism: To indicate if CTR_DRBG or HMAC_DRBG is used for
- * the DRBG instantiation.
- */
-typedef struct drbg_state drbg_state_t;
-
-/**
  * Instantiates the DRBG system.
  *
  * Initializes the DRBG and the context for DRBG. Gets the required
  * entropy input automatically from the entropy source.
  *
- * @param drbg_state Pointer to the DRBG working state
- * @param nonce Pointer to the nonce bit-string
- * @param perso_string Pointer to personalization bitstring
- * @return Result of the DRBG instantiate operation
+ * @param nonce Pointer to the nonce bit-string.
+ * @param perso_string Pointer to personalization bitstring.
+ * @return Result of the DRBG instantiate operation.
  */
-crypto_status_t otcrypto_drbg_instantiate(drbg_state_t *drbg_state,
-                                          crypto_uint8_buf_t nonce,
+crypto_status_t otcrypto_drbg_instantiate(crypto_uint8_buf_t nonce,
                                           crypto_uint8_buf_t perso_string);
 
 /**
@@ -56,12 +33,10 @@ crypto_status_t otcrypto_drbg_instantiate(drbg_state_t *drbg_state,
  * Reseeds the DRBG with fresh entropy that is automatically fetched
  * from the entropy source and updates the working state parameters.
  *
- * @param drbg_state Pointer to the DRBG working state
- * @param additional_input Pointer to the additional input for DRBG
- * @return Result of the DRBG reseed operation
+ * @param additional_input Pointer to the additional input for DRBG.
+ * @return Result of the DRBG reseed operation.
  */
-crypto_status_t otcrypto_drbg_reseed(drbg_state_t *drbg_state,
-                                     crypto_uint8_buf_t additional_input);
+crypto_status_t otcrypto_drbg_reseed(crypto_uint8_buf_t additional_input);
 
 /**
  * Instantiates the DRBG system.
@@ -69,15 +44,14 @@ crypto_status_t otcrypto_drbg_reseed(drbg_state_t *drbg_state,
  * Initializes DRBG and the DRBG context. Gets the required entropy
  * input from the user through the `entropy` parameter.
  *
- * @param drbg_state Pointer to the DRBG working state
- * @param entropy Pointer to the user defined entropy value
- * @param nonce Pointer to the nonce bit-string
- * @param personalization_string Pointer to personalization bitstring
- * @return Result of the DRBG manual instantiation
+ * @param entropy Pointer to the user defined entropy value.
+ * @param nonce Pointer to the nonce bit-string.
+ * @param personalization_string Pointer to personalization bitstring.
+ * @return Result of the DRBG manual instantiation.
  */
 crypto_status_t otcrypto_drbg_manual_instantiate(
-    drbg_state_t *drbg_state, crypto_uint8_buf_t entropy,
-    crypto_uint8_buf_t nonce, crypto_uint8_buf_t perso_string);
+    crypto_uint8_buf_t entropy, crypto_uint8_buf_t nonce,
+    crypto_uint8_buf_t perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.
@@ -85,14 +59,12 @@ crypto_status_t otcrypto_drbg_manual_instantiate(
  * Reseeds the DRBG with entropy input from the user through `entropy`
  * parameter and updates the working state parameters.
  *
- * @param drbg_state Pointer to the DRBG working state
- * @param entropy Pointer to the user defined entropy value
- * @param additional_input Pointer to the additional input for DRBG
- * @return Result of the manual DRBG reseed operation
+ * @param entropy Pointer to the user defined entropy value.
+ * @param additional_input Pointer to the additional input for DRBG.
+ * @return Result of the manual DRBG reseed operation.
  */
 crypto_status_t otcrypto_drbg_manual_reseed(
-    drbg_state_t *drbg_state, crypto_uint8_buf_t entropy,
-    crypto_uint8_buf_t additional_input);
+    crypto_uint8_buf_t entropy, crypto_uint8_buf_t additional_input);
 
 /**
  * DRBG function for generating random bits.
@@ -106,24 +78,21 @@ crypto_status_t otcrypto_drbg_manual_reseed(
  * and the output length does not match, an error message will be
  * returned.
  *
- * @param drbg_state Pointer to the DRBG working state
- * @param additional_input Pointer to the additional data
- * @param output_len Required len of pseudorandom output, in bytes
- * @param drbg_output Pointer to the generated pseudo random bits
- * @return Result of the DRBG generate operation
+ * @param additional_input Pointer to the additional data.
+ * @param output_len Required len of pseudorandom output, in bytes.
+ * @param[out] drbg_output Pointer to the generated pseudo random bits.
+ * @return Result of the DRBG generate operation.
  */
-crypto_status_t otcrypto_drbg_generate(drbg_state_t *drbg_state,
-                                       crypto_uint8_buf_t additional_input,
+crypto_status_t otcrypto_drbg_generate(crypto_uint8_buf_t additional_input,
                                        size_t output_len,
                                        crypto_uint8_buf_t *drbg_output);
 
 /**
  * Uninstantiates DRBG and clears the context.
  *
- * @param drbg_state Pointer to the DRBG working state
- * @return Result of the DRBG uninstantiate operation
+ * @return Result of the DRBG uninstantiate operation.
  */
-crypto_status_t otcrypto_drbg_uninstantiate(drbg_state_t *drbg_state);
+crypto_status_t otcrypto_drbg_uninstantiate();
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -107,17 +107,25 @@ typedef struct ecc_curve {
 /**
  * Performs the key generation for ECDSA operation.
  *
- * Computes private key (d) and public key (Q) keys for ECDSA
- * operation.
+ * Computes private key (d) and public key (Q) keys for ECDSA operation.
  *
- * The domain_parameter field of the `elliptic_curve` is required
- * only for a custom curve. For named curves this field is ignored
- * and can be set to NULL.
+ * The caller should allocate and partially populate the blinded key struct,
+ * including populating the key configuration and allocating space for the
+ * keyblob. The caller should indicate the length of the allocated keyblob;
+ * this function will return an error if the keyblob length does not match
+ * expectations. For hardware-backed keys, the keyblob length is 0 and the
+ * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
+ * should be twice the length of the key. The value in the `checksum` field of
+ * the blinded key struct will be populated by the key generation function.
  *
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @param private_key Pointer to the blinded private key (d) struct
- * @param public_key Pointer to the unblinded public key (Q) struct
- * @return Result of the ECDSA key generation
+ * The `domain_parameter` field of the `elliptic_curve` is required only for a
+ * custom curve. For named curves this field is ignored and can be set to
+ * `NULL`.
+ *
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @param[out] private_key Pointer to the blinded private key (d) struct.
+ * @param[out] public_key Pointer to the unblinded public key (Q) struct.
+ * @return Result of the ECDSA key generation.
  */
 crypto_status_t otcrypto_ecdsa_keygen(ecc_curve_t *elliptic_curve,
                                       crypto_blinded_key_t *private_key,
@@ -126,15 +134,15 @@ crypto_status_t otcrypto_ecdsa_keygen(ecc_curve_t *elliptic_curve,
 /**
  * Performs the ECDSA digital signature generation.
  *
- * The domain_parameter field of the `elliptic_curve` is required
+ * The `domain_parameter` field of the `elliptic_curve` is required
  * only for a custom curve. For named curves this field is ignored
- * and can be set to NULL.
+ * and can be set to `NULL`.
  *
- * @param private_key Pointer to the blinded private key (d) struct
- * @param input_message Input message to be signed
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @param signature Pointer to the signature struct with (r,s) values
- * @return Result of the ECDSA signature generation
+ * @param private_key Pointer to the blinded private key (d) struct.
+ * @param input_message Input message to be signed.
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @param[out] signature Pointer to the signature struct with (r,s) values.
+ * @return Result of the ECDSA signature generation.
  */
 crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
                                     crypto_const_uint8_buf_t input_message,
@@ -148,15 +156,15 @@ crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
  * signature generation is deterministically generated from the
  * private key and the input message. Refer to RFC6979 for details.
  *
- * The domain_parameter field of the `elliptic_curve` is required
+ * The `domain_parameter` field of the `elliptic_curve` is required
  * only for a custom curve. For named curves this field is ignored
- * and can be set to NULL.
+ * and can be set to `NULL`.
  *
- * @param private_key Pointer to the blinded private key (d) struct
- * @param input_message Input message to be signed
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @param signature Pointer to the signature struct with (r,s) values
- * @return Result of the deterministic ECDSA signature
+ * @param private_key Pointer to the blinded private key (d) struct.
+ * @param input_message Input message to be signed.
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @param[out] signature Pointer to the signature struct with (r,s) values.
+ * @return Result of the deterministic ECDSA signature.
  * generation
  */
 crypto_status_t otcrypto_deterministic_ecdsa_sign(
@@ -167,16 +175,17 @@ crypto_status_t otcrypto_deterministic_ecdsa_sign(
 /**
  * Performs the ECDSA digital signature verification.
  *
- * The domain_parameter field of the `elliptic_curve` is required
+ * The `domain_parameter` field of the `elliptic_curve` is required
  * only for a custom curve. For named curves this field is ignored
- * and can be set to NULL.
+ * and can be set to `NULL`.
  *
- * @param public_key Pointer to the unblinded public key (Q) struct
- * @param input_message Input message to be signed for verification
- * @param signature Pointer to the signature to be verified
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @param verification_result Result of verification (Pass/Fail)
- * @return Result of the ECDSA verification operation
+ * @param public_key Pointer to the unblinded public key (Q) struct.
+ * @param input_message Input message to be signed for verification.
+ * @param signature Pointer to the signature to be verified.
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @param[out] verification_result Result of signature verification
+ * (Pass/Fail).
+ * @return Result of the ECDSA verification operation.
  */
 crypto_status_t otcrypto_ecdsa_verify(
     const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
@@ -186,17 +195,25 @@ crypto_status_t otcrypto_ecdsa_verify(
 /**
  * Performs the key generation for ECDH key agreement.
  *
- * Computes private key (d) and public key (Q) keys for ECDSA
- * operation.
+ * Computes private key (d) and public key (Q) keys for ECDSA operation.
  *
- * The domain_parameter field of the `elliptic_curve` is required
- * only for a custom curve. For named curves this field is ignored
- * and can be set to NULL.
+ * The `domain_parameter` field of the `elliptic_curve` is required only for a
+ * custom curve. For named curves this field is ignored and can be set to
+ * `NULL`.
  *
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @param private_key Pointer to the blinded private key (d) struct
- * @param public_key Pointer to the unblinded public key (Q) struct
- * @return Result of the ECDH key generation
+ * The caller should allocate and partially populate the blinded key struct,
+ * including populating the key configuration and allocating space for the
+ * keyblob. The caller should indicate the length of the allocated keyblob;
+ * this function will return an error if the keyblob length does not match
+ * expectations. For hardware-backed keys, the keyblob length is 0 and the
+ * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
+ * should be twice the length of the key. The value in the `checksum` field of
+ * the blinded key struct will be populated by the key generation function.
+ *
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @param[out] private_key Pointer to the blinded private key (d) struct.
+ * @param[out] public_key Pointer to the unblinded public key (Q) struct.
+ * @return Result of the ECDH key generation.
  */
 crypto_status_t otcrypto_ecdh_keygen(ecc_curve_t *elliptic_curve,
                                      crypto_blinded_key_t *private_key,
@@ -205,15 +222,15 @@ crypto_status_t otcrypto_ecdh_keygen(ecc_curve_t *elliptic_curve,
 /**
  * Performs Elliptic Curve Diffie Hellman shared secret generation.
  *
- * The domain_parameter field of the `elliptic_curve` is required
+ * The `domain_parameter` field of the `elliptic_curve` is required
  * only for a custom curve. For named curves this field is ignored
- * and can be set to NULL.
+ * and can be set to `NULL`.
  *
- * @param private_key Pointer to the blinded private key (d) struct
- * @param public_key Pointer to the unblinded public key (Q) struct
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @param shared_secret Pointer to generated blinded shared key struct
- * @return Result of ECDH shared secret generation
+ * @param private_key Pointer to the blinded private key (d) struct.
+ * @param public_key Pointer to the unblinded public key (Q) struct.
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @param[out] shared_secret Pointer to generated blinded shared key struct.
+ * @return Result of ECDH shared secret generation.
  */
 crypto_status_t otcrypto_ecdh(const crypto_blinded_key_t *private_key,
                               const ecc_public_key_t *public_key,
@@ -226,11 +243,20 @@ crypto_status_t otcrypto_ecdh(const crypto_blinded_key_t *private_key,
  * Computes the private exponent (d) and public key (Q) based on
  * Curve25519.
  *
- * No domain_parameter is needed and is automatically set for Ed25519.
+ * No `domain_parameter` is needed and is automatically set for Ed25519.
  *
- * @param private_key Pointer to the blinded private key struct
- * @param public_key Pointer to the unblinded public key struct
- * @return Result of the Ed25519 key generation
+ * The caller should allocate and partially populate the blinded key struct,
+ * including populating the key configuration and allocating space for the
+ * keyblob. The caller should indicate the length of the allocated keyblob;
+ * this function will return an error if the keyblob length does not match
+ * expectations. For hardware-backed keys, the keyblob length is 0 and the
+ * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
+ * should be twice the length of the key. The value in the `checksum` field of
+ * the blinded key struct will be populated by the key generation function.
+ *
+ * @param[out] private_key Pointer to the blinded private key struct.
+ * @param[out] public_key Pointer to the unblinded public key struct.
+ * @return Result of the Ed25519 key generation.
  */
 crypto_status_t otcrypto_ed25519_keygen(crypto_blinded_key_t *private_key,
                                         crypto_unblinded_key_t *public_key);
@@ -238,11 +264,11 @@ crypto_status_t otcrypto_ed25519_keygen(crypto_blinded_key_t *private_key,
 /**
  * Generates an Ed25519 digital signature.
  *
- * @param private_key Pointer to the blinded private key struct
- * @param input_message Input message to be signed
- * @param sign_mode Parameter for EdDSA or Hash EdDSA sign mode
- * @param signature Pointer to the EdDSA signature with (r,s) values
- * @return Result of the EdDSA signature generation
+ * @param private_key Pointer to the blinded private key struct.
+ * @param input_message Input message to be signed.
+ * @param sign_mode Parameter for EdDSA or Hash EdDSA sign mode.
+ * @param[out] signature Pointer to the EdDSA signature with (r,s) values.
+ * @return Result of the EdDSA signature generation.
  */
 crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
                                       crypto_const_uint8_buf_t input_message,
@@ -252,13 +278,13 @@ crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
 /**
  * Verifies an Ed25519 signature.
  *
- * @param public_key Pointer to the unblinded public key struct
- * @param input_message Input message to be signed for verification
- * @param sign_mode Parameter for EdDSA or Hash EdDSA sign mode
- * @param signature Pointer to the signature to be verified
- * @param verification_result Returns the result of signature
- * verification (Pass/Fail)
- * @return Result of the EdDSA verification operation
+ * @param public_key Pointer to the unblinded public key struct.
+ * @param input_message Input message to be signed for verification.
+ * @param sign_mode Parameter for EdDSA or Hash EdDSA sign mode.
+ * @param signature Pointer to the signature to be verified.
+ * @param[out] verification_result Result of signature verification
+ * (Pass/Fail).
+ * @return Result of the EdDSA verification operation.
  */
 crypto_status_t otcrypto_ed25519_verify(
     const crypto_unblinded_key_t *public_key,
@@ -271,11 +297,20 @@ crypto_status_t otcrypto_ed25519_verify(
  * Computes the private scalar (d) and public key (Q) based on
  * Curve25519.
  *
- * No domain_parameter is needed and is automatically set for X25519.
+ * No `domain_parameter` is needed and is automatically set for X25519.
  *
- * @param private_key Pointer to the blinded private key struct
- * @param public_key Pointer to the unblinded public key struct
- * @return Result of the X25519 key generation
+ * The caller should allocate and partially populate the blinded key struct,
+ * including populating the key configuration and allocating space for the
+ * keyblob. The caller should indicate the length of the allocated keyblob;
+ * this function will return an error if the keyblob length does not match
+ * expectations. For hardware-backed keys, the keyblob length is 0 and the
+ * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
+ * should be twice the length of the key. The value in the `checksum` field of
+ * the blinded key struct will be populated by the key generation function.
+ *
+ * @param[out] private_key Pointer to the blinded private key struct.
+ * @param[out] public_key Pointer to the unblinded public key struct.
+ * @return Result of the X25519 key generation.
  */
 crypto_status_t otcrypto_x25519_keygen(crypto_blinded_key_t *private_key,
                                        crypto_unblinded_key_t *public_key);
@@ -283,10 +318,10 @@ crypto_status_t otcrypto_x25519_keygen(crypto_blinded_key_t *private_key,
 /**
  * Performs the X25519 Diffie Hellman shared secret generation.
  *
- * @param private_key Pointer to blinded private key (u-coordinate)
- * @param public_key Pointer to the public scalar from the sender
- * @param shared_secret Pointer to shared secret key (u-coordinate)
- * @return Result of the X25519 operation
+ * @param private_key Pointer to blinded private key (u-coordinate).
+ * @param public_key Pointer to the public scalar from the sender.
+ * @param[out] shared_secret Pointer to shared secret key (u-coordinate).
+ * @return Result of the X25519 operation.
  */
 crypto_status_t otcrypto_x25519(const crypto_blinded_key_t *private_key,
                                 const crypto_unblinded_key_t *public_key,
@@ -298,17 +333,16 @@ crypto_status_t otcrypto_x25519(const crypto_blinded_key_t *private_key,
  * Initializes OTBN and starts the OTBN routine to compute the private
  * key (d) and public key (Q) for ECDSA operation.
  *
- * The domain_parameter field of the `elliptic_curve` is required
+ * The `domain_parameter` field of the `elliptic_curve` is required
  * only for a custom curve. For named curves this field is ignored
- * and can be set to NULL.
+ * and can be set to `NULL`.
  *
  * Returns `kCryptoStatusOK` if the operation was successfully
  * started, or`kCryptoStatusInternalError` if the operation cannot be
  * started.
  *
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @return Result of asynchronous ECDSA keygen start
- * operation.
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @return Result of asynchronous ECDSA keygen start operation.
  */
 crypto_status_t otcrypto_ecdsa_keygen_async_start(ecc_curve_t *elliptic_curve);
 
@@ -320,10 +354,9 @@ crypto_status_t otcrypto_ecdsa_keygen_async_start(ecc_curve_t *elliptic_curve);
  * `kCryptoStatusAsyncIncomplete` if the OTBN is busy or
  * `kCryptoStatusInternalError` if there is an error.
  *
- * @param private_key Pointer to the blinded private key (d) struct
- * @param public_key Pointer to the unblinded public key (Q) struct
- * @return Result of asynchronous ECDSA keygen
- * finalize operation
+ * @param[out] private_key Pointer to the blinded private key (d) struct.
+ * @param[out] public_key Pointer to the unblinded public key (Q) struct.
+ * @return Result of asynchronous ECDSA keygen finalize operation.
  */
 crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
     crypto_blinded_key_t *private_key, ecc_public_key_t *public_key);
@@ -332,14 +365,14 @@ crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
  * Starts the asynchronous ECDSA digital signature generation.
  *
  * Initializes OTBN and starts the OTBN routine to compute the digital
- * signature on the input message. The domain_parameter field of the
+ * signature on the input message. The `domain_parameter` field of the
  * `elliptic_curve` is required only for a custom curve. For named
- * curves this field is ignored and can be set to NULL.
+ * curves this field is ignored and can be set to `NULL`.
  *
- * @param private_key Pointer to the blinded private key (d) struct
- * @param input_message Input message to be signed
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @return Result of async ECDSA start operation
+ * @param private_key Pointer to the blinded private key (d) struct.
+ * @param input_message Input message to be signed.
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @return Result of async ECDSA start operation.
  */
 crypto_status_t otcrypto_ecdsa_sign_async_start(
     const crypto_blinded_key_t *private_key,
@@ -352,8 +385,8 @@ crypto_status_t otcrypto_ecdsa_sign_async_start(
  * status is done, or `kCryptoStatusAsyncIncomplete` if the OTBN is
  * busy or `kCryptoStatusInternalError` if there is an error.
  *
- * @param signature Pointer to the signature struct with (r,s) values
- * @return Result of async ECDSA finalize operation
+ * @param[out] signature Pointer to the signature struct with (r,s) values.
+ * @return Result of async ECDSA finalize operation.
  */
 crypto_status_t otcrypto_ecdsa_sign_async_finalize(ecc_signature_t *signature);
 
@@ -361,14 +394,14 @@ crypto_status_t otcrypto_ecdsa_sign_async_finalize(ecc_signature_t *signature);
  * Starts the asynchronous deterministic ECDSA digital signature generation.
  *
  * Initializes OTBN and starts the OTBN routine to compute the digital
- * signature on the input message. The domain_parameter field of the
+ * signature on the input message. The `domain_parameter` field of the
  * `elliptic_curve` is required only for a custom curve. For named
- * curves this field is ignored and can be set to NULL.
+ * curves this field is ignored and can be set to `NULL`.
  *
- * @param private_key Pointer to the blinded private key (d) struct
- * @param input_message Input message to be signed
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @return Result of async ECDSA start operation
+ * @param private_key Pointer to the blinded private key (d) struct.
+ * @param input_message Input message to be signed.
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @return Result of async ECDSA start operation.
  */
 crypto_status_t otcrypto_deterministic_ecdsa_sign_async_start(
     const crypto_blinded_key_t *private_key,
@@ -385,9 +418,8 @@ crypto_status_t otcrypto_deterministic_ecdsa_sign_async_start(
  * status is done, or `kCryptoStatusAsyncIncomplete` if the OTBN is
  * busy or `kCryptoStatusInternalError` if there is an error.
  *
- * @param signature Pointer to the signature struct with (r,s) values
- * @return Result of async deterministic ECDSA finalize
- * operation
+ * @param[out] signature Pointer to the signature struct with (r,s) values.
+ * @return Result of async deterministic ECDSA finalize operation.
  */
 crypto_status_t otcrypto_ecdsa_deterministic_sign_async_finalize(
     ecc_signature_t *signature);
@@ -396,15 +428,15 @@ crypto_status_t otcrypto_ecdsa_deterministic_sign_async_finalize(
  * Starts the asynchronous ECDSA digital signature verification.
  *
  * Initializes OTBN and starts the OTBN routine to recover ‘r’ value
- * from the input signature ‘s’ value. The domain_parameter field of
+ * from the input signature ‘s’ value. The `domain_parameter` field of
  * `elliptic_curve` is required only for a custom curve. For named
- * curves this field is ignored and can be set to NULL.
+ * curves this field is ignored and can be set to `NULL`.
  *
- * @param public_key Pointer to the unblinded public key (Q) struct
- * @param input_message Input message to be signed for verification
- * @param signature Pointer to the signature to be verified
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @return Result of async ECDSA verify start function
+ * @param public_key Pointer to the unblinded public key (Q) struct.
+ * @param input_message Input message to be signed for verification.
+ * @param signature Pointer to the signature to be verified.
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @return Result of async ECDSA verify start function.
  */
 crypto_status_t otcrypto_ecdsa_verify_async_start(
     const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
@@ -419,9 +451,9 @@ crypto_status_t otcrypto_ecdsa_verify_async_start(
  * The computed signature is compared against the input signature
  * and a PASS or FAIL is returned.
  *
- * @param verification_result Returns the result of verification
- * @return Result of async ECDSA verify finalize
- * operation
+ * @param[out] verification_result Result of signature verification
+ * (Pass/Fail).
+ * @return Result of async ECDSA verify finalize operation.
  */
 crypto_status_t otcrypto_ecdsa_verify_async_finalize(
     verification_status_t *verification_result);
@@ -432,17 +464,16 @@ crypto_status_t otcrypto_ecdsa_verify_async_finalize(
  * Initializes OTBN and starts the OTBN routine to compute the private
  * key (d) and public key (Q) for ECDH operation.
  *
- * The domain_parameter field of the `elliptic_curve` is required
+ * The `domain_parameter` field of the `elliptic_curve` is required
  * only for a custom curve. For named curves this field is ignored
- * and can be set to NULL.
+ * and can be set to `NULL`.
  *
  * Returns `kCryptoStatusOK` if the operation was successfully
  * started, or`kCryptoStatusInternalError` if the operation cannot be
  * started.
  *
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @return Result of asynchronous ECDH keygen start
- * operation.
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @return Result of asynchronous ECDH keygen start operation.
  */
 crypto_status_t otcrypto_ecdh_keygen_async_start(ecc_curve_t *elliptic_curve);
 
@@ -454,10 +485,9 @@ crypto_status_t otcrypto_ecdh_keygen_async_start(ecc_curve_t *elliptic_curve);
  * `kCryptoStatusAsyncIncomplete` if the OTBN is busy or
  * `kCryptoStatusInternalError` if there is an error.
  *
- * @param private_key Pointer to the blinded private key (d) struct
- * @param public_key Pointer to the unblinded public key (Q) struct
- * @return Result of asynchronous ECDH keygen
- * finalize operation
+ * @param[out] private_key Pointer to the blinded private key (d) struct.
+ * @param[out] public_key Pointer to the unblinded public key (Q) struct.
+ * @return Result of asynchronous ECDH keygen finalize operation.
  */
 crypto_status_t otcrypto_ecdh_keygen_async_finalize(
     crypto_blinded_key_t *private_key, ecc_public_key_t *public_key);
@@ -466,14 +496,14 @@ crypto_status_t otcrypto_ecdh_keygen_async_finalize(
  * Starts the asynchronous Elliptic Curve Diffie Hellman shared
  * secret generation.
  *
- * The domain_parameter field of the `elliptic_curve` is required
+ * The `domain_parameter` field of the `elliptic_curve` is required
  * only for a custom curve. For named curves this field is ignored
- * and can be set to NULL.
+ * and can be set to `NULL`.
  *
- * @param private_key Pointer to the blinded private key (d) struct
- * @param public_key Pointer to the unblinded public key (Q) struct
- * @param elliptic_curve Pointer to the elliptic curve to be used
- * @return Result of async ECDH start operation
+ * @param private_key Pointer to the blinded private key (d) struct.
+ * @param public_key Pointer to the unblinded public key (Q) struct.
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @return Result of async ECDH start operation.
  */
 crypto_status_t otcrypto_ecdh_async_start(
     const crypto_blinded_key_t *private_key, const ecc_public_key_t *public_key,
@@ -487,8 +517,8 @@ crypto_status_t otcrypto_ecdh_async_start(
  * status is done, or `kCryptoStatusAsyncIncomplete` if the OTBN
  * is busy or `kCryptoStatusInternalError` if there is an error.
  *
- * @param shared_secret Pointer to generated blinded shared key struct
- * @return Result of async ECDH finalize operation
+ * @param[out] shared_secret Pointer to generated blinded shared key struct.
+ * @return Result of async ECDH finalize operation.
  */
 crypto_status_t otcrypto_ecdh_async_finalize(
     crypto_blinded_key_t *shared_secret);
@@ -499,10 +529,9 @@ crypto_status_t otcrypto_ecdh_async_finalize(
  * Initializes OTBN and starts the OTBN routine to compute the private
  * exponent (d) and public key (Q) based on Curve25519.
  *
- * No domain_parameter is needed and is automatically set for X25519.
+ * No `domain_parameter` is needed and is automatically set for X25519.
  *
- * @return Result of asynchronous ed25519 keygen start
- * operation.
+ * @return Result of asynchronous ed25519 keygen start operation.
  */
 crypto_status_t otcrypto_ed25519_keygen_async_start();
 
@@ -514,10 +543,9 @@ crypto_status_t otcrypto_ed25519_keygen_async_start();
  * if the OTBN is busy or `kCryptoStatusInternalError` if there is an
  * error.
  *
- * @param private_key Pointer to the blinded private key struct
- * @param public_key Pointer to the unblinded public key struct
- * @return Result of asynchronous ed25519 keygen
- * finalize operation.
+ * @param[out] private_key Pointer to the blinded private key struct.
+ * @param[out] public_key Pointer to the unblinded public key struct.
+ * @return Result of asynchronous ed25519 keygen finalize operation.
  */
 crypto_status_t otcrypto_ed25519_keygen_async_finalize(
     crypto_blinded_key_t *private_key, crypto_unblinded_key_t *public_key);
@@ -526,14 +554,14 @@ crypto_status_t otcrypto_ed25519_keygen_async_finalize(
  * Starts the asynchronous Ed25519 digital signature generation.
  *
  * Initializes OTBN and starts the OTBN routine to compute the digital
- * signature on the input message. The domain_parameter field for
+ * signature on the input message. The `domain_parameter` field for
  * Ed25519 is automatically set.
  *
- * @param private_key Pointer to the blinded private key struct
- * @param input_message Input message to be signed
- * @param sign_mode Parameter for EdDSA or Hash EdDSA sign mode
- * @param signature Pointer to the EdDSA signature to get (r) value
- * @return Result of async Ed25519 start operation
+ * @param private_key Pointer to the blinded private key struct.
+ * @param input_message Input message to be signed.
+ * @param sign_mode Parameter for EdDSA or Hash EdDSA sign mode.
+ * @param[out] signature Pointer to the EdDSA signature to get (r) value.
+ * @return Result of async Ed25519 start operation.
  */
 crypto_status_t otcrypto_ed25519_sign_async_start(
     const crypto_blinded_key_t *private_key,
@@ -547,8 +575,8 @@ crypto_status_t otcrypto_ed25519_sign_async_start(
  * status is done, or `kCryptoStatusAsyncIncomplete` if the OTBN is
  * busy or `kCryptoStatusInternalError` if there is an error.
  *
- * @param signature Pointer to the EdDSA signature to get (s) value
- * @return Result of async Ed25519 finalize operation
+ * @param[out] signature Pointer to the EdDSA signature to get (s) value.
+ * @return Result of async Ed25519 finalize operation.
  */
 crypto_status_t otcrypto_ed25519_sign_async_finalize(
     ecc_signature_t *signature);
@@ -557,16 +585,13 @@ crypto_status_t otcrypto_ed25519_sign_async_finalize(
  * Starts the asynchronous Ed25519 digital signature verification.
  *
  * Initializes OTBN and starts the OTBN routine to verify the
- * signature. The domain_parameter for Ed25519 is set automatically.
+ * signature. The `domain_parameter` for Ed25519 is set automatically.
  *
- * @param public_key Pointer to the unblinded public key struct
- * @param input_message Input message to be signed for verification
- * @param sign_mode Parameter for EdDSA or Hash EdDSA sign mode
- * @param signature Pointer to the signature to be verified
- * @param verification_result Returns the result of signature
- * verification (Pass/Fail)
- * @return Result of async Ed25519 verification start
- * function
+ * @param public_key Pointer to the unblinded public key struct.
+ * @param input_message Input message to be signed for verification.
+ * @param sign_mode Parameter for EdDSA or Hash EdDSA sign mode.
+ * @param signature Pointer to the signature to be verified.
+ * @return Result of async Ed25519 verification start operation.
  */
 crypto_status_t otcrypto_ed25519_verify_async_start(
     const crypto_unblinded_key_t *public_key,
@@ -581,9 +606,9 @@ crypto_status_t otcrypto_ed25519_verify_async_start(
  * `kCryptoStatusAsyncIncomplete` if the OTBN is busy or
  * `kCryptoStatusInternalError` if there is an error.
  *
- * @param verification_result Returns the result of verification
- * @return Result of async Ed25519 verification
- * finalize function
+ * @param[out] verification_result Result of signature verification
+ * (Pass/Fail).
+ * @return Result of async Ed25519 verification finalize operation.
  */
 crypto_status_t otcrypto_ed25519_verify_async_finalize(
     verification_status_t *verification_result);
@@ -594,10 +619,9 @@ crypto_status_t otcrypto_ed25519_verify_async_finalize(
  * Initializes OTBN and starts the OTBN routine to compute the private
  * exponent (d) and public key (Q) based on Curve25519.
  *
- * No domain_parameter is needed and is automatically set for X25519.
+ * No `domain_parameter` is needed and is automatically set for X25519.
  *
- * @return Result of asynchronous X25519 keygen start
- * operation.
+ * @return Result of asynchronous X25519 keygen start operation.
  */
 crypto_status_t otcrypto_x25519_keygen_async_start();
 
@@ -609,10 +633,9 @@ crypto_status_t otcrypto_x25519_keygen_async_start();
  * if the OTBN is busy or `kCryptoStatusInternalError` if there is an
  * error.
  *
- * @param private_key Pointer to the blinded private key struct
- * @param public_key Pointer to the unblinded public key struct
- * @return Result of asynchronous X25519 keygen
- * finalize operation.
+ * @param[out] private_key Pointer to the blinded private key struct.
+ * @param[out] public_key Pointer to the unblinded public key struct.
+ * @return Result of asynchronous X25519 keygen finalize operation.
  */
 crypto_status_t otcrypto_x25519_keygen_async_finalize(
     crypto_blinded_key_t *private_key, crypto_unblinded_key_t *public_key);
@@ -625,10 +648,9 @@ crypto_status_t otcrypto_x25519_keygen_async_finalize(
  * Hellman shared secret generation based on Curve25519. The
  * domain parameter is automatically set for X25519 API.
  *
- * @param private_key Pointer to the blinded private key
- * (u-coordinate)
- * @param public_key Pointer to the public scalar from the sender
- * @return Result of the async X25519 start operation
+ * @param private_key Pointer to the blinded private key (u-coordinate).
+ * @param public_key Pointer to the public scalar from the sender.
+ * @return Result of the async X25519 start operation.
  */
 crypto_status_t otcrypto_x25519_async_start(
     const crypto_blinded_key_t *private_key,
@@ -642,8 +664,8 @@ crypto_status_t otcrypto_x25519_async_start(
  * status is done, or `kCryptoStatusAsyncIncomplete` if the OTBN
  * is busy or `kCryptoStatusInternalError` if there is an error.
  *
- * @param shared_secret Pointer to shared secret key (u-coordinate)
- * @return Result of async X25519 finalize operation
+ * @param[out] shared_secret Pointer to shared secret key (u-coordinate).
+ * @return Result of async X25519 finalize operation.
  */
 crypto_status_t otcrypto_x25519_async_finalize(
     crypto_blinded_key_t *shared_secret);

--- a/sw/device/lib/crypto/include/hash.h
+++ b/sw/device/lib/crypto/include/hash.h
@@ -75,10 +75,10 @@ typedef struct hash_context hash_context_t;
  * This function hashes the `input_message` using the `hash_mode_t`
  * hash function and returns a `digest`.
  *
- * @param input_message Input message to be hashed
- * @param hash_mode Required hash mode for the digest
- * @param digest Output digest after hashing the input message
- * @return Result of the hash operation
+ * @param input_message Input message to be hashed.
+ * @param hash_mode Required hash mode for the digest.
+ * @param[out] digest Output digest after hashing the input message.
+ * @return Result of the hash operation.
  */
 crypto_status_t otcrypto_hash(crypto_const_uint8_buf_t input_message,
                               hash_mode_t hash_mode,
@@ -101,13 +101,13 @@ crypto_status_t otcrypto_hash(crypto_const_uint8_buf_t input_message,
  * length and the output length does not match, an error message will
  * be returned.
  *
- * @param input_message Input message for extendable output function
- * @param hash_mode Required extendable output function
- * @param function_name_string NIST Function name string
- * @param customization_string Customization string for cSHAKE
- * @param required_output_len Required output length, in bytes
- * @param digest Output from the extendable output function
- * @return Result of the xof operation
+ * @param input_message Input message for extendable output function.
+ * @param hash_mode Required extendable output function.
+ * @param function_name_string NIST Function name string.
+ * @param customization_string Customization string for cSHAKE.
+ * @param required_output_len Required output length, in bytes.
+ * @param[out] digest Output from the extendable output function.
+ * @return Result of the xof operation.
  */
 crypto_status_t otcrypto_xof(crypto_const_uint8_buf_t input_message,
                              xof_mode_t xof_mode,
@@ -129,9 +129,9 @@ crypto_status_t otcrypto_xof(crypto_const_uint8_buf_t input_message,
  * populates the required fields are internal to the specific hash
  * implementation.
  *
- * @param ctx Pointer to the generic hash context struct
- * @param hash_mode Required hash mode
- * @return Result of the hash init operation
+ * @param ctx Pointer to the generic hash context struct.
+ * @param hash_mode Required hash mode.
+ * @return Result of the hash init operation.
  */
 crypto_status_t otcrypto_hash_init(hash_context_t *const ctx,
                                    hash_mode_t hash_mode);
@@ -146,9 +146,9 @@ crypto_status_t otcrypto_hash_init(hash_context_t *const ctx,
  *
  * #otcrypto_hash_init should be called before this function.
  *
- * @param ctx Pointer to the generic hash context struct
- * @param input_message Input message to be hashed
- * @return Result of the hash update operation
+ * @param ctx Pointer to the generic hash context struct.
+ * @param input_message Input message to be hashed.
+ * @return Result of the hash update operation.
  */
 crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
                                      crypto_const_uint8_buf_t input_message);
@@ -167,9 +167,9 @@ crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
  * length and the output length does not match, an error message will
  * be returned.
  *
- * @param ctx Pointer to the generic hash context struct
- * @param digest Output digest after hashing the input blocks
- * @return Result of the hash final operation
+ * @param ctx Pointer to the generic hash context struct.
+ * @param[out] digest Output digest after hashing the input blocks.
+ * @return Result of the hash final operation.
  */
 crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
                                     crypto_uint8_buf_t *digest);

--- a/sw/device/lib/crypto/include/kdf.h
+++ b/sw/device/lib/crypto/include/kdf.h
@@ -34,12 +34,22 @@ typedef enum kdf_type {
  * The required PRF engine for the KDF function is selected using the
  * `kdf_mode` parameter.
  *
- * @param key_derivation_key Pointer to the blinded key derivation key
- * @param kdf_mode Required KDF mode, with HMAC or KMAC as a PRF
- * @param key_mode Crypto mode for which the derived key is intended
- * @param required_bit_len Required length of the derived key in bits
- * @param keying_material Pointer to the blinded keying material
- * @return Result of the key derivation operation
+ * The caller should allocate and partially populate the `keying_material`
+ * blinded key struct, including populating the key configuration and
+ * allocating space for the keyblob. The caller should indicate the length of
+ * the allocated keyblob; this function will return an error if the keyblob
+ * length does not match expectations. For hardware-backed keys, the keyblob
+ * length is 0 and the keyblob pointer may be `NULL`. For non-hardware-backed
+ * keys, the keyblob should be twice the length of the key. The value in the
+ * `checksum` field of the blinded key struct will be populated by this
+ * function.
+ *
+ * @param key_derivation_key Pointer to the blinded key derivation key.
+ * @param kdf_mode Required KDF mode, with HMAC or KMAC as a PRF.
+ * @param key_mode Crypto mode for which the derived key is intended.
+ * @param required_bit_len Required length of the derived key in bits.
+ * @param[out] keying_material Pointer to the blinded keying material.
+ * @return Result of the key derivation operation.
  */
 crypto_status_t otcrypto_kdf_ctr(const crypto_blinded_key_t key_derivation_key,
                                  kdf_type_t kdf_mode, key_mode_t key_mode,

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -20,10 +20,10 @@ extern "C" {
 /**
  * Builds an unblinded key struct from a user (plain) key.
  *
- * @param plain_key Pointer to the user defined plain key
- * @param key_mode Crypto mode for which the key usage is intended
- * @param unblinded_key Generated unblinded key struct
- * @return Result of the build unblinded key operation
+ * @param plain_key Pointer to the user defined plain key.
+ * @param key_mode Crypto mode for which the key usage is intended.
+ * @param[out] unblinded_key Generated unblinded key struct.
+ * @return Result of the build unblinded key operation.
  */
 crypto_status_t otcrypto_build_unblinded_key(
     crypto_const_uint8_buf_t plain_key, key_mode_t key_mode,
@@ -32,17 +32,24 @@ crypto_status_t otcrypto_build_unblinded_key(
 /**
  * Builds a blinded key struct from a plain key.
  *
- * This API takes as input a plain key from the user and masks
- * it using an implantation specific masking with ‘n’ shares and
- * generates a blinded key struct as output.
+ * This API takes as input a plain key from the user and masks it using an
+ * implantation specific masking with ‘n’ shares writing the output to
+ * `blinded_key.keyblob`.
  *
- * @param plain_key Pointer to the user defined plain key
- * @param key_mode Crypto mode for which the key usage is intended
- * @param blinded_key Generated blinded key struct
- * @return Result of the build blinded key operation
+ * The caller should allocate and partially populate the blinded key struct,
+ * including populating the key configuration and allocating space for the
+ * keyblob. The caller should indicate the length of the allocated keyblob;
+ * this function will return an error if the keyblob length does not match
+ * expectations. For hardware-backed keys, the keyblob length is 0 and the
+ * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
+ * should be twice the length of the key. The value in the `checksum` field of
+ * the blinded key struct will be populated by the key generation function.
+ *
+ * @param plain_key Pointer to the user defined plain key.
+ * @param[out] blinded_key Destination blinded key struct.
+ * @return Result of the build blinded key operation.
  */
 crypto_status_t otcrypto_build_blinded_key(crypto_const_uint8_buf_t plain_key,
-                                           key_mode_t key_mode,
                                            crypto_blinded_key_t blinded_key);
 
 /**
@@ -51,9 +58,9 @@ crypto_status_t otcrypto_build_blinded_key(crypto_const_uint8_buf_t plain_key,
  * This API takes as input a blinded key masked with ‘n’ shares, and
  * removes the masking and generates an unblinded key struct as output.
  *
- * @param blinded_key Blinded key struct to be unmasked
- * @param unblinded_key Generated unblinded key struct
- * @return Result of the blinded key export operation
+ * @param blinded_key Blinded key struct to be unmasked.
+ * @param[out] unblinded_key Generated unblinded key struct.
+ * @return Result of the blinded key export operation.
  */
 crypto_status_t otcrypto_blinded_to_unblinded_key(
     const crypto_blinded_key_t blinded_key,
@@ -62,9 +69,18 @@ crypto_status_t otcrypto_blinded_to_unblinded_key(
 /**
  * Build a blinded key struct from an unblinded key struct.
  *
- * @param unblinded_key Blinded key struct to be unmasked
- * @param blinded_key Generated (unmasked) unblinded key struct
- * @return Result of unblinded key export operation
+ * The caller should allocate and partially populate the blinded key struct,
+ * including populating the key configuration and allocating space for the
+ * keyblob. The caller should indicate the length of the allocated keyblob;
+ * this function will return an error if the keyblob length does not match
+ * expectations. For hardware-backed keys, the keyblob length is 0 and the
+ * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
+ * should be twice the length of the key. The value in the `checksum` field of
+ * the blinded key struct will be populated by the key generation function.
+ *
+ * @param unblinded_key Unblinded key struct to be masked.
+ * @param[out] blinded_key Generated (masked) blinded key struct.
+ * @return Result of blinding operation.
  */
 crypto_status_t otcrypto_unblinded_to_blinded_key(
     const crypto_unblinded_key unblinded_key, crypto_blinded_key_t blinded_key);

--- a/sw/device/lib/crypto/include/mac.h
+++ b/sw/device/lib/crypto/include/mac.h
@@ -39,61 +39,71 @@ typedef enum mac_mode {
 typedef struct hmac_context hmac_context_t;
 
 /**
+ * Generates a new HMAC or KMAC key.
+ *
+ * The caller should allocate and partially populate the blinded key struct,
+ * including populating the key configuration and allocating space for the
+ * keyblob. The caller should indicate the length of the allocated keyblob;
+ * this function will return an error if the keyblob length does not match
+ * expectations. For hardware-backed keys, the keyblob length is 0 and the
+ * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
+ * should be twice the length of the key. The value in the `checksum` field of
+ * the blinded key struct will be populated by the key generation function.
+ *
+ * @param[out] key Destination blinded key struct.
+ * @return The result of the key generation operation.
+ */
+crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key);
+
+/**
  * Performs the HMAC / KMAC function on the input data.
  *
  * HMAC: This function computes the required MAC function on the
- * `input_message` using the `key` and returns a `digest`.
+ * `input_message` using the `key` and returns a `tag`.
  *
- * KMAC: This function computes the KMAC on the `input_message` using
- * the `key` and returns a `digest` of `required_output_len`. The
- * customization string is passed through `customization_string`
- * parameter. If no customization is desired it can be empty. The
- * `customization_string` and `required_output_len` is only used for
- * KMAC modes and is ignored for the HMAC mode.
+ * KMAC: This function computes the KMAC on the `input_message` using the `key`
+ * and returns a `tag` of `required_output_len`. The customization string is
+ * passed through `customization_string` parameter. If no customization is
+ * desired it can be empty. The `customization_string` and
+ * `required_output_len` is only used for KMAC modes and is ignored for the
+ * HMAC mode.
  *
- * The caller should allocate space for the `digest` buffer, (expected
- * length is 32 bytes for HMAC and `required_output_len`for KMAC), and
- * set the length of expected output in the `len` field of `digest`.
- * If the user-set length and the output length does not match, an
- * error message will be returned.
+ * The caller should allocate space for the `tag` buffer, (expected length is
+ * 32 bytes for HMAC and `required_output_len`for KMAC), and set the length of
+ * expected output in the `len` field of `tag`.  If the user-set length and the
+ * output length does not match, an error message will be returned.
  *
- * @param key Pointer to the blinded key struct with key shares
- * @param input_message Input message to be hashed
- * @param mac_mode Required operation to be performed (HMAC/KMAC)
- * @param customization_string Customization string for KMAC
- * @param required_output_len Required output length from KMAC, in
- * bytes
- * @param digest Output digest after hashing the input data
- * @return The result of the KMAC128 operation
+ * @param key Pointer to the blinded key struct with key shares.
+ * @param input_message Input message to be hashed.
+ * @param mac_mode Required operation to be performed (HMAC/KMAC).
+ * @param customization_string Customization string for KMAC.
+ * @param required_output_len Required output length from KMAC, in bytes.
+ * @param[out] tag Output authentication tag.
+ * @return The result of the MAC operation.
  */
 crypto_status_t otcrypto_mac(const crypto_blinded_key_t *key,
                              crypto_const_uint8_buf_t input_message,
                              mac_mode_t mac_mode,
                              crypto_uint8_buf_t customization_string,
                              size_t required_output_len,
-                             crypto_uint8_buf_t *digest);
+                             crypto_uint8_buf_t *tag);
 
 /**
  * Performs the INIT operation for HMAC.
  *
- * Initializes the generic HMAC context. The required HMAC mode is
- * selected through the `hmac_mode` parameter. Populates the HMAC
- * context with the digest size, block size, HMAC update and HMAC
- * final APIs to be called based on the mode.
+ * Initializes the generic HMAC context. The required HMAC mode is selected
+ * through the `hmac_mode` parameter. The structure of HMAC context and how it
+ * populates the required fields based on the HMAC mode are internal to the
+ * specific HMAC implementation.
  *
- * The structure of HMAC context and how it populates the required
- * fields based on the HMAC mode are internal to the specific HMAC
- * implementation.
+ * The HMAC streaming API supports only the `kMacModeHmacSha256` mode.  Other
+ * modes are not supported and an error would be returned. The interface is
+ * designed to be generic to support other required modes in the future.
  *
- * The HMAC streaming API supports only the `kMacModeHmacSha256` mode.
- * Other modes are not supported and an error would be returned. The
- * interface is designed to be generic to support other required modes
- * in the future.
- *
- * @param ctx Pointer to the generic HMAC context struct
- * @param key Pointer to the blinded HMAC key struct
- * @param hmac_mode Required HMAC mode
- * @return Result of the HMAC init operation
+ * @param ctx Pointer to the generic HMAC context struct.
+ * @param key Pointer to the blinded HMAC key struct.
+ * @param hmac_mode Required HMAC mode.
+ * @return Result of the HMAC init operation.
  */
 crypto_status_t otcrypto_hmac_init(hmac_context_t *ctx,
                                    const crypto_blinded_key_t *key,
@@ -103,15 +113,15 @@ crypto_status_t otcrypto_hmac_init(hmac_context_t *ctx,
  * Performs the UPDATE operation for HMAC.
  *
  * The update operation processes the `input_message` using the selected
- * compression function. The intermediate digest is stored in the HMAC
- * context `ctx`. Any partial data is stored back in the context and
- * combined with the subsequent bytes.
+ * compression function. The intermediate state is stored in the HMAC context
+ * `ctx`. Any partial data is stored back in the context and combined with the
+ * subsequent bytes.
  *
  * #otcrypto_hmac_init should be called before calling this function.
  *
- * @param ctx Pointer to the generic HMAC context struct
- * @param input_message Input message to be hashed
- * @return Result of the HMAC update operation
+ * @param ctx Pointer to the generic HMAC context struct.
+ * @param input_message Input message to be hashed.
+ * @return Result of the HMAC update operation.
  */
 crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
                                      crypto_const_uint8_buf_t input_message);
@@ -119,22 +129,22 @@ crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
 /**
  * Performs the FINAL operation for HMAC.
  *
- * The final operation processes the remaining partial blocks,
- * computes the final digest and copies it to the `digest` parameter.
+ * The final operation processes the remaining partial blocks, computes the
+ * final authentication code and copies it to the `tag` parameter.
  *
  * #otcrypto_hmac_update should be called before calling this function.
  *
- * The caller should allocate space for the `digest` buffer, (expected
- * length is 32 bytes for HMAC), and set the length of expected output
- * in the `len` field of `digest`. If the user-set length and the
- * output length does not match, an error message will be returned.
+ * The caller should allocate space for the `tag` buffer, (expected length is
+ * 32 bytes for HMAC), and set the length of expected output in the `len` field
+ * of `tag`. If the user-set length and the output length does not match, an
+ * error message will be returned.
  *
- * @param ctx Pointer to the generic HMAC context struct
- * @param digest Output digest after hashing the input blocks
- * @return Result of the HMAC final operation
+ * @param ctx Pointer to the generic HMAC context struct.
+ * @param[out] tag Output authentication tag.
+ * @return Result of the HMAC final operation.
  */
 crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
-                                    crypto_uint8_buf_t *digest);
+                                    crypto_uint8_buf_t *tag);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -82,10 +82,23 @@ typedef struct rsa_public_key {
  * Computes RSA private key (d) and RSA public key exponent (e) and
  * modulus (n).
  *
- * @param required_key_len Requested key length
- * @param rsa_public_key Pointer to RSA public exponent struct
- * @param rsa_private_key Pointer to RSA private exponent struct
- * @return Result of the RSA key generation
+ * The caller should allocate and partially populate all blinded and unblinded
+ * key structs underneath `rsa_private_key` and `rsa_public_key`. For unblinded
+ * keys, this means setting the key mode, allocating a buffer for the key
+ * material, and recording the length of the allocated buffer in `key_length`.
+ * If the buffer size does not match expectations, this function will return an
+ * error.  For blinded key structs, the caller should fully populate the key
+ * configuration and allocate space for the keyblob. As for unblinded keys, the
+ * caller should record the allocated buffer length and this function will
+ * return an error if the keyblob length does not match expectations. The
+ * keyblob should be twice the length of the key. The value in the `checksum`
+ * field of the blinded key struct will be populated by the key generation
+ * function.
+ *
+ * @param required_key_len Requested key length.
+ * @param[out] rsa_public_key Pointer to RSA public exponent struct.
+ * @param[out] rsa_private_key Pointer to RSA private exponent struct.
+ * @return Result of the RSA key generation.
  */
 crypto_status_t otcrypto_rsa_keygen(rsa_key_size_t required_key_len,
                                     rsa_public_key_t *rsa_public_key,
@@ -100,12 +113,12 @@ crypto_status_t otcrypto_rsa_keygen(rsa_key_size_t required_key_len,
  * `signature`. If the user-set length and the output length does not
  * match, an error message will be returned.
  *
- * @param rsa_private_key Pointer to RSA private exponent struct
- * @param input_message Input message to be signed
- * @param padding_mode Padding scheme to be used for the data
- * @param hash_mode Hashing scheme to be used for the signature scheme
- * @param signature Pointer to generated signature struct
- * @return The result of the RSA sign generation
+ * @param rsa_private_key Pointer to RSA private exponent struct.
+ * @param input_message Input message to be signed.
+ * @param padding_mode Padding scheme to be used for the data.
+ * @param hash_mode Hashing scheme to be used for the signature scheme.
+ * @param[out] signature Pointer to generated signature struct.
+ * @return The result of the RSA sign generation.
  */
 crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
                                   crypto_const_uint8_buf_t input_message,
@@ -119,14 +132,14 @@ crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
  * The generated signature is compared against the input signature and
  * PASS / FAIL is returned.
  *
- * @param rsa_public_key Pointer to RSA public exponent struct
- * @param input_message Input message to be signed for verification
- * @param padding_mode Padding scheme to be used for the data
- * @param hash_mode Hashing scheme to be used for the signature scheme
- * @param signature Pointer to the input signature to be verified
- * @param verification_result Returns the result of signature
- * verification (Pass/Fail)
- * @return The status of the RSA verify operation
+ * @param rsa_public_key Pointer to RSA public exponent struct.
+ * @param input_message Input message to be signed for verification.
+ * @param padding_mode Padding scheme to be used for the data.
+ * @param hash_mode Hashing scheme to be used for the signature scheme.
+ * @param signature Pointer to the input signature to be verified.
+ * @param[out] verification_result Result of signature verification
+ * (Pass/Fail).
+ * @return Result of the RSA verify operation.
  */
 crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
                                     crypto_const_uint8_buf_t input_message,
@@ -145,8 +158,8 @@ crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
  * started, or`kCryptoStatusInternalError` if the operation cannot be
  * started.
  *
- * @param required_key_len Requested key length
- * @return Result of async RSA keygen start operation
+ * @param required_key_len Requested key length.
+ * @return Result of async RSA keygen start operation.
  */
 crypto_status_t otcrypto_rsa_keygen_async_start(
     rsa_key_size_t required_key_len);
@@ -159,10 +172,9 @@ crypto_status_t otcrypto_rsa_keygen_async_start(
  * or `kCryptoStatusAsyncIncomplete` if the OTBN is busy or
  * `kCryptoStatusInternalError` if there is an error.
  *
- * @param rsa_public_key Pointer to RSA public exponent struct
- * @param rsa_private_key Pointer to RSA private exponent struct
- * @return Result of asynchronous RSA keygen finalize
- * operation
+ * @param[out] rsa_public_key Pointer to RSA public exponent struct.
+ * @param[out] rsa_private_key Pointer to RSA private exponent struct.
+ * @return Result of asynchronous RSA keygen finalize operation.
  */
 crypto_status_t otcrypto_rsa_keygen_async_finalize(
     rsa_public_key_t *rsa_public_key, rsa_private_key_t *rsa_private_key);
@@ -177,11 +189,11 @@ crypto_status_t otcrypto_rsa_keygen_async_finalize(
  * started, or`kCryptoStatusInternalError` if the operation cannot be
  * started.
  *
- * @param rsa_private_key Pointer to RSA private exponent struct
- * @param input_message Input message to be signed
- * @param padding_mode Padding scheme to be used for the data
- * @param hash_mode Hashing scheme to be used for the signature scheme
- * @return Result of async RSA sign start operation
+ * @param rsa_private_key Pointer to RSA private exponent struct.
+ * @param input_message Input message to be signed.
+ * @param padding_mode Padding scheme to be used for the data.
+ * @param hash_mode Hashing scheme to be used for the signature scheme.
+ * @return Result of async RSA sign start operation.
  */
 crypto_status_t otcrypto_rsa_sign_async_start(
     const rsa_private_key_t *rsa_private_key,
@@ -201,8 +213,8 @@ crypto_status_t otcrypto_rsa_sign_async_start(
  * `signature`. If the user-set length and the output length does not
  * match, an error message will be returned.
  *
- * @param signature Pointer to generated signature struct
- * @return Result of async RSA sign finalize operation
+ * @param[out] signature Pointer to generated signature struct.
+ * @return Result of async RSA sign finalize operation.
  */
 crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_uint8_buf_t *signature);
 
@@ -212,9 +224,9 @@ crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_uint8_buf_t *signature);
  * Initializes OTBN and starts the OTBN routine to recover the message
  * from the input signature.
  *
- * @param rsa_public_key Pointer to RSA public exponent struct
- * @param signature Pointer to the input signature to be verified
- * @return Result of async RSA verify start operation
+ * @param rsa_public_key Pointer to RSA public exponent struct.
+ * @param signature Pointer to the input signature to be verified.
+ * @return Result of async RSA verify start operation.
  */
 crypto_status_t otcrypto_rsa_verify_async_start(
     const rsa_public_key_t *rsa_public_key, crypto_const_uint8_buf_t signature);
@@ -228,12 +240,12 @@ crypto_status_t otcrypto_rsa_verify_async_start(
  * The (hash of) recovered message is compared against the input
  * message and a PASS or FAIL is returned.
  *
- * @param input_message Input message to be signed for verification
- * @param padding_mode Padding scheme to be used for the data
- * @param hash_mode Hashing scheme to be used for the signature scheme
- * @param verification_result Returns the result of verification
- * @return Result of async RSA verify finalize
- * operation
+ * @param input_message Input message to be signed for verification.
+ * @param padding_mode Padding scheme to be used for the data.
+ * @param hash_mode Hashing scheme to be used for the signature scheme.
+ * @param[out] verification_result Result of signature verification
+ * (Pass/Fail).
+ * @return Result of async RSA verify finalize operation.
  */
 crypto_status_t otcrypto_rsa_verify_async_finalize(
     crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,


### PR DESCRIPTION
Changes since the last update:
- Key generation functions for symmetric crypto (AES, KMAC, HMAC) since these are needed for sideloading
- New exposed blinded key configuration struct to help caller allocate space for blinded keys and communicate requirements
- AES init/cipher merged into one function
- DRBG state struct removed (the state is the hardware state, and providing a software state implies it's possible to instantiate multiple DRBGs)