### PR TITLE
[aes] Update testplans

### DIFF
--- a/hw/ip/aes/data/aes_sec_cm_testplan.hjson
+++ b/hw/ip/aes/data/aes_sec_cm_testplan.hjson
@@ -31,7 +31,10 @@
     }
     {
       name: sec_cm_lc_escalate_en_intersig_mubi
-      desc: "Verify the countermeasure(s) LC_ESCALATE_EN.INTERSIG.MUBI."
+      desc: '''
+            Verify the countermeasure(s) LC_ESCALATE_EN.INTERSIG.MUBI.
+            Upon randomly switching the life cycle escalation input signal, it is ensured that the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
       stage: V2S
       tests: ["aes_alert_reset"]
     }
@@ -43,9 +46,13 @@
     }
     {
       name: sec_cm_main_config_sparse
-      desc: "Verify the countermeasure(s) MAIN.CONFIG.SPARSE."
+      desc: '''
+            Verify the countermeasure(s) MAIN.CONFIG.SPARSE.
+            Illegally encoded values are written into the main control register via register interface and it is ensured that the values are resolved to the correct legal values.
+            Internal wires carrying the corresponding signals are forced to invalid values and it is ensured that the DUT stops processing data and signals an alert.
+            '''
       stage: V2S
-        tests: ["aes_stress", "aes_smoke"]
+      tests: ["aes_stress", "aes_smoke", "aes_alert_reset"]
     }
     {
       name: sec_cm_aux_config_shadow
@@ -55,7 +62,10 @@
     }
     {
       name: sec_cm_aux_config_regwen
-      desc: "Verify the countermeasure(s) AUX.CONFIG.REGWEN."
+      desc: '''
+            Verify the countermeasure(s) AUX.CONFIG.REGWEN.
+            It is ensured that once the REGWEN bit is set to 0, the content of the CTRL_AUX_SHADOWED register cannot be altered anymore until reset.
+            '''
       stage: V2S
         tests: ["aes_stress", "aes_readability"]
     }
@@ -63,35 +73,50 @@
       name: sec_cm_key_sideload
       desc: "Verify the countermeasure(s) KEY.SIDELOAD."
       stage: V2S
-      tests: ["aes_stress","aes_sideload"]
+      tests: ["aes_stress", "aes_sideload"]
     }
     {
       name: sec_cm_key_sw_unreadable
-      desc: "Verify the countermeasure(s) KEY.SW_UNREADABLE."
+      desc: '''
+            Verify the countermeasure(s) KEY.SW_UNREADABLE.
+            It is ensured that the initial key registers cannot be read via register interface.
+            '''
       stage: V2S
       tests: ["aes_readability"]
     }
     {
       name: sec_cm_data_reg_sw_unreadable
-      desc: "Verify the countermeasure(s) DATA_REG.SW_UNREADABLE."
+      desc: '''
+            Verify the countermeasure(s) DATA_REG.SW_UNREADABLE.
+            It is ensured that the input data registers cannot be read via register interface.
+            '''
       stage: V2S
       tests: ["aes_readability"]
     }
     {
       name: sec_cm_key_sec_wipe
-      desc: "Verify the countermeasure(s) KEY.SEC_WIPE."
+      desc: '''
+            Verify the countermeasure(s) KEY.SEC_WIPE.
+            It is ensured that after triggering the clearing of the initial key registers with pseudo-random data, the content of these registers indeed changes to a different value.
+            '''
       stage: V2S
       tests: ["aes_readability"]
     }
     {
       name: sec_cm_iv_config_sec_wipe
-      desc: "Verify the countermeasure(s) IV.CONFIG.SEC_WIPE."
+      desc: '''
+            Verify the countermeasure(s) IV.CONFIG.SEC_WIPE.
+            It is ensured that after triggering the clearing of the IV registers with pseudo-random data, the values read back from these registers via register interface indeed change.
+            '''
       stage: V2S
       tests: ["aes_readability"]
     }
     {
       name: sec_cm_data_reg_sec_wipe
-      desc: "Verify the countermeasure(s) DATA_REG.SEC_WIPE."
+      desc: '''
+            Verify the countermeasure(s) DATA_REG.SEC_WIPE.
+            It is ensured that after triggering the clearing of the input and output data registers with pseudo-random data, the values read back from output data registers via register interface indeed change and that the content of the input data registers changes to a different value.
+            '''
       stage: V2S
       tests: ["aes_readability"]
     }
@@ -117,75 +142,111 @@
     }
     {
       name: sec_cm_main_fsm_sparse
-      desc: "Verify the countermeasure(s) MAIN.FSM.SPARSE."
+      desc: '''
+            Verify the countermeasure(s) MAIN.FSM.SPARSE.
+            It is ensured that upon randomly forcing bits in the state register of the main FSM, the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
       stage: V2S
-        tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
+        tests: ["aes_fi"]
     }
     {
       name: sec_cm_main_fsm_redun
-      desc: "Verify the countermeasure(s) MAIN.FSM.REDUN."
+      desc: '''
+            Verify the countermeasure(s) MAIN.FSM.REDUN.
+            It is ensured that upon randomly forcing the state, inputs or outputs of any of the independent, redundant logic rails of the main FSM to both valid and invalid encodings, the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
       stage: V2S
-      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
+      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi", "aes_ctr_fi"]
     }
     {
       name: sec_cm_cipher_fsm_sparse
-      desc: "Verify the countermeasure(s) CIPHER.FSM.SPARSE."
+      desc: '''
+            Verify the countermeasure(s) CIPHER.FSM.SPARSE.
+            It is ensured that upon randomly forcing bits in the state register of the cipher core FSM, the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
       stage: V2S
-      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
+      tests: ["aes_fi"]
     }
     {
       name: sec_cm_cipher_fsm_redun
-      desc: "Verify the countermeasure(s) CIPHER.FSM.REDUN."
+      desc: '''
+            Verify the countermeasure(s) CIPHER.FSM.REDUN.
+            It is ensured that upon randomly forcing the state, inputs or outputs of any of the independent, redundant logic rails of the cipher core FSM to both valid and invalid encodings, the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
       stage: V2S
       tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
     }
     {
       name: sec_cm_cipher_ctr_redun
-      desc: "Verify the countermeasure(s) CIPHER.CTR.REDUN."
+      desc: '''
+            Verify the countermeasure(s) CIPHER.CTR.REDUN.
+            It is ensured that upon randomly forcing the value of any of the independent, redundant logic rails of round counter inside the cipher core FSM, the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
       stage: V2S
       tests: ["aes_cipher_fi"]
     }
     {
       name: sec_cm_ctr_fsm_sparse
-      desc: "Verify the countermeasure(s) CTR.FSM.SPARSE."
-      stage: V2S
-      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
-    }
-    {
-      name: sec_cm_ctr_fsm_redun
-      desc: "Verify the countermeasure(s) CTR.FSM.REDUN."
-      stage: V2S
-      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
-    }
-    {
-      name: sec_cm_ctrl_sparse
-      desc: "Verify the countermeasure(s) CTRL.SPARSE."
-      stage: V2S
-      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
-    }
-    {
-      name: sec_cm_main_fsm_global_esc
-      desc: "Verify the countermeasure(s) MAIN.FSM.GLOBAL_ESC."
+      desc: '''
+            Verify the countermeasure(s) CTR.FSM.SPARSE.
+            It is ensured that upon randomly forcing bits in the state register of the CTR mode FSM, the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
       stage: V2S
       tests: ["aes_fi"]
     }
     {
-      name: sec_cm_main_fsm_local_esc
-      desc: "Verify the countermeasure(s) MAIN.FSM.LOCAL_ESC."
+      name: sec_cm_ctr_fsm_redun
+      desc: '''
+            Verify the countermeasure(s) CTR.FSM.REDUN.
+            It is ensured that upon randomly forcing the state, inputs or outputs of any of the independent, redundant logic rails of the CTR mode FSM to both valid and invalid encodings, the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
       stage: V2S
-      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
+      tests: ["aes_fi", "aes_control_fi", "aes_ctr_fi"]
+    }
+    {
+      name: sec_cm_ctrl_sparse
+      desc: '''
+            Verify the countermeasure(s) CTRL.SPARSE.
+            It is ensured that upon randomly forcing the value of any of these critical control signals to an invalid encoding, the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
+      stage: V2S
+      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi", "aes_ctr_fi"]
+    }
+    {
+      name: sec_cm_main_fsm_global_esc
+      desc: '''
+            Verify the countermeasure(s) MAIN.FSM.GLOBAL_ESC.
+            Upon randomly switching the life cycle escalation input signal, it is ensured that the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
+      stage: V2S
+      tests: ["aes_alert_reset"]
+    }
+    {
+      name: sec_cm_main_fsm_local_esc
+      desc: '''
+            Verify the countermeasure(s) MAIN.FSM.LOCAL_ESC.
+            Upon detecting a local alert condition it is ensured that the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
+      stage: V2S
+      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi", "aes_ctr_fi"]
     }
     {
       name: sec_cm_cipher_fsm_local_esc
-      desc: "Verify the countermeasure(s) CIPHER.FSM.LOCAL_ESC."
+      desc: '''
+            Verify the countermeasure(s) CIPHER.FSM.LOCAL_ESC.
+            Upon detecting a local alert condition it is ensured that the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
       stage: V2S
-      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
+      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi", "aes_ctr_fi"]
     }
     {
       name: sec_cm_ctr_fsm_local_esc
-      desc: "Verify the countermeasure(s) CTR.FSM.LOCAL_ESC."
+      desc: '''
+            Verify the countermeasure(s) CTR.FSM.LOCAL_ESC.
+            Upon detecting a local alert condition it is ensured that the DUT stops processing data, locks up and triggers a fatal alert.
+            '''
       stage: V2S
-      tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
+      tests: ["aes_fi", "aes_control_fi", "aes_ctr_fi"]
     }
     {
       name: sec_cm_data_reg_local_esc

--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -127,16 +127,16 @@
     {
       name: reseeding
       desc: '''
-            excercise the different reseeding configuations
+            excercise the different PRNG reseeding configurations
             for reseeding every 8k blocks the DUT internal block counter will be manually changed to something close to 8k.
             to provoke the reseeding within reasonable simulation time '''
       stage: V2S
-      tests: ["aes_deinit"]
+      tests: ["aes_reseed"]
     }
     {
       name:fault_inject
       desc: '''
-            Verify that injecting bit errors in one of the statemachines or the round counter triggers an error '''
+            Verify that injecting bit errors in one of the state machines or the round counter triggers an error '''
       stage: V2S
         tests: ["aes_fi", "aes_control_fi", "aes_cipher_fi"]
     }
@@ -148,7 +148,7 @@ covergroups: [
      name: key_iv_data_cg
      desc: '''
            Covers that these registers have been written in random order and interleaved and that it has triggered an operation.
-           - the indiviadual registers (KEY/IV/DATA) can be written in random order
+           - the individual registers (KEY/IV/DATA) can be written in random order
            - The writes to these registers can also be interleaved
            - Data out can be read in random order
            '''
@@ -156,7 +156,7 @@ covergroups: [
     {
      name: ctrl_reg_cg
      desc: '''
-           Covers that all valid seetings have been tested.
+           Covers that all valid settings have been tested.
            Further more it covers that also illegal values have been tested.
            Individual control settings that are covered includes:
            - operation (encode/decode/illegal)

--- a/hw/ip/aes/dv/env/seq_lib/aes_alert_reset_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_alert_reset_vseq.sv
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test that injects random resets &
-// bit errors into FSMs
+// This test randomly injects resets and alert conditions such as:
+// - invalid mode configuration values, and
+// - life cycle escalation.
 class aes_alert_reset_vseq extends aes_base_vseq;
   `uvm_object_utils(aes_alert_reset_vseq)
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_cipher_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_cipher_fi_vseq.sv
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test that injects random resets &
-// bit errors into FSMs
+// This test randomly forces critical control signals inside one of the independent, redundant
+// logic rails of the cipher core FSM. The test then checks that the DUT triggers a fatal
+// alert and cannot proceed until a reset is triggered.
 class aes_cipher_fi_vseq extends aes_base_vseq;
   `uvm_object_utils(aes_cipher_fi_vseq)
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_control_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_control_fi_vseq.sv
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test that injects random resets &
-// bit errors into FSMs
+// This test randomly forces critical control signals inside one of the independent, redundant
+// logic rails of the main control FSM. The test then checks that the DUT triggers a fatal
+// alert and cannot proceed until a reset is triggered.
 class aes_control_fi_vseq extends aes_base_vseq;
   `uvm_object_utils(aes_control_fi_vseq)
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_ctr_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_ctr_fi_vseq.sv
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test that injects random resets &
-// bit errors into FSMs
+// This test randomly forces critical control signals inside one of the independent, redundant
+// logic rails of the CTR mode FSM. The test then checks that the DUT triggers a fatal
+// alert and cannot proceed until a reset is triggered.
 class aes_ctr_fi_vseq extends aes_base_vseq;
   `uvm_object_utils(aes_ctr_fi_vseq)
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_fi_vseq.sv
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test that injects random resets &
-// bit errors into FSMs
+// This test randomly forces the state registers in any of the main FSMs, cipher core FSMs, and
+// CTR mode FSMs. Each of these FSMs is replicated three times (multi-rail control logic). The
+// FSMs themselves use sparse state encodings.
+// The test then checks that the DUT triggers a fatal alert and cannot proceed until a reset
+// is triggered.
 class aes_fi_vseq extends aes_base_vseq;
   `uvm_object_utils(aes_fi_vseq)
 
@@ -14,7 +17,7 @@ class aes_fi_vseq extends aes_base_vseq;
   bit  wait_for_alert_clear = 0;
   bit  alert = 0;
 
-  typedef enum int { fsm = 0, cipher_fsm = 1, round_cntr = 2 } fi_t;
+  typedef enum int { main_fsm = 0, cipher_fsm = 1, ctr_fsm = 2 } fi_t;
 
   localparam bit FORCE   = 0;
   localparam bit RELEASE = 1;
@@ -77,7 +80,7 @@ class aes_fi_vseq extends aes_base_vseq;
   // (target select, rel = 0 : force signal)
   task force_signal(fi_t target, bit rel, int if_num);
     case (target)
-      fsm: begin
+      main_fsm: begin
         if (!rel) cfg.aes_fi_vif[if_num].force_state(force_state);
         else cfg.aes_fi_vif[if_num].release_state();
       end
@@ -87,7 +90,7 @@ class aes_fi_vseq extends aes_base_vseq;
         else cfg.aes_cipher_fi_vif[if_num].release_state();
       end
 
-      round_cntr: begin
+      ctr_fsm: begin
         if (!rel) cfg.aes_ctr_fi_vif[if_num].force_state(force_state);
         else cfg.aes_ctr_fi_vif[if_num].release_state();
       end

--- a/hw/ip/aes/dv/env/seq_lib/aes_nist_vectors_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_nist_vectors_vseq.sv
@@ -2,11 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// basic wake up sequence in place to verify that environment is hooked up correctly.
-// static test that is running same data set every time
+// Test to encrypt/decrypt NIST test vectors.
+// The output of the DUT is compared both against the output of the golden model
+// and against the known test vector output.
 
-
-//`include "nist_vectors.sv"
 import nist_vectors_pkg::*;
 class aes_nist_vectors_vseq extends aes_base_vseq;
   `uvm_object_utils(aes_nist_vectors_vseq)

--- a/hw/ip/aes/dv/err_injection_if/fi_cipher_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_cipher_if.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// target specific signals inside the
+// target specific signals inside the cipher core FSM
 interface fi_cipher_if
   import uvm_pkg::*;
   (

--- a/hw/ip/aes/dv/err_injection_if/fi_control_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_control_if.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// target specific signals inside the
+// target specific signals inside the main control FSM
 interface fi_control_if
   import uvm_pkg::*;
   (

--- a/hw/ip/aes/dv/err_injection_if/fi_ctr_fsm_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_ctr_fsm_if.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// target specific signals inside the
+// target specific signals inside the CTR mode FSM
 interface fi_ctr_fsm_if
   import uvm_pkg::*;
   (


### PR DESCRIPTION
This PR mainly updates the AES testplans to:
- Map previously unmapped tests
- Improve test descriptions
- Explain how the countermeasures are tested by the different tests

Specifically for the FI tests, the PR:
- Gives more explanation to distinguish the different tests.
- Corrects the mapping in the testplan.