### PR TITLE
[rom] Fix pinmux indexing and set attributes first.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/pinmux.c
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.c
@@ -25,7 +25,8 @@ enum {
  */
 typedef struct pinmux_input {
   top_earlgrey_pinmux_peripheral_in_t periph;
-  top_earlgrey_pinmux_insel_t pad;
+  top_earlgrey_pinmux_insel_t pad_insel;
+  top_earlgrey_muxed_pads_t pad;
 } pinmux_input_t;
 
 /**
@@ -41,7 +42,8 @@ typedef struct pinmux_output {
  */
 static const pinmux_input_t kInputUart0 = {
     .periph = kTopEarlgreyPinmuxPeripheralInUart0Rx,
-    .pad = kTopEarlgreyPinmuxInselIoc3,
+    .pad_insel = kTopEarlgreyPinmuxInselIoc3,
+    .pad = kTopEarlgreyMuxedPadsIoc3,
 };
 
 /**
@@ -58,15 +60,18 @@ static const pinmux_output_t kOutputUart0 = {
  */
 static const pinmux_input_t kInputSwStrap0 = {
     .periph = kTopEarlgreyPinmuxPeripheralInGpioGpio22,
-    .pad = kTopEarlgreyPinmuxInselIoc0,
+    .pad_insel = kTopEarlgreyPinmuxInselIoc0,
+    .pad = kTopEarlgreyMuxedPadsIoc0,
 };
 static const pinmux_input_t kInputSwStrap1 = {
     .periph = kTopEarlgreyPinmuxPeripheralInGpioGpio23,
-    .pad = kTopEarlgreyPinmuxInselIoc1,
+    .pad_insel = kTopEarlgreyPinmuxInselIoc1,
+    .pad = kTopEarlgreyMuxedPadsIoc1,
 };
 static const pinmux_input_t kInputSwStrap2 = {
     .periph = kTopEarlgreyPinmuxPeripheralInGpioGpio24,
-    .pad = kTopEarlgreyPinmuxInselIoc2,
+    .pad_insel = kTopEarlgreyPinmuxInselIoc2,
+    .pad = kTopEarlgreyMuxedPadsIoc2,
 };
 
 /**
@@ -77,7 +82,7 @@ static const pinmux_input_t kInputSwStrap2 = {
 static void configure_input(pinmux_input_t input) {
   abs_mmio_write32(kBase + PINMUX_MIO_PERIPH_INSEL_0_REG_OFFSET +
                        input.periph * sizeof(uint32_t),
-                   input.pad);
+                   input.pad_insel);
 }
 
 /**
@@ -85,24 +90,11 @@ static void configure_input(pinmux_input_t input) {
  *
  * @param pad A MIO pad.
  */
-static void enable_pull_down(top_earlgrey_pinmux_insel_t pad) {
+static void enable_pull_down(top_earlgrey_muxed_pads_t pad) {
   uint32_t reg =
       bitfield_bit32_write(0, PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, true);
   abs_mmio_write32(
       kBase + PINMUX_MIO_PAD_ATTR_0_REG_OFFSET + pad * sizeof(uint32_t), reg);
-}
-
-/**
- * Configures the given pin as input and enables the internal pull-down.
- *
- * We enable internal pull-downs since we expect strong pull-ups on the strap
- * pins.
- *
- * @param input A peripheral input and MIO pad to link it to.
- */
-static void configure_strap_pin(pinmux_input_t input) {
-  configure_input(input);
-  enable_pull_down(input.pad);
 }
 
 /**
@@ -121,9 +113,14 @@ void pinmux_init(void) {
       otp_read32(OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_EN_OFFSET);
   if (launder32(bootstrap_en) == kHardenedBoolTrue) {
     HARDENED_CHECK_EQ(bootstrap_en, kHardenedBoolTrue);
-    configure_strap_pin(kInputSwStrap0);
-    configure_strap_pin(kInputSwStrap1);
-    configure_strap_pin(kInputSwStrap2);
+    // Note: attributes should be configured before the pinmux matrix to avoid
+    // "undesired electrical behavior and/or contention at the pads".
+    enable_pull_down(kInputSwStrap0.pad);
+    enable_pull_down(kInputSwStrap1.pad);
+    enable_pull_down(kInputSwStrap2.pad);
+    configure_input(kInputSwStrap0);
+    configure_input(kInputSwStrap1);
+    configure_input(kInputSwStrap2);
   }
 
   configure_input(kInputUart0);

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -45,7 +45,7 @@ class InitTest : public PinmuxTest {
            static_cast<uint32_t>(index) * sizeof(uint32_t);
   }
 
-  uint32_t RegPadAttr(top_earlgrey_pinmux_insel_t pad) {
+  uint32_t RegPadAttr(top_earlgrey_muxed_pads_t pad) {
     return base_ + PINMUX_MIO_PAD_ATTR_0_REG_OFFSET +
            static_cast<uint32_t>(pad) * sizeof(uint32_t);
   }
@@ -73,18 +73,18 @@ TEST_F(InitTest, WithBootstrap) {
   // The inputs that will be configured.
   EXPECT_CALL(otp_, read32(OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_EN_OFFSET))
       .WillOnce(Return(kHardenedBoolTrue));
+  EXPECT_ABS_WRITE32(RegPadAttr(kTopEarlgreyMuxedPadsIoc0),
+                     {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
+  EXPECT_ABS_WRITE32(RegPadAttr(kTopEarlgreyMuxedPadsIoc1),
+                     {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
+  EXPECT_ABS_WRITE32(RegPadAttr(kTopEarlgreyMuxedPadsIoc2),
+                     {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
   EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInGpioGpio22),
                      kTopEarlgreyPinmuxInselIoc0)
-  EXPECT_ABS_WRITE32(RegPadAttr(kTopEarlgreyPinmuxInselIoc0),
-                     {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
   EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInGpioGpio23),
                      kTopEarlgreyPinmuxInselIoc1)
-  EXPECT_ABS_WRITE32(RegPadAttr(kTopEarlgreyPinmuxInselIoc1),
-                     {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
   EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInGpioGpio24),
                      kTopEarlgreyPinmuxInselIoc2)
-  EXPECT_ABS_WRITE32(RegPadAttr(kTopEarlgreyPinmuxInselIoc2),
-                     {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
   EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInUart0Rx),
                      kTopEarlgreyPinmuxInselIoc3);
 


### PR DESCRIPTION
Fixes a couple of issues with ROM pinmux initialization that I found while working on https://github.com/lowRISC/opentitan/issues/14496.

1. The pinmux initialization previously used the pinmux input selector value as the pad index (e.g. for finding the attribute register), which results in an off-by-two error since the input selector is actually (pad index + 2).
2. The pinmux documentation [specifies](https://docs.opentitan.org/hw/ip/pinmux/doc/#pad-attributes-1) that pad attributes should be set first, before configuring the pinmux matrix, so this change moves attribute-setting to precede IO configuration.