### PR TITLE
[dv/edn] regwen test

### DIFF
--- a/hw/ip/edn/data/edn_sec_cm_testplan.hjson
+++ b/hw/ip/edn/data/edn_sec_cm_testplan.hjson
@@ -27,7 +27,7 @@
       name: sec_cm_config_regwen
       desc: "Verify the countermeasure(s) CONFIG.REGWEN."
       stage: V2S
-      tests: []
+      tests: ["edn_regwen"]
     }
     {
       name: sec_cm_config_mubi

--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -60,6 +60,13 @@
     }
 
     {
+      name: edn_regwen
+      uvm_test: edn_smoke_test
+      uvm_test_seq: edn_regwen_vseq
+      reseed: 10
+    }
+
+    {
       name: edn_genbits
       uvm_test: edn_genbits_test
       uvm_test_seq: edn_genbits_vseq

--- a/hw/ip/edn/dv/env/edn_env.core
+++ b/hw/ip/edn/dv/env/edn_env.core
@@ -23,6 +23,7 @@ filesets:
       - seq_lib/edn_base_vseq.sv: {is_include_file: true}
       - seq_lib/edn_common_vseq.sv: {is_include_file: true}
       - seq_lib/edn_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/edn_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/edn_genbits_vseq.sv: {is_include_file: true}
       - seq_lib/edn_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/edn_intr_vseq.sv: {is_include_file: true}

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -19,7 +19,12 @@ class edn_base_vseq extends cip_base_vseq #(
   bit [18:0]                                    glen;
   bit [csrng_pkg::CSRNG_CMD_WIDTH - 1:0]        cmd_data;
 
+  rand bit                                      set_regwen;
   virtual edn_cov_if                            cov_vif;
+
+  constraint regwen_c {
+    set_regwen == 0;
+  }
 
   virtual task body();
     cov_vif.cg_cfg_sample(.cfg(cfg));
@@ -100,6 +105,12 @@ class edn_base_vseq extends cip_base_vseq #(
         `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
         wr_cmd(.cmd_type("generate"), .cmd_data(cmd_data));
       end
+    end
+
+    // If set_regwen is set, write random value to the EDN, and expect the write won't be taken.
+    if (set_regwen) begin
+      csr_wr(.ptr(ral.regwen), .value(0));
+      csr_wr(.ptr(ral.ctrl), .value($urandom));
     end
   endtask
 

--- a/hw/ip/edn/dv/env/seq_lib/edn_regwen_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_regwen_vseq.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: add CSR supports in scb so we can apply randomize `set_regwen` in any test.
+// Currently this randomization will fail in stress_all tests.
+class edn_regwen_vseq extends edn_smoke_vseq;
+  `uvm_object_utils(edn_regwen_vseq)
+
+  `uvm_object_new
+
+  constraint regwen_c {
+    set_regwen == 1;
+  }
+
+endclass

--- a/hw/ip/edn/dv/env/seq_lib/edn_vseq_list.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_vseq_list.sv
@@ -5,6 +5,7 @@
 `include "edn_base_vseq.sv"
 `include "edn_common_vseq.sv"
 `include "edn_smoke_vseq.sv"
+`include "edn_regwen_vseq.sv"
 `include "edn_genbits_vseq.sv"
 `include "edn_stress_all_vseq.sv"
 `include "edn_intr_vseq.sv"


### PR DESCRIPTION
This PR adds a regwen test to randomize ctrl register value after the regwen is locked.
This test will ensure that ctrl register cannot be written anymore after regwen is set.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>