### PR TITLE
[entropy_src/dv] Remove bad call to uvm_reg.reset()

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -322,7 +322,6 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     ral.fw_ov_sha3_start.fw_ov_insert_start.set(MuBi4False);
     csr_update(.csr(ral.fw_ov_sha3_start));
 
-    ral.alert_threshold.reset();
     csr_wr(.ptr(ral.alert_threshold), .value(ral.alert_threshold.get_reset()));
 
     `uvm_info(`gfn, "Safe configuration", UVM_MEDIUM)


### PR DESCRIPTION
The "reset()" method for uvm_reg does not actually reset or even attempt to reset the DUT's register, only the mirrored value and associated mirror state.  This is a problem if the register is locked from the hardware side.

This commit removes a redundant call to reset, that apparently had already been supplemented with a call to `csr_wr(ral.<reg>.get_reset())`

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>