### PR TITLE
[top/dv] Give pins a default value before enabling wakeup

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
@@ -19,6 +19,9 @@ class chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq extends chip_sw_base_vseq;
     int repeat_count = 1;
     super.body();
 
+    // Give the pin a default value.
+    cfg.chip_vif.pinmux_wkup_if.set_pulldown_en(1'b1);
+
     if ($value$plusargs("do_random=%b", twice_each) && twice_each) begin
       repeat_count = 2;
     end


### PR DESCRIPTION
Without a default value, the pin value becomes X and triggers an unintended prim_sync assertion.

Signed-off-by: Timothy Chen <timothytim@google.com>