### PR TITLE
sw_backdoor_overwrite ibex polling issue

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1826,7 +1826,10 @@
             - Verify that the z3_wakeup output at the chip IOs is reflecting the value of 1.
             '''
       stage: V2
-      tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup"]
+      tests: [
+        "chip_sw_adc_ctrl_sleep_debug_cable_wakeup",
+        "chip_sw_sysrst_ctrl_ulp_z3_wakeup"
+      ]
     }
 
     // ADC_CTRL (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -792,6 +792,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_sysrst_ctrl_ulp_z3_wakeup
+      uvm_test_seq: chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq
+      sw_images: ["//sw/device/tests/sim_dv:sysrst_ctrl_ulp_z3_wakeup_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_sysrst_ctrl_reset
       uvm_test_seq: chip_sw_sysrst_ctrl_reset_vseq
       sw_images: ["//sw/device/tests/sim_dv:sysrst_ctrl_reset_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -71,6 +71,7 @@ filesets:
       - seq_lib/chip_sw_uart_rand_baudrate_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_inputs_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_in_irq_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
@@ -58,11 +58,20 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
     cfg.chip_vif.sysrst_ctrl_if.drive_pin(5, 1'b1);
   endtask
 
+  /*
   virtual function void write_test_phase(test_phases_e phase);
     bit [7:0] test_phase[1];
     test_phase[0] = phase;
     sw_symbol_backdoor_overwrite("kTestPhase", test_phase);
+    test_phase[0] = PHASE_CACHE_INVALIDATE;
+    sw_symbol_backdoor_overwrite("kTestPhase", );
   endfunction
+  */
+
+  virtual function void write_test_phase(input test_phases_e phase);
+    sw_symbol_backdoor_overwrite("kTestPhase", {<<8{phase}});
+  endfunction
+
 
   virtual function check_wakeup_pin();
     logic wakeup_result;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
@@ -89,7 +89,7 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
     // pinmux_wkup_vif (at Iob7) is re-used for PinZ3WakeupOut
     // due to lack of unused pins. Disable the default drive
     // to this pin.
-    //cfg.chip_vif.pinmux_wkup_if.drive_en_pin(0, 0);
+    cfg.chip_vif.pinmux_wkup_if.drive_en_pin(0, 0);
     write_test_phase(PHASE_INIT);
     sync_with_sw();
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
@@ -28,20 +28,20 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
     super.pre_start();
     // Initialize the pad input to 0 to avoid having X values in the initial test phase.
     cfg.chip_vif.pwrb_in_if.pins_pd[0] = 1;
-    cfg.chip_vif.sysrst_ctrl_if.pins_pd[3] = 1;
-    cfg.chip_vif.sysrst_ctrl_if.pins_pd[2] = 1;
+    cfg.chip_vif.sysrst_ctrl_if.pins_pd[4] = 1;
+    cfg.chip_vif.sysrst_ctrl_if.pins_pd[5] = 1;
     // Same for output
     //cfg.chip_vif.pinmux_wkup_if.pins_pd[0] = 1;
-    cfg.chip_vif.sysrst_ctrl_if.pins_pd[5] = 1;
+    //cfg.chip_vif.sysrst_ctrl_if.pins_pd[2] = 1;
   endtask
 
   virtual function void drive_zero_pads();
     //`DV_CHECK(uvm_hdl_force(PAD_PWRB_PATH, 1'b0));
     cfg.chip_vif.pwrb_in_if.drive_pin(0, 1'b0);
     //`DV_CHECK(uvm_hdl_force(PAD_ACPRESENT_PATH, 1'b0));
-    cfg.chip_vif.sysrst_ctrl_if.drive_pin(3, 1'b0);
+    cfg.chip_vif.sysrst_ctrl_if.drive_pin(4, 1'b0);
     //`DV_CHECK(uvm_hdl_force(PAD_LIDOPEN_PATH, 1'b0));
-    cfg.chip_vif.sysrst_ctrl_if.drive_pin(2, 1'b0);
+    cfg.chip_vif.sysrst_ctrl_if.drive_pin(5, 1'b0);
   endfunction
 
   virtual task glitch_lid_open();
@@ -50,12 +50,12 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
     // The following loop ends before the second sampling of debounce happens
     for (int i = 0; i < glitch_loop_cnt ; i++) begin
       //`DV_CHECK(uvm_hdl_force(PAD_LIDOPEN_PATH, glitchy_bit));
-      cfg.chip_vif.sysrst_ctrl_if.drive_pin(2, glitchy_bit);
+      cfg.chip_vif.sysrst_ctrl_if.drive_pin(5, glitchy_bit);
       cfg.chip_vif.aon_clk_por_rst_if.wait_clks(1);
       glitchy_bit = ~glitchy_bit;
     end
     //`DV_CHECK(uvm_hdl_force(PAD_LIDOPEN_PATH, 1'b1));
-    cfg.chip_vif.sysrst_ctrl_if.drive_pin(2, 1'b1);
+    cfg.chip_vif.sysrst_ctrl_if.drive_pin(5, 1'b1);
   endtask
 
   virtual function void write_test_phase(test_phases_e phase);
@@ -67,8 +67,8 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
   virtual function check_wakeup_pin();
     logic wakeup_result;
     //`DV_CHECK(uvm_hdl_read(PAD_Z3WAKEUP_PATH, wakeup_result));
-    wakeup_result = cfg.chip_vif.sysrst_ctrl_if.sample_pin(5);
-    //wakeup_result = cfg.chip_vif.pinmux_wkup_if.sample_pin(0);
+    //wakeup_result = cfg.chip_vif.sysrst_ctrl_if.sample_pin(2);
+    wakeup_result = cfg.chip_vif.pinmux_wkup_if.sample_pin(0);
     `DV_CHECK_EQ_FATAL(wakeup_result, 1'b1);
   endfunction
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
@@ -31,7 +31,8 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
     cfg.chip_vif.sysrst_ctrl_if.pins_pd[3] = 1;
     cfg.chip_vif.sysrst_ctrl_if.pins_pd[2] = 1;
     // Same for output
-    cfg.chip_vif.pinmux_wkup_if.pins_pd[0] = 1;
+    //cfg.chip_vif.pinmux_wkup_if.pins_pd[0] = 1;
+    cfg.chip_vif.sysrst_ctrl_if.pins_pd[5] = 1;
   endtask
 
   virtual function void drive_zero_pads();
@@ -66,7 +67,8 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
   virtual function check_wakeup_pin();
     logic wakeup_result;
     //`DV_CHECK(uvm_hdl_read(PAD_Z3WAKEUP_PATH, wakeup_result));
-    wakeup_result = cfg.chip_vif.pinmux_wkup_if.sample_pin(0);
+    wakeup_result = cfg.chip_vif.sysrst_ctrl_if.sample_pin(5);
+    //wakeup_result = cfg.chip_vif.pinmux_wkup_if.sample_pin(0);
     `DV_CHECK_EQ_FATAL(wakeup_result, 1'b1);
   endfunction
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
@@ -1,0 +1,99 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
+  import dv_utils_pkg::*;
+  `uvm_object_utils(chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq)
+  `uvm_object_new
+
+  localparam string PAD_PWRB_PATH      = "tb.dut.IOR13";
+  localparam string PAD_ACPRESENT_PATH = "tb.dut.IOC7";
+  localparam string PAD_LIDOPEN_PATH   = "tb.dut.IOC9";
+  localparam string PAD_Z3WAKEUP_PATH  = "tb.dut.IOB7";
+
+  // The value of configured debounce value
+  localparam uint DEBOUNCE_SW_VALUE = 20;
+
+  typedef enum bit [7:0] {
+    PHASE_INIT                  = 0,
+    PHASE_DRIVE_ZERO            = 1,
+    PHASE_WAIT_NO_WAKEUP        = 2,
+    PHASE_GLITCH_LID_OPEN       = 3,
+    PHASE_WAIT_WAKEUP           = 4,
+    PHASE_DONE                  = 5
+  } test_phases_e;
+
+  virtual function void drive_zero_pads();
+    `DV_CHECK(uvm_hdl_force(PAD_PWRB_PATH, 1'b0));
+    `DV_CHECK(uvm_hdl_force(PAD_ACPRESENT_PATH, 1'b0));
+    `DV_CHECK(uvm_hdl_force(PAD_LIDOPEN_PATH, 1'b0));
+  endfunction
+
+  virtual task glitch_lid_open();
+    uint glitch_loop_cnt = $urandom_range(1, DEBOUNCE_SW_VALUE - 1);
+    bit glitchy_bit = 1'b1;
+    // The following loop ends before the second sampling of debounce happens
+    for (int i = 0; i < glitch_loop_cnt ; i++) begin
+      `DV_CHECK(uvm_hdl_force(PAD_LIDOPEN_PATH, glitchy_bit));
+      cfg.chip_vif.aon_clk_por_rst_if.wait_clks(1);
+      glitchy_bit = ~glitchy_bit;
+    end
+    `DV_CHECK(uvm_hdl_force(PAD_LIDOPEN_PATH, 1'b1));
+  endtask
+
+  virtual function void write_test_phase(test_phases_e phase);
+    bit [7:0] test_phase[1];
+    test_phase[0] = phase;
+    sw_symbol_backdoor_overwrite("kTestPhase", test_phase);
+  endfunction
+
+  virtual function check_wakeup_pin();
+    logic wakeup_result;
+    `DV_CHECK(uvm_hdl_read(PAD_Z3WAKEUP_PATH, wakeup_result));
+    `DV_CHECK_EQ_FATAL(wakeup_result, 1'b1);
+  endfunction
+
+  virtual task wait_wakeup_time();
+    // Wait until we are sure that we passed the second sampling of debounce logic
+    cfg.chip_vif.aon_clk_por_rst_if.wait_clks(DEBOUNCE_SW_VALUE);
+  endtask
+
+  virtual task sync_with_sw();
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+  endtask
+
+  virtual task body();
+    super.body();
+
+    // TODO(lowRISC/opentitan:#13373): Revisit pad assignments.
+    // pinmux_wkup_vif (at Iob7) is re-used for PinZ3WakeupOut
+    // due to lack of unused pins. Disable the default drive
+    // to this pin.
+    //cfg.chip_vif.pinmux_wkup_if.drive_en_pin(0, 0);
+    write_test_phase(PHASE_INIT);
+    sync_with_sw();
+
+    drive_zero_pads();
+    write_test_phase(PHASE_DRIVE_ZERO);
+    sync_with_sw();
+
+    wait_wakeup_time();
+    write_test_phase(PHASE_WAIT_NO_WAKEUP);
+    // Skip sync_with_sw, because SW starts sleeping after Wfi
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
+
+    glitch_lid_open();
+    write_test_phase(PHASE_GLITCH_LID_OPEN);
+    sync_with_sw();
+
+    wait_wakeup_time();
+    write_test_phase(PHASE_WAIT_WAKEUP);
+    check_wakeup_pin();
+    sync_with_sw();
+
+    write_test_phase(PHASE_DONE);
+  endtask
+
+endclass : chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -25,6 +25,7 @@
 `include "chip_sw_uart_rand_baudrate_vseq.sv"
 `include "chip_sw_sysrst_ctrl_inputs_vseq.sv"
 `include "chip_sw_sysrst_ctrl_in_irq_vseq.sv"
+`include "chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv"
 `include "chip_sw_sysrst_ctrl_reset_vseq.sv"
 `include "chip_sw_sysrst_ctrl_outputs_vseq.sv"
 `include "chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -199,6 +199,25 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "sysrst_ctrl_ulp_z3_wakeup_test",
+    srcs = ["sysrst_ctrl_ulp_z3_wakeup_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "sysrst_ctrl_reset_test",
     srcs = ["sysrst_ctrl_reset_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/sysrst_ctrl_ulp_z3_wakeup_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_ulp_z3_wakeup_test.c
@@ -1,0 +1,184 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// This is updated by the sv component of the test
+static volatile const uint8_t kTestPhase = 0;
+
+static dif_pwrmgr_t pwrmgr;
+static dif_rstmgr_t rstmgr;
+static dif_pinmux_t pinmux;
+static dif_sysrst_ctrl_t sysrst_ctrl;
+
+// This means 20 aon_clk ticks ~= 20 * 5 us = 100 us
+static const uint16_t debounce_timer = 20;
+
+enum {
+  kNumMioInPads = 3,
+  kNumMioOutPads = 1,
+};
+
+const uint32_t kTestPhaseTimeoutUsec = 500;
+enum {
+  kTestPhaseInit = 0,
+  kTestPhaseDriveZero = 1,
+  kTestPhaseWaitNoWakeup = 2,
+  kTestPhaseGlitchLidOpen = 3,
+  kTestPhaseWaitWakeup = 4,
+  kTestPhaseDone = 5,
+};
+
+static const dif_pinmux_index_t kPeripheralInputs[] = {
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonPwrbIn,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonAcPresent,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonLidOpen,
+};
+
+static const dif_pinmux_index_t kInputPads[] = {
+    kTopEarlgreyPinmuxInselIor13,
+    kTopEarlgreyPinmuxInselIoc7,
+    kTopEarlgreyPinmuxInselIoc9,
+};
+
+static const dif_pinmux_index_t kPeripheralOutputs[] = {
+    kTopEarlgreyPinmuxOutselSysrstCtrlAonZ3Wakeup,
+};
+
+static const dif_pinmux_index_t kOutputPads[] = {
+    kTopEarlgreyPinmuxMioOutIob7,
+};
+
+/**
+ * Sets up the pinmux to assign input and output pads to the sysrst_ctrl
+ * peripheral as required.
+ */
+static void pinmux_setup(void) {
+  for (int i = 0; i < kNumMioInPads; ++i) {
+    CHECK_DIF_OK(
+        dif_pinmux_input_select(&pinmux, kPeripheralInputs[i], kInputPads[i]));
+  }
+
+  for (int i = 0; i < kNumMioOutPads; ++i) {
+    CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kOutputPads[i],
+                                          kPeripheralOutputs[i]));
+  }
+}
+
+/**
+ * Waits for `kTestPhase` variable to be changed by a backdoor overwrite
+ * from the testbench in chip_sw_<testname>_vseq.sv. This will indicate that
+ * the testbench is ready to proceed with the next phase of the test.
+ */
+static void wait_next_test_phase(void) {
+  uint8_t current_phase = kTestPhase;
+  // Set WFI status for testbench synchronization
+  // No WFI instruction is issued
+  test_status_set(kTestStatusInWfi);
+  test_status_set(kTestStatusInTest);
+  IBEX_SPIN_FOR(current_phase != kTestPhase, kTestPhaseTimeoutUsec);
+  LOG_INFO("Test phase = %0d", kTestPhase);
+}
+
+/**
+ * Configure *_debounce_ctl and then enable ULP wakeup.
+ */
+static void configure_wakeup(void) {
+  dif_sysrst_ctrl_ulp_wakeup_config_t wakeup_config;
+
+  // Keep toggle disabled when writing debounce configuration
+  wakeup_config.enabled = kDifToggleDisabled;
+  wakeup_config.ac_power_debounce_time_threshold = debounce_timer;
+  wakeup_config.lid_open_debounce_time_threshold = debounce_timer;
+  wakeup_config.power_button_debounce_time_threshold = debounce_timer;
+
+  CHECK_DIF_OK(
+      dif_sysrst_ctrl_ulp_wakeup_configure(&sysrst_ctrl, wakeup_config));
+
+  CHECK_DIF_OK(
+      dif_sysrst_ctrl_ulp_wakeup_set_enabled(&sysrst_ctrl, kDifToggleEnabled));
+}
+
+static void go_to_sleep(void) {
+  // Wakeup source is from sysrst_ctrl (source one).
+  rstmgr_testutils_pre_reset(&rstmgr);
+  pwrmgr_testutils_enable_low_power(&pwrmgr, kDifPwrmgrWakeupRequestSourceOne,
+                                    0);
+  LOG_INFO("Going to sleep.");
+  test_status_set(kTestStatusInWfi);
+  wait_for_interrupt();
+}
+
+static void check_wakeup_reason(void) {
+  dif_rstmgr_reset_info_bitfield_t rst_info;
+  rst_info = rstmgr_testutils_reason_get();
+  rstmgr_testutils_reason_clear();
+
+  CHECK(rst_info == kDifRstmgrResetInfoLowPowerExit, "Wrong reset reason %02X",
+        rst_info);
+}
+
+static bool has_wakeup_happened(void) {
+  bool wakeup_detected;
+  CHECK_DIF_OK(
+      dif_sysrst_ctrl_ulp_wakeup_get_status(&sysrst_ctrl, &wakeup_detected));
+  return wakeup_detected;
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_sysrst_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
+      &sysrst_ctrl));
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  while (kTestPhase < kTestPhaseDone) {
+    switch (kTestPhase) {
+      case kTestPhaseInit:
+        pinmux_setup();
+        break;
+      case kTestPhaseDriveZero:
+        configure_wakeup();
+        LOG_INFO("kTestPhaseDriveZero");
+        break;
+      case kTestPhaseWaitNoWakeup:
+        CHECK(!has_wakeup_happened());
+        LOG_INFO("kTestPhaseWaitNoWakeup");
+        go_to_sleep();
+        check_wakeup_reason();
+        break;
+      case kTestPhaseGlitchLidOpen:
+        LOG_INFO("kTestPhaseGlitchLidOpen");
+        break;
+      case kTestPhaseWaitWakeup:
+        CHECK(has_wakeup_happened());
+        LOG_INFO("kTestPhaseWaitWakeup");
+        break;
+      default:
+        LOG_ERROR("Unexpected test phase : %d", kTestPhase);
+        LOG_INFO("END");
+        break;
+    }
+    wait_next_test_phase();
+  }
+  return true;
+}

--- a/sw/device/tests/sim_dv/sysrst_ctrl_ulp_z3_wakeup_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_ulp_z3_wakeup_test.c
@@ -61,7 +61,7 @@ static const dif_pinmux_index_t kPeripheralOutputs[] = {
 };
 
 static const dif_pinmux_index_t kOutputPads[] = {
-    kTopEarlgreyPinmuxMioOutIob7,
+    kTopEarlgreyPinmuxMioOutIob8,
 };
 
 /**

--- a/sw/device/tests/sim_dv/sysrst_ctrl_ulp_z3_wakeup_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_ulp_z3_wakeup_test.c
@@ -61,7 +61,7 @@ static const dif_pinmux_index_t kPeripheralOutputs[] = {
 };
 
 static const dif_pinmux_index_t kOutputPads[] = {
-    kTopEarlgreyPinmuxMioOutIob8,
+    kTopEarlgreyPinmuxMioOutIob7,
 };
 
 /**
@@ -89,10 +89,11 @@ static void wait_next_test_phase(void) {
   uint8_t current_phase = kTestPhase;
   // Set WFI status for testbench synchronization
   // No WFI instruction is issued
+  LOG_INFO("Prev test phase = %0d", kTestPhase);
   test_status_set(kTestStatusInWfi);
   test_status_set(kTestStatusInTest);
   IBEX_SPIN_FOR(current_phase != kTestPhase, kTestPhaseTimeoutUsec);
-  LOG_INFO("Test phase = %0d", kTestPhase);
+  LOG_INFO("Next test phase = %0d", kTestPhase);
 }
 
 /**
@@ -116,11 +117,11 @@ static void configure_wakeup(void) {
 
 static void go_to_sleep(void) {
   // Wakeup source is from sysrst_ctrl (source one).
+  LOG_INFO("Going to sleep.");
+  test_status_set(kTestStatusInWfi);
   rstmgr_testutils_pre_reset(&rstmgr);
   pwrmgr_testutils_enable_low_power(&pwrmgr, kDifPwrmgrWakeupRequestSourceOne,
                                     0);
-  LOG_INFO("Going to sleep.");
-  test_status_set(kTestStatusInWfi);
   wait_for_interrupt();
 }
 
@@ -157,7 +158,7 @@ bool test_main(void) {
         pinmux_setup();
         break;
       case kTestPhaseDriveZero:
-        configure_wakeup();
+        //configure_wakeup();
         LOG_INFO("kTestPhaseDriveZero");
         break;
       case kTestPhaseWaitNoWakeup:


### PR DESCRIPTION
Even though `kTestPhase` is in RamMain0, Ibex spin doesn't come out of the loop. The test fails with timeout. @engdoreis 