### PR TITLE
[bazel/ci] Query for git_repository rule in bazel to keep them out of…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,6 +162,8 @@ jobs:
   - bash: ci/scripts/check-bazel-tags.sh
     displayName: Check Bazel Tags
     continueOnError: True
+  - bash: ci/scripts/check-bazel-banned-rules.sh
+    displayName: Check for banned rules
   - bash: ci/scripts/check-generated.sh
     displayName: Check Generated
     # Ensure all generated files are clean and up-to-date

--- a/ci/jobs/slow-lint.sh
+++ b/ci/jobs/slow-lint.sh
@@ -14,6 +14,9 @@ set -e
 echo -e "\n### Check tags on Bazel artifacts"
 ci/scripts/check-bazel-tags.sh
 
+echo -e "\n### Ensure bazel doesn't use 'git_repository's"
+ci/scripts/check-bazel-banned-rules.sh
+
 echo -e "\n### Ensure all generated files are clean and up-to-date"
 ci/scripts/check-generated.sh
 

--- a/ci/scripts/check-bazel-banned-rules.sh
+++ b/ci/scripts/check-bazel-banned-rules.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+GIT_REPOS=$(./bazelisk.sh query "kind('(new_)?git_repository', //external:*)")
+if [[ ${GIT_REPOS} ]]; then
+  echo "Bazel's 'git_repository' rule is insecure and incompatible with OpenTitan's airgapping strategy."
+  echo "Please replace $GIT_REPOS with our 'http_archive_or_local' rule and set a sha256 so it can be canonically reproducible."
+  exit 1
+fi


### PR DESCRIPTION
Fixes: https://github.com/lowRISC/opentitan/issues/15878

I prefer this one to #15924 because it doesn't involve relying on the structure of the tree and can be checked during CI runs.
I also like that the CI checks look similar to the tagging query so the shell script isn't doing anything interesting.

Signed-off-by: Drew Macrae <drewmacrae@google.com>