### PR TITLE
[dv/spi] Clean up some names and interfaces

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -39,6 +39,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   spi_mode_e       spi_mode;
   // Cmd info configs
   spi_flash_cmd_info cmd_infos[bit[7:0]];
+  // Controls address size for flash_cmd_info of type SpiFlashAddrCfg.
   bit              flash_addr_4b_en;
 
   // set this mode before starting an item

--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -124,8 +124,14 @@ class spi_device_driver extends spi_driver;
 
           forever begin
             cfg.wait_sck_edge(DrivingEdge);
-            for (int i = 0; i < item.num_lanes; i++) begin
-              sio_bits[i] = bits_q.size > 0 ? bits_q.pop_front() : $urandom_range(0, 1);
+            // The first bit in bits_q is the MSB, which is driven on the sio
+            // lane with the highest active index.
+            for (int i = $high(sio_bits); i >= $low(sio_bits); i--) begin
+              if (i >= item.num_lanes) begin
+                sio_bits[i] = 1'bz;
+              end else begin
+                sio_bits[i] = bits_q.size > 0 ? bits_q.pop_front() : $urandom_range(0, 1);
+              end
             end
             send_data_to_sio(spi_mode, sio_bits);
           end

--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -2,6 +2,22 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// The spi_device_driver responds to bus transactions initiated by a SPI host,
+// and its responses depend on cfg.spi_func_mode.
+//
+// For SpiModeGeneric, the driver waits for CSB to be asserted, then drives
+// the contents of spi_item.data sequentially, timed with the SPI host's clock
+// output.
+//
+// For SpiModeFlash, the spi_item must be submitted at exactly the moment when
+// the driver is to begin driving the response. The driver sends the contents
+// of spi_item.payload_q sequentially, timed with the SPI host's clock output.
+// Note that spi_device_driver does NOT observe the command, address, or dummy
+// cycles, and it assumes those phases have already passed. For this mode,
+// spi_device_driver is anticipated to be used in conjunction with the
+// spi_monitor's req_analysis_port, which writes a spi_item into the
+// spi_sequencer's connected req_analysis_fifo at the moment those phases have
+// completed.
 class spi_device_driver extends spi_driver;
   `uvm_component_utils(spi_device_driver)
   `uvm_component_new

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -608,7 +608,8 @@ module spi_host
   `ASSERT_KNOWN(CioSckEnKnownO_A, cio_sck_en_o)
   `ASSERT_KNOWN(CioCsbKnownO_A, cio_csb_o)
   `ASSERT_KNOWN(CioCsbEnKnownO_A, cio_csb_en_o)
-  `ASSERT_KNOWN(CioSdKnownO_A, cio_sd_o)
+  `ASSERT_KNOWN_IF(CioSdKnownO_A, cio_sd_o, !passthrough_i.passthrough_en |
+    (passthrough_i.passthrough_en && passthrough_i.csb_en && !passthrough_i.csb))
   `ASSERT_KNOWN(CioSdEnKnownO_A, cio_sd_en_o)
   `ASSERT_KNOWN(IntrSpiEventKnownO_A, intr_spi_event_o)
   `ASSERT_KNOWN(IntrErrorKnownO_A, intr_error_o)

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -17,7 +17,7 @@ class chip_env extends cip_base_env #(
   jtag_riscv_agent       m_jtag_riscv_agent;
   jtag_riscv_reg_adapter m_jtag_riscv_reg_adapter;
   // spi host agent that transmits trasnactions to dut spi device
-  spi_agent              m_spi_agent;
+  spi_agent              m_spi_host_agent;
   pwm_monitor            m_pwm_monitor[NUM_PWM_CHANNELS];
   pattgen_agent          m_pattgen_agent;
 
@@ -108,8 +108,8 @@ class chip_env extends cip_base_env #(
     m_jtag_riscv_reg_adapter.cfg = cfg.m_jtag_riscv_agent_cfg;
 
     // dut spi device, tb spi host
-    m_spi_agent = spi_agent::type_id::create("m_spi_agent", this);
-    uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent*", "cfg", cfg.m_spi_agent_cfg);
+    m_spi_host_agent = spi_agent::type_id::create("m_spi_host_agent", this);
+    uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_host_agent*", "cfg", cfg.m_spi_host_agent_cfg);
 
     // instantiate pwm_monitor
     foreach (m_pwm_monitor[i]) begin
@@ -154,8 +154,8 @@ class chip_env extends cip_base_env #(
       virtual_sequencer.jtag_sequencer_h = m_jtag_riscv_agent.sequencer;
     end
 
-    if (cfg.is_active && cfg.m_spi_agent_cfg.is_active) begin
-      virtual_sequencer.spi_sequencer_h = m_spi_agent.sequencer;
+    if (cfg.is_active && cfg.m_spi_host_agent_cfg.is_active) begin
+      virtual_sequencer.spi_sequencer_h = m_spi_host_agent.sequencer;
     end
 
     // The chip level scoreboard is intentionally kept lightweight, since most tests are directed,

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -155,7 +155,7 @@ class chip_env extends cip_base_env #(
     end
 
     if (cfg.is_active && cfg.m_spi_host_agent_cfg.is_active) begin
-      virtual_sequencer.spi_sequencer_h = m_spi_host_agent.sequencer;
+      virtual_sequencer.spi_host_sequencer_h = m_spi_host_agent.sequencer;
     end
 
     // The chip level scoreboard is intentionally kept lightweight, since most tests are directed,

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -84,7 +84,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   rand spi_agent_cfg        m_spi_device_agent_cfgs[NUM_SPI_HOSTS];
   rand jtag_riscv_agent_cfg m_jtag_riscv_agent_cfg;
   rand jtag_agent_cfg       m_jtag_agent_cfg;
-  rand spi_agent_cfg        m_spi_agent_cfg;
+  rand spi_agent_cfg        m_spi_host_agent_cfg;
   pwm_monitor_cfg           m_pwm_monitor_cfg[NUM_PWM_CHANNELS];
   rand i2c_agent_cfg        m_i2c_agent_cfgs[NUM_I2CS];
   rand pattgen_agent_cfg    m_pattgen_agent_cfg;
@@ -112,7 +112,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
   `uvm_object_utils_begin(chip_env_cfg)
     `uvm_field_object(m_jtag_riscv_agent_cfg, UVM_DEFAULT)
-    `uvm_field_object(m_spi_agent_cfg,        UVM_DEFAULT)
+    `uvm_field_object(m_spi_host_agent_cfg,   UVM_DEFAULT)
     `uvm_field_object(jtag_dmi_ral,           UVM_DEFAULT)
   `uvm_object_utils_end
 
@@ -171,7 +171,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     end
 
     // create spi agent config obj
-    m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");
+    m_spi_host_agent_cfg = spi_agent_cfg::type_id::create("m_spi_host_agent_cfg");
 
     // create pwm monitor config obj
     foreach (m_pwm_monitor_cfg[i]) begin

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -654,7 +654,7 @@ interface chip_if;
     uvm_config_db#(virtual tl_if)::set(
         null, "*.env.m_tl_agent_chip_reg_block*", "vif", cpu_d_tl_if);
 
-    uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_host_if);
+    uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_host_agent*", "vif", spi_host_if);
 
     // foreach (alert_if[i]) begin
     //   uvm_config_db#(virtual alert_esc_if)::set(null, $sformatf("*.env.m_alert_agent_%0s",

--- a/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
+++ b/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
@@ -12,7 +12,7 @@ class chip_virtual_sequencer extends cip_base_virtual_sequencer #(
   spi_sequencer        spi_device_sequencer_hs[NUM_SPI_HOSTS];
   i2c_sequencer        i2c_sequencer_hs[NUM_I2CS];
   jtag_riscv_sequencer jtag_sequencer_h;
-  spi_sequencer        spi_sequencer_h;
+  spi_sequencer        spi_host_sequencer_h;
 
   // Grab packets from UART TX port for in-sequence checking.
   uvm_tlm_analysis_fifo #(uart_item) uart_tx_fifos[NUM_UARTS];

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -239,7 +239,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     info.num_lanes = 1;
     info.dummy_cycles = 8;
     info.write_command = 0;
-    cfg.m_spi_agent_cfg.add_cmd_info(info);
+    cfg.m_spi_host_agent_cfg.add_cmd_info(info);
 
     info = spi_flash_cmd_info::type_id::create("info");
     info.addr_mode = SpiFlashAddrDisabled;
@@ -247,7 +247,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     info.num_lanes = 1;
     info.dummy_cycles = 0;
     info.write_command = 0;
-    cfg.m_spi_agent_cfg.add_cmd_info(info);
+    cfg.m_spi_host_agent_cfg.add_cmd_info(info);
 
     info = spi_flash_cmd_info::type_id::create("info");
     info.addr_mode = SpiFlashAddrDisabled;
@@ -255,7 +255,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     info.num_lanes = 0;
     info.dummy_cycles = 0;
     info.write_command = 0;
-    cfg.m_spi_agent_cfg.add_cmd_info(info);
+    cfg.m_spi_host_agent_cfg.add_cmd_info(info);
 
     info = spi_flash_cmd_info::type_id::create("info");
     info.addr_mode = SpiFlashAddrDisabled;
@@ -263,7 +263,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     info.num_lanes = 0;
     info.dummy_cycles = 0;
     info.write_command = 0;
-    cfg.m_spi_agent_cfg.add_cmd_info(info);
+    cfg.m_spi_host_agent_cfg.add_cmd_info(info);
 
     info = spi_flash_cmd_info::type_id::create("info");
     info.addr_mode = SpiFlashAddr3b;
@@ -271,9 +271,9 @@ class chip_sw_base_vseq extends chip_base_vseq;
     info.num_lanes = 1;
     info.dummy_cycles = 0;
     info.write_command = 1;
-    cfg.m_spi_agent_cfg.add_cmd_info(info);
+    cfg.m_spi_host_agent_cfg.add_cmd_info(info);
 
-    cfg.m_spi_agent_cfg.spi_func_mode = SpiModeFlash;
+    cfg.m_spi_host_agent_cfg.spi_func_mode = SpiModeFlash;
   endfunction
 
   // Periodically probe the device for its busy bit and wait for up to
@@ -341,8 +341,8 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     // Set CSB inactive times to reasonable values. sys_clk is at 24 MHz, and
     // it needs to capture CSB pulses.
-    cfg.m_spi_agent_cfg.min_idle_ns_after_csb_drop = 50;
-    cfg.m_spi_agent_cfg.max_idle_ns_after_csb_drop = 200;
+    cfg.m_spi_host_agent_cfg.min_idle_ns_after_csb_drop = 50;
+    cfg.m_spi_host_agent_cfg.max_idle_ns_after_csb_drop = 200;
 
     // Configure the spi_agent for flash mode and add command info.
     spi_host_agent_configure_flash_cmds();
@@ -365,7 +365,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
       .spinwait_delay_ns(5000));
 
     // sdo from chip is unknown, ignore checking that
-    cfg.m_spi_agent_cfg.en_monitor_checks = 0;
+    cfg.m_spi_host_agent_cfg.en_monitor_checks = 0;
 
     read_sw_frames(sw_image, sw_byte_q);
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_device_tpm_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_device_tpm_vseq.sv
@@ -14,7 +14,7 @@ class chip_sw_spi_device_tpm_vseq extends chip_sw_base_vseq;
   virtual task tpm_txn (bit wr, bit [23:0] addr, bit [7:0] data_q[$] = {0},
                         int len, output logic [7:0] rdata_q[]);
     spi_host_tpm_seq m_host_tpm_seq;
-    `uvm_create_on(m_host_tpm_seq, p_sequencer.spi_sequencer_h)
+    `uvm_create_on(m_host_tpm_seq, p_sequencer.spi_host_sequencer_h)
 
     // Common attribute assignments
     m_host_tpm_seq.write_command = wr;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_device_tpm_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_device_tpm_vseq.sv
@@ -45,8 +45,8 @@ class chip_sw_spi_device_tpm_vseq extends chip_sw_base_vseq;
     cfg.chip_vif.enable_spi_tpm = 1;
 
     // Directly set the expected cs_id
-    cfg.m_spi_agent_cfg.csb_sel_in_cfg = 1;
-    cfg.m_spi_agent_cfg.csid = 1;
+    cfg.m_spi_host_agent_cfg.csb_sel_in_cfg = 1;
+    cfg.m_spi_host_agent_cfg.csid = 1;
 
     // enable spi agent interface to begin
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "Begin TPM Test",

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_tx_rx_vseq.sv
@@ -60,7 +60,7 @@ class chip_sw_spi_tx_rx_vseq extends chip_sw_base_vseq;
 
   virtual task send_spi_host_rx_data(ref bit [7:0] device_data[$],input int size);
     spi_host_seq m_spi_host_seq;
-    `uvm_create_on(m_spi_host_seq, p_sequencer.spi_sequencer_h)
+    `uvm_create_on(m_spi_host_seq, p_sequencer.spi_host_sequencer_h)
     if (size == SPI_DEVICE_DATA_SIZE) begin
       `DV_CHECK_RANDOMIZE_WITH_FATAL(m_spi_host_seq,
                                      data.size() == size;


### PR DESCRIPTION
- Document how the spi_device_driver works.
- Change names of top-level sequencers and agents to reflect their role.
- Adjust SVAs that check for X on passthrough to allow it while CSB is not asserted.
- Fix the spi_device_driver's bit mapping for flash transactions so that the lane with the highest index gets the MSB.