### PR TITLE
[spi_device/dv] Test incomplete opcode for tpm and flash mode

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_host_dummy_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_host_dummy_seq.sv
@@ -6,12 +6,20 @@ class spi_host_dummy_seq extends spi_base_seq;
   `uvm_object_utils(spi_host_dummy_seq)
   `uvm_object_new
 
+  rand bit [CSB_WIDTH-1:0] csb_sel;
+  rand bit [7:0] dummy_data;
+
   virtual task body();
     req = spi_item::type_id::create("req");
     start_item(req);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
-                                   item_type inside {SpiTransSckNoCsb, SpiTransCsbNoSck};
-                                   data.size() == 1; // no used, set to 1 to simpify randomization
+                                   item_type inside {SpiTransSckNoCsb, SpiTransCsbNoSck,
+                                                    SpiTransIncompleteOpcode};
+                                   if (cfg.spi_func_mode == SpiModeGeneric) {
+                                    item_type != SpiTransIncompleteOpcode;
+                                   }
+                                   csb_sel == local::csb_sel;
+                                   data.size() == 1; // use for SpiTransIncompleteOpcode
                                    )
     finish_item(req);
     get_response(rsp);

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -31,7 +31,8 @@ package spi_agent_pkg;
     // device dut
     SpiTransNormal,    // normal SPI trans
     SpiTransSckNoCsb,  // bad SPI trans with sck but no csb
-    SpiTransCsbNoSck   // bad SPI trans with csb but no sck
+    SpiTransCsbNoSck,  // bad SPI trans with csb but no sck
+    SpiTransIncompleteOpcode  // bad SPI trans with incompleted opcode for flash/tpm mode only
   } spi_trans_type_e;
 
   // sck edge type - used by driver and monitor

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -10,7 +10,8 @@ class spi_device_base_vseq extends cip_base_vseq #(
     );
   `uvm_object_utils(spi_device_base_vseq)
 
-  bit [1:0] spi_mode = 0; // TODO fixed value in spec now
+  // knob to control sending dummy transaction or incompleted opcode
+  int allow_dummy_trans_pct = 5;
 
   rand bit sck_polarity;
   rand bit sck_phase;
@@ -153,7 +154,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
     cfg.spi_host_agent_cfg.num_bytes_per_trans_in_mon = 4;
 
     // update device rtl
-    ral.control.mode.set(spi_mode);
+    ral.control.mode.set(GenericMode);
     csr_update(.csr(ral.control));
     ral.cfg.cpol.set(sck_polarity);
     ral.cfg.cpha.set(sck_phase);
@@ -284,6 +285,8 @@ class spi_device_base_vseq extends cip_base_vseq #(
   virtual task spi_host_xfer_dummy_item();
     spi_host_dummy_seq m_spi_host_seq;
     `uvm_create_on(m_spi_host_seq, p_sequencer.spi_sequencer_h)
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(m_spi_host_seq,
+                                   csb_sel inside {FW_FLASH_CSB_ID, TPM_CSB_ID};)
     `uvm_send(m_spi_host_seq)
   endtask
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_dummy_item_extra_dly_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_dummy_item_extra_dly_vseq.sv
@@ -7,15 +7,12 @@ class spi_device_dummy_item_extra_dly_vseq extends spi_device_txrx_vseq;
   `uvm_object_utils(spi_device_dummy_item_extra_dly_vseq)
   `uvm_object_new
 
-  constraint en_dummy_host_xfer_c {
-    en_dummy_host_xfer == 1;
-  }
-
   constraint en_extra_dly_c {
     en_extra_dly == 1;
   }
 
   virtual task spi_device_fw_init();
+    allow_dummy_trans_pct = 100;
     super.spi_device_fw_init();
     // use more aggressive delay, but if higher than below values, timeout may happen
     randcase

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -557,6 +557,9 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
                 UVM_MEDIUM)
     end
 
+    if ($urandom_range(0, 99) < allow_dummy_trans_pct) begin
+      spi_host_xfer_dummy_item();
+    end
     // randomly read last_read_addr for scb to check
     if ($urandom_range(0, 2) == 0) begin
       bit [TL_DW-1:0] rdata;

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
@@ -159,5 +159,9 @@ class spi_device_tpm_base_vseq extends spi_device_base_vseq;
                                    })
     `uvm_send(m_host_tpm_seq)
     payload_q = m_host_tpm_seq.rsp.data;
+
+    if ($urandom_range(0, 99) < allow_dummy_trans_pct) begin
+      spi_host_xfer_dummy_item();
+    end
   endtask
 endclass : spi_device_tpm_base_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
@@ -20,7 +20,6 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
   rand uint rx_delay;
   rand uint spi_delay;
 
-  rand bit  en_dummy_host_xfer;
   rand bit  en_extra_dly;
 
   // helper rand variable
@@ -65,13 +64,6 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
 
   constraint num_trans_c {
     num_trans inside {[2:3]};
-  }
-
-  constraint en_dummy_host_xfer_c {
-    en_dummy_host_xfer dist {
-      0 :/ 4,
-      1 :/ 1 // 20% enable dummy transfer
-    };
   }
 
   // lower 2 bits are ignored, use word granularity to contrain the sram setting
@@ -131,7 +123,8 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
           done_xfer = 1;
         end
         begin // drive dummy host item
-          while (!done_xfer && en_dummy_host_xfer) begin
+          bit en_dummy = $urandom_range(0, 99) < allow_dummy_trans_pct;
+          while (!done_xfer && en_dummy) begin
             `DV_CHECK_MEMBER_RANDOMIZE_FATAL(tx_delay)
             cfg.clk_rst_vif.wait_clks(tx_delay);
             spi_host_xfer_dummy_item();


### PR DESCRIPTION
1. Update spi_host_driver to send incomplete opcode as a dummy item
2. update vseq to send dummy transaction following normal items with 5% chance
3. update scb as dummy item also latches the flash_status

Signed-off-by: Weicai Yang <weicai@google.com>