### PR TITLE
[otbn,rtl] Latch various internal state errors

### DIFF
--- a/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
@@ -91,7 +91,7 @@ module otbn_rf_bignum_ff
 
   assign unused_addr = ^rd_addr_a_i ^ ^rd_addr_b_i ^ ^wr_addr_i;
 
-  logic we_err;
+  logic we_err, we_err_d;
   logic [1:0][NWdr-1:0] we_onehot_unbuf, we_onehot_buf;
 
   for (genvar k = 0; k < 2; k++) begin : g_check
@@ -126,13 +126,17 @@ module otbn_rf_bignum_ff
     .err_o(we_err)
   );
 
-  // We need to register this to avoid timing loops.
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_err
-    if (!rst_ni) begin
-      we_err_o <= '0;
-    end else begin
-      we_err_o <= we_err;
-    end
-  end
+  assign we_err_d = we_err | we_err_o;
+
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_we_err_flop (
+    .clk_i,
+    .rst_ni,
+
+    .d_i(we_err_d),
+    .q_o(we_err_o)
+  );
 
 endmodule

--- a/hw/ip/otbn/rtl/otbn_stack.sv
+++ b/hw/ip/otbn/rtl/otbn_stack.sv
@@ -56,6 +56,7 @@ module otbn_stack
   logic [StackDepthW-1:0] stack_rd_idx, stack_wr_idx;
   logic [StackDepthW:0]   next_stack_wr_ptr;
   logic [StackDepthW-1:0] next_stack_rd_idx;
+  logic                   cnt_err, cnt_err_d, cnt_err_q;
 
   logic stack_empty;
   logic stack_full;
@@ -86,8 +87,23 @@ module otbn_stack
     .step_i     ((StackDepthW+1)'(1'b1)),
     .cnt_o      (stack_wr_ptr),
     .cnt_next_o (next_stack_wr_ptr),
-    .err_o      (cnt_err_o)
+    .err_o      (cnt_err)
   );
+
+  assign cnt_err_d = cnt_err_q | cnt_err;
+
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_cnt_err_flop (
+    .clk_i,
+    .rst_ni,
+
+    .d_i(cnt_err_d),
+    .q_o(cnt_err_q)
+  );
+
+  assign cnt_err_o = cnt_err_d;
 
   always_ff @(posedge clk_i) begin
     if (stack_write) begin


### PR DESCRIPTION
FPV has revealed it was possible for some internal state errors to be ignored, so no alert was triggered, if they occurred the same cycle or the cycle before a start command was issues to OTBN. This was due to some errors only appearing for a single cycle and others getting reset by the start command.

This adds latching behaviour to various internal errors, so once seen they will remain asserted until reset.

I'm not convinced this bug would actually lead to a security problem. Principally because the start signal would have been resetting/clearing various things anyway so the un-detected faults couldn't do anything useful.

Still seems sensible to ensure they cannot occur.

With this fix I get 100% proved in the sec CM FPV run.
