### PR TITLE
[top-level,test] add initial power virus test boilerplate

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1643,3 +1643,23 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "power_virus_systemtest",
+    srcs = ["power_virus_systemtest.c"],
+    targets = [
+        # TODO(#14814): add more targets
+        "cw310_test_rom",
+        "dv",
+    ],
+    deps = [
+        "//hw/ip/adc_ctrl/data:adc_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:adc_ctrl",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -1,0 +1,99 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_adc_ctrl.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_macros.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "adc_ctrl_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = true,
+                        .can_clobber_uart = false, );
+
+/**
+ * Peripheral DIF Handles.
+ */
+static dif_pinmux_t pinmux;
+static dif_gpio_t gpio;
+static dif_adc_ctrl_t adc_ctrl;
+
+/**
+ * Test configuration parameters.
+ */
+enum {
+  /**
+   * ADC controller parameters.
+   */
+  kAdcCtrlPowerUpTimeAonCycles = 15,  // maximum power-up time
+};
+
+/**
+ * Initializes all DIF handles for each peripheral used in this test.
+ */
+static void init_peripheral_handles() {
+  CHECK_DIF_OK(dif_adc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_ADC_CTRL_AON_BASE_ADDR), &adc_ctrl));
+  CHECK_DIF_OK(
+      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+}
+
+/**
+ * Configures GPIO 0 (mapped to pad IOA2) as an indicator pin, to go high during
+ * the power state(s) of interest.
+ */
+static void configure_gpio_indicator_pin() {
+  CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIoa2,
+                                        kTopEarlgreyPinmuxOutselGpioGpio0));
+  CHECK_DIF_OK(
+      dif_gpio_output_set_enabled(&gpio, /*pin=*/0, kDifToggleEnabled));
+}
+
+/**
+ * Configures adc_ctrl to continuously sample data (applying all filters across
+ * both channels) in normal power mode, which is the most power intensive
+ * sampling mode.
+ */
+static void configure_adc_ctrl_to_continuously_sample() {
+  CHECK_DIF_OK(dif_adc_ctrl_configure(
+      &adc_ctrl,
+      (dif_adc_ctrl_config_t){
+          .mode = kDifAdcCtrlNormalPowerScanMode,
+          .power_up_time_aon_cycles = kAdcCtrlPowerUpTimeAonCycles,
+          // Below configurations are unused, so set them to their reset values.
+          .wake_up_time_aon_cycles = ADC_CTRL_ADC_PD_CTL_WAKEUP_TIME_MASK,
+          .num_low_power_samples = ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_RESVAL,
+          .num_normal_power_samples = ADC_CTRL_ADC_SAMPLE_CTL_REG_RESVAL,
+      }));
+  for (size_t filter = 0; filter < ADC_CTRL_PARAM_NUM_ADC_FILTER; ++filter) {
+    for (size_t channel = 0; channel < ADC_CTRL_PARAM_NUM_ADC_CHANNEL;
+         ++channel) {
+      CHECK_DIF_OK(dif_adc_ctrl_configure_filter(
+          &adc_ctrl, (dif_adc_ctrl_channel_t)channel,
+          (dif_adc_ctrl_filter_config_t){
+              .filter = (dif_adc_ctrl_filter_t)filter,
+              // Set max range.
+              .min_voltage = 0,
+              .max_voltage = ADC_CTRL_ADC_CHN0_FILTER_CTL_0_MAX_V_0_MASK,
+              .in_range = true,
+              .generate_wakeup_on_match = false,
+              .generate_irq_on_match = false,
+          },
+          kDifToggleEnabled));
+    }
+  }
+}
+
+bool test_main(void) {
+  init_peripheral_handles();
+  configure_gpio_indicator_pin();
+  configure_adc_ctrl_to_continuously_sample();
+  return true;
+}


### PR DESCRIPTION
This adds the boilerplate code for the power virus test to partially address #14814. Since this test will be rather large/complex, it will be committed in pieces over time. This initial commit contains a basic test checklist (that will be added-to/improved over time) and basic configurations for the pinmux, gpio, and adc_ctrl peripherals.

Signed-off-by: Timothy Trippel <ttrippel@google.com>