### PR TITLE
[entropy_src/rtl] Remove redundant AlertState transition

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -304,8 +304,6 @@ module entropy_src_main_sm #(
       Sha3Quiesce: begin
         if (!enable_i || fw_ov_ent_insert_i) begin
           state_d = Idle;
-        end else if (alert_thresh_fail_i) begin
-          state_d = AlertState;
         end else begin
           state_d = ContHTStart;
         end


### PR DESCRIPTION
This commit cleans up an inconsistency in the `main_sm` which has been identified in FSM coverage maps.

Background:

In commit 84a680b3cf (PR #14391) the `entropy_src_main_sm` was modified to check and trigger health test alerts _before_ starting the SHA3 condititioner.  This is is important for verification which expects failing entropy to remain in the conditioner until a successful health check.  (Such is the behavior of the Startup Phase, though the Continuous phase did not follow this convention at first).

However in PR #14391 the _original_ transition to the AlertState was left in place.  This transition is still an error, because in the Startup and Continuous phases, the alert checks are to be done when all the health test results have been completed at the end of the health test window.

This second post-SHA alert transition is theoretically still reachable, and so it would not be removed by UNR coverage exclusions. It would however take a very unusual set of coincidences to reach it. (For example, a new health test failure, likely a REPCNT failure, would have to occur immediately after the end of the previous successful window, while the SHA conditioner is still processing.) So it is unlikely to be seen in verification, and it has never to my knowledge been seen in FSM coverage.

It is still an incorrect transition which should have been removed in PR #14391, particularly since the UNR analysis says that it could still be triggered under some events.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>