### PR TITLE
[rdc/spid] Add waiver for FwMode FIFOs

### DIFF
--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
@@ -28,3 +28,6 @@ create_reset -interval 10 -high -waveform SPI_DEV_CLK top_earlgrey.u_spi_device.
 
 # Define SPI_DEVICE TPM CSb as reset
 create_reset -interval 10 -high -waveform SPI_DEV_CLK top_earlgrey.u_spi_device.rst_tpm_csb_buf
+
+# SPI_DEVICE CONTROL.mode is stable during the reset analysis
+# set_stable_value top_earlgrey.u_spi_device.u_reg.u_control_mode.q -name SpidControlMode -comment {SW changes the CSR when SPI is idle}

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -59,19 +59,21 @@ set_reset_scenario { \
 #  They can be asserted only in Generic Mode. Keep Mode in Generic then assert
 #  reset.
 #
-# Assume control_mode is Generic mode `{constraint {@t0 0}}`
+# Assume control_mode is Generic mode `CONTROL.mode {constraint {@t0 0}}`
 # Then `CONTROL.rst_rxfifo` 0 -> 1 {after 10 clks} -> 0 {after 4 clks}
 set_reset_scenario { \
   { {top_earlgrey.u_spi_device.u_reg.u_control_rst_rxfifo.q[0]} \
     {reset  { @t0 0 } { #10 1} { #4 0 }} } \
-  { top_earlgrey.u_spi_device.u_reg.u_control_mode.q[0] \
-    {constraint {@t0 0}}} \
+  { top_earlgrey.u_spi_device.u_reg.u_control_mode.q \
+    {constraint { @t0 S } } } \
+  { top_earlgrey.u_spi_device.rst_csb_buf {constraint { @t0 1 } } } \
   } -name SpidRstRxFifo -comment "SPI_DEVICE Async RX FIFO Functional Reset"
 set_reset_scenario { \
   { {top_earlgrey.u_spi_device.u_reg.u_control_rst_txfifo.q[0]} \
     {reset  { @t0 0 } { #10 1} { #4 0 }} } \
-  { top_earlgrey.u_spi_device.u_reg.u_control_mode.q[0] \
-    {constraint {@t0 0}}} \
+  { top_earlgrey.u_spi_device.u_reg.u_control_mode.q \
+    {constraint { @t0 S } } } \
+  { top_earlgrey.u_spi_device.rst_csb_buf {constraint { @t0 1 } } } \
   } -name SpidRstTxFifo -comment "SPI_DEVICE Async TX FIFO Functional Reset"
 
 # SPI_DEVICE CSb Reset. IP reset should be stable

--- a/hw/top_earlgrey/rdc/rdc_waivers.spi_device.tcl
+++ b/hw/top_earlgrey/rdc/rdc_waivers.spi_device.tcl
@@ -76,6 +76,15 @@ set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
   -comment {Assumption is to reset RX/TX FIFO when SPI is idle. \
     SW reads FIFO PTR not at the same time.}
 
+set_rule_status -rule {E_RDC_METASTABILITY} -status {Waived} \
+  -expression {(SourceReset=~"*u_spi_device.u_reg.u_control_rst_txfifo*") && \
+    (ResetFlop=~"*u_spi_device.u_fwmode.u_tx_fifo.fifo_rptr*") && \
+    (MetaStableFlop=~"*u_spi_device.u_fwmode.u_tx_fifo.storage*")} \
+  -comment {TXFIFO reset may cause the output data change (surely). \
+    RDC reports the RDC_METASTABILITY caused by this. \
+    To avoid the issue, rst_sync + data sync should be implemented. \
+    However, due to the lack of the SCK, rst_sync cannot be added.}
+
 # CSb to Any SPI_CLK path (RDC could not figure out the relation between CSb and SPI_CLK)
 set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
   -expression {(SourceReset=~"*u_spi_device.rst_csb_buf") && \

--- a/hw/top_earlgrey/rdc/rdc_waivers.spi_device.tcl
+++ b/hw/top_earlgrey/rdc/rdc_waivers.spi_device.tcl
@@ -40,6 +40,42 @@ set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
     (MetaStableFlop=~"*u_spi_device.u_fwmode.u_*x_fifo.fifo_*ptr*")} \
   -comment {CSb does not conflict to SPI_CLK if host system follows the protocol}
 
+# Rx/Tx FIFO resets are issued when SPI is idle.
+set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
+  -expression {(SourceReset=~"*u_spi_device.u_reg.u_control_rst_rxfifo*") && \
+    (MetaStableFlop=~"*u_spi_device.u_fwmode.u_rxf_ctrl.*")} \
+  -comment {Assumption is to reset RX/TX FIFO when SPI is idle}
+set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
+  -expression {(SourceReset=~"*u_spi_device.u_reg.u_control_rst_rxfifo*") && \
+    (MetaStableFlop=~"*u_spi_device.rxf_full_q")} \
+  -comment {Assumption is to reset RX/TX FIFO when SPI is idle}
+set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
+  -expression {(SourceReset=~"*u_spi_device.u_reg.u_control_rst_*xfifo*") && \
+    (ResetFlop=~"*u_spi_device.u_fwmode.u_rx_fifo.fifo_rptr_q*") && \
+    (MetaStableFlop=~"*u_spi_device.u_reg.u_reg_if.rdata_q*")} \
+  -comment {Assumption is to reset RX/TX FIFO when SPI is idle. \
+    SW reads FIFO PTR not at the same time.}
+set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
+  -expression {(SourceReset=~"*u_spi_device.u_reg.u_control_rst_*xfifo*") && \
+    (MetastableFlopReset=~"*u_spi_device.u_reg.u_control_mode.q*")} \
+  -comment {CONTROL.mode dose not change.}
+set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
+  -expression {(SourceReset=~"*u_spi_device.u_reg.u_control_rst_txfifo*") && \
+    (MetaStableFlop=~"*u_spi_device.txf_empty_q")} \
+  -comment {Assumption is to reset RX/TX FIFO when SPI is idle}
+set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
+  -expression {(SourceReset=~"*u_spi_device.u_reg.u_control_rst_*xfifo*") && \
+    (ResetFlop=~"*u_spi_device.u_fwmode.u_tx_fifo.fifo_rptr_*") && \
+    (MetaStableFlop=~"*u_spi_device.u_reg.u_reg_if.rdata_q*")} \
+  -comment {Assumption is to reset RX/TX FIFO when SPI is idle. \
+    SW reads FIFO PTR not at the same time.}
+set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
+  -expression {(SourceReset=~"*u_spi_device.u_reg.u_control_rst_*xfifo*") && \
+    (ResetFlop=~"*u_spi_device.u_fwmode.u_tx_fifo.fifo_rptr_q*") && \
+    (MetaStableFlop=~"*u_spi_device.u_p2s.out_shift*")} \
+  -comment {Assumption is to reset RX/TX FIFO when SPI is idle. \
+    SW reads FIFO PTR not at the same time.}
+
 # CSb to Any SPI_CLK path (RDC could not figure out the relation between CSb and SPI_CLK)
 set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
   -expression {(SourceReset=~"*u_spi_device.rst_csb_buf") && \


### PR DESCRIPTION
There were a few violations on Sw FIFO Reset signals to the RX/TX FIFOs in FwMode. The violations can be waived if we assume the SPI is in idle. If not in idle state, the metastability issue may occur.

But in that case, in my opinion, it is OK to define the behavior as undefined.