### PR TITLE
[spi_device] Fix RDC Metastability

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -1176,14 +1176,6 @@
           name: "cmdaddr_notempty"
           desc: "If 1, the TPM_CMD_ADDR has a valid data. This status is reported via the interrupt also."
         } // f: cmdaddr_notempty
-        { bits: "1"
-          name: "rdfifo_notempty"
-          desc: "If 1, the TPM_READ_FIFO still has pending data."
-        } // f: rdfifo_notempty
-        { bits: "7+TpmRdFifoPtrW:8"
-          name: "rdfifo_depth"
-          desc: "This field represents the current read FIFO depth"
-        } // f: rdfifo_depth
         { bits: "15+TpmWrFifoPtrW:16"
           name: "wrfifo_depth"
           desc: "This field represents the current write FIFO depth."

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -83,11 +83,8 @@ module spi_device
   localparam int unsigned TpmWrFifoDepth  = 64; // 64B
   localparam int unsigned TpmRdFifoDepth  = 16;
   localparam int unsigned TpmWrFifoPtrW   = $clog2(TpmWrFifoDepth+1);
-  localparam int unsigned TpmRdFifoPtrW   = $clog2(TpmRdFifoDepth+1);
   `ASSERT_INIT(TpmWrPtrMatch_A,
     TpmWrFifoPtrW == spi_device_reg_pkg::TpmWrFifoPtrW)
-  `ASSERT_INIT(TpmRdPtrMatch_A,
-    TpmRdFifoPtrW == spi_device_reg_pkg::TpmRdFifoPtrW)
 
   // Derived parameters
 
@@ -365,8 +362,7 @@ module spi_device
   logic cfg_tpm_invalid_locality, cfg_tpm_reg_chk_dis;
 
   // TPM_STATUS
-  logic tpm_status_cmdaddr_notempty, tpm_status_rdfifo_notempty;
-  logic [TpmRdFifoPtrW-1:0] tpm_status_rdfifo_depth;
+  logic tpm_status_cmdaddr_notempty;
   logic [TpmWrFifoPtrW-1:0] tpm_status_wrfifo_depth;
 
   // TPM ---------------------------------------------------------------
@@ -1871,8 +1867,6 @@ module spi_device
     .sys_rdfifo_wready_o (tpm_rdfifo_wready),
 
     .sys_cmdaddr_notempty_o (tpm_status_cmdaddr_notempty),
-    .sys_rdfifo_notempty_o  (tpm_status_rdfifo_notempty ),
-    .sys_rdfifo_depth_o     (tpm_status_rdfifo_depth    ),
     .sys_wrfifo_depth_o     (tpm_status_wrfifo_depth    )
   );
 
@@ -1895,8 +1889,6 @@ module spi_device
   //  STATUS:
   assign hw2reg.tpm_status = '{
     cmdaddr_notempty: '{ de: 1'b 1, d: tpm_status_cmdaddr_notempty },
-    rdfifo_notempty:  '{ de: 1'b 1, d: tpm_status_rdfifo_notempty  },
-    rdfifo_depth:     '{ de: 1'b 1, d: tpm_status_rdfifo_depth     },
     wrfifo_depth:     '{ de: 1'b 1, d: tpm_status_wrfifo_depth     }
   };
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -654,14 +654,6 @@ package spi_device_reg_pkg;
       logic        de;
     } cmdaddr_notempty;
     struct packed {
-      logic        d;
-      logic        de;
-    } rdfifo_notempty;
-    struct packed {
-      logic [4:0]  d;
-      logic        de;
-    } rdfifo_depth;
-    struct packed {
       logic [6:0]  d;
       logic        de;
     } wrfifo_depth;
@@ -727,20 +719,20 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [290:267]
-    spi_device_hw2reg_cfg_reg_t cfg; // [266:265]
-    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [264:249]
-    spi_device_hw2reg_status_reg_t status; // [248:242]
-    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [241:225]
-    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [224:208]
-    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [207:176]
-    spi_device_hw2reg_flash_status_reg_t flash_status; // [175:152]
-    spi_device_hw2reg_upload_status_reg_t upload_status; // [151:136]
-    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [135:117]
-    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [116:109]
-    spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [108:77]
-    spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [76:58]
-    spi_device_hw2reg_tpm_status_reg_t tpm_status; // [57:40]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [282:259]
+    spi_device_hw2reg_cfg_reg_t cfg; // [258:257]
+    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [256:241]
+    spi_device_hw2reg_status_reg_t status; // [240:234]
+    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [233:217]
+    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [216:200]
+    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [199:168]
+    spi_device_hw2reg_flash_status_reg_t flash_status; // [167:144]
+    spi_device_hw2reg_upload_status_reg_t upload_status; // [143:128]
+    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [127:109]
+    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [108:101]
+    spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [100:69]
+    spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [68:50]
+    spi_device_hw2reg_tpm_status_reg_t tpm_status; // [49:40]
     spi_device_hw2reg_tpm_cmd_addr_reg_t tpm_cmd_addr; // [39:8]
     spi_device_hw2reg_tpm_write_fifo_reg_t tpm_write_fifo; // [7:0]
   } spi_device_hw2reg_t;

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1510,8 +1510,6 @@ module spi_device_reg_top (
   logic tpm_cfg_invalid_locality_qs;
   logic tpm_cfg_invalid_locality_wd;
   logic tpm_status_cmdaddr_notempty_qs;
-  logic tpm_status_rdfifo_notempty_qs;
-  logic [4:0] tpm_status_rdfifo_depth_qs;
   logic [6:0] tpm_status_wrfifo_depth_qs;
   logic tpm_access_0_we;
   logic [7:0] tpm_access_0_access_0_qs;
@@ -18469,58 +18467,6 @@ module spi_device_reg_top (
     .qs     (tpm_status_cmdaddr_notempty_qs)
   );
 
-  //   F[rdfifo_notempty]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
-  ) u_tpm_status_rdfifo_notempty (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.tpm_status.rdfifo_notempty.de),
-    .d      (hw2reg.tpm_status.rdfifo_notempty.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (tpm_status_rdfifo_notempty_qs)
-  );
-
-  //   F[rdfifo_depth]: 12:8
-  prim_subreg #(
-    .DW      (5),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (5'h0)
-  ) u_tpm_status_rdfifo_depth (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.tpm_status.rdfifo_depth.de),
-    .d      (hw2reg.tpm_status.rdfifo_depth.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (tpm_status_rdfifo_depth_qs)
-  );
-
   //   F[wrfifo_depth]: 22:16
   prim_subreg #(
     .DW      (7),
@@ -21453,8 +21399,6 @@ module spi_device_reg_top (
 
       addr_hit[66]: begin
         reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
-        reg_rdata_next[1] = tpm_status_rdfifo_notempty_qs;
-        reg_rdata_next[12:8] = tpm_status_rdfifo_depth_qs;
         reg_rdata_next[22:16] = tpm_status_wrfifo_depth_qs;
       end
 

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -134,8 +134,6 @@ module spi_tpm
 
   // TPM_STATUS
   output logic                  sys_cmdaddr_notempty_o,
-  output logic                  sys_rdfifo_notempty_o,
-  output logic [RdFifoPtrW-1:0] sys_rdfifo_depth_o,
   output logic [WrFifoPtrW-1:0] sys_wrfifo_depth_o
 );
 
@@ -371,7 +369,7 @@ module spi_tpm
   // Read FIFO uses inverted SCK (clk_out_i)
   logic                     isck_rdfifo_rvalid, isck_rdfifo_rready;
   logic [RdFifoWidth-1:0]   isck_rdfifo_rdata;
-  logic [RdFifoPtrW-1:0]    sys_rdfifo_wdepth, isck_rdfifo_rdepth;
+  logic [RdFifoPtrW-1:0]    isck_rdfifo_rdepth;
 
   logic [RdFifoOffsetW-1:0]     isck_rdfifo_idx;
   logic                         isck_rd_byte_sent;
@@ -1207,7 +1205,7 @@ module spi_tpm
     .wvalid_i  (sys_rdfifo_wvalid_i),
     .wready_o  (sys_rdfifo_wready_o),
     .wdata_i   (sys_rdfifo_wdata_i),
-    .wdepth_o  (sys_rdfifo_wdepth),
+    .wdepth_o  (),
 
     .clk_rd_i  (clk_out_i),
     .rst_rd_ni (rst_n),
@@ -1217,22 +1215,6 @@ module spi_tpm
     .rdepth_o  (isck_rdfifo_rdepth)
 
   );
-
-  // When CS# is de-asserted, there's chance the sys_rdfifo becomes metastable
-  // as RDFIFO reset is CS# (after async assert, sync de-assert rst sync logic)
-  // One solution is to change the rst sync to sync assert sync de-assert.
-  // However, it creates extra latency to the CS# inactive time. In this
-  // module, the logic simply latches the depth signal to remove the
-  // metastable state.
-  prim_flop_2sync #(
-    .Width (RdFifoPtrW)
-  ) u_rdfifo_depth_sync (
-    .clk_i  (sys_clk_i),
-    .rst_ni (sys_rst_ni),
-    .d_i    (sys_rdfifo_wdepth),
-    .q_o    (sys_rdfifo_depth_o)
-  );
-  assign sys_rdfifo_notempty_o = |sys_rdfifo_depth_o;
 
   // Logic Not Used
   logic unused_logic;

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -1353,10 +1353,6 @@ dif_result_t dif_spi_device_tpm_get_data_status(
       mmio_region_read32(spi->dev.base_addr, SPI_DEVICE_TPM_STATUS_REG_OFFSET);
   status->cmd_addr_valid =
       bitfield_bit32_read(reg_val, SPI_DEVICE_TPM_STATUS_CMDADDR_NOTEMPTY_BIT);
-  status->read_fifo_not_empty =
-      bitfield_bit32_read(reg_val, SPI_DEVICE_TPM_STATUS_RDFIFO_NOTEMPTY_BIT);
-  status->read_fifo_occupancy =
-      bitfield_field32_read(reg_val, SPI_DEVICE_TPM_STATUS_RDFIFO_DEPTH_FIELD);
   status->write_fifo_occupancy =
       bitfield_field32_read(reg_val, SPI_DEVICE_TPM_STATUS_WRFIFO_DEPTH_FIELD);
   return kDifOk;
@@ -1574,9 +1570,9 @@ dif_result_t dif_spi_device_tpm_write_data(dif_spi_device_handle_t *spi,
   if (result != kDifOk) {
     return result;
   }
-  if ((DIF_SPI_DEVICE_TPM_FIFO_DEPTH - status.read_fifo_occupancy) *
-          sizeof(uint32_t) <
-      length) {
+
+  // TODO: Ensure the received length is greater than FIFO SIZE
+  if (DIF_SPI_DEVICE_TPM_FIFO_DEPTH * sizeof(uint32_t) < length) {
     return kDifOutOfRange;
   }
   for (int i = 0; i < length; i += 4) {

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -1007,10 +1007,6 @@ dif_result_t dif_spi_device_tpm_configure(dif_spi_device_handle_t *spi,
 typedef struct dif_spi_device_tpm_data_status {
   /** True if a command and address have been captured and are can be read. */
   bool cmd_addr_valid;
-  /** True if there is data still to be read from the Read FIFO. */
-  bool read_fifo_not_empty;
-  /** Current Read FIFO occupancy. */
-  uint8_t read_fifo_occupancy;
   /** Current Write FIFO occupancy. */
   uint8_t write_fifo_occupancy;
 } dif_spi_device_tpm_data_status_t;

--- a/sw/device/lib/dif/dif_spi_device_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_device_unittest.cc
@@ -1794,27 +1794,19 @@ TEST_F(TpmTest, CommandAndData) {
   EXPECT_READ32(SPI_DEVICE_TPM_STATUS_REG_OFFSET,
                 {
                     {SPI_DEVICE_TPM_STATUS_CMDADDR_NOTEMPTY_BIT, 0},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_NOTEMPTY_BIT, 1},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_DEPTH_OFFSET, 3},
                     {SPI_DEVICE_TPM_STATUS_WRFIFO_DEPTH_OFFSET, 4},
                 });
   EXPECT_DIF_OK(dif_spi_device_tpm_get_data_status(&spi_, &status));
   EXPECT_FALSE(status.cmd_addr_valid);
-  EXPECT_TRUE(status.read_fifo_not_empty);
-  EXPECT_EQ(status.read_fifo_occupancy, 3);
   EXPECT_EQ(status.write_fifo_occupancy, 4);
 
   EXPECT_READ32(SPI_DEVICE_TPM_STATUS_REG_OFFSET,
                 {
                     {SPI_DEVICE_TPM_STATUS_CMDADDR_NOTEMPTY_BIT, 1},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_NOTEMPTY_BIT, 0},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_DEPTH_OFFSET, 0},
                     {SPI_DEVICE_TPM_STATUS_WRFIFO_DEPTH_OFFSET, 2},
                 });
   EXPECT_DIF_OK(dif_spi_device_tpm_get_data_status(&spi_, &status));
   EXPECT_TRUE(status.cmd_addr_valid);
-  EXPECT_FALSE(status.read_fifo_not_empty);
-  EXPECT_EQ(status.read_fifo_occupancy, 0);
   EXPECT_EQ(status.write_fifo_occupancy, 2);
 
   EXPECT_READ32(SPI_DEVICE_TPM_CMD_ADDR_REG_OFFSET,
@@ -1829,28 +1821,6 @@ TEST_F(TpmTest, CommandAndData) {
   EXPECT_READ32(SPI_DEVICE_TPM_STATUS_REG_OFFSET,
                 {
                     {SPI_DEVICE_TPM_STATUS_CMDADDR_NOTEMPTY_BIT, 0},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_NOTEMPTY_BIT, 1},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_DEPTH_OFFSET, 14},
-                    {SPI_DEVICE_TPM_STATUS_WRFIFO_DEPTH_OFFSET, 4},
-                });
-  EXPECT_EQ(dif_spi_device_tpm_write_data(&spi_, /*length=*/9, data),
-            kDifOutOfRange);
-
-  EXPECT_READ32(SPI_DEVICE_TPM_STATUS_REG_OFFSET,
-                {
-                    {SPI_DEVICE_TPM_STATUS_CMDADDR_NOTEMPTY_BIT, 0},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_NOTEMPTY_BIT, 1},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_DEPTH_OFFSET, 15},
-                    {SPI_DEVICE_TPM_STATUS_WRFIFO_DEPTH_OFFSET, 4},
-                });
-  EXPECT_EQ(dif_spi_device_tpm_write_data(&spi_, /*length=*/5, data),
-            kDifOutOfRange);
-
-  EXPECT_READ32(SPI_DEVICE_TPM_STATUS_REG_OFFSET,
-                {
-                    {SPI_DEVICE_TPM_STATUS_CMDADDR_NOTEMPTY_BIT, 0},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_NOTEMPTY_BIT, 1},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_DEPTH_OFFSET, 1},
                     {SPI_DEVICE_TPM_STATUS_WRFIFO_DEPTH_OFFSET, 4},
                 });
   EXPECT_WRITE32(SPI_DEVICE_TPM_READ_FIFO_REG_OFFSET,
@@ -1861,8 +1831,6 @@ TEST_F(TpmTest, CommandAndData) {
   EXPECT_READ32(SPI_DEVICE_TPM_STATUS_REG_OFFSET,
                 {
                     {SPI_DEVICE_TPM_STATUS_CMDADDR_NOTEMPTY_BIT, 1},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_NOTEMPTY_BIT, 1},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_DEPTH_OFFSET, 3},
                     {SPI_DEVICE_TPM_STATUS_WRFIFO_DEPTH_OFFSET, 0},
                 });
   EXPECT_EQ(dif_spi_device_tpm_read_data(&spi_, /*length=*/1, data),
@@ -1871,8 +1839,6 @@ TEST_F(TpmTest, CommandAndData) {
   EXPECT_READ32(SPI_DEVICE_TPM_STATUS_REG_OFFSET,
                 {
                     {SPI_DEVICE_TPM_STATUS_CMDADDR_NOTEMPTY_BIT, 1},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_NOTEMPTY_BIT, 1},
-                    {SPI_DEVICE_TPM_STATUS_RDFIFO_DEPTH_OFFSET, 3},
                     {SPI_DEVICE_TPM_STATUS_WRFIFO_DEPTH_OFFSET, 4},
                 });
   for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
The Read FIFO in SPI TPM module uses TPM CS# as a reset for both write and read ports. The intention is to reset the FIFO at the end of every SPI TPM transaction.

As TPM CS# is controlled by TPM host system, the timing of CS# de-assertion (0 -> 1) is independant of the SYS_CLK. If release of CS# coincidently hit the posedge of the SYS_CLK, there's chance the Read FIFO depth signal may trigger metastability issues.

To avoid the issue, I may suggest two solutions quickly.

1. Convert the CS# rst synchronizer to sync assert, sync de-assert.
2. Add 2FF sync to the depth signal to eliminate metastability.

In this commit, I implement the option 2. Here's why I avoid the option 1.

Option 1 delays the assertion time of the reset on the write port of the read FIFO by 2 SYS_CLK. To reset the internal pointers correctly, both write/ read ports should be reset. To satisfy the requirement, CS# should remain high (inactive) for at least 2 SYS_CLK (+ 1 SYS_CLK at worst case). In real time scale, it is around 120ns. The minimum TPM CS# inactive time can be as low as 50ns. So, I wanted to avoid the case. However, in other logic inside TPM may require 2 SYS_CLK inactive time.

With the option 2, the TPM CS# inactive requirement is not needed. However, the status represented in CSRs will be delayed by 2 SYS_CLK. Fortunately, the read FIFO depth or notempty status are not latency sensitive signals.
