### PR TITLE
[entropy_src/dv] Fine tune extht timing cases (DV)

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -2142,8 +2142,11 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
 
         if(window.size() < window_rng_frames && !dut_pipeline_enabled) break;
 
+        // Wait for the XHT to complete, but give up no later than two cycles after the DUT has
+        // disabled.
         `DV_SPINWAIT_EXIT(wait(cfg.m_xht_agent_cfg.vif.req.window_wrap_pulse);,
-                          wait(!dut_pipeline_enabled);)
+                          wait(!dut_pipeline_enabled);
+                          cfg.clk_rst_vif.wait_clks(2);)
         if (!cfg.m_xht_agent_cfg.vif.req.window_wrap_pulse) break;
         cfg.clk_rst_vif.wait_clks(1);
         `uvm_info(`gfn, "FULL_WINDOW", UVM_FULL)


### PR DESCRIPTION
This commit fixes DV corner cases to capture the last RNG data accepted into the DUT before it is disabled.  Since the new EXTHT agent introduces a slight synchronization delay this adjustment is needed to make sure that all samples are counted.

In the worst case the window_wrap_pulse ends two cycles after the DUT has been disabled. (One cycle if RNG bit selection is disabled two if it is enabled) Rather than dumping the a partial HT window immediately when the DUT is disabled, wait these extra two cycles to catch the last sample.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>