### PR TITLE
[top/dv] Add lc_ctrl wait to wait_rom_check_done

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -19,7 +19,6 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
     for (int ram_idx = 0; ram_idx < cfg.num_ram_main_tiles; ram_idx++) begin
       cfg.mem_bkdr_util_h[chip_mem_e'(RamMain0 + ram_idx)].randomize_mem();
     end
-    wait_rom_check_done();
   endtask
 
   virtual task body();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -29,6 +29,14 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     super.pre_start();
   endtask
 
+  virtual task post_apply_reset(string reset_kind = "HARD");
+    super.post_apply_reset(reset_kind);
+
+    // Wait until rom_ctrl and lc_ctrl have finished to ensure stub_cpu
+    // does not conflict with any background power-up activity
+    wait_rom_check_done();
+  endtask
+
   task post_start();
     super.post_start();
 


### PR DESCRIPTION
After the reset domain change, the rom_ctrl checks happen in parallel with life cycle control initilization.

This means waiting for rom_ctrl alone to be done is insufficient and we need to wait for life cycle control to be done as well.

Signed-off-by: Timothy Chen <timothytim@google.com>