### PR TITLE
[tests] Mark rom_e2e_shutdown_error_redact tests as broken

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1172,7 +1172,10 @@ test_cases = [
         bitstream = bitstream_target,
         exit_failure = MSG_PASS,
         exit_success = MSG_BOOT_FAULT + bfv_val,
-        tags = ["vivado"],
+        tags = [
+            "broken",  # TODO: pending on the issues noted in #14271
+            "vivado",
+        ],
     ),
     signed = False,
     targets = ["cw310_rom"],


### PR DESCRIPTION
The latest revert on CI uncovered some issues with the otp splicing process used by the shutdown error redaction tests. I'm marking these as broken until the issues noted in #14271 can be fixed.

Signed-off-by: Miles Dai <milesdai@google.com>