### PR TITLE
[python] Removing numpy from the python requirements

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -6,7 +6,6 @@
 hjson==3.1.0
 libcst==0.4.1
 mako==1.1.6
-numpy==1.19.5
 pluralizer==1.2.0
 pycryptodome==3.15.0
 pyelftools==0.29


### PR DESCRIPTION
Removing numpy from python-requirements.txt as it is not currently used.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>