### PR TITLE
[dv/shadow_reg] Add coverplan for shadow reg

### DIFF
--- a/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson
@@ -83,4 +83,17 @@
       tests: ["{name}_shadow_reg_errors_with_csr_rw"]
     }
   ]
+
+  covergroups: [
+    {
+      name: shadow_field_errs_cg
+      desc: '''Cover all shadow register errors for each register field.
+
+            For all register fields within the shadowed register, this coverpoint covers the
+            following errors:
+            - Update error
+            - Storage error
+            '''
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds the covergroup plans for shadow_field_errs_cg.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>