### PR TITLE
[chip dv] Exclude alertdump and crashdump from coverage

### DIFF
--- a/hw/top_earlgrey/dv/cov/chip_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover.cfg
@@ -11,6 +11,15 @@ begin tgl(portsonly)
   +module padring
   +module rv_core_ibex
   +moduletree top_earlgrey 2
+
+  // [LOW_RISK] These are covered in FPV. These are partly covered by some tests in DV as well, but
+  // it is not feasible to get a full 100% coverage on all of the bits. The rationale for this
+  // exclusion is documented in more detail in the issue lowrisc/opentitan#15427.
+  -node tb.dut.top_earlgrey.u_rv_core_ibex.u_core crash_dump_o.*
+  -node tb.dut.top_earlgrey.u_rv_core_ibex crash_dump_o.*
+  -node tb.dut.top_earlgrey.u_rstmgr_aon cpu_dump_i.*
+  -node tb.dut.top_earlgrey.u_alert_handler crashdump_o.*
+  -node tb.dut.top_earlgrey.u_rstmgr_aon alert_dump_i.*
 end
 
 // Include all coverage metrics in non-preverified modules.


### PR DESCRIPTION
This commit excludes the alertdump and crashdump signals from coverage collection, as discussed in #15427.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>