### PR TITLE
[chip,dv,flash_ctrl] Add flash crush escalation test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -967,6 +967,18 @@
       stage: V2
       tests: ["chip_sw_all_escalation_resets"]
     }
+    {
+      name: chip_sw_flash_ctrl_escalation_reset
+      desc: '''Verify the flash ctrl fatal error does not disturb escalation process
+            and operation of ibex core.
+
+            Trigger an internal fatal fault (host_gnt_err) from flash_ctrl
+            and let it escalate to reset. Upon alert escalation reset,
+            the internal status should be clean and should not send out more alerts.
+            '''
+      stage: V2
+      tests: ["chip_sw_flash_crash_alert"]
+    }
 
     // PWRMGR tests:
     {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1439,6 +1439,13 @@
       run_opts: ["+usb_max_drift=1", "+usb_fast_sof=1"]
       reseed: 1
     }
+    {
+      name: chip_sw_flash_crash_alert
+      uvm_test_seq: chip_sw_flash_host_gnt_err_inj_vseq
+      sw_images: ["//sw/device/tests/sim_dv:flash_escalation_reset_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+test_timeout_ns=8_000_000", "+bypass_alert_ready_to_end_check=1"]
+    }
   ]
 
   // List of regressions.

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -110,6 +110,7 @@ filesets:
       - seq_lib/chip_sw_patt_ios_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rv_core_ibex_lockstep_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_aes_masking_off_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - alerts_if.sv
       - ast_ext_clk_if.sv

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence waits for a host request from flash_core bank1,
+// then force asserts the host_grant error.
+// A fatal error is expected, and checked by the c test (flash_escalation_reset_test.c)
+class chip_sw_flash_host_gnt_err_inj_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_flash_host_gnt_err_inj_vseq)
+  `uvm_object_new
+
+  localparam string FLASH_BANK1_HOST_GNT_PATH =
+       "tb.dut.top_earlgrey.u_flash_ctrl.u_eflash.gen_flash_cores[1].u_core.host_req_i";
+  localparam string FLASH_BANK1_HOST_GNT_ERR_PATH =
+       "tb.dut.top_earlgrey.u_flash_ctrl.u_eflash.gen_flash_cores[1].u_core.muxed_part";
+
+  virtual task body();
+    int polling_timeout_ns = 300_000;
+    super.body();
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `DV_SPINWAIT(polling_host_gnt();,
+                 "polling_host_gnt is timed out",
+                 polling_timeout_ns)
+    `uvm_info(`gfn, "polling is done", UVM_MEDIUM)
+    `DV_CHECK(uvm_hdl_force(FLASH_BANK1_HOST_GNT_ERR_PATH, 1))
+    // This value picked to be long enough more than one
+    // host request to be sure grant error get asserted.
+    #2us;
+    `DV_CHECK(uvm_hdl_release(FLASH_BANK1_HOST_GNT_ERR_PATH))
+  endtask // body
+
+  task polling_host_gnt();
+    bit val;
+    while (!val) begin
+      `DV_CHECK(uvm_hdl_read(FLASH_BANK1_HOST_GNT_PATH, val));
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+  endtask // polling_host_gnt
+endclass // chip_sw_flash_host_gnt_err_inj_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -71,3 +71,4 @@
 `include "chip_sw_patt_ios_vseq.sv"
 `include "chip_sw_spi_device_tpm_vseq.sv"
 `include "chip_sw_aes_masking_off_vseq.sv"
+`include "chip_sw_flash_host_gnt_err_inj_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -453,6 +453,30 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "flash_escalation_reset_test",
+    srcs = ["flash_escalation_reset_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing:aon_timer_testutils",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "clkmgr_external_clk_src_for_lc_test",
     srcs = ["clkmgr_external_clk_src_for_lc_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/flash_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/flash_escalation_reset_test.c
@@ -1,0 +1,238 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test triggers a catastrophic flash controller error
+// (fault_status.host_gnt_err), and checks the alert escalation
+// process and ibex core are not distubed by this flash_ctrl error.
+#include <assert.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "alert_handler_regs.h"
+#include "flash_ctrl_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kPlicTarget = kTopEarlgreyPlicTargetIbex0,
+  kWdogBarkMicros = 200,          // 200 us
+  kWdogBiteMicros = 600,          // 600 us
+  kEscalationStartMicros = 100,   // 100 us
+  kEscalationPhase0Micros = 100,  // 100 us
+  kEscalationPhase1Micros = 100,  // 100 us
+  kMaxInterrupts = 30,
+  kRegionBaseBank1Page0Index = TOP_EARLGREY_EFLASH_SIZE_BYTES / 2,
+  kPageSize = FLASH_CTRL_PARAM_BYTES_PER_PAGE,
+  kNumTestWords = 16,
+  kNumTestBytes = kNumTestWords * sizeof(uint32_t),
+  kExpectedAlertNumber = 0,
+};
+
+static_assert(kWdogBarkMicros < kWdogBiteMicros &&
+                  kWdogBarkMicros > kEscalationPhase0Micros,
+              "The wdog bite shall happen only if escalation reset fails.");
+
+static dif_rv_plic_t plic;
+static dif_alert_handler_t alert_handler;
+static dif_aon_timer_t aon_timer;
+static dif_rstmgr_t rstmgr;
+static dif_flash_ctrl_state_t flash_ctrl_state;
+
+/**
+ * External ISR.
+ *
+ * Handles all peripheral interrupts on Ibex. PLIC asserts an external interrupt
+ * line to the CPU, which results in a call to this OTTF ISR. This ISR
+ * overrides the default OTTF implementation.
+ */
+void ottf_external_isr(void) {
+  top_earlgrey_plic_peripheral_t peripheral;
+  dif_rv_plic_irq_id_t irq_id;
+  uint32_t irq = 0;
+
+  LOG_INFO("At regular external ISR");
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));
+
+  peripheral = (top_earlgrey_plic_peripheral_t)
+      top_earlgrey_plic_interrupt_for_peripheral[irq_id];
+
+  LOG_INFO("peripheral: %d  irq_id:%d", peripheral, irq_id);
+
+  if (peripheral == kTopEarlgreyPlicPeripheralAonTimerAon) {
+    irq =
+        (dif_aon_timer_irq_t)(irq_id -
+                              (dif_rv_plic_irq_id_t)
+                                  kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+
+    CHECK(false, "Unexpected aon timer interrupt %d", irq);
+  } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
+    irq = (irq_id -
+           (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAlertHandlerClassa);
+
+    // Check if class A alert.
+    CHECK(irq == 0, "ClassA('d0) was expected but got %d", irq);
+  }
+
+  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kPlicTarget, irq_id));
+
+  LOG_INFO("Regular external ISR exiting");
+}
+
+/**
+ * Initialize the peripherals used in this test.
+ */
+static void init_peripherals(void) {
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
+
+  CHECK_DIF_OK(dif_alert_handler_init(
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
+      &alert_handler));
+
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash_ctrl_state,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+}
+
+/**
+ * Program the alert handler to escalate on flash_ctrl fatal alerts and reset on
+ * phase 2, and to start escalation after timing out due to an unacknowledged
+ * interrupt.
+ */
+static void alert_handler_config(void) {
+  dif_alert_handler_alert_t alerts[] = {kTopEarlgreyAlertIdFlashCtrlFatalErr};
+  dif_alert_handler_class_t alert_classes[] = {kDifAlertHandlerClassA};
+
+  dif_alert_handler_escalation_phase_t esc_phases[] = {
+      {.phase = kDifAlertHandlerClassStatePhase0,
+       .signal = 0,
+       .duration_cycles =
+           alert_handler_testutils_get_cycles_from_us(kEscalationPhase0Micros) *
+           alert_handler_testutils_cycle_rescaling_factor()},
+      {.phase = kDifAlertHandlerClassStatePhase1,
+       .signal = 3,
+       .duration_cycles =
+           alert_handler_testutils_get_cycles_from_us(kEscalationPhase1Micros) *
+           alert_handler_testutils_cycle_rescaling_factor()}};
+
+  uint32_t deadline_cycles =
+      alert_handler_testutils_get_cycles_from_us(kEscalationStartMicros) *
+      alert_handler_testutils_cycle_rescaling_factor();
+  LOG_INFO("Configuring class A with %d cycles and %d occurrences",
+           deadline_cycles, UINT16_MAX);
+  dif_alert_handler_class_config_t class_config[] = {{
+      .auto_lock_accumulation_counter = kDifToggleDisabled,
+      .accumulator_threshold = UINT16_MAX,
+      .irq_deadline_cycles = deadline_cycles,
+      .escalation_phases = esc_phases,
+      .escalation_phases_len = ARRAYSIZE(esc_phases),
+      .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase3,
+  }};
+
+  dif_alert_handler_class_t classes[] = {kDifAlertHandlerClassA};
+  dif_alert_handler_config_t config = {
+      .alerts = alerts,
+      .alert_classes = alert_classes,
+      .alerts_len = ARRAYSIZE(alerts),
+      .classes = classes,
+      .class_configs = class_config,
+      .classes_len = ARRAYSIZE(class_config),
+      .ping_timeout = 0,
+  };
+
+  alert_handler_testutils_configure_all(&alert_handler, config,
+                                        kDifToggleEnabled);
+  // Enables alert handler irq.
+  CHECK_DIF_OK(dif_alert_handler_irq_set_enabled(
+      &alert_handler, kDifAlertHandlerIrqClassa, kDifToggleEnabled));
+}
+
+/**
+ * Send flash read from the host interface.
+ */
+static void read_host_if(uint32_t addr) {
+  uint32_t host_data[kNumTestWords];
+  mmio_region_memcpy_from_mmio32(
+      mmio_region_from_addr(TOP_EARLGREY_EFLASH_BASE_ADDR), addr, &host_data,
+      kNumTestBytes);
+}
+
+static void set_aon_timers(const dif_aon_timer_t *aon_timer) {
+  uint32_t bark_cycles =
+      aon_timer_testutils_get_aon_cycles_from_us(kWdogBarkMicros);
+  uint32_t bite_cycles =
+      aon_timer_testutils_get_aon_cycles_from_us(kWdogBiteMicros);
+
+  LOG_INFO(
+      "Wdog will bark after %u us (%u cycles) and bite after %u us (%u cycles)",
+      (uint32_t)kWdogBarkMicros, bark_cycles, (uint32_t)kWdogBiteMicros,
+      bite_cycles);
+
+  // Setup the wdog bark and bite timeouts.
+  aon_timer_testutils_watchdog_config(aon_timer, bark_cycles, bite_cycles,
+                                      /*pause_in_sleep=*/false);
+}
+
+bool test_main(void) {
+  // Enable global and external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  init_peripherals();
+
+  // Enable all the interrupts used in this test.
+  rv_plic_testutils_irq_range_enable(
+      &plic, kPlicTarget, kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired,
+      kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark);
+  rv_plic_testutils_irq_range_enable(&plic, kPlicTarget,
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassa,
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassd);
+
+  dif_rstmgr_reset_info_bitfield_t rst_info;
+  rst_info = rstmgr_testutils_reason_get();
+  rstmgr_testutils_reason_clear();
+
+  LOG_INFO("reset reason %x", rst_info);
+
+  if (rst_info == kDifRstmgrResetInfoPor) {
+    alert_handler_config();
+    LOG_INFO("host read start");
+    read_host_if(kPageSize * kRegionBaseBank1Page0Index);
+    // Set the timer value longer than escalation timeout.
+    // 'static_assert' is added to check it.
+    set_aon_timers(&aon_timer);
+    wait_for_interrupt();
+  } else if (rst_info == kDifRstmgrResetInfoEscalation) {
+    LOG_INFO("Booting for the second time due to escalation reset");
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Address item 7 of #15340  and item1 of #15649
Porting block level test https://github.com/lowRISC/opentitan/blob/2f668bcd9da6aaa3771b1bc9f3b05f20a6bf7167/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson#L267 
to chip level and check
whether the flash_ctrl fatal error does not disburb escalation process and ibex core.


Signed-off-by: Jaedon Kim <jdonjdon@google.com>