### PR TITLE
[dv/edn] Update EDN TB

### DIFF
--- a/hw/ip/edn/data/edn_sec_cm_testplan.hjson
+++ b/hw/ip/edn/data/edn_sec_cm_testplan.hjson
@@ -39,19 +39,19 @@
       name: sec_cm_main_sm_fsm_sparse
       desc: "Verify the countermeasure(s) MAIN_SM.FSM.SPARSE."
       stage: V2S
-      tests: []
+      tests: ["edn_sec_cm"]
     }
     {
       name: sec_cm_ack_sm_fsm_sparse
       desc: "Verify the countermeasure(s) ACK_SM.FSM.SPARSE."
       stage: V2S
-      tests: []
+      tests: ["edn_sec_cm"]
     }
     {
       name: sec_cm_ctr_redun
       desc: "Verify the countermeasure(s) CTR.REDUN."
       stage: V2S
-      tests: []
+      tests: ["edn_sec_cm"]
     }
     {
       name: sec_cm_main_sm_ctr_local_esc

--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -12,7 +12,7 @@
   tb: tb
 
   // Simulator used to sign off this block
-  tool: xcelium
+  tool: vcs
 
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:edn_sim:0.1
@@ -40,9 +40,6 @@
              "sec_cm_prim_sparse_fsm_flop_bind",
              "sec_cm_prim_count_bind",
              "sec_cm_prim_onehot_check_bind"]
-
-  // TODO: Redo for V2S
-  xcelium_cov_refine_files: ["{proj_root}/hw/ip/edn/dv/cov/edn_UNR.vRefine"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/edn/dv/env/seq_lib/edn_common_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_common_vseq.sv
@@ -20,12 +20,6 @@ class edn_common_vseq extends edn_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
-  // TODO: remove this when #15829 merged.
-  virtual task sec_cm_inject_fault(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
-    csr_wr(.ptr(ral.ctrl.edn_enable), .value(MuBi4True));
-    super.sec_cm_inject_fault(if_proxy);
-  endtask : sec_cm_inject_fault
-
   virtual task check_sec_cm_fi_resp(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
     if (!uvm_re_match("*.cnt_q*", if_proxy.path)) begin
       csr_rd_check(.ptr(ral.err_code.edn_cntr_err), .compare_value(1'b1));


### PR DESCRIPTION
1). Change the signoff tool from Xcelium to VCS, just because the new DV
  contributor (me) is more familiar with VCS.
  But can still use `-t xcelium` to run in xcelium.
2). Update sec_cm testbench with sec_cm common test. 3). Remove a TODO in common test because PR #15829 is merged.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>