### PR TITLE
[dv] remove unfinished tests from nightly dashboard

### DIFF
--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -843,7 +843,7 @@
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2
-      tests: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_jtag_inject_tests"]
+      tests: []
     }
 
 
@@ -906,7 +906,7 @@
             '''
       tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
-      tests: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_asm_interrupt_handler"]
+      tests: []
     }
 
     {


### PR DESCRIPTION
Some ROM E2E tests that were not yet running in in DV were mistakenly added to the testplan "tests" reference field, which makes them show up incorrectly in the nightly dashboard.

Signed-off-by: Timothy Trippel <ttrippel@google.com>