### PR TITLE
[flash_ctrl,dv] regression fix for error tests

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -85,7 +85,6 @@ class flash_ctrl_env #(
     // flash_ctrl_base_test.
     // So this value has to be updated 'after' build_phase.
     cfg.m_fpp_agent_cfg.scb_otf_en = cfg.scb_otf_en;
-
   endfunction
 
 endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -422,7 +422,9 @@ class flash_ctrl_scoreboard #(
     // post test checks - ensure that all local fifos and queues are empty
     `DV_EOT_PRINT_TLM_FIFO_CONTENTS(tl_seq_item, eflash_tl_a_chan_fifo)
     `DV_EOT_PRINT_TLM_FIFO_CONTENTS(tl_seq_item, eflash_tl_d_chan_fifo)
-    `DV_CHECK_EQ(eflash_addr_phase_queue.size, 0)
+    if (cfg.en_scb) begin
+      `DV_CHECK_EQ(eflash_addr_phase_queue.size, 0)
+    end
     if (cfg.scb_check && cfg.check_full_scb_mem_model) begin
       cfg.check_mem_model();
     end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
@@ -21,11 +21,12 @@ class flash_ctrl_disable_vseq extends flash_ctrl_otf_base_vseq;
        `uvm_info("SEQ", $sformatf("disable is set"), UVM_MEDIUM)
        csr_utils_pkg::wait_no_outstanding_access();
        cfg.m_tl_agent_cfg.check_tl_errs = 0;
-
     end
     `uvm_info("SEQ", $sformatf("disable txn start"), UVM_MEDIUM)
     // mp error or tlul error expected
 
+    // Wait until disable is set.
+    cfg.clk_rst_vif.wait_clks(10);
     send_rand_ops(1, exp_err);
 
     `DV_CHECK_EQ(cfg.tlul_core_obs_cnt, cfg.tlul_core_exp_cnt)
@@ -43,7 +44,8 @@ class flash_ctrl_disable_vseq extends flash_ctrl_otf_base_vseq;
         mubi4_t dis_val;
         dis_val = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(4));
         csr_wr(.ptr(ral.dis), .value(dis_val));
-        is_disable = (dis_val != MuBi4False);
+        // DIS acts as true if program value is 4b0xxx or xxx0.
+        is_disable = ~(dis_val[3] & dis_val[0]);
       end
     endcase // randcase
     exp_err = is_disable;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_err_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_err_base_vseq.sv
@@ -41,4 +41,15 @@ class flash_ctrl_err_base_vseq extends flash_ctrl_rw_vseq;
     apply_reset();
     init_controller();
   endtask // clean_up
+
+  // Call this task from 'run_error_event' if 'run_main_event' cannot be stopped gracefully.
+  virtual task drain_n_finish_err_event();
+    cfg.tlul_core_exp_cnt = cfg.tlul_core_obs_cnt;
+    cfg.en_scb = 0;
+    // Give some drain time
+    cfg.clk_rst_vif.wait_n_clks(100);
+    cfg.seq_cfg.disable_flash_init = 1;
+    cfg.seq_cfg.en_init_keys_seeds = 0;
+    apply_reset();
+  endtask
 endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
@@ -20,10 +20,9 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
 
     `uvm_info(`gfn, "FLASH_CTRL_HW_RMA", UVM_LOW)
 
-    // Keep this assertoff for temporary until prim_sync issue is resolved.
-    $assertoff(0, "tb.dut.u_flash_hw_if.u_sync_rma_req.gen_flops.OutputDelay_A");
     // These are valid assertoff's.
     $assertoff(0, "tb.dut.u_flash_hw_if.ProgRdVerify_A");
+    $assertoff(0, "tb.dut.u_flash_hw_if.DisableChk_A");
 
     // RMA TESTS
 
@@ -72,7 +71,7 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
             csr_spinwait(.ptr(ral.debug_state),
                          .exp_data(flash_ctrl_env_pkg::FlashLcInvalid),
                          .spinwait_delay_ns(500_000),
-                         .timeout_ns(100_000_000));
+                         .timeout_ns(200_000_000));
             cfg.clk_rst_vif.wait_clks(3);
             `uvm_info(`gfn, "RMA FAIL DUE TO Wipe out write data failure (expected)", UVM_LOW)
             collect_err_cov_status(ral.std_fault_status);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
@@ -31,6 +31,7 @@ class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_
       end
 
       if (add_err1 == 0 && add_err2 == 0) begin
+        $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
         randcase
           1: begin
             add_err1 = 1;
@@ -48,6 +49,10 @@ class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_
     end // repeat (2)
     check_fault(ral.fault_status.spurious_ack);
     collect_err_cov_status(ral.fault_status);
-    csr_rd_check(.ptr(ral.err_code), .compare_value(0));
+    // sw error can be unpredictably triggered. (err_code.prog_err)
+    // In stead of checking err_code == 0,
+    // make sure hw_fault.prog_err doesn't happen.
+    csr_rd_check(.ptr(ral.fault_status.prog_err), .compare_value(0));
+    drain_n_finish_err_event();
   endtask
 endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -17,6 +17,9 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
     // unit 100 ns;
     delay = $urandom_range(1, 10);
     #(delay * 100ns);
+    cfg.otf_scb_h.comp_off = 1;
+    cfg.otf_scb_h.mem_mon_off = 1;
+
     `DV_CHECK(uvm_hdl_force(path, 2'h0))
 
     delay = $urandom_range(1, 10);
@@ -24,6 +27,12 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
     `DV_CHECK(uvm_hdl_release(path))
     check_fault(ral.fault_status.arb_err);
     collect_err_cov_status(ral.fault_status);
-    csr_rd_check(.ptr(ral.err_code), .compare_value(0));
+    // host transaction unpredictably triggers err_code.mp_err.
+    // In stead of checking err_code == 0, make sure hw_fault.mp_err doesn't happen.
+    csr_rd_check(.ptr(ral.fault_status.mp_err), .compare_value(0));
+    drain_n_finish_err_event();
   endtask
+  task clean_up();
+    init_controller();
+  endtask // clean_up
 endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv
@@ -23,7 +23,6 @@ class flash_ctrl_phy_host_grant_err_vseq extends flash_ctrl_err_base_vseq;
      // This can happen when host_read is sent to info partition (by force).
      // After that, fatal error happen. So turning off these assertion
      // just to make sure test run to complete.
-     $assertoff(0, "tb.dut");
 
      // set error counter high number to skip unpredictable error
      cfg.scb_h.exp_tl_rsp_intg_err = 1;
@@ -39,8 +38,7 @@ class flash_ctrl_phy_host_grant_err_vseq extends flash_ctrl_err_base_vseq;
     `DV_CHECK(uvm_hdl_release(path))
 
     collect_err_cov_status(ral.fault_status);
-    csr_rd_check(.ptr(ral.err_code), .compare_value(0));
-    cfg.tlul_core_exp_cnt = cfg.tlul_core_obs_cnt;
+    drain_n_finish_err_event();
   endtask
 
   task launch_host_rd();
@@ -64,4 +62,8 @@ class flash_ctrl_phy_host_grant_err_vseq extends flash_ctrl_err_base_vseq;
     end
     csr_utils_pkg::wait_no_outstanding_access();
   endtask // launch_host_rd
+
+  task clean_up();
+    init_controller();
+  endtask // clean_up
 endclass

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -409,15 +409,15 @@
     {
       name: flash_ctrl_phy_ack_consistency
       uvm_test_seq: flash_ctrl_phy_ack_consistency_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=5", "+ecc_mode=1",
-                 "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=10", "+ecc_mode=1",
+                 "+otf_rd_pct=4", "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
       reseed: 5
     }
     {
       name: flash_ctrl_config_regwen
       uvm_test_seq: flash_ctrl_config_regwen_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_all=1"]
-      reseed: 1
+      reseed: 5
     }
     {
       name: flash_ctrl_rma_err
@@ -430,7 +430,7 @@
       uvm_test_seq: flash_ctrl_lcmgr_intg_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=1",
                  "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
-      reseed: 3
+      reseed: 20
     }
     {
       name: flash_ctrl_hw_read_seed_err

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -246,10 +246,10 @@
 
       The phy arbiter for controller and host is redundant.
       The arbiter has two instance underneath that are constantly compared to each other.
+      tb.dut.u_eflash.gen_flash_cores[0].u_core.u_host_arb.gen_input_bufs[0].u_req_buf.out_o[1:0]
       tb.dut.u_eflash.gen_flash_cores[0].u_core.u_host_arb.gen_input_bufs[1].u_req_buf.out_o[1:0]
-      tb.dut.u_eflash.gen_flash_cores[0].u_core.u_host_arb.gen_input_bufs[0]
-      tb.dut.u_eflash.gen_flash_cores[0].u_core.u_host_arb.gen_input_bufs[1]
-      make output of both mismatch and check fault_status.arb_err is triggered.
+
+      Make output of both mismatch and check fault_status.arb_err is triggered.
       '''
       stage: V2S
       tests: ["flash_ctrl_phy_arb_redun"]


### PR DESCRIPTION
- sec_cm: 
  prim_reg_we_check triggers fatal_std_err while prim_reg_check under eflash triggers fatal_prim_fatal_alert.  
  Adjust sb accordingly.
- flash_ctrl_disable: flash_ctrl.dis is effective when bit3 or bit0 of the value is '0'
- Add apply_reset for some error tests
- Update apply_reset to call one physical clock interface
- Replace polling status csr with csr_spinwait to be aware reset event

Signed-off-by: Jaedon Kim <jdonjdon@google.com>