### PR TITLE
[entropy_src/dv] FSM coverage closure support

### DIFF
--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov.core
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:ip:entropy_src
     files:
       - entropy_src_cov_if.sv
+      - entropy_src_fsm_cov_if.sv
       - entropy_src_cov_bind.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/entropy_src/dv/cov/entropy_src_fsm_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_fsm_cov_if.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Provides a window into the main_sm to help predict proper timing when trying to trigger
+// particular state transitions.
+interface entropy_src_fsm_cov_if
+  import entropy_src_pkg::*;
+  import prim_mubi_pkg::*;
+  import entropy_src_main_sm_pkg::*;
+
+(
+  input wire clk_i,
+  input state_e state_i
+);
+
+  state_e next_state;
+  assign next_state = state_e'(state_i);
+
+  // Sample the _next_ state (not the current state) of the main FSM, to allow VSeq's to fire an
+  // enable or abort at the correct time to sample all FSM transitions
+  clocking state_cb @(posedge clk_i);
+    input next_state;
+  endclocking
+
+endinterface

--- a/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
@@ -381,4 +381,28 @@ class entropy_src_dut_cfg extends uvm_object;
     end
   endfunction
 
+  function void pre_randomize();
+    check_knob_vals();
+    super.pre_randomize();
+  endfunction
+
+  function void check_knob_vals();
+    `DV_CHECK(en_intr_pct <= 100);
+    `DV_CHECK(module_enable_pct <= 100);
+    `DV_CHECK(preconfig_disable_pct <= 100);
+    `DV_CHECK(me_regwen_pct <= 100);
+    `DV_CHECK(sw_regupd_pct <= 100);
+    `DV_CHECK(fips_enable_pct <= 100);
+    `DV_CHECK(entropy_data_reg_enable_pct <= 100);
+    `DV_CHECK(ht_threshold_scope_pct <= 100);
+    `DV_CHECK(rng_bit_enable_pct <= 100);
+    `DV_CHECK(route_software_pct <= 100);
+    `DV_CHECK(type_bypass_pct <= 100);
+    `DV_CHECK(fw_read_pct <= 100);
+    `DV_CHECK(fw_over_pct <= 100);
+    `DV_CHECK(fw_ov_insert_start_pct <= 100);
+    `DV_CHECK(default_ht_thresholds_pct <= 100);
+    `DV_CHECK(bad_mubi_cfg_pct <= 100);
+  endfunction
+
 endclass

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.core
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.core
@@ -8,6 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:ip:entropy_src_pkg
+      - lowrisc:ip:entropy_src_main_sm_pkg
       - lowrisc:dv:ralgen
       - lowrisc:dv:dv_utils
       - lowrisc:dv:cip_lib

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -68,6 +68,11 @@ class entropy_src_env extends cip_base_env #(
       `uvm_fatal(get_full_name(), "failed to get precon_fifo_vif from uvm_config_db")
     end
 
+    if (!uvm_config_db#(virtual entropy_src_fsm_cov_if)::get(this, "",
+                        "main_sm_cov_vif", cfg.fsm_tracking_vif)) begin
+      `uvm_fatal(get_full_name(), "failed to get fsm_tracking_vif from uvm_config_db")
+    end
+
     if (!uvm_config_db#(virtual pins_if#(8))::get(this, "", "otp_en_es_fw_read_vif",
         cfg.otp_en_es_fw_read_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get otp_en_es_fw_read_vif from uvm_config_db")

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -17,6 +17,7 @@ package entropy_src_env_pkg;
   import entropy_src_pkg::*;
   import prim_mubi_pkg::*;
   import entropy_subsys_fifo_exception_pkg::*;
+  import entropy_src_main_sm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -88,6 +88,9 @@ module tb;
   bind prim_packer_fifo : dut.u_entropy_src_core.u_prim_packer_fifo_precon
     entropy_subsys_fifo_exception_if#(1) u_fifo_exc_if (.clk_i, .rst_ni, .wready_o, .wvalid_i);
 
+  bind prim_sparse_fsm_flop : dut.u_entropy_src_core.u_entropy_src_main_sm.u_state_regs
+    entropy_src_fsm_cov_if u_fsm_cov_if (.clk_i, .state_i);
+
   initial begin
     // Drive clk and rst_n from clk_if
     // Set interfaces in config_db
@@ -106,6 +109,8 @@ module tb;
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual entropy_subsys_fifo_exception_if#(1))::set(null, "*.env",
         "precon_fifo_vif", dut.u_entropy_src_core.u_prim_packer_fifo_precon.u_fifo_exc_if);
+    uvm_config_db#(virtual entropy_src_fsm_cov_if)::set(null, "*.env", "main_sm_cov_vif",
+        dut.u_entropy_src_core.u_entropy_src_main_sm.u_state_regs.u_fsm_cov_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH)))::set
         (null, "*.env.m_rng_agent*", "vif", rng_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)))::

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -50,7 +50,9 @@ class entropy_src_base_test extends cip_base_test #(
     cfg.soft_mtbf                 = -1.0;
     cfg.hard_mtbf                 = -1.0;
 
-    cfg.dut_cfg.bad_mubi_cfg_pct  = 0;
+    cfg.dut_cfg.bad_mubi_cfg_pct       = 0;
+    cfg.induce_targeted_transition_pct = 0;
+
   endfunction
 
 endclass : entropy_src_base_test

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -54,6 +54,8 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.dut_cfg.fips_enable_pct             = 50;
     cfg.dut_cfg.module_enable_pct           = 100;
     cfg.dut_cfg.bad_mubi_cfg_pct            = 50;
+    cfg.induce_targeted_transition_pct      = 25;
+
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)


### PR DESCRIPTION
NOTE TO GITHUB REVIEWERS: This commit depends on #15651, which is included here as the first commit.  Please only review the second commit in this PR.

This commit adds support in the entropy_src_rng vseq for closing coverage of rare FSM transitions.

- Adds a new thread `targeted_transition_thread` to monitor the upcoming state of the `main_sm`, and a helper function to immediately send a disable command, at appropriate times to close coverage.
  - The helper function functions by temporarily removing delays in the `tl_agent`.  (Note that such disable commands still have to be done by frontdoor CSR transactions if the scoreboard is to continue functioning properly.)
  - The _upcoming_ state is not visible via the CSR interface and so a new `entropy_src_fsm_cov_if` has been added to monitor the state machine internals.
  - Changes have also been added to the interrupt handler thread to coordinate these targeted transitions and ensure that these new CSR events do not disrupt other processes in the vseq.
- The `entropy_src_rng` now maintains a list of rare transitions, and a checklist vector of those that have been triggered in this run.
  - The checklist aims to ensure that this feature does not force each transistion more than once per run.
- Since each rare transition does not need to be induced every run, there is also a new `induce_targeted_transition_pct` knob in the `env_cfg` to limit the frequency of these new CSR events.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>