### PR TITLE
[bazel] exclude foundry repo from Verilator build

### DIFF
--- a/hw/BUILD
+++ b/hw/BUILD
@@ -94,7 +94,11 @@ genrule(
 # relationships between verilog components.
 filegroup(
     name = "all_files",
-    srcs = glob(["**"]) + [
+    srcs = glob(
+        ["**"],
+        # TODO(lowRISC/opentitan#15882): make Verilator work with foundry repo present.
+        exclude = ["foundry/**"],
+    ) + [
         "//hw/ip:all_files",
         "//hw/top_earlgrey:all_files",
     ],


### PR DESCRIPTION
HDL constructs in the foundry repo are preventing Verilator builds from succeeding. This addresses #15882 in the short term, by excluding the foundry repo from Verilator sim binary builds.

Signed-off-by: Timothy Trippel <ttrippel@google.com>