### PR TITLE
[flash_ctrl] Fix hardware info page attribute

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -233,8 +233,8 @@ package flash_ctrl_pkg;
     rd_en:       MuBi4True,
     prog_en:     MuBi4False,
     erase_en:    MuBi4False,
-    scramble_en: MuBi4False,
-    ecc_en:      MuBi4False, // TODO, update to 1 once tb supports ECC
+    scramble_en: MuBi4True,
+    ecc_en:      MuBi4True,
     he_en:       MuBi4True
   };
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -233,8 +233,8 @@ package flash_ctrl_pkg;
     rd_en:       MuBi4True,
     prog_en:     MuBi4False,
     erase_en:    MuBi4False,
-    scramble_en: MuBi4False,
-    ecc_en:      MuBi4False, // TODO, update to 1 once tb supports ECC
+    scramble_en: MuBi4True,
+    ecc_en:      MuBi4True,
     he_en:       MuBi4True
   };
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -239,8 +239,8 @@ package flash_ctrl_pkg;
     rd_en:       MuBi4True,
     prog_en:     MuBi4False,
     erase_en:    MuBi4False,
-    scramble_en: MuBi4False,
-    ecc_en:      MuBi4False, // TODO, update to 1 once tb supports ECC
+    scramble_en: MuBi4True,
+    ecc_en:      MuBi4True,
     he_en:       MuBi4True
   };
 

--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -36,9 +36,16 @@ enum {
 };
 
 static void write_info_page(dif_flash_ctrl_state_t *flash, uint32_t page_id,
-                            const keymgr_testutils_secret_t *data) {
-  uint32_t address = flash_ctrl_testutils_info_region_setup(
-      flash, page_id, kFlashInfoBankId, kFlashInfoPartitionId);
+                            const keymgr_testutils_secret_t *data,
+                            bool scramble) {
+  uint32_t address;
+  if (scramble) {
+    address = flash_ctrl_testutils_info_region_scrambled_setup(
+        flash, page_id, kFlashInfoBankId, kFlashInfoPartitionId);
+  } else {
+    address = flash_ctrl_testutils_info_region_setup(
+        flash, page_id, kFlashInfoBankId, kFlashInfoPartitionId);
+  }
 
   CHECK(flash_ctrl_testutils_erase_and_write_page(
       flash, address, kFlashInfoPartitionId, data->value,
@@ -56,8 +63,10 @@ void keymgr_testutils_flash_init(
     const keymgr_testutils_secret_t *creator_secret,
     const keymgr_testutils_secret_t *owner_secret) {
   // Initialize flash secrets.
-  write_info_page(flash, kFlashInfoPageIdCreatorSecret, creator_secret);
-  write_info_page(flash, kFlashInfoPageIdOwnerSecret, owner_secret);
+  write_info_page(flash, kFlashInfoPageIdCreatorSecret, creator_secret,
+                  /*scramble=*/true);
+  write_info_page(flash, kFlashInfoPageIdOwnerSecret, owner_secret,
+                  /*scramble=*/true);
 }
 
 void keymgr_testutils_startup(dif_keymgr_t *keymgr, dif_kmac_t *kmac) {

--- a/sw/device/tests/sim_dv/flash_init_test.c
+++ b/sw/device/tests/sim_dv/flash_init_test.c
@@ -43,6 +43,9 @@ enum {
   kTestPhaseCheckScrambledInit1 = 4,
   kTestPhaseCheckBackdoor0 = 5,
   kTestPhaseCheckBackdoor1 = 6,
+  kTestPhaseKeymgrPrep = 7,
+  kTestPhaseKeymgrTest0 = 8,
+  kTestPhaseKeymgrTest1 = 9,
 };
 
 enum {
@@ -335,6 +338,13 @@ bool rom_test_main(void) {
     case kTestPhaseCheckBackdoor0:
     case kTestPhaseCheckBackdoor1:
       check_scrambled_backdoor_data();
+      break;
+    case kTestPhaseKeymgrPrep:
+    case kTestPhaseKeymgrTest0:
+    case kTestPhaseKeymgrTest1:
+      flash_init();
+      test_status_set(kTestStatusInWfi);
+      wait_for_interrupt();
       break;
     default:
       break;


### PR DESCRIPTION
fixes #15659

Now the seed page are properly read back as both ECC and scramble enabled.

This commit only addresses the top level change, the block level changes still need to be done.

Signed-off-by: Timothy Chen <timothytim@google.com>