### PR TITLE
[test] Run GDB in batch mode so errors are fatal

### DIFF
--- a/rules/scripts/gdb_test_coordinator.py
+++ b/rules/scripts/gdb_test_coordinator.py
@@ -130,6 +130,7 @@ def main(rom_kind: str = typer.Option(...),
         # GDB to drop to the interactive prompt when the script ends rather than
         # exit.
         "/tools/riscv/bin/riscv32-unknown-elf-gdb",
+        "--batch",
         "--command=" + gdb_script_path,
     ]
     console_command = opentitantool_prefix + [
@@ -172,8 +173,9 @@ def main(rom_kind: str = typer.Option(...),
             background.push(proc)
             continue
 
+        print(f"{background.get_name(proc)} exited with code {returncode}")
+
         if returncode != 0:
-            print(f"{background.get_name(proc)} exited with code {returncode}")
             sys.exit(returncode)
 
         background.forget(proc)


### PR DESCRIPTION
I tried setting a breakpoint on a symbol that doesn't exist, and noticed that the GDB test incorrectly passed, even though the log indicated a syntax error in the GDB script. Enabling batch mode causes GDB to treat script errors as fatal.

The GDB manual[^0] describes the `-batch` flag:

    Exit with nonzero status if an error occurs in executing the GDB
    commands in the command files.

[^0]: https://sourceware.org/gdb/onlinedocs/gdb/Mode-Options.html

Signed-off-by: Dan McArdle <dmcardle@google.com>