### PR TITLE
[spid] fix: TPM RdFIFO reset

### DIFF
--- a/hw/ip/rstmgr/rtl/rstmgr_por.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_por.sv
@@ -28,7 +28,7 @@ module rstmgr_por #(
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) rst_sync (
+  ) u_rst_sync (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
     .d_i(1'b1),

--- a/hw/ip/spi_device/lint/spi_tpm.waiver
+++ b/hw/ip/spi_device/lint/spi_tpm.waiver
@@ -9,6 +9,9 @@
 waive -rules {RESET_DRIVER RESET_MUX} -location {spi_tpm.sv} \
       -regexp {'rst_n' is driven} \
       -comment "Async reset generated from TPM_CS#"
+waive -rules {RESET_MUX} -location {spi_device.sv} \
+      -regexp {'sys_tpm_rst_n' is driven by a multiplexer} \
+      -comment {The mux is scan mux}
 
 waive -rules TERMINAL_STATE -location {spi_tpm.sv} \
     -regexp {'(StEnd|StInvalid)'} \

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -75,6 +75,7 @@ module spi_tpm
 
   input sys_rst_ni,
   input rst_n,
+  input sys_sync_rst_ni,
 
   // SPI interface
   input        csb_i, // TPM needs separate CS#
@@ -1205,7 +1206,7 @@ module spi_tpm
     .OutputZeroIfEmpty (1'b 1)
   ) u_rdfifo (
     .clk_wr_i  (sys_clk_i),
-    .rst_wr_ni (rst_n),     // Need synchronizer?
+    .rst_wr_ni (sys_sync_rst_ni),
     .wvalid_i  (sys_rdfifo_wvalid_i),
     .wready_o  (sys_rdfifo_wready_o),
     .wdata_i   (sys_rdfifo_wdata_i),

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -16,6 +16,7 @@ filesets:
       - lowrisc:prim:mubi
       - lowrisc:prim:ram_2p_adv
       - lowrisc:prim:edge_detector
+      - lowrisc:prim:rst_sync
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:prim:lc_sync
       - lowrisc:ip:spi_device_pkg

--- a/hw/top_earlgrey/lint/top_earlgrey.waiver
+++ b/hw/top_earlgrey/lint/top_earlgrey.waiver
@@ -28,7 +28,7 @@ waive -rules CLOCK_MUX -location {clkmgr.sv top_earlgrey.sv} -regexp {.*clk_io_d
       -comment "Divided clocks go through prim_clock_div, which use muxes for scan bypass and clock step down"
 
 # scan reset is a legal asynchronous reset
-waive -rules RESET_USE -location {top_earlgrey.sv} -regexp {'scan_rst_ni' is connected to .* port 'scan_rst_ni', and used as an asynchronous reset or set 'rst_ni' at} \
+waive -rules RESET_USE -location {top_earlgrey.sv} -regexp {'scan_rst_ni' is connected to .* port 'scan_rst_ni', and used as an asynchronous reset or set 'rst_.*ni' at} \
       -comment "Scan reset is a legal asynchronous reset"
 
 # intentionally unused


### PR DESCRIPTION
In previous design, TPM CSb (after scan mux) directly connects to the write port reset of TPM Read FIFO.

The issue here is that if TPM CSb is asserted, it may trigger metastability of the write port of the FIFO as the timing of the release is independent of the SYS_CLK (write port clock).

This commit fixes the issue by adding a reset synchronizer to the reset path. As read FIFO is being used after 32 SPI_CLK cycles, the 2 SYS_CLK delay on the reset path will not cause an issue.