### PR TITLE
[bazel] Add OTP alert_handler digest generation

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:autogen.bzl", "autogen_hjson_header")
-load("//rules:otp.bzl", "otp_image", "otp_json", "otp_partition")
+load("//rules:otp.bzl", "otp_alert_digest", "otp_image", "otp_json", "otp_partition")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
@@ -122,10 +122,6 @@ otp_json(
                     "0x0",
                     "0x0",
                 ],
-                "OWNER_SW_CFG_ROM_ALERT_DIGEST_DEV": "0xf23b13fb",
-                "OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD": "0x9c933414",
-                "OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_END": "0x68d8d091",
-                "OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA": "0x36ed9cb0",
             },
         ),
     ],
@@ -344,12 +340,19 @@ otp_json(
     seed = "01931961561863975174",
 )
 
+# Create an overlay for the alert_handler digest.
+otp_alert_digest(
+    name = "otp_json_alert_digest_cfg",
+    otp_img = ":otp_json_owner_sw_cfg",
+)
+
 otp_image(
     name = "img_dev",
     src = ":otp_json_dev",
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
+        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -360,6 +363,7 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
+        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -370,6 +374,7 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
+        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -380,6 +385,7 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
+        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -390,6 +396,7 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
+        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -400,6 +407,7 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
+        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -421,6 +429,7 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
+        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
         ":otp_json_exec_disabled",
     ],
@@ -443,6 +452,7 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
+        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
         ":otp_json_bootstrap_disabled",
     ],

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -102,6 +102,43 @@ otp_json = rule(
     },
 )
 
+def _otp_alert_digest_impl(ctx):
+    file = ctx.actions.declare_file("{}.json".format(ctx.attr.name))
+
+    outputs = [file]
+
+    inputs = [
+        ctx.file._opentitantool,
+        ctx.file.otp_img,
+    ]
+
+    args = ctx.actions.args()
+    args.add_all(("otp", "alert-digest", ctx.file.otp_img))
+    args.add("--output", file)
+
+    ctx.actions.run(
+        outputs = outputs,
+        inputs = inputs,
+        arguments = [args],
+        executable = ctx.file._opentitantool.path,
+    )
+
+    return [DefaultInfo(files = depset([file]))]
+
+otp_alert_digest = rule(
+    implementation = _otp_alert_digest_impl,
+    attrs = {
+        "otp_img": attr.label(
+            allow_single_file = [".json", ".hjson"],
+            doc = "The OTP image file containing alert_handler values.",
+        ),
+        "_opentitantool": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            allow_single_file = True,
+        ),
+    },
+)
+
 def _otp_image(ctx):
     output = ctx.actions.declare_file(ctx.attr.name + ".24.vmem")
     args = ctx.actions.args()

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -449,6 +449,7 @@ opentitan_functest(
     overlays = [
         "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+        "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
     ],
 ) for lc_state in structs.to_dict(CONST.LCV)]
@@ -570,6 +571,7 @@ BOOT_POLICY_NEWER_CASES = [
     overlays = [
         "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+        "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
     ],
 ) for lc_state in structs.to_dict(CONST.LCV)]
@@ -657,6 +659,7 @@ otp_json(
     overlays = [
         "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+        "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
         ":otp_json_boot_policy_rollback",
     ],
@@ -767,6 +770,7 @@ opentitan_flash_binary(
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             ":otp_json_sigverify_mod_exp_{}".format(t["name"]),
         ],
@@ -1021,6 +1025,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             ":otp_json_sec_ver_{}".format(sec_ver),
         ],
@@ -1157,6 +1162,7 @@ SHUTDOWN_WATCHDOG_CASES = [
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             ":otp_json_shutdown_watchdog_{}_{}".format(
                 t["lc_state"],
@@ -1274,6 +1280,7 @@ BOOT_POLICY_VALID_CASES = [
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
         ],
     )
@@ -1349,6 +1356,7 @@ OTP_CFGS_EXEC_DISABLED = [
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_exec_disabled",
         ],
@@ -1572,6 +1580,7 @@ REDACT.update({"INVALID": 0x0})
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             ":otp_json_{}_overlay".format(redact.lower()),
         ],


### PR DESCRIPTION
This PR builds on https://github.com/lowRISC/opentitan/pull/14013.

This adds a rule, `otp_alert_digest`, that creates an additional OTP image overlay containing the `OWNER_SW_CFG_ROM_ALERT_DIGEST_<LC_STATE>` values.

Right now this is only done for RMA.

Leaving this as draft status as https://github.com/lowRISC/opentitan/pull/14013 currently doesn't produce a JSON format that is accepted by the python tools. From what I can tell, this is because the python tools expect the items to be in the form of quoted hex values, and right now opentitantool is outputting these fields as regular JSON numbers in decimal. 