### PR TITLE
[entropy_src/dv] Prevent alert_sts race condition

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -123,13 +123,17 @@ class entropy_src_base_vseq extends cip_base_vseq #(
   endtask
 
   task disable_dut();
+    bit [TL_DW - 1:0] regval;
+
     csr_wr(.ptr(ral.module_enable.module_enable), .value(MuBi4False));
 
     // Disabling the module will clear the error state,
     // as well as the observe and entropy_data FIFOs
     // Clear all interupts here
     csr_wr(.ptr(ral.intr_state), .value(32'hf));
-    // Leave alerts alone as the handlers for those conditions need to see them
+
+    // Check, but do not clear alert_sts, as the handlers for those conditions may need to see them.
+    csr_rd(.ptr(ral.recov_alert_sts.es_main_sm_alert), .value(regval));
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_check_ht_diag)
     if (do_check_ht_diag) begin

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -249,21 +249,6 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
   endtask
 
-  // Check for any outstanding HT failures.  If so, disable the DUT (possibly checking the HT
-  // statistics) and reset the RNG input to the DUT.
-  // If a HT failure is detected, the DUT is left in the disabled state.
-  // It is anticipated that a new configuration will be applied immediately afterward.
-  task fix_ht_alerts();
-    bit alert_sts;
-    csr_rd(.ptr(ral.recov_alert_sts.es_main_sm_alert), .value(alert_sts));
-
-    if (alert_sts) begin
-      `uvm_info(`gfn, "HT Failure: Disabling DUT", UVM_HIGH)
-      disable_dut();
-      wait_no_outstanding_access();
-    end
-  endtask
-
   task process_interrupts();
     bit [TL_DW - 1:0] intr_status;
     bit               interrupt_shutdown = 0;
@@ -795,7 +780,8 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
         if(!continue_sim) break;
         `uvm_info(`gfn, "Resuming single thread operation", UVM_LOW)
 
-        fix_ht_alerts();
+        // Disable the DUT and get HT stats.
+        disable_dut();
 
         //
         // Resetting and/or reconfiguring before the next loop.


### PR DESCRIPTION
The `RECOV_ALERT_STS` register is continuously updating while enabled, and race conditions can sometimes cause scoreboarding failures.  This commit delays checks on this register until after the DUT is disabled.

(Note: Though the interrupts are continuously updating as well they are not strictly scoreboarded and so they can be checked while live with out causing test failures.)

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>