### PR TITLE
[bazel] Check for invalid use of git_repository rule with native.existing_rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,3 +105,9 @@ hooks_repo(name = "manufacturer_test_hooks")
 # The nonhermetic_repo imports environment variables needed to run vivado.
 load("//rules:nonhermetic.bzl", "nonhermetic_repo")
 nonhermetic_repo(name = "nonhermetic")
+
+# Load this last
+# Monitor the workspace to check for git_repositories that will break airgapped builds
+# You can experimentally add git_repos below this check, but they shouldn't be comitted
+load("//rules:git_repo_check.bzl","git_repo_check")
+git_repo_check()

--- a/rules/git_repo_check.bzl
+++ b/rules/git_repo_check.bzl
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be run at the end of WORKSPACE definition to check that there aren't any git_repository or new_git_repository rules
+def git_repo_check():
+  for repos in native.existing_rules().values():
+    if "git_repository" in repos["kind"]:
+      fail(
+"""OpenTitan's security model and airgapping strategy requires use of only http_archives.
+Rule '{}' contains a '{}'
+Details: {}""".format(repos["name"],repos["kind"],repos)
+      )


### PR DESCRIPTION
I think this is the canonical way to check for use of the git_repository rule. If used it will fail when the workspace is loaded. It can be worked around temporarily by loading after the check, and such a workaround is detailed in the workspace.

Fixes: #15878

Signed-off-by: Drew Macrae <drewmacrae@google.com>