### PR TITLE
[spi_device/dv] Fix some regression issues

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_read_buffer_direct_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_read_buffer_direct_vseq.sv
@@ -11,6 +11,10 @@ class spi_device_read_buffer_direct_vseq extends spi_device_flash_mode_vseq;
   task body();
     int start_addr = 0;
     int payload_size;
+
+    // scb is off for this test. Enable CSR auto_predict, otherwise, csr_update doesn't work
+    // correctly as `needs_update` may be wrong due to the incorrect mirrored value.
+    ral.default_map.set_auto_predict(1);
     spi_device_flash_pass_init();
 
     // disable watermark event

--- a/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
@@ -295,6 +295,7 @@ class spi_device_env_cov extends cip_base_env_cov #(.CFG_T(spi_device_env_cfg));
     spi_device_addr_4b_enter_exit_command_cg = new();
     sw_update_addr4b_cg = new();
     spi_device_write_enable_disable_cg = new();
+    spi_device_buffer_boundary_cg = new();
     tpm_interleave_with_flash_item_cg = new();
   endfunction : new
 

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -84,7 +84,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
 
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
-    fork
+    if (cfg.en_scb) fork
       process_upstream_spi_host_fifo();
       process_upstream_spi_device_fifo();
       process_downstream_spi_fifo();
@@ -658,8 +658,6 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
     end
     start_addr = convert_addr_from_byte_queue(up_item.address_q);
 
-    if (cfg.is_in_mailbox_region(start_addr)) start_at_mailbox = 1;
-
     if (dn_item != null) `DV_CHECK_EQ(up_item.payload_q.size, dn_item.payload_q.size)
     foreach (up_item.payload_q[i]) begin
       cur_addr = start_addr + i;
@@ -667,6 +665,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
       if (cfg.is_in_mailbox_region(cur_addr)) begin
         bit [31:0] offset = cur_addr % MAILBOX_BUFFER_SIZE;
         compare_mem_byte(MAILBOX_START_ADDR, offset, up_item.payload_q[i], i, "Mailbox");
+        if (i == 0) start_at_mailbox = 1;
         been_mailbox = 1;
       end else begin // out of mbx region
         string str;

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -193,6 +193,8 @@
     {
       name: spi_device_read_buffer_direct
       uvm_test_seq: spi_device_read_buffer_direct_vseq
+      // it's a direct test, and checking is done in seq
+      run_opts: ["+en_scb=0"]
     }
 
     {


### PR DESCRIPTION
1. Fixed the null point for a coverage object
2. Fixed `start_at_mailbox`, need to consider a case when payload.size == 0
3. Disabled scb for spi_device_read_buffer_direct, as it's a direct test

Signed-off-by: Weicai Yang <weicai@google.com>