### PR TITLE
[entropy_src/rtl] Support tight HT thresholds

### DIFF
--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -52,6 +52,7 @@ class entropy_src_base_test extends cip_base_test #(
 
     cfg.dut_cfg.bad_mubi_cfg_pct       = 0;
     cfg.induce_targeted_transition_pct = 0;
+    cfg.dut_cfg.tight_thresholds_pct   = 0;
 
   endfunction
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
@@ -21,12 +21,18 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
     cfg.soft_mtbf                           = 7500us;
 
     // Apply truly impossible standards, to confirm that HT's don't matter here
-    cfg.dut_cfg.adaptp_sigma_min            = 0.0;
-    cfg.dut_cfg.adaptp_sigma_max            = 0.0;
-    cfg.dut_cfg.bucket_sigma_min            = 0.0;
-    cfg.dut_cfg.bucket_sigma_max            = 0.0;
-    cfg.dut_cfg.markov_sigma_min            = 0.0;
-    cfg.dut_cfg.markov_sigma_max            = 0.0;
+    cfg.dut_cfg.adaptp_sigma_min_typ        = 0.0;
+    cfg.dut_cfg.adaptp_sigma_min_tight      = 0.0;
+    cfg.dut_cfg.adaptp_sigma_max_typ        = 0.0;
+    cfg.dut_cfg.adaptp_sigma_max_tight      = 0.0;
+    cfg.dut_cfg.bucket_sigma_min_typ        = 0.0;
+    cfg.dut_cfg.bucket_sigma_min_tight      = 0.0;
+    cfg.dut_cfg.bucket_sigma_max_typ        = 0.0;
+    cfg.dut_cfg.bucket_sigma_max_tight      = 0.0;
+    cfg.dut_cfg.markov_sigma_min_typ        = 0.0;
+    cfg.dut_cfg.markov_sigma_min_tight      = 0.0;
+    cfg.dut_cfg.markov_sigma_max_typ        = 0.0;
+    cfg.dut_cfg.markov_sigma_max_tight      = 0.0;
 
     cfg.dut_cfg.sw_regupd_pct               = 50;
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -24,12 +24,20 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.soft_mtbf                   = 7500us;
 
     // Apply standards ranging from strict to relaxed
-    cfg.dut_cfg.adaptp_sigma_min            = 3.0;
-    cfg.dut_cfg.adaptp_sigma_max            = 6.0;
-    cfg.dut_cfg.bucket_sigma_min            = 3.0;
-    cfg.dut_cfg.bucket_sigma_max            = 6.0;
-    cfg.dut_cfg.markov_sigma_min            = 3.0;
-    cfg.dut_cfg.markov_sigma_max            = 6.0;
+    cfg.dut_cfg.adaptp_sigma_min_tight      = 0.5;
+    cfg.dut_cfg.bucket_sigma_max_tight      = 2.0;
+    cfg.dut_cfg.adaptp_sigma_min_typ        = 3.0;
+    cfg.dut_cfg.adaptp_sigma_max_typ        = 6.0;
+
+    cfg.dut_cfg.bucket_sigma_min_tight      = 0.5;
+    cfg.dut_cfg.bucket_sigma_max_tight      = 2.0;
+    cfg.dut_cfg.bucket_sigma_min_typ        = 3.0;
+    cfg.dut_cfg.bucket_sigma_max_typ        = 6.0;
+
+    cfg.dut_cfg.markov_sigma_min_tight      = 0.5;
+    cfg.dut_cfg.markov_sigma_max_tight      = 2.0;
+    cfg.dut_cfg.markov_sigma_min_typ        = 3.0;
+    cfg.dut_cfg.markov_sigma_max_typ        = 6.0;
 
     cfg.dut_cfg.sw_regupd_pct               = 50;
     cfg.dut_cfg.preconfig_disable_pct       = 50;
@@ -39,7 +47,7 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.otp_en_es_fw_read_pct               = 50;
     cfg.otp_en_es_fw_over_pct               = 50;
 
-    cfg.dut_cfg.type_bypass_pct             = 25;
+    cfg.dut_cfg.type_bypass_pct             = 75;
     cfg.dut_cfg.ht_threshold_scope_pct      = 50;
     cfg.dut_cfg.default_ht_thresholds_pct   = 0;
 
@@ -51,10 +59,11 @@ class entropy_src_rng_test extends entropy_src_base_test;
 
     cfg.dut_cfg.rng_bit_enable_pct          = 50;
 
-    cfg.dut_cfg.fips_enable_pct             = 50;
+    cfg.dut_cfg.fips_enable_pct             = 25;
     cfg.dut_cfg.module_enable_pct           = 100;
     cfg.dut_cfg.bad_mubi_cfg_pct            = 50;
     cfg.induce_targeted_transition_pct      = 25;
+    cfg.dut_cfg.tight_thresholds_pct        = 75;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 


### PR DESCRIPTION
Adds a new `tight_thresholds_pct` knob to support occasion regressions with tight HT thresholds.  These tighter thresholds are very good for emulating the behavior of the DUT when operating with RNG streams with marginal HT quality, as the tighter thesholds will induce infrequent HT failures.  Therefore these thresholds are important for closing behavioral coverage.

This PR:
 - Adds constraints so that only one HT is using tight constraints at a time, otherwise the frequent failure of multiple alternating tests will lead to zero passing HT windows.
   - Adds new parameters for a second range of tighter thresholds to use then tight thresholds are enabled.
 - Limits the fraction of regressions using this feature.
 - Establishes default values for these knobs, and an initial estimate for the correct value `entropy_src_rng_test` to provide reasonable coverage.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>