### PR TITLE
Add some missing unit tests for ROM flash_ctrl driver

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -263,6 +263,21 @@ TEST_F(TransferTest, ReadDataOk) {
   EXPECT_EQ(words_out, words_);
 }
 
+TEST_F(TransferTest, ReadInfoOk) {
+  // Address of the `kFlashCtrlInfoPageOwnerSlot0` page, see `info_page_addr`.
+  const uint32_t addr =
+      1 * FLASH_CTRL_PARAM_BYTES_PER_BANK + 2 * FLASH_CTRL_PARAM_BYTES_PER_PAGE;
+  ExpectTransferStart(1, 0, 0, FLASH_CTRL_CONTROL_OP_VALUE_READ,
+                      addr + 0x01234567, words_.size());
+  ExpectReadData(words_);
+  ExpectWaitForDone(true, false);
+  std::vector<uint32_t> words_out(words_.size());
+  EXPECT_EQ(flash_ctrl_info_read(kFlashCtrlInfoPageOwnerSlot0, 0x01234567,
+                                 words_.size(), &words_out.front()),
+            kErrorOk);
+  EXPECT_EQ(words_out, words_);
+}
+
 TEST_F(TransferTest, ProgDataOk) {
   ExpectTransferStart(0, 0, 0, FLASH_CTRL_CONTROL_OP_VALUE_PROG, 0x01234567,
                       words_.size());

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -308,6 +308,17 @@ TEST_F(TransferTest, EraseDataPageOk) {
             kErrorOk);
 }
 
+TEST_F(TransferTest, EraseInfoPageOk) {
+  // Address of the `kFlashCtrlInfoPageOwnerSlot0` page, see `info_page_addr`.
+  const uint32_t addr =
+      1 * FLASH_CTRL_PARAM_BYTES_PER_BANK + 2 * FLASH_CTRL_PARAM_BYTES_PER_PAGE;
+  ExpectTransferStart(1, 0, 0, FLASH_CTRL_CONTROL_OP_VALUE_ERASE, addr, 1);
+  ExpectWaitForDone(true, false);
+  EXPECT_EQ(flash_ctrl_info_erase(kFlashCtrlInfoPageOwnerSlot0,
+                                  kFlashCtrlEraseTypePage),
+            kErrorOk);
+}
+
 TEST_F(TransferTest, ProgAcrossWindows) {
   static const uint32_t kWinSize = FLASH_CTRL_PARAM_REG_BUS_PGM_RES_BYTES;
   static const uint32_t kManyWordsSize = 2 * kWinSize / sizeof(uint32_t);

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -287,6 +287,19 @@ TEST_F(TransferTest, ProgDataOk) {
             kErrorOk);
 }
 
+TEST_F(TransferTest, ProgInfoOk) {
+  // Address of the `kFlashCtrlInfoPageOwnerSlot0` page, see `info_page_addr`.
+  const uint32_t addr =
+      1 * FLASH_CTRL_PARAM_BYTES_PER_BANK + 2 * FLASH_CTRL_PARAM_BYTES_PER_PAGE;
+  ExpectTransferStart(1, 0, 0, FLASH_CTRL_CONTROL_OP_VALUE_PROG,
+                      addr + 0x01234567, words_.size());
+  ExpectProgData(words_);
+  ExpectWaitForDone(true, false);
+  EXPECT_EQ(flash_ctrl_info_write(kFlashCtrlInfoPageOwnerSlot0, 0x01234567,
+                                  words_.size(), &words_.front()),
+            kErrorOk);
+}
+
 TEST_F(TransferTest, EraseDataPageOk) {
   ExpectTransferStart(0, 0, 0, FLASH_CTRL_CONTROL_OP_VALUE_ERASE, 0x01234567,
                       1);


### PR DESCRIPTION
Adds unit tests for the `flash_ctrl_info_{read,write,erase}` functions.

`kFlashCtrlInfoPageOwnerSlot0` chosen since it has non-zero bank and page indices. This ensures the page address lookup is done in the functions under test.