### PR TITLE
[utils,gpio] Add new hjson key 'auto_split' as hint for regtool

### DIFF
--- a/hw/ip/gpio/data/gpio.hjson
+++ b/hw/ip/gpio/data/gpio.hjson
@@ -17,6 +17,7 @@
     { name: "gpio",
       width: 32,
       desc: "raised if any of GPIO pin detects configured interrupt mode"
+      auto_split: "true"
     }
   ],
   alert_list: [
@@ -151,7 +152,9 @@
       hwext: "true",
       hwqe: "true",
       fields: [
-        { bits: "31:0" }
+        { bits: "31:0",
+          auto_split: "true"
+        }
       ],
     },
     { name: "MASKED_OE_LOWER",

--- a/util/reggen/gen_tock.py
+++ b/util/reggen/gen_tock.py
@@ -193,14 +193,19 @@ def gen_field_definitions(
         raise TypeError(type(reg))
 
     for field in fields:
-        genout(fieldout, "\n{} OFFSET({}) NUMBITS({}) [", field.name.upper(),
-               field.bits.lsb, field.bits.width())
-        if getattr(field, 'enum', None) is not None:
-            for enum in field.enum:
-                genout(fieldout, "\n{} = {},", sanitize_name(enum.name).upper(), enum.value)
-            genout(fieldout, "\n],")
+        if field.auto_split:
+            for sub_field_id in range(field.bits.lsb, field.bits.width()):
+                genout(fieldout, "\n{} OFFSET({}) NUMBITS({}) [],",
+                       "{}_{}".format(field.name.upper(), sub_field_id), sub_field_id, 1)
         else:
-            genout(fieldout, "],")
+            genout(fieldout, "\n{} OFFSET({}) NUMBITS({}) [", field.name.upper(),
+                   field.bits.lsb, field.bits.width())
+            if getattr(field, 'enum', None) is not None:
+                for enum in field.enum:
+                    genout(fieldout, "\n{} = {},", sanitize_name(enum.name).upper(), enum.value)
+                genout(fieldout, "\n],")
+            else:
+                genout(fieldout, "],")
     else:
         genout(fieldout, "\n],\n")
 

--- a/util/reggen/interrupt.py
+++ b/util/reggen/interrupt.py
@@ -6,7 +6,7 @@ from typing import Sequence
 
 from reggen.access import JsonEnum
 from reggen.bits import Bits
-from reggen.lib import check_keys, check_name, check_str, check_int, check_list
+from reggen.lib import check_keys, check_name, check_str, check_int, check_bool, check_list
 from reggen.signal import Signal
 
 
@@ -20,13 +20,14 @@ _intr_type_map = {'event': IntrType.Event, 'status': IntrType.Status}
 
 class Interrupt(Signal):
 
-    def __init__(self, name: str, desc: str, bits: Bits, intr_type: IntrType):
+    def __init__(self, name: str, desc: str, bits: Bits, auto_split: bool, intr_type: IntrType):
         super().__init__(name, desc, bits)
         self.intr_type = intr_type
+        self.auto_split = auto_split
 
     @staticmethod
     def from_raw(what: str, lsb: int, raw: object) -> 'Interrupt':
-        rd = check_keys(raw, what, ['name', 'desc'], ['width', 'type'])
+        rd = check_keys(raw, what, ['name', 'desc'], ['width', 'type', 'auto_split'])
 
         name = check_name(rd['name'], 'name field of ' + what)
         desc = check_str(rd['desc'], 'desc field of ' + what)
@@ -38,6 +39,7 @@ class Interrupt(Signal):
         bits = Bits(lsb + width - 1, lsb)
         intr_type_str = check_str(rd.get('type', 'event'),
                                   'intr_type field of ' + what)
+        auto_split = check_bool(rd.get('auto_split', False), 'auto_split of ' + what)
 
         try:
             intr_type = _intr_type_map[intr_type_str.lower()]
@@ -47,7 +49,7 @@ class Interrupt(Signal):
                 'has value {}, but should be either event or status.'.format(
                     name, what, intr_type_str))
 
-        return Interrupt(name, desc, bits, intr_type)
+        return Interrupt(name, desc, bits, auto_split, intr_type,)
 
     @staticmethod
     def from_raw_list(what: str, raw: object) -> Sequence['Interrupt']:

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -482,7 +482,8 @@ class RegBlock:
                                 bits=signal.bits,
                                 resval=0,
                                 enum=None,
-                                mubi=False))
+                                mubi=False,
+                                auto_split=False))
 
         reg = Register(self.offset,
                        reg_name,


### PR DESCRIPTION
Introduces a new optional key 'auto_split' to serve as a hint for register map generator script. Adds support to 'auto_split' in the TockOS register map generator.

If the bitfield or signal has key 'auto_split' set to value true generator will split this filed to multiple one-bit fields. The name of each generated bitfiled will consist of the original bitfield name and an offset. If the parameter is set to false, the current behavior of the regtool is not replaced. The default value of the new key is set to false.

Signed-off-by: Michał Mazurek <maz@semihalf.com>