### PR TITLE
[dv/adc_ctrl] Fix adc_ctrl regression error

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
@@ -170,10 +170,7 @@ class adc_ctrl_fsm_reset_vseq extends adc_ctrl_base_vseq;
                 end
                 AdcCtrlResetModeHw: begin
                   // Hardware reset
-                  fork
-                    cfg.clk_aon_rst_vif.apply_reset();
-                    cfg.clk_rst_vif.apply_reset();
-                  join
+                  apply_reset();
                 end
                 default: `uvm_fatal(`gfn, "Undefined test mode")
               endcase


### PR DESCRIPTION
This PR fixes adc_ctrl regression error due to reset_aon_ni and reset_ni not issuing at the same time.
Because the reset_aon_ni has very small frequency compares to reset_ni clock, so issuing reset with normal `apply_reset` task would cause the following issue:
The reset_ni will finsh toggle but reset_aon_ni has not start activation yet.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>