### PR TITLE
[dv/chip] improve assigning the initial value in sysctrl_rst test

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -99,6 +99,12 @@ package chip_env_pkg;
     LcOtpError
   } lc_ctrl_status_e;
 
+  typedef enum bit[1:0] {
+    SysrstCtrlPadKey0 = 0,
+    SysrstCtrlPadKey1 = 1,
+    SysrstCtrlPadKey2 = 2
+  } sysrst_ctrl_pad_key_idx_e;
+
   // Typical SPI flash opcodes.
   typedef enum bit [7:0] {
     SpiFlashReadJedec    = 8'h9F,

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv
@@ -31,7 +31,10 @@ class chip_sw_sysrst_ctrl_outputs_vseq extends chip_sw_base_vseq;
   virtual task pre_start();
     super.pre_start();
     // Initialize the pad input to 0 to avoid having X values in the initial test phase.
-    set_loopback_pads(0);
+    cfg.chip_vif.sysrst_ctrl_if.pins_pd[SysrstCtrlPadKey0] = 1;
+    cfg.chip_vif.sysrst_ctrl_if.pins_pd[SysrstCtrlPadKey1] = 1;
+    cfg.chip_vif.sysrst_ctrl_if.pins_pd[SysrstCtrlPadKey2] = 1;
+    cfg.chip_vif.pwrb_in_if.pins_pd[0] = 1;
   endtask
 
   virtual function void write_test_phase(input test_phases_e phase);


### PR DESCRIPTION
PR #15546 fixes a regression issue by assigning an initial value to sysrst_ctrl input. However, a better way (I think) to do it is to use the pulldown method.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>