### PR TITLE
[test] Add rom_e2e_boot_policy_rollback

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -447,7 +447,7 @@ SEC_VERS = [
     srcs = ["empty_test.c"],
     devices = ["fpga_cw310"],
     local_defines = [
-        "EMPTY_TEST_MSG=\"slot={} security_version={}\"".format(slot, sec_ver),
+        'EMPTY_TEST_MSG=\\"slot=%p,\\ security_version=%01d\\",manifest_def_get(),manifest_def_get()->security_version',
     ],
     manifest = ":manifest_sec_ver_{}".format(sec_ver),
     signed = True,
@@ -472,47 +472,52 @@ SEC_VERS = [
     devices = ["fpga_cw310"],
 ) for sec_ver_a in SEC_VERS for sec_ver_b in SEC_VERS]
 
-# [[sec_ver_a, sec_ver_b, correct_slot, correct_sec_ver], ...]
 BOOT_POLICY_NEWER_CASES = [
-    [
-        0,
-        0,
-        "a",
-        0,
-    ],
-    [
-        0,
-        1,
-        "b",
-        1,
-    ],
-    [
-        1,
-        0,
-        "a",
-        1,
-    ],
-    [
-        1,
-        1,
-        "a",
-        1,
-    ],
+    {
+        "a": 0,
+        "b": 0,
+        "exit_success": "slot=0x20000000, security_version=0",
+    },
+    {
+        "a": 0,
+        "b": 1,
+        "exit_success": "slot=0x20080000, security_version=1",
+    },
+    {
+        "a": 1,
+        "b": 0,
+        "exit_success": "slot=0x20000000, security_version=1",
+    },
+    {
+        "a": 1,
+        "b": 1,
+        "exit_success": "slot=0x20000000, security_version=1",
+    },
 ]
 
 [opentitan_functest(
-    name = "boot_policy_newer_a_{}_b_{}".format(sec_ver_a, sec_ver_b),
+    name = "boot_policy_newer_a_{}_b_{}".format(
+        t["a"],
+        t["b"],
+    ),
     cw310 = cw310_params(
-        exit_success = "slot={} security_version={}".format(correct_slot, correct_sec_ver),
+        exit_success = t["exit_success"],
     ),
     key = "multislot",
-    ot_flash_binary = ":sec_ver_{}_{}_image".format(sec_ver_a, sec_ver_b),
+    ot_flash_binary = ":sec_ver_{}_{}_image".format(
+        t["a"],
+        t["b"],
+    ),
     targets = ["cw310_rom"],
-) for sec_ver_a, sec_ver_b, correct_slot, correct_sec_ver in BOOT_POLICY_NEWER_CASES]
+) for t in BOOT_POLICY_NEWER_CASES]
 
 test_suite(
     name = "boot_policy_newer",
-    tests = ["boot_policy_newer_a_{}_b_{}".format(sec_ver_a, sec_ver_b) for sec_ver_a, sec_ver_b, _, _ in BOOT_POLICY_NEWER_CASES],
+    tests = ["boot_policy_newer_a_{}_b_{}".format(
+        t["a"],
+        t["b"],
+    ) for t in BOOT_POLICY_NEWER_CASES],
+)
 )
 
 SIGVERIFY_MOD_EXP_CASES = [

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -30,9 +30,11 @@ _BFV_TEMPLATE = "{}{}(?s:.*){}{}".format(MSG_BOOT_FAULT, "{0}", MSG_BOOT_FAULT, 
 
 MSG_STARTING_ROM_EXT = "Starting ROM_EXT"
 
-MSG_STORE_ACCESS_FAULT = _BFV_TEMPLATE.format("07495202")
+MSG_INSTRUCTION_ACCESS_FAULT = _BFV_TEMPLATE.format("01495202")
 
 MSG_ILLEGAL_INSTRUCTION_FAULT = _BFV_TEMPLATE.format("02495202")
+
+MSG_STORE_ACCESS_FAULT = _BFV_TEMPLATE.format("07495202")
 
 MSG_PASS = "PASS!"
 
@@ -75,7 +77,7 @@ opentitan_functest(
         # Note: This test never prints a failure message so it will fail only
         # when it times out.
         exit_failure = "NO_FAILURE_MESSAGE",
-        exit_success = "BFV:01495202(?s:.*)BFV:01495202",
+        exit_success = MSG_INSTRUCTION_ACCESS_FAULT,
     ),
     dv = dv_params(
         rom = "//sw/device/silicon_creator/rom",
@@ -89,7 +91,7 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "eternal",
         exit_failure = "NO_FAILURE_MESSAGE",
-        exit_success = "BFV:01495202(?s:.*)BFV:01495202",
+        exit_success = MSG_INSTRUCTION_ACCESS_FAULT,
         rom = "//sw/device/silicon_creator/rom",
     ),
     deps = [

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -435,6 +435,7 @@ test_suite(
 SEC_VERS = [
     0,
     1,
+    2,
 ]
 
 [manifest({
@@ -520,6 +521,53 @@ test_suite(
         t["b"],
     ) for t in BOOT_POLICY_NEWER_CASES],
 )
+
+BOOT_POLICY_ROLLBACK_CASES = [
+    # TODO(#14473): Enable after OTP splicing is ready.
+    # {
+    #     "a": 0,
+    #     "b": 0,
+    #     "exit_success": MSG_BOOT_POLICY_ROLLBACK,
+    # },
+    {
+        "a": 0,
+        "b": 1,
+        "exit_success": "slot=0x20080000, security_version=1",
+    },
+    {
+        "a": 2,
+        "b": 0,
+        "exit_success": "slot=0x20000000, security_version=2",
+    },
+    {
+        "a": 1,
+        "b": 1,
+        "exit_success": "slot=0x20000000, security_version=1",
+    },
+]
+
+[opentitan_functest(
+    name = "boot_policy_rollback_a_{}_b_{}".format(
+        t["a"],
+        t["b"],
+    ),
+    cw310 = cw310_params(
+        exit_success = t["exit_success"],
+    ),
+    key = "multislot",
+    ot_flash_binary = ":sec_ver_{}_{}_image".format(
+        t["a"],
+        t["b"],
+    ),
+    targets = ["cw310_rom"],
+) for t in BOOT_POLICY_ROLLBACK_CASES]
+
+test_suite(
+    name = "boot_policy_rollback",
+    tests = ["boot_policy_rollback_a_{}_b_{}".format(
+        t["a"],
+        t["b"],
+    ) for t in BOOT_POLICY_ROLLBACK_CASES],
 )
 
 SIGVERIFY_MOD_EXP_CASES = [

--- a/sw/device/silicon_creator/rom/e2e/empty_test.c
+++ b/sw/device/silicon_creator/rom/e2e/empty_test.c
@@ -6,12 +6,13 @@
 
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
 #ifdef EMPTY_TEST_MSG
-  LOG_INFO(OT_STRINGIFY(EMPTY_TEST_MSG));
+  LOG_INFO(EMPTY_TEST_MSG);
 #endif
   return true;
 }


### PR DESCRIPTION
This PR improves `empty_test.c` so that log messages can use the manifest and adds `rom_e2e_boot_policy_rollback`. This PR also updates `rom_e2e_shutdown_exception` to use the BFV template for the boot loop expectation.

Signed-off-by: Alphan Ulusoy <alphan@google.com>