### PR TITLE
feat(doc): Upgrade Hugo Extended to 0.104.3

### DIFF
--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -26,7 +26,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'hugo_extended': {
-        'min_version': '0.82.0',
+        'min_version': '0.104.3',
         'as_needed': True
     },
     'verible': {

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -409,9 +409,9 @@ def install_hugo(install_dir):
                         '/hugo_extended_{version}_Linux-64bit.tar.gz').format(
                             version=HUGO_EXTENDED_VERSION)
 
-    elif platform.system() == 'Darwin' and platform.machine() == 'x86_64':
+    elif platform.system() == 'Darwin':
         download_url = ('https://github.com/gohugoio/hugo/releases/download/v{version}'
-                        '/hugo_extended_{version}_macOS-64bit.tar.gz').format(
+                        '/hugo_extended_{version}_darwin-universal.tar.gz').format(
                             version=HUGO_EXTENDED_VERSION)
 
     else:


### PR DESCRIPTION
By upgrading Hugo Extended version to 0.104.3, now the `util/build_docs.py` supports macOS Apple Silicon too

