### PR TITLE
[top/test] Add chip_rv_dm_lc_disabled test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -439,8 +439,6 @@
             and RMA, regardless of the value on DFT SW straps.
             '''
       stage: V2
-      // TODO: add chip_tap_straps_test_unlocked0 also (#14147)
-      // TODO: add chip_tap_straps_test_locked0 also (#14147)
       tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
     }
 
@@ -610,17 +608,18 @@
       name: chip_rv_dm_lc_disabled
       desc: '''Verify that the debug capabilities are disabled in certain life cycle stages.
 
-            - Put life cycle on states other than Test, RMA and DEV.
+            - Put life cycle in a random life cycle state.
             - Verify that the rv_dm bus device is inaccessible from the CPU as well as external
-              JTAG.
-            - Verify that the debug ROM is not accessible by the CPU.
-            - Verify that the JTAG TAP is unavailable.
+              JTAG if the life cycle state is not in TEST_UNLOCKED*, DEV or RMA.
+            - The bus access check is performed by randomly reading or writing a CSR inside the
+              RV_DM and checking whether the TL-UL bus errors out.
+            - The JTAG access check is performed by writing and then reading a register that is
+              accessible via the TAP/DMI inside the RV_DM. If the JTAG wires are gated, it is
+              expected that the RV_DM returns all-zero instead of the written value.
             - X-ref'ed with `chip_tap_strap_sampling`
             '''
       stage: V2
-      tests: [// Checks rv_dm from both JTAG and CPU side in stub CPU mode.
-              "chip_rv_dm_lc_disabled"
-      ]
+      tests: ["chip_rv_dm_lc_disabled"]
     }
 
     // RV_TIMER (pre-verified IP) integration tests:
@@ -1505,8 +1504,6 @@
             correctness.
             '''
       stage: V2
-      // TODO: add chip_tap_straps_test_unlocked0 also (#14147)
-      // TODO: add chip_tap_straps_test_locked0 also (#14147)
       tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
     }
     {
@@ -1618,24 +1615,23 @@
             '''
       stage: V2
       tests: [
-        "chip_prim_tl_access",                            // lc_dft_en_o: otp_ctrl
-        "chip_tap_straps_dev",                            // lc_dft_en_o, lc_hw_debug_en_o: pinmux
-        "chip_tap_straps_prod",                           // lc_dft_en_o, lc_hw_debug_en_o: pinmux
-        "chip_tap_straps_rma",                            // lc_dft_en_o, lc_hw_debug_en_o: pinmux
-        // TODO: add chip_tap_straps_test_unlocked0 also (#14147)
-        "chip_sw_rom_ctrl_integrity_check",               // lc_dft_en_o, lc_hw_debug_en_o: pwrmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw",         // lc_hw_debug_en_o: clkmgr
-        "chip_sw_sram_ctrl_execution_main",               // lc_hw_debug_en_o: sram_ctrl main
-        "chip_rv_dm_lc_disabled"                          // lc_hw_debug_en_o: rv_dm
-        "chip_sw_keymgr_key_derivation",                  // lc_keymgr_en_o: keymgr
-        "chip_sw_clkmgr_external_clk_src_for_lc",         // lc_clk_byp_req_o: clkmgr
-        "chip_sw_flash_rma_unlocked",                     // lc_flash_rma_req_o, lc_flash_rma_seed_o: flash_ctrl
-        "chip_sw_lc_ctrl_transition",                     // lc_check_byp_en_o: otp_ctrl
-        "chip_sw_flash_ctrl_lc_rw_en",                    // lc_creator*, lc_seed*, lc_owner*, lc_iso*: flash_ctrl
-        "chip_sw_otp_ctrl_lc_signals_test_unlocked0",     // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i
-        "chip_sw_otp_ctrl_lc_signals_dev",                // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i
-        "chip_sw_otp_ctrl_lc_signals_prod",               // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i
-        "chip_sw_otp_ctrl_lc_signals_rma",                // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i
+        "chip_prim_tl_access",                        // lc_dft_en_o: otp_ctrl
+        "chip_tap_straps_dev",                        // lc_dft_en_o, lc_hw_debug_en_o: pinmux
+        "chip_tap_straps_prod",                       // lc_dft_en_o, lc_hw_debug_en_o: pinmux
+        "chip_tap_straps_rma",                        // lc_dft_en_o, lc_hw_debug_en_o: pinmux
+        "chip_sw_rom_ctrl_integrity_check",           // lc_dft_en_o, lc_hw_debug_en_o: pwrmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw",     // lc_hw_debug_en_o: clkmgr
+        "chip_sw_sram_ctrl_execution_main",           // lc_hw_debug_en_o: sram_ctrl main
+        "chip_rv_dm_lc_disabled"                      // lc_hw_debug_en_o: rv_dm
+        "chip_sw_keymgr_key_derivation",              // lc_keymgr_en_o: keymgr
+        "chip_sw_clkmgr_external_clk_src_for_lc",     // lc_clk_byp_req_o: clkmgr
+        "chip_sw_flash_rma_unlocked",                 // lc_flash_rma_req_o, lc_flash_rma_seed_o: flash_ctrl
+        "chip_sw_lc_ctrl_transition",                 // lc_check_byp_en_o: otp_ctrl
+        "chip_sw_flash_ctrl_lc_rw_en",                // lc_creator*, lc_seed*, lc_owner*, lc_iso*: flash_ctrl
+        "chip_sw_otp_ctrl_lc_signals_test_unlocked0", // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
+        "chip_sw_otp_ctrl_lc_signals_dev",            // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
+        "chip_sw_otp_ctrl_lc_signals_prod",           // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
+        "chip_sw_otp_ctrl_lc_signals_rma",            // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
       ]
     }
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -254,6 +254,14 @@
       run_opts: ["+stub_cpu=1"]
     }
     {
+      name: stub_cpu_mode_with_test_rom
+      en_run_modes: ["sw_test_mode_common"]
+      // The tests using this mode only require the ROM init check to succeed.
+      // The example_test_from_rom test is sufficient.
+      sw_images: ["//sw/device/tests:example_test_from_rom:0:test_in_rom"]
+      run_opts: ["+stub_cpu=1"]
+    }
+    {
       // Append stub cpu mode to csr_tests_mode.
       name: csr_tests_mode
       en_run_modes: ["stub_cpu_mode"]
@@ -1392,7 +1400,7 @@
       name: chip_rv_dm_lc_disabled
       build_mode: "cover_reg_top"
       uvm_test_seq: "chip_rv_dm_lc_disabled_vseq"
-      en_run_modes: ["stub_cpu_mode"]
+      en_run_modes: ["stub_cpu_mode_with_test_rom"]
       run_opts: ["+en_scb=0", "+en_scb_tl_err_chk=0", "+use_jtag_dmi=1"]
     }
     {


### PR DESCRIPTION
Apologies for the noise - I made a stupid rebase mistake while adding a second commit on https://github.com/lowRISC/opentitan/pull/15428 for a comment update in `rv_dm.hjson`, and accidentally merged an old, incomplete version of the test. This PR fixes that.

Addresses #14147.

Signed-off-by: Michael Schaffner <msf@google.com>