### PR TITLE
[top/dv] Invalidate cache prior to execution from sram

### DIFF
--- a/sw/device/tests/sim_dv/sram_ctrl_execution_test_main.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_execution_test_main.c
@@ -173,11 +173,13 @@ void do_execute_test(bool debug_func, bool ifetch_en) {
 
   CHECK_DIF_OK(dif_sram_ctrl_exec_set_enabled(&sram_ctrl, kDifToggleEnabled));
   exception_observed = false;
+  icache_invalidate();
   execute_code_in_sram();
   CHECK(exception_observed == csr_enabled_exception_expected,
         "Expected exception not observed whilst executing from SRAM!");
   CHECK_DIF_OK(dif_sram_ctrl_exec_set_enabled(&sram_ctrl, kDifToggleDisabled));
   exception_observed = false;
+  icache_invalidate();
   execute_code_in_sram();
   CHECK(exception_observed == csr_disabled_exception_expected,
         "Expected exception not observed whilst executing from SRAM!");


### PR DESCRIPTION
- The test fails from time to time because the first execute_from_sram call can be cached.  That means when the second call is invoked, it is fetched out of icache instead of sram, causing the test to fail.

- The fix is simply to add an invalidate_icache command prior to invoking execute from sram.

- This will be something to be aware of when execute from sram is used in the future, we should probably always invalidate prior to jumping.

Signed-off-by: Timothy Chen <timothytim@google.com>