### PR TITLE
[python] update numpy version

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -6,7 +6,7 @@
 hjson==3.1.0
 libcst==0.4.1
 mako==1.1.6
-numpy==1.19.5
+numpy==1.22.0
 pluralizer==1.2.0
 pycryptodome==3.15.0
 pyelftools==0.29


### PR DESCRIPTION
The numpy version that was added in #15178 is too old, and is not compatable with newer version of Python, e.g, 3.10. Since we upgraded CI to use Ubunut 20.04, which ships with Python 3.8.5, numpy version 1.22.0 should be compatable with both the officially supported Python version, and more modern versions of Python, e.g., 3.10.

Signed-off-by: Timothy Trippel <ttrippel@google.com>