### PR TITLE
[fpv/edn_sec_cm] Small fixes to pass fpv sec_cm test

### DIFF
--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -132,14 +132,16 @@ module edn
     u_edn_core.u_prim_count_max_reqs_cntr,
     alert_tx_o[1])
 
+  // Gating condition: u_edn_core.mubi_edn_enable != prim_mubi_pkg::MuBi4True
+  // If the gating condition returns 1, the assertion will be gated and disabled.
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(MainFsmCheck_A,
     u_edn_core.u_edn_main_sm.u_state_regs,
-    alert_tx_o[1])
+    alert_tx_o[1], u_edn_core.mubi_edn_enable != prim_mubi_pkg::MuBi4True)
 
   for (genvar i = 0; i < NumEndPoints; i = i+1) begin : gen_edn_fsm_asserts
     `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(AckFsmCheck_A,
       u_edn_core.gen_ep_blk[i].u_edn_ack_sm_ep.u_state_regs,
-      alert_tx_o[1])
+      alert_tx_o[1], u_edn_core.mubi_edn_enable != prim_mubi_pkg::MuBi4True)
   end
 
   // Alert assertions for reg_we onehot check

--- a/hw/ip/edn/rtl/edn_ack_sm.sv
+++ b/hw/ip/edn/rtl/edn_ack_sm.sv
@@ -41,8 +41,7 @@ module edn_ack_sm (
   typedef enum logic [StateWidth-1:0] {
     Idle      = 6'b101101, // idle (hamming distance = 3)
     DataWait  = 6'b111010, // wait for data to return
-    AckPls    = 6'b010110, // signal ack to endpoint
-    Error     = 6'b001000  // illegal state reached and hang
+    AckPls    = 6'b010110  // signal ack to endpoint
   } state_e;
 
   state_e state_d, state_q;
@@ -78,10 +77,7 @@ module edn_ack_sm (
         ack_o = 1'b1;
         state_d = Idle;
       end
-      Error: begin
-        ack_sm_err_o = 1'b1;
-      end
-      default: state_d = Error;
+      default: ack_sm_err_o = 1'b1;
     endcase
   end
 

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -315,7 +315,10 @@ module edn_main_sm #(
       Error: begin
         main_sm_err_o = 1'b1;
       end
-      default: state_d = Error;
+      default: begin
+        main_sm_err_o = 1'b1;
+        state_d = Error;
+      end
     endcase
   end
 


### PR DESCRIPTION
This PR fixes two small cases to pass fpv sec_cm test: 1). Trigger fsm_error_o directly in default case.
    This enhancement prevents the case where attacker continously drive
    to default FSM state.
2). Add a gating condition for fatal alert assertions. The fatal alerts
  will only fire if the edn is enabled.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>