### PR TITLE
[aes] V2S coverage improvements

### DIFF
--- a/hw/ip/aes/data/aes_sec_cm_testplan.hjson
+++ b/hw/ip/aes/data/aes_sec_cm_testplan.hjson
@@ -49,10 +49,10 @@
       desc: '''
             Verify the countermeasure(s) MAIN.CONFIG.SPARSE.
             Illegally encoded values are written into the main control register via register interface and it is ensured that the values are resolved to the correct legal values.
-            Internal wires carrying the corresponding signals are forced to invalid values and it is ensured that the DUT stops processing data and signals an alert.
+            Internal wires carrying the corresponding signals are forced to invalid values and depending on the target wire it is ensured that the DUT stops processing data and signals an alert.
             '''
       stage: V2S
-      tests: ["aes_stress", "aes_smoke", "aes_alert_reset"]
+      tests: ["aes_stress", "aes_smoke", "aes_alert_reset", "aes_core_fi"]
     }
     {
       name: sec_cm_aux_config_shadow

--- a/hw/ip/aes/dv/aes_base_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_base_sim_cfg.hjson
@@ -185,6 +185,12 @@
       run_timeout_mins: 1 // Short test; if not done within 1 min, something's wrong.
     }
     {
+      name: aes_core_fi
+      uvm_test: aes_fi_test
+      uvm_test_seq: aes_core_fi_vseq
+      reseed: 70 // Test must cover 35 bins. Overseed by 2x to get reasonable coverage.
+    }
+    {
       name: aes_readability
       uvm_test: aes_fi_test
       uvm_test_seq: aes_readability_vseq

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -41,6 +41,7 @@ filesets:
       - seq_lib/aes_control_fi_vseq.sv: {is_include_file: true}
       - seq_lib/aes_cipher_fi_vseq.sv: {is_include_file: true}
       - seq_lib/aes_ctr_fi_vseq.sv: {is_include_file: true}
+      - seq_lib/aes_core_fi_vseq.sv: {is_include_file: true}
       - seq_lib/aes_readability_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -25,6 +25,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   virtual fi_control_if aes_control_fi_vif[Sp2VWidth];
   virtual fi_cipher_if aes_cipher_control_fi_vif[Sp2VWidth];
   virtual fi_ctr_fsm_if aes_ctr_fsm_fi_vif[Sp2VWidth];
+  virtual fi_core_if aes_core_fi_vif;
 
   rand key_sideload_agent_cfg keymgr_sideload_agent_cfg;
   // test environment constraints //
@@ -281,6 +282,10 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
                            aes_ctr_fsm_fi_vif[nn])) begin
         `uvm_fatal(`gfn, $sformatf("FAILED TO GET HANDLE TO ROUND COUNTER INJECT INTERFACE %d",nn))
       end
+    end
+    if (!uvm_config_db#(virtual fi_core_if)::get(null, "*.env", "aes_core_fi_vif",
+                         aes_core_fi_vif)) begin
+      `uvm_fatal(`gfn, "FAILED TO GET HANDLE TO CORE FAULT INJECTION INTERFACE")
     end
 
     // only support 1 outstanding TL item

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -94,7 +94,7 @@ class aes_base_vseq extends cip_base_vseq #(
   endtask // set_ctrl_aux_shadowed
   virtual task prng_reseed();
     bit [TL_DW:0] reg_val = '0;
-    reg_val[5] = 1'b1;
+    reg_val[3] = 1'b1;
     csr_wr(.ptr(ral.trigger), .value(reg_val));
   endtask // prng_reseed
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_control_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_control_fi_vseq.sv
@@ -60,9 +60,15 @@ class aes_control_fi_vseq extends aes_base_vseq;
               // the Clear states, and it waits until the FSM has reached the required state.
               clear_regs('{dataout: 1'b1, key_iv_data_in: 1'b1, default: 1'b0});
               `DV_WAIT(cfg.aes_control_fi_vif[if_num].aes_ctrl_cs == await_state)
-            end else if (await_state inside {aes_pkg::CTRL_LOAD, aes_pkg::CTRL_PRNG_RESEED}) begin
-              // The Load state and the PRNG Reseed state are also difficult to hit with a random
-              // delay, but for them simply waiting works.
+            end else if (await_state == aes_pkg::CTRL_PRNG_RESEED) begin
+              // The PRNG Reseed state is also difficult to hit with a random delay. This writes the
+              // trigger register to bring the FSM into the PRNG Reseed state, and it waits until
+              // the FSM has reached that state.
+              prng_reseed();
+              `DV_WAIT(cfg.aes_control_fi_vif[if_num].aes_ctrl_cs == await_state)
+            end else if (await_state == aes_pkg::CTRL_LOAD) begin
+              // The Load state is also difficult to hit with a random delay, but simply waiting
+              // works.
               `DV_WAIT(cfg.aes_control_fi_vif[if_num].aes_ctrl_cs == await_state)
             end else begin
               cfg.clk_rst_vif.wait_clks(cfg.inj_delay);

--- a/hw/ip/aes/dv/env/seq_lib/aes_core_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_core_fi_vseq.sv
@@ -1,0 +1,116 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test randomly forces critical control signals inside aes_core.sv.
+class aes_core_fi_vseq extends aes_base_vseq;
+  `uvm_object_utils(aes_core_fi_vseq)
+
+  `uvm_object_new
+
+  localparam bit FORCE   = 0;
+  localparam bit RELEASE = 1;
+
+  rand bit [31:0]          force_value;
+  rand int                 target;
+  rand aes_pkg::aes_ctrl_e await_state;
+
+  task body();
+
+    int if_size;
+    bit finished_all_msgs = 0;
+    bit wait_for_alert = 0;
+    bit wait_for_idle = 0;
+    bit forcing = 0;
+
+    `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES MAIN SEQUENCE |----\n %s",
+                              cfg.convert2string()), UVM_LOW)
+
+    // generate list of messages //
+    generate_message_queue();
+
+    // process all messages //
+    fork
+      error: begin
+        // workaround for vcs issue
+        if_size = cfg.aes_core_fi_vif.get_if_size();
+        `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(target, target inside { [0:if_size - 1]};)
+        // We are forcing non one-hot values and the individual targets can have different
+        // widths. Determine signal width and whether an alert is expected.
+        if (target == 0) begin
+          `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(force_value,
+              $countones(force_value[aes_pkg::AES_OP_WIDTH-1:0]) > 1;)
+          wait_for_alert = 1;
+        end else if (target == 1) begin
+          `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(force_value,
+              $countones(force_value[aes_pkg::AES_OP_WIDTH-1:0]) > 1;)
+        end else if (target == 2) begin
+          `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(force_value,
+              $countones(force_value[aes_pkg::AES_MODE_WIDTH-1:0]) > 1;)
+          wait_for_idle = 1;
+        end else if (target == 3) begin
+          `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(force_value,
+              $countones(force_value[aes_pkg::AES_KEYLEN_WIDTH-1:0]) > 1;)
+        end else if (target == 4) begin
+          `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(force_value,
+              $countones(force_value[aes_pkg::AES_PRNGRESEEDRATE_WIDTH-1:0]) > 1;)
+        end
+
+        // Wait and apply force.
+        if (await_state inside {aes_pkg::CTRL_PRNG_UPDATE, aes_pkg::CTRL_CLEAR_I,
+                                      aes_pkg::CTRL_CLEAR_CO}) begin
+          // The PRNG Update state and the Clear states are difficult to hit with a random
+          // delay.  This writes the clear register to bring the FSM to the PRNG Update and then
+          // the Clear states, and it waits until the FSM has reached the required state.
+          clear_regs('{dataout: 1'b1, key_iv_data_in: 1'b1, default: 1'b0});
+          `DV_WAIT(cfg.aes_core_fi_vif.aes_ctrl_cs == await_state)
+        end else if (await_state == aes_pkg::CTRL_PRNG_RESEED) begin
+          // The PRNG Reseed state is also difficult to hit with a random delay. This writes the
+          // trigger register to bring the FSM into the PRNG Reseed state, and it waits until the
+          // FSM has reached that state.
+          prng_reseed();
+          `DV_WAIT(cfg.aes_core_fi_vif.aes_ctrl_cs == await_state)
+        end else if (await_state == aes_pkg::CTRL_LOAD) begin
+          // The Load state is also difficult to hit with a random delay, but simply waiting works.
+          `DV_WAIT(cfg.aes_core_fi_vif.aes_ctrl_cs == await_state)
+        end else begin
+          cfg.clk_rst_vif.wait_clks(cfg.inj_delay);
+        end
+        `uvm_info(`gfn, $sformatf("FORCING %h on target %d", force_value, target), UVM_MEDIUM)
+        cfg.aes_core_fi_vif.force_signal(target, FORCE, force_value);
+        forcing = 1;
+
+        // Potentially react to the fault.
+        if (wait_for_alert) begin
+          // The fault is expected to trigger a fatal alert. Ensure this actually happens and
+          // release the signal after reset.
+          `uvm_info(`gfn, $sformatf("Waiting for alert ack to complete"), UVM_MEDIUM)
+          cfg.m_alert_agent_cfg["fatal_fault"].vif.wait_ack_complete();
+          `DV_WAIT(!cfg.clk_rst_vif.rst_n)
+          cfg.aes_core_fi_vif.force_signal(target, RELEASE, force_value);
+        end else if (wait_for_idle) begin
+          // The fault potentially prevents the module from making any progress. DV will try to
+          // clear and restart it but might never succeed resulting in the module being idle and
+          // again busy.
+          csr_spinwait(.ptr(ral.status.idle), .exp_data(1'b1));
+          csr_spinwait(.ptr(ral.status.idle), .exp_data(1'b0));
+          cfg.aes_core_fi_vif.force_signal(target, RELEASE, force_value);
+        end else begin
+          // The fault might trigger a reset or not.
+          `DV_WAIT(!cfg.clk_rst_vif.rst_n || finished_all_msgs)
+          if (!cfg.clk_rst_vif.rst_n) begin
+            cfg.aes_core_fi_vif.force_signal(target, RELEASE, force_value);
+          end
+        end
+      end
+
+      basic: begin
+        send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+        finished_all_msgs = 1;
+      end
+
+    join
+    wait_no_outstanding_access();
+
+  endtask : body
+endclass

--- a/hw/ip/aes/dv/env/seq_lib/aes_vseq_list.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_vseq_list.sv
@@ -15,4 +15,5 @@
 `include "aes_control_fi_vseq.sv"
 `include "aes_cipher_fi_vseq.sv"
 `include "aes_ctr_fi_vseq.sv"
+`include "aes_core_fi_vseq.sv"
 `include "aes_readability_vseq.sv"

--- a/hw/ip/aes/dv/err_injection_if/aes_err_injection.core
+++ b/hw/ip/aes/dv/err_injection_if/aes_err_injection.core
@@ -20,6 +20,9 @@ filesets:
       - fi_cipher_if.sv
       - fi_ctr_fsm_wrapper.sv
       - fi_ctr_fsm_if.sv
+      - fi_core_wrapper.sv
+      - fi_core_if.sv
+
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/aes/dv/err_injection_if/aes_err_injection_bind.sv
+++ b/hw/ip/aes/dv/err_injection_if/aes_err_injection_bind.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module aes_err_injection_bind;
 
-  // bind fault inject if to control_fsm
+  // fault injection IF for state of main control FSM - see aes_fi_vseq.sv
   bind aes_control_fsm signal_force
     #(.Signal("aes_ctrl_cs"),
       .IfName("aes_fi_vif"),
@@ -15,7 +15,7 @@ module aes_err_injection_bind;
      .rst_ni       (rst_ni)
     );
 
-  // bind fault inject if to cipher fsm
+  // fault injection IF for state of cipher core FSM - see aes_fi_vseq.sv
   bind aes_cipher_control_fsm signal_force
     #(.Signal("aes_cipher_ctrl_cs"),
       .IfName("aes_cipher_fi_vif"),
@@ -27,7 +27,7 @@ module aes_err_injection_bind;
      .rst_ni       (rst_ni)
     );
 
-  // bind fault inject if to round counter fsm
+  // fault injection IF for state of CTR mode FSM - see aes_fi_vseq.sv
   bind aes_ctr_fsm signal_force
     #(.Signal("aes_ctr_cs"),
       .IfName("aes_ctr_fi_vif"),
@@ -39,19 +39,34 @@ module aes_err_injection_bind;
      .rst_ni       (rst_ni)
     );
 
+  // fault injection IF for main control FSM signals - see aes_control_fi_vseq.sv
   bind aes_control_fsm fi_control_fsm_wrapper
     #(.IfName("aes_control_fi_vif")
      )
   u_fi_ctrl_fsm (.*);
 
+  // fault injection IF for cipher core FSM signals - see aes_cipher_fi_vseq.sv
   bind aes_cipher_control_fsm fi_cipher_fsm_wrapper
     #(.IfName("aes_cipher_control_fi_vif")
       )
   u_control_cipher_fi (.*);
 
+  // fault injection IF for CTR mode FSM signals - see aes_ctr_fi_vseq.sv
   bind aes_ctr_fsm fi_ctr_fsm_wrapper
     #(.IfName("aes_ctr_fsm_fi_vif")
       )
   u_control_ctr_fsm_fi (.*);
+
+  // fault injection IF for core signals - see aes_core_fi_vseq.sv
+  bind aes_core fi_core_wrapper
+    #(.IfName("aes_core_fi_vif")
+      )
+  u_core_fi
+    (
+      .clk_i      (clk_i),
+      .rst_ni     (rst_ni),
+      .aes_ctrl_cs(u_aes_control.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.u_aes_control_fsm.
+                   aes_ctrl_cs)
+    );
 
 endmodule

--- a/hw/ip/aes/dv/err_injection_if/fi_cipher_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_cipher_if.sv
@@ -39,6 +39,7 @@ interface fi_cipher_if
 
   // multi bit forces
   string intf_mul_array[] = {
+    $sformatf("%s.%s", par_hier, "cyc_ctr_q"),
     $sformatf("%s.%s", par_hier, "rnd_ctr_o"),
     $sformatf("%s.%s", par_hier, "rnd_ctr_q"),
     $sformatf("%s.%s", par_hier, "state_sel_o"),

--- a/hw/ip/aes/dv/err_injection_if/fi_core_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_core_if.sv
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// target specific signals inside aes_core.sv
+interface fi_core_if
+  import uvm_pkg::*;
+  import aes_pkg::*;
+  (
+   input logic      clk_i,
+   input logic      rst_ni,
+   input aes_ctrl_e aes_ctrl_cs
+   );
+
+  `include "dv_fcov_macros.svh"
+  // get bind path to module
+  string       par_hier = dv_utils_pkg::get_parent_hier($sformatf("%m"), 2);
+
+  // multi bit forces
+  string intf_mul_array[] = {
+    // signals triggering fatal alerts
+    $sformatf("%s.%s", par_hier, "cipher_op"),
+    // signals potentially causing mismatches between golden model and RTL
+    $sformatf("%s.%s", par_hier, "aes_op_q"),
+    $sformatf("%s.%s", par_hier, "aes_mode_q"),
+    $sformatf("%s.%s", par_hier, "key_len_q"),
+    // signals not triggering alerts and not causing mismatches
+    $sformatf("%s.%s", par_hier, "prng_reseed_rate_q")
+  };
+
+  function automatic int get_if_size();
+    return intf_mul_array.size();
+  endfunction // get_if_size
+
+  // check which array we need to access and force or releae
+  function automatic void force_signal(int target, bit rel, bit [31:0] value);
+    if (!rel) force_multi_bit((target), value);
+    else release_multi_bit(target);
+  endfunction // force_signal
+
+  function automatic void force_multi_bit(int target, bit [31:0] value);
+    $assertoff(0, "tb.dut");
+    $asserton(1, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscDataOut");
+    $asserton(1, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscIv");
+    if (!uvm_hdl_check_path(intf_mul_array[target])) begin
+      `uvm_fatal("fi_core_if", $sformatf("PATH NOT EXISTING %m"))
+    end
+    if (!uvm_hdl_force(intf_mul_array[target], value)) begin
+      `uvm_error("fi_core_if", $sformatf("Was not able to force %s", intf_mul_array[target]))
+    end
+  endfunction
+
+  function automatic void release_multi_bit(int target);
+    uvm_hdl_release(intf_mul_array[target]);
+    $asserton(0,"tb.dut");
+  endfunction // release_single_bit
+
+  ///////////////////////////////////
+  // Fault inject coverage         //
+  ///////////////////////////////////
+
+  covergroup aes_core_cg (int num_bins) with function sample(int target);
+    // We want to see coverage per instance,
+    // but as the code are copies of eachother
+    // we don't need every instance to achieve 100% coverage
+    // a total of 100% is enough so we set the option
+    // to merge the coverage of the instances
+    option.per_instance         = 0;
+    option.name                 = "aes_core_interleave_cg";
+    type_option.merge_instances = 1;
+
+    cp_target: coverpoint target
+      {
+         bins signal_target[] = {[0:num_bins-1]};
+      }
+
+    // A fault is injected in each state.  Ignore the error state because it is the result of
+    // a fault and not a regular operating condition in which faults are expected to be handled.
+    cp_state: coverpoint aes_ctrl_cs {
+      ignore_bins error = {aes_pkg::CTRL_ERROR};
+    }
+
+    // Each target signal is faulted in each state.
+    target_state_cross: cross cp_target, cp_state;
+  endgroup // aes_core_cg
+
+  `DV_FCOV_INSTANTIATE_CG(aes_core_cg, 1'b1, (intf_mul_array.size()) )
+
+  function automatic void cg_aes_core_sample(int target);
+    aes_core_cg_inst.sample(target);
+  endfunction // cg_aes_core_sample
+
+endinterface

--- a/hw/ip/aes/dv/err_injection_if/fi_core_wrapper.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_core_wrapper.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+
+//wrapper module to avoid having to know/write out the path from tb to bind
+
+
+module fi_core_wrapper
+  import uvm_pkg::*;
+  import aes_env_pkg::*;
+  import aes_pkg::*;
+  #( parameter string IfName = "vif"
+  ) (
+    input logic      clk_i,
+    input logic      rst_ni,
+    input aes_ctrl_e aes_ctrl_cs
+  );
+
+  // declare interface
+  fi_core_if  fi_if (.*);
+  initial begin
+    uvm_config_db#(virtual fi_core_if)::set(null, "*", "aes_core_fi_vif", fi_if);
+  end
+endmodule

--- a/hw/ip/aes/dv/tests/aes_fi_test.sv
+++ b/hw/ip/aes/dv/tests/aes_fi_test.sv
@@ -21,11 +21,11 @@ class aes_fi_test extends aes_base_test;
     cfg.num_messages_max         = 6;
     cfg.unbalanced               = 0;
     // message related knobs
-    cfg.ecb_weight               = 10;
-    cfg.cbc_weight               = 10;
-    cfg.ctr_weight               = 10;
-    cfg.ofb_weight               = 10;
-    cfg.cfb_weight               = 10;
+    cfg.ecb_weight               = 5;
+    cfg.cbc_weight               = 5;
+    cfg.ofb_weight               = 5;
+    cfg.cfb_weight               = 5;
+    cfg.ctr_weight               = 80;
 
     cfg.message_len_min          = 7;    // one block (16bytes=128bits)
     cfg.message_len_max          = 300;


### PR DESCRIPTION
This PR contains two commits to improve the coverage for V2S:
1. Also force the `cyc_ctr_q` signal inside the cipher core. This signal/counter got added relatively late as an additional countermeasure. Previously we there was no coverage for the case when the counter didn't match the state of the handshake signals. It's possible that this introduces some failures similar to #13572 because forcing this counter not always triggers a fatal fault. Probably some more investigation is needed for this.
2. An additional sequence for forcing one-hot encoded signals inside `aes_core.sv` is added. These signals include `cipher_op/op`, `mode`, `key_len`, `prng_reseed_rate`. Coverage analysis showed that there were some holes for these signals as the register interface resolves invalid encodings. So the hardware/data path never sees the invalid encodings. This is what this test is for. The test is heavily inspired by other similar tests we have (`aes_ctr_fi` etc.).