### PR TITLE
[rom-e2e] Tests for bootstrap disabled cases

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -424,6 +424,28 @@ otp_image(
     ],
 )
 
+# Create a bootstrap-disabling overlay
+otp_json(
+    name = "otp_json_bootstrap_disabled",
+    partitions = [
+        otp_partition(
+            name = "OWNER_SW_CFG",
+            items = {"OWNER_SW_CFG_ROM_BOOTSTRAP_EN": "0x1d4"},
+        ),
+    ],
+)
+
+otp_image(
+    name = "img_bootstrap_disabled",
+    src = ":otp_json_rma",
+    overlays = [
+        ":otp_json_creator_sw_cfg",
+        ":otp_json_owner_sw_cfg",
+        ":otp_json_hw_cfg",
+        ":otp_json_bootstrap_disabled",
+    ],
+)
+
 filegroup(
     name = "otp_imgs",
     srcs = [

--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -124,17 +124,24 @@ buildifier_test(
 
 # TODO(cfrantz): Find a way to keep this list of rust targets synchronized
 # with the full set of rust targets in the codebase.
+#
+# $ bazel query 'kind("rust_(binary|library|test)", //...)' | grep -v bindgen
+RUST_TARGETS = [
+    "//sw/device/lib/ujson/rust:roundtrip_test",
+    "//sw/host/cryptotest:cryptotest_parser",
+    "//sw/host/cryptotest:cryptotest_parser_test",
+    "//sw/host/opentitanlib:opentitanlib",
+    "//sw/host/opentitanlib:opentitanlib_test",
+    "//sw/host/opentitansession:opentitansession",
+    "//sw/host/opentitantool:opentitantool",
+    "//sw/host/tests/rom/e2e_bootstrap_disabled:e2e_bootstrap_disabled",
+    "//sw/host/tests/rom/e2e_bootstrap_entry:e2e_bootstrap_entry",
+    "//sw/host/tests/rom/e2e_chip_specific_startup:e2e_chip_specific_startup",
+]
+
 rustfmt_test(
     name = "rustfmt_check",
-    targets = [
-        "//sw/host/cryptotest:cryptotest_parser",
-        "//sw/host/opentitanlib",
-        "//sw/host/opentitansession",
-        "//sw/host/opentitantool",
-        "//sw/host/tests/rom/e2e_bootstrap_entry",
-        "//sw/host/tests/rom/e2e_chip_specific_startup",
-        "//sw/device/lib/ujson/rust:roundtrip_test",
-    ],
+    targets = RUST_TARGETS,
 )
 
 html_coverage_report(

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -50,6 +50,7 @@ def get_otp_images():
         "//hw/ip/otp_ctrl/data:img_test_unlocked0",
         "//hw/ip/otp_ctrl/data:img_prod",
         "//hw/ip/otp_ctrl/data:img_exec_disabled",
+        "//hw/ip/otp_ctrl/data:img_bootstrap_disabled",
     ]
 
     out = []

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -207,6 +207,26 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "e2e_bootstrap_disabled",
+    cw310 = cw310_params(
+        bitstream = "//hw/bitstream:rom_otp_bootstrap_disabled",
+        tags = [
+            "vivado",
+        ],
+        test_cmds = [
+            "--bitstream=\"$(location {bitstream})\"",
+        ],
+    ),
+    # Since the bitstream disables bootstrap, there is no firmware to
+    # load into the chip.  However, opentitan_functest wants to build a
+    # binary target.  We'll build an unsigned do-nothing binary.
+    ot_flash_binary = ":empty_test_slot_a",
+    signed = False,
+    targets = ["cw310_rom"],
+    test_harness = "//sw/host/tests/rom/e2e_bootstrap_disabled",
+)
+
+opentitan_functest(
     name = "e2e_chip_specific_startup",
     srcs = ["chip_specific_startup.c"],
     args = [],

--- a/sw/host/tests/rom/e2e_bootstrap_disabled/BUILD
+++ b/sw/host/tests/rom/e2e_bootstrap_disabled/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "e2e_bootstrap_disabled",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:humantime",
+        "//third_party/rust/crates:log",
+        "//third_party/rust/crates:regex",
+        "//third_party/rust/crates:structopt",
+    ],
+)

--- a/sw/host/tests/rom/e2e_bootstrap_disabled/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_disabled/src/main.rs
@@ -1,0 +1,96 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::bool_assert_comparison)]
+
+use anyhow::{bail, Result};
+use regex::Regex;
+use std::time::Duration;
+use structopt::StructOpt;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::spiflash::SpiFlash;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::{ExitStatus, UartConsole};
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+
+    #[structopt(
+        long, parse(try_from_str=humantime::parse_duration),
+        default_value = "5s",
+        help = "Bootstrap detection timeout",
+    )]
+    timeout: Duration,
+}
+
+fn test_bootstrap_disabled_requested(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // TODO: Should really `opts.init.uart_params.create()` here, but we need to refactor
+    // BootstrapOptions first.
+    //let uart = opts.init.uart_params.create(&transport)?;
+    let uart = transport.uart("console")?;
+    let mut console = UartConsole {
+        timeout: Some(opts.timeout),
+        exit_failure: Some(Regex::new(r"bootstrap:1\r\n")?),
+        exit_success: Some(Regex::new(r"BFV:0142500d")?),
+        ..Default::default()
+    };
+
+    log::info!("Applying pin strapping");
+    transport.apply_pin_strapping("ROM_BOOTSTRAP")?;
+    log::info!("Resetting target");
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+
+    // Now watch the console for the exit conditions.
+    let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
+    if result != ExitStatus::ExitSuccess {
+        bail!("FAIL: {:?}", result);
+    };
+    // Now check whether the SPI device is responding to status messages
+    log::info!("Issuing SPI READ_STATUS");
+    let spi = transport.spi("0")?;
+    assert_eq!(SpiFlash::read_status(&*spi)?, 0xFF);
+    Ok(())
+}
+
+fn test_bootstrap_disabled_not_requested(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // TODO: Should really `opts.init.uart_params.create()` here, but we need to refactor
+    // BootstrapOptions first.
+    //let uart = opts.init.uart_params.create(&transport)?;
+    let uart = transport.uart("console")?;
+    let mut console = UartConsole {
+        timeout: Some(opts.timeout),
+        exit_failure: Some(Regex::new(r"bootstrap:1\r\n")?),
+        exit_success: Some(Regex::new(r"BFV:0142500d")?),
+        ..Default::default()
+    };
+
+    log::info!("Not applying pin strapping");
+    transport.remove_pin_strapping("ROM_BOOTSTRAP")?;
+    log::info!("Resetting target");
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+
+    // Now watch the console for the exit conditions.
+    let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
+    if result != ExitStatus::ExitSuccess {
+        bail!("FAIL: {:?}", result);
+    };
+    // Now check whether the SPI device is responding to status messages
+    log::info!("Issuing SPI READ_STATUS");
+    let spi = transport.spi("0")?;
+    assert_eq!(SpiFlash::read_status(&*spi)?, 0xFF);
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    execute_test!(test_bootstrap_disabled_requested, &opts, &transport);
+    execute_test!(test_bootstrap_disabled_not_requested, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
1. Prepare an OTP image which sets ROM_BOOTSTRAP_EN to false.
2. Splice a bitstream with the that OTP image.
3. Write a test harness which checks bootstrap entry and SPI bus
   properties with the OTP-spliced bitstream.
3a. Verify the ROM does not enter bootstrap when requested.
3b. Verify the ROM does not enter bootstrap when not requested.

Signed-off-by: Chris Frantz <cfrantz@google.com>