### PR TITLE
[chip dv] Minor enhancement to adc_ctrl debug cable test

### DIFF
--- a/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
+++ b/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
@@ -76,6 +76,9 @@ void ottf_external_isr(void) {
   CHECK(peripheral == kTopEarlgreyPlicPeripheralAdcCtrlAon);
   CHECK(adc_ctrl_irq == kDifAdcCtrlIrqMatchDone);
   interrupt_serviced = true;
+
+  // Verify this interrupt was actually expected.
+  CHECK(interrupt_expected);
 }
 
 static void en_plic_irqs(dif_rv_plic_t *plic) {


### PR DESCRIPTION
Check interrupt_expected to be true in the ISR.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>