### PR TITLE
[doc(spid)] Update doc

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -309,7 +309,11 @@
           hwaccess: "hrw" // Updated by EN4B/EX4B
           desc: '''4B Address Mode enable.
 
-            This field configures the internal module to receive 32 bits of the SPI commands. The affected commands are the SPI read commands except QPI, and program commands.
+            This field configures the internal module to receive 32 bits of the
+            SPI commands. The affected commands are the SPI read commands
+            except QPI, and program commands. It is expected for SW to
+            configure this field at the configuration stage and leave the
+            updation to HW until next reset.
 
             Even though Read SFDP command has address fields, the SFDP command
             is not affected by this field. The command always parse 24 bits on

--- a/hw/ip/spi_device/doc/_index.md
+++ b/hw/ip/spi_device/doc/_index.md
@@ -681,10 +681,13 @@ Other registers in the table should be processed by SW.
 
 ## Clock and Phase
 
-The SPI device module has two programmable register bits to control the SPI
-clock, {{< regref "CFG.CPOL" >}} and {{< regref "CFG.CPHA" >}}. CPOL controls clock polarity and CPHA controls the clock
-phase. For further details, please refer to this diagram from Wikipedia:
+The SPI device module has two programmable register bits to control the SPI clock, {{< regref "CFG.CPOL" >}} and {{< regref "CFG.CPHA" >}}.
+CPOL controls clock polarity and CPHA controls the clock phase.
+For further details, please refer to this diagram from Wikipedia:
 [File:SPI_timing_diagram2.svg](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface#/media/File:SPI_timing_diagram2.svg)
+
+This version of SPI_DEVICE HWIP supports mode 0 (CPHA and CPOL as 0) and mode 3 (CPHA and CPOL as 1) for Generic, Flash, and Passthrough modes.
+SW should configure the SPI_DEVICE to mode 0 to enable TPM mode along with other modes.
 
 ## SPI Device Firmware Operation Mode
 

--- a/hw/ip/spi_device/doc/_index.md
+++ b/hw/ip/spi_device/doc/_index.md
@@ -677,6 +677,13 @@ If `invalid_locality` configuration is set, the logic returns `INVALID` value to
 If the request is in the supported locality (0-4), the logic checks `TPM_ACCESS_x.activeLocality` then returns data based on the table 39 in the spec for Return-by-HW registers.
 Other registers in the table should be processed by SW.
 
+## Detecting Reliability Errors
+
+This version of the SPI_DEVICE IP implements the parity to detect bit flip errors on the internal SRAM.
+The HW checks the parity error when the SW reads data from the SRAM.
+The error is reported to the SW via TL D channel error signal.
+SW is recommended to discard the current context if any transaction is ongoing then to reset the IP.
+
 # Design Details
 
 ## Clock and Phase


### PR DESCRIPTION
This PR addresses three items discussed in https://github.com/lowRISC/opentitan/issues/15463

- As @eunchan mentioned, we support {polarity, phase} to be 'b00 or 'b11 for flash/passthrough mode. Please document it in the spec.
- document that SW can only update addr_4b at the beginning before host sends any commands, due to https://github.com/lowRISC/opentitan/issues/15543
- document mem parity in countermeasure section