### PR TITLE
[chip, dv] Remove a testpoint - tl_intg_err

### DIFF
--- a/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson
@@ -2,59 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
+  import_testplans: ["hw/dv/tools/dvsim/testplans/tl_device_access_types_wo_intg_testplan.hjson"]
   testpoints: [
-    {
-      name: tl_d_oob_addr_access
-      desc: "Access out of bounds address and verify correctness of response / behavior"
-      stage: V2
-      tests: ["{name}_tl_errors"]
-    }
-    {
-      name: tl_d_illegal_access
-      desc: '''Drive unsupported requests via TL interface and verify correctness of response
-            / behavior. Below error cases are tested bases on the
-            [TLUL spec]({{< relref "hw/ip/tlul/doc/_index.md#explicit-error-cases" >}})
-            - TL-UL protocol error cases
-              - invalid opcode
-              - some mask bits not set when opcode is `PutFullData`
-              - mask does not match the transfer size, e.g. `a_address = 0x00`, `a_size = 0`,
-                `a_mask = 'b0010`
-              - mask and address misaligned, e.g. `a_address = 0x01`, `a_mask = 'b0001`
-              - address and size aren't aligned, e.g. `a_address = 0x01`, `a_size != 0`
-              - size is greater than 2
-            - OpenTitan defined error cases
-              - access unmapped address, expect `d_error = 1` when `devmode_i == 1`
-              - write a CSR with unaligned address, e.g. `a_address[1:0] != 0`
-              - write a CSR less than its width, e.g. when CSR is 2 bytes wide, only write 1 byte
-              - write a memory with `a_mask != '1` when it doesn't support partial accesses
-              - read a WO (write-only) memory
-              - write a RO (read-only) memory
-              - write with `instr_type = True`'''
-      stage: V2
-      tests: ["{name}_tl_errors"]
-    }
-    {
-      name: tl_d_outstanding_access
-      desc: '''Drive back-to-back requests without waiting for response to ensure there is one
-            transaction outstanding within the TL device. Also, verify one outstanding when back-
-            to-back accesses are made to the same address.'''
-      stage: V2
-      tests: ["{name}_csr_hw_reset",
-              "{name}_csr_rw",
-              "{name}_csr_aliasing",
-              "{name}_same_csr_outstanding"]
-    }
-    {
-      name: tl_d_partial_access
-      desc: '''Access CSR with one or more bytes of data.
-            For read, expect to return all word value of the CSR.
-            For write, enabling bytes should cover all CSR valid fields.'''
-      stage: V2
-      tests: ["{name}_csr_hw_reset",
-              "{name}_csr_rw",
-              "{name}_csr_aliasing",
-              "{name}_same_csr_outstanding"]
-    }
     {
       name: tl_intg_err
       desc: ''' Verify that the data integrity check violation generates an alert.
@@ -68,13 +17,6 @@
     }
   ]
   covergroups: [
-    {
-      name: tl_errors_cg
-      desc: '''Cover the following error cases on TL-UL bus:
-            - TL-UL protocol error cases.
-            - OpenTitan defined error cases, refer to testpoint `tl_d_illegal_access`.
-            '''
-    }
     {
       name: tl_intg_err_cg
       desc: '''Cover all kinds of integrity errors (command, data or both) and cover number of

--- a/hw/dv/tools/dvsim/testplans/tl_device_access_types_wo_intg_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/tl_device_access_types_wo_intg_testplan.hjson
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  testpoints: [
+    {
+      name: tl_d_oob_addr_access
+      desc: "Access out of bounds address and verify correctness of response / behavior"
+      stage: V2
+      tests: ["{name}_tl_errors"]
+    }
+    {
+      name: tl_d_illegal_access
+      desc: '''Drive unsupported requests via TL interface and verify correctness of response
+            / behavior. Below error cases are tested bases on the
+            [TLUL spec]({{< relref "hw/ip/tlul/doc/_index.md#explicit-error-cases" >}})
+            - TL-UL protocol error cases
+              - invalid opcode
+              - some mask bits not set when opcode is `PutFullData`
+              - mask does not match the transfer size, e.g. `a_address = 0x00`, `a_size = 0`,
+                `a_mask = 'b0010`
+              - mask and address misaligned, e.g. `a_address = 0x01`, `a_mask = 'b0001`
+              - address and size aren't aligned, e.g. `a_address = 0x01`, `a_size != 0`
+              - size is greater than 2
+            - OpenTitan defined error cases
+              - access unmapped address, expect `d_error = 1` when `devmode_i == 1`
+              - write a CSR with unaligned address, e.g. `a_address[1:0] != 0`
+              - write a CSR less than its width, e.g. when CSR is 2 bytes wide, only write 1 byte
+              - write a memory with `a_mask != '1` when it doesn't support partial accesses
+              - read a WO (write-only) memory
+              - write a RO (read-only) memory
+              - write with `instr_type = True`'''
+      stage: V2
+      tests: ["{name}_tl_errors"]
+    }
+    {
+      name: tl_d_outstanding_access
+      desc: '''Drive back-to-back requests without waiting for response to ensure there is one
+            transaction outstanding within the TL device. Also, verify one outstanding when back-
+            to-back accesses are made to the same address.'''
+      stage: V2
+      tests: ["{name}_csr_hw_reset",
+              "{name}_csr_rw",
+              "{name}_csr_aliasing",
+              "{name}_same_csr_outstanding"]
+    }
+    {
+      name: tl_d_partial_access
+      desc: '''Access CSR with one or more bytes of data.
+            For read, expect to return all word value of the CSR.
+            For write, enabling bytes should cover all CSR valid fields.'''
+      stage: V2
+      tests: ["{name}_csr_hw_reset",
+              "{name}_csr_rw",
+              "{name}_csr_aliasing",
+              "{name}_same_csr_outstanding"]
+    }
+   ]
+  covergroups: [
+    {
+      name: tl_errors_cg
+      desc: '''Cover the following error cases on TL-UL bus:
+            - TL-UL protocol error cases.
+            - OpenTitan defined error cases, refer to testpoint `tl_d_illegal_access`.
+            '''
+    }
+  ]
+}

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -8,7 +8,8 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      // TODO #5484, comment these 2 lines out because spi host memory is dummy
                      // "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     // Integrity error is tested in a SW test.
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_wo_intg_testplan.hjson",
                      "hw/ip/tlul/data/tlul_testplan.hjson",
                      "sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson",
                      "hw/top_earlgrey/data/chip_conn_testplan.hjson"]


### PR DESCRIPTION
When we import `tl_device_access_types_testplan`, it includes `tl_intg_err` testpoint and 2 common tests.
But in chip-level, we want to use a SW test to verify this. 
Hence, create a common testplan without the integrity testpoint and import it in chip-level.

Signed-off-by: Weicai Yang <weicai@google.com>