### PR TITLE
[aes, dv] Rework SEC_CM: DATA_REG.LOCAL_ESC SVAs

### DIFF
--- a/hw/ip/aes/data/aes_sec_cm_testplan.hjson
+++ b/hw/ip/aes/data/aes_sec_cm_testplan.hjson
@@ -189,9 +189,12 @@
     }
     {
       name: sec_cm_data_reg_local_esc
-      desc: "Verify the countermeasure(s) DATA_REG.LOCAL_ESC."
+      desc: '''
+            Verify the countermeasure(s) DATA_REG.LOCAL_ESC.
+            SVAs inside aes_core.sv are used to ensure that upon local escalation triggered through FI the cipher core doesn't release intermediate state into the readable output data or IV registers.
+            '''
       stage: V2S
-      tests: ["aes_alert_reset"]
+      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
     }
   ]
 }

--- a/hw/ip/aes/dv/env/seq_lib/aes_readability_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_readability_vseq.sv
@@ -22,7 +22,6 @@ class aes_readability_vseq extends aes_base_vseq;
   aes_seq_item cfg_item;
   aes_message_item my_message;
   string str              ="";
-  logic [31:0]          reg_read;
 
   task body();
     aes_seq_item cfg_item       = new();         // the configuration for this message

--- a/hw/ip/aes/dv/err_injection_if/fi_cipher_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_cipher_if.sv
@@ -67,6 +67,8 @@ interface fi_cipher_if
   function automatic void force_single_bit(int target);
     bit  read;
     $assertoff(0, "tb.dut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscDataOut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscIv");
     if (!uvm_hdl_check_path(intf_array[target])) begin
       `uvm_fatal("fi_cipher_if", $sformatf("PATH NOT EXISTING %m"))
     end
@@ -90,6 +92,8 @@ interface fi_cipher_if
   function automatic void force_multi_bit(int target, bit [31:0] value);
     bit  read;
     $assertoff(0, "tb.dut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscDataOut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscIv");
     `uvm_info("if_cipher_if",
        $sformatf(" I am forcing target %d %s, \n value: %0h",
                   target, intf_mul_array[target], value),UVM_LOW);

--- a/hw/ip/aes/dv/err_injection_if/fi_control_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_control_if.sv
@@ -63,6 +63,8 @@ interface fi_control_if
   function automatic void force_single_bit(int target);
     bit  read;
     $assertoff(0, "tb.dut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscDataOut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscIv");
     if (!uvm_hdl_check_path(intf_array[target])) begin
       `uvm_fatal("fi_control_if", $sformatf("PATH NOT EXISTING %m"))
     end
@@ -86,6 +88,8 @@ interface fi_control_if
   function automatic void force_multi_bit(int target, bit [31:0] value);
     bit  read;
     $assertoff(0, "tb.dut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscDataOut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscIv");
     if (!uvm_hdl_check_path(intf_mul_array[target])) begin
       `uvm_fatal("fi_control_if", $sformatf("PATH NOT EXISTING %m"))
     end

--- a/hw/ip/aes/dv/err_injection_if/fi_ctr_fsm_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_ctr_fsm_if.sv
@@ -37,6 +37,8 @@ interface fi_ctr_fsm_if
   function automatic void force_single_bit(int target);
     bit  read;
     $assertoff(0, "tb.dut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscDataOut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscIv");
     if (!uvm_hdl_check_path(intf_array[target])) begin
       `uvm_fatal("fi_ctr_fsm_if", $sformatf("PATH NOT EXISTING %m"))
     end

--- a/hw/ip/aes/dv/err_injection_if/force_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/force_if.sv
@@ -17,6 +17,8 @@ interface force_if
 
   function static void force_state(bit [SignalWidth-1:0] state);
     $assertoff(0, "tb.dut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscDataOut");
+    $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscIv");
     if (!uvm_hdl_check_path(path)) begin
       `uvm_fatal("Force_if", $sformatf("PATH NOT EXISTING %m"))
     end

--- a/hw/ip/aes/dv/sva/aes_bind.sv
+++ b/hw/ip/aes/dv/sva/aes_bind.sv
@@ -30,7 +30,6 @@ module aes_bind;
   bind aes aes_reseed_if u_aes_reseed_if (
     .clk_i                 (clk_i),
     .rst_ni                (rst_ni),
-    .local_esc             (lc_escalate_en_i),
     .entropy_clearing_req  (entropy_clearing_req),
     .entropy_clearing_ack  (entropy_clearing_ack),
     .entropy_masking_req   (entropy_masking_req),
@@ -45,17 +44,7 @@ module aes_bind;
     .ctrl_phase_i          (u_aes_core.u_aes_control.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.
                             u_aes_control_fsm.ctrl_phase_i),
     .ctrl_we_q             (u_aes_core.u_aes_control.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.
-                            u_aes_control_fsm.ctrl_we_q),
-    .block_ctr_decr        (u_aes_core.u_aes_control.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.
-                            u_aes_control_fsm.block_ctr_decr),
-    .block_ctr_expr        (u_aes_core.u_aes_control.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.
-                            u_aes_control_fsm.block_ctr_expr),
-    .add_round_key_out     (u_aes_core.u_aes_cipher_core.add_round_key_out),
-    .iv_q                  (u_aes_core.iv_q),
-    .iv_d                  (u_aes_core.iv_d),
-    .data_in_prev_q        (u_aes_core.data_in_prev_q),
-    .data_out_q            (u_aes_core.data_out_q),
-    .data_out_d            (u_aes_core.data_out_d)
+                            u_aes_control_fsm.ctrl_we_q)
   );
 
 if (`EN_MASKING) begin : gen_prng_bind

--- a/hw/ip/aes/dv/sva/aes_reseed_if.sv
+++ b/hw/ip/aes/dv/sva/aes_reseed_if.sv
@@ -12,34 +12,24 @@ interface aes_reseed_if
   parameter int unsigned EntropyWidth = edn_pkg::ENDPOINT_BUS_WIDTH,
   parameter bit          SecMasking   = `EN_MASKING
 ) (
-  input logic                                      clk_i,
-  input logic                                      rst_ni,
-  input                                            lc_ctrl_pkg::lc_tx_t local_esc,
-  input logic                                      entropy_clearing_req,
-  input logic                                      entropy_clearing_ack,
-  input logic                                      entropy_masking_req,
-  input logic                                      entropy_masking_ack,
-  input                                            prs_rate_e prng_reseed_rate,
-  input logic                                      entropy_req_o,
-  input logic                                      entropy_ack_i,
-  input logic                                      seed_en,
-  input logic [EntropyWidth-1:0]                   entropy_i,
-  input logic [EntropyWidth-1:0]                   buffer_q,
-  input logic [Width-1:0]                          lfsr_q,
-  input logic                                      ctrl_phase_i,
-  input logic                                      ctrl_we_q,
-  input logic                                      block_ctr_decr,
-  input logic                                      block_ctr_expr,
-  input logic [3:0][3:0][7:0]                      add_round_key_out[SecMasking ? 2 : 1],
-  input logic [NumSlicesCtr-1:0][SliceSizeCtr-1:0] iv_q,
-  input logic [NumSlicesCtr-1:0][SliceSizeCtr-1:0] iv_d,
-  input logic [NumRegsData-1:0][31:0]              data_in_prev_q,
-  input logic [NumRegsData-1:0][31:0]              data_out_q,
-  input logic [NumRegsData-1:0][31:0]              data_out_d
-  );
-
-  logic [3:0][3:0][7:0]                            round_key;
-  logic [3:0][3:0][7:0]                            data_out;
+  input logic                    clk_i,
+  input logic                    rst_ni,
+  input logic                    entropy_clearing_req,
+  input logic                    entropy_clearing_ack,
+  input logic                    entropy_masking_req,
+  input logic                    entropy_masking_ack,
+  input                          prs_rate_e prng_reseed_rate,
+  input logic                    entropy_req_o,
+  input logic                    entropy_ack_i,
+  input logic                    seed_en,
+  input logic [EntropyWidth-1:0] entropy_i,
+  input logic [EntropyWidth-1:0] buffer_q,
+  input logic [Width-1:0]        lfsr_q,
+  input logic                    ctrl_phase_i,
+  input logic                    ctrl_we_q,
+  input logic                    block_ctr_decr,
+  input logic                    block_ctr_expr
+);
 
   logic [Width-1:0] seed;
   assign seed = {buffer_q, entropy_i};
@@ -58,20 +48,4 @@ interface aes_reseed_if
   `ASSERT(MaskingPrngReseedCorrectAfter_A, (SecMasking && ctrl_we_q && !ctrl_phase_i) |->
           ##[1:$] entropy_masking_req);
 
-  // local esc checks #15433
-  assign round_key = SecMasking ?
-         (add_round_key_out[1] ^ add_round_key_out[0]) : add_round_key_out[0];
-
-  `ASSERT(DataOutRoundKey_A, !((local_esc == lc_ctrl_pkg::On) &&
-                               (aes_transpose(round_key) == data_out_d )));
-  `ASSERT(DataOutRoundKey_B, !((local_esc == lc_ctrl_pkg::On) &&
-                              ((aes_transpose(round_key) == data_out_d )^iv_q)));
-  `ASSERT(DataOutRoundKey_C, !((local_esc == lc_ctrl_pkg::On) &&
-                              ((aes_transpose(round_key) == data_out_d )^data_in_prev_q)));
-  `ASSERT(IvRoundKey_A,      !((local_esc == lc_ctrl_pkg::On) &&
-                              ((aes_transpose(round_key) == iv_d ))));
-  `ASSERT(IvRoundKey_B,      !((local_esc == lc_ctrl_pkg::On) &&
-                              ((aes_transpose(round_key) == iv_d )^iv_q)));
-  `ASSERT(IvRoundKey_C,      !((local_esc == lc_ctrl_pkg::On) &&
-                              ((aes_transpose(round_key) == iv_d )^data_in_prev_q)));
 endinterface // aes_reseed_if


### PR DESCRIPTION
This PR is a follow-up of #15589. It reworks the SVAs relevant for verifying SEC_CM: DATA_REG.LOCAL_ESC as follows:
- They are moved out of the unrelated reseed IF into the actual RTL.
- They're extended to trigger upon local escalation.
- Correct the mapping in the security CM testplan.
