### PR TITLE
[bazel] update rust toolchain `iso_date` and increase targets built in airgapped mode in CI

### DIFF
--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -19,13 +19,14 @@ sudo ip netns add airgapped
 sudo ip netns exec airgapped ip addr add 127.0.0.1/8 dev lo
 sudo ip netns exec airgapped ip link set dev lo up
 
-# Enter the network namespace and perform a build test.
+# Enter the network namespace and perform several builds.
 sudo ip netns exec airgapped sudo -u "$USER" bash -c \
   "export BAZEL_BITSTREAMS_CACHE=$(pwd)/bazel-airgapped/bitstreams-cache;
-  export BITSTREAM=--offline;
+  export BITSTREAM=\"--offline latest\";
   export BAZEL_PYTHON_WHEELS_REPO=$(pwd)/bazel-airgapped/ot_python_wheels;
   bazel-airgapped/bazel build \
-    --distdir=bazel-airgapped/bazel-distdir \
-    --repository_cache=bazel-airgapped/bazel-cache \
-    //sw/device/tests:uart_smoketest_signed_sim_dv;"
+    --distdir=$(pwd)/bazel-airgapped/bazel-distdir \
+    --repository_cache=$(pwd)/bazel-airgapped/bazel-cache \
+    --define DISABLE_VERILATOR_BUILD=true \
+    //sw/device/silicon_creator/..."
 exit 0

--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -30,7 +30,7 @@ def rust_deps():
         version = "nightly",
         exec_triple = "x86_64-unknown-linux-gnu",
         extra_target_triples = ["riscv32imc-unknown-none-elf"],
-        iso_date = "2022-03-22",
+        iso_date = "2022-09-21",
         edition = "2021",
     )
     rust_bindgen_dependencies()

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -151,7 +151,9 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @python3_toolchains//... \
     @remotejdk11_linux//... \
     @riscv-compliance//... \
-    @rust_linux_x86_64__x86_64-unknown-linux-gnu_tools//...
+    @rust_linux_x86_64__x86_64-unknown-linux-gnu_tools//... \
+    @rust_opentitan_rv32imc__riscv32imc-unknown-none-elf//... \
+    @rust_opentitan_rv32imc__riscv32imc-unknown-none-elf_tools//...
   cp -R "$(${BAZELISK} info output_base)"/external/${BAZEL_PYTHON_WHEEL_REPO} \
     ${BAZEL_AIRGAPPED_DIR}/
   # We don't need all bitstreams in the cache, we just need the latest one so


### PR DESCRIPTION
This contains two commits that:

1. updates the rust toolchain `iso_date` to a version for which a SHA256 string exists in `rules_rust` so it can be cached in the repository cache (needed for airgapped builds), and prefetches the rust toolchain repositories for airgapped builds.

2. increases the targets that are built in an airgapped environment in CI to provide better coverage at catching future breakages.

This fixes #15640.