### PR TITLE
[fpv/rstmgr] Configure additional clocks for fpv

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -134,6 +134,17 @@ if {$env(DUT_TOP) == "pinmux_tb"} {
   clock -rate -default clk_i
   reset -expr {!rst_ni !rst_main_ni}
 
+} elseif {$env(DUT_TOP) == "rstmgr"} {
+  clock clk_main_i
+  clock clk_i -both_edges
+  clock clk_io_i -factor 1
+  clock clk_io_div2_i -factor 1
+  clock clk_io_div4_i -factor 1
+  clock clk_usb_i -factor 1
+  clock clk_aon_i -factor 2
+  clock -rate -default clk_i
+  reset -expr {!rst_ni !rst_por_ni}
+
 } else {
   clock clk_i -both_edges
   reset -expr {!rst_ni}


### PR DESCRIPTION
The rstmgr unit uses multiple clocks, which fpv assertions use. The default fpv settings only configure clk_i, so many fpv assertions had no chance of working.

This change assumes CDC is correct, so it simplifies the clock frequency and phase relations.

Signed-off-by: Guillermo Maturana <maturana@google.com>