### PR TITLE
[spi_device/dv] Add covergroups for flash/passthrough mode

### DIFF
--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -542,6 +542,7 @@
     {
       name: flash_cmd_info_cg
       desc: '''
+            Cover flash/passthrough mode.
             Cover all opcode enabled in cmd info.
             Cover all payload direction.
             Cover all address modes.
@@ -550,10 +551,10 @@
             Cover upload enable.
             Cover busy enable.
             Cover all dummy sizes.
-            Cover all payload enables.
+            Cover number of payload lanes (single, dual and quad modes or no payload).
 
-            cross payload directions, address modes, addr/payload swap enable.
-            cross payload directions, address modes, payload enables.
+            cross mode, payload directions, address modes, addr/payload swap enable.
+            cross mode, payload directions, dummy sizes, number of lanes.
             '''
     }
     {
@@ -592,7 +593,7 @@
             Cover payload size of upload transaction exceeds 256B limit (wrap around).'''
     }
     {
-      name: flash_busy_bit_cg
+      name: flash_command_while_busy_set_cg
       desc: '''
             Cover host sends flash commands while busy bit is set.
             Cover above with filter enabled/disabled on that command.
@@ -632,22 +633,22 @@
             '''
     }
     {
-      name: spi_device_buffer_boundary_cg
+      name: sw_update_addr4b_cg
       desc: '''
-            Cover buffer boundary crossing (2 buffer flips).'''
-    }
-    {
-      name: spi_device_lanes_cg
-      desc: '''
-            Cover out commands that use dual mode.
-            Cover out commands that use quad mode.
-            Cross dual and quad modes with flash/passthrough mode.'''
+            Cover SW updating addr4b to another value.
+            '''
     }
     {
       name: spi_device_write_enable_disable_cg
       desc: '''
             Cover write enable and write disable commands.
             Cross this with the previous flash_status.wel value.'''
+    }
+    {
+      name: spi_device_buffer_boundary_cg
+      desc: '''
+            Cover all the read commands.
+            Cover buffer boundary crossing (2 buffer flips).'''
     }
     {
       name: tpm_interleave_with_flash_item_cg

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -155,8 +155,14 @@ package spi_device_env_pkg;
   parameter bit[7:0] EN4B                        = 8'hB7;
   parameter bit[7:0] EX4B                        = 8'hE9;
 
-  parameter bit[7:0] READ_CMD_LIST[] = {READ_NORMAL, READ_FAST, READ_DUAL,
-                                        READ_QUAD, READ_DUALIO, READ_QUADIO};
+  `define ALL_READ_CMDS \
+      READ_NORMAL, READ_FAST, READ_DUAL, READ_QUAD, READ_DUALIO, READ_QUADIO
+  `define ALL_INTERNAL_PROCESS_CMDS \
+      READ_JEDEC, READ_SFDP, READ_STATUS_1, READ_STATUS_2, READ_STATUS_3, `ALL_READ_CMDS
+  parameter bit[7:0] READ_CMD_LIST[] = {`ALL_READ_CMDS};
+  // exclude WREN, WRDI, EN4B, EX4B
+  parameter bit[7:0] INTERNAL_PROCESS_CMD_LIST[] = {`ALL_INTERNAL_PROCESS_CMDS};
+
   string msg_id = "spi_device_env_pkg";
 
   // functions


### PR DESCRIPTION
1. Implement covergroups and sample them in scb
2. Minor updates in testplan
  - consolidate 2 covergroups
  - add sw_update_addr4b_cg

Signed-off-by: Weicai Yang <weicai@google.com>