### PR TITLE
[dv/edn] Fix stress_all_with_rand_reset test

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
@@ -21,5 +21,6 @@ class csrng_agent_cfg extends dv_base_agent_cfg;
          min_cmd_rdy_dly, max_cmd_rdy_dly,
          reseed_cnt, generate_cnt, generate_between_reseeds_cnt;
   bit    cmd_zero_delays;
+  bit    under_reset;
 
 endclass

--- a/hw/dv/sv/csrng_agent/csrng_device_driver.sv
+++ b/hw/dv/sv/csrng_agent/csrng_device_driver.sv
@@ -21,6 +21,7 @@ class csrng_device_driver extends csrng_driver;
 
   // drive trans received from sequencer
   virtual task get_and_drive();
+    wait (cfg.under_reset == 0);
     forever begin
       seq_item_port.get_next_item(req);
       `uvm_info(`gfn, $sformatf("Received item: %s", req.convert2string()), UVM_HIGH)
@@ -28,14 +29,16 @@ class csrng_device_driver extends csrng_driver;
       rsp.set_id_info(req);
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(
           cmd_ack_dly, cmd_ack_dly inside {cfg.min_cmd_ack_dly, cfg.max_cmd_ack_dly};)
-      repeat(cmd_ack_dly) @(cfg.vif.device_cb);
-      cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b1;
-      `DV_CHECK_STD_RANDOMIZE_FATAL(rsp_sts)
-      cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= rsp_sts;
-      @(cfg.vif.device_cb);
-      cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
-      cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= 1'b0;
-      `uvm_info(`gfn, "item sent", UVM_HIGH)
+      `DV_SPINWAIT_EXIT(
+          repeat(cmd_ack_dly) @(cfg.vif.device_cb);
+          cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b1;
+          `DV_CHECK_STD_RANDOMIZE_FATAL(rsp_sts)
+          cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= rsp_sts;
+          @(cfg.vif.device_cb);
+          cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
+          cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= 1'b0;,
+          wait (cfg.under_reset == 1);)
+      `uvm_info(`gfn, cfg.under_reset ? "item sent during reset" : "item sent", UVM_HIGH)
       seq_item_port.item_done(rsp);
     end
   endtask

--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -20,8 +20,6 @@ class csrng_monitor extends dv_base_monitor #(
   uvm_tlm_analysis_fifo#(push_pull_item#(.HostDataWidth(csrng_pkg::CSRNG_CMD_WIDTH)))
       csrng_cmd_fifo;
 
-  bit in_reset;
-
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -47,10 +45,10 @@ class csrng_monitor extends dv_base_monitor #(
   virtual protected task handle_reset();
     forever begin
       @(negedge cfg.vif.rst_n);
-      in_reset = 1;
+      cfg.under_reset = 1;
       // TODO: sample any reset-related covergroups
       @(posedge cfg.vif.rst_n);
-      in_reset = 0;
+      cfg.under_reset = 0;
     end
   endtask
 
@@ -138,7 +136,7 @@ class csrng_monitor extends dv_base_monitor #(
         // After picking up a request, wait until a response is sent before
         // detecting another request, as this is not a pipelined protocol.
         `DV_SPINWAIT_EXIT(while (!cfg.vif.mon_cb.cmd_rsp.csrng_rsp_ack) @(cfg.vif.mon_cb);,
-                          wait(in_reset))
+                          wait(cfg.under_reset))
         rsp_sts_ap.write(cfg.vif.cmd_rsp.csrng_rsp_sts);
        end
     end

--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -69,6 +69,11 @@
     }
 
     {
+      name: edn_stress_all_with_rand_reset
+      uvm_test: edn_stress_all_test
+    }
+
+    {
       name: edn_intr
       uvm_test: edn_intr_test
       uvm_test_seq: edn_intr_vseq


### PR DESCRIPTION
This PR fixes stress_all_with_rand_reset test for EDN. 1). Use a valid uvm_test
2). Handle reset in csrng device agent.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>