### PR TITLE
[ci] Add fixed tests back to CI

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1472,8 +1472,7 @@
               "chip_sw_hmac_enc",
               "chip_sw_aes_enc_jitter_en",
               "chip_sw_rom_ctrl_integrity_check",
-              // TODO(#15371): this currently failing on nightly regression
-              // "chip_sw_lc_walkthrough_testunlocks",
+              "chip_sw_lc_walkthrough_testunlocks",
               "chip_prim_tl_access"]
     }
     {
@@ -1484,9 +1483,8 @@
               "chip_sw_usb_ast_clk_calib",
               "chip_sw_kmac_mode_cshake",
               "chip_sw_plic_sw_irq",
-              "chip_sw_aes_enc"]
-              // TODO(#15371): this currently failing on nightly regression
-              // "chip_sw_lc_walkthrough_dev",
+              "chip_sw_aes_enc",
+              "chip_sw_lc_walkthrough_dev"]
     }
     {
       name: xcelium_ci_2


### PR DESCRIPTION
Since these tests have been fixed, they can be added back to CI (see #15371).

Signed-off-by: Michael Schaffner <msf@google.com>