### PR TITLE
[prim_diff_decode] Update SVAs to make them compatible with sim CDC

### DIFF
--- a/hw/ip/prim/rtl/prim_diff_decode.sv
+++ b/hw/ip/prim/rtl/prim_diff_decode.sv
@@ -218,57 +218,52 @@ module prim_diff_decode #(
   `ASSERT(SigintFallCheck_A,  sigint_o |-> !fall_o)
 
   if (AsyncOn) begin : gen_async_assert
-`ifdef INC_ASSERT
     // assertions for asynchronous case
-    // in this case we need to sample the input signals onto the local clock to avoid race
-    // conditions between the RTL and assertion sampling in simulation.
-    logic hlp_diff_pq, hlp_diff_nq;
-    always_ff @(posedge clk_i or negedge rst_ni) begin : p_edge_reg
-      if (!rst_ni) begin
-        hlp_diff_pq  <= 1'b0;
-        hlp_diff_nq  <= 1'b1;
-      end else begin
-        hlp_diff_pq  <= diff_pi;
-        hlp_diff_nq  <= diff_ni;
-      end
-    end
-
+`ifdef INC_ASSERT
   `ifndef FPV_ALERT_NO_SIGINT_ERR
     // correctly detect sigint issue (only one transition cycle of permissible due to skew)
-    `ASSERT(SigintCheck0_A, hlp_diff_pq == hlp_diff_nq [*2] |-> ##[0:1] sigint_o)
+    `ASSERT(SigintCheck0_A, gen_async.diff_pd == gen_async.diff_nd [*2] |-> sigint_o)
     // the synchronizer adds 2 cycles of latency with respect to input signals.
     `ASSERT(SigintCheck1_A,
-        ##1 (hlp_diff_pq ^ hlp_diff_nq) && $stable(hlp_diff_pq) && $stable(hlp_diff_nq) ##1
-        $rose(hlp_diff_pq) && $stable(hlp_diff_nq) ##1 $stable(hlp_diff_pq) && $fell(hlp_diff_nq)
-        |->
-        ##1 rise_o)
+        ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
+        $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+        $rose(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+        $stable(gen_async.diff_pd) && $fell(gen_async.diff_nd)
+        |-> rise_o)
     `ASSERT(SigintCheck2_A,
-        ##1 (hlp_diff_pq ^ hlp_diff_nq) && $stable(hlp_diff_pq) && $stable(hlp_diff_nq) ##1
-        $fell(hlp_diff_pq) && $stable(hlp_diff_nq) ##1 $stable(hlp_diff_pq) && $rose(hlp_diff_nq)
-        |->
-        ##1 fall_o)
+        ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
+        $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+        $fell(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+        $stable(gen_async.diff_pd) && $rose(gen_async.diff_nd)
+        |-> fall_o)
     `ASSERT(SigintCheck3_A,
-        ##1 (hlp_diff_pq ^ hlp_diff_nq) && $stable(hlp_diff_pq) && $stable(hlp_diff_nq) ##1
-        $rose(hlp_diff_nq) && $stable(hlp_diff_pq) ##1 $stable(hlp_diff_nq) && $fell(hlp_diff_pq)
-        |->
-        ##1 fall_o)
+        ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
+        $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+        $rose(gen_async.diff_nd) && $stable(gen_async.diff_pd) ##1
+        $stable(gen_async.diff_nd) && $fell(gen_async.diff_pd)
+        |-> fall_o)
     `ASSERT(SigintCheck4_A,
-        ##1 (hlp_diff_pq ^ hlp_diff_nq) && $stable(hlp_diff_pq) && $stable(hlp_diff_nq) ##1
-        $fell(hlp_diff_nq) && $stable(hlp_diff_pq) ##1 $stable(hlp_diff_nq) && $rose(hlp_diff_pq)
-        |->
-        ##1 rise_o)
+        ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
+        $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+        $fell(gen_async.diff_nd) && $stable(gen_async.diff_pd) ##1
+        $stable(gen_async.diff_nd) && $rose(gen_async.diff_pd)
+        |-> rise_o)
   `endif
 
     // correctly detect edges
-    `ASSERT(RiseCheck_A,  ##1 $rose(hlp_diff_pq)     && (hlp_diff_pq ^ hlp_diff_nq) |->
-        ##[1:2] rise_o,  clk_i, !rst_ni || sigint_o)
-    `ASSERT(FallCheck_A,  ##1 $fell(hlp_diff_pq)     && (hlp_diff_pq ^ hlp_diff_nq) |->
-        ##[1:2] fall_o,  clk_i, !rst_ni || sigint_o)
-    `ASSERT(EventCheck_A, ##1 $changed(hlp_diff_pq)  && (hlp_diff_pq ^ hlp_diff_nq) |->
-        ##[1:2] event_o, clk_i, !rst_ni || sigint_o)
+    `ASSERT(RiseCheck_A,
+        !sigint_o ##1 $rose(gen_async.diff_pd) && (gen_async.diff_pd ^ gen_async.diff_nd) |->
+        ##[0:1] rise_o,  clk_i, !rst_ni || sigint_o)
+    `ASSERT(FallCheck_A,
+        !sigint_o ##1 $fell(gen_async.diff_pd) && (gen_async.diff_pd ^ gen_async.diff_nd) |->
+        ##[0:1] fall_o,  clk_i, !rst_ni || sigint_o)
+    `ASSERT(EventCheck_A,
+        !sigint_o ##1 $changed(gen_async.diff_pd) && (gen_async.diff_pd ^ gen_async.diff_nd) |->
+        ##[0:1] event_o, clk_i, !rst_ni || sigint_o)
     // correctly detect level
-    `ASSERT(LevelCheck0_A, !sigint_o && (hlp_diff_pq ^ hlp_diff_nq) [*3] |=>
-        $past(hlp_diff_pq, 1) == level_o,
+    `ASSERT(LevelCheck0_A,
+        !sigint_o && (gen_async.diff_pd ^ gen_async.diff_nd) [*2] |->
+        gen_async.diff_pd == level_o,
         clk_i, !rst_ni || sigint_o)
 `endif
   end else begin : gen_sync_assert


### PR DESCRIPTION
This is done in preparation for CDC instrumentation in simulation, see here: https://github.com/lowRISC/opentitan/pull/15863

Since the CDC instrumentation in simulation inserts delays inside the synchronizer, we move the sampling point for the SVAs from the synchronizer input to the synchronizer output so that they don't break when CDC is enabled in sims.

