### PR TITLE
[doc] Fix System Requirements commands

### DIFF
--- a/doc/getting_started/_index.md
+++ b/doc/getting_started/_index.md
@@ -75,7 +75,7 @@ It should show `~/.local/bin/pip3`.
 If it doesn't, add `~/.local/bin` to your `PATH`, e.g. by adding the following line to your `~/.bashrc` file:
 
 ```console {title=~/.bashrc}
-export PATH=$PATH:~/.local/bin
+export PATH=~/.local/bin:$PATH
 ```
 
 Now install additional Python dependencies:

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -254,7 +254,8 @@ def generate_pkg_reqs():
         cmd_lines = textwrap.wrap(cmd,
                                   width=78,
                                   replace_whitespace=True,
-                                  subsequent_indent='    ')
+                                  subsequent_indent='    ',
+                                  break_on_hyphens=False)
         # Newlines need to be escaped
         cmd = " \\\n".join(cmd_lines)
 


### PR DESCRIPTION
Fixes two small issues in commands in the Getting Started, Check System Requirements section:

1. Prevents the apt install command from breaking on hyphens, since this breaks cut and paste of the command.
2. Ensures the local bin is added to the path at the start so that it's checked first.