### PR TITLE
[ci] Experimentally run some JTAG tests on CI 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -534,8 +534,33 @@ jobs:
   - bash: |
       set -e
       . util/build_consts.sh
-      ci/scripts/run-fpga-cw310-tests.sh cw310_test_rom || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-cw310-tests.sh cw310_test_rom,-jtag || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
+
+- job: execute_rom_fpga_jtag_tests_cw310
+  displayName: Experimental CW310 ROM JTAG Tests
+  pool: FPGA
+  timeoutInMinutes: 45
+  dependsOn:
+    - chip_earlgrey_cw310
+    - sw_build
+  condition: succeeded( 'chip_earlgrey_cw310', 'sw_build' )
+  steps:
+  - template: ci/checkout-template.yml
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_earlgrey_cw310
+        - sw_build
+  - bash: |
+      set -e
+      . util/build_consts.sh
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+      ci/scripts/run-fpga-cw310-tests.sh cw310_rom,jtag || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+    displayName: Execute tests
+    # TODO(lowRISC/opentitan#16067) Fail CI when JTAG tests fail.
+    continueOnError: True
 
 - job: execute_rom_fpga_tests_cw310
   displayName: CW310 ROM Tests
@@ -557,7 +582,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh cw310_rom || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-cw310-tests.sh cw310_rom,-jtag || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
 
 - job: deploy_release_artifacts

--- a/rules/scripts/gdb_test_coordinator.py
+++ b/rules/scripts/gdb_test_coordinator.py
@@ -123,7 +123,8 @@ def main(rom_kind: str = typer.Option(...),
          gdb_script_path: str = typer.Option(...),
          bitstream_path: str = typer.Option(...),
          opentitantool_path: str = typer.Option(...),
-         exit_success_pattern: Optional[str] = typer.Option(None)):
+         exit_success_pattern: Optional[str] = typer.Option(None),
+         cw310_uarts: Optional[str] = typer.Option(None)):
 
     opentitantool_prefix = [
         opentitantool_path,
@@ -131,6 +132,9 @@ def main(rom_kind: str = typer.Option(...),
         "--logging=info",
         "--interface=cw310",
     ]
+    if cw310_uarts is not None:
+        opentitantool_prefix.append('--cw310-uarts=' + cw310_uarts)
+
     load_bitstream_command = opentitantool_prefix + [
         "fpga",
         "load-bitstream",
@@ -157,7 +161,7 @@ def main(rom_kind: str = typer.Option(...),
     console_command = opentitantool_prefix + [
         "console",
         "--timeout",
-        "5s",
+        "20s",
     ]
     if exit_success_pattern is not None:
         console_command.append("--exit-success=" + exit_success_pattern)

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1601,8 +1601,7 @@ SRAM_JTAG_INJECTION_GDB_SCRIPT = """
         rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
         rom_kind = "Rom",
         tags = [
-            "cw310",
-            "exclusive",
+            "cw310_rom",
             "vivado",
         ],
     )
@@ -1612,7 +1611,7 @@ SRAM_JTAG_INJECTION_GDB_SCRIPT = """
 test_suite(
     name = "rom_e2e_jtag_inject_tests",
     tags = [
-        "cw310",
+        "cw310_rom",
         "vivado",
     ],
     tests = ["sram_program_fpga_cw310_test_otp_" + otp_name for otp_name in OTP_CFGS_EXEC_DISABLED],
@@ -1640,7 +1639,8 @@ test_suite(
         rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
         rom_kind = "Rom",
         tags = [
-            "cw310",
+            "cw310_rom",
+            "skip_in_ci",
             "vivado",
         ],
     )
@@ -1691,8 +1691,8 @@ test_suite(
         rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
         rom_kind = "Rom",
         tags = [
-            "cw310",
-            "exclusive",
+            "cw310_rom",
+            "skip_in_ci",
             "vivado",
         ],
     )
@@ -1778,8 +1778,8 @@ REDACT = structs.to_dict(CONST.SHUTDOWN.REDACT)
         rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
         rom_kind = "Rom",
         tags = [
-            "cw310",
-            "exclusive",
+            "cw310_rom",
+            "skip_in_ci",
             "vivado",
         ],
     )
@@ -1843,8 +1843,8 @@ REDACT = structs.to_dict(CONST.SHUTDOWN.REDACT)
         rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
         rom_kind = "Rom",
         tags = [
-            "cw310",
-            "exclusive",
+            "cw310_rom",
+            "skip_in_ci",
             "vivado",
         ],
     )


### PR DESCRIPTION
The tests were originally tagged with "cw310", but they need to be "cw310_rom" to be picked up by [ci/scripts/run-fpga-cw310-tests.sh](https://cs.opensource.google/opentitan/opentitan/+/master:ci/scripts/run-fpga-cw310-tests.sh;l=41;drc=46b156a66e1d0e4f7e651b55790347a8fae4fbc0).

TODO:

* [ ] Before merging, check that `sram_program_fpga_cw310_test_otp_*` tests ran on the "CW310 Tests" job.