### PR TITLE
[dv] Fix race condition in otbn_escalate_if

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_escalate_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_escalate_if.sv
@@ -13,19 +13,19 @@ interface otbn_escalate_if (
   lc_ctrl_pkg::lc_tx_t req;
   lc_ctrl_pkg::lc_tx_t ack;
 
-  function automatic void reset_signals();
-    enable = lc_ctrl_pkg::Off;
-    req = lc_ctrl_pkg::Off;
-  endfunction
+  task automatic reset_signals();
+    enable <= lc_ctrl_pkg::Off;
+    req <= lc_ctrl_pkg::Off;
+  endtask
 
   task automatic randomize_rma_req_after_n_clocks(int unsigned n, int t_weight = 2,
                                                   int f_weight = 2, int other_weight = 1);
     // Send Req
     `DV_SPINWAIT_EXIT(begin
         repeat (n) @(posedge clk_i);
-          req = cip_base_pkg::get_rand_lc_tx_val(.t_weight(t_weight),
-                                                 .f_weight(f_weight),
-                                                 .other_weight(other_weight));
+          req <= cip_base_pkg::get_rand_lc_tx_val(.t_weight(t_weight),
+                                                  .f_weight(f_weight),
+                                                  .other_weight(other_weight));
       end, @(negedge rst_ni);, "Not setting req signal because we've gone into reset",
                       "otbn_escalate_if")
   endtask
@@ -34,9 +34,9 @@ interface otbn_escalate_if (
                                                  int other_weight = 1);
     `DV_SPINWAIT_EXIT(begin
         repeat (n) @(posedge clk_i);
-          enable = cip_base_pkg::get_rand_lc_tx_val(.t_weight(t_weight),
-                                                    .f_weight(f_weight),
-                                                    .other_weight(other_weight));
+          enable <= cip_base_pkg::get_rand_lc_tx_val(.t_weight(t_weight),
+                                                     .f_weight(f_weight),
+                                                     .other_weight(other_weight));
       end, @(negedge rst_ni);, "Not setting enable signal because we've gone into reset",
                       "otbn_escalate_if")
   endtask


### PR DESCRIPTION
Previously this interface used blocking assignment to set these. This led to the updates happening in the wrong place in the simulation scheduler. In particular it led to the failure of the `OutputDelay_A` assertion in prim_lc_sync in some cases.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>