### PR TITLE
[top] Update test count comparison

### DIFF
--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -580,7 +580,9 @@ static void collect_alert_dump_and_compare(test_round_t round) {
   }
 
   for (int i = 0; i < ALERT_HANDLER_PARAM_N_CLASSES; ++i) {
-    CHECK(kExpectedInfo[round].alert_info.class_accum_cnt[i] ==
+    // We cannot do an "equal" check here since some of the alerts may
+    // be fatal and cause the accumulated count to continuously grow.
+    CHECK(kExpectedInfo[round].alert_info.class_accum_cnt[i] <=
               actual_info.class_accum_cnt[i],
           "alert_info.class_accum_cnt[%d] mismatch exp:0x%x  obs:0x%x", i,
           kExpectedInfo[round].alert_info.class_accum_cnt[i],


### PR DESCRIPTION
Previously, the test looked for an exact match on accmumulated count. This would occassionally break because the triggered alert could have been fatal.  Fatal alerts continuously send alerts and thus can cause the count to be bigger than expected.

Relax the check to be less than or equal.

Signed-off-by: Timothy Chen <timothytim@google.com>