### PR TITLE
[aes, sw] Add AES masking off test and associated utility functions

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -47,8 +47,11 @@ cc_library(
     hdrs = ["aes_testutils.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:aes",
+        "//sw/device/lib/dif:edn",
         "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/testing:csrng_testutils",
         "//sw/device/lib/testing/test_framework:check",
     ],
 )

--- a/sw/device/lib/testing/aes_testutils.c
+++ b/sw/device/lib/testing/aes_testutils.c
@@ -4,7 +4,191 @@
 
 #include "sw/device/lib/testing/aes_testutils.h"
 
+#if !OT_IS_ENGLISH_BREAKFAST
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/testing/csrng_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+
+#include "csrng_regs.h"  // Generated
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#endif
+
 // `extern` declarations to give the inline functions in the
 // corresponding header a link location.
 
 extern bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t flag);
+
+#if !OT_IS_ENGLISH_BREAKFAST
+/**
+ * Constants for switching AES masking off.
+ */
+enum {
+  kCsrngBlockLen = 4,
+  kCsrngKeyLen = 8,
+  kEdnSeedMaterialLen = 12,
+};
+
+// CSRNG needs to constantly output these bits to EDN. The AES masking PRNG
+// consists of five 32-bit LFSRs each followed by a linear permutation and a
+// non-linear layer and ultimately a secret permutation spanning all five
+// LFSRs. Only if the non-linear layers of all five LFSRs output an all-zero
+// vector, the PRNG output is zero as well.
+//
+const uint32_t kAesMaskingPrngZeroOutputSeed[kCsrngBlockLen] = {
+    0xff00ffff, 0xff00ffff, 0xff00ffff, 0xff00ffff};
+
+// Seed material for instantiate command. The CTR_DRBG construction
+// implemented by CSRNG produces
+//
+// key = 00 01 02 03 04 05 06 07 - 08 09 0a 0b 0c 0d 0e 0f
+//       10 11 12 13 14 15 16 17 - 18 19 1a 1b 1c 1d 1e 1f
+//
+//   V = 8d 97 b4 1b c2 0a cb bb - 81 06 d3 91 85 46 67 f8
+//
+// from this seed material upon instantiate. The key is arbitrarity chosen.
+// Encrypting V using this key then gives the required
+// kAesMaskingPrngZeroOutputSeed above.
+const uint32_t kEdnSeedMaterialInstantiate[kEdnSeedMaterialLen] = {
+    0xf0405279, 0x50a4261f, 0xf5ace1cf, 0xfff7b7d1, 0xa6ee8307, 0x1f57dfc8,
+    0x59757d79, 0xdeb6522e, 0xc8c67d84, 0xa16abefa, 0xc34030be, 0x530e88f8};
+
+// V and key after instantiate.
+const uint32_t kCsrngVInstantiate[kCsrngBlockLen] = {0x854667f7, 0x8106d391,
+                                                     0xc20acbbb, 0x8d97b41b};
+const uint32_t kCsrngKeyInstantiate[kCsrngKeyLen] = {
+    0x1c1d1e1f, 0x18191a1b, 0x14151617, 0x10111213,
+    0x0c0d0e0f, 0x08090a0b, 0x04050607, 0x00010203};
+
+// V and key after generate.
+const uint32_t kCsrngVGenerate[kCsrngBlockLen] = {0x1569e491, 0xe854f642,
+                                                  0xe931a570, 0x60939074};
+const uint32_t kCsrngKeyGenerate[kCsrngKeyLen] = {
+    0xfdab6b68, 0x31920240, 0x32a48b64, 0xda4189d7,
+    0xf49b7a55, 0x3d86fe43, 0xf4eaeab1, 0x8fae023a};
+
+// Seed material for reseed command. After one generate, this seed material
+// will bring the key and V of CSRNG back to the state after instantiate.
+// I.e., one can again run one generate to produce the seed required for AES
+// (see kAesMaskingPrngZeroOutputSeed).
+const uint32_t kEdnSeedMaterialReseed[kEdnSeedMaterialLen] = {
+    0x5f6fb665, 0x21ca8e3f, 0x5ba3dba1, 0x2c10a9ec, 0x03b8cd4b, 0x8264aaea,
+    0x371e6305, 0x8fb186e1, 0xf622bc3e, 0x98e5d247, 0x73040c38, 0x6596739e};
+
+void aes_testutils_masking_prng_zero_output_seed(void) {
+  const dif_csrng_t csrng = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR)};
+  const dif_edn_t edn0 = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
+
+  // Shutdown EDN0 and CSRNG
+  CHECK_DIF_OK(dif_edn_stop(&edn0));
+  CHECK_DIF_OK(dif_csrng_stop(&csrng));
+
+  // Re-eanble CSRNG
+  CHECK_DIF_OK(dif_csrng_configure(&csrng));
+
+  // Re-enable EDN0 and configure it to produce the seed that if loaded into AES
+  // causes the AES masking PRNG to output and all-zero output.
+  dif_edn_auto_params_t edn0_params = {
+      .instantiate_cmd =
+          {
+              .cmd = 0x000000c1 |              // Instantiate, clen = 12 words.
+                     kMultiBitBool4True << 8,  // Use the provided seed only.
+              .seed_material =
+                  {
+                      .len = kEdnSeedMaterialLen,
+                  },
+          },
+      .reseed_cmd =
+          {
+              .cmd = 0x000000c2 |              // Reseed, clen = 12 words.
+                     kMultiBitBool4True << 8,  // Use provided seed only.
+              .seed_material =
+                  {
+                      .len = kEdnSeedMaterialLen,
+                  },
+          },
+      .generate_cmd =
+          {
+              .cmd = 0x00001003 |  // 1 generate returns 1 block.
+                     kMultiBitBool4True
+                         << 8,  // Don't use entropy from the entropy src.
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
+          },
+      .reseed_interval = 1,  // Reseed after every single generate.
+  };
+  memcpy(edn0_params.instantiate_cmd.seed_material.data,
+         kEdnSeedMaterialInstantiate, sizeof(kEdnSeedMaterialInstantiate));
+  memcpy(edn0_params.reseed_cmd.seed_material.data, kEdnSeedMaterialReseed,
+         sizeof(kEdnSeedMaterialReseed));
+  CHECK_DIF_OK(dif_edn_set_auto_mode(&edn0, edn0_params));
+}
+
+void aes_testutils_csrng_kat(void) {
+  const dif_csrng_t csrng = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR)};
+
+  // Instantiate CSRNG with seed material suitable for switching the AES masking
+  // off.
+  dif_csrng_seed_material_t seed_material_instantiate = {
+      .seed_material_len = 12,
+  };
+  memcpy(seed_material_instantiate.seed_material, kEdnSeedMaterialInstantiate,
+         sizeof(kEdnSeedMaterialInstantiate));
+  dif_csrng_internal_state_t expected_state_instantiate = {
+      .reseed_counter = 1,
+      .instantiated = true,
+      .fips_compliance = false,
+  };
+  memcpy(expected_state_instantiate.v, kCsrngVInstantiate,
+         sizeof(kCsrngVInstantiate));
+  memcpy(expected_state_instantiate.key, kCsrngKeyInstantiate,
+         sizeof(kCsrngKeyInstantiate));
+  csrng_testutils_kat_instantiate(&csrng, false, &seed_material_instantiate,
+                                  &expected_state_instantiate);
+
+  // Generate one block containting the required seed for the AES masking PRNG
+  // to output an all-zero vector.
+  dif_csrng_internal_state_t expected_state_generate = {
+      .reseed_counter = 2,
+      .instantiated = true,
+      .fips_compliance = false,
+  };
+  memcpy(expected_state_generate.v, kCsrngVGenerate, sizeof(kCsrngVGenerate));
+  memcpy(expected_state_generate.key, kCsrngKeyGenerate,
+         sizeof(kCsrngKeyGenerate));
+  csrng_testutils_kat_generate(&csrng, 1, kCsrngBlockLen,
+                               kAesMaskingPrngZeroOutputSeed,
+                               &expected_state_generate);
+
+  // Reseed the CSRNG instance to produce the required seed for the AES masking
+  // PRNG to output an all-zero vector upon the next generate command.
+  dif_csrng_seed_material_t seed_material_reseed = {
+      .seed_material_len = 12,
+  };
+  memcpy(seed_material_reseed.seed_material, kEdnSeedMaterialReseed,
+         sizeof(kEdnSeedMaterialReseed));
+  dif_csrng_internal_state_t expected_state_reseed = {
+      .reseed_counter = 1,
+      .instantiated = true,
+      .fips_compliance = false,
+  };
+  memcpy(expected_state_reseed.v, kCsrngVInstantiate,
+         sizeof(kCsrngVInstantiate));
+  memcpy(expected_state_reseed.key, kCsrngKeyInstantiate,
+         sizeof(kCsrngKeyInstantiate));
+  csrng_testutils_kat_reseed(&csrng, &seed_material_reseed,
+                             &expected_state_reseed);
+
+  // Generate one block containting the required seed for the AES masking PRNG
+  // to output an all-zero vector.
+  csrng_testutils_kat_generate(&csrng, 1, kCsrngBlockLen,
+                               kAesMaskingPrngZeroOutputSeed,
+                               &expected_state_generate);
+}
+#endif

--- a/sw/device/lib/testing/aes_testutils.h
+++ b/sw/device/lib/testing/aes_testutils.h
@@ -33,4 +33,25 @@ inline bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t flag) {
   IBEX_SPIN_FOR(aes_testutils_get_status((aes_), (flag_)) == (value_),    \
                 (timeout_usec_))
 
+#if !OT_IS_ENGLISH_BREAKFAST
+/**
+ * Initializes the entropy complex for performing AES SCA measurements with
+ * masking switched off.
+ *
+ * Initializes CSRNG and EDN0 to produce a fixed seed which after being loaded
+ * into AES causes the AES masking PRNG to output an all-zero vector. Entropy
+ * src and EDN1 are left untouched.
+ */
+void aes_testutils_masking_prng_zero_output_seed(void);
+
+/**
+ * CTR_DRBG Known-Answer-Test (KAT) using the CSRNG SW application interface.
+ *
+ * Initializes CSRNG and then runs multiple generate and a reseed command to
+ * ensure the seed leading to an all-zero output of the AES masking PRNG can
+ * repeatedly be generated.
+ */
+void aes_testutils_csrng_kat(void);
+#endif
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_AES_TESTUTILS_H_

--- a/sw/device/lib/testing/csrng_testutils.h
+++ b/sw/device/lib/testing/csrng_testutils.h
@@ -33,6 +33,45 @@ void csrng_testutils_check_internal_state(
     const dif_csrng_t *csrng, const dif_csrng_internal_state_t *expected);
 
 /**
+ * CTR_DRBG Known-Answer-Test (KAT) for INSTANTIATE command.
+ *
+ * @param csrng A CSRNG handle.
+ * @param fail_expected Expected fail.
+ * @param seed_material Seed material to use for the command.
+ * @param expected_state Expected CSRNG internal state after the command.
+ */
+void csrng_testutils_kat_instantiate(
+    const dif_csrng_t *csrng, bool fail_expected,
+    const dif_csrng_seed_material_t *seed_material,
+    const dif_csrng_internal_state_t *expected_state);
+
+/**
+ * CTR_DRBG Known-Answer-Test (KAT) for GENERATE command.
+ *
+ * @param csrng A CSRNG handle.
+ * @param num_generates Number of GENERATE commands to run.
+ * @param output_len Number of output words to read from CSRNG after the last
+ * command.
+ * @param expected_output Expected CSRNG output after the last command.
+ * @param expected_state Expected CSRNG internal state after the last command.
+ */
+void csrng_testutils_kat_generate(
+    const dif_csrng_t *csrng, uint32_t num_generates, uint32_t output_len,
+    const uint32_t *expected_output,
+    const dif_csrng_internal_state_t *expected_state);
+
+/**
+ * CTR_DRBG Known-Answer-Test (KAT) for RESEED command.
+ *
+ * @param csrng A CSRNG handle.
+ * @param seed_material Seed material to use for the command.
+ * @param expected_state Expected CSRNG internal state after the command.
+ */
+void csrng_testutils_kat_reseed(
+    const dif_csrng_t *csrng, const dif_csrng_seed_material_t *seed_material,
+    const dif_csrng_internal_state_t *expected_state);
+
+/**
  * CTR DRBG Known-Answer-Test (KAT) for INSTANTIATE command.
  *
  * @param csrng Handle.

--- a/sw/device/sca/BUILD
+++ b/sw/device/sca/BUILD
@@ -6,6 +6,15 @@ load("//rules:opentitan.bzl", "opentitan_flash_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+alias(
+    name = "aes_serial_aes_testutils",
+    actual = select({
+        "//sw/device:is_english_breakfast": "//sw/device:nothing",
+        "//conditions:default": "//sw/device/lib/testing:aes_testutils",
+    }),
+    visibility = ["//visibility:private"],
+)
+
 opentitan_flash_binary(
     name = "aes_serial",
     srcs = ["aes_serial.c"],
@@ -14,6 +23,8 @@ opentitan_flash_binary(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:aes",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aes_testutils",
+        "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/sca/lib:prng",

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -178,7 +178,7 @@ static void aes_serial_key_set(const uint8_t *key, size_t key_len) {
  * @param plaintext Plaintext.
  * @param plaintext_len Length of the plaintext.
  */
-static void aes_serial_encrypt(const uint8_t *plaintext, size_t plaintext_len) {
+static void aes_encrypt(const uint8_t *plaintext, size_t plaintext_len) {
   bool ready = false;
   do {
     SS_CHECK_DIF_OK(dif_aes_get_status(&aes, kDifAesStatusInputReady, &ready));
@@ -242,7 +242,7 @@ static void aes_serial_single_encrypt(const uint8_t *plaintext,
   }
 
   sca_set_trigger_high();
-  aes_serial_encrypt(plaintext, plaintext_len);
+  aes_encrypt(plaintext, plaintext_len);
   sca_set_trigger_low();
 
   aes_send_ciphertext(false);
@@ -291,7 +291,7 @@ static void aes_serial_batch_encrypt(const uint8_t *data, size_t data_len) {
   for (uint32_t i = 0; i < num_encryptions; ++i) {
     uint8_t plaintext[kAesTextLength];
     prng_rand_bytes(plaintext, kAesTextLength);
-    aes_serial_encrypt(plaintext, kAesTextLength);
+    aes_encrypt(plaintext, kAesTextLength);
   }
   sca_set_trigger_low();
 
@@ -404,7 +404,7 @@ static void aes_serial_fvsr_key_batch_encrypt(const uint8_t *data,
   sca_set_trigger_high();
   for (uint32_t i = 0; i < num_encryptions; ++i) {
     aes_key_mask_and_config(batch_keys[i], kAesKeyLength);
-    aes_serial_encrypt(batch_plaintexts[i], kAesTextLength);
+    aes_encrypt(batch_plaintexts[i], kAesTextLength);
   }
   sca_set_trigger_low();
 

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -5,11 +5,16 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/dif/dif_aes.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/sca/lib/prng.h"
 #include "sw/device/sca/lib/sca.h"
 #include "sw/device/sca/lib/simple_serial.h"
+
+#if !OT_IS_ENGLISH_BREAKFAST
+#include "sw/device/lib/testing/aes_testutils.h"
+#endif
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -442,6 +447,14 @@ bool test_main(void) {
 
   LOG_INFO("Initializing AES unit.");
   init_aes();
+
+#if !OT_IS_ENGLISH_BREAKFAST
+  if (transaction.masking == kDifAesMaskingForceZero) {
+    LOG_INFO("Initializing entropy complex.");
+    aes_testutils_masking_prng_zero_output_seed();
+    CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerPrngReseed));
+  }
+#endif
 
   LOG_INFO("Starting simple serial packet handling.");
   while (true) {

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -169,24 +169,4 @@ void seed_lfsr(uint32_t seed);
  */
 uint32_t next_lfsr(void);
 
-/**
- * Prints an error message over UART if the given DIF evaluates to anthing but
- * kDifOk.
- * TODO: Remove once there is a CHECK_DIF_OK version that does not require test
- * library dependencies.
- */
-#define CHECK_DIF_OK(dif_call, ...)                  \
-  do {                                               \
-    if (dif_call != kDifOk) {                        \
-      /* NOTE: because the condition in this if      \
-         statement can be statically determined,     \
-         only one of the below string constants      \
-         will be included in the final binary.*/     \
-      if (OT_VA_ARGS_COUNT(_, ##__VA_ARGS__) == 0) { \
-        LOG_ERROR("DIF-fail: " #dif_call);           \
-      } else {                                       \
-        LOG_ERROR("DIF-fail: " __VA_ARGS__);         \
-      }                                              \
-    }                                                \
-  } while (false)
 #endif  // OPENTITAN_SW_DEVICE_SCA_LIB_SCA_H_

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -422,7 +422,7 @@ static dif_result_t kmac_get_digest(uint32_t *out, size_t len) {
  * This function configures KMAC to use software entropy.
  */
 static void kmac_init(void) {
-  CHECK_DIF_OK(
+  SS_CHECK_DIF_OK(
       dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
 
   dif_kmac_config_t config = (dif_kmac_config_t){
@@ -432,7 +432,7 @@ static void kmac_init(void) {
       .entropy_fast_process = false,
       .msg_mask = true,
   };
-  CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
+  SS_CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
 
   kmac_block_until_idle();
 }

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -24,6 +24,24 @@ exports_files(glob([
 ]))
 
 opentitan_functest(
+    name = "aes_masking_off_test",
+    srcs = ["aes_masking_off_test.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//hw/ip/aes:model",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:aes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aes_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "aes_entropy_test",
     srcs = ["aes_entropy_test.c"],
     cw310 = cw310_params(

--- a/sw/device/tests/aes_masking_off_test.c
+++ b/sw/device/tests/aes_masking_off_test.c
@@ -1,0 +1,136 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/ip/aes/model/aes_modes.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/multibits.h"
+#include "sw/device/lib/dif/dif_aes.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_csrng_shared.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aes_testutils.h"
+#include "sw/device/lib/testing/csrng_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+enum {
+  kTestTimeout = (1000 * 1000),
+};
+
+// The mask share, used to mask kKey. Note that the masking should not be done
+// manually. Software is expected to get the key in two shares right from the
+// beginning.
+static const uint8_t kKeyShare1[] = {
+    0x0f, 0x1f, 0x2f, 0x3F, 0x4f, 0x5f, 0x6f, 0x7f, 0x8f, 0x9f, 0xaf,
+    0xbf, 0xcf, 0xdf, 0xef, 0xff, 0x0a, 0x1a, 0x2a, 0x3a, 0x4a, 0x5a,
+    0x6a, 0x7a, 0x8a, 0x9a, 0xaa, 0xba, 0xca, 0xda, 0xea, 0xfa,
+};
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  // Test seed generation using CSRNG SW application interface.
+  //
+  // We try to generate the seed leading to an all-zero output of the AES
+  // masking PRNG using the CSRNG SW application interface. Unlike the HW
+  // application interfaces of CSRNG that connect to the EDNs, this interface
+  // allows for probing the internal state of the CSRNG instance after
+  // individual commands. This gives us higher visibility. If for some reason
+  // this phase isn't succesful, we don't even need to try it on the HW
+  // interfaces.
+  LOG_INFO("Testing CSRNG SW application interface");
+
+  // Disable EDN connected to AES as well as CSRNG.
+  const dif_edn_t edn = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
+  const dif_csrng_t csrng = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR)};
+  CHECK_DIF_OK(dif_edn_stop(&edn));
+  CHECK_DIF_OK(dif_csrng_stop(&csrng));
+
+  // Re-eanble CSRNG.
+  CHECK_DIF_OK(dif_csrng_configure(&csrng));
+
+  // Perform the known-answer testing on the CSRNG SW application interface.
+  aes_testutils_csrng_kat();
+
+  // Test AES with masking switched off.
+  //
+  // For this to work:
+  // - CSRNG needs to generate the required seed to have the AES masking PRNG
+  //   output an all-zero vector and forward that to AES over EDN.
+  // - AES needs to be configured with the CTRL_SHADOWED.FORCE_ZERO_MASKS bit
+  //   set.
+  //
+  // Since the masking is transparent to software, software cannot actually
+  // verify that the masking is off. Instead, DV needs to probe into the design.
+  LOG_INFO("Testing AES with masking switched off");
+
+  // Initialize EDN and CSRNG to generate the required seed.
+  aes_testutils_masking_prng_zero_output_seed();
+
+  // Initialise AES.
+  dif_aes_t aes;
+  CHECK_DIF_OK(
+      dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  CHECK_DIF_OK(dif_aes_reset(&aes));
+
+  // Mask the key. Note that this should not be done manually. Software is
+  // expected to get the key in two shares right from the beginning.
+  uint8_t key_share0[sizeof(kAesModesKey128)];
+  for (int i = 0; i < sizeof(kAesModesKey128); ++i) {
+    key_share0[i] = kAesModesKey128[i] ^ kKeyShare1[i];
+  }
+
+  // "Convert" key share byte arrays to `dif_aes_key_share_t`.
+  dif_aes_key_share_t key;
+  memcpy(key.share0, key_share0, sizeof(key.share0));
+  memcpy(key.share1, kKeyShare1, sizeof(key.share1));
+
+  // Setup ECB encryption transaction with the CTRL_SHADOWED.FORCE_ZERO_MASKS
+  // bit set.
+  dif_aes_transaction_t transaction = {
+      .operation = kDifAesOperationEncrypt,
+      .mode = kDifAesModeEcb,
+      .key_len = kDifAesKey128,
+      .key_provider = kDifAesKeySoftwareProvided,
+      .mask_reseeding = kDifAesReseedPer8kBlock,
+      .manual_operation = kDifAesManualOperationAuto,
+      .masking = kDifAesMaskingForceZero,
+      .reseed_on_key_change = false,
+      .reseed_on_key_change_lock = false,
+  };
+  CHECK_DIF_OK(dif_aes_start(&aes, &transaction, &key, NULL));
+
+  // Trigger a reseed of the internal PRNGs. This will load the seed generated
+  // by CSRNG to be loaded into the AES masking PRNG. After this point, the AES
+  // masking PRNG outputs an all-zero vector.
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true, kTestTimeout);
+  CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerPrngReseed));
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true, kTestTimeout);
+
+  // "Convert" plain data byte arrays to `dif_aes_data_t` array.
+  enum {
+    kAesNumBlocks = 4,
+  };
+  dif_aes_data_t plain_text[kAesNumBlocks];
+  dif_aes_data_t cipher_text[kAesNumBlocks];
+  memcpy(plain_text[0].data, kAesModesPlainText, sizeof(kAesModesPlainText));
+
+  // Encrypt kAesNumBlocks blocks.
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
+                                kTestTimeout);
+  CHECK_DIF_OK(dif_aes_process_data(&aes, plain_text, cipher_text,
+                                    (size_t)kAesNumBlocks));
+
+  // Check the produced cipher text.
+  CHECK_ARRAYS_EQ((uint8_t *)cipher_text[0].data, kAesModesCipherTextEcb128,
+                  sizeof(kAesModesCipherTextEcb128));
+
+  return true;
+}

--- a/sw/device/tests/sim_dv/csrng_fuse_en_sw_app_read.c
+++ b/sw/device/tests/sim_dv/csrng_fuse_en_sw_app_read.c
@@ -39,43 +39,12 @@ static const uint32_t kOtpCsrngFwReadBitOffset =
      OTP_CTRL_PARAM_EN_SRAM_IFETCH_OFFSET) *
     8;
 
-enum {
-  kExpectedOutputLen = 16,
-};
-
 /**
  * CTR DRBG Known-Answer-Test (KAT) for GENERATE command.
  */
 static void test_fuse_enable(const dif_csrng_t *csrng) {
   csrng_testutils_fips_instantiate_kat(csrng, /*fail_expected=*/false);
-  LOG_INFO("%s", __func__);
-
-  uint32_t got[kExpectedOutputLen];
-
-  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
-  csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen);
-  const dif_csrng_internal_state_t kExpectedState = {
-      .reseed_counter = 3,
-      .v = {0xe73e3392, 0x7d2e92b1, 0x1a0bac9d, 0x53c78ac6},
-
-      .key = {0x66d1b85a, 0xc19d4dfd, 0x053b73e3, 0xe9dc0f90, 0x3f015bc8,
-              0x4436e5fd, 0x1cccc697, 0x1a1c6e5f},
-      .instantiated = true,
-      .fips_compliance = false,
-  };
-  csrng_testutils_check_internal_state(csrng, &kExpectedState);
-
-  // TODO(#13342): csrng does not provide a linear output order. For example,
-  // note the test vector output word order: 12,13,14,15 8,9,10,11 4,5,6,7
-  // 0,1,2,3.
-  const uint32_t kExpectedOutput[kExpectedOutputLen] = {
-      0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9, 0xdf82ab22, 0x771c619b,
-      0xd40fccb1, 0x87189e99, 0x510494b3, 0x64f7ac0c, 0x2581f391, 0x80b1dc2f,
-      0x793e01c5, 0x87b107ae, 0xdb17514c, 0xa43c41b7,
-  };
-
-  CHECK_ARRAYS_EQ(got, kExpectedOutput, kExpectedOutputLen,
-                  "Generate command KAT output mismatch");
+  csrng_testutils_fips_generate_kat(csrng);
 }
 
 /**


### PR DESCRIPTION
These test functions can be used to configure CSRNG and EDN to produce the seed required by the AES masking PRNG to output an all-zero vector. In combination with setting the CTRL_SHADOWED.FORCE_ZERO_MASKS bit for AES, this allows to effectively switch of the AES masking which is needed for ES.

This is related to https://github.com/lowRISC/opentitan/issues/14240.