### PR TITLE
[top-test] csrng_edn_concurrency_test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2305,7 +2305,7 @@
             X'ref'ed with each IP test that requsts entropy from EDN.
             '''
       stage: V2
-      tests: ['chip_sw_edn_entropy_reqs']
+      tests: ["chip_sw_edn_entropy_reqs"]
     }
 
     // KEYMGR (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1046,6 +1046,15 @@
       run_timeout_mins: 60
     }
     {
+      name: chip_sw_csrng_edn_concurrency
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:csrng_edn_concurrency_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000", "+rng_srate_value_min=15",
+                 "+rng_srate_value_max=20"]
+      run_timeout_mins: 240
+    }
+    {
       name: chip_sw_csrng_kat_test
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:csrng_kat_test:1"]

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -62,6 +62,8 @@ typedef enum dif_otbn_err_bits {
   kDifOtbnErrBitsIllegalInsn = (1 << 3),
   /** A LOOP error was observed. */
   kDifOtbnErrBitsLoop = (1 << 4),
+  /** A RND_FIPS_CHECK_FAIL error was observed. */
+  kDifOtbnErrBitsRndFipsChkFail = (1 << 7),
   /** A IMEM_INTG_VIOLATION error was observed. */
   kDifOtbnErrBitsImemIntgViolation = (1 << 16),
   /** A DMEM_INTG_VIOLATION error was observed. */

--- a/sw/device/lib/runtime/otbn.c
+++ b/sw/device/lib/runtime/otbn.c
@@ -37,6 +37,8 @@ otbn_result_t otbn_busy_wait_for_done(otbn_t *ctx) {
     return kOtbnError;
   }
   if (err_bits != kDifOtbnErrBitsNoError) {
+    LOG_ERROR("otbn err_bits got: 0x%x, want: 0x%x", err_bits,
+              kDifOtbnErrBitsNoError);
     return kOtbnOperationFailed;
   }
   return kOtbnOk;

--- a/sw/device/lib/runtime/otbn.c
+++ b/sw/device/lib/runtime/otbn.c
@@ -14,14 +14,22 @@
  */
 const int kOtbnWlenBytes = 256 / 8;
 
+otbn_result_t otbn_busy_check(otbn_t *ctx, bool *is_busy) {
+  dif_otbn_status_t status;
+  if (dif_otbn_get_status(&ctx->dif, &status) != kDifOk) {
+    return kOtbnError;
+  }
+  *is_busy = status != kDifOtbnStatusIdle && status != kDifOtbnStatusLocked;
+  return kOtbnOk;
+}
+
 otbn_result_t otbn_busy_wait_for_done(otbn_t *ctx) {
   bool busy = true;
   while (busy) {
-    dif_otbn_status_t status;
-    if (dif_otbn_get_status(&ctx->dif, &status) != kDifOk) {
-      return kOtbnError;
+    otbn_result_t result = otbn_busy_check(ctx, &busy);
+    if (result != kOtbnOk) {
+      return result;
     }
-    busy = status != kDifOtbnStatusIdle && status != kDifOtbnStatusLocked;
   }
 
   dif_otbn_err_bits_t err_bits;

--- a/sw/device/lib/runtime/otbn.h
+++ b/sw/device/lib/runtime/otbn.h
@@ -223,6 +223,15 @@ otbn_result_t otbn_load_app(otbn_t *ctx, const otbn_app_t app);
 otbn_result_t otbn_execute(otbn_t *ctx);
 
 /**
+ * Checks if OTBN is in busy status.
+ *
+ * @param ctx The context object
+ * @param[out] is_busy Set to true if OTBN is not in idle or in an error state.
+ * @return otbn_result_t The result of the operation.
+ */
+otbn_result_t otbn_busy_check(otbn_t *ctx, bool *is_busy);
+
+/**
  * Busy waits for OTBN to be done with the current operation.
  *
  * After an operation, triggered by a command, OTBN is back in idle state.

--- a/sw/device/lib/testing/rand_testutils.c
+++ b/sw/device/lib/testing/rand_testutils.c
@@ -25,7 +25,7 @@ static const uint32_t kLfsrPolynomialCoefficients = 0x80000057;
 /**
  * The default timeout in usecs for fetching data from the entropy source.
  */
-static const uint32_t kEntropyFetchTimeoutMicros = 1000;
+static const uint32_t kEntropyFetchTimeoutMicros = 100000;
 
 rand_testutils_rng_t rand_testutils_init(dif_rv_core_ibex_t *rv_core_ibex) {
   CHECK(rv_core_ibex != NULL);

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -627,6 +627,33 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "csrng_edn_concurrency_test",
+    srcs = ["csrng_edn_concurrency_test.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        ":otbn_randomness_impl",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:base",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:csrng_shared",
+        "//sw/device/lib/dif:edn",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:otbn",
+        "//sw/device/lib/testing:csrng_testutils",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "csrng_kat_test",
     srcs = ["csrng_kat_test.c"],
     deps = [

--- a/sw/device/tests/csrng_edn_concurrency_test.c
+++ b/sw/device/tests/csrng_edn_concurrency_test.c
@@ -1,0 +1,371 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_csrng_shared.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/otbn.h"
+#include "sw/device/lib/testing/csrng_testutils.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_macros.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/tests/otbn_randomness_impl.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
+
+static dif_csrng_t csrng;
+static dif_edn_t edn0;
+static dif_edn_t edn1;
+static dif_entropy_src_t entropy_src;
+static otbn_t otbn;
+static dif_rv_plic_t plic;
+static dif_rv_core_ibex_t rv_core_ibex;
+
+enum {
+  /**
+   * The number of test iterations per target.
+   */
+  kTestParamNumIterationsSim = 2,
+  kTestParamNumIterationsOther = 20,
+  /**
+   * The number of test iterations per entropy consumer.
+   */
+  kTestParamNumOtbnIterationsMax = 4,
+  kTestParamNumIbexIterationsMax = 16,
+};
+
+/**
+ * Test execution states. These are use to control the execution state of all
+ * test tasks.
+ */
+typedef enum test_state {
+  /**
+   * Configure entropy complex for next test iteration.
+   */
+  kTestStateSetup,
+  /**
+   * Request entropy from various endpoints.
+   */
+  kTestStateRun,
+  /**
+   * Tear down tasks.
+   */
+  kTestStateTearDown,
+  /**
+   * Number of test states.
+   */
+  kTestStateCount,
+} test_state_t;
+static volatile test_state_t execution_state;
+
+static const char *kStatusNames[kTestStateCount] = {"Setup", "Run", "TearDown"};
+static_assert(ARRAYSIZE(kStatusNames) == kTestStateCount,
+              "Unexpected kStatusNames array size.");
+
+/**
+ * Each task uses the task ID to update flag and counter arrays.
+ */
+typedef enum task_id {
+  /**
+   * Assigned to `main_task()`.
+   */
+  kTestTaskIdMain,
+  /**
+   * Assigned to `otbn_task()`.
+   */
+  kTestTaskIdOtbn,
+  /**
+   * Assigned to `ibex_task()`.
+   */
+  kTestTaskIdIbex,
+  /**
+   * Number of tasks. Used to define task flag and counter arrays.
+   */
+  kTestTaskIdCount
+} task_id_t;
+/**
+ * Flags used to track when a task is done executing a test iteration.
+ */
+static volatile bool task_done[kTestTaskIdCount];
+/**
+ * Flags used to track the number of test iterations per task.
+ */
+static volatile uint32_t task_iter_count_max[kTestTaskIdCount];
+
+OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = true,
+                        .can_clobber_uart = false, );
+
+/**
+ * Initializes the peripherals used in this test.
+ */
+static void init_peripherals(void) {
+  CHECK_DIF_OK(dif_csrng_init(
+      mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
+  CHECK_DIF_OK(
+      dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));
+  CHECK_DIF_OK(
+      dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR), &edn1));
+  CHECK_DIF_OK(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
+  CHECK_DIF_OK(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+  CHECK(otbn_init(&otbn, mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR)) ==
+        kOtbnOk);
+}
+
+/**
+ * Returns randomized seed material.
+ */
+static dif_edn_seed_material_t edn_seed_material_build(void) {
+  dif_edn_seed_material_t seed;
+  seed.len =
+      rand_testutils_gen32_range(/*min=*/0, kDifEntropySeedMaterialMaxWordLen);
+  for (size_t i = 0; i < seed.len; ++i) {
+    seed.data[i] = rand_testutils_gen32();
+  }
+  return seed;
+}
+
+/**
+ * Returns a randomized EDN auto mode configuration.
+ */
+static dif_edn_auto_params_t edn_auto_params_build(void) {
+  dif_edn_seed_material_t seed0 = edn_seed_material_build();
+  dif_edn_seed_material_t seed1 = edn_seed_material_build();
+  return (dif_edn_auto_params_t){
+      .instantiate_cmd =
+          {
+              .cmd = csrng_cmd_header_build(kCsrngAppCmdInstantiate,
+                                            kDifCsrngEntropySrcToggleEnable,
+                                            seed0.len,
+                                            /*generate_len=*/0),
+              .seed_material = seed0,
+          },
+      .reseed_cmd =
+          {
+              .cmd = csrng_cmd_header_build(kCsrngAppCmdReseed,
+                                            kDifCsrngEntropySrcToggleEnable,
+                                            seed1.len,
+                                            /*generate_len=*/0),
+              .seed_material = seed1,
+          },
+      .generate_cmd =
+          {
+              .cmd = csrng_cmd_header_build(kCsrngAppCmdGenerate,
+                                            kDifCsrngEntropySrcToggleEnable,
+                                            /*cmd_len=*/0,
+                                            /*generate_len=*/1),
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
+          },
+      .reseed_interval = 4,
+  };
+}
+
+/**
+ * Helper function used to set the task done flag.
+ *
+ * Issues a `ottf_task_yield()` to ensure control is handed over to pending
+ * tasks.
+ *
+ * @param task_id The task ID.
+ */
+static void task_done_set_and_yield(task_id_t task_id) {
+  task_done[task_id] = true;
+  ottf_task_yield();
+}
+
+/**
+ * OTBN task.
+ *
+ * Executes OTBN randomness test the the test state is set to `kTestStateRun`.
+ *
+ * @param task_parameters Unused. Set to NULL by ottf.
+ */
+static void otbn_task(void *task_parameters) {
+  while (true) {
+    if (execution_state == kTestStateTearDown) {
+      break;
+    }
+    if (execution_state == kTestStateSetup || task_done[kTestTaskIdOtbn]) {
+      ottf_task_yield();
+      continue;
+    }
+    LOG_INFO("OTBN:START");
+    for (size_t i = 0; i < task_iter_count_max[kTestTaskIdOtbn]; ++i) {
+      otbn_randomness_test_start(&otbn);
+      bool is_busy = true;
+      while (is_busy) {
+        CHECK(otbn_busy_check(&otbn, &is_busy) == kOtbnOk);
+        if (!is_busy) {
+          break;
+        }
+        ottf_task_yield();
+      }
+      CHECK(otbn_randomness_test_end(&otbn, /*skip_otbn_done_check=*/false));
+    }
+    LOG_INFO("OTBN:DONE");
+    task_done_set_and_yield(kTestTaskIdOtbn);
+  }
+  OTTF_TASK_DELETE_SELF_OR_DIE;
+}
+
+/**
+ * Ibex task.
+ *
+ * Executes Ibex randomness test the the test state is set to `kTestStateRun`.
+ *
+ * @param task_parameters Unused. Set to NULL by ottf.
+ */
+static void ibex_task(void *task_parameters) {
+  while (true) {
+    if (execution_state == kTestStateTearDown) {
+      break;
+    }
+    if (execution_state == kTestStateSetup || task_done[kTestTaskIdIbex]) {
+      ottf_task_yield();
+      continue;
+    }
+    LOG_INFO("Ibex:START");
+    uint32_t prev_data = 0;
+    for (size_t i = 0; i < task_iter_count_max[kTestTaskIdIbex];) {
+      dif_rv_core_ibex_rnd_status_t status;
+      CHECK_DIF_OK(dif_rv_core_ibex_get_rnd_status(&rv_core_ibex, &status));
+      if ((status & kDifRvCoreIbexRndStatusValid) == 0) {
+        ottf_task_yield();
+        continue;
+      }
+      i++;
+      uint32_t new_data;
+      CHECK_DIF_OK(dif_rv_core_ibex_read_rnd_data(&rv_core_ibex, &new_data));
+
+      // The following checks have a probability of returning false negatives.
+      // Flakiness issues can potentially be addressed by switching to error
+      // counters.
+      CHECK(new_data != prev_data, "Unexpected duplicate data");
+      CHECK(new_data != 0);
+      CHECK(new_data != UINT32_MAX);
+      prev_data = new_data;
+    }
+    LOG_INFO("Ibex:DONE");
+    task_done_set_and_yield(kTestTaskIdIbex);
+  }
+  OTTF_TASK_DELETE_SELF_OR_DIE;
+}
+
+/**
+ * Verifies that the entropy req interrupt is triggered on EDN instantiate and
+ * reseed commands.
+ */
+static void entropy_config(void) {
+  entropy_testutils_auto_mode_init();
+
+  LOG_INFO("Generating EDN params");
+  dif_edn_auto_params_t edn_params0 = edn_auto_params_build();
+  dif_edn_auto_params_t edn_params1 = edn_auto_params_build();
+
+  task_iter_count_max[kTestTaskIdOtbn] =
+      rand_testutils_gen32_range(/*min=*/1, kTestParamNumOtbnIterationsMax);
+  task_iter_count_max[kTestTaskIdIbex] =
+      rand_testutils_gen32_range(/*min=*/1, kTestParamNumIbexIterationsMax);
+
+  entropy_testutils_stop_all();
+  CHECK_DIF_OK(dif_entropy_src_configure(
+      &entropy_src, entropy_testutils_config_default(), kDifToggleEnabled));
+  CHECK_DIF_OK(dif_csrng_configure(&csrng));
+  CHECK_DIF_OK(dif_edn_set_auto_mode(&edn0, edn_params0));
+  CHECK_DIF_OK(dif_edn_set_auto_mode(&edn1, edn_params1));
+}
+
+/**
+ * Updates and logs the execution state.
+ *
+ * @param next_state The next state.
+ */
+static void execution_state_update(test_state_t next_state) {
+  CHECK(next_state < kTestStateCount);
+  LOG_INFO("Test state: %s", kStatusNames[next_state]);
+  execution_state = next_state;
+}
+
+/**
+ * Main test task.
+ *
+ * Configures entropy complex and signals test tasks to run an iteration loop.
+ *
+ * @param task_parameters Unused. Set to NULL by ottf.
+ */
+static void main_task(void *task_parameters) {
+  task_iter_count_max[kTestTaskIdMain] = kTestParamNumIterationsSim;
+  if (kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator) {
+    task_iter_count_max[kTestTaskIdMain] = kTestParamNumIterationsOther;
+  }
+
+  uint32_t iter_count = 0;
+  while (true) {
+    if (execution_state == kTestStateRun) {
+      uint32_t count = 0;
+      for (size_t i = 0; i < kTestTaskIdCount; ++i) {
+        count += task_done[i] ? 1 : 0;
+      }
+      if (count < kTestTaskIdCount) {
+        ottf_task_yield();
+        continue;
+      }
+      // Consider this test iteration done if all tasks are done. Update the
+      // iteration counter and set the execution state to `kTestStateSetup`
+      // to continue with configuring the entropy blocks for the next test
+      // run iteration.
+      if (++iter_count >= task_iter_count_max[kTestTaskIdMain]) {
+        execution_state_update(kTestStateTearDown);
+        break;
+      }
+      execution_state_update(kTestStateSetup);
+      csrng_testutils_recoverable_alerts_check(&csrng);
+    }
+    // The rest of this code block is executed when
+    // `execute_state == kTestStateSetup`.
+    entropy_config();
+    for (size_t i = 0; i < kTestTaskIdCount; ++i) {
+      task_done[i] = false;
+    }
+    // Signal the other tasks to start test execution.
+    execution_state_update(kTestStateRun);
+    // This is required to ensure the aggregation of task_done entries is equal
+    // to `kTestTaskIdCount`.
+    task_done_set_and_yield(kTestTaskIdMain);
+  }
+  OTTF_TASK_DELETE_SELF_OR_DIE;
+}
+
+bool test_main(void) {
+  init_peripherals();
+
+  // Initialize the test `execution_state` before launching the tasks.
+  execution_state_update(kTestStateSetup);
+
+  CHECK(ottf_task_create(main_task, "main", kOttfFreeRtosMinStackSize, 1));
+  CHECK(ottf_task_create(otbn_task, "otbn", kOttfFreeRtosMinStackSize, 1));
+  CHECK(ottf_task_create(ibex_task, "ibex", kOttfFreeRtosMinStackSize, 1));
+
+  // There is no need to poll for completion as the tasks above will execute
+  // with higher priority and control will not be returned to this task until
+  // all tasks are done executing.
+  ottf_task_yield();
+  return true;
+}


### PR DESCRIPTION
This test randomizes the EDN0 and EDN1 auto mode configuration, selecting random seed_material length and values. It currently does not randomize the generate command length output.