### PR TITLE
[top_earlgrey/dv] Add SPI passthrough test

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_host_flash_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_host_flash_seq.sv
@@ -65,7 +65,7 @@ class spi_host_flash_seq extends spi_base_seq;
                                     }
                                    }
                                   // TODO, consolidate data and payload later
-                                  data.size == 1;)
+                                  data.size == 0;)
     finish_item(req);
     get_response(rsp);
   endtask

--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -46,6 +46,9 @@ class spi_device_driver extends spi_driver;
       active_csb = req.csb_sel;
       $cast(rsp, req.clone());
       rsp.set_id_info(req);
+      // The response should read the payload actually consumed, not start with
+      // it filled out.
+      rsp.payload_q = '{};
 
       wait (!under_reset && !cfg.vif.csb[active_csb]);
       fork

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -154,14 +154,14 @@
               testbench.
             - Verify the flash commands which pass through spi_host0, are received on chip IOs.
             - Verify spi_host1 doesn't send out any data from spi_device
-            - Run with min (6MHz), typical (30-48Mhz) and max(48MHz) SPI clk frequencies.
+            - Run with min (6MHz), typical (24Mhz) and max (30MHz) SPI clk frequencies.
             - Run with single, dual and quad SPI modes.
             - Testbench should test the following commands:
               - Read Normal, Fast Read, Fast Dual, Fast Quad, Chip Erase, Program
 
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_spi_device_pass_through"]
     }
     {
       name: chip_sw_spi_device_pass_through_filter

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -508,6 +508,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_spi_device_pass_through
+      uvm_test_seq: chip_sw_spi_passthrough_vseq
+      sw_images: ["//sw/device/tests/sim_dv:spi_passthrough_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_gpio
       uvm_test_seq: chip_sw_gpio_vseq
       sw_images: ["//sw/device/tests/sim_dv:gpio_test:1"]
@@ -1443,6 +1449,7 @@
       tests: ["xbar_chip_smoke",
               "chip_sw_uart_tx_rx",
               "chip_sw_spi_host_tx_rx",
+              "chip_sw_spi_device_pass_through",
               "chip_sw_i2c_host_tx_rx",
               "chip_plic_all_irqs",
               "chip_sw_example_flash",

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -88,6 +88,7 @@ filesets:
       - seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_host_tx_rx_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_spi_passthrough_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -243,9 +243,65 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     info = spi_flash_cmd_info::type_id::create("info");
     info.addr_mode = SpiFlashAddrDisabled;
+    info.opcode = SpiFlashReadJedec;
+    info.num_lanes = 1;
+    info.dummy_cycles = 0;
+    info.write_command = 0;
+    agent_cfg.add_cmd_info(info);
+
+    info = spi_flash_cmd_info::type_id::create("info");
+    info.addr_mode = SpiFlashAddrDisabled;
     info.opcode = SpiFlashReadSts1;
     info.num_lanes = 1;
     info.dummy_cycles = 0;
+    info.write_command = 0;
+    agent_cfg.add_cmd_info(info);
+
+    info = spi_flash_cmd_info::type_id::create("info");
+    info.addr_mode = SpiFlashAddrDisabled;
+    info.opcode = SpiFlashReadSts2;
+    info.num_lanes = 1;
+    info.dummy_cycles = 0;
+    info.write_command = 0;
+    agent_cfg.add_cmd_info(info);
+
+    info = spi_flash_cmd_info::type_id::create("info");
+    info.addr_mode = SpiFlashAddrDisabled;
+    info.opcode = SpiFlashReadSts3;
+    info.num_lanes = 1;
+    info.dummy_cycles = 0;
+    info.write_command = 0;
+    agent_cfg.add_cmd_info(info);
+
+    info = spi_flash_cmd_info::type_id::create("info");
+    info.addr_mode = SpiFlashAddrCfg;
+    info.opcode = SpiFlashReadNormal;
+    info.num_lanes = 1;
+    info.dummy_cycles = 0;
+    info.write_command = 0;
+    agent_cfg.add_cmd_info(info);
+
+    info = spi_flash_cmd_info::type_id::create("info");
+    info.addr_mode = SpiFlashAddrCfg;
+    info.opcode = SpiFlashReadFast;
+    info.num_lanes = 1;
+    info.dummy_cycles = 8;
+    info.write_command = 0;
+    agent_cfg.add_cmd_info(info);
+
+    info = spi_flash_cmd_info::type_id::create("info");
+    info.addr_mode = SpiFlashAddrCfg;
+    info.opcode = SpiFlashReadDual;
+    info.num_lanes = 2;
+    info.dummy_cycles = 8;
+    info.write_command = 0;
+    agent_cfg.add_cmd_info(info);
+
+    info = spi_flash_cmd_info::type_id::create("info");
+    info.addr_mode = SpiFlashAddrCfg;
+    info.opcode = SpiFlashReadQuad;
+    info.num_lanes = 4;
+    info.dummy_cycles = 8;
     info.write_command = 0;
     agent_cfg.add_cmd_info(info);
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
@@ -1,0 +1,136 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_spi_passthrough_vseq)
+
+  `uvm_object_new
+
+  // The sequence of opcodes used for the test.
+  spi_flash_cmd_e test_opcodes[$];
+  // Whether to check for transactions appearing on the unused spi_host.
+  bit en_unused_spi_host_monitoring = 1'b1;
+  // Frequencies to use for testing the sequences.
+  time sck_periods_ps[] = '{
+    41_000, // 24 MHz
+    33_000, // 30 MHz
+    167_000 // 6 MHz
+  };
+
+  // Generate a random permutation of the following opcodes, and place them in
+  // the test_opcodes queue:
+  //   - SpiFlashReadNormal
+  //   - SpiFlashReadFast
+  //   - SpiFlashReadDual
+  //   - SpiFlashReadQuad
+  //   - SpiFlashChipErase
+  //   - SpiFlashPageProgram
+  virtual function void generate_spi_flash_sequence();
+    test_opcodes = '{
+      SpiFlashReadNormal,
+      SpiFlashReadFast,
+      SpiFlashReadDual,
+      SpiFlashReadQuad,
+      SpiFlashChipErase,
+      SpiFlashPageProgram
+    };
+    test_opcodes.shuffle();
+  endfunction
+
+  // Assert that spi_host does not send any transactions.
+  virtual task monitor_unused_spi_host();
+    spi_agent_cfg agent_cfg = cfg.m_spi_device_agent_cfgs[1];
+    // CSB should never assert
+    wait (agent_cfg.vif.rst_n && !agent_cfg.vif.csb[0]);
+    `uvm_fatal(`gfn, $sformatf(
+      "Observed SPI transaction on spi_host1, which should be inactive"));
+  endtask
+
+  // Send the sequence of commands indicated by the `test_opcodes` member.
+  // These commands must be registered with the host and device agents, as the
+  // command info determines the actions takes for each opcode. Random data of
+  // random size will be generated for each command that has a payload phase.
+  virtual task execute_spi_flash_sequence();
+    const int max_payload_size = 1024;
+    spi_device_flash_seq m_spi_device_seq;
+    spi_host_flash_seq m_spi_host_seq;
+    spi_item host_rsp, device_rsp;
+    spi_agent_cfg agent_cfg = cfg.m_spi_host_agent_cfg;
+
+    while (test_opcodes.size() > 0) begin
+      bit [7:0] opcode = test_opcodes.pop_front();
+
+      `uvm_create_on(m_spi_device_seq, p_sequencer.spi_device_sequencer_hs[0]);
+      `uvm_create_on(m_spi_host_seq, p_sequencer.spi_host_sequencer_h);
+      // Prepare for specific opcode. The address_q is kept empty, which will
+      // trigger m_spi_host_seq to do the lookup and supply a random value.
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(m_spi_host_seq,
+                                     opcode == local::opcode;
+                                     address_q.size() == 0;
+                                     payload_q.size() <= local::max_payload_size;
+                                     read_size == payload_q.size(););
+      fork
+        begin
+          `uvm_send(m_spi_device_seq);
+        end
+        begin
+          `uvm_send(m_spi_host_seq);
+        end
+      join
+
+      // Check that the command, address, and data sent matches on both sides.
+      host_rsp = m_spi_host_seq.rsp;
+      device_rsp = m_spi_device_seq.rsp;
+      `DV_CHECK_EQ(host_rsp.opcode, device_rsp.opcode);
+      `DV_CHECK_Q_EQ(host_rsp.address_q, device_rsp.address_q);
+      `DV_CHECK_EQ(host_rsp.dummy_cycles, device_rsp.dummy_cycles);
+      `DV_CHECK_EQ(host_rsp.num_lanes, device_rsp.num_lanes);
+      `DV_CHECK_Q_EQ(host_rsp.payload_q, device_rsp.payload_q);
+    end
+  endtask
+
+  virtual task body();
+    // Turn off the FIFO data output assertion, as spi_device issues a read
+    // before it knows whether it needs the data.
+    $assertoff(0, "tb.dut.top_earlgrey.u_spi_device.u_readcmd.u_readsram.u_sram_fifo.DataKnown_A");
+    $assertoff(0, "tb.dut.top_earlgrey.u_spi_device.u_readcmd.u_readsram.u_fifo.DataKnown_A");
+
+    super.body();
+
+    // Enable the monitor for the agent connected to spi_host0.
+    cfg.m_spi_device_agent_cfgs[0].en_monitor = 1'b1;
+    cfg.m_spi_device_agent_cfgs[0].byte_order = '0;
+
+    // Set CSB inactive times to reasonable values. sys_clk is at 24 MHz, and
+    // it needs to capture CSB pulses.
+    cfg.m_spi_host_agent_cfg.min_idle_ns_after_csb_drop = 50;
+    cfg.m_spi_host_agent_cfg.max_idle_ns_after_csb_drop = 200;
+
+    spi_agent_configure_flash_cmds(cfg.m_spi_host_agent_cfg);
+    spi_agent_configure_flash_cmds(cfg.m_spi_device_agent_cfgs[0]);
+    // Enable the spi agents.
+    cfg.chip_vif.enable_spi_host = 1;
+    cfg.chip_vif.enable_spi_device(.inst_num(0), .enable(1));
+    cfg.chip_vif.enable_spi_device(.inst_num(1), .enable(1));
+
+    // Wait until we reach the SW test state.
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest,
+             "Timed out waiting for SwTestStatusInTest",
+             10_000_000)
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Test setup complete.",
+             "Timeout waiting for software to complete setup.")
+
+    if (en_unused_spi_host_monitoring) begin
+      fork
+        monitor_unused_spi_host();
+      join_none
+    end
+    foreach (sck_periods_ps[i]) begin
+      cfg.m_spi_host_agent_cfg.sck_period_ps = sck_periods_ps[i];
+      generate_spi_flash_sequence();
+      execute_spi_flash_sequence();
+    end
+    override_test_status_and_finish(1'b1);
+  endtask
+endclass : chip_sw_spi_passthrough_vseq;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -39,6 +39,7 @@
 `include "chip_sw_lc_walkthrough_testunlocks_vseq.sv"
 `include "chip_sw_spi_tx_rx_vseq.sv"
 `include "chip_sw_spi_host_tx_rx_vseq.sv"
+`include "chip_sw_spi_passthrough_vseq.sv"
 `include "chip_sw_rom_ctrl_integrity_check_vseq.sv"
 `include "chip_sw_sram_ctrl_execution_main_vseq.sv"
 `include "chip_sw_sram_ctrl_scrambled_access_vseq.sv"

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -69,8 +69,7 @@ extern const uint64_t kClockFreqCpuHz;
 /**
  * The peripheral clock frequency of the device, in hertz.
  * This is the operating clock used by timers, uarts,
- * other peripheral interfaces and the software interface
- * to the USB controller.
+ * other peripheral interfaces.
  */
 extern const uint64_t kClockFreqPeripheralHz;
 
@@ -82,7 +81,8 @@ extern const uint64_t kClockFreqHiSpeedPeripheralHz;
 
 /**
  * The USB clock frequency of the device, in hertz.
- * This is the operating clock used by the USB phy interface.
+ * This is the operating clock used by the USB phy interface and USB's software
+ * interface.
  */
 extern const uint64_t kClockFreqUsbHz;
 

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -139,6 +139,30 @@ dif_result_t dif_spi_device_configure(dif_spi_device_handle_t *spi,
   return kDifOk;
 }
 
+dif_result_t dif_spi_device_set_passthrough_mode(dif_spi_device_handle_t *spi,
+                                                 dif_toggle_t enable) {
+  if (spi == NULL || !dif_is_valid_toggle(enable)) {
+    return kDifBadArg;
+  }
+  uint32_t control =
+      mmio_region_read32(spi->dev.base_addr, SPI_DEVICE_CONTROL_REG_OFFSET);
+  uint32_t mode = bitfield_field32_read(control, SPI_DEVICE_CONTROL_MODE_FIELD);
+  if (mode != SPI_DEVICE_CONTROL_MODE_VALUE_FLASHMODE &&
+      mode != SPI_DEVICE_CONTROL_MODE_VALUE_PASSTHROUGH) {
+    return kDifBadArg;
+  }
+  if (dif_toggle_to_bool(enable)) {
+    control = bitfield_field32_write(control, SPI_DEVICE_CONTROL_MODE_FIELD,
+                                     SPI_DEVICE_CONTROL_MODE_VALUE_PASSTHROUGH);
+  } else {
+    control = bitfield_field32_write(control, SPI_DEVICE_CONTROL_MODE_FIELD,
+                                     SPI_DEVICE_CONTROL_MODE_VALUE_FLASHMODE);
+  }
+  mmio_region_write32(spi->dev.base_addr, SPI_DEVICE_CONTROL_REG_OFFSET,
+                      control);
+  return kDifOk;
+}
+
 dif_result_t dif_spi_device_reset_generic_tx_fifo(
     dif_spi_device_handle_t *spi) {
   if (spi == NULL) {

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -159,6 +159,20 @@ dif_result_t dif_spi_device_configure(dif_spi_device_handle_t *spi,
                                       dif_spi_device_config_t config);
 
 /**
+ * Turn on/off passthrough without changing any other configuration.
+ *
+ * This changes the mode to one of flash mode or passthrough mode. The current
+ * mode must be one of those, else this function will fail.
+ *
+ * @param spi A SPI handle.
+ * @param enable Whether to turn on passthrough mode.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_set_passthrough_mode(dif_spi_device_handle_t *spi,
+                                                 dif_toggle_t enable);
+
+/**
  * Resets the asynchronous TX FIFO in generic mode.
  *
  * This function should only be called when the upstream spi host is held in

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -773,6 +773,25 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "spi_passthrough_test",
+    srcs = ["spi_passthrough_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/dif:spi_host",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "rv_dm_ndm_reset_req",
     srcs = ["rv_dm_ndm_reset_req.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/spi_passthrough_test.c
+++ b/sw/device/tests/sim_dv/spi_passthrough_test.c
@@ -1,0 +1,443 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <stdbool.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_spi_device.h"
+#include "sw/device/lib/dif/dif_spi_host.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_pinmux_t pinmux;
+static dif_spi_device_handle_t spi_device;
+static dif_spi_host_t spi_host0;
+static dif_spi_host_t spi_host1;
+
+typedef struct pinmux_pad_attributes {
+  dif_pinmux_index_t pad;
+  dif_pinmux_pad_kind_t kind;
+  dif_pinmux_pad_attr_flags_t flags;
+} pinmux_pad_attributes_t;
+
+// Enable pull-ups for spi_host data pins to avoid floating inputs.
+static const pinmux_pad_attributes_t pinmux_pad_config[] = {
+    {
+        .pad = kTopEarlgreyMuxedPadsIob1,
+        .kind = kDifPinmuxPadKindMio,
+        .flags = kDifPinmuxPadAttrPullResistorEnable |
+                 kDifPinmuxPadAttrPullResistorUp,
+    },
+    {
+        .pad = kTopEarlgreyMuxedPadsIob3,
+        .kind = kDifPinmuxPadKindMio,
+        .flags = kDifPinmuxPadAttrPullResistorEnable |
+                 kDifPinmuxPadAttrPullResistorUp,
+    },
+    {
+        .pad = kTopEarlgreyDirectPadsSpiHost0Sd0,
+        .kind = kDifPinmuxPadKindDio,
+        .flags = kDifPinmuxPadAttrPullResistorEnable |
+                 kDifPinmuxPadAttrPullResistorUp,
+    },
+    {
+        .pad = kTopEarlgreyDirectPadsSpiHost0Sd1,
+        .kind = kDifPinmuxPadKindDio,
+        .flags = kDifPinmuxPadAttrPullResistorEnable |
+                 kDifPinmuxPadAttrPullResistorUp,
+    },
+    {
+        .pad = kTopEarlgreyDirectPadsSpiHost0Sd2,
+        .kind = kDifPinmuxPadKindDio,
+        .flags = kDifPinmuxPadAttrPullResistorEnable |
+                 kDifPinmuxPadAttrPullResistorUp,
+    },
+    {
+        .pad = kTopEarlgreyDirectPadsSpiHost0Sd3,
+        .kind = kDifPinmuxPadKindDio,
+        .flags = kDifPinmuxPadAttrPullResistorEnable |
+                 kDifPinmuxPadAttrPullResistorUp,
+    },
+};
+
+typedef struct pinmux_select {
+  dif_pinmux_index_t pad;
+  dif_pinmux_index_t peripheral;
+} pinmux_select_t;
+
+static const pinmux_select_t pinmux_out_config[] = {
+    {
+        .pad = kTopEarlgreyPinmuxMioOutIob0,
+        .peripheral = kTopEarlgreyPinmuxOutselSpiHost1Csb,
+    },
+    {
+        .pad = kTopEarlgreyPinmuxMioOutIob2,
+        .peripheral = kTopEarlgreyPinmuxOutselSpiHost1Sck,
+    },
+    {
+        .pad = kTopEarlgreyPinmuxMioOutIob1,
+        .peripheral = kTopEarlgreyPinmuxOutselSpiHost1Sd0,
+    },
+    {
+        .pad = kTopEarlgreyPinmuxMioOutIob3,
+        .peripheral = kTopEarlgreyPinmuxOutselSpiHost1Sd1,
+    },
+    // These peripheral I/Os are not assigned for tests.
+    //     {
+    //         .pad = ???,
+    //         .peripheral = kTopEarlgreyPinmuxOutselSpiHost1Sd2,
+    //     },
+    //     {
+    //         .pad = ???,
+    //         .peripheral = kTopEarlgreyPinmuxOutselSpiHost1Sd3,
+    //     },
+};
+
+static const pinmux_select_t pinmux_in_config[] = {
+    {
+        .pad = kTopEarlgreyPinmuxInselIob1,
+        .peripheral = kTopEarlgreyPinmuxOutselSpiHost1Sd0,
+    },
+    {
+        .pad = kTopEarlgreyPinmuxInselIob3,
+        .peripheral = kTopEarlgreyPinmuxOutselSpiHost1Sd1,
+    },
+    // These peripheral I/Os are not assigned for tests.
+    //     {
+    //         .pad = ???,
+    //         .peripheral = kTopEarlgreyPinmuxOutselSpiHost1Sd2,
+    //     },
+    //     {
+    //         .pad = ???,
+    //         .peripheral = kTopEarlgreyPinmuxOutselSpiHost1Sd3,
+    //     },
+};
+
+/**
+ * A set of typical opcodes for the named flash commands.
+ */
+enum spi_flash_opcode {
+  kSpiFlashOpReadJedec = 0x9f,
+  kSpiFlashOpReadSfdp = 0x5a,
+  kSpiFlashOpReadNormal = 0x03,
+  kSpiFlashOpReadFast = 0x0b,
+  kSpiFlashOpReadDual = 0x3b,
+  kSpiFlashOpReadQuad = 0x6b,
+  kSpiFlashOpWriteEnable = 0x06,
+  kSpiFlashOpWriteDisable = 0x04,
+  kSpiFlashOpReadStatus1 = 0x05,
+  kSpiFlashOpReadStatus2 = 0x35,
+  kSpiFlashOpReadStatus3 = 0x15,
+  kSpiFlashOpWriteStatus1 = 0x01,
+  kSpiFlashOpWriteStatus2 = 0x31,
+  kSpiFlashOpWriteStatus3 = 0x11,
+  kSpiFlashOpChipErase = 0xc7,
+  kSpiFlashOpSectorErase = 0x20,
+  kSpiFlashOpPageProgram = 0x02,
+  kSpiFlashOpEnter4bAddr = 0xb7,
+  kSpiFlashOpExit4bAddr = 0xe9,
+};
+
+enum spi_device_command_slot {
+  kSpiDeviceReadCommandSlotBase = 0,
+  kSpiDeviceWriteCommandSlotBase = 11,
+};
+
+/**
+ * Initialize the provided SPI host. For the most part, the values provided are
+ * filler, as spi_host0 will be in passthrough mode and spi_host1 will remain
+ * unused throughout the test.
+ */
+void init_spi_host(dif_spi_host_t *spi_host,
+                   uint32_t peripheral_clock_freq_hz) {
+  dif_spi_host_config_t config = {
+      .spi_clock = peripheral_clock_freq_hz / 2,
+      .peripheral_clock_freq_hz = peripheral_clock_freq_hz,
+      .chip_select =
+          {
+              .idle = 2,
+              .trail = 2,
+              .lead = 2,
+          },
+  };
+  CHECK_DIF_OK(dif_spi_host_configure(spi_host, config));
+  CHECK_DIF_OK(dif_spi_host_output_set_enabled(spi_host, /*enabled=*/true));
+}
+
+/**
+ * Initialize the SPI device to be in passthrough mode and allow the following
+ * commands to pass through:
+ *  - ReadJedec
+ *  - ReadSfdp
+ *  - ReadNormal
+ *  - ReadFast
+ *  - ReadDual
+ *  - ReadQuad
+ *  - WriteEnable
+ *  - WriteDisable
+ *  - ReadStatus1
+ *  - ReadStatus2
+ *  - ReadStatus3
+ *  - WriteStatus1
+ *  - WriteStatus2
+ *  - WriteStatus3
+ *  - ChipErase
+ *  - SectorErase
+ *  - PageProgram
+ *  - Enter4bAddr
+ *  - Exit4bAddr
+ *
+ */
+void init_spi_device(void) {
+  dif_spi_device_config_t spi_device_config = {
+      .clock_polarity = kDifSpiDeviceEdgePositive,
+      .data_phase = kDifSpiDeviceEdgeNegative,
+      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .device_mode = kDifSpiDeviceModePassthrough,
+  };
+  CHECK_DIF_OK(dif_spi_device_configure(&spi_device, spi_device_config));
+
+  dif_spi_device_passthrough_intercept_config_t intercept_config = {
+      .status = false,
+      .jedec_id = false,
+      .sfdp = false,
+      .mailbox = false,
+  };
+  CHECK_DIF_OK(dif_spi_device_set_passthrough_intercept_config(
+      &spi_device, intercept_config));
+
+  // Set up passthrough filter to allow all commands.
+  CHECK_DIF_OK(dif_spi_device_set_all_passthrough_command_filters(
+      &spi_device, kDifToggleDisabled));
+
+  dif_spi_device_flash_command_t read_commands[] = {
+      {
+          // Slot 0: ReadStatus1
+          .opcode = kSpiFlashOpReadStatus1,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 1: ReadStatus2
+          .opcode = kSpiFlashOpReadStatus2,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 2: ReadStatus3
+          .opcode = kSpiFlashOpReadStatus3,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 3: ReadJedecID
+          .opcode = kSpiFlashOpReadJedec,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 4: ReadSfdp
+          .opcode = kSpiFlashOpReadSfdp,
+          .address_type = kDifSpiDeviceFlashAddr3Byte,
+          .dummy_cycles = 8,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 5: ReadNormal
+          .opcode = kSpiFlashOpReadNormal,
+          .address_type = kDifSpiDeviceFlashAddrCfg,
+          .passthrough_swap_address = true,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 6: ReadFast
+          .opcode = kSpiFlashOpReadFast,
+          .address_type = kDifSpiDeviceFlashAddrCfg,
+          .passthrough_swap_address = true,
+          .dummy_cycles = 8,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 7: ReadDual
+          .opcode = kSpiFlashOpReadDual,
+          .address_type = kDifSpiDeviceFlashAddrCfg,
+          .passthrough_swap_address = true,
+          .dummy_cycles = 8,
+          .payload_io_type = kDifSpiDevicePayloadIoDual,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 8: ReadQuad
+          .opcode = kSpiFlashOpReadQuad,
+          .address_type = kDifSpiDeviceFlashAddrCfg,
+          .passthrough_swap_address = true,
+          .dummy_cycles = 8,
+          .payload_io_type = kDifSpiDevicePayloadIoQuad,
+          .payload_dir_to_host = true,
+      },
+  };
+  for (int i = 0; i < ARRAYSIZE(read_commands); ++i) {
+    uint8_t slot = i + kSpiDeviceReadCommandSlotBase;
+    CHECK_DIF_OK(dif_spi_device_set_flash_command_slot(
+        &spi_device, slot, kDifToggleEnabled, read_commands[i]));
+  }
+  dif_spi_device_flash_command_t write_commands[] = {
+      {
+          // Slot 11: WriteStatus1
+          .opcode = kSpiFlashOpWriteStatus1,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = false,
+      },
+      {
+          // Slot 12: WriteStatus2
+          .opcode = kSpiFlashOpWriteStatus2,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = false,
+      },
+      {
+          // Slot 13: WriteStatus3
+          .opcode = kSpiFlashOpWriteStatus3,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = false,
+      },
+      {
+          // Slot 14: ChipErase
+          .opcode = kSpiFlashOpChipErase,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .payload_io_type = kDifSpiDevicePayloadIoNone,
+      },
+      {
+          // Slot 15: SectorErase
+          .opcode = kSpiFlashOpSectorErase,
+          .address_type = kDifSpiDeviceFlashAddrCfg,
+          .payload_io_type = kDifSpiDevicePayloadIoNone,
+      },
+      {
+          // Slot 16: PageProgram
+          .opcode = kSpiFlashOpPageProgram,
+          .address_type = kDifSpiDeviceFlashAddrCfg,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = false,
+      },
+  };
+  for (int i = 0; i < ARRAYSIZE(write_commands); ++i) {
+    uint8_t slot = i + kSpiDeviceWriteCommandSlotBase;
+    CHECK_DIF_OK(dif_spi_device_set_flash_command_slot(
+        &spi_device, slot, kDifToggleEnabled, write_commands[i]));
+  }
+  CHECK_DIF_OK(dif_spi_device_configure_flash_wren_command(
+      &spi_device, kDifToggleEnabled, kSpiFlashOpWriteEnable));
+  CHECK_DIF_OK(dif_spi_device_configure_flash_wrdi_command(
+      &spi_device, kDifToggleEnabled, kSpiFlashOpWriteDisable));
+  CHECK_DIF_OK(dif_spi_device_configure_flash_en4b_command(
+      &spi_device, kDifToggleEnabled, kSpiFlashOpEnter4bAddr));
+  CHECK_DIF_OK(dif_spi_device_configure_flash_ex4b_command(
+      &spi_device, kDifToggleEnabled, kSpiFlashOpExit4bAddr));
+}
+
+bool test_main(void) {
+  // Initialize the pinmux.
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  pinmux_testutils_init(&pinmux);
+  for (int i = 0; i < ARRAYSIZE(pinmux_pad_config); ++i) {
+    dif_pinmux_pad_attr_t attr, attr_check;
+    pinmux_pad_attributes_t config = pinmux_pad_config[i];
+    CHECK_DIF_OK(
+        dif_pinmux_pad_get_attrs(&pinmux, config.pad, config.kind, &attr));
+    attr.flags = config.flags;
+    CHECK_DIF_OK(dif_pinmux_pad_write_attrs(&pinmux, config.pad, config.kind,
+                                            attr, &attr_check));
+    // Check that attributes were accepted?
+  }
+  for (int i = 0; i < ARRAYSIZE(pinmux_in_config); ++i) {
+    pinmux_select_t setting = pinmux_in_config[i];
+    CHECK_DIF_OK(
+        dif_pinmux_input_select(&pinmux, setting.peripheral, setting.pad));
+  }
+  for (int i = 0; i < ARRAYSIZE(pinmux_out_config); ++i) {
+    pinmux_select_t setting = pinmux_out_config[i];
+    CHECK_DIF_OK(
+        dif_pinmux_output_select(&pinmux, setting.pad, setting.peripheral));
+  }
+
+  // Initialize the spi_host devices.
+  CHECK_DIF_OK(dif_spi_host_init(
+      mmio_region_from_addr(TOP_EARLGREY_SPI_HOST0_BASE_ADDR), &spi_host0));
+  CHECK_DIF_OK(dif_spi_host_init(
+      mmio_region_from_addr(TOP_EARLGREY_SPI_HOST0_BASE_ADDR), &spi_host1));
+  init_spi_host(&spi_host0, (uint32_t)kClockFreqHiSpeedPeripheralHz);
+  init_spi_host(&spi_host1, (uint32_t)kClockFreqPeripheralHz);
+
+  // Initialize spi_device.
+  mmio_region_t spi_device_base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR);
+  CHECK_DIF_OK(dif_spi_device_init_handle(spi_device_base_addr, &spi_device));
+  init_spi_device();
+
+  // Send the DV environment a specific message for synchronization. The
+  // sequencer can pick this up and know it can begin sending SPI flash
+  // transactions.
+  LOG_INFO("Test setup complete.");
+
+  // Enable all spi_device and spi_host interrupts, and check that they do not
+  // trigger.
+  dif_spi_device_irq_t all_spi_device_irqs[] = {
+      kDifSpiDeviceIrqGenericRxFull,
+      kDifSpiDeviceIrqGenericRxWatermark,
+      kDifSpiDeviceIrqGenericTxWatermark,
+      kDifSpiDeviceIrqGenericRxError,
+      kDifSpiDeviceIrqGenericRxOverflow,
+      kDifSpiDeviceIrqGenericTxUnderflow,
+      kDifSpiDeviceIrqUploadCmdfifoNotEmpty,
+      kDifSpiDeviceIrqUploadPayloadNotEmpty,
+      kDifSpiDeviceIrqUploadPayloadOverflow,
+      kDifSpiDeviceIrqReadbufWatermark,
+      kDifSpiDeviceIrqReadbufFlip,
+      kDifSpiDeviceIrqTpmHeaderNotEmpty,
+  };
+  for (int i = 0; i < ARRAYSIZE(all_spi_device_irqs); ++i) {
+    dif_spi_device_irq_t irq = all_spi_device_irqs[i];
+    CHECK_DIF_OK(dif_spi_device_irq_set_enabled(&spi_device.dev, irq,
+                                                kDifToggleEnabled));
+  }
+  CHECK_DIF_OK(dif_spi_host_irq_set_enabled(&spi_host0, kDifSpiHostIrqError,
+                                            kDifToggleEnabled));
+  CHECK_DIF_OK(dif_spi_host_irq_set_enabled(&spi_host0, kDifSpiHostIrqSpiEvent,
+                                            kDifToggleEnabled));
+  irq_external_ctrl(/*en=*/true);
+  wait_for_interrupt();
+
+  // No interrupts are expected, so fail if one occurred. Note that the DV
+  // environment is the only one that can signal that the test has passed.
+  LOG_INFO("Received unexpected interrupt, ending wfi");
+  return false;
+}


### PR DESCRIPTION
- Add SPI passthrough test that sends various commands in a random order, across 3 different SPI frequencies.
- Add a DIF to toggle passthrough mode on/off.
- Adjust the chip_if to connect to spi_if inout ports directly, in addition to disabling the pull-down resistors for the rest of the SPI host DIOs.
- Random addition: Fix up the description of USB's clocking.

Resolves #14148