### PR TITLE
[top-level] Add CSRNG command header builder.

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -203,7 +203,6 @@ cc_library(
         "dif_csrng.h",
         "dif_csrng_shared.h",
     ],
-    visibility = ["//visibility:private"],
     deps = [
         ":base",
         "//sw/device/lib/base:bitfield",

--- a/sw/device/lib/dif/dif_csrng_shared.c
+++ b/sw/device/lib/dif/dif_csrng_shared.c
@@ -6,26 +6,31 @@
 
 #include "sw/device/lib/base/multibits.h"
 
-OT_WARN_UNUSED_RESULT
+// The application command header is not specified as a register in the
+// hardware specification, so the fields are mapped here by hand. The
+// command register also accepts arbitrary 32bit data.
+static const bitfield_field32_t kAppCmdFieldFlag0 = {.mask = 0xf, .index = 8};
+static const bitfield_field32_t kAppCmdFieldCmdId = {.mask = 0xf, .index = 0};
+static const bitfield_field32_t kAppCmdFieldCmdLen = {.mask = 0xf, .index = 4};
+static const bitfield_field32_t kAppCmdFieldGlen = {.mask = 0x7ffff,
+                                                    .index = 12};
+
+uint32_t csrng_cmd_header_build(
+    csrng_app_cmd_id_t id, dif_csrng_entropy_src_toggle_t entropy_src_enable,
+    uint32_t cmd_len, uint32_t generate_len) {
+  uint32_t reg = bitfield_field32_write(0, kAppCmdFieldCmdId, id);
+  reg = bitfield_field32_write(reg, kAppCmdFieldCmdLen, cmd_len);
+  reg = bitfield_field32_write(
+      reg, kAppCmdFieldFlag0,
+      (entropy_src_enable == kDifCsrngEntropySrcToggleDisable
+           ? kMultiBitBool4True
+           : kMultiBitBool4False));
+  reg = bitfield_field32_write(reg, kAppCmdFieldGlen, generate_len);
+  return reg;
+}
+
 dif_result_t csrng_send_app_cmd(mmio_region_t base_addr, ptrdiff_t offset,
                                 csrng_app_cmd_t cmd) {
-  // The application command header is not specified as a register in the
-  // hardware specification, so the fields are mapped here by hand. The
-  // command register also accepts arbitrary 32bit data.
-  static const bitfield_field32_t kAppCmdFieldFlag0 = {.mask = 0xf, .index = 8};
-  static const bitfield_field32_t kAppCmdFieldCmdId = {.mask = 0xf, .index = 0};
-  static const bitfield_field32_t kAppCmdFieldCmdLen = {.mask = 0xf,
-                                                        .index = 4};
-  static const bitfield_field32_t kAppCmdFieldGlen = {.mask = 0x7ffff,
-                                                      .index = 12};
-
-  uint32_t cmd_len =
-      cmd.seed_material == NULL ? 0 : cmd.seed_material->seed_material_len;
-
-  if (cmd_len & ~kAppCmdFieldCmdLen.mask) {
-    return kDifBadArg;
-  }
-
   // Ensure the `seed_material` array is word-aligned, so it can be loaded to a
   // CPU register with natively aligned loads.
   if (cmd.seed_material != NULL &&
@@ -33,17 +38,15 @@ dif_result_t csrng_send_app_cmd(mmio_region_t base_addr, ptrdiff_t offset,
     return kDifBadArg;
   }
 
-  // Build and write application command header.
-  uint32_t reg = bitfield_field32_write(0, kAppCmdFieldCmdId, cmd.id);
-  reg = bitfield_field32_write(reg, kAppCmdFieldCmdLen, cmd_len);
-  reg = bitfield_field32_write(
-      reg, kAppCmdFieldFlag0,
-      (cmd.entropy_src_enable == kDifCsrngEntropySrcToggleDisable)
-          ? kMultiBitBool4True
-          : kMultiBitBool4False);
-  reg = bitfield_field32_write(reg, kAppCmdFieldGlen, cmd.generate_len);
-  mmio_region_write32(base_addr, offset, reg);
+  uint32_t cmd_len =
+      cmd.seed_material == NULL ? 0 : cmd.seed_material->seed_material_len;
+  if (cmd_len & ~kAppCmdFieldCmdLen.mask) {
+    return kDifBadArg;
+  }
 
+  mmio_region_write32(base_addr, offset,
+                      csrng_cmd_header_build(cmd.id, cmd.entropy_src_enable,
+                                             cmd_len, cmd.generate_len));
   for (size_t i = 0; i < cmd_len; ++i) {
     mmio_region_write32(base_addr, offset, cmd.seed_material->seed_material[i]);
   }

--- a/sw/device/lib/dif/dif_csrng_shared.h
+++ b/sw/device/lib/dif/dif_csrng_shared.h
@@ -62,6 +62,27 @@ typedef struct csrng_app_cmd {
 } csrng_app_cmd_t;
 
 /**
+ * Builds a CSRNG command header.
+ *
+ * Build a CSRNG command header following the CSRNG specification. The caller is
+ * responsible for verifying the correctness of the parameters passed into this
+ * function.
+ *
+ * @param id CSRNG command ID.
+ * @param entropy_src_enable Entropy source enable flag. Mapped to flag0 in the
+ * command header.
+ * @param cmd_len The overall command lend. It should be set to the number of
+ * seed material words, or zero.
+ * @param generate_len Number of 128bit blocks to request if the command ID is
+ * set to `kCsrngAppCmdGenerate`.
+ * @return CSRNG command header in `uint32_t` format.
+ */
+OT_WARN_UNUSED_RESULT
+uint32_t csrng_cmd_header_build(
+    csrng_app_cmd_id_t id, dif_csrng_entropy_src_toggle_t entropy_src_enable,
+    uint32_t cmd_len, uint32_t generate_len);
+
+/**
  * Writes application command `cmd` to the CSRNG_CMD_REQ_REG register.
  * Returns the result of the operation.
  */

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -49,6 +49,7 @@ cc_library(
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:aes",
+        "//sw/device/lib/dif:csrng_shared",
         "//sw/device/lib/dif:edn",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/testing:csrng_testutils",
@@ -116,6 +117,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:csrng_shared",
         "//sw/device/lib/dif:edn",
         "//sw/device/lib/dif:entropy_src",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/lib/testing/aes_testutils.c
+++ b/sw/device/lib/testing/aes_testutils.c
@@ -7,6 +7,7 @@
 #if !OT_IS_ENGLISH_BREAKFAST
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_csrng_shared.h"
 #include "sw/device/lib/dif/dif_edn.h"
 #include "sw/device/lib/testing/csrng_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
@@ -94,8 +95,10 @@ void aes_testutils_masking_prng_zero_output_seed(void) {
   dif_edn_auto_params_t edn0_params = {
       .instantiate_cmd =
           {
-              .cmd = 0x000000c1 |              // Instantiate, clen = 12 words.
-                     kMultiBitBool4True << 8,  // Use the provided seed only.
+              .cmd = csrng_cmd_header_build(kCsrngAppCmdInstantiate,
+                                            kDifCsrngEntropySrcToggleDisable,
+                                            kEdnSeedMaterialLen,
+                                            /*generate_len=*/0),
               .seed_material =
                   {
                       .len = kEdnSeedMaterialLen,
@@ -103,8 +106,10 @@ void aes_testutils_masking_prng_zero_output_seed(void) {
           },
       .reseed_cmd =
           {
-              .cmd = 0x000000c2 |              // Reseed, clen = 12 words.
-                     kMultiBitBool4True << 8,  // Use provided seed only.
+              .cmd = csrng_cmd_header_build(kCsrngAppCmdReseed,
+                                            kDifCsrngEntropySrcToggleDisable,
+                                            kEdnSeedMaterialLen,
+                                            /*generate_len=*/0),
               .seed_material =
                   {
                       .len = kEdnSeedMaterialLen,
@@ -112,9 +117,10 @@ void aes_testutils_masking_prng_zero_output_seed(void) {
           },
       .generate_cmd =
           {
-              .cmd = 0x00001003 |  // 1 generate returns 1 block.
-                     kMultiBitBool4True
-                         << 8,  // Don't use entropy from the entropy src.
+              .cmd = csrng_cmd_header_build(kCsrngAppCmdGenerate,
+                                            kDifCsrngEntropySrcToggleDisable,
+                                            /*cmd_len=*/0,
+                                            /*generate_len=*/1),
               .seed_material =
                   {
                       .len = 0,


### PR DESCRIPTION
This commits adds a CSRNG command header function to switch to a more consistent command generation interface across top-level test cases. The new API will be used to implement additional EDN/CSRNG test cases.