### PR TITLE
[prim-lfsr] Fix DefaultSeedLocal compile scope

### DIFF
--- a/hw/ip/prim/rtl/prim_double_lfsr.sv
+++ b/hw/ip/prim/rtl/prim_double_lfsr.sv
@@ -84,7 +84,7 @@ module prim_double_lfsr #(
     );
   end
 
-`ifndef SYNTHESIS
+`ifdef SIMULATION
 `ifndef VERILATOR
   // Ensure both LFSRs start off with the same default seed. if randomized in simulations.
   initial begin : p_sync_lfsr_default_seed

--- a/hw/ip/prim/rtl/prim_lfsr.sv
+++ b/hw/ip/prim/rtl/prim_lfsr.sv
@@ -312,8 +312,9 @@ module prim_lfsr #(
   logic [LfsrDw-1:0] next_lfsr_state, coeffs;
 
   // Enable the randomization of DefaultSeed using DefaultSeedLocal in DV simulations.
-  `ifndef SIMULATION
-    localparam logic [LfsrDw-1:0] DefaultSeedLocal = DefaultSeed;
+  `ifdef SIMULATION
+  `ifdef VERILATOR
+      localparam logic [LfsrDw-1:0] DefaultSeedLocal = DefaultSeed;
 
   `else
     logic [LfsrDw-1:0] DefaultSeedLocal;
@@ -334,7 +335,12 @@ module prim_lfsr #(
       end
       $display("%m: DefaultSeed = 0x%0h, DefaultSeedLocal = 0x%0h", DefaultSeed, DefaultSeedLocal);
     end
-  `endif
+  `endif  // ifdef VERILATOR
+
+  `else
+    localparam logic [LfsrDw-1:0] DefaultSeedLocal = DefaultSeed;
+
+  `endif  // ifdef SIMULATION
 
   ////////////////
   // Galois XOR //


### PR DESCRIPTION
Use `ifdef SIMULATION` compilation scope for DefaultSeedLocal` setting in prim_lfsr / prim_double_lfsr.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>