### PR TITLE
[spi_device/dv] Fix regression issues

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_perf_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_perf_vseq.sv
@@ -9,11 +9,6 @@ class spi_device_perf_vseq extends spi_device_txrx_vseq;
   `uvm_object_utils(spi_device_perf_vseq)
   `uvm_object_new
 
-  // additional constraint for tx_total_bytes to transfer more data
-  constraint tx_total_bytes_additional_c {
-    tx_total_bytes inside {[5 * SRAM_SIZE : 10 * SRAM_SIZE]};
-  }
-
   constraint tx_delay_c {
     tx_delay inside {[0 : 1]};
   }
@@ -23,7 +18,7 @@ class spi_device_perf_vseq extends spi_device_txrx_vseq;
   }
 
   constraint num_trans_c {
-    num_trans inside {[2:3]};
+    num_trans == 2;
   }
 
 endclass : spi_device_perf_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_stress_all_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_stress_all_vseq.sv
@@ -5,7 +5,6 @@
 // Combine most of the spi_device sequences in one test to run sequentially, except csr sequences.
 // mainly test these:
 // - Modes switch among FW, flash, passthrough and tpm.
-// - send some dummy transactions along with normal transactions
 // - Randomly add reset between each sequence
 class spi_device_stress_all_vseq extends spi_device_base_vseq;
   `uvm_object_utils(spi_device_stress_all_vseq)
@@ -14,7 +13,6 @@ class spi_device_stress_all_vseq extends spi_device_base_vseq;
   constraint num_trans_c {
     num_trans inside {[3:5]};
   }
-  rand bit en_dummy_host_xfer;
 
   task body();
     int num_flash_tpm_seq;
@@ -56,19 +54,7 @@ class spi_device_stress_all_vseq extends spi_device_base_vseq;
         common_vseq.common_seq_type = "intr_test";
       end
 
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(en_dummy_host_xfer)
-      fork
-        begin : main_seq
-          spi_vseq.start(p_sequencer);
-          done_xfer = 1;
-        end : main_seq
-        begin : dummy_item_seq
-          while (!done_xfer && en_dummy_host_xfer) begin
-            cfg.clk_rst_vif.wait_clks($urandom_range(10, 1000));
-            spi_host_xfer_dummy_item();
-          end
-        end : dummy_item_seq
-      join
+      spi_vseq.start(p_sequencer);
     end
   endtask : body
 endclass : spi_device_stress_all_vseq

--- a/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
@@ -32,7 +32,8 @@ class spi_device_env_cov extends cip_base_env_cov #(.CFG_T(spi_device_env_cfg));
     cp_tpm_enabled: coverpoint tpm_enabled;
     cr_all: cross cp_mode, cp_tpm_enabled {
       // FW mode can't run with TPM enabled
-      illegal_bins invalid = binsof(cp_mode) intersect { GenericMode } &&
+      // but if we turn the mode on without realling sending transactions, it's fine.
+      ignore_bins invalid = binsof(cp_mode) intersect { GenericMode } &&
                              binsof(cp_tpm_enabled) intersect { 1 };
     }
   endgroup

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -76,6 +76,7 @@
     {
       name: spi_device_extreme_fifo_size
       uvm_test_seq: spi_device_extreme_fifo_size_vseq
+      run_timeout_mins: 90
     }
 
     {


### PR DESCRIPTION
This will make most of tests 100% pass, except stress_all
1. Update constrain for flash_mode, need to check mailbox_en before pick an address
2. Update scb to fix prediction of flash_status for a corner case that dummy item involves
3. Fix some regression timeout
4. Remove dummy item in stress_all as it's added in subseq already
5. fix a fcov error

Signed-off-by: Weicai Yang <weicai@google.com>