### PR TITLE
[flash_ctrl,dv] update tb with hw_cfg secret partitions

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -116,6 +116,7 @@ package flash_ctrl_env_pkg;
   parameter uint FlashCreatorPartStartAddr = 32'h00000800;  // Info Partition Page 1
   parameter uint FlashOwnerPartStartAddr = 32'h00001000;  // Info Partition Page 2
   parameter uint FlashIsolPartStartAddr = 32'h00001800;
+  parameter uint FlashIsolPartEndAddr   = 32'h00001FFF;
 
   parameter uint FlashData0StartAddr = 32'h00000000;
   parameter uint FlashData0EndAddr = 32'h00080000;
@@ -518,6 +519,21 @@ package flash_ctrl_env_pkg;
                                                req.part, req.info_sel))
     return FlashPartData;
   endfunction // get_part_name
+
+  // Struct convertion from rtl to dv.
+  function automatic flash_bank_mp_info_page_cfg_t conv2env_mp_info(info_page_cfg_t info);
+    flash_bank_mp_info_page_cfg_t env_info;
+
+    env_info.en    = info.en;
+    env_info.read_en       = info.rd_en;
+    env_info.program_en  = info.prog_en;
+    env_info.erase_en      = info.erase_en;
+    env_info.scramble_en = info.scramble_en;
+    env_info.ecc_en        = info.ecc_en;
+    env_info.he_en         = info.he_en;
+    return env_info;
+  endfunction
+
 
   // package sources
   `include "flash_mem_bkdr_util.sv"

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_config_regwen_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_config_regwen_vseq.sv
@@ -43,10 +43,10 @@ class flash_ctrl_config_regwen_vseq extends flash_ctrl_otf_base_vseq;
 
     // Launch long operation
     flash_program_data_c.constraint_mode(0);
-    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(rand_op, rand_op.op == FlashOpProgram;)
+    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(rand_op, rand_op.op == FlashOpProgram;
+                                          rand_op.partition == FlashPartData;)
     rand_op.addr[8:0] = 0;
     rand_op.num_words = 16;
-
     flash_ctrl_start_op(rand_op);
     csr_rd(.ptr(ral.control), .value(exp_data));
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
@@ -16,7 +16,7 @@ class flash_ctrl_derr_detect_vseq extends flash_ctrl_otf_base_vseq;
     cfg.scb_h.do_alert_check = 1;
     cfg.m_tl_agent_cfg.check_tl_errs = 0;
     cfg.m_tl_agent_cfgs["flash_ctrl_eflash_reg_block"].check_tl_errs = 0;
-
+    cfg.otf_scb_h.stop = 0;
     cfg.clk_rst_vif.wait_clks(5);
 
     fork

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
@@ -72,7 +72,6 @@ class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
           end
           `uvm_info("Test", "RESET", UVM_LOW)
           lc_ctrl_if_rst();  // Restore lc_ctrl_if to Reset Values
-          cfg.seq_cfg.disable_flash_init = 1;  // Disable Flash Random Initialisation
           apply_reset();
         end
       join_any

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
@@ -236,13 +236,19 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
     flash_bank_mp_info_page_cfg_t info_regions[flash_ctrl_reg_pkg::NumInfos0];
 
     foreach (info_regions[i]) begin
-      info_regions[i].en         = MuBi4True;
-      info_regions[i].read_en    = MuBi4True;
-      info_regions[i].program_en = MuBi4True;
-      info_regions[i].erase_en   = MuBi4True;
-    end
-
-    foreach (info_regions[i]) begin
+      // Get secret partition cfg from flash_ctrl_pkg
+      if ( i inside {1, 2}) begin
+        // Copy protection from hw_cfg.
+        info_regions[i] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
+        // Update program and erase control for the test purpose.
+        info_regions[i].program_en = MuBi4True;
+        info_regions[i].erase_en   = MuBi4True;
+      end else begin
+        info_regions[i].en         = MuBi4True;
+        info_regions[i].read_en    = MuBi4True;
+        info_regions[i].program_en = MuBi4True;
+        info_regions[i].erase_en   = MuBi4True;
+      end
       flash_ctrl_mp_info_page_cfg(.bank(0), .info_part(0), .page(i), .page_cfg(info_regions[i]));
     end
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_rd_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_rd_vseq.sv
@@ -10,6 +10,8 @@ class flash_ctrl_intr_rd_vseq extends flash_ctrl_legacy_base_vseq;
 
   task pre_start();
     cfg.intr_mode = 1;
+    cfg.skip_init = 1;
+
     super.pre_start();
   endtask
   virtual task body();

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -132,6 +132,11 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
       `uvm_info(`gfn, $sformatf("MP regions values %p", mp_regions[k]), UVM_HIGH)
     end
 
+    for (int i = 1; i < 4; i++) begin
+      mp_info_pages[0][0][i].ecc_en = MuBi4True;
+      mp_info_pages[0][0][i].scramble_en = MuBi4True;
+    end
+
     foreach (mp_info_pages[i, j, k]) begin
       flash_ctrl_mp_info_page_cfg(i, j, k, mp_info_pages[i][j][k]);
       `uvm_info(`gfn, $sformatf("MP INFO regions values %p", mp_info_pages[i][j][k]), UVM_HIGH)
@@ -139,7 +144,6 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     //Enable Bank erase
     bank_erase_en = {NumBanks{1'b1}};
     flash_ctrl_bank_erase_cfg(.bank_erase_en(bank_erase_en));
-
     flash_op.op  = FlashOpProgram;
     flash_op_inv = flash_op;
     flash_op_rd  = flash_op;
@@ -155,6 +159,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     flash_op_inv.op       = FlashOpInvalid;
     flash_ctrl_start_op(flash_op_inv);
     wait_flash_op_done();
+
     ral.err_code.op_err.predict(expect_alert);
     check_exp_alert_status(expect_alert, "op_err", flash_op_inv, flash_op_data);
     cfg.scb_h.exp_alert["recov_err"] = 0;
@@ -182,7 +187,6 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     flash_ctrl_start_op(flash_op_rd);
     flash_ctrl_read(flash_op_rd.num_words, flash_op_data, poll_fifo_status);
     wait_flash_op_done();
-
   endtask : do_op
 
 endclass : flash_ctrl_invalid_op_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
@@ -27,7 +27,9 @@ class flash_ctrl_lcmgr_intg_vseq extends flash_ctrl_err_base_vseq;
 
       $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
       `DV_CHECK(uvm_hdl_force(path, $urandom))
-      cfg.clk_rst_vif.wait_clks(10);
+      // Make sure this is not too long.
+      // If this is too long, it will causes other fatal errors.
+      cfg.clk_rst_vif.wait_clks(5);
       `DV_CHECK(uvm_hdl_release(path))
       collect_err_cov_status(ral.std_fault_status);
       csr_rd_check(.ptr(ral.std_fault_status.lcmgr_intg_err), .compare_value(1));

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -97,6 +97,11 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
     };
   }
 
+  task pre_start();
+    cfg.skip_init_buf_en = 1;
+    super.pre_start();
+  endtask // pre_start
+
   virtual task body();
     cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::On;
     cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::On;
@@ -147,6 +152,7 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
       join
       wait_cfg_prog_rd();
     end
+
     // erase suspend interrupt
     fork
       begin : isolation_fork_erase_suspend
@@ -164,11 +170,13 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
       end : isolation_fork_erase_suspend
     join
     wait_cfg_prog_rd();
+
     // cleaning before full memory check
     for (int i = 0; i < NUM_TRANS; i++) begin
       do_erase(flash_op_q[i]);
       wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
     end
+
     // read interrupt
     `DV_CHECK_RANDOMIZE_WITH_FATAL(this, flash_op.op == FlashOpRead;
                                          flash_op.partition == FlashPartData;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
@@ -31,6 +31,12 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
                 DVWaitRmaRsp        = 7
                 } reset_index_e;
 
+
+  task pre_start();
+    cfg.skip_init = 1;
+    super.pre_start();
+  endtask
+
   task body();
     int state_wait_timeout_ns = 50000; // 50 us
     int long_wait_timeout_ns = 5000000; // 5ms
@@ -38,6 +44,7 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
     string path;
     logic [RmaSeedWidth-1:0] rma_seed;
      cfg.scb_h.do_alert_check = 0;
+
     repeat(4) begin
       update_assert(.enable(0));
       fork begin


### PR DESCRIPTION
After hw_cfg update for secret partition, data in the secret partition 'always' scrambled and ecc enabled.
Following updates have been done in this PR to absorb the change.

- Create key before memory init and write scrambled / ecc enabled data to owner / creator partition during init stage.
- Secret partition access is excluded from non-scrambed tests.
- Update sw cfg for secret partition to have scramble and ecc always enabled.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>