### PR TITLE
[chip, dv] update testplan for chip_sw_data_integrity test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -492,17 +492,14 @@
     {
       name: chip_sw_data_integrity
       desc: '''
-            Verify the alert signaling mechanism due to data integrity violation.
+            Verify the alert signaling mechanism due to memory data integrity violation.
 
-            An automated SW test which performs the following for each IP:
-            - Pick a CSR to write.
-            - Corrupt a random control / data / integrity bit at the CPU source using SV force.
-            - Verify that the device detects the integrity violation causing an alert.
-            - Verify the alert upto the NMI stage.
-            - Now pick a CSR to read.
-            - Corrupt a random control / data / integrity bit at the device using SV force.
-            - Verify that the CPU detects the integrity violation causing an alert.
-            - Verify the alert upto the NMI stage.
+            An SW test which performs the following on ret_sram to verify the memory end to end
+            integrity scheme.
+            - Corrupt a random data / integrity bit in the memory using SV force.
+            - SW reads that address and the corrupted data is sent to ibex.
+            - Verify that ibex detects the integrity violation and triggers an alert.
+            - Verify the alert upto the NMI stage or full reset, and alert cause is from ibex.
             '''
       stage: V2
       tests: []


### PR DESCRIPTION
As discussed, we have chip_sw_all_escalation_resets to test integrity errors due to wr_en violation for all the IPs.
This chip_sw_data_integrity test only needs to inject integrity error on a memory to test memory e2e integrity scheme.

Signed-off-by: Weicai Yang <weicai@google.com>