### PR TITLE
[rom_ctrl dv] Fix FSM state invalid check

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_if.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_if.sv
@@ -5,4 +5,5 @@
 interface rom_ctrl_if;
   rom_ctrl_pkg::pwrmgr_data_t pwrmgr_data;
   rom_ctrl_pkg::keymgr_data_t keymgr_data;
+  rom_ctrl_pkg::fsm_state_e   checker_fsm_state;
 endinterface

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -33,9 +33,8 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
   endfunction
 
   virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
-    rom_ctrl_pkg::fsm_state_e rdata_state;
     super.check_sec_cm_fi_resp(if_proxy);
-    `DV_CHECK_EQ(rdata_state, rom_ctrl_pkg::Invalid)
+    `DV_CHECK_EQ(cfg.rom_ctrl_vif.checker_fsm_state, rom_ctrl_pkg::Invalid)
   endtask : check_sec_cm_fi_resp
 
   virtual function void sec_cm_fi_ctrl_svas(sec_cm_base_if_proxy if_proxy, bit enable);

--- a/hw/ip/rom_ctrl/dv/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb.sv
@@ -65,6 +65,8 @@ module tb;
     .kmac_data_o          (kmac_data_out)
   );
 
+  assign rom_ctrl_if.checker_fsm_state = dut.gen_fsm_scramble_enabled.u_checker_fsm.state_q;
+
   // Instantitate the memory backdoor util instance.
   `define ROM_CTRL_MEM_HIER \
     tb.dut.gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom.gen_generic.u_impl_generic.mem


### PR DESCRIPTION
The fsm state check that was added for the sec_cm tests was not actually probing the FSM state. This change fixes that. This was caught by the fix made to the DV_CHECK macros.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>