### PR TITLE
[i2c,dv] Refactoring host mode tb

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -106,7 +106,7 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
         rd_data_cnt++;
       end
       WrData: begin
-        // nothing to do here at the moment
+        // nothing to do
       end
       default: begin
         `uvm_fatal(`gfn, $sformatf("\n  device_driver, received invalid request"))
@@ -129,7 +129,7 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
   endtask : process_reset
 
   virtual task release_bus();
-    `uvm_info(`gfn, "Driver released the bus", UVM_MEDIUM)
+    `uvm_info(`gfn, "Driver released the bus", UVM_HIGH)
     cfg.vif.scl_o = 1'b1;
     cfg.vif.sda_o = 1'b1;
   endtask : release_bus

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -157,11 +157,11 @@ interface i2c_if(
                                  input bit bit_i);
     sda_o = 1'b1;
     wait_for_dly(tc.tClockLow);
-    `uvm_info(msg_id, "device_send_bit::Drive bit", UVM_MEDIUM)
+    `uvm_info(msg_id, "device_send_bit::Drive bit", UVM_HIGH)
     sda_o = bit_i;
     wait_for_dly(tc.tSetupBit);
     @(posedge scl_i);
-    `uvm_info(msg_id, "device_send_bit::Value sampled ", UVM_MEDIUM)
+    `uvm_info(msg_id, "device_send_bit::Value sampled ", UVM_HIGH)
     // flip sda_target2host during the clock pulse of scl_host2target causes sda_unstable irq
     sda_o = ~sda_o;
     wait_for_dly(tc.tSdaUnstable);

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -39,7 +39,8 @@ class i2c_monitor extends dv_base_monitor #(
         begin: iso_fork
           fork
             begin
-              collect_thread(phase);
+              if (cfg.if_mode == Device) collect_device_item(phase);
+              else collect_host_item(phase);
             end
             begin // if (on-the-fly) reset is monitored, drop the item
               wait_for_reset_and_drop_item();
@@ -53,8 +54,13 @@ class i2c_monitor extends dv_base_monitor #(
     end
   endtask : run_phase
 
-  // collect transactions forever
-  virtual protected task collect_thread(uvm_phase phase);
+  // collect transactions for 'target mode' dut.
+  virtual protected task collect_host_item(uvm_phase phase);
+    //TBD
+  endtask
+
+  // collect transactions for 'host mode' dut.
+  virtual protected task collect_device_item(uvm_phase phase);
     i2c_item full_item;
     wait(cfg.en_monitor);
     if (mon_dut_item.stop ||
@@ -81,7 +87,7 @@ class i2c_monitor extends dv_base_monitor #(
           full_item.sprint()), UVM_DEBUG)
     end
     mon_dut_item.clear_data();
-  endtask: collect_thread
+  endtask: collect_device_item
 
   virtual protected task address_thread();
     i2c_item clone_item;
@@ -91,19 +97,19 @@ class i2c_monitor extends dv_base_monitor #(
     mon_dut_item.tran_id = num_dut_tran;
     for (int i = cfg.target_addr_mode - 1; i >= 0; i--) begin
       cfg.vif.get_bit_data("host", cfg.timing_cfg, mon_dut_item.addr[i]);
-      `uvm_info(`gfn, $sformatf("\nmonitor, address[%0d] %b", i, mon_dut_item.addr[i]), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("\nmonitor, address[%0d] %b", i, mon_dut_item.addr[i]), UVM_MEDIUM)
     end
-    `uvm_info(`gfn, $sformatf("\nmonitor, address %0x", mon_dut_item.addr), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("\nmonitor, address %0x", mon_dut_item.addr), UVM_MEDIUM)
     cfg.vif.get_bit_data("host", cfg.timing_cfg, rw_req);
-    `uvm_info(`gfn, $sformatf("\nmonitor, rw %d", rw_req), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("\nmonitor, rw %d", rw_req), UVM_MEDIUM)
     mon_dut_item.bus_op = (rw_req) ? BusOpRead : BusOpWrite;
     // get ack after transmitting address
     mon_dut_item.drv_type = DevAck;
     `downcast(clone_item, mon_dut_item.clone());
-    `uvm_info(`gfn, $sformatf("Req analysis port: address thread"), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("Req analysis port: address thread"), UVM_MEDIUM)
     req_analysis_port.write(clone_item);
     cfg.vif.wait_for_device_ack(cfg.timing_cfg);
-    `uvm_info(`gfn, "\nmonitor, address, detect TARGET ACK", UVM_HIGH)
+    `uvm_info(`gfn, "\nmonitor, address, detect TARGET ACK", UVM_MEDIUM)
   endtask : address_thread
 
   virtual protected task read_thread();

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
@@ -34,25 +34,16 @@ class i2c_base_seq extends dv_base_seq #(
   virtual task send_device_mode_txn();
     // get seq for agent running in Device mode
     bit [7:0] rdata;
-    fork
-      forever begin
-        p_sequencer.req_analysis_fifo.get(req);
-        req_q.push_back(req);
+    forever begin
+      p_sequencer.req_analysis_fifo.get(req);
+      // if it's a read type response, randomize the return data
+      if (req.drv_type == RdData) begin
+        `DV_CHECK_STD_RANDOMIZE_FATAL(rdata)
+        req.rdata = rdata;
       end
-      forever begin
-        wait(req_q.size > 0);
-        rsp = req_q.pop_front();
-
-        // if it's a read type response, randomize the return data
-        if (rsp.drv_type == RdData) begin
-           `DV_CHECK_STD_RANDOMIZE_FATAL(rdata)
-           rsp.rdata = rdata;
-        end
-
-        start_item(rsp);
-        finish_item(rsp);
-      end
-    join
+      start_item(req);
+      finish_item(req);
+    end
   endtask
 
   virtual task send_host_mode_txn();

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -14,6 +14,8 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   i2c_seq_cfg seq_cfg;
   bit [7:0]  lastbyte;
 
+  tran_type_e trans_type = ReadWrite;
+
   `uvm_object_utils_begin(i2c_env_cfg)
     `uvm_field_object(m_i2c_agent_cfg, UVM_DEFAULT)
   `uvm_object_utils_end

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -26,7 +26,7 @@ class i2c_base_vseq extends cip_base_vseq #(
   rand uint                   num_wr_bytes;
   rand uint                   num_rd_bytes;
   rand uint                   num_data_ovf;
-  rand bit                    rw_bit;
+  rand bit                    rw_bit; // 0 write, 1 read
   rand bit   [7:0]            wr_data[$];
   rand bit   [9:0]            addr;  // support both 7-bit and 10-bit target address
   rand bit   [6:0]            target_addr0;  // Target Address 0
@@ -173,6 +173,10 @@ class i2c_base_vseq extends cip_base_vseq #(
     }
   }
 
+  constraint rw_bit_c {
+    (cfg.trans_type == ReadOnly) -> rw_bit == 1;
+    (cfg.trans_type == WriteOnly) -> rw_bit == 0;
+  }
   `uvm_object_new
 
   virtual task pre_start();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_fmt_empty_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_fmt_empty_vseq.sv
@@ -26,12 +26,13 @@ class i2c_host_fifo_fmt_empty_vseq extends i2c_rx_tx_vseq;
       end
       begin
         for (uint i = 1; i <= num_trans; i++) begin
-        do_interrupt = 1'b1;
-        host_send_trans(1,WriteOnly,0,1);
-        do_interrupt = 1'b0; // gracefully stop process_interrupts
-        csr_rd_check(.ptr(ral.status.fmtempty), .compare_value(1));
-        `DV_CHECK_EQ(cfg.lastbyte, 8'hee)
-        cfg.lastbyte = 8'h00;
+          do_interrupt = 1'b1;
+          cfg.trans_type = WriteOnly;
+          host_send_trans(.read(0), .stopbyte(1));
+          do_interrupt = 1'b0; // gracefully stop process_interrupts
+          csr_rd_check(.ptr(ral.status.fmtempty), .compare_value(1));
+          `DV_CHECK_EQ(cfg.lastbyte, 8'hee)
+          cfg.lastbyte = 8'h00;
         end
       end
     join

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_overflow_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_overflow_vseq.sv
@@ -56,7 +56,8 @@ class i2c_host_fifo_overflow_vseq extends i2c_rx_tx_vseq;
           // -> verify the number of received fmt_watermark interrupt
           // -> verify fmt_data dropped is performed scoreboard
           if (check_fmt_overflow) begin
-            host_send_trans(1, WriteOnly);
+            cfg.trans_type = WriteOnly;
+            host_send_trans();
             check_fmt_overflow = 1'b0;
             // number of fmt_overflow received is at most num_data_ovf
             // since fmt_fifo can be drained thus decreasing cnt_fmt_overflow counter
@@ -73,7 +74,8 @@ class i2c_host_fifo_overflow_vseq extends i2c_rx_tx_vseq;
           // -> verify the number of received rx_overflow interrupt
           // -> verify the rx_data dropped is performed in scoreboard
           if (check_rx_overflow) begin
-            host_send_trans(1, ReadOnly);
+            cfg.trans_type = ReadOnly;
+            host_send_trans();
             check_rx_overflow = 1'b0;
             if (!cfg.under_reset) begin
               `DV_CHECK_EQ(cnt_rx_overflow, 1)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_reset_rx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_reset_rx_vseq.sv
@@ -43,7 +43,7 @@ class i2c_host_fifo_reset_rx_vseq extends i2c_rx_tx_vseq;
         while (!cfg.under_reset && check_fifo_full) process_fifo_full_status();
       end
       begin
-        host_send_trans(1, ReadWrite, read);
+        host_send_trans(.read(read));
         check_fifo_full = 1'b0; // gracefully stop process_fifo_full_status
       end
     join

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_watermark_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_watermark_vseq.sv
@@ -47,7 +47,8 @@ class i2c_host_fifo_watermark_vseq extends i2c_rx_tx_vseq;
           // -> check write complete -> stop pooling fmt_watermark interrupt
           // -> verify the number of received fmt_watermark interrupt
           if (check_fmt_watermark) begin
-            host_send_trans(1, WriteOnly);
+            cfg.trans_type = WriteOnly;
+            host_send_trans();
             check_fmt_watermark = 1'b0;  // gracefully stop process_fmt_watermark_intr
             // depending the programmed fmtivl and the DUT configuration
             // (timing regsisters), cnt_fmt_watermark could be
@@ -68,7 +69,8 @@ class i2c_host_fifo_watermark_vseq extends i2c_rx_tx_vseq;
             // first en_rx_watermark is unset to quickly fill up rx_fifo and
             // watermark interrupt is assuredly triggered
             // until rx_fifo becomes full, en_rx_watermark is set to start reading rx_fifo
-            host_send_trans(1, ReadOnly);
+            cfg.trans_type = ReadOnly;
+            host_send_trans();
             check_rx_watermark = 1'b0; // gracefully stop process_rx_watermark_intr
             // for fmtilvl > 4, rx_watermark is disabled (cnt_rx_watermark = 0)
             // otherwise, cnt_rx_watermark must be 1

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_stretch_timeout_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_stretch_timeout_vseq.sv
@@ -32,7 +32,8 @@ class i2c_host_stretch_timeout_vseq extends i2c_rx_tx_vseq;
       fork
         begin
           check_wr_stretch = 1'b1;
-          host_send_trans(1, WriteOnly);
+          cfg.trans_type = WriteOnly;
+          host_send_trans();
           check_wr_stretch = 1'b0;
           if (!cfg.under_reset) begin
             // host clock is stretched for every target's ACK thus
@@ -42,7 +43,8 @@ class i2c_host_stretch_timeout_vseq extends i2c_rx_tx_vseq;
           end
 
           check_rd_stretch = 1'b1;
-          host_send_trans(1, ReadOnly);
+          cfg.trans_type = ReadOnly;
+          host_send_trans();
           check_rd_stretch = 1'b0;
           if (!cfg.under_reset) begin
             // check_rd_stretchretch_timeout must be equal to 1

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
@@ -25,7 +25,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
     `uvm_info(`gfn, "\n--> end of sequence", UVM_DEBUG)
   endtask : body
 
-  virtual task host_send_trans(int max_trans = num_trans, tran_type_e trans_type = ReadWrite,
+  virtual task host_send_trans(int max_trans = 1,
                                bit read = 1'b1, bit stopbyte = 1'b0);
     bit last_tran, chained_read;
 
@@ -45,19 +45,9 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
           // or when the previous transaction is completed
           if (fmt_item.stop || cur_tran == 1) begin
             `DV_CHECK_RANDOMIZE_FATAL(this)
-            // if trans_type is provided, then rw_bit is overridden
-            // otherwise, rw_bit is randomized
-            rw_bit = (trans_type  == WriteOnly) ? 1'b0 :
-                     ((trans_type == ReadOnly)  ? 1'b1 : rw_bit);
             get_timing_values();
             program_registers();
           end
-
-          // if trans_type is provided, then rw_bit is overridden
-          // otherwise, rw_bit is randomized
-          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rw_bit)
-          rw_bit = (trans_type  == WriteOnly) ? 1'b0 :
-                   ((trans_type == ReadOnly)  ? 1'b1 : rw_bit);
 
           // program address for folowing transaction types
           chained_read = fmt_item.read && fmt_item.rcont;
@@ -69,7 +59,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
 
           last_tran = (cur_tran == max_trans);
           `uvm_info(`gfn, $sformatf("\n  start sending %s transaction %0d/%0d",
-              (rw_bit) ? "READ" : "WRITE", cur_tran, max_trans), UVM_DEBUG)
+              (rw_bit) ? "READ" : "WRITE", cur_tran, max_trans), UVM_MEDIUM)
           if (chained_read) begin
             // keep programming chained read transaction
             program_control_read_to_target(last_tran);
@@ -80,14 +70,14 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
 
           `uvm_info(`gfn, $sformatf("\n  finish sending %s transaction, %0s at the end, %0d/%0d, ",
               (rw_bit) ? "read" : "write",
-              (fmt_item.stop) ? "stop" : "rstart", cur_tran, max_trans), UVM_DEBUG)
+              (fmt_item.stop) ? "stop" : "rstart", cur_tran, max_trans), UVM_MEDIUM)
 
           // check a completed transaction is programmed to the host/dut (stop bit must be issued)
           // and check if the host/dut is in idle before allow re-programming the timing registers
           if (fmt_item.stop) begin
             wait_for_reprogram_registers();
           end
-        end
+        end // for (uint cur_tran = 1; cur_tran <= max_trans; cur_tran++)
         complete_program_fmt_fifo = 1'b1;
       end
       if (read) begin
@@ -107,13 +97,13 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
       rcont == 1'b0;
     )
     if (cfg.target_addr_mode == Addr7BitMode) begin
-      fmt_item.fbyte = (rw_bit) ? {addr[6:0], BusOpRead} : {addr[6:0], BusOpWrite};
+      fmt_item.fbyte = {addr[6:0], rw_bit};
     end else begin // Addr10BitMode
-      fmt_item.fbyte = (rw_bit) ? {addr[9:0], BusOpRead} : {addr[9:0], BusOpWrite};
+      fmt_item.fbyte = {addr[9:0], rw_bit};
     end
     `uvm_info(`gfn, $sformatf("\nprogram, %s address %x",
         fmt_item.fbyte[0] ? "read" : "write", fmt_item.fbyte[7:1]), UVM_DEBUG)
-    program_format_flag(fmt_item, "  program_address_to_target");
+    program_format_flag(fmt_item, "  program_address_to_target", 0);
   endtask : program_address_to_target
 
   virtual task program_control_read_to_target(bit last_tran);
@@ -145,7 +135,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
           "with STOP, next transaction should begin with START" :
           "without STOP, next transaction should begin with RSTART"), UVM_DEBUG)
     end
-    program_format_flag(fmt_item, "  program number of bytes to read");
+    program_format_flag(fmt_item, "  program number of bytes to read", 0);
   endtask : program_control_read_to_target
 
   virtual task read_data_from_target();
@@ -213,7 +203,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
             "with STOP, next transaction should begin with START" :
             "without STOP, next transaction should begin with RSTART"), UVM_DEBUG)
       end
-      program_format_flag(fmt_item, "program_write_data_to_target");
+      program_format_flag(fmt_item, "program_write_data_to_target", 0);
     end
   endtask : program_write_data_to_target
 

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -12,7 +12,7 @@
   tb: tb
 
   // Simulator used to sign off this block
-  tool: xcelium
+  tool: vcs
 
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:i2c_sim:0.1


### PR DESCRIPTION
- Change default tool to 'vcs'
- Rewrite 'host_send_trans' task to simplify randomization
- Add place holder for device mode monitor
- Remove unnecessary code from i2c_base_seq
    
Signed-off-by: Jaedon Kim <jdonjdon@google.com>

