### PR TITLE
[util] Add new features to entropy buffer generator

### DIFF
--- a/util/topgen/entropy_buffer_generator.py
+++ b/util/topgen/entropy_buffer_generator.py
@@ -13,8 +13,11 @@ This will create a file 'entropy_buffer.npy' consisting of 100 bytes.
 """
 import argparse
 
+import logging as log
 import numpy as np
 import random
+import secrets
+import sys
 
 
 def parse_args():
@@ -34,6 +37,17 @@ def parse_args():
                         type=int,
                         default=16,
                         help="""number of bytes to generate""")
+    parser.add_argument("--sec",
+                        action="store_true",
+                        default=False,
+                        help="""Generate random numbers from the most secure
+                        source of randomness the OS provides. Cannot be used
+                        together with --seed.""")
+    parser.add_argument("-s",
+                        "--seed",
+                        type=int,
+                        help="""Custom seed for RNG to generate the entropy
+                        buffer. Cannot be used if sec = True.""")
     return parser.parse_args()
 
 
@@ -42,10 +56,25 @@ def main():
     args = parse_args()
     k = args.num_bytes
     out = args.output_file
+    sec = args.sec
+    seed = args.seed
+
+    if (sec and seed):
+        log.error("Options --sec and --seed cannot be used together")
+        sys.exit(1)
+
+    if not (sec or seed):
+        seed = random.getrandbits(64)
+        log.warning("No seed specified, setting to {}.".format(seed))
 
     buffer = np.zeros(k, dtype='uint8')
-    for i in range(k):
-        buffer[i] = random.getrandbits(8)
+    if sec:
+        for i in range(k):
+            buffer[i] = secrets.randbelow(256)
+    else:
+        random.seed(seed)
+        for i in range(k):
+            buffer[i] = random.getrandbits(8)
 
     np.savetxt(out, buffer, fmt='%d')
 


### PR DESCRIPTION
Add --sec feature to enable using class secret.py for generating entropy. This class always uses fresh randomness from OS. Add --seed argument to generate entropy buffer from a specified integer seed. This argument is ignored when --sec feature is enabled.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>