### PR TITLE
[entropy_src/dv] Simplify recoverable alert coverage

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -92,10 +92,12 @@
     {
       name: alerts
       desc: '''
-            Verify es_alert_count_met asserts as expected.
+            Verify that all recoverable alerts are asserted as expected.
+            Any alerts not encountered as part of the usual entropy_src_rng test will be generated
+            by the `entropy_src_functional_alerts` test.
             '''
       stage: V2
-      tests: ["entropy_src_alert"]
+      tests: ["entropy_src_functional_alerts", "entropy_src_rng"]
     }
     {
       name: stress_all

--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -356,6 +356,7 @@ interface entropy_src_cov_if
     // Cross coverage points
 
     // Entropy data interface is tested with all valid configurations
+
     cr_config: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit_enable,
         cp_rng_bit_sel, cp_es_type;
 
@@ -675,6 +676,16 @@ interface entropy_src_cov_if
 
   endgroup : one_way_ht_threshold_reg_cg
 
+  covergroup recov_alert_cg with function sample(int alert_bit);
+    option.name         = "recov_alert_cg";
+    option.per_instance = 1;
+
+    cp_alert_bit : coverpoint alert_bit {
+      bins alert_bits[] = {0, 1, 2, 3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    }
+  endgroup : recov_alert_cg
+
+
   `DV_FCOV_INSTANTIATE_CG(err_test_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(mubi_err_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(sm_err_cg, en_full_cov)
@@ -690,6 +701,7 @@ interface entropy_src_cov_if
   `DV_FCOV_INSTANTIATE_CG(alert_cnt_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(observe_fifo_threshold_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(one_way_ht_threshold_reg_cg, en_full_cov)
+  `DV_FCOV_INSTANTIATE_CG(recov_alert_cg, en_full_cov)
 
   // Sample functions needed for xcelium
   function automatic void cg_err_test_sample(bit [4:0] err_code);
@@ -817,6 +829,11 @@ interface entropy_src_cov_if
   function automatic void cg_one_way_ht_threshold_reg_sample(int offset, bit rejected, bit fips);
     one_way_ht_threshold_reg_cg_inst.sample(offset, rejected, fips);
   endfunction
+
+  function automatic void cg_recov_alert_sample(int which_bit);
+    recov_alert_cg_inst.sample(which_bit);
+  endfunction
+
 
   // Sample the csrng_hw_cg whenever data is output on the csrng pins
   logic csrng_if_req, csrng_if_ack;

--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -81,7 +81,7 @@
     }
 
     {
-      name: entropy_src_alert
+      name: entropy_src_functional_alerts
       uvm_test: entropy_src_alert_test
       uvm_test_seq: entropy_src_alert_vseq
     }

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -63,8 +63,10 @@ class entropy_src_env extends cip_base_env #(
     cfg.m_xht_agent_cfg.en_cov            = cfg.en_cov;
     cfg.m_xht_agent_cfg.is_active         = 1'b1;
 
-    uvm_config_db#(virtual entropy_subsys_fifo_exception_if#(1))::get(this, "", "precon_fifo_vif",
-        cfg.precon_fifo_vif);
+    if (!uvm_config_db#(virtual entropy_subsys_fifo_exception_if#(1))::get(this, "",
+                        "precon_fifo_vif", cfg.precon_fifo_vif)) begin
+      `uvm_fatal(get_full_name(), "failed to get precon_fifo_vif from uvm_config_db")
+    end
 
     if (!uvm_config_db#(virtual pins_if#(8))::get(this, "", "otp_en_es_fw_read_vif",
         cfg.otp_en_es_fw_read_vif)) begin

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_alert_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_alert_vseq.sv
@@ -2,260 +2,73 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test recoverable alerts with invalid mubi data type inputs and
-// es_bus_cmp_alert as well as es_main_sm_alert
+// Tests any alerts not acheivable by the entropy_src_rng test
+// At this time this is just the es_bus_cmp_alert.
+//
+// Please see previous revisions of this test to find routines for
+// testing other recoverable alerts
 
 class entropy_src_alert_vseq extends entropy_src_base_vseq;
   `uvm_object_utils(entropy_src_alert_vseq)
 
   `uvm_object_new
 
-  push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)        m_rng_push_seq;
-  push_pull_indefinite_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH) m_csrng_pull_seq;
+  push_pull_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)        m_rng_push_seq;
+  push_pull_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH) m_csrng_pull_seq;
 
-  bit [31:0] exp_recov_alert_sts;
+  int window_size = 512;
 
-  task test_es_thresh_cfg_alert();
-    bit [15:0] alert_thresh;
-    bit [15:0] alert_thresh_inv;
-    // First turn off module_enable to write registers
-    csr_wr(.ptr(ral.module_enable), .value(prim_mubi_pkg::MuBi4False));
-
-    `DV_CHECK_STD_RANDOMIZE_FATAL(alert_thresh)
-    ral.alert_threshold.alert_threshold.set(alert_thresh);
-    ral.alert_threshold.alert_threshold_inv.set(alert_thresh);
-    csr_update(.csr(ral.alert_threshold));
-    // Check recov_alert_sts register
-    exp_recov_alert_sts = 32'b0;
-    exp_recov_alert_sts[ral.recov_alert_sts.es_thresh_cfg_alert.get_lsb_pos()] = 1;
-    csr_rd_check(.ptr(ral.recov_alert_sts.es_thresh_cfg_alert), .compare_value(1'b1));
-
-    // Write back correct threshold
-    alert_thresh_inv = ~alert_thresh;
-    ral.alert_threshold.alert_threshold.set(alert_thresh);
-    ral.alert_threshold.alert_threshold_inv.set(alert_thresh_inv);
-    csr_update(.csr(ral.alert_threshold));
-
-    // Clear recov_alert_sts register
-    csr_wr(.ptr(ral.recov_alert_sts), .value(0));
-
-    // Check recov_alert_sts register
-    cfg.clk_rst_vif.wait_clks(100);
-    csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(0));
-  endtask // test_es_thresh_cfg_alert
+  task pre_start();
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(cfg.dut_cfg, cfg.dut_cfg.fips_window_size == window_size;)
+    super.pre_start();
+  endtask
 
   task test_es_bus_cmp_alert();
-    int num_reqs = 60;
-    // First turn off module_enable to write registers
-    csr_wr(.ptr(ral.module_enable), .value(prim_mubi_pkg::MuBi4False));
-    // Set the threshold to make health test not to fail
-    ral.repcnt_thresholds.fips_thresh.set(16'hfffe);
-    ral.repcnt_thresholds.bypass_thresh.set(16'hfffe);
-    csr_update(.csr(ral.repcnt_thresholds));
+    // We need two matching outputs. The first Startup seed will take twice as much data
+    // and so will be different from the others.
+    int num_reqs = 3;
+    bit alert_val;
 
-    // configs
-    ral.conf.fips_enable.set(prim_mubi_pkg::MuBi4True);
-    ral.conf.entropy_data_reg_enable.set(prim_mubi_pkg::MuBi4True);
-    ral.conf.threshold_scope.set(prim_mubi_pkg::MuBi4True);
-    ral.conf.rng_bit_enable.set(prim_mubi_pkg::MuBi4False);
-    csr_update(.csr(ral.conf));
-    ral.fw_ov_control.fw_ov_mode.set(prim_mubi_pkg::MuBi4False);
-    csr_update(.csr(ral.fw_ov_control));
-    ral.entropy_control.es_route.set(prim_mubi_pkg::MuBi4False);
-    ral.entropy_control.es_type.set(prim_mubi_pkg::MuBi4False);
-    csr_update(.csr(ral.entropy_control));
-    ral.module_enable.set(prim_mubi_pkg::MuBi4True);
-    csr_update(.csr(ral.module_enable));
-
-    // Create and start rng host sequence
-    m_rng_push_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::type_id::
+    // Create and rng host sequence
+    m_rng_push_seq = push_pull_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::type_id::
          create("m_rng_push_seq");
-    m_rng_push_seq.num_trans = num_reqs *
-                               entropy_src_pkg::CSRNG_BUS_WIDTH/entropy_src_pkg::RNG_BUS_WIDTH;
+
+    // Rememeber that the startup seed requires twice as many samples
+    m_rng_push_seq.num_trans = (num_reqs + 1) * window_size/entropy_src_pkg::RNG_BUS_WIDTH;
+
     // Use a randomly generated but fixed rng_val through this test to make the entropy bus
     // value keep stable to induce the es_bus_cmp_alert
     `DV_CHECK_STD_RANDOMIZE_FATAL(rng_val)
     for (int i = 0; i < m_rng_push_seq.num_trans; i++) begin
       cfg.m_rng_agent_cfg.add_h_user_data(rng_val);
     end
+
     // Create csrng host sequence
-    m_csrng_pull_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)::
+    m_csrng_pull_seq = push_pull_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)::
          type_id::create("m_csrng_pull_seq");
     m_csrng_pull_seq.num_trans = num_reqs;
+
+    csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value('0));
+
+    enable_dut();
 
     fork
       // Start sequences
       m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
       m_csrng_pull_seq.start(p_sequencer.csrng_sequencer_h);
-
-      begin
-        cfg.clk_rst_vif.wait_clks(50000);
-        // Check the recov_alert_sts register
-        csr_rd_check(.ptr(ral.recov_alert_sts.es_bus_cmp_alert), .compare_value(1'b1));
-
-        cfg.clk_rst_vif.wait_clks(1000);
-        // Clear the recov_alert_sts register
-        csr_wr(.ptr(ral.recov_alert_sts), .value(32'b0));
-        // Check the recov_alert_sts register
-        csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(0));
-
-        // Stop the sequences
-        `uvm_info(`gfn, "Stopping CSRNG seq", UVM_LOW)
-        m_csrng_pull_seq.stop(.hard(1));
-        m_csrng_pull_seq.wait_for_sequence_state(UVM_FINISHED);
-        `uvm_info(`gfn, "Stopping RNG seq", UVM_LOW)
-        m_rng_push_seq.stop(.hard(0));
-        m_rng_push_seq.wait_for_sequence_state(UVM_FINISHED);
-        `uvm_info(`gfn, "Exiting test body.", UVM_LOW)
-      end
     join
+
+    cfg.clk_rst_vif.wait_clks(10);
+
+    csr_rd(.ptr(ral.recov_alert_sts.es_bus_cmp_alert), .value(alert_val));
+    `DV_CHECK_EQ(alert_val, 1)
+
   endtask // test_es_bus_cmp_alert
 
-  task test_es_main_sm_alert();
-    // First turn off module_enable to write registers
-    csr_wr(.ptr(ral.module_enable), .value(prim_mubi_pkg::MuBi4False));
-    // Set some thresholds to cause health test to fail
-    ral.repcnt_thresholds.fips_thresh.set(16'h0008);
-    ral.repcnt_thresholds.bypass_thresh.set(16'h0008);
-    csr_update(.csr(ral.repcnt_thresholds));
-    // enable
-    ral.conf.fips_enable.set(prim_mubi_pkg::MuBi4True);
-    ral.conf.entropy_data_reg_enable.set(prim_mubi_pkg::MuBi4True);
-    ral.conf.threshold_scope.set(prim_mubi_pkg::MuBi4True);
-    ral.conf.rng_bit_enable.set(prim_mubi_pkg::MuBi4False);
-    csr_update(.csr(ral.conf));
-    ral.fw_ov_control.fw_ov_mode.set(prim_mubi_pkg::MuBi4False);
-    csr_update(.csr(ral.fw_ov_control));
-    ral.entropy_control.es_route.set(prim_mubi_pkg::MuBi4False);
-    csr_update(.csr(ral.entropy_control));
-    ral.module_enable.set(prim_mubi_pkg::MuBi4True);
-    csr_update(.csr(ral.module_enable));
-
-    // Create rng host sequence
-    m_rng_push_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::type_id::
-         create("m_rng_push_seq");
-    m_rng_push_seq.num_trans = 8*entropy_src_pkg::CSRNG_BUS_WIDTH/entropy_src_pkg::RNG_BUS_WIDTH;
-    // Use randomly generated but fixed rng_val through this test  to cause the repcnt health
-    // test to fail
-    `DV_CHECK_STD_RANDOMIZE_FATAL(rng_val)
-    for (int i = 0; i < m_rng_push_seq.num_trans; i++) begin
-      cfg.m_rng_agent_cfg.add_h_user_data(rng_val);
-    end
-
-    fork
-      m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
-      begin
-        cfg.clk_rst_vif.wait_clks(20000);
-        // Check the recov_alert_sts register
-        csr_rd_check(.ptr(ral.recov_alert_sts.es_main_sm_alert), .compare_value(1'b1));
-
-        // Set the threshold to make health test not to fail
-        ral.repcnt_thresholds.fips_thresh.set(16'hfffe);
-        ral.repcnt_thresholds.bypass_thresh.set(16'hfffe);
-        csr_update(.csr(ral.repcnt_thresholds));
-        // Set to normal sequence
-        for (int i = 0; i < m_rng_push_seq.num_trans; i++) begin
-          rng_val = i % 16;
-          cfg.m_rng_agent_cfg.add_h_user_data(rng_val);
-        end
-        // Reset the sm
-        ral.module_enable.set(prim_mubi_pkg::MuBi4False);
-        csr_update(.csr(ral.module_enable));
-        ral.module_enable.set(prim_mubi_pkg::MuBi4True);
-        csr_update(.csr(ral.module_enable));
-
-        cfg.clk_rst_vif.wait_clks(100);
-        // Make sure bit is still on
-        csr_rd_check(.ptr(ral.recov_alert_sts.es_main_sm_alert), .compare_value(1'b1));
-
-        // Clear the recov_alert_sts register
-        csr_wr(.ptr(ral.recov_alert_sts), .value(32'b0));
-
-        cfg.clk_rst_vif.wait_clks(100);
-        // Check the recov_alert_sts register
-        csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(0));
-        // Stop the sequence
-        m_rng_push_seq.stop(.hard(0));
-        m_rng_push_seq.wait_for_sequence_state(UVM_FINISHED);
-      end
-    join
-  endtask // test_es_main_sm_alert
-
   task body();
-    string        reg_name;
-    string        fld_name;
-    int           first_index;
-    uvm_reg       csr;
-    uvm_reg_field fld;
-
-    // Set the fields to invalid values
-    ral.conf.threshold_scope.set(cfg.dut_cfg.ht_threshold_scope);
-    csr_update(.csr(ral.conf));
-    ral.fw_ov_control.fw_ov_mode.set(cfg.dut_cfg.fw_read_enable);
-    ral.fw_ov_control.fw_ov_entropy_insert.set(cfg.dut_cfg.fw_over_enable);
-    csr_update(.csr(ral.fw_ov_control));
-    ral.fw_ov_sha3_start.fw_ov_insert_start.set(cfg.dut_cfg.fw_ov_insert_start);
-    csr_update(.csr(ral.fw_ov_sha3_start));
-
-    cfg.clk_rst_vif.wait_clks(100);
-
-    // Check the recov_alert_sts register
-    reg_name = "recov_alert_sts";
-    fld_name = cfg.dut_cfg.which_invalid_mubi.name();
-
-    if (fld_name == "invalid_alert_threshold") begin
-      // Test es_thresh_cfg_alert
-      test_es_thresh_cfg_alert();
-    end else begin
-      // Test invalid mubi alert
-      first_index = find_index("_", fld_name, "first");
-
-      csr = ral.get_reg_by_name(reg_name);
-      fld = csr.get_field_by_name({fld_name.substr(first_index+1, fld_name.len()-1),
-            "_field_alert"});
-
-      exp_recov_alert_sts = 32'b0;
-      exp_recov_alert_sts[fld.get_lsb_pos()] = 1;
-      csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
-
-      cfg.clk_rst_vif.wait_clks(100);
-
-      // write back valid values
-      ral.module_enable.set(prim_mubi_pkg::MuBi4False);
-      csr_update(.csr(ral.module_enable));
-      ral.entropy_control.es_type.set(prim_mubi_pkg::MuBi4False);
-      ral.entropy_control.es_route.set(prim_mubi_pkg::MuBi4False);
-      csr_update(.csr(ral.entropy_control));
-      ral.fw_ov_control.fw_ov_mode.set(prim_mubi_pkg::MuBi4True);
-      ral.fw_ov_control.fw_ov_entropy_insert.set(prim_mubi_pkg::MuBi4True);
-      csr_update(.csr(ral.fw_ov_control));
-      ral.fw_ov_sha3_start.fw_ov_insert_start.set(prim_mubi_pkg::MuBi4True);
-      csr_update(.csr(ral.fw_ov_sha3_start));
-      ral.conf.fips_enable.set(prim_mubi_pkg::MuBi4True);
-      ral.conf.entropy_data_reg_enable.set(prim_mubi_pkg::MuBi4True);
-      ral.conf.threshold_scope.set(prim_mubi_pkg::MuBi4False);
-      ral.conf.rng_bit_enable.set(prim_mubi_pkg::MuBi4False);
-      csr_update(.csr(ral.conf));
-
-      // Clear recov_alert_sts register
-      csr_wr(.ptr(ral.recov_alert_sts), .value(0));
-
-      // Check recov_alert_sts register
-      cfg.clk_rst_vif.wait_clks(100);
-      csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(0));
-    end
 
     // Test es_bus_cmp alert
     test_es_bus_cmp_alert();
-
-    // Wait for some time between tests
-    cfg.clk_rst_vif.wait_clks(1000);
-
-    // Test es_main_sm alert
-    test_es_main_sm_alert();
-
-    // Turn assertions back on
-    cfg.entropy_src_assert_vif.assert_on_alert();
 
   endtask : body
 

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
@@ -9,15 +9,17 @@ class entropy_src_smoke_vseq extends entropy_src_base_vseq;
 
   int seed_cnt;
 
-  push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH) m_rng_push_seq;
+  push_pull_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH) m_rng_push_seq;
 
   task body();
 
     seed_cnt = cfg.seed_cnt;
 
     // Create rng host sequence
-    m_rng_push_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::type_id::
+    m_rng_push_seq = push_pull_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::type_id::
                      create("m_rng_push_seq");
+
+    m_rng_push_seq.num_trans = 96;
 
     fork
       m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
@@ -31,8 +33,6 @@ class entropy_src_smoke_vseq extends entropy_src_base_vseq;
           // Update the count of remaining seeds to read
           seed_cnt -= available_seeds;
         end while (seed_cnt > 0);
-        m_rng_push_seq.stop(.hard(0));
-        m_rng_push_seq.wait_for_sequence_state(UVM_FINISHED);
       end
     join
   endtask : body

--- a/hw/ip/entropy_src/dv/tests/entropy_src_alert_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_alert_test.sv
@@ -10,16 +10,16 @@ class entropy_src_alert_test extends entropy_src_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.en_scb                              = 0;
-    cfg.dut_cfg.bad_mubi_cfg_pct            = 100;
-    cfg.dut_cfg.route_software_pct          = 0;
-    cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
-    cfg.dut_cfg.fw_read_pct                 = 100;
-    cfg.dut_cfg.fw_over_pct                 = 100;
-    cfg.dut_cfg.module_enable_pct           = 0;
+    cfg.en_scb                              = 1;
     cfg.dut_cfg.fips_enable_pct             = 100;
-    cfg.dut_cfg.sw_regupd_pct               = 100;
-    cfg.dut_cfg.type_bypass_pct             = 0;
+    cfg.dut_cfg.entropy_data_reg_enable_pct = 100;
+    cfg.dut_cfg.rng_bit_enable_pct          = 0;
+    cfg.dut_cfg.fw_read_pct                 = 0;
+    cfg.dut_cfg.fw_over_pct                 = 0;
+    cfg.dut_cfg.bad_mubi_cfg_pct            = 0;
+    cfg.dut_cfg.route_software_pct          = 0;
+    cfg.dut_cfg.module_enable_pct           = 0;
+    cfg.dut_cfg.default_ht_thresholds_pct   = 100;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 


### PR DESCRIPTION
The `entropy_src_alert` test is intended to ensure that all recoverable alert codes are detected.  However it was created before many of the required features it tries to test were implemented in scoreboarding.

In order to enhance maintainability, this commit updates this test to make better use scoreboarding and of the configuration features in the `entropy_src_base_vseq`.  It also adds a new covergroup to catch all the recoverable alert conditions not included in the `mubi_err_cg`.

Since almost of the recov_alert coverpoints can be accessed by the `entropy_src_rng` test and confirmed in scoreboarding, most of the `entropy_src_alert` test has been trimmed down to just perform the tests that can not be performed elsewhere.

Finally in addition to streamlining the `entropy_src_alert_vseq` this test simplifies the `entropy_src_smoke_vseq` to use basic `push_pull_host_seq` (as opposed to the indefinite variety.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>