### PR TITLE
[edn] Tweak fifo clear logic

### DIFF
--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -67,9 +67,7 @@ module edn_core import edn_pkg::*;
     EnDelay,
     IntrStatus,
     SendReseedCmd,
-    ReseedCmdClr,
     SendGenCmd,
-    GenCmdClr,
     OutputClr,
     MainFsmEn,
     CmdFifoCnt,
@@ -554,9 +552,7 @@ module edn_core import edn_pkg::*;
 
   assign sfifo_rescmd_pop = send_rescmd;
 
-  assign sfifo_rescmd_clr =
-         (!edn_enable_fo[ReseedCmdClr]) ? '0 :
-         (cmd_fifo_rst_fo[1] || main_sm_done_pulse);
+  assign sfifo_rescmd_clr = (cmd_fifo_rst_fo[1] || main_sm_done_pulse);
 
   assign sfifo_rescmd_err =
          {(sfifo_rescmd_push && sfifo_rescmd_full),
@@ -600,9 +596,7 @@ module edn_core import edn_pkg::*;
 
   assign sfifo_gencmd_pop = send_gencmd || boot_send_gencmd;
 
-  assign sfifo_gencmd_clr =
-         (!edn_enable_fo[GenCmdClr]) ? '0 :
-         (cmd_fifo_rst_fo[2] || main_sm_done_pulse);
+  assign sfifo_gencmd_clr = (cmd_fifo_rst_fo[2] || main_sm_done_pulse);
 
   assign sfifo_gencmd_err =
          {(sfifo_gencmd_push && sfifo_gencmd_full),


### PR DESCRIPTION
Only last commit is relevant, others will be rebased away. 

- Currently, the generate and reseed command fifos can only be cleared when edn is enabled. This means when software disables the edn to reset it into a different mode (boot to auto for example), it has to actually wait until edn is re-enabled to clear the FIFOs.  This can lead to some odd corner cases where the edn / csrng interface can actually get stuck because a previous command accidentally goes through.

- To get around this, allow the reseed / generate command fifos to be cleared regardless of the edn enable state.

- This fixes #14506

Signed-off-by: Timothy Chen <timothytim@google.com>