### PR TITLE
[test] Add test for SYSRST CTRL to detect input change

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1673,13 +1673,15 @@
               pins to trigger an interrupt by writing to key_intr_ctl register.
             - Program the key_intr_debounce_ctl register to debounce an appropriate time.
             - Enable the interrupt at SYSRST ctrl as well as at the PLIC.
+            - Create glitches only for some time less than detection time and check that there is no
+            - interrupt triggered.
             - Glitch the inputs at the chip IOs before stabilizing on the programmed transitions.
             - SW services the interrupt when triggered, verifies the pin input value and
               key_intr_status for correctness and clears the interrupt status.
-            - Verify separately, eack key combination sufccessfully generates an interrupt.
+            - Verify separately, each key combination sufccessfully generates an interrupt.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_sysrst_ctrl_in_irq"]
     }
     {
       name: chip_sw_sysrst_ctrl_sleep_wakeup

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -759,6 +759,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_sysrst_ctrl_in_irq
+      uvm_test_seq: chip_sw_sysrst_ctrl_in_irq_vseq
+      sw_images: ["//sw/device/tests/sim_dv:sysrst_ctrl_in_irq_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_sysrst_ctrl_reset
       uvm_test_seq: chip_sw_sysrst_ctrl_reset_vseq
       sw_images: ["//sw/device/tests/sim_dv:sysrst_ctrl_reset_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -69,6 +69,7 @@ filesets:
       - seq_lib/chip_sw_uart_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_rand_baudrate_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_inputs_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_sysrst_ctrl_in_irq_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_in_irq_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_in_irq_vseq.sv
@@ -1,0 +1,114 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_sysrst_ctrl_in_irq_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_sysrst_ctrl_in_irq_vseq)
+
+  `uvm_object_new
+
+  localparam string PAD_KEY0_PATH = "tb.dut.IOB3";
+  localparam string PAD_KEY1_PATH = "tb.dut.IOB6";
+  localparam string PAD_KEY2_PATH = "tb.dut.IOB8";
+  localparam string PAD_PWRB_PATH = "tb.dut.IOR13";
+  localparam string PAD_ACPRES_PATH = "tb.dut.IOC7";
+  localparam string PAD_LIDOPEN_PATH = "tb.dut.IOC9";
+  localparam string PAD_ECRST_PATH = "tb.dut.IOR8";
+  localparam string PAD_FLASHWP_PATH = "tb.dut.IOR9";
+
+  int test_phase = 0;
+
+  virtual function void set_pads(input bit [7:0] pad_values);
+    `DV_CHECK(uvm_hdl_force(PAD_PWRB_PATH, pad_values[0]));
+    `DV_CHECK(uvm_hdl_force(PAD_KEY0_PATH, pad_values[1]));
+    `DV_CHECK(uvm_hdl_force(PAD_KEY1_PATH, pad_values[2]));
+    `DV_CHECK(uvm_hdl_force(PAD_KEY2_PATH, pad_values[3]));
+    `DV_CHECK(uvm_hdl_force(PAD_ACPRES_PATH, pad_values[4]));
+    `DV_CHECK(uvm_hdl_force(PAD_ECRST_PATH, pad_values[5]));
+    `DV_CHECK(uvm_hdl_force(PAD_FLASHWP_PATH, pad_values[6]));
+    `DV_CHECK(uvm_hdl_force(PAD_LIDOPEN_PATH, pad_values[7]));
+  endfunction
+
+  virtual function void write_test_phase(input int phase);
+    bit [7:0] test_phase[1];
+    test_phase[0] = phase;
+    sw_symbol_backdoor_overwrite("kCurrentTestPhase", test_phase);
+  endfunction
+
+  virtual task create_glitch_on_pads(time glitch_duration, bit [7:0] pad_values_prev,
+                                     bit [7:0] pad_values_next);
+    time glitch_pulse_duration;
+    while (glitch_duration > 0ns) begin
+      glitch_pulse_duration = $urandom_range(0, glitch_duration);
+      glitch_duration -= glitch_pulse_duration;
+      set_pads(pad_values_prev);
+      #glitch_pulse_duration;
+
+      glitch_pulse_duration = $urandom_range(0, glitch_duration);
+      glitch_duration -= glitch_pulse_duration;
+      set_pads(pad_values_next);
+      #glitch_pulse_duration;
+    end
+  endtask
+
+  virtual task sync_with_sw();
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
+  endtask
+
+  virtual task set_pads_and_synch(time glitch_duration, bit [7:0] pad_values_prev,
+                                  bit [7:0] pad_values_next);
+    sync_with_sw();
+
+    // Apply glitch with a total length less than the detection timer and check
+    // that the interrupt is not triggered in sw side.
+    set_pads(pad_values_prev);
+    create_glitch_on_pads(glitch_duration, pad_values_prev, pad_values_next);
+    set_pads(pad_values_prev);
+    #10us;
+
+    write_test_phase(++test_phase);
+
+    sync_with_sw();
+
+    // Apply an input pulse with a glitch and check that there is only one
+    // interrupt is triggered in sw side, not multiple.
+    set_pads(pad_values_prev);
+    #10us;
+    create_glitch_on_pads(glitch_duration, pad_values_prev, pad_values_next);
+    set_pads(pad_values_next);
+
+    write_test_phase(++test_phase);
+  endtask
+
+  virtual task body();
+    super.body();
+
+    // Set initial value.
+    set_pads(8'b00000000);
+
+    // Test 7 H2L input transition.
+    for (int i = 0; i < 7; i++) begin
+      set_pads_and_synch(500ns, (8'b00000001 << i), 8'b00000000);
+    end
+
+    // Test 7 L2H input transition.
+    for (int i = 0; i < 7; i++) begin
+      set_pads_and_synch(500ns, 8'b00000000, (8'b00000001 << i));
+    end
+
+    // Test 4 different combo key intr sources with 2, 3, 4 and 5 combo key
+    // transition H2L.
+    set_pads_and_synch(500ns, 8'b00000011, 8'b00000000);
+
+    set_pads_and_synch(500ns, 8'b00011100, 8'b00000000);
+
+    set_pads_and_synch(500ns, 8'b00011011, 8'b00000000);
+
+    set_pads_and_synch(500ns, 8'b00011111, 8'b00000000);
+
+    // Last sync with sw.
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -24,6 +24,7 @@
 `include "chip_sw_uart_tx_rx_vseq.sv"
 `include "chip_sw_uart_rand_baudrate_vseq.sv"
 `include "chip_sw_sysrst_ctrl_inputs_vseq.sv"
+`include "chip_sw_sysrst_ctrl_in_irq_vseq.sv"
 `include "chip_sw_sysrst_ctrl_reset_vseq.sv"
 `include "chip_sw_sysrst_ctrl_outputs_vseq.sv"
 `include "chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv"

--- a/sw/device/lib/dif/dif_sysrst_ctrl.h
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.h
@@ -12,6 +12,7 @@
  */
 
 #include "sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.h"
+#include "sysrst_ctrl_regs.h"  // Generated.
 
 #ifdef __cplusplus
 extern "C" {
@@ -199,6 +200,108 @@ typedef enum dif_sysrst_ctrl_input_change {
    */
   kDifSysrstCtrlInputAll = ((1U << 15) - 1) & ~(1U << 7),
 } dif_sysrst_ctrl_input_change_t;
+
+/**
+ * System Reset Controller key interrupt sources.
+ */
+typedef enum dif_sysrst_ctrl_key_intr_src {
+  /**
+   * Power button input signal high-to-low.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputPowerButtonH2L =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_PWRB_H2L_BIT,
+  /**
+   * Key 0 input signal high-to-low.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputKey0H2L =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_KEY0_IN_H2L_BIT,
+  /**
+   * Key 1 input signal high-to-low.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputKey1H2L =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_KEY1_IN_H2L_BIT,
+  /**
+   * Key 2 input signal high-to-low.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputKey2H2L =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_KEY2_IN_H2L_BIT,
+  /**
+   * AC power present input signal high-to-low.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputAcPowerPresetH2L =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_AC_PRESENT_H2L_BIT,
+  /**
+   * Embedded controller reset input signal high-to-low.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputEcResetH2L =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_EC_RST_L_H2L_BIT,
+  /**
+   * Flash write protect input signal high-to-low.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputFlashWriteProtectH2L =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_FLASH_WP_L_H2L_BIT,
+  /**
+   * Power button input signal low-to-high.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputPowerButtonL2H =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_PWRB_L2H_BIT,
+  /**
+   * Key 0 input signal low-to-high.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputKey0L2H =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_KEY0_IN_L2H_BIT,
+  /**
+   * Key 1 input signal low-to-high.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputKey1L2H =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_KEY1_IN_L2H_BIT,
+  /**
+   * Key 2 input signal low-to-high.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputKey2L2H =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_KEY2_IN_L2H_BIT,
+  /**
+   * AC power present input signal low-to-high.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputAcPowerPresetL2H =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_AC_PRESENT_L2H_BIT,
+  /**
+   * Embedded controller reset input signal low-to-high.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputEcResetL2H =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_EC_RST_L_L2H_BIT,
+  /**
+   * Flash write protect input signal low-to-high.
+   */
+  kDifSysrstCtrlKeyIntrStatusInputFlashWriteProtectL2H =
+      1U << SYSRST_CTRL_KEY_INTR_STATUS_FLASH_WP_L_L2H_BIT,
+} dif_sysrst_ctrl_key_intr_src_t;
+
+/**
+ * System Reset Controller combo interrupt sources.
+ */
+typedef enum dif_sysrst_ctrl_combo_intr_src {
+  /**
+   * Power button input signal high-to-low.
+   */
+  kDifSysrstCtrlComboIntrStatusCombo0H2L =
+      1U << SYSRST_CTRL_COMBO_INTR_STATUS_COMBO0_H2L_BIT,
+  /**
+   * Key 0 input signal high-to-low.
+   */
+  kDifSysrstCtrlComboIntrStatusCombo1H2L =
+      1U << SYSRST_CTRL_COMBO_INTR_STATUS_COMBO1_H2L_BIT,
+  /**
+   * Key 1 input signal high-to-low.
+   */
+  kDifSysrstCtrlComboIntrStatusCombo2H2L =
+      1U << SYSRST_CTRL_COMBO_INTR_STATUS_COMBO2_H2L_BIT,
+  /**
+   * Key 2 input signal high-to-low.
+   */
+  kDifSysrstCtrlComboIntrStatusCombo3H2L =
+      1U << SYSRST_CTRL_COMBO_INTR_STATUS_COMBO3_H2L_BIT,
+} dif_sysrst_ctrl_combo_intr_src_t;
 
 /**
  * Runtime configuration for the System Reset Controller input signal change

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -182,6 +182,23 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "sysrst_ctrl_in_irq_test",
+    srcs = ["sysrst_ctrl_in_irq_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "sysrst_ctrl_reset_test",
     srcs = ["sysrst_ctrl_reset_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test.c
@@ -1,0 +1,253 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_sysrst_ctrl_t sysrst_ctrl;
+static dif_rv_plic_t plic;
+
+enum {
+  kCurrentTestPhaseTimeoutUsec = 20,
+  kPlicTarget = kTopEarlgreyPlicTargetIbex0,
+};
+
+static volatile dif_sysrst_ctrl_irq_t irq;
+static volatile top_earlgrey_plic_peripheral_t peripheral;
+dif_rv_plic_irq_id_t irq_id;
+
+// Test phase written by testbench.
+static volatile const uint8_t kCurrentTestPhase = 0;
+uint8_t phase = 0;
+
+enum {
+  kOutputNumPads = 0x8,
+  kOutputNunMioPads = 0x6,
+};
+
+static const dif_pinmux_index_t kPeripheralInputs[] = {
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey0In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey1In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey2In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonPwrbIn,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonAcPresent,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonLidOpen,
+};
+
+static const dif_pinmux_index_t kInputPads[] = {
+    kTopEarlgreyPinmuxInselIob3, kTopEarlgreyPinmuxInselIob6,
+    kTopEarlgreyPinmuxInselIob8, kTopEarlgreyPinmuxInselIor13,
+    kTopEarlgreyPinmuxInselIoc7, kTopEarlgreyPinmuxInselIoc9,
+};
+
+static const dif_sysrst_ctrl_pin_t kSysrstCtrlInputs[] = {
+    kDifSysrstCtrlPinKey0In,           kDifSysrstCtrlPinKey1In,
+    kDifSysrstCtrlPinKey2In,           kDifSysrstCtrlPinPowerButtonIn,
+    kDifSysrstCtrlPinAcPowerPresentIn, kDifSysrstCtrlPinLidOpenIn,
+    kDifSysrstCtrlPinEcResetInOut,     kDifSysrstCtrlPinFlashWriteProtectInOut,
+};
+
+void test_phase_sync() {
+  test_status_set(kTestStatusInTest);
+  test_status_set(kTestStatusInWfi);
+}
+
+/**
+ * Configure for input change detection, sync with DV side, wait for input
+ * change interrupt, check the interrupt cause and clear it.
+ */
+void sysrst_ctrl_input_change_detect(
+    dif_sysrst_ctrl_key_intr_src_t expected_key_intr_src) {
+  peripheral = UINT32_MAX;
+  IBEX_SPIN_FOR(phase++ == kCurrentTestPhase, kCurrentTestPhaseTimeoutUsec);
+
+  // Configure for input change.
+  dif_sysrst_ctrl_input_change_t input_change;
+  if (expected_key_intr_src >= kDifSysrstCtrlKeyIntrStatusInputPowerButtonL2H) {
+    input_change = (dif_sysrst_ctrl_input_change_t)expected_key_intr_src << 1;
+  } else {
+    input_change = (dif_sysrst_ctrl_input_change_t)expected_key_intr_src;
+  }
+  dif_sysrst_ctrl_input_change_config_t config = {
+      .input_changes = input_change,
+      .debounce_time_threshold = 1,  // 5us
+  };
+  CHECK_DIF_OK(
+      dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl, config));
+
+  test_phase_sync();
+
+  IBEX_SPIN_FOR(phase++ == kCurrentTestPhase, kCurrentTestPhaseTimeoutUsec);
+  // Check that the interrupt isn't triggered at the first part of the test.
+  CHECK(peripheral == UINT32_MAX,
+        "The interrupt is triggered during input glitch.");
+  test_phase_sync();
+
+  wait_for_interrupt();
+  // Check that the interrupt is triggered at the second part of the test.
+  CHECK(peripheral == kTopEarlgreyPlicPeripheralSysrstCtrlAon,
+        "The interrupt is not triggered during the test.");
+  CHECK(irq_id == kTopEarlgreyPlicIrqIdSysrstCtrlAonEventDetected,
+        "Wrong irq_id");
+
+  uint32_t causes;
+  CHECK_DIF_OK(
+      dif_sysrst_ctrl_input_change_irq_get_causes(&sysrst_ctrl, &causes));
+  CHECK(causes == expected_key_intr_src, "Intr cause do not match: %d vs %d!",
+        causes, (int)expected_key_intr_src);
+
+  CHECK_DIF_OK(
+      dif_sysrst_ctrl_input_change_irq_clear_causes(&sysrst_ctrl, causes));
+
+  // Reset configuration for input change.
+  config.input_changes = 0;
+  CHECK_DIF_OK(
+      dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl, config));
+}
+
+/**
+ * Configure for key combo change detection, sync with DV side, wait for input
+ * change interrupt, check the interrupt cause and clear it.
+ */
+void sysrst_ctrl_key_combo_detect(dif_sysrst_ctrl_key_combo_t key_combo,
+                                  uint32_t combo_keys) {
+  peripheral = UINT32_MAX;
+  IBEX_SPIN_FOR(phase++ == kCurrentTestPhase, kCurrentTestPhaseTimeoutUsec);
+
+  // Configure for key combo
+  dif_sysrst_ctrl_key_combo_config_t sysrst_ctrl_key_combo_config = {
+      .keys = combo_keys,
+      .detection_time_threshold = 1,
+      .actions = kDifSysrstCtrlKeyComboActionInterrupt,
+      .embedded_controller_reset_duration = 1,
+  };
+  CHECK_DIF_OK(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl, key_combo, sysrst_ctrl_key_combo_config));
+
+  test_phase_sync();
+
+  IBEX_SPIN_FOR(phase++ == kCurrentTestPhase, kCurrentTestPhaseTimeoutUsec);
+  // Check that the interrupt isn't triggered at the first part of the test.
+  CHECK(peripheral == UINT32_MAX,
+        "The interrupt is triggered during input glitch.");
+  test_phase_sync();
+
+  wait_for_interrupt();
+  // Check that the interrupt is triggered at the second part of the test.
+  CHECK(peripheral == kTopEarlgreyPlicPeripheralSysrstCtrlAon,
+        "The interrupt is not triggered during the test.");
+  CHECK(irq_id == kTopEarlgreyPlicIrqIdSysrstCtrlAonEventDetected,
+        "Wrong irq_id");
+
+  uint32_t causes;
+  CHECK_DIF_OK(dif_sysrst_ctrl_key_combo_irq_get_causes(&sysrst_ctrl, &causes));
+  CHECK(causes == key_combo, "Intr cause do not match: %d vs %d!", causes,
+        (int)key_combo);
+
+  CHECK_DIF_OK(
+      dif_sysrst_ctrl_key_combo_irq_clear_causes(&sysrst_ctrl, causes));
+
+  // Reset configuration for key combo.
+  sysrst_ctrl_key_combo_config.keys = 0;
+  CHECK_DIF_OK(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl, key_combo, sysrst_ctrl_key_combo_config));
+}
+
+/**
+ * External interrupt handler.
+ */
+void ottf_external_isr(void) {
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));
+
+  peripheral = (top_earlgrey_plic_peripheral_t)
+      top_earlgrey_plic_interrupt_for_peripheral[irq_id];
+
+  if (peripheral == kTopEarlgreyPlicPeripheralSysrstCtrlAon) {
+    irq =
+        (dif_sysrst_ctrl_irq_t)(irq_id -
+                                (dif_rv_plic_irq_id_t)
+                                    kTopEarlgreyPlicIrqIdSysrstCtrlAonEventDetected);
+    CHECK_DIF_OK(dif_sysrst_ctrl_irq_acknowledge(&sysrst_ctrl, irq));
+  }
+
+  // Complete the IRQ by writing the IRQ source to the Ibex specific CC.
+  // register.
+  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kPlicTarget, irq_id));
+}
+
+bool test_main(void) {
+  // Enable global and external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  // Initialize the PLIC.
+  mmio_region_t plic_base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
+  CHECK_DIF_OK(dif_rv_plic_init(plic_base_addr, &plic));
+
+  // Enable all the SYSRST CTRL interrupts on PLIC.
+  rv_plic_testutils_irq_range_enable(
+      &plic, kPlicTarget, kTopEarlgreyPlicIrqIdSysrstCtrlAonEventDetected,
+      kTopEarlgreyPlicIrqIdSysrstCtrlAonEventDetected);
+
+  // Initialize sysrst ctrl.
+  CHECK_DIF_OK(dif_sysrst_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
+      &sysrst_ctrl));
+
+  // Enable sysrst ctrl irq.
+  dif_toggle_t irq_state = kDifToggleEnabled;
+  CHECK_DIF_OK(dif_sysrst_ctrl_irq_set_enabled(
+      &sysrst_ctrl, kDifSysrstCtrlIrqEventDetected, irq_state));
+
+  // Set input pins.
+  dif_pinmux_t pinmux;
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  for (int i = 0; i < kOutputNunMioPads; ++i) {
+    CHECK_DIF_OK(
+        dif_pinmux_input_select(&pinmux, kPeripheralInputs[i], kInputPads[i]));
+  }
+
+  // Test 14 different input transition. 7 L2H and 7 H2L input transition.
+  for (dif_sysrst_ctrl_key_intr_src_t i =
+           kDifSysrstCtrlKeyIntrStatusInputPowerButtonH2L;
+       i <= kDifSysrstCtrlKeyIntrStatusInputFlashWriteProtectL2H; i = i << 1) {
+    sysrst_ctrl_input_change_detect(i);
+  }
+
+  // Test 4 different combo key intr sources with 2, 3, 4 and 5 combo key
+  // transition H2L.
+  uint32_t combo_keys_0 = kDifSysrstCtrlKeyPowerButton | kDifSysrstCtrlKey0;
+  sysrst_ctrl_key_combo_detect(kDifSysrstCtrlKeyCombo0, combo_keys_0);
+
+  uint32_t combo_keys_1 =
+      kDifSysrstCtrlKey1 | kDifSysrstCtrlKey2 | kDifSysrstCtrlKeyAcPowerPresent;
+  sysrst_ctrl_key_combo_detect(kDifSysrstCtrlKeyCombo1, combo_keys_1);
+
+  uint32_t combo_keys_2 = kDifSysrstCtrlKeyPowerButton | kDifSysrstCtrlKey0 |
+                          kDifSysrstCtrlKey2 | kDifSysrstCtrlKeyAcPowerPresent;
+  sysrst_ctrl_key_combo_detect(kDifSysrstCtrlKeyCombo2, combo_keys_2);
+
+  uint32_t combo_keys_3 = kDifSysrstCtrlKeyPowerButton | kDifSysrstCtrlKey0 |
+                          kDifSysrstCtrlKey1 | kDifSysrstCtrlKey2 |
+                          kDifSysrstCtrlKeyAcPowerPresent;
+  sysrst_ctrl_key_combo_detect(kDifSysrstCtrlKeyCombo3, combo_keys_3);
+
+  // Last sync with dv side.
+  test_status_set(kTestStatusInTest);
+  return true;
+}


### PR DESCRIPTION
On DV side the inputs of the SYSRST_CTRL are changed and this change is triggerred interrupt on PLIC. Necessary configuration are done for SYSRST_CTRL and PLIC. SW handles the interrupt when triggerred, verifies the pin input value and key_intr_status for correctness and clears the interrupt status.

Signed-off-by: Abdullah Varici <abdullah.varici@lowrisc.org>