### PR TITLE
[entropy_src/dv] FW_OV updates

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -68,6 +68,11 @@ class entropy_src_env extends cip_base_env #(
       `uvm_fatal(get_full_name(), "failed to get precon_fifo_vif from uvm_config_db")
     end
 
+    if (!uvm_config_db#(virtual entropy_subsys_fifo_exception_if#(1))::get(this, "",
+                        "bypass_fifo_vif", cfg.bypass_fifo_vif)) begin
+      `uvm_fatal(get_full_name(), "failed to get precon_fifo_vif from uvm_config_db")
+    end
+
     if (!uvm_config_db#(virtual entropy_src_fsm_cov_if)::get(this, "",
                         "main_sm_cov_vif", cfg.fsm_tracking_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get fsm_tracking_vif from uvm_config_db")

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -32,9 +32,10 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
 
   // handle to the interrupt interface
   dv_utils_pkg::intr_vif interrupt_vif;
-  // Pointer to the preconditioning fifo exception interface.
+  // Pointer to the preconditioning and bypass fifo exception interfaces.
   // (For tracking errors during FW_OV mode)
   virtual entropy_subsys_fifo_exception_if#(1) precon_fifo_vif;
+  virtual entropy_subsys_fifo_exception_if#(1) bypass_fifo_vif;
 
   // Pointer to the FSM state tracking interface.
   // (Coverage completion requires earlier notice of following state).

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -88,6 +88,9 @@ module tb;
   bind prim_packer_fifo : dut.u_entropy_src_core.u_prim_packer_fifo_precon
     entropy_subsys_fifo_exception_if#(1) u_fifo_exc_if (.clk_i, .rst_ni, .wready_o, .wvalid_i);
 
+  bind prim_packer_fifo : dut.u_entropy_src_core.u_prim_packer_fifo_bypass
+    entropy_subsys_fifo_exception_if#(1) u_fifo_exc_if (.clk_i, .rst_ni, .wready_o, .wvalid_i);
+
   bind prim_sparse_fsm_flop : dut.u_entropy_src_core.u_entropy_src_main_sm.u_state_regs
     entropy_src_fsm_cov_if u_fsm_cov_if (.clk_i, .state_i);
 
@@ -109,6 +112,8 @@ module tb;
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual entropy_subsys_fifo_exception_if#(1))::set(null, "*.env",
         "precon_fifo_vif", dut.u_entropy_src_core.u_prim_packer_fifo_precon.u_fifo_exc_if);
+    uvm_config_db#(virtual entropy_subsys_fifo_exception_if#(1))::set(null, "*.env",
+        "bypass_fifo_vif", dut.u_entropy_src_core.u_prim_packer_fifo_bypass.u_fifo_exc_if);
     uvm_config_db#(virtual entropy_src_fsm_cov_if)::set(null, "*.env", "main_sm_cov_vif",
         dut.u_entropy_src_core.u_entropy_src_main_sm.u_state_regs.u_fsm_cov_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH)))::set


### PR DESCRIPTION
- Check OTP FW_OVER enable instead of OTP FW_READ to check allowability of FW_OV mode.
- More consistant use of monitor clocking blocks for generating single cycle pulses from the precon fifo monitor
- Monitor es_bypass_fifo for in fw_ov + bypass modes for FW errors This commit adds a second FIFO monitoring interface to detect FIFO overflow conditions inside the DUT, and to properly predict alerts and changes to the output seeds when such sim'd errors occur.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>