### PR TITLE
[dv/chip] Fix prim_tl_access xcelium failure

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -560,6 +560,8 @@ interface chip_if;
 
   wire pwrmgr_low_power = `PWRMGR_HIER.low_power_o;
 
+  wire ast_tlul_rst = `AST_HIER.rst_ast_tlul_ni;
+
   // alert_esc_if alert_if[NUM_ALERTS](.clk  (`ALERT_HANDLER_HIER.clk_i),
   //                                   .rst_n(`ALERT_HANDLER_HIER.rst_ni));
   // for (genvar i = 0; i < NUM_ALERTS; i++) begin : gen_alert_rx_conn

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_prim_tl_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_prim_tl_access_vseq.sv
@@ -6,7 +6,7 @@
 // This sequence access prim_tlul access with randomly backdoor-loaded LC state.
 // If the LC state gates the prim_tlul interface, we are expecting to see a TLUL d_error.
 // In current chip-level design, only otp_ctrl's prim_tl_i/o will be gated by lc_dft_en_i.
-class chip_prim_tl_access_vseq extends chip_stub_cpu_base_vseq;
+class chip_prim_tl_access_vseq extends chip_common_vseq;
   `uvm_object_utils(chip_prim_tl_access_vseq)
 
   `uvm_object_new

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -67,6 +67,10 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
 
     if (cfg.mem_bkdr_util_h[Otp].read32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset) ==
         prim_mubi_pkg::MuBi4True) begin
+
+      // Wait for AST tlul interface reset signal set to 1.
+      `DV_WAIT(cfg.chip_vif.ast_rst == 1;)
+
       for (int i = 0; i < ast_pkg::AstRegsNum; i++) begin
         data = cfg.mem_bkdr_util_h[Otp].read32(otp_ctrl_reg_pkg::CreatorSwCfgAstCfgOffset + i * 4);
         `uvm_info(`gfn, $sformatf("Writing 0x%0h to 0x%0h", data, ast_addr), UVM_MEDIUM)


### PR DESCRIPTION
This PR fixes prim_tl_access xcelium failure due to the following scenario:
In dut_init, the stub_cpu sequence tries to write ast's csr. But in xcelium, it happened before the ast_tlul_rst is set to 1. So the write is ignored.

The fix is to wait for the reset to set to 1 before doing the CSR write.

This fixes issue #15459.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>