### PR TITLE
[fpga] Enable AES PRNG reseeding on CW310

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -983,7 +983,6 @@ module chip_earlgrey_cw310 #(
     .SecAesSBoxImpl(aes_pkg::SBoxImplDom),
     .SecAesStartTriggerDelay(40),
     .SecAesAllowForcingMasks(1'b1),
-    .SecAesSkipPRNGReseeding(1'b1),
     .KmacEnMasking(0),
     .SecKmacCmdDelay(40),
     .SecKmacIdleAcceptSwMsg(1'b1),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1055,7 +1055,6 @@ module chip_${top["name"]}_${target["name"]} #(
     .SecAesSBoxImpl(aes_pkg::SBoxImplDom),
     .SecAesStartTriggerDelay(40),
     .SecAesAllowForcingMasks(1'b1),
-    .SecAesSkipPRNGReseeding(1'b1),
     .KmacEnMasking(0),
     .SecKmacCmdDelay(40),
     .SecKmacIdleAcceptSwMsg(1'b1),


### PR DESCRIPTION
So far, we have been skipping reseeding operations for AES on the CW310 to simplify SCA (the reseeding disturbs the actual measurement). In the meantime we have added an alternative but safe way to skip the reseeding in software if really desired. Thus we no longer need the hardware modification on the CW310.

It is however still needed for the CW305 where the entropy complex isn't implemented.