### PR TITLE
[dv/edn] Add an assertion to check EDN data stable

### DIFF
--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -117,6 +117,9 @@ module edn
   // Endpoint Asserts
   for (genvar i = 0; i < NumEndPoints; i = i+1) begin : gen_edn_if_asserts
     `ASSERT_KNOWN(EdnEndPointOut_A, edn_o[i])
+    // This assertion checks that EDN data will be stable from edn_ack until the next edn request.
+    `ASSERT(EdnDataStable_A, edn_o[i].edn_ack |=>
+            $stable(edn_o[i].edn_bus) throughout edn_i[i].edn_req[->1])
   end : gen_edn_if_asserts
 
   // CSRNG Asserts


### PR DESCRIPTION
This PR adds an assertion in EDN design code to ensure that EDN output data stays stable (once valid), until next EDN request.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>