### PR TITLE
[spi_device/dv] Fix a constraint error

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_read_buffer_direct_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_read_buffer_direct_vseq.sv
@@ -51,9 +51,9 @@ class spi_device_read_buffer_direct_vseq extends spi_device_flash_mode_vseq;
     check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(0));
 
     // testing ReadbufWatermark
-    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(read_threshold_val, read_threshold_val > 0;)
-    ral.read_threshold.set(read_threshold_val);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.read_threshold.threshold, value > 0;)
     csr_update(ral.read_threshold);
+    read_threshold_val = ral.read_threshold.get();
 
     if (read_threshold_val > 1) begin
       `uvm_info(`gfn, "reading from 0 to read_threshold_val - 2", UVM_MEDIUM)


### PR DESCRIPTION
Recent constraint update affected the direct test - read_buffer_direct Changed to call a uvm_reg_field randomize instead of vseq randomize, since this direct test doesn't need to the complex constraint in base_vseq.

Signed-off-by: Weicai Yang <weicai@google.com>