### PR TITLE
[bazel] rollforward rust toolchain update

### DIFF
--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -30,7 +30,7 @@ def rust_deps():
         version = "nightly",
         exec_triple = "x86_64-unknown-linux-gnu",
         extra_target_triples = ["riscv32imc-unknown-none-elf"],
-        iso_date = "2022-03-22",
+        iso_date = "2022-09-21",
         edition = "2021",
     )
     rust_bindgen_dependencies()

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -151,7 +151,9 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @python3_toolchains//... \
     @remotejdk11_linux//... \
     @riscv-compliance//... \
-    @rust_linux_x86_64__x86_64-unknown-linux-gnu_tools//...
+    @rust_linux_x86_64__x86_64-unknown-linux-gnu_tools//... \
+    @rust_opentitan_rv32imc__riscv32imc-unknown-none-elf//... \
+    @rust_opentitan_rv32imc__riscv32imc-unknown-none-elf_tools//...
   cp -R "$(${BAZELISK} info output_base)"/external/${BAZEL_PYTHON_WHEEL_REPO} \
     ${BAZEL_AIRGAPPED_DIR}/
   # We don't need all bitstreams in the cache, we just need the latest one so


### PR DESCRIPTION
This rollsforward the rust toolchain update originally commited in PR #15775, which was temporarily rolled back to deal with internal airgapped system infrastructure issues that have since been resolved.

Signed-off-by: Timothy Trippel <ttrippel@google.com>