### PR TITLE
[chip, dv] Fix uncovered *tl*.a_user.instr_type

### DIFF
--- a/hw/ip/tlul/generic_dv/env/seq_lib/xbar_seq_err_item.sv
+++ b/hw/ip/tlul/generic_dv/env/seq_lib/xbar_seq_err_item.sv
@@ -15,5 +15,7 @@ class xbar_seq_err_item extends cip_tl_seq_item;
     no_d_error_c.constraint_mode(0);
   endfunction
 
+  // Remove modification on a_user, so it's freely randomized
+  function void post_randomize();
+  endfunction
 endclass
-


### PR DESCRIPTION
Remove unnecessary constraint on a_user.instr_type in xbar tests. For other IPs, this needs to be MubiFalse, but xbar doesn't process this field, we could just randomize it.

This will fix uncovered toggle coverage at this TLUL field.

Signed-off-by: Weicai Yang <weicai@google.com>