### PR TITLE
[test] Implement rom_e2e_jtag_inject test 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -215,6 +215,7 @@ jobs:
       --build_tests_only=false \
       --test_output=errors \
       --define DISABLE_VERILATOR_BUILD=true \
+      --build_tag_filters=-vivado \
       --test_tag_filters=-broken,-cw310,-verilator,-dv \
       -- //... \
       -//quality/... \

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -177,8 +177,8 @@ otp_json(
         ),
         otp_partition(
             name = "LIFE_CYCLE",
-            count = 0,
-            state = "RAW",
+            count = 1,
+            state = "TEST_UNLOCKED0",
         ),
     ],
     seed = "01931961561863975174",

--- a/sw/device/examples/sram_program/BUILD
+++ b/sw/device/examples/sram_program/BUILD
@@ -5,6 +5,8 @@
 load("//rules:opentitan.bzl", "opentitan_ram_binary")
 load("//rules:opentitan_gdb_test.bzl", "opentitan_gdb_fpga_cw310_test")
 load("//rules:linker.bzl", "ld_library")
+load("//rules:otp.bzl", "otp_image", "otp_json", "otp_partition")
+load("//rules:splice.bzl", "bitstream_splice")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -37,11 +39,7 @@ opentitan_ram_binary(
     ],
 )
 
-opentitan_gdb_fpga_cw310_test(
-    name = "sram_program_fpga_cw310_test",
-    timeout = "short",
-    exit_success_pattern = "sram_program\\.c:\\d+\\] PC: 0x100020e0, SRAM: \\[0x10000000, 0x10020000\\)",
-    gdb_script = """
+GDB_SCRIPT = """
         target extended-remote :3333
 
         echo :::: Send OpenOCD the 'reset halt' command.\\n
@@ -128,12 +126,70 @@ opentitan_gdb_fpga_cw310_test(
         print sram_main()
 
         echo :::: Done.\\n
-    """,
-    gdb_script_symlinks = {
-        ":sram_program_fpga_cw310.elf": "sram_program.elf",
-        "//sw/device/silicon_creator/rom:rom_fpga_cw310.elf": "rom.elf",
-    },
-    rom_bitstream = "//hw/bitstream:rom_otp_exec_disabled",
-    rom_kind = "Rom",
-    tags = ["manual"],
+"""
+
+OTP_IMAGES = [
+    "test_unlocked0",
+    "dev",
+    "rma",
+]
+
+[
+    otp_image(
+        name = "img_{}_exec_disabled".format(otp_name),
+        src = "//hw/ip/otp_ctrl/data:otp_json_" + otp_name,
+        overlays = [
+            "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_exec_disabled",
+        ],
+        visibility = ["//visibility:private"],
+    )
+    for otp_name in OTP_IMAGES
+]
+
+[
+    bitstream_splice(
+        name = "rom_otp_{}_exec_disabled".format(otp_name),
+        src = "//hw/bitstream:rom",
+        data = "img_{}_exec_disabled".format(otp_name),
+        meminfo = "//hw/bitstream:otp_mmi",
+        tags = [
+            "manual",
+            "vivado",
+        ],
+        update_usr_access = True,
+        visibility = ["//visibility:private"],
+    )
+    for otp_name in OTP_IMAGES
+]
+
+[
+    opentitan_gdb_fpga_cw310_test(
+        name = "sram_program_fpga_cw310_test_otp_" + otp_name,
+        timeout = "short",
+        exit_success_pattern = "sram_program\\.c:\\d+\\] PC: 0x100020e0, SRAM: \\[0x10000000, 0x10020000\\)",
+        gdb_script = GDB_SCRIPT,
+        gdb_script_symlinks = {
+            ":sram_program_fpga_cw310.elf": "sram_program.elf",
+            "//sw/device/silicon_creator/rom:rom_fpga_cw310.elf": "rom.elf",
+        },
+        rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
+        rom_kind = "Rom",
+        tags = [
+            "cw310",
+            "vivado",
+        ],
+    )
+    for otp_name in OTP_IMAGES
+]
+
+test_suite(
+    name = "rom_e2e_jtag_inject_tests",
+    tags = [
+        "cw310",
+        "vivado",
+    ],
+    tests = ["sram_program_fpga_cw310_test_otp_" + otp_name for otp_name in OTP_IMAGES],
 )

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -843,7 +843,7 @@
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2
-      tests: []
+      tests: ["//sw/device/examples/sram_program:rom_e2e_jtag_inject_tests"]
     }
 
 


### PR DESCRIPTION
~~[ **TODO: Fix conflict after merging #15617** ]~~

This PR generalizes the SRAM execution GDB test so we can instantiate it with different OTP images.

Fixes https://github.com/lowRISC/opentitan/issues/14486