### PR TITLE
[toplevel] Fix timeout errors in pwrmgr_random_sleep_all_reset

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_sleep_all_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_sleep_all_reset_vseq.sv
@@ -59,6 +59,7 @@ class chip_sw_random_sleep_all_reset_vseq extends chip_sw_base_vseq;
 
     repeat (NumRound) begin
       `uvm_info(`gfn, $sformatf("loop: %0d / %0d", loop_idx++, NumRound), UVM_MEDIUM)
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == "New reset event")
       `DV_WAIT(
             cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" ||
             cfg.sw_logger_vif.printed_log ==
@@ -67,6 +68,8 @@ class chip_sw_random_sleep_all_reset_vseq extends chip_sw_base_vseq;
             cfg.sw_logger_vif.printed_log ==
                 "Booting and setting normal sleep followed by sysrst" ||
             cfg.sw_logger_vif.printed_log == "Let SV wait timer reset" ||
+            cfg.sw_logger_vif.printed_log ==
+                "Booting and running normal sleep followed by escalation reset" ||
             cfg.sw_logger_vif.printed_log == "Last Booting" ||
             cfg.sw_logger_vif.printed_log == "Test finish")
 

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
@@ -503,6 +503,8 @@ bool test_main(void) {
             rst_info == kDifRstmgrResetInfoSw,
         "Wrong reset reason %02X", rst_info);
 
+  LOG_INFO("New reset event");
+
   switch (RST_IDX[event_idx] / 2) {
     case 0:
       if (RST_IDX[event_idx] % 2) {


### PR DESCRIPTION
This test occasionally experiences timeout errors as described in #15278

It seems that the timeout happens because the sv sequence reads an old LOG_INFO message twice. This sometimes causes sequence to get stuck in the `execute_reset()` task.

This PR resolves this problem by adding a `LOG_INFO("New reset event");` inside a loop to ensure that sv sequence and the c test are properly synchronised. 

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>