### PR TITLE
[uart/dv] Fix regression timeout

### DIFF
--- a/hw/ip/uart/dv/env/seq_lib/uart_perf_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_perf_vseq.sv
@@ -32,4 +32,8 @@ class uart_perf_vseq extends uart_fifo_full_vseq;
     };
   }
 
+  // don't use the slowest baud rate, otherwise, it may take over 1hr
+  constraint baud_rate_extra_c {
+    baud_rate >= BaudRate115200;
+  }
 endclass : uart_perf_vseq


### PR DESCRIPTION
Avoid using the lowest baud rate in uart_perf as this test using minimum delay to poll status via TLUL, which make sim run 1hr+
With this change, it takes <30 min
Fixed #15606
Signed-off-by: Weicai Yang <weicai@google.com>