### PR TITLE
Build OpenOCD 0.12.0-rc1 with Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,14 +60,15 @@ load("//third_party/cargo_raze:repos.bzl", "raze_repos")
 raze_repos()
 load("//third_party/cargo_raze:deps.bzl", "raze_deps")
 raze_deps()
-# The raze instructions would have us call `cargo_raze_transitive_deps`, but that
-# wants to re-instantiate rules_rust and mess up our rust configuration.
-# Instead, we perform the single other action that transitive_deps would perform:
-# load and instantiate `rules_foreign_cc_dependencies`.
-#load("@cargo_raze//:transitive_deps.bzl", "cargo_raze_transitive_deps")
-#cargo_raze_transitive_deps()
-load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
-rules_foreign_cc_dependencies()
+# The raze instructions would have us call `cargo_raze_transitive_deps`, but
+# that wants to re-instantiate rules_rust and mess up our rust configuration.
+# The single other action that transitive_deps would perform is to load and
+# instantiate `rules_foreign_cc_dependencies`, but this has already been done
+# above, so we can do nothing here.
+
+# OpenOCD
+load("//third_party/openocd:repos.bzl", "openocd_repos")
+openocd_repos()
 
 # Protobuf Toolchain
 load("//third_party/protobuf:repos.bzl", "protobuf_repos")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,11 +7,10 @@
 
 variables:
   #
-  # If updating VERILATOR_VERSION, OPENOCD_VERSION, TOOLCHAIN_VERSION or RUST_VERSION
-  # update the definitions in util/container/Dockerfile as well.
+  # If updating VERILATOR_VERSION, TOOLCHAIN_VERSION or RUST_VERSION, update the
+  # definitions in util/container/Dockerfile as well.
   #
   VERILATOR_VERSION: 4.210
-  OPENOCD_VERSION: 0.11.0
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-2135-gb534c1fe
   RUST_VERSION: 1.60.0

--- a/ci/install-package-dependencies.sh
+++ b/ci/install-package-dependencies.sh
@@ -8,7 +8,6 @@ set -e
 usage()
 {
     echo "Usage: install-package-dependencies.sh --verilator-version V"
-    echo "                                       --openocd-version V"
     echo "                                       --verible-version V"
     echo "                                       --rust-version V"
     exit 1
@@ -20,11 +19,11 @@ error()
     exit 1
 }
 
+# TODO(#15846) Stop accepting --openocd-version once Private CI stops using it.
 long="verilator-version:,openocd-version:,verible-version:,rust-version:"
 ARGS="$(getopt -o "" -l "$long" -- "$@")" || usage
 
 VERILATOR_VERSION=
-OPENOCD_VERSION=
 VERIBLE_VERSION=
 
 eval set -- "$ARGS"
@@ -32,7 +31,7 @@ while :
 do
     case "$1" in
         --verilator-version) VERILATOR_VERSION="$2"; shift 2 ;;
-        --openocd-version)   OPENOCD_VERSION="$2";   shift 2 ;;
+        --openocd-version)   echo "Ignoring --openocd-version"; shift 2 ;;
         --verible-version)   VERIBLE_VERSION="$2";   shift 2 ;;
         --rust-version)      RUST_VERSION="$2";      shift 2 ;;
         --) shift; break ;;
@@ -42,7 +41,6 @@ done
 
 # Check that we've seen all the expected versions
 test -n "$VERILATOR_VERSION" || error "Missing --verilator-version"
-test -n "$OPENOCD_VERSION"   || error "Missing --openocd-version"
 test -n "$VERIBLE_VERSION"   || error "Missing --verible-version"
 test -n "$RUST_VERSION"      || error "Missing --rust-version"
 
@@ -103,7 +101,6 @@ sudo $APT_CMD update || {
 ci_reqs="$TMPDIR/apt-requirements-ci.txt"
 cp apt-requirements.txt "$ci_reqs"
 echo "verilator-${VERILATOR_VERSION}" >> "$ci_reqs"
-echo "openocd-${OPENOCD_VERSION}" >> "$ci_reqs"
 echo rsync >> "$ci_reqs"
 
 # NOTE: We use sed to remove all comments from apt-requirements-ci.txt,

--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -26,7 +26,6 @@ steps:
       cd ${{ parameters.REPO_TOP }}
       ci/install-package-dependencies.sh \
         --verilator-version $(VERILATOR_VERSION) \
-        --openocd-version $(OPENOCD_VERSION) \
         --verible-version $(VERIBLE_VERSION) \
         --rust-version $(RUST_VERSION)
     retryCountOnTaskFailure: 3

--- a/doc/getting_started/install_openocd.md
+++ b/doc/getting_started/install_openocd.md
@@ -5,20 +5,20 @@ title: Install OpenOCD
 OpenOCD is a tool to connect with the target chip over JTAG and similar transports.
 It also provides a GDB server which is an "intermediate" when debugging software on the chip with GDB.
 
-At least OpenOCD 0.11.0 is required.
-
 It is recommended to use the regular upstream version of OpenOCD instead of the [RISC-V downstream fork](https://github.com/riscv/riscv-openocd).
 
-As most distributions do not yet include OpenOCD 0.11 in its package repositories building from source is likely to be required.
-The following steps build OpenOCD (this should be done outside the `$REPO_TOP` directory):
+It is trivial to install OpenOCD because we manage the dependency with Bazel.
+The Bazel-built OpenOCD binary lives at `//third_party/openocd:openocd_bin`.
+It's not runnable, but we also provide a runnable wrapper: `//third_party/openocd`.
+
+OpenOCD also ships with a library of config files.
+Instead of using use whichever config files happen to be installed on the system, prefer the Bazel-exposed config files that match OpenOCD source.
+Currently, we only expose OpenTitan's default JTAG adapter config as `//third_party/openocd:jtag_adapter_cfg`.
 
 ```console
-wget https://downloads.sourceforge.net/project/openocd/openocd/0.11.0/openocd-0.11.0.tar.bz2
-tar -xf openocd-0.11.0.tar.bz2
-cd openocd-0.11.0/
-mkdir build
-cd build
-../configure --enable-ftdi --enable-verbose-jtag-io --disable-vsllink --enable-remote-bitbang --prefix=/tools/openocd
-make -j4
-sudo make install
+# Manually run OpenOCD:
+./bazelisk.sh run //third_party/openocd -- arg1 arg2
+
+# Get the path of the OpenOCD binary:
+./bazelisk.sh outquery //third_party/openocd:openocd_bin
 ```

--- a/rules/opentitan_gdb_test.bzl
+++ b/rules/opentitan_gdb_test.bzl
@@ -19,10 +19,12 @@ def _opentitan_gdb_fpga_cw310_test(ctx):
         set -ex
         {} """.format(shell.quote(ctx.executable._coordinator.short_path))
     args = [
-        ("--gdb-script-path", gdb_script_file.short_path),
-        ("--openocd-earlgrey-config", ctx.file._openocd_earlgrey_config.path),
-        ("--bitstream-path", ctx.file.rom_bitstream.short_path),
         ("--rom-kind", ctx.attr.rom_kind),
+        ("--openocd-path", ctx.file._openocd.short_path),
+        ("--openocd-earlgrey-config", ctx.file._openocd_earlgrey_config.path),
+        ("--openocd-jtag-adapter-config", ctx.file._openocd_jtag_adapter_config.path),
+        ("--gdb-script-path", gdb_script_file.short_path),
+        ("--bitstream-path", ctx.file.rom_bitstream.short_path),
         ("--opentitantool-path", ctx.file._opentitantool.short_path),
     ]
     if ctx.attr.exit_success_pattern != None:
@@ -50,7 +52,9 @@ def _opentitan_gdb_fpga_cw310_test(ctx):
     test_script_runfiles = ctx.runfiles(
         files = [
             ctx.file._openocd_earlgrey_config,
+            ctx.file._openocd_jtag_adapter_config,
             ctx.file._opentitantool,
+            ctx.file._openocd,
             ctx.file.rom_bitstream,
             gdb_script_file,
         ],
@@ -87,6 +91,15 @@ opentitan_gdb_fpga_cw310_test = rv_rule(
         "_openocd_earlgrey_config": attr.label(
             default = "//util/openocd/target:lowrisc-earlgrey.cfg",
             allow_single_file = True,
+        ),
+        "_openocd_jtag_adapter_config": attr.label(
+            default = "//third_party/openocd:jtag_adapter_cfg",
+            allow_single_file = True,
+        ),
+        "_openocd": attr.label(
+            default = "//third_party/openocd:openocd_bin",
+            allow_single_file = True,
+            cfg = "exec",
         ),
     },
     test = True,

--- a/rules/scripts/gdb_test_coordinator.py
+++ b/rules/scripts/gdb_test_coordinator.py
@@ -98,11 +98,13 @@ app = typer.Typer(pretty_exceptions_enable=False)
 
 @app.command()
 def main(rom_kind: str = typer.Option(...),
+         openocd_path: str = typer.Option(...),
          openocd_earlgrey_config: str = typer.Option(...),
-         exit_success_pattern: Optional[str] = typer.Option(None),
-         bitstream_path: str = typer.Option(...),
+         openocd_jtag_adapter_config: str = typer.Option(...),
          gdb_script_path: str = typer.Option(...),
-         opentitantool_path: str = typer.Option(...)):
+         bitstream_path: str = typer.Option(...),
+         opentitantool_path: str = typer.Option(...),
+         exit_success_pattern: Optional[str] = typer.Option(None)):
 
     opentitantool_prefix = [
         opentitantool_path,
@@ -117,9 +119,9 @@ def main(rom_kind: str = typer.Option(...),
         bitstream_path,
     ]
     openocd_command = [
-        "openocd",
+        openocd_path,
         "-f",
-        "/usr/share/openocd/scripts/interface/ftdi/olimex-arm-usb-tiny-h.cfg",
+        openocd_jtag_adapter_config,
         "-c",
         "adapter speed 0; transport select jtag; reset_config trst_and_srst",
         "-f",

--- a/third_party/google/deps.bzl
+++ b/third_party/google/deps.bzl
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 def google_deps():
     rules_pkg_dependencies()
+
+    # Finish setting up rules_foreign_cc, per instructions:
+    # https://bazelbuild.github.io/rules_foreign_cc/0.9.0/index.html
+    rules_foreign_cc_dependencies()

--- a/third_party/google/repos.bzl
+++ b/third_party/google/repos.bzl
@@ -42,3 +42,10 @@ def google_repos(
         strip_prefix = "googletest-release-1.11.0",
         url = "https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip",
     )
+
+    http_archive_or_local(
+        name = "rules_foreign_cc",
+        strip_prefix = "rules_foreign_cc-0.9.0",
+        sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz",
+    )

--- a/third_party/openocd/BUILD
+++ b/third_party/openocd/BUILD
@@ -1,0 +1,56 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:private"])
+
+load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
+
+# Extract the `openocd` binary from :build_openocd. Although the binary itself
+# is executable, Bazel does not believe it is runnable. If you want to run
+# OpenOCD, use the runnable wrapper like so: `bazel run //third_party/openocd`.
+filegroup(
+    name = "openocd_bin",
+    srcs = [":build_openocd"],
+    output_group = "openocd",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "openocd",
+    outs = ["openocd.sh"],
+    cmd = """
+    echo '#!/bin/bash' > $@
+    echo './$(execpath :openocd_bin) $$@' >> $@
+    """,
+    executable = True,
+    tools = [":openocd_bin"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "jtag_adapter_cfg",
+    srcs = ["@openocd//:tcl/interface/ftdi/olimex-arm-usb-tiny-h.cfg"],
+    visibility = ["//visibility:public"],
+)
+
+configure_make(
+    name = "build_openocd",
+    # Speed up the build with multiple jobs, but set an upper bound to constrain
+    # memory consumption. Bazel is not aware of foreign builds' resource usage.
+    # See <https://github.com/bazelbuild/rules_foreign_cc/issues/329>.
+    args = [
+        "-j",
+        "`nproc`",
+    ],
+    configure_in_place = True,
+    configure_options = [
+        "--enable-ftdi",
+        "--enable-verbose-jtag-io",
+        "--disable-vsllink",
+        "--enable-remote-bitbang",
+    ],
+    copts = ["-Wno-error=unused-variable"],
+    lib_source = "@openocd//:all_srcs",
+    out_binaries = ["openocd"],
+)

--- a/third_party/openocd/BUILD.openocd.bazel
+++ b/third_party/openocd/BUILD.openocd.bazel
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+exports_files(glob(["**"]))
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/openocd/repos.bzl
+++ b/third_party/openocd/repos.bzl
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:repo.bzl", "http_archive_or_local")
+
+def openocd_repos(local = None):
+    http_archive_or_local(
+        name = "openocd",
+        local = local,
+        url = "https://sourceforge.net/projects/openocd/files/openocd/0.12.0-rc1/openocd-0.12.0-rc1.tar.gz",
+        strip_prefix = "openocd-0.12.0-rc1",
+        build_file = Label("//third_party/openocd:BUILD.openocd.bazel"),
+        sha256 = "cdd3654a6c2fd046fe766de5ed897d75467138be9b9c271229bbd7409eb902a5",
+    )

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -7,7 +7,6 @@
 
 # Global configuration options.
 ARG VERILATOR_VERSION=4.210
-ARG OPENOCD_VERSION=0.11.0
 ARG VERIBLE_VERSION=v0.0-2135-gb534c1fe
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20220210-1
@@ -20,7 +19,6 @@ ARG GCC_VERSION=9
 # Main container image.
 FROM ubuntu:20.04 AS opentitan
 ARG VERILATOR_VERSION
-ARG OPENOCD_VERSION
 ARG VERIBLE_VERSION
 ARG RISCV_TOOLCHAIN_TAR_VERSION
 ARG RUST_VERSION
@@ -70,7 +68,6 @@ ENV TZ=UTC
 
 COPY apt-requirements.txt /tmp/apt-requirements.txt
 RUN echo "verilator-${VERILATOR_VERSION}" >>/tmp/apt-requirements.txt \
-    && echo "openocd-${OPENOCD_VERSION}"  >>/tmp/apt-requirements.txt \
     && sed -i -e '/^$/d' -e '/^#/d' -e 's/#.*//' /tmp/apt-requirements.txt \
     && apt-get update \
     && xargs apt-get install -y </tmp/apt-requirements.txt \


### PR DESCRIPTION
Now, we can use @openocd//:openocd_bin instead of the system binary.

This commit also switches the GDB test coordinator script over to @openocd//:openocd_bin.

I verified locally that the following test still passes: //sw/device/silicon_creator/rom/e2e:sram_program_fpga_cw310_test_otp_dev.

Fixes #15846

Signed-off-by: Dan McArdle <dmcardle@google.com>