### PR TITLE
[spi_device] Test SPI phase/polarity 'b11

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_mailbox_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_mailbox_vseq.sv
@@ -31,4 +31,11 @@ class spi_device_mailbox_vseq extends spi_device_intercept_vseq;
       ReadAddrOutsideMailbox     :/ 1
     };
   }
+
+  virtual task pre_start();
+    // always set both mailbox enables
+    cfg_mailbox_en_pct = 100;
+    intercept_mailbox_en_pct = 100;
+    super.pre_start();
+  endtask
 endclass : spi_device_mailbox_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
@@ -65,8 +65,11 @@ class spi_device_tpm_base_vseq extends spi_device_base_vseq;
     ral.cfg.cpol.set(1'b0);
     ral.cfg.cpha.set(1'b0);
     csr_update(.csr(ral.cfg));
-    cfg.spi_cfg_sema.put();
 
+    // tpm_cfg needs to be included in cfg.spi_cfg_sema, because tpm and flash may be enabled
+    // in 2 separate threads, but when tpm is on, sck polariy/phase needs to be 'b00, while flash
+    // can support 'b11. Hence, when enable flash mode, need to check tpm_cfg.en before setting
+    // sck polariy/phase.
     ral.tpm_cfg.en.set(1'b1);
     ral.tpm_cfg.tpm_mode.set(mode);
     if (is_hw_return) begin
@@ -80,6 +83,7 @@ class spi_device_tpm_base_vseq extends spi_device_base_vseq;
     end
     csr_update(.csr(ral.tpm_cfg));
     `uvm_info(`gfn, ral.tpm_cfg.sprint(), UVM_MEDIUM)
+    cfg.spi_cfg_sema.put();
   endtask : tpm_init
 
   // Check the CMD_ADDR/wrFIFO contents.

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -183,7 +183,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
           end // if (!cfg.is_read_buffer_cmd(item))
 
           latch_flash_status(set_busy, update_wel, wel_val);
-          if (`gmv(ral.tpm_cfg.en)) begin
+          if (cfg.en_cov && `gmv(ral.tpm_cfg.en)) begin
             cov.tpm_interleave_with_flash_item_cg.sample(.is_tpm_item(0), .is_flash_item(1));
           end
         end


### PR DESCRIPTION
1. Update spi_host_driver to support this clk config
2. Update sequence to avoid using 'b11 configuration when tpm mode is enabled
3. Also randomize mailbox setting

Signed-off-by: Weicai Yang <weicai@google.com>