### PR TITLE
[flash_ctrl,dv] config_regwen test fix

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_config_regwen_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_config_regwen_vseq.sv
@@ -8,6 +8,7 @@
 // While operation is on going, try write random data but register value should not be changed.
 // Finally, release flash_ctrl.ctrl_regwen and does write and readback check
 // with a random data.
+// This test does not include any flash data transaction.
 class flash_ctrl_config_regwen_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_config_regwen_vseq)
   `uvm_object_new
@@ -23,8 +24,14 @@ class flash_ctrl_config_regwen_vseq extends flash_ctrl_otf_base_vseq;
 
   task body();
     uvm_reg_data_t exp_data, dumb_data;
-    cfg.scb_h.skip_read_check = 1;
 
+    // Randomized program of control register can trigger
+    // unintended or illegal transactions.
+    // Since the purpose of this test is to check regwen function,
+    // turn off scoreboard to avoid spurious transaction error.
+    // Also cover csr read, write check in this sequence.
+    cfg.scb_h.skip_read_check = 1;
+    cfg.scb_check = 0;
     // Write and read back control register
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(ctrl_data)
     // Capture for expected data after regwen force '0'


### PR DESCRIPTION
Replace default csr check(scoreboard) with write read back check (sequence)

Signed-off-by: Jaedon Kim <jdonjdon@google.com>