### PR TITLE
[spi_device/dv] Add test - spi_device_flash_and_tpm_min_idle

### DIFF
--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -471,7 +471,7 @@
             - 2 flash transactions.
             - a tpm transaction and a flash transaction.'''
       stage: V2
-      tests: []
+      tests: ["spi_device_flash_and_tpm_min_idle"]
     }
     {
       name: stress_all

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -137,6 +137,11 @@ class spi_device_base_vseq extends cip_base_vseq #(
       end else begin
         cfg.spi_host_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps * core_spi_freq_ratio;
       end
+
+      // min inactive time needs to be 2 core clks.
+      cfg.spi_host_agent_cfg.min_idle_ns_after_csb_drop = cfg.clk_rst_vif.clk_period_ps / 1000 * 2;
+      cfg.spi_host_agent_cfg.max_idle_ns_after_csb_drop = cfg.clk_rst_vif.clk_period_ps / 1000 * 10;
+
       cfg.do_spi_clk_configure = 0;
     end
   endtask

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_all_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_all_vseq.sv
@@ -7,7 +7,9 @@ class spi_device_flash_all_vseq extends spi_device_pass_base_vseq;
   `uvm_object_utils(spi_device_flash_all_vseq)
   `uvm_object_new
 
-  int write_flash_status_pct = 30;
+  int write_flash_status_pct = 20;
+  int read_flash_status_pct  = 20;
+  int read_addr4b_pct        = 20;
 
   constraint device_mode_c {
     device_mode inside {PassthroughMode, FlashMode};
@@ -47,11 +49,13 @@ class spi_device_flash_all_vseq extends spi_device_pass_base_vseq;
       for (int j = 0; j < 20; ++j) begin
         if ($urandom_range(0, 99) < write_flash_status_pct) begin
           random_access_flash_status(.write(1), .busy(1));
-        end else if ($urandom_range(0, 1)) begin
+        end
+        if ($urandom_range(0, 99) < read_flash_status_pct) begin
           random_access_flash_status(.write(0));
         end
-
-        if ($urandom_range(0, 1)) read_and_check_4b_en();
+        if ($urandom_range(0, 99) < read_addr4b_pct) begin
+          read_and_check_4b_en();
+        end
 
         randomize_op_addr_size();
         `uvm_info(`gfn, $sformatf("Testing op_num %0d/20, op = 0x%0h", j, opcode), UVM_MEDIUM)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_and_tpm_min_idle_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_and_tpm_min_idle_vseq.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// inherit from spi_device_flash_and_tpm_vseq and override the task to always
+// use `min_idle_ns_after_csb_drop`.
+class spi_device_flash_and_tpm_min_idle_vseq extends spi_device_flash_and_tpm_vseq;
+  `uvm_object_utils(spi_device_flash_and_tpm_min_idle_vseq)
+  `uvm_object_new
+
+  virtual task spi_clk_init();
+    super.spi_clk_init();
+    // always use the min value
+    cfg.spi_host_agent_cfg.max_idle_ns_after_csb_drop =
+        cfg.spi_host_agent_cfg.min_idle_ns_after_csb_drop;
+  endtask
+endclass : spi_device_flash_and_tpm_min_idle_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_mode_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_mode_vseq.sv
@@ -25,6 +25,9 @@ class spi_device_flash_mode_vseq extends spi_device_intercept_vseq;
     // in order to exercise watermark and flip events
     large_payload_weight = 6;
 
+    // always read the last_read_addr for check
+    read_last_read_addr_pct = 100;
+
     mailbox_addr_size_c.constraint_mode(0);
     forever_read_buffer_update_nonblocking();
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -30,6 +30,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
   // knob to control read_buffer_update thread
   bit stop_forever_read_buffer_update;
   bit read_buffer_update_ongoing;
+  int read_last_read_addr_pct = 20;
 
   rand device_mode_e device_mode;
 
@@ -309,9 +310,6 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     spi_clk_init();
     `uvm_info(`gfn, "Initialize flash/passthrough mode", UVM_MEDIUM)
 
-    // TODO, #14940. EN4B/EX4B may fail if the next item comes very shortly
-    cfg.spi_host_agent_cfg.min_idle_ns_after_csb_drop = 500;
-
     // avoid updating these CSRs at the same time as tpm_init
     cfg.spi_cfg_sema.get();
 
@@ -561,7 +559,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
       spi_host_xfer_dummy_item();
     end
     // randomly read last_read_addr for scb to check
-    if ($urandom_range(0, 2) == 0) begin
+    if ($urandom_range(0, 99) < read_last_read_addr_pct) begin
       bit [TL_DW-1:0] rdata;
 
       // This is synced from the other clock domain. It takes around 3-4 cycles.

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -36,4 +36,5 @@
 `include "spi_device_read_buffer_direct_vseq.sv"
 `include "spi_device_flash_all_vseq.sv"
 `include "spi_device_flash_and_tpm_vseq.sv"
+`include "spi_device_flash_and_tpm_min_idle_vseq.sv"
 `include "spi_device_stress_all_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -52,6 +52,7 @@ filesets:
       - seq_lib/spi_device_read_buffer_direct_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_flash_all_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_flash_and_tpm_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_flash_and_tpm_min_idle_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -204,6 +204,11 @@
       name: spi_device_flash_and_tpm
       uvm_test_seq: spi_device_flash_and_tpm_vseq
     }
+
+    {
+      name: spi_device_flash_and_tpm_min_idle
+      uvm_test_seq: spi_device_flash_and_tpm_min_idle_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
It inherits from spi_device_flash_and_tpm_vseq and configure the min idle period btw 2 SPI items.

Also adjusted the chance to add CSR accesses after a SPI item, to increase the chance to send
b2b SPI items.
Signed-off-by: Weicai Yang <weicai@google.com>