### PR TITLE
[fpv/conn] Fix connectivity failure

### DIFF
--- a/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
@@ -20,7 +20,7 @@
 CONNECTION, AST_DFT_SPI_DEVICE_RAM_2P_CFG, u_ast.u_ast_dft, "{dpram_rmf_o, dpram_rml_o}", top_earlgrey.u_spi_device.u_memory_2p.u_mem.gen_generic.u_impl_generic, cfg_i
 
 # To usbdev.
-CONNECTION, AST_DFT_USBDEV_RAM_2P_CFG, u_ast.u_ast_dft, "{dpram_rmf_o, dpram_rml_o}", top_earlgrey.u_usbdev.u_memory_2p.i_prim_ram_2p_async_adv.u_mem.gen_generic.u_impl_generic, cfg_i
+CONNECTION, AST_DFT_USBDEV_RAM_2P_CFG, u_ast.u_ast_dft, "{dpram_rmf_o, dpram_rml_o}", top_earlgrey.u_usbdev.gen_no_stubbed_memory.u_memory_2p.i_prim_ram_2p_async_adv.u_mem.gen_generic.u_impl_generic, cfg_i
 
 # Single port RAMs.
 # To otbn.


### PR DESCRIPTION
this PR fixes connecitivity test failure due to adding a layer of hierarchy in usbdev.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>