### PR TITLE
[dv/edn] Add valid CSRs to scb

### DIFF
--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -142,8 +142,9 @@ class edn_scoreboard extends cip_base_scoreboard #(
       end
       "recov_alert_sts": begin
       end
-      "alert_test": begin
+      "alert_test", "main_sm_state", "err_code", "err_code_test", "regwen": begin
         // Do nothing.
+        // TODO: Found error in stress_all_with_rand_reset. Check if need to verify them.
       end
       default: begin
         `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))


### PR DESCRIPTION
This PR adds more valid CSRs in scb to pass the
stress_all_with_rand_reset test.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>