### PR TITLE
[spi_deivce/dv] Fix the out of mem error

### DIFF
--- a/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
@@ -210,7 +210,7 @@ class spi_device_env_cov extends cip_base_env_cov #(.CFG_T(spi_device_env_cfg));
     cp_filtered: coverpoint filtered;
     cp_payload_size: coverpoint payload_size {
       bins frequent_use_values[] = {[0:4], 256};
-      bins excess_fifo[]         = {[257:$]};
+      bins excess_fifo           = {[257:$]};
     }
     cr_all: cross cp_opcode, cp_filtered, cp_payload_size;
   endgroup


### PR DESCRIPTION
I probably accidentally added a wrong bracket `[]` after I tested my change locally. This causes all spi_device tests ran out of mem in nightly

Signed-off-by: Weicai Yang <weicai@google.com>