### PR TITLE
[flash_ctrl,dv] update coverage collection

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -47,7 +47,6 @@ class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
   endgroup : sw_error_cg
 
   covergroup std_fault_cg with function sample(input bit [31:0] err_val);
-    `DV_FCOV_EXPR_SEEN(reg_intg_err,   err_val[FlashStdFaultRegIntgErr])
     `DV_FCOV_EXPR_SEEN(prog_intg_err,  err_val[FlashStdFaultProgIntgErr])
     `DV_FCOV_EXPR_SEEN(lcmgr_err,      err_val[FlashStdFaultLcmgrErr])
     `DV_FCOV_EXPR_SEEN(lcmgr_intg_err, err_val[FlashStdFaultLcmgrIntgErr])

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
@@ -55,6 +55,7 @@ class flash_ctrl_wr_path_intg_vseq extends flash_ctrl_rw_vseq;
             endcase
           end // repeat (cfg.otf_num_rw)
           // Check std_fault.prog_intg_err,  err_code.prog_err
+          collect_err_cov_status(ral.std_fault_status);
           csr_rd_check(.ptr(ral.std_fault_status.prog_intg_err), .compare_value(1));
           csr_rd_check(.ptr(ral.err_code.prog_err), .compare_value(1));
           csr_rd_check(.ptr(ral.op_status.err), .compare_value(1));


### PR DESCRIPTION
- Add coverage collection to wr_intg test
- Remove reg_intg cover point because it is covered by autogen covergroup

Signed-off-by: Jaedon Kim <jdonjdon@google.com>