### PR TITLE
[dv,top-level] Fix all_escalation_resets test for flash_ctrl

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -61,6 +61,7 @@ cc_library(
     deps = [
         "//sw/device/lib/dif:alert_handler",
         "//sw/device/lib/dif:base",
+        "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/testing/test_framework:check",
     ],
 )

--- a/sw/device/lib/testing/alert_handler_testutils.c
+++ b/sw/device/lib/testing/alert_handler_testutils.c
@@ -2,12 +2,87 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/dif/dif_alert_handler.h"
 #include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
 #include "alert_handler_regs.h"  // Generated
+
+/**
+ * This is used to traverse the dump treating it as an array of bits, and
+ * extract a number of bits placing them in a uint32_t. The word and bit index
+ * are updated by num_bits before returning.
+ */
+static uint32_t get_next_n_bits(
+    int num_bits, const dif_rstmgr_alert_info_dump_segment_t *dump,
+    int *word_index, int *bit_index) {
+  CHECK(num_bits <= 32);
+  CHECK(*bit_index < 32);
+  uint32_t word = dump[*word_index] >> *bit_index;
+  if (*bit_index + num_bits >= 32) {
+    (*word_index) += 1;
+    *bit_index = *bit_index + num_bits - 32;
+  } else {
+    *bit_index += num_bits;
+  }
+  word &= (1 << num_bits) - 1;
+  return word;
+}
+
+alert_info_t alert_info_dump_to_struct(
+    const dif_rstmgr_alert_info_dump_segment_t *dump, int dump_size) {
+  int word_index = 0;
+  int bit_index = 0;
+  alert_info_t info;
+  for (int i = 0; i < ALERT_HANDLER_PARAM_N_CLASSES; ++i) {
+    info.class_esc_state[i] = get_next_n_bits(3, dump, &word_index, &bit_index);
+  }
+  for (int i = 0; i < ALERT_HANDLER_PARAM_N_CLASSES; ++i) {
+    info.class_esc_cnt[i] = get_next_n_bits(32, dump, &word_index, &bit_index);
+  }
+  for (int i = 0; i < ALERT_HANDLER_PARAM_N_CLASSES; ++i) {
+    info.class_accum_cnt[i] =
+        get_next_n_bits(16, dump, &word_index, &bit_index);
+  }
+  info.loc_alert_cause = get_next_n_bits(7, dump, &word_index, &bit_index);
+  CHECK(word_index < dump_size);
+  for (int i = 0; i < ALERT_HANDLER_PARAM_N_ALERTS; ++i) {
+    info.alert_cause[i] = get_next_n_bits(1, dump, &word_index, &bit_index);
+  }
+  CHECK(word_index < dump_size);
+  return info;
+}
+
+void alert_info_to_string(const alert_info_t *info) {
+  LOG_INFO("alert_info:");
+  LOG_INFO("esc_state [0]=%x, [1]=%x, [2]=%x, [3]=%x", info->class_esc_state[0],
+           info->class_esc_state[1], info->class_esc_state[2],
+           info->class_esc_state[3]);
+  LOG_INFO("esc_cnt [0]=0x%x, [1]=0x%x, [2]=0x%x, [3]=0x%x",
+           info->class_esc_cnt[0], info->class_esc_cnt[1],
+           info->class_esc_cnt[2], info->class_esc_cnt[3]);
+  LOG_INFO("accum_cnt [0]=0x%x, [1]=0x%x, [2]=0x%x, [3]=0x%x",
+           info->class_accum_cnt[0], info->class_accum_cnt[1],
+           info->class_accum_cnt[2], info->class_accum_cnt[3]);
+  LOG_INFO("loc_alert_cause=0x%x", info->loc_alert_cause);
+  char cause_bits[81];
+  cause_bits[80] = '\0';
+  int string_index = 0;
+  for (int i = 0; i < ALERT_HANDLER_PARAM_N_ALERTS; ++i) {
+    cause_bits[string_index] = info->alert_cause[i] ? '1' : '0';
+    ++string_index;
+    if (i % 8 == 0) {
+      cause_bits[string_index] = '_';
+      ++string_index;
+    }
+  }
+  cause_bits[string_index] = '\0';
+  LOG_INFO("alert_cause=%s (in increasing order left to right)", cause_bits);
+}
 
 void alert_handler_testutils_configure_all(
     const dif_alert_handler_t *alert_handler, dif_alert_handler_config_t config,
@@ -67,4 +142,8 @@ uint32_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds) {
         "The value 0x%08x%08x can't fit into the 32 bits timer counter.",
         (cycles >> 32), (uint32_t)cycles);
   return (uint32_t)cycles;
+}
+
+uint32_t alert_handler_testutils_cycle_rescaling_factor() {
+  return kDeviceType == kDeviceSimDV ? 1 : 10;
 }

--- a/sw/device/lib/testing/alert_handler_testutils.h
+++ b/sw/device/lib/testing/alert_handler_testutils.h
@@ -5,8 +5,49 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_ALERT_HANDLER_TESTUTILS_H_
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_ALERT_HANDLER_TESTUTILS_H_
 
+#include <stdbool.h>
+
 #include "sw/device/lib/dif/dif_alert_handler.h"
 #include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+
+#include "alert_handler_regs.h"
+
+typedef enum alert_handler_class_state {
+  kCstateIdle = 0,
+  kCstateTimeout = 1,
+  kCstateTerminal = 3,
+  kCstatePhase0 = 4,
+  kCstatePhase1 = 5,
+  kCstatePhase2 = 6,
+  kCstatePhase3 = 7,
+  kCstateFsmError = 2
+} alert_handler_class_state_t;
+
+/**
+ * Represents the hardware alert crash dump in a more software-friendly manner.
+ */
+typedef struct alert_info {
+  bool alert_cause[ALERT_HANDLER_PARAM_N_ALERTS];
+  uint8_t loc_alert_cause;                                  // 7bit
+  uint16_t class_accum_cnt[ALERT_HANDLER_PARAM_N_CLASSES];  // 4x16bit
+  uint32_t class_esc_cnt[ALERT_HANDLER_PARAM_N_CLASSES];    // 4x32bit
+  alert_handler_class_state_t
+      class_esc_state[ALERT_HANDLER_PARAM_N_CLASSES];  // 4x3bit
+} alert_info_t;
+
+/**
+ * Converts the hardware alert crash dump into an alert_info_t.
+ *
+ * This makes it easier to compare and display the different fields.
+ */
+alert_info_t alert_info_dump_to_struct(
+    const dif_rstmgr_alert_info_dump_segment_t *dump, int dump_size);
+
+/**
+ * Displays an alert_info_t as strings.
+ */
+void alert_info_to_string(const alert_info_t *info);
 
 /**
  * Configures alert handler with all required runtime information.
@@ -29,5 +70,23 @@ void alert_handler_testutils_configure_all(
  * Returns the number of cycles corresponding to the given microseconds.
  */
 uint32_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds);
+
+/**
+ * Returns a scaling factor for conversion of time to cycles.
+ *
+ * Setting escalation cycle counts must be such that the ISRs have time to
+ * complete before the next escalation stage starts. We tend to generate cycle
+ * counts from time durations, and given that the relevant clock frequencies
+ * are much lower in non-sim_dv devices we may end up having to set quite high
+ * time durations to avoid incomplete ISRs for fpga or verilator.
+ *
+ * This function allows the time durations to be set for the sim_dv clock
+ * frequencies, and other platforms get the cycle count rescaled by a factor
+ * of 10. It should be used in the conversion of time duration to cycle counts,
+ * as in
+ *  cycles = udiv64_slow(micros * clockFreqHz, 1000000, NULL) *
+ *           cycle_rescaling_factor();
+ */
+uint32_t alert_handler_testutils_cycle_rescaling_factor();
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_ALERT_HANDLER_TESTUTILS_H_

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -211,9 +211,9 @@ bool test_main(void) {
       &plic, kPlicTarget, kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired,
       kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark);
 
-  // Executing the test using randon time bounds calculated from the clock
+  // Executing the test using random time bounds calculated from the clock
   // frequency to make sure the aon timer is generating the interrupt after the
-  // choosen time and there's no error in the reference time measurement. This
+  // chosen time and there's no error in the reference time measurement. This
   // calculation is required as the various platforms used for testing have
   // differing clocks frequencies. A minimum amount of cycles is required for
   // the interrupt to note the elapsed time so the test fails with an

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -397,6 +397,7 @@ opentitan_functest(
         "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/dif:sram_ctrl",
+        "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:alert_handler_testutils",
         "//sw/device/lib/testing:aon_timer_testutils",

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -66,10 +66,6 @@ enum {
   kEscalationPhase2Micros = 50,                               // 50 us
 };
 
-uint32_t cycle_rescaling_factor() {
-  return kDeviceType == kDeviceSimDV ? 1 : 10;
-}
-
 static_assert(
     kWdogBarkMicros < kWdogBiteMicros &&
         kWdogBarkMicros > kEscalationPhase0Micros &&
@@ -183,28 +179,24 @@ static void alert_handler_config(void) {
       {.phase = kDifAlertHandlerClassStatePhase0,
        .signal = 0,
        .duration_cycles =
-           udiv64_slow(kEscalationPhase0Micros * kClockFreqPeripheralHz,
-                       1000000, NULL) *
-           cycle_rescaling_factor()},
+           alert_handler_testutils_get_cycles_from_us(kEscalationPhase0Micros) *
+           alert_handler_testutils_cycle_rescaling_factor()},
       {.phase = kDifAlertHandlerClassStatePhase1,
        .signal = 1,
        .duration_cycles =
-           udiv64_slow(kEscalationPhase1Micros * kClockFreqPeripheralHz,
-                       1000000, NULL) *
-           cycle_rescaling_factor()},
+           alert_handler_testutils_get_cycles_from_us(kEscalationPhase1Micros) *
+           alert_handler_testutils_cycle_rescaling_factor()},
       {.phase = kDifAlertHandlerClassStatePhase2,
        .signal = 3,
        .duration_cycles =
-           udiv64_slow(kEscalationPhase2Micros * kClockFreqPeripheralHz,
-                       1000000, NULL) *
-           cycle_rescaling_factor()}};
+           alert_handler_testutils_get_cycles_from_us(kEscalationPhase2Micros) *
+           alert_handler_testutils_cycle_rescaling_factor()}};
 
   dif_alert_handler_class_config_t class_config[] = {{
       .auto_lock_accumulation_counter = kDifToggleDisabled,
       .accumulator_threshold = 0,
-      .irq_deadline_cycles =
-          udiv64_slow(10 * kClockFreqPeripheralHz, 1000000, NULL) *
-          cycle_rescaling_factor(),
+      .irq_deadline_cycles = alert_handler_testutils_get_cycles_from_us(10) *
+                             alert_handler_testutils_cycle_rescaling_factor(),
       .escalation_phases = esc_phases,
       .escalation_phases_len = ARRAYSIZE(esc_phases),
       .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase3,
@@ -235,10 +227,10 @@ static void config_escalate(dif_aon_timer_t *aon_timer,
                             const dif_pwrmgr_t *pwrmgr) {
   uint64_t bark_cycles =
       udiv64_slow(kWdogBarkMicros * kClockFreqAonHz, 1000000, NULL) *
-      cycle_rescaling_factor();
+      alert_handler_testutils_cycle_rescaling_factor();
   uint64_t bite_cycles =
       udiv64_slow(kWdogBiteMicros * kClockFreqAonHz, 1000000, NULL) *
-      cycle_rescaling_factor();
+      alert_handler_testutils_cycle_rescaling_factor();
 
   CHECK(bite_cycles < UINT32_MAX,
         "The value %u can't fit into the 32 bits timer counter.", bite_cycles);

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
@@ -67,10 +67,6 @@ enum {
   kEscalationPhase2Micros = 50,                               // 50 us
 };
 
-uint32_t cycle_rescaling_factor() {
-  return kDeviceType == kDeviceSimDV ? 1 : 10;
-}
-
 static_assert(
     kWdogBarkMicros < kWdogBiteMicros &&
         kWdogBarkMicros > kEscalationPhase0Micros &&
@@ -184,28 +180,24 @@ static void alert_handler_config(void) {
       {.phase = kDifAlertHandlerClassStatePhase0,
        .signal = 0,
        .duration_cycles =
-           udiv64_slow(kEscalationPhase0Micros * kClockFreqPeripheralHz,
-                       1000000, NULL) *
-           cycle_rescaling_factor()},
+           alert_handler_testutils_get_cycles_from_us(kEscalationPhase0Micros) *
+           alert_handler_testutils_cycle_rescaling_factor()},
       {.phase = kDifAlertHandlerClassStatePhase1,
        .signal = 1,
        .duration_cycles =
-           udiv64_slow(kEscalationPhase1Micros * kClockFreqPeripheralHz,
-                       1000000, NULL) *
-           cycle_rescaling_factor()},
+           alert_handler_testutils_get_cycles_from_us(kEscalationPhase1Micros) *
+           alert_handler_testutils_cycle_rescaling_factor()},
       {.phase = kDifAlertHandlerClassStatePhase2,
        .signal = 3,
        .duration_cycles =
-           udiv64_slow(kEscalationPhase2Micros * kClockFreqPeripheralHz,
-                       1000000, NULL) *
-           cycle_rescaling_factor()}};
+           alert_handler_testutils_get_cycles_from_us(kEscalationPhase2Micros) *
+           alert_handler_testutils_cycle_rescaling_factor()}};
 
   dif_alert_handler_class_config_t class_config[] = {{
       .auto_lock_accumulation_counter = kDifToggleDisabled,
       .accumulator_threshold = 0,
-      .irq_deadline_cycles =
-          udiv64_slow(10 * kClockFreqPeripheralHz, 1000000, NULL) *
-          cycle_rescaling_factor(),
+      .irq_deadline_cycles = alert_handler_testutils_get_cycles_from_us(10) *
+                             alert_handler_testutils_cycle_rescaling_factor(),
       .escalation_phases = esc_phases,
       .escalation_phases_len = ARRAYSIZE(esc_phases),
       .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase3,
@@ -236,10 +228,10 @@ static void config_escalate(dif_aon_timer_t *aon_timer,
                             const dif_pwrmgr_t *pwrmgr) {
   uint64_t bark_cycles =
       udiv64_slow(kWdogBarkMicros * kClockFreqAonHz, 1000000, NULL) *
-      cycle_rescaling_factor();
+      alert_handler_testutils_cycle_rescaling_factor();
   uint64_t bite_cycles =
       udiv64_slow(kWdogBiteMicros * kClockFreqAonHz, 1000000, NULL) *
-      cycle_rescaling_factor();
+      alert_handler_testutils_cycle_rescaling_factor();
 
   CHECK(bite_cycles < UINT32_MAX,
         "The value %u can't fit into the 32 bits timer counter.", bite_cycles);


### PR DESCRIPTION
Capture the alert info dump to confirm the alert after the escalation reset. For flash_ctrl onlyh, ignore the check for ISRs having run, since flash accesses are blocked for flash_ctrl integrity errors. Provide a partial solution to #8945.
Fixes a TODO in rstmgr_alert_info_test.c related to the creation of the C struct equivalent to the hardware bit stream for alert_info dump. Replaces some code that computes cycle counts from time durations by the corresponding code in alert_handler_testutils.

Fixes #14899

Signed-off-by: Guillermo Maturana <maturana@google.com>