### PR TITLE
[doc] Minor tweaks to test triage issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-triage.yml
+++ b/.github/ISSUE_TEMPLATE/test-triage.yml
@@ -31,9 +31,9 @@ body:
     attributes:
       label: Steps to Reproduce
       value: |
-        - Commit hash where failure was observed
+        - GitHub Revision: HASH_VALUE
         - dvsim invocation command to reproduce the failure, inclusive of build and run seeds:
-          ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i {TEST_NAME} --fixed-seed {FAILING_SEED} --build-seed {BUILD_SEED} --waves -v h
+          ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i TEST_NAME --build-seed BUILD_SEED --fixed-seed FAILING_SEED --waves fsdb
         - Kokoro build number if applicable
     validations:
       required: true


### PR DESCRIPTION
When copy pasting seeds, test name etc from the dashboard, I often find it annoying that I have to manually delete the curly braces after double clicking the ALL_CAPS placeholder and replacing it with the actual value. This patch tweaks that to make it more convenient to file a test triage issue.

Signed-off-by: Michael Schaffner <msf@google.com>