### PR TITLE
[bazel] Check targets that depend on Verilator and Vivado are tagged

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,6 +161,7 @@ jobs:
   - template: ci/install-package-dependencies.yml
   - bash: ci/scripts/check-bazel-tags.sh
     displayName: Check Bazel Tags
+    continueOnError: True
   - bash: ci/scripts/check-generated.sh
     displayName: Check Generated
     # Ensure all generated files are clean and up-to-date

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,6 +159,8 @@ jobs:
   steps:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml
+  - bash: ci/scripts/check-bazel-tags.sh
+    displayName: Check Bazel Tags
   - bash: ci/scripts/check-generated.sh
     displayName: Check Generated
     # Ensure all generated files are clean and up-to-date

--- a/ci/jobs/slow-lint.sh
+++ b/ci/jobs/slow-lint.sh
@@ -11,6 +11,9 @@
 
 set -e
 
+echo -e "\n### Check tags on Bazel artifacts"
+ci/scripts/check-bazel-tags.sh
+
 echo -e "\n### Ensure all generated files are clean and up-to-date"
 ci/scripts/check-generated.sh
 

--- a/ci/scripts/check-bazel-tags.sh
+++ b/ci/scripts/check-bazel-tags.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+untagged=$(./bazelisk.sh query "rdeps(//..., //hw:verilator) except attr(tags, '[\\[ ](verilator|manual)[,\\]]', //...)")
+if [[ ${untagged} ]]; then # Check that all targets that depend on verilator are tagged
+  echo "Target(s): ${untagged} depend(s) on //hw:verilator, please tag it with verilator or manual";
+  exit 1
+fi
+
+untagged=$(./bazelisk.sh query "rdeps(//..., kind('bitstream_splice', //...)) except attr(tags, '[\\[ ](cw310_rom|cw310_test_rom|vivado|manual)[,\\]]', //...)")
+if [[ ${untagged} ]]; then # Check that all targets that depend on vivado are tagged
+  echo "Target(s): ${untagged} depend(s) on a bitstream_splice but isn't tagged with vivado or manual";
+  exit 1
+fi

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -365,6 +365,7 @@ opentitan_functest(
 
 test_suite(
     name = "address_translation",
+    tags = ["manual"],
     tests = [
         "rom_ext_a_flash_a",
         "rom_ext_a_flash_a_bad_addr_trans",
@@ -611,6 +612,7 @@ BOOT_POLICY_ROLLBACK_CASES = [
 
 test_suite(
     name = "boot_policy_rollback",
+    tags = ["manual"],
     tests = ["boot_policy_rollback_a_{}_b_{}".format(
         t["a"],
         t["b"],
@@ -648,6 +650,7 @@ SIGVERIFY_MOD_EXP_CASES = [
 
 test_suite(
     name = "sigverify_mod_exp",
+    tags = ["manual"],
     tests = ["sigverify_mod_exp_{}".format(t["name"]) for t in SIGVERIFY_MOD_EXP_CASES],
 )
 
@@ -838,6 +841,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
 
 test_suite(
     name = "boot_policy_bad_manifest",
+    tags = ["manual"],
     tests = ["boot_policy_bad_manifest_{}_{}".format(
         t["name"],
         slot,
@@ -922,6 +926,7 @@ BOOT_POLICY_VALID_CASES = [
 
 test_suite(
     name = "boot_policy_valid",
+    tags = ["manual"],
     tests = [
         "boot_policy_valid_a_{}_b_{}".format(
             a["desc"],


### PR DESCRIPTION
Either a manual tag, a verilator tag or a vivado tag can keep these from getting brought into wildcards when people are on systems that don't support them.