### PR TITLE
[flash_ctrl,dv] move rma_err to v2 testplan from v2s

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -372,6 +372,17 @@
       tests: ["flash_ctrl_fs_sup"]
     }
     {
+      name: rma_write_process_error
+      desc: '''Verify error handling process duing the rma wipe process.
+      In normal rma process, inject bit error at the write path
+      (tb.dut.u_eflash.gen_flash_cores[0].u_core.gen_prog_data.u_prog.pack_data).
+      This should make debug_state to flash_ctrl_env_pkg::FlashLcIvalid and
+      fatal error (std_fault_status.lcmgr_err) should be triggered.
+      '''
+      stage: V2
+      tests: ["flash_ctrl_rma_err"]
+    }
+    {
       name: robustness
       desc: '''
             Enable full randomization in order to fully stress DUT. Perform illegal accesses in

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -293,16 +293,5 @@
       stage: V2S
       tests: ["flash_ctrl_sec_cm"]
     }
-    {
-      name: rma_write_process_error
-      desc: '''Verify error handling process duing the rma wipe process.
-      In normal rma process, inject bit error at the write path
-      (tb.dut.u_eflash.gen_flash_cores[0].u_core.gen_prog_data.u_prog.pack_data).
-      This should make debug_state to flash_ctrl_env_pkg::FlashLcIvalid and
-      fatal error (std_fault_status.lcmgr_err) should be triggered.
-      '''
-      stage: V2S
-      tests: ["flash_ctrl_rma_err"]
-    }
   ]
 }


### PR DESCRIPTION
To avoid lint failure, move rma_err test point to v2

Signed-off-by: Jaedon Kim <jdonjdon@google.com>