### PR TITLE
[rv_dm] Add generated registers to docs

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -42,6 +42,7 @@
       name:    "jtag",
       act:     "rsp",
       package: "jtag_pkg",
+      desc:    "JTAG signals for the RISC-V TAP."
     },
     { struct:  "lc_tx"
       type:    "uni"
@@ -49,6 +50,10 @@
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
+      desc:    '''
+               Multibit life cycle hardware debug enable signal coming from life cycle controller,
+               asserted when the hardware debug mechanisms are enabled in the system.
+               '''
     },
     // TBD: should we connect this to the clock manager?
     { struct:  "logic"
@@ -56,21 +61,31 @@
       name:    "unavailable"
       act:     "rcv"
       default: "1'b0"
+      desc:    '''
+               This signal indicates to the debug module that the main processor is not available
+               for debug (e.g. due to a low-power state).
+               '''
     },
     { struct:  "logic"
       type:    "uni"
       name:    "ndmreset_req"
       act:     "req"
+      desc:    "Non-debug module reset request going to the system reset infrastructure."
     },
     { struct:  "logic"
       type:    "uni"
       name:    "dmactive"
       act:     "req"
+      desc:    '''
+               This signal indicates whether the debug module is active and can be used to prevent
+               power down of the core and bus-attached peripherals.
+               '''
     },
     { struct:  "logic [rv_dm_reg_pkg::NrHarts-1:0]"
       type:    "uni"
       name:    "debug_req"
       act:     "req"
+      desc:    "This is the debug request interrupt going to the main processor."
     },
   ]
   countermeasures: [

--- a/hw/ip/rv_dm/doc/_index.md
+++ b/hw/ip/rv_dm/doc/_index.md
@@ -55,18 +55,6 @@ All hardware interfaces of the debug system are documented in the [PULP RISC-V D
 
 {{< incGenFromIpDesc "../data/rv_dm.hjson" "hwcfg" >}}
 
-The table below lists other debug module signals.
-
-Signal                     | Direction        | Type                               | Description
----------------------------|------------------|------------------------------------|---------------
-`lc_hw_debug_en_i`         | `input`          | `lc_ctrl_pkg::lc_tx_t`             | Multibit life cycle hardware debug enable signal coming from life cycle controller, asserted when the hardware debug mechanisms are enabled in the system.
-`ndmreset_req_o`           | `output`         | `logic`                            | Non-debug module reset request going to the system reset infrastructure.
-`dmactive_o`               | `output`         | `logic`                            | This signal indicates whether the debug module is active and can be used to prevent power down of the core and bus-attached peripherals.
-`debug_req_o`              | `output`         | `logic`                            | This is the debug request interrupt going to the main processor.
-`unavailable_i`            | `input`          | `logic`                            | This signal indicates to the debug module that the main processor is not available for debug (e.g. due to a low-power state).
-`jtag_i`                   | `input`          | `jtag_pkg::jtag_req_t`             | JTAG input signals
-`jtag_o`                   | `output`         | `jtag_pkg::jtag_rsp_t`             | JTAG output signals
-
 ### Life Cycle Control
 
 Debug system functionality is controlled by the [HW_DEBUG_EN]({{< relref "hw/ip/lc_ctrl/doc/#hw_debug_en" >}}) function of the life cycle controller.
@@ -138,3 +126,7 @@ The debug system wrapper provides a TL-UL host bus interface for SBA.
 output tlul_pkg::tl_h2d_t  tl_h_o,
 input  tlul_pkg::tl_d2h_t  tl_h_i,
 ```
+
+## Register Table
+
+{{< incGenFromIpDesc "../data/rv_dm.hjson" "registers" >}}

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5034,6 +5034,7 @@
       [
         {
           name: jtag
+          desc: JTAG signals for the RISC-V TAP.
           struct: jtag
           package: jtag_pkg
           type: req_rsp
@@ -5046,6 +5047,11 @@
         }
         {
           name: lc_hw_debug_en
+          desc:
+            '''
+            Multibit life cycle hardware debug enable signal coming from life cycle controller,
+            asserted when the hardware debug mechanisms are enabled in the system.
+            '''
           struct: lc_tx
           package: lc_ctrl_pkg
           type: uni
@@ -5058,6 +5064,11 @@
         }
         {
           name: unavailable
+          desc:
+            '''
+            This signal indicates to the debug module that the main processor is not available
+            for debug (e.g. due to a low-power state).
+            '''
           struct: logic
           type: uni
           act: rcv
@@ -5068,6 +5079,7 @@
         }
         {
           name: ndmreset_req
+          desc: Non-debug module reset request going to the system reset infrastructure.
           struct: logic
           type: uni
           act: req
@@ -5082,6 +5094,11 @@
         }
         {
           name: dmactive
+          desc:
+            '''
+            This signal indicates whether the debug module is active and can be used to prevent
+            power down of the core and bus-attached peripherals.
+            '''
           struct: logic
           type: uni
           act: req
@@ -5091,6 +5108,7 @@
         }
         {
           name: debug_req
+          desc: This is the debug request interrupt going to the main processor.
           struct: logic [rv_dm_reg_pkg::NrHarts-1:0]
           type: uni
           act: req
@@ -17622,6 +17640,7 @@
       }
       {
         name: jtag
+        desc: JTAG signals for the RISC-V TAP.
         struct: jtag
         package: jtag_pkg
         type: req_rsp
@@ -17634,6 +17653,11 @@
       }
       {
         name: lc_hw_debug_en
+        desc:
+          '''
+          Multibit life cycle hardware debug enable signal coming from life cycle controller,
+          asserted when the hardware debug mechanisms are enabled in the system.
+          '''
         struct: lc_tx
         package: lc_ctrl_pkg
         type: uni
@@ -17646,6 +17670,11 @@
       }
       {
         name: unavailable
+        desc:
+          '''
+          This signal indicates to the debug module that the main processor is not available
+          for debug (e.g. due to a low-power state).
+          '''
         struct: logic
         type: uni
         act: rcv
@@ -17656,6 +17685,7 @@
       }
       {
         name: ndmreset_req
+        desc: Non-debug module reset request going to the system reset infrastructure.
         struct: logic
         type: uni
         act: req
@@ -17670,6 +17700,11 @@
       }
       {
         name: dmactive
+        desc:
+          '''
+          This signal indicates whether the debug module is active and can be used to prevent
+          power down of the core and bus-attached peripherals.
+          '''
         struct: logic
         type: uni
         act: req
@@ -17679,6 +17714,7 @@
       }
       {
         name: debug_req
+        desc: This is the debug request interrupt going to the main processor.
         struct: logic [rv_dm_reg_pkg::NrHarts-1:0]
         type: uni
         act: req


### PR DESCRIPTION
The rendered register table was missing in the docs.
The PR also cleans up the interface signal descriptions (the table can be removed since we now generate this automatically, see #14718).

Signed-off-by: Michael Schaffner <msf@google.com>