### PR TITLE
[dv/edn] Support sec_cm

### DIFF
--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -36,7 +36,10 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["edn_bind", "edn_cov_bind", "sec_cm_prim_onehot_check_bind"]
+  sim_tops: ["edn_bind", "edn_cov_bind",
+             "sec_cm_prim_sparse_fsm_flop_bind",
+             "sec_cm_prim_count_bind",
+             "sec_cm_prim_onehot_check_bind"]
 
   // TODO: Redo for V2S
   xcelium_cov_refine_files: ["{proj_root}/hw/ip/edn/dv/cov/edn_UNR.vRefine"]

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -80,6 +80,7 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = edn_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_alert";
+    sec_cm_alert_name = "fatal_alert";
     super.initialize(csr_base_addr);
 
     // create config objects

--- a/hw/ip/edn/dv/env/seq_lib/edn_common_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_common_vseq.sv
@@ -20,4 +20,20 @@ class edn_common_vseq extends edn_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+  // TODO: remove this when #15829 merged.
+  virtual task sec_cm_inject_fault(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
+    csr_wr(.ptr(ral.ctrl.edn_enable), .value(MuBi4True));
+    super.sec_cm_inject_fault(if_proxy);
+  endtask : sec_cm_inject_fault
+
+  virtual task check_sec_cm_fi_resp(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
+    if (!uvm_re_match("*.cnt_q*", if_proxy.path)) begin
+      csr_rd_check(.ptr(ral.err_code.edn_cntr_err), .compare_value(1'b1));
+    end else if (!uvm_re_match("*.u_edn_ack_sm_ep*", if_proxy.path)) begin
+      csr_rd_check(.ptr(ral.err_code.edn_ack_sm_err), .compare_value(1'b1));
+    end else if (!uvm_re_match("*.u_edn_main_sm*", if_proxy.path)) begin
+      csr_rd_check(.ptr(ral.err_code.edn_main_sm_err), .compare_value(1'b1));
+    end
+    // TODO: check local escalation and check other EDN request will be blocked.
+  endtask
 endclass


### PR DESCRIPTION
This test supports edn sec_cm test:
1). Add bind interfaces
2). Add checking before and after sec_cm injection.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>