### PR TITLE
[bazel] rollback #15817 again

### DIFF
--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -30,7 +30,7 @@ def rust_deps():
         version = "nightly",
         exec_triple = "x86_64-unknown-linux-gnu",
         extra_target_triples = ["riscv32imc-unknown-none-elf"],
-        iso_date = "2022-09-21",
+        iso_date = "2022-03-22",
         edition = "2021",
     )
     rust_bindgen_dependencies()

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -151,9 +151,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @python3_toolchains//... \
     @remotejdk11_linux//... \
     @riscv-compliance//... \
-    @rust_linux_x86_64__x86_64-unknown-linux-gnu_tools//... \
-    @rust_opentitan_rv32imc__riscv32imc-unknown-none-elf//... \
-    @rust_opentitan_rv32imc__riscv32imc-unknown-none-elf_tools//...
+    @rust_linux_x86_64__x86_64-unknown-linux-gnu_tools//...
   cp -R "$(${BAZELISK} info output_base)"/external/${BAZEL_PYTHON_WHEEL_REPO} \
     ${BAZEL_AIRGAPPED_DIR}/
   # We don't need all bitstreams in the cache, we just need the latest one so


### PR DESCRIPTION
This rolls back the rust toolchain update again as there seems to be inconsistencies between slightly different variations in our airgapped environments.

Before rolling this change forward again (in #15817), I ran the DV smoke regression test suite on an airgapped VM, and it completed successfully. However, after merging the #15817, the automated job that generates the new Bazel airgapped image (as a result of merging #15817) failed to run the same DV smoke regression test suite, on what *should* be the exact same VM (with the same tool images). My initial theory is there an environment inconsistency between VMs, but I am rolling this change back again until I can pinpoint the issue.

Signed-off-by: Timothy Trippel <ttrippel@google.com>