### PR TITLE
[entropy_src/dv] Updates to FSM closure (PR #15663)

### DIFF
--- a/hw/ip/entropy_src/dv/cov/entropy_src_fsm_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_fsm_cov_if.sv
@@ -11,16 +11,19 @@ interface entropy_src_fsm_cov_if
 
 (
   input wire clk_i,
-  input state_e state_i
+  input state_e state_i,
+  input state_e state_o
 );
 
-  state_e next_state;
+  state_e next_state, current_state;
   assign next_state = state_e'(state_i);
+  assign current_state = state_e'(state_o);
 
   // Sample the _next_ state (not the current state) of the main FSM, to allow VSeq's to fire an
   // enable or abort at the correct time to sample all FSM transitions
   clocking state_cb @(posedge clk_i);
     input next_state;
+    input current_state;
   endclocking
 
 endinterface

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -92,7 +92,7 @@ module tb;
     entropy_subsys_fifo_exception_if#(1) u_fifo_exc_if (.clk_i, .rst_ni, .wready_o, .wvalid_i);
 
   bind prim_sparse_fsm_flop : dut.u_entropy_src_core.u_entropy_src_main_sm.u_state_regs
-    entropy_src_fsm_cov_if u_fsm_cov_if (.clk_i, .state_i);
+    entropy_src_fsm_cov_if u_fsm_cov_if (.clk_i, .state_i, .state_o);
 
   initial begin
     // Drive clk and rst_n from clk_if


### PR DESCRIPTION
- Fixes an interrupt handler bug by from the DV_WAIT watchdog's added in PR #15663. (Thanks for the suggestion @waicaiyang).
- Adds more states the list of rare transitions.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>