### PR TITLE
[dv/cdc] Use cycle based CDC instrumentation

### DIFF
--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -37,5 +37,4 @@ end
 
 begin assert
   +moduletree *csr_assert_fpv
-  -moduletree prim_cdc_rand_delay // TODO: CDC not enabled yet
 end

--- a/hw/ip/prim/lint/prim_cdc_rand_delay.waiver
+++ b/hw/ip/prim/lint/prim_cdc_rand_delay.waiver
@@ -8,12 +8,10 @@ waive -rules {IFDEF_CODE} -location {prim_cdc_rand_delay.sv} -regexp {.*containe
       -comment "Ifdefs are required for prim_rand_cdc_delay since it is turned on only for simulation."
 
 waive -rules {HIER_BRANCH_NOT_READ} -location {prim_cdc_rand_delay.sv} -regexp {.*dst_clk.*} \
-      -comment "Destination clock is only used when attempting to simulate random delays."
+      -comment "Destination clock is only used when simulating random delays."
 
-waive -rules {INPUT_NOT_READ} -location {prim_cdc_rand_delay.sv} -regexp {dst_clk|src_clk} \
-      -comment "Source/Destination clock is only used when attempting to simulate random delays."
+waive -rules {INPUT_NOT_READ} -location {prim_cdc_rand_delay.sv} -regexp {clk_i|rst_ni|prev_data_i} \
+      -comment "Clock, reset, and previous data are only used when simulating random delays."
 
-waive -rules {PARAM_NOT_USED} -location {prim_cdc_rand_delay.sv} -regexp {UseSourceClock|LatencyPs|JitterPs} \
-      -comment "Randomization parameters are only used when attempting to simulate random delays."
-
-
+waive -rules {PARAM_NOT_USED} -location {prim_cdc_rand_delay.sv} -regexp {Enable} \
+      -comment "Enable parameter is only used when simulating random delays."

--- a/hw/ip/prim/lint/prim_flop_2sync.waiver
+++ b/hw/ip/prim/lint/prim_flop_2sync.waiver
@@ -4,3 +4,8 @@
 #
 # waiver file for prim_flop_2sync
 
+waive -rules {IFDEF_CODE} -location {prim_flop_2sync.sv} -regexp {.*contained within \`else block.*} \
+      -comment "Ifdefs are required for prim_flop_2sync since it is turned on only for simulation."
+
+waive -rules {PARAM_NOT_USED} -location {prim_flop_2sync.sv} -regexp {Parameter 'EnablePrimCdcRand' not used in module.*} \
+      -comment "This parameter is used when cdc instrumentation is enabled."

--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -320,7 +320,7 @@ module prim_alert_sender
     // output must be driven diff unless sigint issue detected
     `ASSERT(DiffEncoding_A, (alert_rx_i.ack_p ^ alert_rx_i.ack_n) &&
         (alert_rx_i.ping_p ^ alert_rx_i.ping_n) |->
-        ##3 alert_tx_o.alert_p ^ alert_tx_o.alert_n)
+        ##[3:4] alert_tx_o.alert_p ^ alert_tx_o.alert_n)
 
     // handshakes can take indefinite time if blocked due to sigint on outgoing
     // lines (which is not visible here). thus, we only check whether the

--- a/hw/ip/prim/rtl/prim_cdc_rand_delay.sv
+++ b/hw/ip/prim/rtl/prim_cdc_rand_delay.sv
@@ -6,232 +6,62 @@
 // and allows DV to model real CDC delays within simulations, especially useful at the chip level
 // or in IPs that communicate across clock domains.
 //
-// If not, delay randomization is enabled - the faster of the two clocks is used to latch src_data,
-// dst_data is synchronously driven with a random combination of the current src_data and
-// the delayed version of src_data.
+// The instrumentation is very simple: when this is enabled the input into the first
+// synchronizer flop has a mux where the select is randomly set. One of the mux inputs is the input
+// of this module, and the other is the output of the first flop: selecting the latter models the
+// effect of the first flop missing the input transition.
 //
-// If a source clock isn't used, the input src_data is latched after a parameterizable latency
-// as `src_data_with_latency`, and an internal version of the output data `src_data_delayed` is set
-// to this same value after a parameterizable jitter period.
-//
-// This is meant to model skew between synchronizer bits and wire delay between the src and dst
-// flops.
-//
-// Four different random delay modes are available:
-//
-// - RandDelayDisable: If this delay mode is picked, this module acts as a passthrough.
-//
-// - RandDelaySlow: If this delay mode is picked, the output to the dst domain is
-//                  continuously driven to `src_data_delayed`.
-//
-// - RandDelayOnce: If this delay mode is picked, the mask `out_data_mask` used to combine
-//                  `src_data_with_latency` and `src_data_delayed` is randomized once at the
-//                  start of the simulation.
-//
-// - RandDelayInterval: If this delay mode is picked, the mask `out_data_mask` used to
-//                      combine `src_data_with_latency` and `src_data_delayed` is fully
-//                      randomized every `prim_cdc_rand_delay_interval` times the src_data
-//                      value changes. If the `prim_cdc_rand_delay_interval` is set to 0,
-//                      then out_data_mask is randomized on every src_data change.
-//
-// DV has control of the weights corresponding to each random delay mode when the delay mode is
-// randomized, but can also directly override the delay mode as desired.
-//
-// DV also has control over whether the source clock is used, the latency, and the jitter values -
-// these can be modified through the provided setter tasks.
+// Notice the delay should cause the input to be skipped by at most a single cycle. As a perhaps
+// unnecessary precaution, the select will only be allowed to be random when the input changes.
 
 module prim_cdc_rand_delay #(
     parameter int DataWidth = 1,
-    parameter bit UseSourceClock = 1,
-    parameter int LatencyPs = 1000,
-    parameter int JitterPs = 1000
+    parameter bit Enable = 1
 ) (
-    input logic                 src_clk,
-    input logic [DataWidth-1:0] src_data,
-
-    input logic                   dst_clk,
-    output logic [DataWidth-1:0]  dst_data
+    input logic                   clk_i,
+    input logic                   rst_ni,
+    input logic [DataWidth-1:0]   prev_data_i,
+    input logic [DataWidth-1:0]   src_data_i,
+    output logic [DataWidth-1:0]  dst_data_o
 );
-
-  `ASSERT_INIT(LegalDataWidth_A, DataWidth > 0)
-  `ASSERT_INIT(LegalLatencyPs_A, LatencyPs >= 0)
-  `ASSERT_INIT(LegalJitterPs_A,  JitterPs >= 0)
-
 `ifdef SIMULATION
-`ifndef DISABLE_PRIM_CDC_RAND_DELAY
+  if (Enable) begin : gen_enable
 
-  // macro includes
-  `include "uvm_macros.svh"
-  `include "dv_macros.svh"
+    // This controls dst_data_o: any bit with its data_sel set uses prev_data_i, others use
+    // src_data_i.
+    bit [DataWidth-1:0] data_sel;
+    bit                 cdc_instrumentation_enabled;
 
-  typedef enum bit [1:0] {
-    RandDelayModeDisable,
-    RandDelayModeSlow,
-    RandDelayModeOnce,
-    RandDelayModeInterval
-  } rand_delay_mode_e;
+    function automatic bit [DataWidth-1:0] fast_randomize();
+      bit [DataWidth-1:0] data;
+      if (DataWidth <= 32) begin
+        data = $urandom();
+      end else begin
+        `DV_CHECK_STD_RANDOMIZE_FATAL(data, "Randomization of data failed", $sformatf("%m"))
+      end
+      return data;
+    endfunction
 
-  rand_delay_mode_e prim_cdc_rand_delay_mode;
-  int unsigned prim_cdc_rand_delay_interval = 10;
-  int unsigned prim_cdc_rand_delay_disable_weight  = 1;
-  int unsigned prim_cdc_rand_delay_slow_weight     = 2;
-  int unsigned prim_cdc_rand_delay_once_weight     = 4;
-  int unsigned prim_cdc_rand_delay_interval_weight = 3;
-  bit [3:0] mode;  // onehot encoded version of prim_cdc_rand_delay_mode.
-
-  int unsigned prim_cdc_jitter_ps = JitterPs;
-  int unsigned prim_cdc_latency_ps = LatencyPs;
-
-  logic [DataWidth-1:0] out_data_mask;
-  logic [DataWidth-1:0] src_data_with_latency;
-  logic [DataWidth-1:0] src_data_delayed;
-
-  function automatic void set_prim_cdc_rand_delay_mode(int val);
-    prim_cdc_rand_delay_mode = rand_delay_mode_e'(val);
-    update_settings();
-  endfunction
-
-  function automatic void set_prim_cdc_rand_delay_interval(int unsigned val);
-    prim_cdc_rand_delay_interval = val;
-  endfunction
-
-  function automatic void set_prim_cdc_jitter_ps(int val);
-    `ASSERT_I(LegalJitter_A, prim_cdc_jitter_ps >= 0)
-    prim_cdc_jitter_ps = val;
-  endfunction
-
-  function automatic void set_prim_cdc_latency_ps(int val);
-    `ASSERT_I(LegalLatencyPs_A, val >= 0)
-    prim_cdc_latency_ps = val;
-  endfunction
-
-  // Internal method called after prim_cdc_rand_delay_mode is set.
-  function automatic void update_settings();
-    mode = '0;
-    mode[prim_cdc_rand_delay_mode] = 1'b1;
-    if (prim_cdc_rand_delay_mode == RandDelayModeSlow) out_data_mask = '1;
-    if (prim_cdc_rand_delay_mode == RandDelayModeOnce) fast_randomize(out_data_mask);
-  endfunction
-
-  // A slightly more performant version of std::randomize(), using $urandom.
-  //
-  // Empirically, using std::randomize() has been found to be slower than $urandom, since the latter
-  // operates on a fixed data width of 32-bits. There may be an incredibly large number of instances
-  // of this module in the DUT, causing this preformance hit to be noticeable. This method
-  // randomizes the data piece-wise, 32-bits at a time using $urandom instead.
-  function automatic void fast_randomize(output logic [DataWidth-1:0] data);
-    for (int i = 0; i < DataWidth; i += 32) data = (data << 32) | $urandom();
-  endfunction
-
-  // Retrieves settings via plusargs.
-  //
-  // prefix is a string prefix to retrieve the plusarg.
-  // Returns 1 if prim_cdc_rand_delay_mode was set, else 0.
-  function automatic bit get_plusargs(string prefix = "");
-    string mode = "";
-    int unsigned val;
-    if (prefix != "") prefix = {prefix, "."};
-    void'($value$plusargs({prefix, "prim_cdc_rand_delay_mode=%0s"}, mode));
-    `ASSERT_I(ValidMode_A, mode inside {"", "disable", "slow", "once", "interval"})
-    void'($value$plusargs({prefix, "prim_cdc_rand_delay_interval=%0d"},
-                          prim_cdc_rand_delay_interval));
-    void'($value$plusargs({prefix, "prim_cdc_rand_delay_disable_weight=%0d"},
-                          prim_cdc_rand_delay_disable_weight));
-    void'($value$plusargs({prefix, "prim_cdc_rand_delay_slow_weight=%0d"},
-                          prim_cdc_rand_delay_slow_weight));
-    void'($value$plusargs({prefix, "prim_cdc_rand_delay_once_weight=%0d"},
-                          prim_cdc_rand_delay_once_weight));
-    void'($value$plusargs({prefix, "prim_cdc_rand_delay_interval_weight=%0d"},
-                          prim_cdc_rand_delay_interval_weight));
-    void'($value$plusargs({prefix, "prim_cdc_jitter_ps=%0d"}, prim_cdc_jitter_ps));
-    void'($value$plusargs({prefix, "prim_cdc_latency_ps=%0d"}, prim_cdc_latency_ps));
-
-    case (mode)
-      "disable":  prim_cdc_rand_delay_mode = RandDelayModeDisable;
-      "slow":     prim_cdc_rand_delay_mode = RandDelayModeSlow;
-      "once":     prim_cdc_rand_delay_mode = RandDelayModeOnce;
-      "interval": prim_cdc_rand_delay_mode = RandDelayModeInterval;
-      default:    return 0;
-    endcase
-    return 1;
-  endfunction
-
-  initial begin
-    bit res;
-
-    // Command-line override via plusargs (global, applies to ALL instances).
-    // Example: +prim_cdc_rand_delay_mode=once
-    res = get_plusargs();
-
-    // Command-line override via plusargs (instance-specific).
-    // Example: +tb.dut.u_foo.u_bar.u_flop_2sync.u_prim_cdc_rand_delay.prim_cdc_latency_ps=200
-    res |= get_plusargs($sformatf("%m"));
-
-    if (!res) begin
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(prim_cdc_rand_delay_mode,
-        prim_cdc_rand_delay_mode dist {
-          RandDelayModeDisable   :/ prim_cdc_rand_delay_disable_weight,
-          RandDelayModeSlow      :/ prim_cdc_rand_delay_slow_weight,
-          RandDelayModeOnce      :/ prim_cdc_rand_delay_once_weight,
-          RandDelayModeInterval  :/ prim_cdc_rand_delay_interval_weight
-        };,
-      , $sformatf("%m"))
+    initial begin
+      void'($value$plusargs("cdc_instrumentation_enabled=%d", cdc_instrumentation_enabled));
+      data_sel = '0;
     end
-    update_settings();
+
+    // Set data_sel at random combinationally when the input changes.
+    always @(src_data_i) begin
+      data_sel = cdc_instrumentation_enabled ? fast_randomize() : 0;
+    end
+
+    // Clear data_del on any cycle start.
+    always @(posedge clk_i or negedge rst_ni) begin
+      data_sel <= 0;
+    end
+
+    always_comb dst_data_o = (prev_data_i & data_sel) | (src_data_i & ~data_sel);
+  end else begin : gen_no_enable
+    assign dst_data_o = src_data_i;
   end
-
-  // TODO: Run some performance experiments using this implementation versus an implementation that
-  // primarily uses `forever` blocks rather than RTL constructs. Need to also check if this
-  // alternate implementation is still valid when compiling/simulating the design.
-  if (UseSourceClock) begin : gen_use_source_clock
-
-    // If relying on src_clk, insert a delay on the faster clock.
-    always_ff @(posedge src_clk or posedge dst_clk) begin
-      src_data_delayed <= src_data;
-    end
-    assign src_data_with_latency = src_data;
-
-  end else begin : gen_no_use_source_clock
-
-    // If not relying on src_clk, delay by a fixed number of ps determined by the module parameters.
-    always @(src_data) begin
-      src_data_with_latency <= #(prim_cdc_latency_ps * 1ps) src_data;
-    end
-    always @(src_data_with_latency) begin
-      src_data_delayed <= #(prim_cdc_jitter_ps * 1ps) src_data_with_latency;
-    end
-
-  end : gen_no_use_source_clock
-
-  // Randomize delayed random data selection when input data changes, every
-  // prim_cdc_rand_delay_interval number of changes.
-  int counter = 0;
-  always @(src_data_with_latency) begin
-    if (mode[RandDelayModeInterval]) begin
-      counter <= (counter >= prim_cdc_rand_delay_interval) ? '0 : counter + 1;
-      if (counter == prim_cdc_rand_delay_interval) fast_randomize(out_data_mask);
-    end else begin
-      counter <= 0;
-    end
-  end
-
-  assign dst_data = mode[RandDelayModeDisable] ? src_data :
-                    ((src_data_delayed & out_data_mask) | (src_data_with_latency & ~out_data_mask));
-
-`else
-
-  // Direct pass through.
-  assign dst_data = src_data;
-
-`endif  // DISABLE_PRIM_CDC_RAND_DELAY
-
-`else
-
-  // Direct pass through.
-  assign dst_data = src_data;
-
+`else  // SIMULATION
+    assign dst_data_o = src_data_i;
 `endif  // SIMULATION
-
-  //TODO: coverage
-
 endmodule

--- a/hw/ip/prim/rtl/prim_flop_2sync.sv
+++ b/hw/ip/prim/rtl/prim_flop_2sync.sv
@@ -9,8 +9,7 @@
 module prim_flop_2sync #(
   parameter int               Width      = 16,
   parameter logic [Width-1:0] ResetValue = '0,
-  parameter int               CdcLatencyPs = 1000,
-  parameter int               CdcJitterPs = 1000
+  parameter bit               EnablePrimCdcRand = 1
 ) (
   input                    clk_i,
   input                    rst_ni,
@@ -19,20 +18,23 @@ module prim_flop_2sync #(
 );
 
   logic [Width-1:0] d_o;
+  logic [Width-1:0] intq;
+
+`ifdef SIMULATION
 
   prim_cdc_rand_delay #(
     .DataWidth(Width),
-    .UseSourceClock(0),
-    .LatencyPs(CdcLatencyPs),
-    .JitterPs(CdcJitterPs)
+    .Enable(EnablePrimCdcRand)
   ) u_prim_cdc_rand_delay (
-    .src_clk(),
-    .src_data(d_i),
-    .dst_clk(clk_i),
-    .dst_data(d_o)
+    .clk_i,
+    .rst_ni,
+    .src_data_i(d_i),
+    .prev_data_i(intq),
+    .dst_data_o(d_o)
   );
-
-  logic [Width-1:0] intq;
+`else // !`ifdef SIMULATION
+   always_comb d_o = d_i;
+`endif // !`ifdef SIMULATION
 
   prim_flop #(
     .Width(Width),

--- a/hw/ip/prim/rtl/prim_lc_sync.sv
+++ b/hw/ip/prim/rtl/prim_lc_sync.sv
@@ -67,7 +67,9 @@ module prim_lc_sync #(
       always_ff @(posedge clk_i) begin
         lc_en_in_sva_q <= lc_en_i;
       end
-    `ASSERT(OutputDelay_A, rst_ni |-> ##2 lc_en_o == {NumCopies{$past(lc_en_in_sva_q, 1)}})
+    `ASSERT(OutputDelay_A,
+            rst_ni |-> ##3 lc_en_o == {NumCopies{$past(lc_en_in_sva_q, 2)}} ||
+                           ($past(lc_en_in_sva_q, 2) != $past(lc_en_in_sva_q, 1)))
 `endif
   end else begin : gen_no_flops
     //VCS coverage off

--- a/hw/ip/prim/rtl/prim_mubi12_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi12_sync.sv
@@ -122,8 +122,8 @@ module prim_mubi12_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
-      `ASSERT(OutputDelay_A, rst_ni |-> ##3 sig_unstable ||
-                                            mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+      `ASSERT(OutputDelay_A,
+              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -132,7 +132,9 @@ module prim_mubi12_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A, rst_ni |-> ##2 mubi_o == {NumCopies{$past(mubi_in_sva_q, 1)}})
+      `ASSERT(OutputDelay_A,
+              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi16_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi16_sync.sv
@@ -122,8 +122,8 @@ module prim_mubi16_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
-      `ASSERT(OutputDelay_A, rst_ni |-> ##3 sig_unstable ||
-                                            mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+      `ASSERT(OutputDelay_A,
+              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -132,7 +132,9 @@ module prim_mubi16_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A, rst_ni |-> ##2 mubi_o == {NumCopies{$past(mubi_in_sva_q, 1)}})
+      `ASSERT(OutputDelay_A,
+              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi4_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi4_sync.sv
@@ -122,8 +122,8 @@ module prim_mubi4_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
-      `ASSERT(OutputDelay_A, rst_ni |-> ##3 sig_unstable ||
-                                            mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+      `ASSERT(OutputDelay_A,
+              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -132,7 +132,9 @@ module prim_mubi4_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A, rst_ni |-> ##2 mubi_o == {NumCopies{$past(mubi_in_sva_q, 1)}})
+      `ASSERT(OutputDelay_A,
+              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi8_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi8_sync.sv
@@ -122,8 +122,8 @@ module prim_mubi8_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
-      `ASSERT(OutputDelay_A, rst_ni |-> ##3 sig_unstable ||
-                                            mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+      `ASSERT(OutputDelay_A,
+              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -132,7 +132,9 @@ module prim_mubi8_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A, rst_ni |-> ##2 mubi_o == {NumCopies{$past(mubi_in_sva_q, 1)}})
+      `ASSERT(OutputDelay_A,
+              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_rst_sync.sv
+++ b/hw/ip/prim/rtl/prim_rst_sync.sv
@@ -13,11 +13,7 @@ module prim_rst_sync #(
 
   // In certain case, Scan may be inserted at the following reset chain.
   // Set SkipScan to 1'b 1 in that case.
-  parameter bit SkipScan   = 1'b 0,
-
-  // CDC parameters
-  parameter int CdcLatencyPs = 1000,
-  parameter int CdcJitterPs  = 1000
+  parameter bit SkipScan   = 1'b 0
 ) (
   input        clk_i,
   input        d_i, // raw reset (not synched to clk_i)
@@ -42,9 +38,7 @@ module prim_rst_sync #(
 
   prim_flop_2sync #(
     .Width        (1),
-    .ResetValue   (ActiveHigh),
-    .CdcLatencyPs (CdcLatencyPs),
-    .CdcJitterPs  (CdcJitterPs)
+    .ResetValue   (ActiveHigh)
   ) u_sync (
     .clk_i,
     .rst_ni (async_rst_n),

--- a/util/design/data/prim_mubi_sync.sv.tpl
+++ b/util/design/data/prim_mubi_sync.sv.tpl
@@ -122,8 +122,8 @@ module prim_mubi${n_bits}_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
-      `ASSERT(OutputDelay_A, rst_ni |-> ##3 sig_unstable ||
-                                            mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+      `ASSERT(OutputDelay_A,
+              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -132,7 +132,9 @@ module prim_mubi${n_bits}_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A, rst_ni |-> ##2 mubi_o == {NumCopies{$past(mubi_in_sva_q, 1)}})
+      `ASSERT(OutputDelay_A,
+              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
 `endif
     end
   end else begin : gen_no_flops


### PR DESCRIPTION
This changes the DCD instrumentation to be cycle-based, randomly adding an
extra cycle in the inputs to the first flop in prim_flop_2sync, replacing
the time-delay instrumentation.

Fixes #15768

Signed-off-by: Guillermo Maturana <maturana@google.com>