### PR TITLE
[test] Set pmpaddr0 to match the entire address space

### DIFF
--- a/sw/device/examples/sram_program/BUILD
+++ b/sw/device/examples/sram_program/BUILD
@@ -104,7 +104,7 @@ opentitan_gdb_fpga_cw310_test(
         # Write "L NAPOT X W R" to pmp{0,1,2,3}cfg in pmpcfg0. Crucially, this
         # value is no less permissive than whatever the current value is.
         monitor reg pmpcfg0 0x9f9f9f9f
-        monitor reg pmpaddr0 0x7fffffff
+        monitor reg pmpaddr0 0xffffffff
 
         echo :::: Value of CREATOR_SW_CFG_ROM_EXEC_EN.\\n
         monitor mdw 0x40131108


### PR DESCRIPTION
From riscv-privileged-20211203.pdf:
![image](https://user-images.githubusercontent.com/57949550/196779755-0daae93c-bc2b-49d7-a580-c8fcb07ece7a.png)
