### PR TITLE
[entropy_src/rtl] Fix handshaking delay

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -2442,8 +2442,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign msg_data[0] = pfifo_cond_wdata;
 
   // The SHA3 block cannot take messages except between the
-  // start and process pulses (Even though in this time it still asserts ready)
-  assign sha3_msg_end        = sha3_process;
+  // start and cs_aes_req pulses
+  assign sha3_msg_end        = cs_aes_halt_req;
 
   assign sha3_msg_rdy_mask_d = sha3_start ? 1'b1 :
                                sha3_msg_end ? 1'b0 :

--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -163,7 +163,7 @@ module entropy_src_main_sm
               state_d = StartupFail1;
             end else begin
               // Passed two consecutive tests
-              state_d = Sha3MsgDone;
+              state_d = Sha3Prep;
               rst_alert_cntr_o = 1'b1;
             end
           end
@@ -200,7 +200,7 @@ module entropy_src_main_sm
             if (alert_thresh_fail_i) begin
               state_d = AlertState;
             end else if (!ht_fail_pulse_i) begin
-              state_d = Sha3MsgDone;
+              state_d = Sha3Prep;
               rst_alert_cntr_o = 1'b1;
             end
           end
@@ -217,11 +217,6 @@ module entropy_src_main_sm
         if (!enable_i) begin
           state_d = Idle;
         end else if (!fw_ov_sha3_start_i) begin
-          state_d = Sha3MsgDone;
-        end
-      end
-      Sha3MsgDone: begin
-        if (!cs_aes_halt_ack_i) begin
           state_d = Sha3Prep;
         end
       end
@@ -246,13 +241,18 @@ module entropy_src_main_sm
       Sha3Done: begin
         if (!enable_i) begin
           sha3_done_o = prim_mubi_pkg::MuBi4True;
-          state_d = Sha3Quiesce;
+          state_d = Sha3MsgDone;
         end else begin
           if (main_stage_rdy_i) begin
             sha3_done_o = prim_mubi_pkg::MuBi4True;
             main_stage_push_o = 1'b1;
-            state_d = Sha3Quiesce;
+            state_d = Sha3MsgDone;
           end
+        end
+      end
+      Sha3MsgDone: begin
+        if (!cs_aes_halt_ack_i) begin
+          state_d = Sha3Quiesce;
         end
       end
       Sha3Quiesce: begin


### PR DESCRIPTION
Because of CS_AES_REQ/ACK DELAYs the conditioner can time to receive more input to before the processing actually begins. This commit fixes the msg timing mask so that input is stalled as soon as the req goes to the AES handshake.

Also, for this to be effective, the 4-phase ACK has to be closed before starting a new digest, otherwise delays in the ACK signals can cause similar problems.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>