### PR TITLE
[xbar] Reduce fifo depth

### DIFF
--- a/hw/ip/tlul/rtl/tlul_socket_1n.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_1n.sv
@@ -47,10 +47,10 @@ module tlul_socket_1n #(
   parameter bit           HRspPass     = 1'b1,
   parameter bit [N-1:0]   DReqPass     = {N{1'b1}},
   parameter bit [N-1:0]   DRspPass     = {N{1'b1}},
-  parameter bit [3:0]     HReqDepth    = 4'h2,
-  parameter bit [3:0]     HRspDepth    = 4'h2,
-  parameter bit [N*4-1:0] DReqDepth    = {N{4'h2}},
-  parameter bit [N*4-1:0] DRspDepth    = {N{4'h2}},
+  parameter bit [3:0]     HReqDepth    = 4'h1,
+  parameter bit [3:0]     HRspDepth    = 4'h1,
+  parameter bit [N*4-1:0] DReqDepth    = {N{4'h1}},
+  parameter bit [N*4-1:0] DRspDepth    = {N{4'h1}},
   parameter bit           ExplicitErrs = 1'b1,
 
   // The width of dev_select_i. We must be able to select any of the N devices

--- a/hw/ip/tlul/rtl/tlul_socket_m1.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_m1.sv
@@ -26,12 +26,12 @@ module tlul_socket_m1 #(
   parameter int unsigned  M         = 4,
   parameter bit [M-1:0]   HReqPass  = {M{1'b1}},
   parameter bit [M-1:0]   HRspPass  = {M{1'b1}},
-  parameter bit [M*4-1:0] HReqDepth = {M{4'h2}},
-  parameter bit [M*4-1:0] HRspDepth = {M{4'h2}},
+  parameter bit [M*4-1:0] HReqDepth = {M{4'h1}},
+  parameter bit [M*4-1:0] HRspDepth = {M{4'h1}},
   parameter bit           DReqPass  = 1'b1,
   parameter bit           DRspPass  = 1'b1,
-  parameter bit [3:0]     DReqDepth = 4'h2,
-  parameter bit [3:0]     DRspDepth = 4'h2
+  parameter bit [3:0]     DReqDepth = 4'h1,
+  parameter bit [3:0]     DRspDepth = 4'h1
 ) (
   input                     clk_i,
   input                     rst_ni,

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -8661,7 +8661,8 @@
           type: device
           clock: clk_main_i
           reset: rst_main_ni
-          pipeline: false
+          req_fifo_pass: false
+          rsp_fifo_pass: false
           inst_type: rom_ctrl
           addr_range:
           [
@@ -8672,7 +8673,7 @@
           ]
           xbar: false
           stub: false
-          req_fifo_pass: true
+          pipeline: true
         }
         {
           name: peri
@@ -8701,7 +8702,8 @@
           type: device
           clock: clk_spi_host0_i
           reset: rst_spi_host0_ni
-          pipeline: false
+          req_fifo_pass: false
+          rsp_fifo_pass: false
           inst_type: spi_host
           addr_range:
           [
@@ -8712,14 +8714,15 @@
           ]
           xbar: false
           stub: false
-          req_fifo_pass: true
+          pipeline: true
         }
         {
           name: spi_host1
           type: device
           clock: clk_spi_host1_i
           reset: rst_spi_host1_ni
-          pipeline: false
+          req_fifo_pass: false
+          rsp_fifo_pass: false
           inst_type: spi_host
           addr_range:
           [
@@ -8730,14 +8733,15 @@
           ]
           xbar: false
           stub: false
-          req_fifo_pass: true
+          pipeline: true
         }
         {
           name: usbdev
           type: device
           clock: clk_usb_i
           reset: rst_usb_ni
-          pipeline: false
+          req_fifo_pass: false
+          rsp_fifo_pass: false
           inst_type: usbdev
           addr_range:
           [
@@ -8748,7 +8752,7 @@
           ]
           xbar: false
           stub: false
-          req_fifo_pass: true
+          pipeline: true
         }
         {
           name: flash_ctrl.core
@@ -9021,7 +9025,8 @@
           type: device
           clock: clk_main_i
           reset: rst_main_ni
-          pipeline: false
+          req_fifo_pass: false
+          rsp_fifo_pass: false
           inst_type: sram_ctrl
           addr_range:
           [
@@ -9032,7 +9037,7 @@
           ]
           xbar: false
           stub: false
-          req_fifo_pass: true
+          pipeline: true
         }
         {
           name: sram_ctrl_main.ram

--- a/hw/top_earlgrey/data/xbar_main.hjson
+++ b/hw/top_earlgrey/data/xbar_main.hjson
@@ -8,13 +8,27 @@
   reset_primary: "rst_main_ni", // Main reset, used in sockets
   other_reset_list: [ "rst_fixed_ni", "rst_spi_host0_ni", "rst_spi_host1_ni", "rst_usb_ni"] // Secondary clocks used by specific nodes
 
+  // Rationale for pipeline and req/rsp_fifo_pass:
+  // For host interfaces that are used during production state (corei/cored),
+  // minimize the amount of host introduced latency.  This is accomplished
+  // by setting pipeline to false.
+  // For host interfaces that are only used for debug, relax the timing by
+  // inserting a register slice and not allowing passthrough (more access
+  // latency. This is accomplished by setting `req/rsp_fifo_pass` to false,
+  // and implicitly using the default of pipeline true.
+  //
+  // For device interfaces, especially configuration registers, latency is
+  // not generally a concern, thus use `req/rsp_fifo_pass` false and pipeline
+  // true.
+  // For device accesses to memories (ram / rom / flash), performance is a concern,
+  // so use pipeline false where permissible by timing. If not, find a combination
+  // that works.
   nodes: [
     { name:  "rv_core_ibex.corei",
       type:  "host",
       clock: "clk_main_i",
       reset: "rst_main_ni",
       pipeline: false
-
     },
     { name:  "rv_core_ibex.cored",
       type:  "host",
@@ -54,7 +68,8 @@
       type:      "device",
       clock:     "clk_main_i",
       reset:     "rst_main_ni",
-      pipeline:  false,
+      req_fifo_pass: false,
+      rsp_fifo_pass: false,
     },
     { name:      "peri",
       type:      "device",
@@ -67,19 +82,22 @@
       type:      "device",
       clock:     "clk_spi_host0_i",
       reset:     "rst_spi_host0_ni",
-      pipeline:  false
+      req_fifo_pass: false,
+      rsp_fifo_pass: false,
     },
     { name:      "spi_host1",
       type:      "device",
       clock:     "clk_spi_host1_i",
       reset:     "rst_spi_host1_ni",
-      pipeline:  false
+      req_fifo_pass: false,
+      rsp_fifo_pass: false,
     },
     { name:      "usbdev",
       type:      "device",
       clock:     "clk_usb_i",
       reset:     "rst_usb_ni",
-      pipeline:  false
+      req_fifo_pass: false,
+      rsp_fifo_pass: false,
     },
     { name:      "flash_ctrl.core",
       type:      "device",
@@ -95,6 +113,8 @@
       req_fifo_pass: false,
       rsp_fifo_pass: false,
     },
+    // Return and examine whether this path
+    // latency can be improved.
     { name:      "flash_ctrl.mem",
       type:      "device",
       clock:     "clk_main_i",
@@ -184,13 +204,14 @@
       type:      "device",
       clock:     "clk_main_i",
       reset:     "rst_main_ni",
-      pipeline: false
+      req_fifo_pass: false,
+      rsp_fifo_pass: false,
     },
     { name:      "sram_ctrl_main.ram",
       type:      "device",
       clock:     "clk_main_i",
       reset:     "rst_main_ni",
-      pipeline: false
+      pipeline:  false
     },
   ],
   connections: {

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -222,7 +222,8 @@
       type: device
       clock: clk_main_i
       reset: rst_main_ni
-      pipeline: false
+      req_fifo_pass: false
+      rsp_fifo_pass: false
       inst_type: rom_ctrl
       addr_range:
       [
@@ -233,7 +234,7 @@
       ]
       xbar: false
       stub: false
-      req_fifo_pass: true
+      pipeline: true
     }
     {
       name: peri
@@ -262,7 +263,8 @@
       type: device
       clock: clk_spi_host0_i
       reset: rst_spi_host0_ni
-      pipeline: false
+      req_fifo_pass: false
+      rsp_fifo_pass: false
       inst_type: spi_host
       addr_range:
       [
@@ -273,14 +275,15 @@
       ]
       xbar: false
       stub: false
-      req_fifo_pass: true
+      pipeline: true
     }
     {
       name: spi_host1
       type: device
       clock: clk_spi_host1_i
       reset: rst_spi_host1_ni
-      pipeline: false
+      req_fifo_pass: false
+      rsp_fifo_pass: false
       inst_type: spi_host
       addr_range:
       [
@@ -291,14 +294,15 @@
       ]
       xbar: false
       stub: false
-      req_fifo_pass: true
+      pipeline: true
     }
     {
       name: usbdev
       type: device
       clock: clk_usb_i
       reset: rst_usb_ni
-      pipeline: false
+      req_fifo_pass: false
+      rsp_fifo_pass: false
       inst_type: usbdev
       addr_range:
       [
@@ -309,7 +313,7 @@
       ]
       xbar: false
       stub: false
-      req_fifo_pass: true
+      pipeline: true
     }
     {
       name: flash_ctrl.core
@@ -582,7 +586,8 @@
       type: device
       clock: clk_main_i
       reset: rst_main_ni
-      pipeline: false
+      req_fifo_pass: false
+      rsp_fifo_pass: false
       inst_type: sram_ctrl
       addr_range:
       [
@@ -593,7 +598,7 @@
       ]
       xbar: false
       stub: false
-      req_fifo_pass: true
+      pipeline: true
     }
     {
       name: sram_ctrl_main.ram

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
@@ -992,8 +992,8 @@ end
   tlul_socket_m1 #(
     .HReqDepth (8'h0),
     .HRspDepth (8'h0),
-    .DReqDepth (4'h0),
-    .DRspDepth (4'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
     .M         (2)
   ) u_sm1_33 (
     .clk_i        (clk_main_i),
@@ -1296,8 +1296,8 @@ end
   tlul_socket_m1 #(
     .HReqDepth (8'h0),
     .HRspDepth (8'h0),
-    .DReqDepth (4'h0),
-    .DRspDepth (4'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
     .M         (2)
   ) u_sm1_55 (
     .clk_i        (clk_main_i),

--- a/util/tlgen/elaborate.py
+++ b/util/tlgen/elaborate.py
@@ -162,11 +162,11 @@ def process_pipeline(xbar):
             if full_fifo:
                 dnode.hreq_pass = 0
                 dnode.hrsp_pass = 0
-                dnode.hdepth = 2
+                dnode.hdepth = 1
             elif fifo_passthru:
                 dnode.hreq_pass = req_pass
                 dnode.hrsp_pass = rsp_pass
-                dnode.hdepth = 2
+                dnode.hdepth = 1
             elif full_passthru:
                 dnode.hreq_pass = 1
                 dnode.hrsp_pass = 1
@@ -184,12 +184,12 @@ def process_pipeline(xbar):
             dnode.hreq_pass = dnode.hreq_pass & ~(1 << idx)
             if full_fifo:
                 log.info("fifo present no bypass")
-                dnode.hdepth = dnode.hdepth | (2 << idx * 4)
+                dnode.hdepth = dnode.hdepth | (1 << idx * 4)
             elif fifo_passthru:
                 log.info("fifo present with bypass")
                 dnode.hreq_pass = dnode.hreq_pass | (req_pass << idx)
                 dnode.hreq_pass = dnode.hrsp_pass | (rsp_pass << idx)
-                dnode.hdepth = dnode.hdepth | (2 << idx * 4)
+                dnode.hdepth = dnode.hdepth | (1 << idx * 4)
             elif full_passthru:
                 log.info("fifo not present")
                 dnode.hreq_pass = dnode.hreq_pass | (1 << idx)
@@ -241,11 +241,11 @@ def process_pipeline(xbar):
             unode.dreq_pass = unode.dreq_pass & ~(1 << idx)
             unode.drsp_pass = unode.drsp_pass & ~(1 << idx)
             if full_fifo:
-                unode.ddepth = unode.ddepth | (2 << idx * 4)
+                unode.ddepth = unode.ddepth | (1 << idx * 4)
             elif fifo_passthru:
                 unode.dreq_pass = unode.dreq_pass | (req_pass << idx)
                 unode.drsp_pass = unode.drsp_pass | (rsp_pass << idx)
-                unode.ddepth = unode.ddepth | (2 << idx * 4)
+                unode.ddepth = unode.ddepth | (1 << idx * 4)
             elif full_passthru:
                 unode.dreq_pass = unode.dreq_pass | (1 << idx)
                 unode.drsp_pass = unode.drsp_pass | (1 << idx)
@@ -259,12 +259,12 @@ def process_pipeline(xbar):
                 log.info("Fifo present with no passthrough")
                 unode.dreq_pass = 0
                 unode.drsp_pass = 0
-                unode.ddepth = 2
+                unode.ddepth = 1
             elif fifo_passthru:
                 log.info("Fifo present with passthrough")
                 unode.dreq_pass = req_pass
                 unode.drsp_pass = rsp_pass
-                unode.ddepth = 2
+                unode.ddepth = 1
             elif full_passthru:
                 log.info("No Fifo")
                 unode.dreq_pass = 1

--- a/util/tlgen/xbar.rtl.sv.tpl
+++ b/util/tlgen/xbar.rtl.sv.tpl
@@ -228,7 +228,7 @@ ${"end" if loop.last else ""}
     % if block.hrsp_pass != 1:
     .HRspPass  (1'b${block.hrsp_pass}),
     % endif
-    % if block.hdepth != 2:
+    % if block.hdepth != 1:
     .HReqDepth (4'h${block.hdepth}),
     .HRspDepth (4'h${block.hdepth}),
     % endif
@@ -238,7 +238,7 @@ ${"end" if loop.last else ""}
     % if block.drsp_pass != 2**(len(block.ds)) -1:
     .DRspPass  (${len(block.ds)}'h${"%x" % block.drsp_pass}),
     % endif
-    % if block.ddepth != 2:
+    % if block.ddepth != 1:
     .DReqDepth (${len(block.ds)*4}'h${"%x" % block.ddepth}),
     .DRspDepth (${len(block.ds)*4}'h${"%x" % block.ddepth}),
     % endif
@@ -260,7 +260,7 @@ ${"end" if loop.last else ""}
     % if block.hrsp_pass != 2**(len(block.us)) - 1:
     .HRspPass  (${len(block.us)}'h${"%x" % block.hrsp_pass}),
     % endif
-    % if block.hdepth != 2:
+    % if block.hdepth != 1:
     .HReqDepth (${len(block.us)*4}'h${"%x" % block.hdepth}),
     .HRspDepth (${len(block.us)*4}'h${"%x" % block.hdepth}),
     % endif
@@ -270,7 +270,7 @@ ${"end" if loop.last else ""}
     % if block.drsp_pass != 1:
     .DRspPass  (1'b${block.drsp_pass}),
     % endif
-    % if block.ddepth != 2:
+    % if block.ddepth != 1:
     .DReqDepth (4'h${block.ddepth}),
     .DRspDepth (4'h${block.ddepth}),
     % endif


### PR DESCRIPTION
- Reduce socketm1/socket1n default fifo's to depth of 1
- There is no need for deeper fifos in our current system
- Add rationale for why xbar nodes are configured as they are

Signed-off-by: Timothy Chen <timothytim@google.com>