### PR TITLE
[aes/dv] Adds security measure verification

### DIFF
--- a/hw/ip/aes/data/aes_sec_cm_testplan.hjson
+++ b/hw/ip/aes/data/aes_sec_cm_testplan.hjson
@@ -181,12 +181,11 @@
       stage: V2S
       tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
     }
-      // TODO how to check is this? I think we talked about this not beeing feasible
     {
       name: sec_cm_data_reg_local_esc
       desc: "Verify the countermeasure(s) DATA_REG.LOCAL_ESC."
       stage: V2S
-      tests: []
+      tests: ["aes_alert_reset"]
     }
   ]
 }

--- a/hw/ip/aes/dv/cov/aes_cov_if.sv
+++ b/hw/ip/aes/dv/cov/aes_cov_if.sv
@@ -293,11 +293,6 @@ interface aes_cov_if
   endgroup // aes_reg_interleave_cg
 
 
-  //TODO
-  //LC escalate -> FSM DEADLOCK
-  // will be covered by Assertion
-
-
   ///////////////////////////////////
   // Instantiation Macros          //
   ///////////////////////////////////

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -91,7 +91,6 @@ class aes_base_vseq extends cip_base_vseq #(
   virtual task set_ctrl_aux_shadowed(bit val);
     csr_wr(.ptr(ral.ctrl_aux_shadowed), .value(val), .en_shadow_wr(1'b1), .blocking(1));
   endtask // set_ctrl_aux_shadowed
-
   virtual task prng_reseed();
     bit [TL_DW:0] reg_val = '0;
     reg_val[5] = 1'b1;

--- a/hw/ip/aes/dv/sva/aes_bind.sv
+++ b/hw/ip/aes/dv/sva/aes_bind.sv
@@ -30,6 +30,7 @@ module aes_bind;
   bind aes aes_reseed_if u_aes_reseed_if (
     .clk_i                 (clk_i),
     .rst_ni                (rst_ni),
+    .local_esc             (lc_escalate_en_i),
     .entropy_clearing_req  (entropy_clearing_req),
     .entropy_clearing_ack  (entropy_clearing_ack),
     .entropy_masking_req   (entropy_masking_req),
@@ -48,7 +49,13 @@ module aes_bind;
     .block_ctr_decr        (u_aes_core.u_aes_control.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.
                             u_aes_control_fsm.block_ctr_decr),
     .block_ctr_expr        (u_aes_core.u_aes_control.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.
-                            u_aes_control_fsm.block_ctr_expr)
+                            u_aes_control_fsm.block_ctr_expr),
+    .add_round_key_out     (u_aes_core.u_aes_cipher_core.add_round_key_out),
+    .iv_q                  (u_aes_core.iv_q),
+    .iv_d                  (u_aes_core.iv_d),
+    .data_in_prev_q        (u_aes_core.data_in_prev_q),
+    .data_out_q            (u_aes_core.data_out_q),
+    .data_out_d            (u_aes_core.data_out_d)
   );
 
 if (`EN_MASKING) begin : gen_prng_bind

--- a/hw/ip/aes/dv/sva/aes_reseed_if.sv
+++ b/hw/ip/aes/dv/sva/aes_reseed_if.sv
@@ -12,24 +12,34 @@ interface aes_reseed_if
   parameter int unsigned EntropyWidth = edn_pkg::ENDPOINT_BUS_WIDTH,
   parameter bit          SecMasking   = `EN_MASKING
 ) (
-  input logic                    clk_i,
-  input logic                    rst_ni,
-  input logic                    entropy_clearing_req,
-  input logic                    entropy_clearing_ack,
-  input logic                    entropy_masking_req,
-  input logic                    entropy_masking_ack,
-  input prs_rate_e               prng_reseed_rate,
-  input logic                    entropy_req_o,
-  input logic                    entropy_ack_i,
-  input logic                    seed_en,
-  input logic [EntropyWidth-1:0] entropy_i,
-  input logic [EntropyWidth-1:0] buffer_q,
-  input logic [Width-1:0]        lfsr_q,
-  input logic                    ctrl_phase_i,
-  input logic                    ctrl_we_q,
-  input logic                    block_ctr_decr,
-  input logic                    block_ctr_expr
+  input logic                                      clk_i,
+  input logic                                      rst_ni,
+  input                                            lc_ctrl_pkg::lc_tx_t local_esc,
+  input logic                                      entropy_clearing_req,
+  input logic                                      entropy_clearing_ack,
+  input logic                                      entropy_masking_req,
+  input logic                                      entropy_masking_ack,
+  input                                            prs_rate_e prng_reseed_rate,
+  input logic                                      entropy_req_o,
+  input logic                                      entropy_ack_i,
+  input logic                                      seed_en,
+  input logic [EntropyWidth-1:0]                   entropy_i,
+  input logic [EntropyWidth-1:0]                   buffer_q,
+  input logic [Width-1:0]                          lfsr_q,
+  input logic                                      ctrl_phase_i,
+  input logic                                      ctrl_we_q,
+  input logic                                      block_ctr_decr,
+  input logic                                      block_ctr_expr,
+  input logic [3:0][3:0][7:0]                      add_round_key_out[SecMasking ? 2 : 1],
+  input logic [NumSlicesCtr-1:0][SliceSizeCtr-1:0] iv_q,
+  input logic [NumSlicesCtr-1:0][SliceSizeCtr-1:0] iv_d,
+  input logic [NumRegsData-1:0][31:0]              data_in_prev_q,
+  input logic [NumRegsData-1:0][31:0]              data_out_q,
+  input logic [NumRegsData-1:0][31:0]              data_out_d
   );
+
+  logic [3:0][3:0][7:0]                            round_key;
+  logic [3:0][3:0][7:0]                            data_out;
 
   logic [Width-1:0] seed;
   assign seed = {buffer_q, entropy_i};
@@ -47,4 +57,21 @@ interface aes_reseed_if
   // check the reseed happens after the block counter resets (when control register is updated)
   `ASSERT(MaskingPrngReseedCorrectAfter_A, (SecMasking && ctrl_we_q && !ctrl_phase_i) |->
           ##[1:$] entropy_masking_req);
+
+  // local esc checks #15433
+  assign round_key = SecMasking ?
+         (add_round_key_out[1] ^ add_round_key_out[0]) : add_round_key_out[0];
+
+  `ASSERT(DataOutRoundKey_A, !((local_esc == lc_ctrl_pkg::On) &&
+                               (aes_transpose(round_key) == data_out_d )));
+  `ASSERT(DataOutRoundKey_B, !((local_esc == lc_ctrl_pkg::On) &&
+                              ((aes_transpose(round_key) == data_out_d )^iv_q)));
+  `ASSERT(DataOutRoundKey_C, !((local_esc == lc_ctrl_pkg::On) &&
+                              ((aes_transpose(round_key) == data_out_d )^data_in_prev_q)));
+  `ASSERT(IvRoundKey_A,      !((local_esc == lc_ctrl_pkg::On) &&
+                              ((aes_transpose(round_key) == iv_d ))));
+  `ASSERT(IvRoundKey_B,      !((local_esc == lc_ctrl_pkg::On) &&
+                              ((aes_transpose(round_key) == iv_d )^iv_q)));
+  `ASSERT(IvRoundKey_C,      !((local_esc == lc_ctrl_pkg::On) &&
+                              ((aes_transpose(round_key) == iv_d )^data_in_prev_q)));
 endinterface // aes_reseed_if


### PR DESCRIPTION
this PR adds two things
1. the readability test has been updated to check that registers are cleared with pseudo random data
2.  assertions in the reseed interface to make sure information is not spilled into readable registers on local esc asserted.
this PR relates to Issue #13579 
this leaves two outstanding issues in the sec_cm testplan
