### PR TITLE
[dv/chip] Fix sysrst_ctrl nightly regression failure

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv
@@ -18,6 +18,7 @@ class chip_sw_sysrst_ctrl_ec_rst_l_vseq extends chip_sw_base_vseq;
 
   localparam int PAD_KEY0 = 0;
   localparam int PAD_KEY1 = 1;
+  localparam int PAD_KEY2 = 2;
 
   typedef enum {
     PHASE_INITIAL               = 0,
@@ -32,9 +33,22 @@ class chip_sw_sysrst_ctrl_ec_rst_l_vseq extends chip_sw_base_vseq;
   logic       output_ec_rst_read_values;
   logic       ec_rst_timer_over;
 
+  virtual task pre_start();
+    super.pre_start();
+    sysrst_init();
+  endtask
+
   virtual function void write_test_phase(input test_phases_e phase);
     sw_symbol_backdoor_overwrite("kTestPhase", {<<8{phase}});
   endfunction
+
+  // Initialize the pad mio input to 0 to avoid having X values in the initial test phase.
+  virtual task sysrst_init();
+    cfg.chip_vif.sysrst_ctrl_if.drive_pin(PAD_KEY0, 0);
+    cfg.chip_vif.sysrst_ctrl_if.drive_pin(PAD_KEY1, 0);
+    cfg.chip_vif.sysrst_ctrl_if.drive_pin(PAD_KEY2, 0);
+    cfg.chip_vif.pwrb_in_if.drive_pin(0, 0);
+  endtask
 
   virtual task set_combo0_pads_low();
     cfg.chip_vif.sysrst_ctrl_if.drive_pin(PAD_KEY0, 0);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv
@@ -28,6 +28,12 @@ class chip_sw_sysrst_ctrl_outputs_vseq extends chip_sw_base_vseq;
   logic [3:0] loopback_pad_read_values;
   logic [7:0] output_pad_read_values;
 
+  virtual task pre_start();
+    super.pre_start();
+    // Initialize the pad input to 0 to avoid having X values in the initial test phase.
+    set_loopback_pads(0);
+  endtask
+
   virtual function void write_test_phase(input test_phases_e phase);
     sw_symbol_backdoor_overwrite("kTestPhase", {<<8{phase}});
   endfunction


### PR DESCRIPTION
This PR fixes sysrst_ctrl nightly failure regarding havig X in sysrst output. The reason is in the inital test, the C test sets up sysrst_ctrl by configuring pinmux mio values to sysrst outputs such as keys. However, this pinmux mio values are not driven, so ended up having output unknown assertion errors.
The solution is to initialize the mio pins before running the C test. Fix issue #15537

Signed-off-by: Cindy Chen <chencindy@opentitan.org>