### PR TITLE
[bazel] Build verilated model with -j 4 by default

### DIFF
--- a/ci/scripts/build-chip-verilator.sh
+++ b/ci/scripts/build-chip-verilator.sh
@@ -22,6 +22,7 @@ case "$tl" in
         fusesoc_core=lowrisc:dv:chip_verilator_sim
         vname=Vchip_sim_tb
         verilator_options="--threads 4"
+        make_options="-j 4"
         ;;
     englishbreakfast)
         fileset=fileset_topgen
@@ -29,7 +30,7 @@ case "$tl" in
         vname=Vchip_englishbreakfast_verilator
         # Englishbreakfast on CI runs on a 2-core CPU
         verilator_options="--threads 2"
-
+        make_options="-j 2"
         util/topgen-fusesoc.py --files-root=. --topname=top_englishbreakfast
         ;;
     *)
@@ -51,7 +52,8 @@ fusesoc --cores-root=. \
   run --flag=$fileset --target=sim --setup --build \
   --build-root="$OBJ_DIR/hw" \
   $fusesoc_core \
-  --verilator_options="${verilator_options}"
+  --verilator_options="${verilator_options}" \
+  --make_options="${make_options}"
 
 cp "$OBJ_DIR/hw/sim-verilator/${vname}" \
    "$BIN_DIR/hw/top_${tl}/Vchip_${tl}_verilator"

--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -15,6 +15,7 @@ ci/bazelisk.sh test \
     --test_tag_filters=verilator,-broken \
     --test_output=errors \
     --//hw:verilator_options=--threads,1 \
+    --//hw:make_options=-j,1 \
     //sw/device/tests:aes_smoketest_sim_verilator \
     //sw/device/tests:uart_smoketest_sim_verilator \
     //sw/device/tests:crt_test_sim_verilator \

--- a/hw/BUILD
+++ b/hw/BUILD
@@ -7,9 +7,8 @@ load("//rules:fusesoc.bzl", "fusesoc_build")
 
 # This configuration exposes fusesoc's "verilator_options" option to the
 # command line. This is intended to allow CI to specifically build a single
-# -threaded Verilator model since the build environment there is more resource
-# -constrained.
-# By default and in all other cases, the Verilator model should be built to
+# -threaded Verilated model to suit it's resource constraints.
+# By default, the Verilated model should be built to
 # run with 4 threads.
 load("@bazel_skylib//rules:common_settings.bzl", "string_list_flag")
 
@@ -17,6 +16,18 @@ string_list_flag(
     name = "verilator_options",
     build_setting_default = [
         "--threads",
+        "4",
+    ],
+)
+
+# This configuration exposes fusesoc's "make_options" to enable parallel
+# compilation of the verilated model. Compilation takes about 30m of cpu time
+# and 5m of time that isn't parallelized by this option, so this should reduce
+# the total runtime to ~12m.
+string_list_flag(
+    name = "make_options",
+    build_setting_default = [
+        "-j",
         "4",
     ],
 )
@@ -30,6 +41,7 @@ fusesoc_build(
         "//:cores",
     ],
     data = ["//hw/ip/otbn:all_files"],
+    make_options = ":make_options",
     output_groups = {
         "binary": ["sim-verilator/Vchip_sim_tb"],
     },
@@ -49,7 +61,7 @@ filegroup(
 )
 
 # This is used in CI steps that do not want to run Verilator tests, and thus
-# do not want to build the Verilator model. This causes the //hw:verilator
+# do not want to build the Verilated model. This causes the //hw:verilator
 # target to not emit any files, which will break any tests that rely on this;
 # builds will succeed, tests will fail.
 config_setting(

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -31,6 +31,7 @@ def _fusesoc_build_impl(ctx):
     outputs = [out_dir]
     groups = {}
     args = ctx.actions.args()
+
     for group, files in ctx.attr.output_groups.items():
         deps = [ctx.actions.declare_file("{}/{}".format(dirname, f)) for f in files]
         outputs.extend(deps)
@@ -39,6 +40,10 @@ def _fusesoc_build_impl(ctx):
     if ctx.attr.verilator_options:
         verilator_options = ctx.attr.verilator_options[BuildSettingInfo].value
         flags.append("--verilator_options={}".format(" ".join(verilator_options)))
+
+    if ctx.attr.make_options:
+        make_options = ctx.attr.make_options[BuildSettingInfo].value
+        flags.append("--make_options={}".format(" ".join(make_options)))
 
     args.add_all(
         ctx.files.cores,
@@ -97,5 +102,6 @@ fusesoc_build = rule(
             doc = "Mapping of group name to lists of files in that named group",
         ),
         "verilator_options": attr.label(),
+        "make_options": attr.label(),
     },
 )


### PR DESCRIPTION
CI should still be constrained where it's run on smaller VMs

Signed-off-by: Drew Macrae <drewmacrae@google.com>

Fixes #15865