### PR TITLE
[dv,chip] add reduced sysclk freq tests

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -955,15 +955,16 @@
             range clock option via a flag, and running several existing chip-level tests with that
             option, e.g.
 
-              chip_sw_clkmgr_jitter
-              chip_sw_flash_ctrl_ops_jitter_en
-              chip_sw_flash_ctrl_access_jitter_en
-              chip_sw_otbn_ecdsa_op_irq_jitter_en
-              chip_sw_aes_enc_jitter_en
-              chip_sw_hmac_enc_jitter_en
-              chip_sw_keymgr_key_derivation_jitter_en
-              chip_sw_kmac_mode_kmac_jitter_en
-              chip_sw_sram_ctrl_main_scrambled_access_jitter_en
+              chip_sw_clkmgr_jitter_reduced_freq
+              chip_sw_flash_ctrl_ops_jitter_en_reduced_freq
+              chip_sw_flash_ctrl_access_jitter_en_reduced_freq
+              chip_sw_otbn_ecdsa_op_irq_jitter_en_reduced_freq
+              chip_sw_aes_enc_jitter_en_reduced_freq
+              chip_sw_hmac_enc_jitter_en_reduced_freq
+              chip_sw_keymgr_key_derivation_jitter_en_reduced_freq
+              chip_sw_kmac_mode_kmac_jitter_en_reduced_freq
+              chip_sw_sram_ctrl_main_scrambled_access_jitter_en_reduced_freq
+              chip_sw_flash_init_reduced_freq
             '''
       stage: V2
       tests: []

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -953,21 +953,29 @@
 
             This testpoint can be covered by extending the DV environment to support the extended
             range clock option via a flag, and running several existing chip-level tests with that
-            option, e.g.
+            option.
 
-              chip_sw_clkmgr_jitter_reduced_freq
-              chip_sw_flash_ctrl_ops_jitter_en_reduced_freq
-              chip_sw_flash_ctrl_access_jitter_en_reduced_freq
-              chip_sw_otbn_ecdsa_op_irq_jitter_en_reduced_freq
-              chip_sw_aes_enc_jitter_en_reduced_freq
-              chip_sw_hmac_enc_jitter_en_reduced_freq
-              chip_sw_keymgr_key_derivation_jitter_en_reduced_freq
-              chip_sw_kmac_mode_kmac_jitter_en_reduced_freq
-              chip_sw_sram_ctrl_main_scrambled_access_jitter_en_reduced_freq
-              chip_sw_flash_init_reduced_freq
+            Test the following functionalities with reduced clock:
+
+            - flash_ctrl initialization
+            - flash_ctrl program, read and erase operations
+            - AES, HMAC, KMAC and OTBN operations
+            - Keymgr key derivation
+            - Scramble-enabled access from the main SRAM
+            - Csrng edn concurrency
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_clkmgr_jitter_reduced_freq",
+              "chip_sw_flash_ctrl_ops_jitter_en_reduced_freq",
+              "chip_sw_flash_ctrl_access_jitter_en_reduced_freq",
+              "chip_sw_otbn_ecdsa_op_irq_jitter_en_reduced_freq",
+              "chip_sw_aes_enc_jitter_en_reduced_freq",
+              "chip_sw_hmac_enc_jitter_en_reduced_freq",
+              "chip_sw_keymgr_key_derivation_jitter_en_reduced_freq",
+              "chip_sw_kmac_mode_kmac_jitter_en_reduced_freq",
+              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en_reduced_freq",
+              "chip_sw_flash_init_reduced_freq",
+              "chip_sw_csrng_edn_concurrency_reduced_freq"]
     }
     {
       name: chip_sw_clkmgr_deep_sleep_frequency

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1528,7 +1528,8 @@
       // Starting the chip in prod LC state frees up all MIOs for this test.
       run_opts: ["+use_otp_image=OtpTypeLcStProd"]
       reseed: 10
-        {
+    }
+    {
       name: chip_sw_clkmgr_jitter_reduced_freq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:clkmgr_jitter_test:1"]
@@ -1601,6 +1602,15 @@
       en_run_modes: ["sw_test_mode_common"]
       run_opts: ["+sw_test_timeout_ns=25_000_000", "+cal_sys_clk_70mhz=1"]
     }
+    {
+      name: chip_sw_csrng_edn_concurrency_reduced_freq
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:csrng_edn_concurrency_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000", "+rng_srate_value_min=15",
+                 "+rng_srate_value_max=20", "+cal_sys_clk_70mhz=1", "+en_jitter=1"]
+      run_timeout_mins: 240
+    }
   ]
 
   // List of regressions.
@@ -1641,7 +1651,9 @@
               "chip_sw_hmac_enc_jitter_en_reduced_freq",
               "chip_sw_keymgr_key_derivation_jitter_en_reduced_freq",
               "chip_sw_kmac_mode_kmac_jitter_en_reduced_freq",
-              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en_reduced_freq"]
+              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en_reduced_freq",
+              "chip_sw_flash_init_reduced_freq",
+              "chip_sw_csrng_edn_concurrency_reduced_freq"]
     }
     {
       name: xcelium_ci_0

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1528,6 +1528,78 @@
       // Starting the chip in prod LC state frees up all MIOs for this test.
       run_opts: ["+use_otp_image=OtpTypeLcStProd"]
       reseed: 10
+        {
+      name: chip_sw_clkmgr_jitter_reduced_freq
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:clkmgr_jitter_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+cal_sys_clk_70mhz=1"]
+    }
+    {
+      name: chip_sw_flash_ctrl_ops_jitter_en_reduced_freq
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:flash_ctrl_ops_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=14_000_000", "+en_jitter=1", "+cal_sys_clk_70mhz=1"]
+    }
+    {
+      name: chip_sw_flash_ctrl_access_jitter_en_reduced_freq
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:flash_ctrl_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+en_jitter=1", "+cal_sys_clk_70mhz=1"]
+    }
+    {
+      name: chip_sw_otbn_ecdsa_op_irq_jitter_en_reduced_freq
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:otbn_ecdsa_op_irq_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=33_000_000", "+rng_srate_value=30", "+en_jitter=1", "+cal_sys_clk_70mhz=1"]
+      run_timeout_mins: 1000
+    }
+    {
+      name: chip_sw_aes_enc_jitter_en_reduced_freq
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:aes_smoketest:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=26_000_000", "+en_jitter=1", "+cal_sys_clk_70mhz=1"]
+    }
+    {
+      name: chip_sw_hmac_enc_jitter_en_reduced_freq
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:hmac_enc_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+en_jitter=1", "+cal_sys_clk_70mhz=1"]
+    }
+    {
+      name: chip_sw_keymgr_key_derivation_jitter_en_reduced_freq
+      uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
+      sw_images: ["//sw/device/tests/sim_dv:keymgr_key_derivation_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000", "+en_jitter=1", "+cal_sys_clk_70mhz=1"]
+    }
+    {
+      name: chip_sw_kmac_mode_kmac_jitter_en_reduced_freq
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:kmac_mode_kmac_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+en_jitter=1", "+cal_sys_clk_70mhz=1"]
+    }
+    {
+      name: chip_sw_sram_ctrl_main_scrambled_access_jitter_en_reduced_freq
+      uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
+      sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_main_scrambled_access_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+mem_sel=main",
+                 "+sw_test_timeout_ns=12_000_000",
+                 "+en_jitter=1", "+en_scb_tl_err_chk=0", "+cal_sys_clk_70mhz=1"]
+    }
+    {
+      name: chip_sw_flash_init_reduced_freq
+      uvm_test_seq: chip_sw_flash_init_vseq
+      sw_images: ["//sw/device/tests/sim_dv:flash_init_test:0:test_in_rom"]
+      en_run_modes: ["sw_test_mode_common"]
+      run_opts: ["+sw_test_timeout_ns=25_000_000", "+cal_sys_clk_70mhz=1"]
     }
   ]
 
@@ -1558,6 +1630,18 @@
               "chip_sw_keymgr_key_derivation_jitter_en",
               "chip_sw_kmac_mode_kmac_jitter_en",
               "chip_sw_sram_ctrl_main_scrambled_access_jitter_en"]
+    }
+    {
+      name: jitter_reduced_freq
+      tests: ["chip_sw_clkmgr_jitter_reduced_freq",
+              "chip_sw_flash_ctrl_ops_jitter_en_reduced_freq",
+              "chip_sw_flash_ctrl_access_jitter_en_reduced_freq",
+              "chip_sw_otbn_ecdsa_op_irq_jitter_en_reduced_freq",
+              "chip_sw_aes_enc_jitter_en_reduced_freq",
+              "chip_sw_hmac_enc_jitter_en_reduced_freq",
+              "chip_sw_keymgr_key_derivation_jitter_en_reduced_freq",
+              "chip_sw_kmac_mode_kmac_jitter_en_reduced_freq",
+              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en_reduced_freq"]
     }
     {
       name: xcelium_ci_0


### PR DESCRIPTION
Signed-off-by: arielc <ariel.cohen@nuvoton.com>
Added tests running with 70Mhz system clock frequency, according to issue  #14782  