### PR TITLE
[dv/csrng_agent] Add csrng_agent cov

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_agent_cov.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_cov.sv
@@ -6,10 +6,62 @@ class csrng_agent_cov extends dv_base_agent_cov#(csrng_agent_cfg);
   `uvm_component_utils(csrng_agent_cov)
 
   // covergroups
+  covergroup cmd_cg with function sample(csrng_item item, bit sts);
+    option.name         = "csrng_cmd_cg";
+    option.per_instance = 1;
+
+    csrng_cmd_cp: coverpoint item.acmd {
+      bins inv = {INV};
+      bins ins = {INS};
+      bins res = {RES};
+      bins gen = {GEN};
+      bins upd = {UPD};
+      bins genb = {GENB};
+      bins genu = {GENU};
+      illegal_bins il = default;
+    }
+    csrng_clen_cp: coverpoint item.clen {
+      bins zero = {0};
+      bins other_bins[2] = {[1:15]};
+    }
+    // TODO: do not use enum to sample non-true/false data
+    csrng_flag_cp: coverpoint item.flags {
+      bins mubi_true = {MuBi4True};
+      bins mubi_false = {MuBi4False};
+    }
+    csrng_sts: coverpoint sts {
+      bins pass = {0};
+      bins fail = {1};
+    }
+
+    csrng_cmd_cross: cross csrng_cmd_cp, csrng_clen_cp, csrng_sts, csrng_flag_cp;
+  endgroup
+
+  covergroup genbits_cg with function sample(csrng_item item, bit sts);
+    option.name         = "csrng_genbits_cg";
+    option.per_instance = 1;
+
+    csrng_glen: coverpoint item.glen {
+      // TODO: current max length is limited.
+      bins glens[5] = {[1:80]};
+    }
+    csrng_sts: coverpoint sts {
+      bins pass = {0};
+      bins fail = {1};
+    }
+
+    csrng_genbits_cross: cross csrng_glen, csrng_sts;
+  endgroup
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // instantiate all covergroups here
+    cmd_cg = new();
+    genbits_cg = new();
+  endfunction
+
+  function void sample_csrng_cmds(csrng_item item, bit sts);
+    cmd_cg.sample(item, cfg.vif.cmd_rsp.csrng_rsp_sts);
+    if (item.acmd == csrng_pkg::GEN) genbits_cg.sample(item, cfg.vif.cmd_rsp.csrng_rsp_sts);
   endfunction
 
 endclass

--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -87,6 +87,8 @@ class csrng_monitor extends dv_base_monitor #(
       cfg.vif.wait_cmd_ack();
       `uvm_info(`gfn, $sformatf("Writing analysis_port: %s", cs_item.convert2string()), UVM_HIGH)
       analysis_port.write(cs_item);
+
+      if (cfg.en_cov) cov.sample_csrng_cmds(cs_item, cfg.vif.cmd_rsp.csrng_rsp_sts);
     end
   endtask
 


### PR DESCRIPTION
This PR adds some coverage for CSRNG agent.
It includes coverage for cmd and genbits.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>