### PR TITLE
[test] RV_DM access after chip sleep test

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_if.sv
+++ b/hw/dv/sv/jtag_agent/jtag_if.sv
@@ -56,6 +56,8 @@ interface jtag_if #(time JtagDefaultTckPeriodNs = 20ns) ();
     trst_n <= 1'b0;
     wait_tck(cycles);
     trst_n <= 1'b1;
+    // Give time for subsequent events to get away from the reset edge
+    wait_tck(1);
   endtask
 
   // Generate the tck, with UartDefaultClkPeriodNs period as default

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -634,7 +634,7 @@
             - If waking up from deep sleep, an activation is required for RV_DM CSR accesses to work.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_rv_dm_access_after_wakeup"]
     }
     {
       name: chip_sw_rv_dm_jtag_tap_sel

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1430,6 +1430,13 @@
       run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
     }
     {
+      name: chip_sw_rv_dm_access_after_wakeup
+      uvm_test_seq: chip_sw_rv_dm_access_after_wakeup_vseq
+      sw_images: ["//sw/device/tests/sim_dv:rv_dm_access_after_wakeup:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_jtag_dmi=1"]
+    }
+    {
       name: chip_sw_pwrmgr_normal_sleep_all_wake_ups
       uvm_test_seq: "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq"
       sw_images: ["//sw/device/tests/sim_dv:pwrmgr_normal_sleep_all_wake_ups:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -98,6 +98,7 @@ filesets:
       - seq_lib/chip_sw_keymgr_sideload_kmac_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_ast_clk_outputs_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sensor_ctrl_status_intr_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rv_dm_access_after_wakeup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_repeat_reset_wkup_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_dm_access_after_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_dm_access_after_wakeup_vseq.sv
@@ -1,0 +1,118 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_rv_dm_access_after_wakeup_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_rv_dm_access_after_wakeup_vseq)
+
+  `uvm_object_new
+
+  virtual task pre_start();
+    super.pre_start();
+    // Release power button.
+    cfg.chip_vif.pwrb_in_if.drive(1'b1);
+  endtask : pre_start
+
+  task activate_jtag_dmi();
+    // Set up JTAG RV_DM TAP.
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
+    cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
+
+    // Attempt to activate RV_DM via JTAG.
+    csr_wr(.ptr(cfg.jtag_dmi_ral.dmcontrol.dmactive), .value(1), .blocking(1), .predict(1));
+    cfg.clk_rst_vif.wait_clks(5);
+  endtask : activate_jtag_dmi
+
+  virtual task body();
+    uint           timeout_long       = 10_000_000;
+    uint           timeout_short      = 1_000_000;
+    bit [7:0]      software_barrier[] = '{0};
+    uvm_reg_data_t exp_data = $urandom();
+
+    super.body();
+
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Software Setup.");,
+                 "Timed out waiting for software setup.", timeout_long)
+
+    activate_jtag_dmi();
+    csr_wr(
+      .ptr(cfg.jtag_dmi_ral.progbuf[0]),
+      .value(exp_data),
+      .path(UVM_FRONTDOOR));
+    csr_rd_check(
+      .ptr(cfg.jtag_dmi_ral.progbuf[0]),
+      .compare_value(exp_data),
+      .path(UVM_FRONTDOOR),
+      .err_msg("straight after write."));
+
+    // Allow the software to continue execution.
+    software_barrier[0] = 1;
+    `uvm_info(`gfn, "SoftwareBarrier = 1", UVM_LOW)
+    sw_symbol_backdoor_overwrite("kSoftwareBarrier", software_barrier);
+
+    // Wait for the software to fall asleep.
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Entering normal sleep.");,
+                 "Timed out waiting for device to enter normal sleep.", timeout_short)
+
+    // Press the power button to wake up the device.
+    `uvm_info(`gfn, "Pushing power button.", UVM_LOW)
+    cfg.chip_vif.pwrb_in_if.drive(1'b0); // pressing power button
+
+    // Wait for the software to wake up.
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Waking up from normal sleep.");,
+                 "Timed out waiting for device to wakeup from normal sleep.", timeout_short)
+
+    `uvm_info(`gfn, "Releasing power button.", UVM_LOW)
+    cfg.chip_vif.pwrb_in_if.drive(1'b1); // releasing power button
+
+    // Check the program buffer retained the expected value after a normal
+    // sleep.
+    csr_rd_check(
+      .ptr(cfg.jtag_dmi_ral.progbuf[0]),
+      .compare_value(exp_data),
+      .path(UVM_FRONTDOOR),
+      .err_msg("after normal sleep."));
+
+    // Allow the software to continue execution.
+    software_barrier[0] = 2;
+    `uvm_info(`gfn, "SoftwareBarrier = 2", UVM_LOW)
+    sw_symbol_backdoor_overwrite("kSoftwareBarrier", software_barrier);
+
+
+    // Wait for the software to fall asleep.
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Entering deep sleep.");,
+                 "Timed out waiting for device to enter deep sleep.", timeout_short)
+
+    // Press the power button to wake up the device.
+    `uvm_info(`gfn, "Pushing power button.", UVM_LOW)
+    cfg.chip_vif.pwrb_in_if.drive(1'b0); // pressing power button
+
+    // Wait for the software to wake up.
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Waking up from deep sleep.");,
+                 "Timed out waiting for device to wakeup from deep sleep.", timeout_long)
+
+    `uvm_info(`gfn, "Releasing power button.", UVM_LOW)
+    cfg.chip_vif.pwrb_in_if.drive(1'b1); // releasing power button
+
+    // We must reset the agent side also to stay synchronized with the design
+    cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.do_trst_n(2);
+    activate_jtag_dmi();
+    exp_data = $urandom();
+    csr_wr(
+      .ptr(cfg.jtag_dmi_ral.progbuf[0]),
+      .value(exp_data),
+      .path(UVM_FRONTDOOR));
+    csr_rd_check(
+      .ptr(cfg.jtag_dmi_ral.progbuf[0]),
+      .compare_value(exp_data),
+      .path(UVM_FRONTDOOR),
+      .err_msg("after deep sleep."));
+
+    // Allow the software to continue execution.
+    software_barrier[0] = 3;
+    `uvm_info(`gfn, "SoftwareBarrier = 3", UVM_LOW)
+    sw_symbol_backdoor_overwrite("kSoftwareBarrier", software_barrier);
+
+  endtask : body
+
+endclass : chip_sw_rv_dm_access_after_wakeup_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -52,6 +52,7 @@
 `include "chip_sw_keymgr_sideload_kmac_vseq.sv"
 `include "chip_sw_ast_clk_outputs_vseq.sv"
 `include "chip_sw_sensor_ctrl_status_intr_vseq.sv"
+`include "chip_sw_rv_dm_access_after_wakeup_vseq.sv"
 `include "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv"
 `include "chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv"
 `include "chip_tap_straps_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -699,6 +699,37 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "rv_dm_access_after_wakeup",
+    srcs = ["rv_dm_access_after_wakeup.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:rv_timer",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing:aon_timer_testutils",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "rom_ctrl_integrity_check_test",
     srcs = ["rom_ctrl_integrity_check_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/rv_dm_access_after_wakeup.c
+++ b/sw/device/tests/sim_dv/rv_dm_access_after_wakeup.c
@@ -1,0 +1,142 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "pwrmgr_regs.h"
+
+/*
+ * RV_DM access after wakeup test.
+ */
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kSoftwareBarrierTimeoutUsec = 24,
+};
+
+// This location will be update from SV
+static volatile const uint8_t kSoftwareBarrier = 0;
+
+// Handle to the plic
+dif_rv_plic_t rv_plic;
+
+/**
+ * External interrupt handler.
+ *
+ * Simply claim the interrupt and does nothing else.
+ */
+void ottf_external_isr(void) {
+  dif_rv_plic_irq_id_t plic_irq_id;
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&rv_plic, kTopEarlgreyPlicTargetIbex0,
+                                     &plic_irq_id));
+}
+
+/**
+ * Put the device to sleep.
+ *
+ * @param pwrmgr A handle to the power manager.
+ * @param deep_sleep Whether or not to enter a deep sleep.
+ */
+static void put_to_sleep(dif_pwrmgr_t *pwrmgr, bool deep_sleep) {
+  dif_pwrmgr_domain_config_t cfg;
+  CHECK_DIF_OK(dif_pwrmgr_get_domain_config(pwrmgr, &cfg));
+  cfg = cfg & (kDifPwrmgrDomainOptionIoClockInLowPower |
+               kDifPwrmgrDomainOptionUsbClockInLowPower |
+               kDifPwrmgrDomainOptionUsbClockInActivePower) |
+        (!deep_sleep ? kDifPwrmgrDomainOptionMainPowerInLowPower : 0);
+
+  pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceOne,
+                                    cfg);
+  LOG_INFO("%s",
+           deep_sleep ? "Entering deep sleep." : "Entering normal sleep.");
+  wait_for_interrupt();
+}
+
+bool test_main(void) {
+  // Enable global and external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  dif_pinmux_t pinmux;
+  dif_pwrmgr_t pwrmgr;
+  dif_sysrst_ctrl_t sysrst_ctrl;
+
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &rv_plic));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
+      &sysrst_ctrl));
+
+  switch (rstmgr_testutils_reason_get()) {
+    case kDifRstmgrResetInfoPor:  // The first power-up.
+      LOG_INFO("Software Setup.");
+      // Wait for sequence to run its checks.
+      IBEX_SPIN_FOR(kSoftwareBarrier == 1, kSoftwareBarrierTimeoutUsec);
+
+      // Enable all the AON interrupts used in this test.
+      rv_plic_testutils_irq_range_enable(&rv_plic, kTopEarlgreyPlicTargetIbex0,
+                                         kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+                                         kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+
+      // Enable pwrmgr interrupt.
+      CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, kDifPwrmgrIrqWakeup,
+                                              kDifToggleEnabled));
+
+      // Set up power button as wake up source.
+      dif_sysrst_ctrl_input_change_config_t config = {
+          .input_changes = kDifSysrstCtrlInputPowerButtonH2L,
+          .debounce_time_threshold = 1,  // 5us
+      };
+      CHECK_DIF_OK(
+          dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl, config));
+      CHECK_DIF_OK(dif_pinmux_input_select(
+          &pinmux, kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonPwrbIn,
+          kTopEarlgreyPinmuxInselIor13));
+
+      // Put the device in a normal sleep.
+      put_to_sleep(&pwrmgr, /*deep_sleep=*/false);
+      LOG_INFO("Waking up from normal sleep.");
+
+      // Clean up wakeup source after sleep.
+      CHECK_DIF_OK(dif_sysrst_ctrl_ulp_wakeup_clear_status(&sysrst_ctrl));
+
+      // Wait for sequence to run its checks.
+      IBEX_SPIN_FOR(kSoftwareBarrier == 2, kSoftwareBarrierTimeoutUsec);
+
+      // Put the device in a deep sleep.
+      put_to_sleep(&pwrmgr, /*deep_sleep=*/true);
+      break;
+
+    case kDifRstmgrResetInfoLowPowerExit:  // The power up after deep sleep.
+      LOG_INFO("Waking up from deep sleep.");
+
+      // Wait for sequence to finish before returning.
+      IBEX_SPIN_FOR(kSoftwareBarrier == 3, kSoftwareBarrierTimeoutUsec);
+      return true;
+
+    default:
+      LOG_ERROR("Device was reset by an unexpected source.");
+      break;
+  }
+  return false;
+}


### PR DESCRIPTION
Closes #14152 

1. It writes to the debug modules' program buffer through JTAG.
2. Puts the device into a normal sleep and wakes it up again.
3. Reads from the program buffer and checks it still has the expected value.

The test currently fails when checking the program buffer's value (step 3), the actual value is 0x0 when expecting 0xDEAF.

The problem appears to be the write not taking effect. It persists when the read and check happens straight after the write (with no sleep between them).

I can't workout why the write isn't taking effect.