### PR TITLE
[top] Enable SecAesAllowForcingMasks parameter for top_earlgrey ES

### DIFF
--- a/hw/top_earlgrey/lint/chip_earlgrey_asic.waiver
+++ b/hw/top_earlgrey/lint/chip_earlgrey_asic.waiver
@@ -124,3 +124,8 @@ waive -rules {RESET_MUX} -location {chip_earlgrey_asic.sv} -regexp {Asynchronous
 waive -rules {RESET_MUX} -location {usb_clk.sv} \
       -regexp {Asynchronous reset 'rst_n' is driven by a multiplexer here, used as a reset 'rst_ni' at prim_generic_flop.sv} \
       -comment "This is reset generation logic, hence reset muxes are allowed."
+
+# REMOVE FOR PRODUCTION, see https://github.com/lowRISC/opentitan/issues/15674
+waive -rules {LHS_TOO_SHORT} -location {aes_prng_masking.sv} \
+      -regexp {Bitlength mismatch between 'unused_assert_static_lint_error' length 1 and 'AesSecAllowForcingMasksNonDefault'\(1'b1\)' length 2} \
+      -comment "For ES we want to be able to switch off the masking inside AES, see https://github.com/lowRISC/opentitan/issues/14240. REMOVE FOR PRODUCTION!"

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -1070,6 +1070,7 @@ module chip_earlgrey_asic #(
   //////////////////////
   top_earlgrey #(
     .PinmuxAonTargetCfg(PinmuxTargetCfg),
+    .SecAesAllowForcingMasks(1'b1),
     .SecRomCtrlDisableScrambling(SecRomCtrlDisableScrambling)
   ) top_earlgrey (
     // ast connections

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -436,9 +436,10 @@ module chip_earlgrey_verilator (
   assign por_n = {ast_pwst.main_pok, ast_pwst.aon_pok};
 
   top_earlgrey #(
-    .SramCtrlRetAonInstrExec(0),
+    .PinmuxAonTargetCfg(PinmuxTargetCfg),
+    .SecAesAllowForcingMasks(1'b1),
     .SramCtrlMainInstrExec(1),
-    .PinmuxAonTargetCfg(PinmuxTargetCfg)
+    .SramCtrlRetAonInstrExec(0)
   ) top_earlgrey (
     // update por / reset connections, this is not quite right here
     .por_n_i                      (por_n             ),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -910,6 +910,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
 % else:
     .PinmuxAonTargetCfg(PinmuxTargetCfg),
+    .SecAesAllowForcingMasks(1'b1),
     .SecRomCtrlDisableScrambling(SecRomCtrlDisableScrambling)
 % endif
   ) top_${top["name"]} (


### PR DESCRIPTION
It has been decided to enable this feature for ES. For reference, see lowRISC/OpenTitan#14240.