### PR TITLE
[top-test] csrng/edn variable cmd

### DIFF
--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -192,6 +192,14 @@ typedef enum dif_csrng_entropy_src_toggle {
   kDifCsrngEntropySrcToggleEnable = 0,
 } dif_csrng_entropy_src_toggle_t;
 
+enum {
+  /**
+   * Maximum seed material number of uint32_t words supported in CSRNG
+   * instantiate and seed commands.
+   */
+  kDifCsrngSeedMaterialMaxWordLen = 12,
+};
+
 /**
  * CSRNG common transaction parameters.
  */
@@ -205,7 +213,7 @@ typedef struct dif_csrng_seed_material {
   /**
    * Seed material used in CSRNG
    */
-  uint32_t seed_material[12];
+  uint32_t seed_material[kDifCsrngSeedMaterialMaxWordLen];
 } dif_csrng_seed_material_t;
 
 /**

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -630,6 +630,7 @@ opentitan_functest(
         "//sw/device/lib/testing:csrng_testutils",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],


### PR DESCRIPTION
Randomize the seed_material len for csrng and edn commands in the entropy_src_csrng_test to help catch csrng-edn interface issues.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>