### PR TITLE
[dv/rstmgr] Exclude sw_rst_ctrl_n CSR from unit csr tests

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -399,7 +399,9 @@
             resval: "1",
           },
         ],
-        tags: [// Don't reset other IPs as it will affect CSR access on these IPs
+        tags: [// Don't reset other IPs as it will affect CSR access on these IPs.
+               // In addition, rapid flips of these bits can occasionally cause the reset
+               // consistency checkers to trigger alerts, which also update err_code bits.
                "excl:CsrAllTests:CsrExclWrite"]
       }
     }

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
@@ -504,14 +504,11 @@ class rstmgr_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, "Done with apply_resets_concurrently", UVM_MEDIUM)
   endtask
 
-  // Disable exclusions for RESET_REQ and SW_RST_CTRL_N: they are meant for full-chip only.
+  // Disable exclusions for RESET_REQ since they cause trouble for full-chip only.
   function void disable_unnecessary_exclusions();
     csr_excl_item csr_excl = ral.get_excl_item();
     `uvm_info(`gfn, "Dealing with exclusions", UVM_MEDIUM)
     csr_excl.enable_excl(.obj("rstmgr_reg_block.reset_req"), .enable(1'b0));
-    for (int i = 0; i < rstmgr_reg_pkg::NumSwResets; i++) begin
-      csr_excl.enable_excl(.obj($sformatf("rstmgr_reg_block.sw_rst_ctrl_n_%0d", i)), .enable(1'b0));
-    end
     csr_excl.print_exclusions(UVM_MEDIUM);
   endfunction
 

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -479,7 +479,9 @@
             resval: "1",
           },
         ],
-        tags: [// Don't reset other IPs as it will affect CSR access on these IPs
+        tags: [// Don't reset other IPs as it will affect CSR access on these IPs.
+               // In addition, rapid flips of these bits can occasionally cause the reset
+               // consistency checkers to trigger alerts, which also update err_code bits.
                "excl:CsrAllTests:CsrExclWrite"]
       }
     }


### PR DESCRIPTION
Rapid flips of these CSR bits can occasionally trigger alerts, which can unpredictably update err_code CSR bits.

Signed-off-by: Guillermo Maturana <maturana@google.com>