### PR TITLE
[dif] support interrupt types in autogenerated DIFs

### DIFF
--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "adc_ctrl_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -46,10 +48,7 @@ dif_result_t dif_adc_ctrl_alert_force(const dif_adc_ctrl_t *adc_ctrl,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool adc_ctrl_get_irq_bit_index(dif_adc_ctrl_irq_t irq,
                                        bitfield_bit32_index_t *index_out) {
@@ -62,6 +61,23 @@ static bool adc_ctrl_get_irq_bit_index(dif_adc_ctrl_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_get_type(const dif_adc_ctrl_t *adc_ctrl,
+                                       dif_adc_ctrl_irq_t irq,
+                                       dif_irq_type_t *type) {
+  if (adc_ctrl == NULL || type == NULL || irq == kDifAdcCtrlIrqMatchDone + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
@@ -91,6 +91,19 @@ typedef enum dif_adc_ctrl_irq {
 typedef uint32_t dif_adc_ctrl_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param adc_ctrl A adc_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_get_type(const dif_adc_ctrl_t *adc_ctrl,
+                                       dif_adc_ctrl_irq_t irq,
+                                       dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param adc_ctrl A adc_ctrl handle.

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
@@ -56,6 +56,37 @@ TEST_F(AlertForceTest, Success) {
       dif_adc_ctrl_alert_force(&adc_ctrl_, kDifAdcCtrlAlertFatalFault));
 }
 
+class IrqGetTypeTest : public AdcCtrlTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_irq_get_type(nullptr, kDifAdcCtrlIrqMatchDone, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_irq_get_type(&adc_ctrl_, kDifAdcCtrlIrqMatchDone, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_irq_get_type(nullptr, kDifAdcCtrlIrqMatchDone, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_type(
+      &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(kDifAdcCtrlIrqMatchDone + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(
+      dif_adc_ctrl_irq_get_type(&adc_ctrl_, kDifAdcCtrlIrqMatchDone, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public AdcCtrlTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_aes_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "aes_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "alert_handler_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -24,10 +26,7 @@ dif_result_t dif_alert_handler_init(mmio_region_t base_addr,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool alert_handler_get_irq_bit_index(dif_alert_handler_irq_t irq,
                                             bitfield_bit32_index_t *index_out) {
@@ -49,6 +48,27 @@ static bool alert_handler_get_irq_bit_index(dif_alert_handler_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_get_type(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq,
+    dif_irq_type_t *type) {
+  if (alert_handler == NULL || type == NULL ||
+      irq == kDifAlertHandlerIrqClassd + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.h
@@ -85,6 +85,19 @@ typedef enum dif_alert_handler_irq {
 typedef uint32_t dif_alert_handler_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param alert_handler A alert_handler handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_get_type(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq,
+    dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param alert_handler A alert_handler handle.

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
@@ -36,6 +36,38 @@ TEST_F(InitTest, Success) {
   EXPECT_DIF_OK(dif_alert_handler_init(dev().region(), &alert_handler_));
 }
 
+class IrqGetTypeTest : public AlertHandlerTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_alert_handler_irq_get_type(
+      nullptr, kDifAlertHandlerIrqClassa, &type));
+
+  EXPECT_DIF_BADARG(dif_alert_handler_irq_get_type(
+      &alert_handler_, kDifAlertHandlerIrqClassa, nullptr));
+
+  EXPECT_DIF_BADARG(dif_alert_handler_irq_get_type(
+      nullptr, kDifAlertHandlerIrqClassa, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_alert_handler_irq_get_type(
+      &alert_handler_,
+      static_cast<dif_alert_handler_irq_t>(kDifAlertHandlerIrqClassd + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_alert_handler_irq_get_type(
+      &alert_handler_, kDifAlertHandlerIrqClassa, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public AlertHandlerTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
@@ -10,6 +10,8 @@
 #include <assert.h>
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "aon_timer_regs.h"  // Generated.
 
 static_assert(AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT ==
@@ -54,10 +56,7 @@ dif_result_t dif_aon_timer_alert_force(const dif_aon_timer_t *aon_timer,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool aon_timer_get_irq_bit_index(dif_aon_timer_irq_t irq,
                                         bitfield_bit32_index_t *index_out) {
@@ -73,6 +72,25 @@ static bool aon_timer_get_irq_bit_index(dif_aon_timer_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aon_timer_irq_get_type(const dif_aon_timer_t *aon_timer,
+                                        dif_aon_timer_irq_t irq,
+                                        dif_irq_type_t *type) {
+  if (aon_timer == NULL || type == NULL ||
+      irq == kDifAonTimerIrqWdogTimerBark + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen.h
@@ -96,6 +96,19 @@ typedef enum dif_aon_timer_irq {
 typedef uint32_t dif_aon_timer_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param aon_timer A aon_timer handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aon_timer_irq_get_type(const dif_aon_timer_t *aon_timer,
+                                        dif_aon_timer_irq_t irq,
+                                        dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param aon_timer A aon_timer handle.

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
@@ -56,6 +56,38 @@ TEST_F(AlertForceTest, Success) {
       dif_aon_timer_alert_force(&aon_timer_, kDifAonTimerAlertFatalFault));
 }
 
+class IrqGetTypeTest : public AonTimerTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_get_type(
+      nullptr, kDifAonTimerIrqWkupTimerExpired, &type));
+
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_get_type(
+      &aon_timer_, kDifAonTimerIrqWkupTimerExpired, nullptr));
+
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_get_type(
+      nullptr, kDifAonTimerIrqWkupTimerExpired, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_get_type(
+      &aon_timer_,
+      static_cast<dif_aon_timer_irq_t>(kDifAonTimerIrqWdogTimerBark + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_aon_timer_irq_get_type(
+      &aon_timer_, kDifAonTimerIrqWkupTimerExpired, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public AonTimerTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "clkmgr_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "csrng_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -48,10 +50,7 @@ dif_result_t dif_csrng_alert_force(const dif_csrng_t *csrng,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool csrng_get_irq_bit_index(dif_csrng_irq_t irq,
                                     bitfield_bit32_index_t *index_out) {
@@ -73,6 +72,25 @@ static bool csrng_get_irq_bit_index(dif_csrng_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_get_type(const dif_csrng_t *csrng,
+                                    dif_csrng_irq_t irq, dif_irq_type_t *type) {
+  if (csrng == NULL || type == NULL || irq == kDifCsrngIrqCsFatalErr + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.h
@@ -110,6 +110,18 @@ typedef enum dif_csrng_irq {
 typedef uint32_t dif_csrng_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param csrng A csrng handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_get_type(const dif_csrng_t *csrng,
+                                    dif_csrng_irq_t irq, dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param csrng A csrng handle.

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
@@ -59,6 +59,37 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_csrng_alert_force(&csrng_, kDifCsrngAlertFatalAlert));
 }
 
+class IrqGetTypeTest : public CsrngTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_get_type(nullptr, kDifCsrngIrqCsCmdReqDone, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_get_type(&csrng_, kDifCsrngIrqCsCmdReqDone, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_get_type(nullptr, kDifCsrngIrqCsCmdReqDone, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_csrng_irq_get_type(
+      &csrng_, static_cast<dif_csrng_irq_t>(kDifCsrngIrqCsFatalErr + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(
+      dif_csrng_irq_get_type(&csrng_, kDifCsrngIrqCsCmdReqDone, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public CsrngTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "edn_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -47,10 +49,7 @@ dif_result_t dif_edn_alert_force(const dif_edn_t *edn, dif_edn_alert_t alert) {
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool edn_get_irq_bit_index(dif_edn_irq_t irq,
                                   bitfield_bit32_index_t *index_out) {
@@ -66,6 +65,23 @@ static bool edn_get_irq_bit_index(dif_edn_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_edn_irq_get_type(const dif_edn_t *edn, dif_edn_irq_t irq,
+                                  dif_irq_type_t *type) {
+  if (edn == NULL || type == NULL || irq == kDifEdnIrqEdnFatalErr + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.h
@@ -98,6 +98,18 @@ typedef enum dif_edn_irq {
 typedef uint32_t dif_edn_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param edn A edn handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_edn_irq_get_type(const dif_edn_t *edn, dif_edn_irq_t irq,
+                                  dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param edn A edn handle.

--- a/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
@@ -59,6 +59,35 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_edn_alert_force(&edn_, kDifEdnAlertFatalAlert));
 }
 
+class IrqGetTypeTest : public EdnTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_edn_irq_get_type(nullptr, kDifEdnIrqEdnCmdReqDone, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_edn_irq_get_type(&edn_, kDifEdnIrqEdnCmdReqDone, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_edn_irq_get_type(nullptr, kDifEdnIrqEdnCmdReqDone, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_edn_irq_get_type(
+      &edn_, static_cast<dif_edn_irq_t>(kDifEdnIrqEdnFatalErr + 1), &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_edn_irq_get_type(&edn_, kDifEdnIrqEdnCmdReqDone, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public EdnTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "entropy_src_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -49,10 +51,7 @@ dif_result_t dif_entropy_src_alert_force(const dif_entropy_src_t *entropy_src,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool entropy_src_get_irq_bit_index(dif_entropy_src_irq_t irq,
                                           bitfield_bit32_index_t *index_out) {
@@ -74,6 +73,27 @@ static bool entropy_src_get_irq_bit_index(dif_entropy_src_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_get_type(const dif_entropy_src_t *entropy_src,
+                                          dif_entropy_src_irq_t irq,
+                                          dif_irq_type_t *type) {
+  if (entropy_src == NULL || type == NULL ||
+      irq == kDifEntropySrcIrqEsFatalErr + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
@@ -111,6 +111,19 @@ typedef enum dif_entropy_src_irq {
 typedef uint32_t dif_entropy_src_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param entropy_src A entropy_src handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_get_type(const dif_entropy_src_t *entropy_src,
+                                          dif_entropy_src_irq_t irq,
+                                          dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param entropy_src A entropy_src handle.

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
@@ -62,6 +62,38 @@ TEST_F(AlertForceTest, Success) {
                                             kDifEntropySrcAlertFatalAlert));
 }
 
+class IrqGetTypeTest : public EntropySrcTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_entropy_src_irq_get_type(
+      nullptr, kDifEntropySrcIrqEsEntropyValid, &type));
+
+  EXPECT_DIF_BADARG(dif_entropy_src_irq_get_type(
+      &entropy_src_, kDifEntropySrcIrqEsEntropyValid, nullptr));
+
+  EXPECT_DIF_BADARG(dif_entropy_src_irq_get_type(
+      nullptr, kDifEntropySrcIrqEsEntropyValid, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_entropy_src_irq_get_type(
+      &entropy_src_,
+      static_cast<dif_entropy_src_irq_t>(kDifEntropySrcIrqEsFatalErr + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_entropy_src_irq_get_type(
+      &entropy_src_, kDifEntropySrcIrqEsEntropyValid, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public EntropySrcTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "flash_ctrl_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -58,10 +60,7 @@ dif_result_t dif_flash_ctrl_alert_force(const dif_flash_ctrl_t *flash_ctrl,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool flash_ctrl_get_irq_bit_index(dif_flash_ctrl_irq_t irq,
                                          bitfield_bit32_index_t *index_out) {
@@ -89,6 +88,25 @@ static bool flash_ctrl_get_irq_bit_index(dif_flash_ctrl_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_get_type(const dif_flash_ctrl_t *flash_ctrl,
+                                         dif_flash_ctrl_irq_t irq,
+                                         dif_irq_type_t *type) {
+  if (flash_ctrl == NULL || type == NULL ||
+      irq == kDifFlashCtrlIrqCorrErr + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h
@@ -128,6 +128,19 @@ typedef enum dif_flash_ctrl_irq {
 typedef uint32_t dif_flash_ctrl_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param flash_ctrl A flash_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_get_type(const dif_flash_ctrl_t *flash_ctrl,
+                                         dif_flash_ctrl_irq_t irq,
+                                         dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param flash_ctrl A flash_ctrl handle.

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
@@ -62,6 +62,37 @@ TEST_F(AlertForceTest, Success) {
       &flash_ctrl_, kDifFlashCtrlAlertRecovPrimFlashAlert));
 }
 
+class IrqGetTypeTest : public FlashCtrlTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_flash_ctrl_irq_get_type(nullptr, kDifFlashCtrlIrqProgEmpty, &type));
+
+  EXPECT_DIF_BADARG(dif_flash_ctrl_irq_get_type(
+      &flash_ctrl_, kDifFlashCtrlIrqProgEmpty, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_flash_ctrl_irq_get_type(nullptr, kDifFlashCtrlIrqProgEmpty, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_flash_ctrl_irq_get_type(
+      &flash_ctrl_,
+      static_cast<dif_flash_ctrl_irq_t>(kDifFlashCtrlIrqCorrErr + 1), &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_flash_ctrl_irq_get_type(&flash_ctrl_,
+                                            kDifFlashCtrlIrqProgEmpty, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public FlashCtrlTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "gpio_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -45,10 +47,7 @@ dif_result_t dif_gpio_alert_force(const dif_gpio_t *gpio,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool gpio_get_irq_bit_index(dif_gpio_irq_t irq,
                                    bitfield_bit32_index_t *index_out) {
@@ -154,6 +153,29 @@ static bool gpio_get_irq_bit_index(dif_gpio_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_get_type(const dif_gpio_t *gpio, dif_gpio_irq_t irq,
+                                   dif_irq_type_t *type) {
+  if (gpio == NULL || type == NULL || irq == kDifGpioIrqGpio31 + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.h
@@ -121,6 +121,18 @@ typedef enum dif_gpio_irq {
 typedef uint32_t dif_gpio_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param gpio A gpio handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_get_type(const dif_gpio_t *gpio, dif_gpio_irq_t irq,
+                                   dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param gpio A gpio handle.

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
@@ -54,6 +54,32 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_gpio_alert_force(&gpio_, kDifGpioAlertFatalFault));
 }
 
+class IrqGetTypeTest : public GpioTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_gpio_irq_get_type(nullptr, kDifGpioIrqGpio0, &type));
+
+  EXPECT_DIF_BADARG(dif_gpio_irq_get_type(&gpio_, kDifGpioIrqGpio0, nullptr));
+
+  EXPECT_DIF_BADARG(dif_gpio_irq_get_type(nullptr, kDifGpioIrqGpio0, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_gpio_irq_get_type(
+      &gpio_, static_cast<dif_gpio_irq_t>(kDifGpioIrqGpio31 + 1), &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_gpio_irq_get_type(&gpio_, kDifGpioIrqGpio0, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public GpioTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "hmac_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -45,10 +47,7 @@ dif_result_t dif_hmac_alert_force(const dif_hmac_t *hmac,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool hmac_get_irq_bit_index(dif_hmac_irq_t irq,
                                    bitfield_bit32_index_t *index_out) {
@@ -67,6 +66,24 @@ static bool hmac_get_irq_bit_index(dif_hmac_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_get_type(const dif_hmac_t *hmac, dif_hmac_irq_t irq,
+                                   dif_irq_type_t *type) {
+  if (hmac == NULL || type == NULL || irq == kDifHmacIrqHmacErr + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.h
@@ -98,6 +98,18 @@ typedef enum dif_hmac_irq {
 typedef uint32_t dif_hmac_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param hmac A hmac handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_get_type(const dif_hmac_t *hmac, dif_hmac_irq_t irq,
+                                   dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param hmac A hmac handle.

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
@@ -54,6 +54,34 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_hmac_alert_force(&hmac_, kDifHmacAlertFatalFault));
 }
 
+class IrqGetTypeTest : public HmacTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_hmac_irq_get_type(nullptr, kDifHmacIrqHmacDone, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_hmac_irq_get_type(&hmac_, kDifHmacIrqHmacDone, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_hmac_irq_get_type(nullptr, kDifHmacIrqHmacDone, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_hmac_irq_get_type(
+      &hmac_, static_cast<dif_hmac_irq_t>(kDifHmacIrqHmacErr + 1), &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_hmac_irq_get_type(&hmac_, kDifHmacIrqHmacDone, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public HmacTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "i2c_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -44,10 +46,7 @@ dif_result_t dif_i2c_alert_force(const dif_i2c_t *i2c, dif_i2c_alert_t alert) {
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool i2c_get_irq_bit_index(dif_i2c_irq_t irq,
                                   bitfield_bit32_index_t *index_out) {
@@ -105,6 +104,25 @@ static bool i2c_get_irq_bit_index(dif_i2c_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_irq_get_type(const dif_i2c_t *i2c, dif_i2c_irq_t irq,
+                                  dif_irq_type_t *type) {
+  if (i2c == NULL || type == NULL || irq == kDifI2cIrqHostTimeout + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.h
@@ -152,6 +152,18 @@ typedef enum dif_i2c_irq {
 typedef uint32_t dif_i2c_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param i2c A i2c handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_irq_get_type(const dif_i2c_t *i2c, dif_i2c_irq_t irq,
+                                  dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param i2c A i2c handle.

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
@@ -54,6 +54,35 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_i2c_alert_force(&i2c_, kDifI2cAlertFatalFault));
 }
 
+class IrqGetTypeTest : public I2cTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_i2c_irq_get_type(nullptr, kDifI2cIrqFmtWatermark, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_i2c_irq_get_type(&i2c_, kDifI2cIrqFmtWatermark, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_i2c_irq_get_type(nullptr, kDifI2cIrqFmtWatermark, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_i2c_irq_get_type(
+      &i2c_, static_cast<dif_i2c_irq_t>(kDifI2cIrqHostTimeout + 1), &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_i2c_irq_get_type(&i2c_, kDifI2cIrqFmtWatermark, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public I2cTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "keymgr_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -48,10 +50,7 @@ dif_result_t dif_keymgr_alert_force(const dif_keymgr_t *keymgr,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool keymgr_get_irq_bit_index(dif_keymgr_irq_t irq,
                                      bitfield_bit32_index_t *index_out) {
@@ -64,6 +63,23 @@ static bool keymgr_get_irq_bit_index(dif_keymgr_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_get_type(const dif_keymgr_t *keymgr,
+                                     dif_keymgr_irq_t irq,
+                                     dif_irq_type_t *type) {
+  if (keymgr == NULL || type == NULL || irq == kDifKeymgrIrqOpDone + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
@@ -94,6 +94,19 @@ typedef enum dif_keymgr_irq {
 typedef uint32_t dif_keymgr_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param keymgr A keymgr handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_get_type(const dif_keymgr_t *keymgr,
+                                     dif_keymgr_irq_t irq,
+                                     dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param keymgr A keymgr handle.

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
@@ -61,6 +61,35 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_keymgr_alert_force(&keymgr_, kDifKeymgrAlertFatalFaultErr));
 }
 
+class IrqGetTypeTest : public KeymgrTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_keymgr_irq_get_type(nullptr, kDifKeymgrIrqOpDone, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_keymgr_irq_get_type(&keymgr_, kDifKeymgrIrqOpDone, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_keymgr_irq_get_type(nullptr, kDifKeymgrIrqOpDone, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_keymgr_irq_get_type(
+      &keymgr_, static_cast<dif_keymgr_irq_t>(kDifKeymgrIrqOpDone + 1), &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_keymgr_irq_get_type(&keymgr_, kDifKeymgrIrqOpDone, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public KeymgrTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "kmac_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -48,10 +50,7 @@ dif_result_t dif_kmac_alert_force(const dif_kmac_t *kmac,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool kmac_get_irq_bit_index(dif_kmac_irq_t irq,
                                    bitfield_bit32_index_t *index_out) {
@@ -70,6 +69,24 @@ static bool kmac_get_irq_bit_index(dif_kmac_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_get_type(const dif_kmac_t *kmac, dif_kmac_irq_t irq,
+                                   dif_irq_type_t *type) {
+  if (kmac == NULL || type == NULL || irq == kDifKmacIrqKmacErr + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.h
@@ -107,6 +107,18 @@ typedef enum dif_kmac_irq {
 typedef uint32_t dif_kmac_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param kmac A kmac handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_get_type(const dif_kmac_t *kmac, dif_kmac_irq_t irq,
+                                   dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param kmac A kmac handle.

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
@@ -60,6 +60,34 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_kmac_alert_force(&kmac_, kDifKmacAlertFatalFaultErr));
 }
 
+class IrqGetTypeTest : public KmacTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_kmac_irq_get_type(nullptr, kDifKmacIrqKmacDone, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_get_type(&kmac_, kDifKmacIrqKmacDone, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_get_type(nullptr, kDifKmacIrqKmacDone, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_kmac_irq_get_type(
+      &kmac_, static_cast<dif_kmac_irq_t>(kDifKmacIrqKmacErr + 1), &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_kmac_irq_get_type(&kmac_, kDifKmacIrqKmacDone, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public KmacTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "lc_ctrl_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "otbn_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -48,10 +50,7 @@ dif_result_t dif_otbn_alert_force(const dif_otbn_t *otbn,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool otbn_get_irq_bit_index(dif_otbn_irq_t irq,
                                    bitfield_bit32_index_t *index_out) {
@@ -64,6 +63,22 @@ static bool otbn_get_irq_bit_index(dif_otbn_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_get_type(const dif_otbn_t *otbn, dif_otbn_irq_t irq,
+                                   dif_irq_type_t *type) {
+  if (otbn == NULL || type == NULL || irq == kDifOtbnIrqDone + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.h
@@ -94,6 +94,18 @@ typedef enum dif_otbn_irq {
 typedef uint32_t dif_otbn_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param otbn A otbn handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_get_type(const dif_otbn_t *otbn, dif_otbn_irq_t irq,
+                                   dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param otbn A otbn handle.

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
@@ -59,6 +59,32 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_otbn_alert_force(&otbn_, kDifOtbnAlertRecov));
 }
 
+class IrqGetTypeTest : public OtbnTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_otbn_irq_get_type(nullptr, kDifOtbnIrqDone, &type));
+
+  EXPECT_DIF_BADARG(dif_otbn_irq_get_type(&otbn_, kDifOtbnIrqDone, nullptr));
+
+  EXPECT_DIF_BADARG(dif_otbn_irq_get_type(nullptr, kDifOtbnIrqDone, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_otbn_irq_get_type(
+      &otbn_, static_cast<dif_otbn_irq_t>(kDifOtbnIrqDone + 1), &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_otbn_irq_get_type(&otbn_, kDifOtbnIrqDone, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public OtbnTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "otp_ctrl_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -58,10 +60,7 @@ dif_result_t dif_otp_ctrl_alert_force(const dif_otp_ctrl_t *otp_ctrl,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool otp_ctrl_get_irq_bit_index(dif_otp_ctrl_irq_t irq,
                                        bitfield_bit32_index_t *index_out) {
@@ -77,6 +76,24 @@ static bool otp_ctrl_get_irq_bit_index(dif_otp_ctrl_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_get_type(const dif_otp_ctrl_t *otp_ctrl,
+                                       dif_otp_ctrl_irq_t irq,
+                                       dif_irq_type_t *type) {
+  if (otp_ctrl == NULL || type == NULL || irq == kDifOtpCtrlIrqOtpError + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h
@@ -115,6 +115,19 @@ typedef enum dif_otp_ctrl_irq {
 typedef uint32_t dif_otp_ctrl_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param otp_ctrl A otp_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_get_type(const dif_otp_ctrl_t *otp_ctrl,
+                                       dif_otp_ctrl_irq_t irq,
+                                       dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param otp_ctrl A otp_ctrl handle.

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
@@ -62,6 +62,37 @@ TEST_F(AlertForceTest, Success) {
       dif_otp_ctrl_alert_force(&otp_ctrl_, kDifOtpCtrlAlertRecovPrimOtpAlert));
 }
 
+class IrqGetTypeTest : public OtpCtrlTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_type(
+      nullptr, kDifOtpCtrlIrqOtpOperationDone, &type));
+
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_type(
+      &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, nullptr));
+
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_type(
+      nullptr, kDifOtpCtrlIrqOtpOperationDone, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_type(
+      &otp_ctrl_, static_cast<dif_otp_ctrl_irq_t>(kDifOtpCtrlIrqOtpError + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_get_type(
+      &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public OtpCtrlTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "pattgen_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -45,10 +47,7 @@ dif_result_t dif_pattgen_alert_force(const dif_pattgen_t *pattgen,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool pattgen_get_irq_bit_index(dif_pattgen_irq_t irq,
                                       bitfield_bit32_index_t *index_out) {
@@ -64,6 +63,24 @@ static bool pattgen_get_irq_bit_index(dif_pattgen_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pattgen_irq_get_type(const dif_pattgen_t *pattgen,
+                                      dif_pattgen_irq_t irq,
+                                      dif_irq_type_t *type) {
+  if (pattgen == NULL || type == NULL || irq == kDifPattgenIrqDoneCh1 + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen.h
@@ -94,6 +94,19 @@ typedef enum dif_pattgen_irq {
 typedef uint32_t dif_pattgen_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param pattgen A pattgen handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pattgen_irq_get_type(const dif_pattgen_t *pattgen,
+                                      dif_pattgen_irq_t irq,
+                                      dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param pattgen A pattgen handle.

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
@@ -55,6 +55,37 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_pattgen_alert_force(&pattgen_, kDifPattgenAlertFatalFault));
 }
 
+class IrqGetTypeTest : public PattgenTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_get_type(nullptr, kDifPattgenIrqDoneCh0, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_get_type(&pattgen_, kDifPattgenIrqDoneCh0, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_get_type(nullptr, kDifPattgenIrqDoneCh0, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_pattgen_irq_get_type(
+      &pattgen_, static_cast<dif_pattgen_irq_t>(kDifPattgenIrqDoneCh1 + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(
+      dif_pattgen_irq_get_type(&pattgen_, kDifPattgenIrqDoneCh0, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public PattgenTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "pinmux_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_pwm_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pwm_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "pwm_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "pwrmgr_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -45,10 +47,7 @@ dif_result_t dif_pwrmgr_alert_force(const dif_pwrmgr_t *pwrmgr,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool pwrmgr_get_irq_bit_index(dif_pwrmgr_irq_t irq,
                                      bitfield_bit32_index_t *index_out) {
@@ -61,6 +60,23 @@ static bool pwrmgr_get_irq_bit_index(dif_pwrmgr_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_get_type(const dif_pwrmgr_t *pwrmgr,
+                                     dif_pwrmgr_irq_t irq,
+                                     dif_irq_type_t *type) {
+  if (pwrmgr == NULL || type == NULL || irq == kDifPwrmgrIrqWakeup + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h
@@ -90,6 +90,19 @@ typedef enum dif_pwrmgr_irq {
 typedef uint32_t dif_pwrmgr_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param pwrmgr A pwrmgr handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_get_type(const dif_pwrmgr_t *pwrmgr,
+                                     dif_pwrmgr_irq_t irq,
+                                     dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param pwrmgr A pwrmgr handle.

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
@@ -54,6 +54,35 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_pwrmgr_alert_force(&pwrmgr_, kDifPwrmgrAlertFatalFault));
 }
 
+class IrqGetTypeTest : public PwrmgrTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_get_type(nullptr, kDifPwrmgrIrqWakeup, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_get_type(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_get_type(nullptr, kDifPwrmgrIrqWakeup, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_get_type(
+      &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(kDifPwrmgrIrqWakeup + 1), &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_pwrmgr_irq_get_type(&pwrmgr_, kDifPwrmgrIrqWakeup, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public PwrmgrTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_rom_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rom_ctrl_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "rom_ctrl_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "rstmgr_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "rv_core_ibex_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "rv_plic_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
@@ -10,6 +10,8 @@
 #include <assert.h>
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "rv_timer_regs.h"  // Generated.
 
 static_assert(RV_TIMER_INTR_STATE0_IS_0_BIT == RV_TIMER_INTR_ENABLE0_IE_0_BIT,
@@ -96,10 +98,7 @@ static bool rv_timer_get_irq_reg_offset(dif_rv_timer_intr_reg_t intr_reg,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool rv_timer_get_irq_bit_index(dif_rv_timer_irq_t irq,
                                        bitfield_bit32_index_t *index_out) {
@@ -112,6 +111,24 @@ static bool rv_timer_get_irq_bit_index(dif_rv_timer_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_timer_irq_get_type(const dif_rv_timer_t *rv_timer,
+                                       dif_rv_timer_irq_t irq,
+                                       dif_irq_type_t *type) {
+  if (rv_timer == NULL || type == NULL ||
+      irq == kDifRvTimerIrqTimerExpiredHart0Timer0 + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen.h
@@ -91,6 +91,19 @@ typedef enum dif_rv_timer_irq {
 typedef uint32_t dif_rv_timer_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param rv_timer A rv_timer handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_timer_irq_get_type(const dif_rv_timer_t *rv_timer,
+                                       dif_rv_timer_irq_t irq,
+                                       dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param rv_timer A rv_timer handle.

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
@@ -56,6 +56,39 @@ TEST_F(AlertForceTest, Success) {
       dif_rv_timer_alert_force(&rv_timer_, kDifRvTimerAlertFatalFault));
 }
 
+class IrqGetTypeTest : public RvTimerTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_type(
+      nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, &type));
+
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_type(
+      &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, nullptr));
+
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_type(
+      nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_type(
+      &rv_timer_,
+      static_cast<dif_rv_timer_irq_t>(kDifRvTimerIrqTimerExpiredHart0Timer0 +
+                                      1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_rv_timer_irq_get_type(
+      &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public RvTimerTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "sensor_ctrl_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -49,10 +51,7 @@ dif_result_t dif_sensor_ctrl_alert_force(const dif_sensor_ctrl_t *sensor_ctrl,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool sensor_ctrl_get_irq_bit_index(dif_sensor_ctrl_irq_t irq,
                                           bitfield_bit32_index_t *index_out) {
@@ -68,6 +67,25 @@ static bool sensor_ctrl_get_irq_bit_index(dif_sensor_ctrl_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_sensor_ctrl_irq_get_type(const dif_sensor_ctrl_t *sensor_ctrl,
+                                          dif_sensor_ctrl_irq_t irq,
+                                          dif_irq_type_t *type) {
+  if (sensor_ctrl == NULL || type == NULL ||
+      irq == kDifSensorCtrlIrqInitStatusChange + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen.h
@@ -99,6 +99,19 @@ typedef enum dif_sensor_ctrl_irq {
 typedef uint32_t dif_sensor_ctrl_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param sensor_ctrl A sensor_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_sensor_ctrl_irq_get_type(const dif_sensor_ctrl_t *sensor_ctrl,
+                                          dif_sensor_ctrl_irq_t irq,
+                                          dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param sensor_ctrl A sensor_ctrl handle.

--- a/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen_unittest.cc
@@ -62,6 +62,38 @@ TEST_F(AlertForceTest, Success) {
                                             kDifSensorCtrlAlertFatalAlert));
 }
 
+class IrqGetTypeTest : public SensorCtrlTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_sensor_ctrl_irq_get_type(
+      nullptr, kDifSensorCtrlIrqIoStatusChange, &type));
+
+  EXPECT_DIF_BADARG(dif_sensor_ctrl_irq_get_type(
+      &sensor_ctrl_, kDifSensorCtrlIrqIoStatusChange, nullptr));
+
+  EXPECT_DIF_BADARG(dif_sensor_ctrl_irq_get_type(
+      nullptr, kDifSensorCtrlIrqIoStatusChange, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_sensor_ctrl_irq_get_type(
+      &sensor_ctrl_,
+      static_cast<dif_sensor_ctrl_irq_t>(kDifSensorCtrlIrqInitStatusChange + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_sensor_ctrl_irq_get_type(
+      &sensor_ctrl_, kDifSensorCtrlIrqIoStatusChange, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public SensorCtrlTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "spi_device_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -46,10 +48,7 @@ dif_result_t dif_spi_device_alert_force(const dif_spi_device_t *spi_device,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool spi_device_get_irq_bit_index(dif_spi_device_irq_t irq,
                                          bitfield_bit32_index_t *index_out) {
@@ -95,6 +94,26 @@ static bool spi_device_get_irq_bit_index(dif_spi_device_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeStatus,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_get_type(const dif_spi_device_t *spi_device,
+                                         dif_spi_device_irq_t irq,
+                                         dif_irq_type_t *type) {
+  if (spi_device == NULL || type == NULL ||
+      irq == kDifSpiDeviceIrqTpmHeaderNotEmpty + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.h
@@ -141,6 +141,19 @@ typedef enum dif_spi_device_irq {
 typedef uint32_t dif_spi_device_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param spi_device A spi_device handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_get_type(const dif_spi_device_t *spi_device,
+                                         dif_spi_device_irq_t irq,
+                                         dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param spi_device A spi_device handle.

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
@@ -56,6 +56,38 @@ TEST_F(AlertForceTest, Success) {
       dif_spi_device_alert_force(&spi_device_, kDifSpiDeviceAlertFatalFault));
 }
 
+class IrqGetTypeTest : public SpiDeviceTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_type(
+      nullptr, kDifSpiDeviceIrqGenericRxFull, &type));
+
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_type(
+      &spi_device_, kDifSpiDeviceIrqGenericRxFull, nullptr));
+
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_type(
+      nullptr, kDifSpiDeviceIrqGenericRxFull, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_type(
+      &spi_device_,
+      static_cast<dif_spi_device_irq_t>(kDifSpiDeviceIrqTpmHeaderNotEmpty + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_spi_device_irq_get_type(
+      &spi_device_, kDifSpiDeviceIrqGenericRxFull, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public SpiDeviceTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "spi_host_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -46,10 +48,7 @@ dif_result_t dif_spi_host_alert_force(const dif_spi_host_t *spi_host,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool spi_host_get_irq_bit_index(dif_spi_host_irq_t irq,
                                        bitfield_bit32_index_t *index_out) {
@@ -65,6 +64,24 @@ static bool spi_host_get_irq_bit_index(dif_spi_host_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_irq_get_type(const dif_spi_host_t *spi_host,
+                                       dif_spi_host_irq_t irq,
+                                       dif_irq_type_t *type) {
+  if (spi_host == NULL || type == NULL || irq == kDifSpiHostIrqSpiEvent + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen.h
@@ -95,6 +95,19 @@ typedef enum dif_spi_host_irq {
 typedef uint32_t dif_spi_host_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param spi_host A spi_host handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_irq_get_type(const dif_spi_host_t *spi_host,
+                                       dif_spi_host_irq_t irq,
+                                       dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param spi_host A spi_host handle.

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
@@ -56,6 +56,37 @@ TEST_F(AlertForceTest, Success) {
       dif_spi_host_alert_force(&spi_host_, kDifSpiHostAlertFatalFault));
 }
 
+class IrqGetTypeTest : public SpiHostTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_get_type(nullptr, kDifSpiHostIrqError, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_get_type(&spi_host_, kDifSpiHostIrqError, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_get_type(nullptr, kDifSpiHostIrqError, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_spi_host_irq_get_type(
+      &spi_host_, static_cast<dif_spi_host_irq_t>(kDifSpiHostIrqSpiEvent + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(
+      dif_spi_host_irq_get_type(&spi_host_, kDifSpiHostIrqError, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public SpiHostTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "sram_ctrl_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "sysrst_ctrl_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -46,10 +48,7 @@ dif_result_t dif_sysrst_ctrl_alert_force(const dif_sysrst_ctrl_t *sysrst_ctrl,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool sysrst_ctrl_get_irq_bit_index(dif_sysrst_ctrl_irq_t irq,
                                           bitfield_bit32_index_t *index_out) {
@@ -62,6 +61,24 @@ static bool sysrst_ctrl_get_irq_bit_index(dif_sysrst_ctrl_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_sysrst_ctrl_irq_get_type(const dif_sysrst_ctrl_t *sysrst_ctrl,
+                                          dif_sysrst_ctrl_irq_t irq,
+                                          dif_irq_type_t *type) {
+  if (sysrst_ctrl == NULL || type == NULL ||
+      irq == kDifSysrstCtrlIrqEventDetected + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.h
@@ -92,6 +92,19 @@ typedef enum dif_sysrst_ctrl_irq {
 typedef uint32_t dif_sysrst_ctrl_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param sysrst_ctrl A sysrst_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_sysrst_ctrl_irq_get_type(const dif_sysrst_ctrl_t *sysrst_ctrl,
+                                          dif_sysrst_ctrl_irq_t irq,
+                                          dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param sysrst_ctrl A sysrst_ctrl handle.

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen_unittest.cc
@@ -56,6 +56,38 @@ TEST_F(AlertForceTest, Success) {
                                             kDifSysrstCtrlAlertFatalFault));
 }
 
+class IrqGetTypeTest : public SysrstCtrlTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_irq_get_type(
+      nullptr, kDifSysrstCtrlIrqEventDetected, &type));
+
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_irq_get_type(
+      &sysrst_ctrl_, kDifSysrstCtrlIrqEventDetected, nullptr));
+
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_irq_get_type(
+      nullptr, kDifSysrstCtrlIrqEventDetected, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_irq_get_type(
+      &sysrst_ctrl_,
+      static_cast<dif_sysrst_ctrl_irq_t>(kDifSysrstCtrlIrqEventDetected + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_sysrst_ctrl_irq_get_type(
+      &sysrst_ctrl_, kDifSysrstCtrlIrqEventDetected, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public SysrstCtrlTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "uart_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -45,10 +47,7 @@ dif_result_t dif_uart_alert_force(const dif_uart_t *uart,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool uart_get_irq_bit_index(dif_uart_irq_t irq,
                                    bitfield_bit32_index_t *index_out) {
@@ -82,6 +81,23 @@ static bool uart_get_irq_bit_index(dif_uart_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_get_type(const dif_uart_t *uart, dif_uart_irq_t irq,
+                                   dif_irq_type_t *type) {
+  if (uart == NULL || type == NULL || irq == kDifUartIrqRxParityErr + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.h
@@ -119,6 +119,18 @@ typedef enum dif_uart_irq {
 typedef uint32_t dif_uart_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param uart A uart handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_get_type(const dif_uart_t *uart, dif_uart_irq_t irq,
+                                   dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param uart A uart handle.

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -54,6 +54,35 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_uart_alert_force(&uart_, kDifUartAlertFatalFault));
 }
 
+class IrqGetTypeTest : public UartTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_uart_irq_get_type(nullptr, kDifUartIrqTxWatermark, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_uart_irq_get_type(&uart_, kDifUartIrqTxWatermark, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_uart_irq_get_type(nullptr, kDifUartIrqTxWatermark, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_uart_irq_get_type(
+      &uart_, static_cast<dif_uart_irq_t>(kDifUartIrqRxParityErr + 1), &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(dif_uart_irq_get_type(&uart_, kDifUartIrqTxWatermark, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public UartTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "usbdev_regs.h"  // Generated.
 
 OT_WARN_UNUSED_RESULT
@@ -45,10 +47,7 @@ dif_result_t dif_usbdev_alert_force(const dif_usbdev_t *usbdev,
 }
 
 /**
- * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
- * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
- * will exist, as templated below.
+ * Get the corresponding interrupt register bit offset of the IRQ.
  */
 static bool usbdev_get_irq_bit_index(dif_usbdev_irq_t irq,
                                      bitfield_bit32_index_t *index_out) {
@@ -109,6 +108,27 @@ static bool usbdev_get_irq_bit_index(dif_usbdev_irq_t irq,
   }
 
   return true;
+}
+
+static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
+};
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_get_type(const dif_usbdev_t *usbdev,
+                                     dif_usbdev_irq_t irq,
+                                     dif_irq_type_t *type) {
+  if (usbdev == NULL || type == NULL || irq == kDifUsbdevIrqLinkOutErr + 1) {
+    return kDifBadArg;
+  }
+
+  *type = irq_types[irq];
+
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
@@ -175,6 +175,19 @@ typedef enum dif_usbdev_irq {
 typedef uint32_t dif_usbdev_irq_state_snapshot_t;
 
 /**
+ * Returns the type of a given interrupt (i.e., event or status) for this IP.
+ *
+ * @param usbdev A usbdev handle.
+ * @param irq An interrupt request.
+ * @param[out] type Out-param for the interrupt type.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_get_type(const dif_usbdev_t *usbdev,
+                                     dif_usbdev_irq_t irq,
+                                     dif_irq_type_t *type);
+
+/**
  * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param usbdev A usbdev handle.

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
@@ -54,6 +54,37 @@ TEST_F(AlertForceTest, Success) {
   EXPECT_DIF_OK(dif_usbdev_alert_force(&usbdev_, kDifUsbdevAlertFatalFault));
 }
 
+class IrqGetTypeTest : public UsbdevTest {};
+
+TEST_F(IrqGetTypeTest, NullArgs) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_get_type(nullptr, kDifUsbdevIrqPktReceived, &type));
+
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_get_type(&usbdev_, kDifUsbdevIrqPktReceived, nullptr));
+
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_get_type(nullptr, kDifUsbdevIrqPktReceived, nullptr));
+}
+
+TEST_F(IrqGetTypeTest, BadIrq) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_BADARG(dif_usbdev_irq_get_type(
+      &usbdev_, static_cast<dif_usbdev_irq_t>(kDifUsbdevIrqLinkOutErr + 1),
+      &type));
+}
+
+TEST_F(IrqGetTypeTest, Success) {
+  dif_irq_type_t type;
+
+  EXPECT_DIF_OK(
+      dif_usbdev_irq_get_type(&usbdev_, kDifUsbdevIrqPktReceived, &type));
+  EXPECT_EQ(type, 0);
+}
+
 class IrqGetStateTest : public UsbdevTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/dif_base.h
+++ b/sw/device/lib/dif/dif_base.h
@@ -105,6 +105,26 @@ typedef enum dif_toggle {
 } dif_toggle_t;
 
 /**
+ * An interrupt type: event, or status.
+ *
+ * This enum may be used instead when describing an interrupt type.
+ * Specifically, event interrupts require software to manually clear them by
+ * writing to the interrupt status register (after handling the root cause),
+ * while status interrupts clear immediately when the root cause of the iterrupt
+ * has been handled.
+ */
+typedef enum dif_irq_type {
+  /**
+   * Event type interrupt.
+   */
+  kDifIrqTypeEvent = 0,
+  /**
+   * Status type interrupt.
+   */
+  kDifIrqTypeStatus = 1,
+} dif_irq_type_t;
+
+/**
  * Checks if a DIF toggle type is valid.
  *
  * @param val A potential dif_toggle_t value.

--- a/sw/device/lib/testing/autogen/isr_testutils.c
+++ b/sw/device/lib/testing/autogen/isr_testutils.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/dif/dif_adc_ctrl.h"
 #include "sw/device/lib/dif/dif_alert_handler.h"
 #include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/dif/dif_csrng.h"
 #include "sw/device/lib/dif/dif_edn.h"
 #include "sw/device/lib/dif/dif_entropy_src.h"
@@ -69,8 +70,12 @@ void isr_testutils_adc_ctrl_isr(
   CHECK_DIF_OK(dif_adc_ctrl_irq_clear_causes(adc_ctrl_ctx.adc_ctrl,
                                              kDifAdcCtrlIrqCauseAll));
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_adc_ctrl_irq_acknowledge(adc_ctrl_ctx.adc_ctrl, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_adc_ctrl_irq_get_type(adc_ctrl_ctx.adc_ctrl, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_adc_ctrl_irq_acknowledge(adc_ctrl_ctx.adc_ctrl, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -107,9 +112,14 @@ void isr_testutils_alert_handler_isr(
           irq, snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(
-      dif_alert_handler_irq_acknowledge(alert_handler_ctx.alert_handler, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_alert_handler_irq_get_type(alert_handler_ctx.alert_handler,
+                                              irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_alert_handler_irq_acknowledge(
+        alert_handler_ctx.alert_handler, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -145,8 +155,12 @@ void isr_testutils_aon_timer_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_aon_timer_irq_acknowledge(aon_timer_ctx.aon_timer, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_aon_timer_irq_get_type(aon_timer_ctx.aon_timer, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_aon_timer_irq_acknowledge(aon_timer_ctx.aon_timer, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -180,8 +194,12 @@ void isr_testutils_csrng_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_csrng_irq_acknowledge(csrng_ctx.csrng, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_csrng_irq_get_type(csrng_ctx.csrng, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_csrng_irq_acknowledge(csrng_ctx.csrng, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -214,8 +232,12 @@ void isr_testutils_edn_isr(plic_isr_ctx_t plic_ctx, edn_isr_ctx_t edn_ctx,
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_edn_irq_acknowledge(edn_ctx.edn, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_edn_irq_get_type(edn_ctx.edn, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_edn_irq_acknowledge(edn_ctx.edn, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -251,9 +273,14 @@ void isr_testutils_entropy_src_isr(
           irq, snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
   CHECK_DIF_OK(
-      dif_entropy_src_irq_acknowledge(entropy_src_ctx.entropy_src, irq));
+      dif_entropy_src_irq_get_type(entropy_src_ctx.entropy_src, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(
+        dif_entropy_src_irq_acknowledge(entropy_src_ctx.entropy_src, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -289,8 +316,14 @@ void isr_testutils_flash_ctrl_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_flash_ctrl_irq_acknowledge(flash_ctrl_ctx.flash_ctrl, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(
+      dif_flash_ctrl_irq_get_type(flash_ctrl_ctx.flash_ctrl, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(
+        dif_flash_ctrl_irq_acknowledge(flash_ctrl_ctx.flash_ctrl, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -323,8 +356,12 @@ void isr_testutils_gpio_isr(plic_isr_ctx_t plic_ctx, gpio_isr_ctx_t gpio_ctx,
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_gpio_irq_acknowledge(gpio_ctx.gpio, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_gpio_irq_get_type(gpio_ctx.gpio, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_gpio_irq_acknowledge(gpio_ctx.gpio, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -357,8 +394,12 @@ void isr_testutils_hmac_isr(plic_isr_ctx_t plic_ctx, hmac_isr_ctx_t hmac_ctx,
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_hmac_irq_acknowledge(hmac_ctx.hmac, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_hmac_irq_get_type(hmac_ctx.hmac, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_hmac_irq_acknowledge(hmac_ctx.hmac, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -391,8 +432,12 @@ void isr_testutils_i2c_isr(plic_isr_ctx_t plic_ctx, i2c_isr_ctx_t i2c_ctx,
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_i2c_irq_acknowledge(i2c_ctx.i2c, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_i2c_irq_get_type(i2c_ctx.i2c, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_i2c_irq_acknowledge(i2c_ctx.i2c, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -426,8 +471,12 @@ void isr_testutils_keymgr_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_keymgr_irq_acknowledge(keymgr_ctx.keymgr, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_keymgr_irq_get_type(keymgr_ctx.keymgr, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_keymgr_irq_acknowledge(keymgr_ctx.keymgr, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -460,8 +509,12 @@ void isr_testutils_kmac_isr(plic_isr_ctx_t plic_ctx, kmac_isr_ctx_t kmac_ctx,
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_kmac_irq_acknowledge(kmac_ctx.kmac, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_kmac_irq_get_type(kmac_ctx.kmac, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_kmac_irq_acknowledge(kmac_ctx.kmac, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -494,8 +547,12 @@ void isr_testutils_otbn_isr(plic_isr_ctx_t plic_ctx, otbn_isr_ctx_t otbn_ctx,
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_otbn_irq_acknowledge(otbn_ctx.otbn, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_otbn_irq_get_type(otbn_ctx.otbn, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_otbn_irq_acknowledge(otbn_ctx.otbn, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -530,8 +587,12 @@ void isr_testutils_otp_ctrl_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_otp_ctrl_irq_acknowledge(otp_ctrl_ctx.otp_ctrl, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_otp_ctrl_irq_get_type(otp_ctrl_ctx.otp_ctrl, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_otp_ctrl_irq_acknowledge(otp_ctrl_ctx.otp_ctrl, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -565,8 +626,12 @@ void isr_testutils_pattgen_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_pattgen_irq_acknowledge(pattgen_ctx.pattgen, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_pattgen_irq_get_type(pattgen_ctx.pattgen, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_pattgen_irq_acknowledge(pattgen_ctx.pattgen, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -600,8 +665,12 @@ void isr_testutils_pwrmgr_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_pwrmgr_irq_acknowledge(pwrmgr_ctx.pwrmgr, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_pwrmgr_irq_get_type(pwrmgr_ctx.pwrmgr, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_pwrmgr_irq_acknowledge(pwrmgr_ctx.pwrmgr, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -637,8 +706,12 @@ void isr_testutils_rv_timer_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_rv_timer_irq_acknowledge(rv_timer_ctx.rv_timer, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_rv_timer_irq_get_type(rv_timer_ctx.rv_timer, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_rv_timer_irq_acknowledge(rv_timer_ctx.rv_timer, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -674,9 +747,14 @@ void isr_testutils_sensor_ctrl_isr(
           irq, snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
   CHECK_DIF_OK(
-      dif_sensor_ctrl_irq_acknowledge(sensor_ctrl_ctx.sensor_ctrl, irq));
+      dif_sensor_ctrl_irq_get_type(sensor_ctrl_ctx.sensor_ctrl, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(
+        dif_sensor_ctrl_irq_acknowledge(sensor_ctrl_ctx.sensor_ctrl, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -712,8 +790,14 @@ void isr_testutils_spi_device_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_spi_device_irq_acknowledge(spi_device_ctx.spi_device, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(
+      dif_spi_device_irq_get_type(spi_device_ctx.spi_device, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(
+        dif_spi_device_irq_acknowledge(spi_device_ctx.spi_device, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -748,8 +832,12 @@ void isr_testutils_spi_host_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_spi_host_irq_acknowledge(spi_host_ctx.spi_host, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_spi_host_irq_get_type(spi_host_ctx.spi_host, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_spi_host_irq_acknowledge(spi_host_ctx.spi_host, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -785,9 +873,14 @@ void isr_testutils_sysrst_ctrl_isr(
           irq, snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
   CHECK_DIF_OK(
-      dif_sysrst_ctrl_irq_acknowledge(sysrst_ctrl_ctx.sysrst_ctrl, irq));
+      dif_sysrst_ctrl_irq_get_type(sysrst_ctrl_ctx.sysrst_ctrl, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(
+        dif_sysrst_ctrl_irq_acknowledge(sysrst_ctrl_ctx.sysrst_ctrl, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -820,8 +913,12 @@ void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx_t uart_ctx,
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_uart_irq_acknowledge(uart_ctx.uart, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_uart_irq_get_type(uart_ctx.uart, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_uart_irq_acknowledge(uart_ctx.uart, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,
@@ -855,8 +952,12 @@ void isr_testutils_usbdev_isr(
           snapshot);
   }
 
-  // Acknowledge the IRQ at the peripheral.
-  CHECK_DIF_OK(dif_usbdev_irq_acknowledge(usbdev_ctx.usbdev, irq));
+  // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+  dif_irq_type_t type;
+  CHECK_DIF_OK(dif_usbdev_irq_get_type(usbdev_ctx.usbdev, irq, &type));
+  if (type == kDifIrqTypeEvent) {
+    CHECK_DIF_OK(dif_usbdev_irq_acknowledge(usbdev_ctx.usbdev, irq));
+  }
 
   // Complete the IRQ at the PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(plic_ctx.rv_plic, plic_ctx.hart_id,

--- a/util/autogen_testutils/templates/isr_testutils.c.tpl
+++ b/util/autogen_testutils/templates/isr_testutils.c.tpl
@@ -5,6 +5,7 @@
 ${autogen_banner}
 
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
+#include "sw/device/lib/dif/dif_base.h"
 
 #include "sw/device/lib/dif/dif_rv_plic.h"
 % for ip in ips_with_difs:
@@ -62,10 +63,15 @@ ${autogen_banner}
           kDifAdcCtrlIrqCauseAll));
     % endif
 
-      // Acknowledge the IRQ at the peripheral.
-      CHECK_DIF_OK(dif_${ip.name_snake}_irq_acknowledge(
-          ${ip.name_snake}_ctx.${ip.name_snake},
-          irq));
+      // Acknowledge the IRQ at the peripheral if IRQ is of the event type.
+      dif_irq_type_t type;
+      CHECK_DIF_OK(dif_${ip.name_snake}_irq_get_type(
+          ${ip.name_snake}_ctx.${ip.name_snake}, irq, &type));
+      if (type == kDifIrqTypeEvent) {
+        CHECK_DIF_OK(dif_${ip.name_snake}_irq_acknowledge(
+            ${ip.name_snake}_ctx.${ip.name_snake},
+            irq));
+      }
 
       // Complete the IRQ at the PLIC.
       CHECK_DIF_OK(dif_rv_plic_irq_complete(

--- a/util/make_new_dif/ip.py
+++ b/util/make_new_dif/ip.py
@@ -52,6 +52,8 @@ class Irq:
         _multiline_description = irq["desc"][0].upper() + irq["desc"][1:]
         self.description = _multiline_description.replace("\n", " ")
         self.width = irq["width"] if "width" in irq else 1
+        self.type = irq["type"] if "type" in irq else "event"
+        assert self.type == "event" or self.type == "status"
 
 
 class Parameter:

--- a/util/make_new_dif/templates/dif_autogen.h.tpl
+++ b/util/make_new_dif/templates/dif_autogen.h.tpl
@@ -125,6 +125,20 @@ dif_result_t dif_${ip.name_snake}_init(
   typedef uint32_t dif_${ip.name_snake}_irq_state_snapshot_t;
 
   /**
+   * Returns the type of a given interrupt (i.e., event or status) for this IP.
+   *
+   * @param ${ip.name_snake} A ${ip.name_snake} handle.
+   * @param irq An interrupt request.
+   * @param[out] type Out-param for the interrupt type.
+   * @return The result of the operation.
+   */
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_get_type(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq,
+    dif_irq_type_t *type);
+
+  /**
    * Returns the state of all interrupts (i.e., pending or not) for this IP.
    *
    * @param ${ip.name_snake} A ${ip.name_snake} handle.

--- a/util/make_new_dif/templates/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/templates/dif_autogen_unittest.cc.tpl
@@ -87,20 +87,82 @@ namespace {
 % endif
 
 % if ip.irqs:
+  class IrqGetTypeTest : public ${ip.name_camel}Test {};
+
+  TEST_F(IrqGetTypeTest, NullArgs) {
+    dif_irq_type_t type;
+
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_type(
+        nullptr,
+      % if ip.irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
+      % else:
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
+      % endif
+        &type));
+
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_type(
+        &${ip.name_snake}_,
+      % if ip.irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
+      % else:
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
+      % endif
+        nullptr));
+
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_type(
+        nullptr,
+      % if ip.irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
+      % else:
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
+      % endif
+        nullptr));
+  }
+
+  TEST_F(IrqGetTypeTest, BadIrq) {
+    dif_irq_type_t type;
+
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_type(
+        &${ip.name_snake}_,
+      % if ip.irqs[-1].width == 1:
+        static_cast<dif_${ip.name_snake}_irq_t>(
+            kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel} + 1),
+      % else:
+        static_cast<dif_${ip.name_snake}_irq_t>(
+            kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel}${ip.irqs[-1].width - 1} + 1),
+      % endif
+        &type));
+  }
+
+  TEST_F(IrqGetTypeTest, Success) {
+    dif_irq_type_t type;
+
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_get_type(
+        &${ip.name_snake}_,
+      % if ip.irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
+      % else:
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
+      % endif
+        &type));
+    EXPECT_EQ(type, 0);
+  }
+
   class IrqGetStateTest : public ${ip.name_camel}Test {};
 
   TEST_F(IrqGetStateTest, NullArgs) {
     dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
 
     EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_state(
-        nullptr, 
+        nullptr,
       % if ip.name_snake == "rv_timer":
         0,
       % endif
         &irq_snapshot));
 
     EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_state(
-        &${ip.name_snake}_, 
+        &${ip.name_snake}_,
       % if ip.name_snake == "rv_timer":
         0,
       % endif


### PR DESCRIPTION
This updates the DIF autogeneration templates and autogenerated DIFs to add a DIF that allows users to query the interrupt type (event or status type). This is in response to #15580.

Note, this depends on #15580, only review the last commit.

Also, this is a large PR because it touches a lot of autogenerated DIF code. Feel free to just review the template changes and a couple instantiations of said templates.

Signed-off-by: Timothy Trippel <ttrippel@google.com>