### PR TITLE
[test-point] Implement chip_sw_csrng_edn_cmd

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2204,14 +2204,13 @@
       name: chip_sw_csrng_edn_cmd
       desc: '''Verify incoming command interface from EDN.
 
-            - Have each EDN instance issue an instantiate command to CSRNG.
-            - When done, verify the reception of cmd req done interrupt.
+            - Have each EDN instance issue an instantiate, reseed and generate command to CSRNG.
+            - On each command done, verify the reception of edn cmd req done interrupt.
+            - Run OTBN randomness test to test the output from EDN0 and EDN1.
             - Check the data returned to EDN via connectivity assertion checks.
-            - TODO: explore the ability to generate predictable data and verify the received value.
-            Details TBD.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_entropy_src_csrng"]
     }
     {
       name: chip_sw_csrng_fuse_en_sw_app_read

--- a/sw/device/lib/dif/dif_edn.h
+++ b/sw/device/lib/dif/dif_edn.h
@@ -284,9 +284,9 @@ dif_result_t dif_edn_get_status(const dif_edn_t *edn, dif_edn_status_t flag,
  * Queries the EDN error flags.
  *
  * @param edn An EDN handle.
- * @param unhealthy_fifos Bitset of FIFOs in an unhealthy state; indices are
- * `dif_edn_fifo_t`.
- * @param errors Bitset of errors relating to the above FIFOs; indices are
+ * @param[out] unhealthy_fifos Bitset of FIFOs in an unhealthy state; indices
+ * are `dif_edn_fifo_t`.
+ * @param[out] errors Bitset of errors relating to the above FIFOs; indices are
  * `dif_edn_error_t`.
  * @return The result of the operation.
  */

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -726,6 +726,7 @@ opentitan_functest(
         timeout = "long",
     ),
     deps = [
+        ":otbn_randomness_impl",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -733,7 +734,9 @@ opentitan_functest(
         "//sw/device/lib/dif:csrng",
         "//sw/device/lib/dif:edn",
         "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:otbn",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:otbn",
         "//sw/device/lib/testing:csrng_testutils",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:isr_testutils",


### PR DESCRIPTION
The chip_sw_entropy_src_csrng test is updated to check for edn command done irqs in addition to csrng entropy request irqs. A generate command is sent using the EDN SW_CMD_REQ register to generate enough entropy for the otbn randomness test. The otbn randomness test is used to check the EDN output.