### PR TITLE
[dv/edn] Minor regression fix

### DIFF
--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -30,7 +30,8 @@ package edn_env_pkg;
   // types
   typedef enum int {
     CmdReqDone  = 0,
-    FifoErr     = 1
+    FifoErr     = 1,
+    NumEdnIntr  = 2
   } edn_intr_e;
 
   typedef enum int {


### PR DESCRIPTION
This PR fixes two minor issues in EDN regression:
1). Add `alert_test` as a valid csr in scb
2). Add functional coverage for interrupts in edn

Signed-off-by: Cindy Chen <chencindy@opentitan.org>