### PR TITLE
[otbn] Declare V2S

### DIFF
--- a/hw/ip/otbn/data/otbn.prj.hjson
+++ b/hw/ip/otbn/data/otbn.prj.hjson
@@ -22,8 +22,10 @@
             version:            "1.0",
             life_stage:         "L1",
             design_stage:       "D2S",
-            verification_stage: "V2",
+            verification_stage: "V2S",
             dif_stage:          "S2",
+            commit_id:          "a6b908283fccba3f8b6b44052c6ad87276dc21e8",
+            notes:              ""
         },
     ]
 }

--- a/hw/ip/otbn/doc/checklist.md
+++ b/hw/ip/otbn/doc/checklist.md
@@ -221,11 +221,11 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Not Started |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
-Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
-Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
+Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
+Tests         | [FPV_SEC_CM_VERIFIED][]                 | Done        |
+Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
+Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | 11 Oct 2022
 
 [SEC_CM_TESTPLAN_COMPLETED]:          {{<relref "/doc/project/checklist.md#sec_cm_testplan_completed" >}}
 [FPV_SEC_CM_VERIFIED]:                {{<relref "/doc/project/checklist.md#fpv_sec_cm_verified" >}}


### PR DESCRIPTION
This PR declares V2S for OTBN.

All checklist items in issue https://github.com/lowRISC/opentitan/issues/15408 are resolved.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>