### PR TITLE
[flash_ctrl,dv] more coverage update

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -167,6 +167,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
                                         flash_mp_region_cfg_t region_cfg = cfg.default_region_cfg);
     uvm_reg_data_t data;
     uvm_reg csr;
+    update_mp_region_cfg_mubifalse(region_cfg);
     data = get_csr_val_with_updated_field(ral.mp_region_cfg[index].en, data,
                                           region_cfg.en);
     data = data | get_csr_val_with_updated_field(ral.mp_region_cfg[index].rd_en, data,
@@ -238,6 +239,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     end
     `uvm_info("mp_info_page_cfg", $sformatf("%s: %p", csr_name, page_cfg), UVM_DEBUG)
     csr = ral.get_reg_by_name(csr_name);
+    update_mp_info_cfg_mubifalse(page_cfg);
     data = get_csr_val_with_updated_field(csr.get_field_by_name("en"), data, page_cfg.en);
     data = data |
         get_csr_val_with_updated_field(csr.get_field_by_name("rd_en"), data, page_cfg.read_en);
@@ -537,7 +539,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     poll_fifo_status                    = 1;
 
     // Disable HW Access to Secret Partition from Life Cycle Controller Interface (Write/Read/Erase)
-    cfg.flash_ctrl_vif.lc_seed_hw_rd_en = lc_ctrl_pkg::Off;
+    cfg.flash_ctrl_vif.lc_seed_hw_rd_en =
+        get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(9));
 
     unique case (secret_part)
       FlashCreatorPart: begin
@@ -636,10 +639,13 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::Off;
     cfg.flash_ctrl_vif.lc_seed_hw_rd_en         = lc_ctrl_pkg::On;
 
-    cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en     = lc_ctrl_pkg::Off;
-    cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en     = lc_ctrl_pkg::Off;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en     =
+        get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
+    cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en     =
+        get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
 
-    cfg.flash_ctrl_vif.lc_nvm_debug_en          = lc_ctrl_pkg::Off;
+    cfg.flash_ctrl_vif.lc_nvm_debug_en          =
+        get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
     cfg.flash_ctrl_vif.lc_escalate_en           = lc_ctrl_pkg::Off;
 
     cfg.flash_ctrl_vif.rma_req                  = lc_ctrl_pkg::Off;
@@ -787,7 +793,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
               UVM_MEDIUM)
 
     // Disable HW Access to Secret Partition from Life Cycle Controller Interface (Write/Read/Erase)
-    cfg.flash_ctrl_vif.lc_seed_hw_rd_en = lc_ctrl_pkg::Off;  // Disable Secret Partition HW Access
+    cfg.flash_ctrl_vif.lc_seed_hw_rd_en =
+        get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
 
     // Select Options
     unique case (part)
@@ -1425,5 +1432,39 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       page++;
     end
   endfunction // update_secret_partition
+
+   function void update_mp_region_cfg_mubifalse(ref flash_mp_region_cfg_t cfg);
+      if (cfg.en != MuBi4True) cfg.en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.read_en != MuBi4True) cfg.read_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.program_en != MuBi4True) cfg.program_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.erase_en != MuBi4True) cfg.erase_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.scramble_en != MuBi4True) cfg.scramble_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.ecc_en != MuBi4True) cfg.ecc_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.he_en != MuBi4True) cfg.he_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+   endfunction
+
+   function void update_mp_info_cfg_mubifalse(ref flash_bank_mp_info_page_cfg_t cfg);
+      if (cfg.en != MuBi4True) cfg.en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.read_en != MuBi4True) cfg.read_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.program_en != MuBi4True) cfg.program_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.erase_en != MuBi4True) cfg.erase_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.scramble_en != MuBi4True) cfg.scramble_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.ecc_en != MuBi4True) cfg.ecc_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+      if (cfg.he_en != MuBi4True) cfg.he_en =
+              get_rand_mubi4_val(.t_weight(0), .f_weight(1), .other_weight(9));
+   endfunction
 
 endclass : flash_ctrl_base_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
@@ -60,7 +60,7 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
                                          flash_op inside {FlashOpProgram, FlashOpErase};)
     end
 
-    sig = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(4));
+    sig = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(8));
     is_valid = is_lc_ctrl_valid(sig);
     cfg.clk_rst_vif.wait_clks(4);
     `uvm_info(`gfn, $sformatf("Check sig:0x%x(is_valid:%0d) part:%s op:%s testtype:%s",

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
@@ -119,7 +119,7 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
                 2'b11: begin
                   if (reset_index == DVWaitDataKey) begin
                     cfg.flash_ctrl_vif.lc_seed_hw_rd_en =
-                      get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
+                      get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(9));
                   end
                 end
                 default: begin

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -72,7 +72,7 @@
     {
       name: flash_ctrl_smoke
       uvm_test_seq: flash_ctrl_smoke_vseq
-      reseed: 5
+      reseed: 50
     }
     {
       name: flash_ctrl_smoke_hw
@@ -111,7 +111,7 @@
       name: flash_ctrl_hw_sec_otp
       uvm_test_seq: flash_ctrl_hw_sec_otp_vseq
       run_opts: ["+test_timeout_ns=300_000_000_000"]
-      reseed: 5
+      reseed: 50
     }
     {
       name: flash_ctrl_erase_suspend
@@ -135,7 +135,7 @@
       name: flash_ctrl_otp_reset
       uvm_test_seq: flash_ctrl_otp_reset_vseq
       run_opts: ["+test_timeout_ns=300_000_000_000"]
-      reseed: 20
+      reseed: 80
     }
     {
       name: flash_ctrl_host_ctrl_arb
@@ -345,7 +345,7 @@
       uvm_test_seq: flash_ctrl_disable_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+en_always_all=1",
                  "+bypass_alert_ready_to_end_check=1"]
-      reseed: 20
+      reseed: 50
     }
     {
       name: flash_ctrl_sec_cm
@@ -354,7 +354,7 @@
     {
       name: flash_ctrl_sec_info_access
       uvm_test_seq: flash_ctrl_info_part_access_vseq
-      reseed: 5
+      reseed: 50
     }
     {
       name: flash_ctrl_stress_all
@@ -363,7 +363,7 @@
     {
       name: flash_ctrl_connect
       uvm_test_seq: flash_ctrl_connect_vseq
-      reseed: 5
+      reseed: 80
     }
     {
       name: flash_ctrl_rd_intg


### PR DESCRIPTION
- Increase reseed for lc_ctrl input tests
- Add non-true value to mubi cfg registers
- Increase weight for 'other' values for lc_tx and mubi rand.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>