### PR TITLE
[sw/silicon_creator] Use sh256 instead of crc32 to check boot_data integrity

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -34,8 +34,8 @@ dual_cc_library(
         shared = [
             ":error",
             "//sw/device/lib/base:macros",
-            "//sw/device/silicon_creator/lib:crc32",
             "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+            "//sw/device/silicon_creator/lib/drivers:hmac",
             "//sw/device/silicon_creator/lib/drivers:lifecycle",
             "//sw/device/silicon_creator/lib/drivers:otp",
         ],


### PR DESCRIPTION
This commit reverts ba9d370d821c84fedc514f8186f7ff06ba45e86c added in #15397 as discussed in the security meeting.

Signed-off-by: Alphan Ulusoy <alphan@google.com>