### PR TITLE
[top] Remove defunct synthesis dashboard

### DIFF
--- a/hw/_index.md
+++ b/hw/_index.md
@@ -13,8 +13,7 @@ See the [Hardware Development Stages]({{< relref "/doc/project/development_stage
 
 Next, we focus on all available [processor cores](#processor-cores) and provide links to their design specifications, DV documents and the DV simulation results.
 
-Finally, we provide the same set of information for all available [top level designs](#top-level-designs), including an additional dashboard with preliminary synthesis results for some of these designs.
-
+Finally, we provide the same set of information for all available [top level designs](#top-level-designs).
 
 ## Results of tool-flows
 
@@ -48,7 +47,6 @@ Finally, we provide the same set of information for all available [top level des
 * [Verilator lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/verilator/latest/report.html)
 * [Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/latest/report.html)
 * [DV Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/lint/veriblelint/latest/report.html)
-* [Synthesis results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/syn/latest/report.html)
 * [CDC results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/cdc/latest/report.html)
 
 ### Earl Grey-specific comportable IPs

--- a/hw/ip/aes/doc/_index.md
+++ b/hw/ip/aes/doc/_index.md
@@ -230,7 +230,6 @@ If the AES unit is busy and running in CBC or CTR mode, the AES unit itself upda
 The cipher core architecture of the AES unit is derived from the architecture proposed by Satoh et al.: ["A compact Rijndael Hardware Architecture with S-Box Optimization"](https://link.springer.com/chapter/10.1007%2F3-540-45682-1_15).
 The expected circuit area in a 110nm CMOS technology is in the order of 12 - 22 kGE (unmasked implementation, AES-128 only).
 The expected circuit area of the entire AES unit with masking enabled is around 110 kGE.
-For more details, refer to the [nightly OpenTitan synthesis results](https://reports.opentitan.org/hw/top_earlgrey/syn/latest/results.html).
 
 For a description of the various sub modules, see the following sections.
 


### PR DESCRIPTION
The synthesis dashboard is currently not working, hence we remove it for the time being.

Signed-off-by: Michael Schaffner <msf@google.com>