### PR TITLE
[ci] Fix typo in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       # Updates are scheduled at the beginning of the work week.
       interval: "weekly"
-      day: "Monday"
+      day: "monday"
       time: "02:00"
       # US Pacific Time
       timezone: "America/Los_Angeles"


### PR DESCRIPTION
Day must be lower case. See [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleday).