### PR TITLE
[sw] Invalidate icache in SRAM GDB test

### DIFF
--- a/sw/device/examples/sram_program/BUILD
+++ b/sw/device/examples/sram_program/BUILD
@@ -40,7 +40,7 @@ opentitan_ram_binary(
 opentitan_gdb_fpga_cw310_test(
     name = "sram_program_fpga_cw310_test",
     timeout = "short",
-    exit_success_pattern = "sram_program\\.c:47\\] PC: 0x100020e0, SRAM: \\[0x10000000, 0x10020000\\)",
+    exit_success_pattern = "sram_program\\.c:\\d+\\] PC: 0x100020e0, SRAM: \\[0x10000000, 0x10020000\\)",
     gdb_script = """
         target extended-remote :3333
 
@@ -114,10 +114,15 @@ opentitan_gdb_fpga_cw310_test(
         load sram_program.elf
         compare-sections
 
-        echo :::: Update registers before calling sram_main().\\n
+        echo :::: Update registers before calling functions.\\n
         set $sp = _stack_end
         set $gp = __global_pointer$
         info registers
+
+        # When testing SRAM execution, we want to be sure the code is running
+        # out of SRAM and not the instruction cache.
+        echo :::: Invalidate the icache.\\n
+        print icache_invalidate()
 
         echo :::: Call sram_main().\\n
         print sram_main()

--- a/sw/device/examples/sram_program/sram_program.c
+++ b/sw/device/examples/sram_program/sram_program.c
@@ -4,9 +4,8 @@
 
 #include <stdint.h>
 
-#include "sw/device/lib/base/macros.h"
-#include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
@@ -47,3 +46,8 @@ void sram_main() {
   LOG_INFO("PC: %p, SRAM: [%p, %p)", pc, kSramStart, kSramEnd);
   CHECK(pc >= kSramStart && pc < kSramEnd, "PC is outside the main SRAM");
 }
+
+// Reference functions that the debugger may wish to call. This prevents the
+// compiler from dropping them as unused functions and has the side benefit of
+// preventing their includes from appearing unused.
+void debugger_support_functions() { (void)icache_invalidate; }


### PR DESCRIPTION
This commit also generalizes the test's success pattern so it does not care about the specific line number.

Fixes #15595

Signed-off-by: Dan McArdle <dmcardle@google.com>