### PR TITLE
[bazel] Set hello_world example visibility to public

### DIFF
--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -6,6 +6,8 @@ load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_flash_binary")
 load("//rules:exclude_files.bzl", "exclude_files")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
+package(default_visibility = ["//visibility:public"])
+
 opentitan_flash_binary(
     name = "hello_world",
     srcs = [


### PR DESCRIPTION
I was playing with 'bazel cquery //...' and was unable to run any queries because of this error:

ERROR: $my_repo_path/release/BUILD:10:8: in pkg_tar_impl rule          \
//release:opentitan: target '//sw/device/examples/hello_world:package' \
is not visible from target '//release:opentitan'. Check the visibility \
declaration of the former target if you think the dependency is        \
legitimate

Signed-off-by: Dan McArdle <dmcardle@google.com>