### PR TITLE
[bazel] enhance airgapped test to build more targets

### DIFF
--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -22,10 +22,12 @@ sudo ip netns exec airgapped ip link set dev lo up
 # Enter the network namespace and perform several builds.
 sudo ip netns exec airgapped sudo -u "$USER" bash -c \
   "export BAZEL_BITSTREAMS_CACHE=$(pwd)/bazel-airgapped/bitstreams-cache;
-  export BITSTREAM=--offline;
+  export BITSTREAM=\"--offline latest\";
   export BAZEL_PYTHON_WHEELS_REPO=$(pwd)/bazel-airgapped/ot_python_wheels;
   bazel-airgapped/bazel build \
-    --distdir=bazel-airgapped/bazel-distdir \
-    --repository_cache=bazel-airgapped/bazel-cache \
-    //sw/device/tests:uart_smoketest_sim_dv"
+    --distdir=$(pwd)/bazel-airgapped/bazel-distdir \
+    --repository_cache=$(pwd)/bazel-airgapped/bazel-cache \
+    --define DISABLE_VERILATOR_BUILD=true \
+    --build_tag_filters=-vivado \
+    //sw/device/silicon_creator/..."
 exit 0

--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -63,7 +63,6 @@ parser.add_argument(
 
 
 class BitstreamCache(object):
-
     def __init__(self, bucket_url, cachedir, latest_update, offline=False):
         """Initialize the Bitstream Cache Manager."""
         if bucket_url[-1] != '/':
@@ -162,7 +161,8 @@ class BitstreamCache(object):
                         self.available[m.group(1)] = key.text
             # Handle any pagination
             is_truncated_elt = et.find('IsTruncated', XMLNS)
-            if (is_truncated_elt is not None) and (is_truncated_elt.text == 'true'):
+            if (is_truncated_elt is not None) and (is_truncated_elt.text
+                                                   == 'true'):
                 marker = et.find('NextMarker', XMLNS).text
             else:
                 break
@@ -265,6 +265,11 @@ class BitstreamCache(object):
         return datetime.datetime.now().isoformat()
 
     def _ConstructBazelString(self, build_file: Path, key: str) -> str:
+        # If `key` passed in is "latest", this updates the `key` to be the hash
+        # that "latest" points to.
+        if key == 'latest':
+            key = self.available['latest']
+
         files_by_extension = self.GetFromCache(key)
 
         if len(files_by_extension.get('orig', set())) != 1 or \

--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -161,8 +161,8 @@ class BitstreamCache(object):
                         self.available[m.group(1)] = key.text
             # Handle any pagination
             is_truncated_elt = et.find('IsTruncated', XMLNS)
-            if (is_truncated_elt is not None) and (is_truncated_elt.text
-                                                   == 'true'):
+            if (is_truncated_elt is not None) and \
+               (is_truncated_elt.text == 'true'):
                 marker = et.find('NextMarker', XMLNS).text
             else:
                 break


### PR DESCRIPTION
This PR contains two commits that:

1. Fixes a bug in the bitstreams cache that was not writing the ROM and OTP MMI filegroup targets to the BUILD.bazel file if the key was "latest".
2. Runs more test builds in the airgapped network namespace in CI to increase test coverage and reduce the chance of an in-properly fetched Bazel dependency from slipping into the repository.