### PR TITLE
[flash_ctrl/doc] Update hjson description.

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -530,7 +530,9 @@
                This is a shortcut mechanism used by the software to completely
                kill flash in case of emergency.
 
-               To disable, set this field to anything other than kMultiBitBool4False.
+               Since this register is rw0c instead of rw, to disable, write any value in the form of
+               0xxx or xxx0, where x could be either 0 or 1.
+
               '''
             resval: false,
           },

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -531,7 +531,9 @@
                This is a shortcut mechanism used by the software to completely
                kill flash in case of emergency.
 
-               To disable, set this field to anything other than kMultiBitBool4False.
+               Since this register is rw0c instead of rw, to disable, write any value in the form of
+               0xxx or xxx0, where x could be either 0 or 1.
+
               '''
             resval: false,
           },

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -536,7 +536,9 @@
                This is a shortcut mechanism used by the software to completely
                kill flash in case of emergency.
 
-               To disable, set this field to anything other than kMultiBitBool4False.
+               Since this register is rw0c instead of rw, to disable, write any value in the form of
+               0xxx or xxx0, where x could be either 0 or 1.
+
               '''
             resval: false,
           },


### PR DESCRIPTION
The flash disable descritpion was incorrect as it claimed any value other than false would cause disable. This is not true as the register is `rw0c` and not `rw` type.

Update the description to reflect this.

Signed-off-by: Timothy Chen <timothytim@google.com>