### PR TITLE
[top/dv] Fix chip_tap_strap tests

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -384,7 +384,7 @@ interface chip_if;
   // Whether the desired JTAG TAP will actually selected or not depends on the LC state and the
   // window of time when the TAP straps are set. It is upto the test sequence to orchestrate it
   // correctly. Disconnect the TAP strap interface to free up the muxed IOs.
-  wire __enable_jtag = (|(tap_straps_if.pins_oe & tap_straps_if.pins_o));
+  wire __enable_jtag = |tap_straps_if.pins_oe;
   jtag_if jtag_if();
 
   assign ios[IoR0] = __enable_jtag ? jtag_if.tms : 1'bz;
@@ -392,6 +392,16 @@ interface chip_if;
   assign ios[IoR2] = __enable_jtag ? jtag_if.tdi : 1'bz;
   assign ios[IoR3] = __enable_jtag ? jtag_if.tck : 1'bz;
   assign ios[IoR4] = __enable_jtag ? jtag_if.trst_n : 1'bz;
+
+  function automatic void set_tdo_pull(bit value);
+    if (value) begin
+      ios_if.pins_pd[IoR1] = 0;
+      ios_if.pins_pu[IoR1] = 1;
+    end else begin
+      ios_if.pins_pu[IoR1] = 0;
+      ios_if.pins_pd[IoR1] = 1;
+    end
+  endfunction
 
   // Functional (muxed) interface: Flash controller JTAG.
   bit enable_flash_ctrl_jtag, flash_ctrl_jtag_enabled;


### PR DESCRIPTION
The test had three issues previously
1. There were no default pulls on the JTAG pins, so when the tb's default pull downs
   were removed, x's would propagate into jtag_if when the jtag interface was not enabled.
   Normally this would not matter, but the test specifically checks that the interface
   is inactive with 0's.

2. The DFT tap test randomly toggles the JTAG pins through forces and releases.
   After the last release the trst_n line can sometimes remain 0.
   This causes jtag transactions to fall through and the whole test to
   misbehave.

3. Similar to issue 1, if the jtag taps were actively driven to 0, the jtag_if
   became completely floating, this also interfered with the test's expectations.

These fixes should allow the chip_strap_tap tests to run again.