### PR TITLE
[dv] Always preload ROM in chip_base_vseq

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -258,15 +258,9 @@
     }
     {
       name: stub_cpu_mode
+      // Note that the chip_base_vseq will preload a random ROM image with valid ECC and digest
+      // so that the ROM check can succeed even if no ROM image is built and supplied via Bazel.
       en_run_modes: ["gen_otp_images_mode"]
-      run_opts: ["+stub_cpu=1"]
-    }
-    {
-      name: stub_cpu_mode_with_test_rom
-      en_run_modes: ["sw_test_mode_common"]
-      // The tests using this mode only require the ROM init check to succeed.
-      // The example_test_from_rom test is sufficient.
-      sw_images: ["//sw/device/tests:example_test_from_rom:0:test_in_rom"]
       run_opts: ["+stub_cpu=1"]
     }
     {
@@ -1437,7 +1431,7 @@
       name: chip_rv_dm_lc_disabled
       build_mode: "cover_reg_top"
       uvm_test_seq: "chip_rv_dm_lc_disabled_vseq"
-      en_run_modes: ["stub_cpu_mode_with_test_rom"]
+      en_run_modes: ["stub_cpu_mode"]
       run_opts: ["+en_scb=0", "+en_scb_tl_err_chk=0", "+use_jtag_dmi=1"]
     }
     {

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -58,6 +58,10 @@ package chip_env_pkg;
   localparam uint TokenWidthBit  = kmac_pkg::MsgWidth * 2;
   localparam uint TokenWidthByte = TokenWidthBit / 8;
 
+  // ROM digest parameters
+  localparam uint RomDigestDw = 256;
+  localparam uint RomMaxCheckAddr = rom_ctrl_reg_pkg::ROM_CTRL_ROM_SIZE - (RomDigestDw / 8);
+
   typedef virtual sw_logger_if         sw_logger_vif;
   typedef virtual sw_test_status_if    sw_test_status_vif;
   typedef virtual ast_supply_if        ast_supply_vif;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_lc_disabled_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_lc_disabled_vseq.sv
@@ -54,23 +54,13 @@ class chip_rv_dm_lc_disabled_vseq extends chip_stub_cpu_base_vseq;
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
-    `uvm_info(`gfn, "Initializing ROM", UVM_MEDIUM)
-    // This vseq derives from the chip_stub_cpu_base_vseq, hence the ROM has to be loaded explicitly.
-    `ifdef DISABLE_ROM_INTEGRITY_CHECK
-        cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".32.vmem"});
-    `else
-        cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".39.scr.vmem"});
-    `endif
+    `uvm_info(`gfn, $sformatf("DUT Init with lc_state %0s", lc_state.name), UVM_LOW)
 
     // TODO(#15624): remove this part later.
-    `uvm_info(`gfn, "Wait for ROM check to complete", UVM_MEDIUM)
-    // In case we are in PROD* or DEV, we need to wait until the strap sampling pulse
-    // is released after the ROM check.
-    if (lc_state inside {LcStDev, LcStProd, LcStProdEnd}) begin
-      wait_rom_check_done();
-      // The strap sampling pulse is released a few cycles after the ROM check completes.
-      cfg.clk_rst_vif.wait_clks(100);
-    end
+    // We already wait for the ROM check to complete in the post_apply_reset sequence of
+    // chip_stub_cpu_base_vseq. However, we need to wait a few additional cycles here since
+    // the strap sampling pulse is released a few cycles after the ROM check completes.
+    cfg.clk_rst_vif.wait_clks(100);
 
     `uvm_info(`gfn, "Attempt to activate RV_DM via JTAG.", UVM_MEDIUM)
     // RV_DM needs to be activated for the registers to work properly.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -29,14 +29,6 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     super.pre_start();
   endtask
 
-  virtual task post_apply_reset(string reset_kind = "HARD");
-    super.post_apply_reset(reset_kind);
-
-    // Wait until rom_ctrl and lc_ctrl have finished to ensure stub_cpu
-    // does not conflict with any background power-up activity
-    wait_rom_check_done();
-  endtask
-
   task post_start();
     super.post_start();
 
@@ -54,7 +46,12 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
+    // Wait until rom_ctrl and lc_ctrl have finished to ensure stub_cpu
+    // does not conflict with any background power-up activity
+    `uvm_info(`gfn, "Wait for ROM check to complete", UVM_MEDIUM)
+    wait_rom_check_done();
     // Program the AST with the configuration data loaded in OTP creator SW config region.
+    `uvm_info(`gfn, "Perform AST configuration", UVM_MEDIUM)
     if (cfg.use_jtag_dmi == 0) do_ast_cfg();
   endtask
 


### PR DESCRIPTION
#15794 introduced a ROM init done check to `post_apply_reset()` in `chip_stub_cpu_base_vseq` which caused the ROM init done check in `dut_init()` of the `chip_rv_dm_lc_disabled_vseq` to hang forever.

This PR removes the ROM init check from `chip_rv_dm_lc_disabled_vseq` to fix that. In addition, it always pre-loads a valid ROM image during the `dut_init()` phase of `chip_stub_cpu_base_vseq` to make sure that the ROM check can succeed successfully. Note that the real hardware will always contain a valid ROM image, so this is not a simulation-only hack and bring simulations closer to the behavior of the real hardware.

This fixes #15893.

Signed-off-by: Michael Schaffner <msf@google.com>