### PR TITLE
[fpv/pinmux] Fix pinmux compile error

### DIFF
--- a/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -706,7 +706,7 @@ module pinmux_assert_fpv
 
   // Fatal alert related assertions
   `ASSUME(TriggerAfterAlertInit_S, $stable(rst_ni) == 0 |->
-          pinmux.u_reg.u_chk.intg_err_o == 0 [*10])
+          pinmux.u_reg.intg_err_o == 0 [*10])
   `ASSERT(TlIntgFatalAlert_A, pinmux.u_reg.intg_err_o |-> (##[0:7] (alert_tx_o[0].alert_p)) [*2])
 
 endmodule : pinmux_assert_fpv


### PR DESCRIPTION
This PR fixes pinmux compile error due to the intg_error hierarchy change.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>