### PR TITLE
[spi_device/dv] Disable overflow/underflow SVAs

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -459,4 +459,15 @@ class spi_device_base_vseq extends cip_base_vseq #(
     end
   endtask
 
+  virtual function void fifo_underflow_overflow_sva_control(bit enable);
+    if (enable) begin
+      $asserton(0, "tb.dut.u_txf_underflow.SrcPulseCheck_M");
+      $asserton(0, "tb.dut.u_txf_underflow.DstPulseCheck_A");
+      $asserton(0, "tb.dut.u_rxf_overflow.SrcPulseCheck_M");
+    end else begin
+      $assertoff(0, "tb.dut.u_txf_underflow.SrcPulseCheck_M");
+      $assertoff(0, "tb.dut.u_txf_underflow.DstPulseCheck_A");
+      $assertoff(0, "tb.dut.u_rxf_overflow.SrcPulseCheck_M");
+    end
+  endfunction
 endclass : spi_device_base_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
@@ -14,7 +14,7 @@ class spi_device_fifo_underflow_overflow_vseq extends spi_device_txrx_vseq;
 
   virtual task body();
     // overflow will occur in this test, disable overflow assertion in RTL
-    $assertoff(0, "tb.dut.u_s2p.BitcountOverflow_A");
+    fifo_underflow_overflow_sva_control(.enable(0));
 
     allow_underflow_overflow = 1;
     // when underflow, sio may be unknown, disable checking it
@@ -22,7 +22,7 @@ class spi_device_fifo_underflow_overflow_vseq extends spi_device_txrx_vseq;
     super.body();
     cfg.spi_host_agent_cfg.en_monitor_checks = 1;
 
-    $asserton(0, "tb.dut.u_s2p.BitcountOverflow_A");
+    fifo_underflow_overflow_sva_control(.enable(1));
   endtask
 
   // there may be some data left due to under/overflow, need to flush out all data

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_intr_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_intr_vseq.sv
@@ -12,6 +12,8 @@ class spi_device_intr_vseq extends spi_device_txrx_vseq;
     spi_device_intr_e spi_dev_intr;
     bit               is_tx_async_fifo_filled;
 
+    // overflow will occur in this test, disable overflow assertion in RTL
+    fifo_underflow_overflow_sva_control(.enable(0));
     for (int i = 1; i <= num_trans; i++) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
       spi_device_fw_init();
@@ -46,7 +48,7 @@ class spi_device_intr_vseq extends spi_device_txrx_vseq;
       end
       `uvm_info(`gfn, $sformatf("finished run %0d/%0d", i, num_trans), UVM_LOW)
     end
-
+    fifo_underflow_overflow_sva_control(.enable(1));
   endtask : body
 
   task drive_and_check_one_intr(spi_device_intr_e spi_dev_intr);


### PR DESCRIPTION
It's fine to have these SVA, but disable them when the test verifies underflow/overflow.

Signed-off-by: Weicai Yang <weicai@google.com>