### PR TITLE
[bitstream] Use the hash of the bitstream as the usr_access value

### DIFF
--- a/sw/host/opentitanlib/src/util/usr_access.rs
+++ b/sw/host/opentitanlib/src/util/usr_access.rs
@@ -8,6 +8,7 @@ use std::convert::TryInto;
 use thiserror::Error;
 
 use chrono::{Datelike, Timelike, Utc};
+use crc::Crc;
 
 const WRITE_USR_ACCESS: [u8; 4] = [0x30, 0x01, 0xa0, 0x01];
 const WRITE_CRC_REG: [u8; 4] = [0x30, 0x00, 0x00, 0x01];
@@ -94,6 +95,12 @@ pub fn usr_access_timestamp() -> u32 {
         | now.hour() << 12
         | now.minute() << 6
         | now.second()
+}
+
+/// Returns the crc32 hash of the bitstream to be used as a USR_ACCESS value
+pub fn usr_access_crc32(bitstream: &mut [u8]) -> Result<u32> {
+    usr_access_set(bitstream, 0)?; // Clear usr_access before hashing
+    Ok(Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(bitstream))
 }
 
 pub fn usr_access_set(bitstream: &mut [u8], val: u32) -> Result<()> {


### PR DESCRIPTION
The current `usr_access` value in the bitstream is a 32-bit value containing a [timestamp](https://github.com/lowRISC/opentitan/blob/850f2ac7ba4b301e8bd7bda17884fff5157230c7/sw/host/opentitanlib/src/util/usr_access.rs#L89). However, when we attempt to generate many spliced bitstreams simultaneously via Bazel (e.g. to cycle through LC states or test different OTP configurations), these `usr_access` values can collide when two timestamps are taken within one second of one another. This can cause the test to incorrectly skip programming the bitstream.

This PR builds on the discussion from #14865 and the work in #14877 which added the original `usr_access` modification code.

This provides a temporary solution to #15818.