### PR TITLE
[edn/dv] Disable test

### DIFF
--- a/hw/ip/edn/data/edn_testplan.hjson
+++ b/hw/ip/edn/data/edn_testplan.hjson
@@ -82,6 +82,14 @@
       tests: ["edn_err"]
     }
     {
+      name: disable
+      desc: '''
+            Disable EDN in all states and verify proper operation when re-enabled.
+            '''
+      stage: V2
+      tests: ["edn_disable"]
+    }
+    {
       name: stress_all
       desc: '''
             Combine the other individual testpoints while injecting TL errors and running CSR tests

--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -98,6 +98,12 @@
       uvm_test_seq: edn_err_vseq
     }
 
+    {
+      name: edn_disable
+      uvm_test: edn_disable_test
+      uvm_test_seq: edn_disable_vseq
+    }
+
     // TODO: add more tests here
   ]
 

--- a/hw/ip/edn/dv/env/edn_env.core
+++ b/hw/ip/edn/dv/env/edn_env.core
@@ -29,6 +29,7 @@ filesets:
       - seq_lib/edn_intr_vseq.sv: {is_include_file: true}
       - seq_lib/edn_alert_vseq.sv: {is_include_file: true}
       - seq_lib/edn_err_vseq.sv: {is_include_file: true}
+      - seq_lib/edn_disable_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -27,6 +27,7 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
 
   // Knobs & Weights
   uint   enable_pct, boot_req_mode_pct, auto_req_mode_pct, cmd_fifo_rst_pct,
+         force_disable_pct,
          min_num_boot_reqs, max_num_boot_reqs,
          min_num_ep_reqs, max_num_ep_reqs,
          invalid_mubi4_pct;
@@ -35,6 +36,7 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
 
   rand mubi4_t   enable, boot_req_mode, auto_req_mode, cmd_fifo_rst;
   rand uint      num_endpoints, num_boot_reqs;
+  rand bit       force_disable;
   rand bit [csrng_pkg::CSRNG_CMD_WIDTH - 1:0]   boot_ins_cmd, boot_gen_cmd;
 
   rand fatal_err_e      which_fatal_err;
@@ -45,6 +47,9 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
 
   // Constraints
   // TODO: utilize suggestions in PR9535 to generate "other" values when testing alerts
+  constraint force_disable_c {force_disable dist {
+    1 :/ force_disable_pct,
+    0 :/ (100 - force_disable_pct) };}
   constraint enable_c {enable dist {
     MuBi4True  :/ enable_pct,
     MuBi4False :/ (100 - enable_pct) };}
@@ -124,6 +129,8 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
         num_endpoints)};
     str = {str,  $sformatf("\n\t |***** num_boot_reqs                : %10d *****| \t",
         num_boot_reqs)};
+    str = {str,  $sformatf("\n\t |***** force_disable                : %10d *****| \t",
+        force_disable)};
     str = {str,  $sformatf("\n\t |------------------- knobs ---------------------------| \t")};
     str = {str,  $sformatf("\n\t |***** enable_pct                   : %10d *****| \t",
         enable_pct)};
@@ -137,6 +144,8 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
         min_num_boot_reqs)};
     str = {str,  $sformatf("\n\t |***** max_num_boot_reqs            : %10d *****| \t",
         max_num_boot_reqs)};
+    str = {str,  $sformatf("\n\t |***** force_disable_pct            : %10d *****| \t",
+        force_disable_pct)};
     str = {str,  $sformatf("\n\t |*****************************************************| \t")};
     str = {str, "\n"};
     return str;

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -149,6 +149,9 @@ class edn_scoreboard extends cip_base_scoreboard #(
         // Do nothing.
         // TODO: Found error in stress_all_with_rand_reset. Check if need to verify them.
       end
+      "main_sm_state": begin
+        do_read_check = 1'b0;
+      end
       default: begin
         `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
       end

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -65,8 +65,14 @@ class edn_base_vseq extends cip_base_vseq #(
       `DV_CHECK_STD_RANDOMIZE_FATAL(glen)
       wr_cmd(.cmd_type("boot_ins"), .acmd(csrng_pkg::INS), .clen(0), .flags(flags), .glen(glen));
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
-      wr_cmd(.cmd_type("boot_gen"), .acmd(csrng_pkg::GEN), .clen(0), .flags(flags),
-             .glen(cfg.num_boot_reqs));
+      if (cfg.force_disable) begin
+        wr_cmd(.cmd_type("boot_gen"), .acmd(csrng_pkg::GEN), .clen(0), .flags(flags),
+               .glen(1'b1));
+      end
+      else begin
+        wr_cmd(.cmd_type("boot_gen"), .acmd(csrng_pkg::GEN), .clen(0), .flags(flags),
+               .glen(cfg.num_boot_reqs));
+      end
     end
 
     // Enable edn, set modes

--- a/hw/ip/edn/dv/env/seq_lib/edn_disable_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_disable_vseq.sv
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class edn_disable_vseq extends edn_base_vseq;
+  `uvm_object_utils(edn_disable_vseq)
+  `uvm_object_new
+
+  push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)
+      m_endpoint_pull_seq[MAX_NUM_ENDPOINTS];
+
+  uint   num_requesters, num_ep_reqs, num_cs_reqs, wait_disable;
+
+  string   enable_path, boot_path, auto_path;
+
+  task body();
+    super.body();
+
+    enable_path = "tb.dut.u_edn_core.mubi_edn_enable";
+    boot_path   = "tb.dut.u_edn_core.mubi_boot_req_mode";
+    auto_path   = "tb.dut.u_edn_core.mubi_auto_req_mode";
+
+    fork
+      begin
+        // Random delay, disable edn
+        // TODO: Modify min/max wait_disable values to hit all states
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(wait_disable,
+                                           wait_disable inside
+                                           { [80:100] };)
+        cfg.clk_rst_vif.wait_clks(wait_disable);
+        // Disable edn, boot_req_mode, auto_req_mode
+        `DV_CHECK(uvm_hdl_deposit(enable_path, MuBi4False));
+        `DV_CHECK(uvm_hdl_deposit(boot_path, MuBi4False));
+        `DV_CHECK(uvm_hdl_deposit(auto_path, MuBi4False));
+        cfg.clk_rst_vif.wait_clks(10);
+        // Enable edn
+        `DV_CHECK(uvm_hdl_deposit(enable_path, MuBi4True));
+      end
+    join_none
+
+    num_requesters = cfg.num_endpoints;
+    num_cs_reqs    = cfg.num_endpoints;
+    num_ep_reqs    = num_cs_reqs * csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH;
+
+    for (int i = 0; i < num_requesters; i++) begin
+      // Create/Configure/Start endpoint_pull_seq
+      m_endpoint_pull_seq[i] = push_pull_host_seq#(FIPS_ENDPOINT_BUS_WIDTH)::
+          type_id::create($sformatf("m_endpoint_pull_seq[%0d]", i));
+      m_endpoint_pull_seq[i].num_trans = num_ep_reqs;
+    end
+
+    // Start endpoint_pull sequences
+    for (int i = 0; i < num_requesters; i++) begin
+      automatic int j = i;
+      fork
+        begin
+          m_endpoint_pull_seq[j].start
+              (p_sequencer.endpoint_sequencer_h[j]);
+        end
+      join_none;
+    end
+  endtask
+
+endclass

--- a/hw/ip/edn/dv/env/seq_lib/edn_vseq_list.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_vseq_list.sv
@@ -11,3 +11,4 @@
 `include "edn_intr_vseq.sv"
 `include "edn_alert_vseq.sv"
 `include "edn_err_vseq.sv"
+`include "edn_disable_vseq.sv"

--- a/hw/ip/edn/dv/tests/edn_disable_test.sv
+++ b/hw/ip/edn/dv/tests/edn_disable_test.sv
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class edn_disable_test extends edn_base_test;
+
+  `uvm_component_utils(edn_disable_test)
+  `uvm_component_new
+
+  function void configure_env();
+    super.configure_env();
+
+    cfg.boot_req_mode_pct = 100;
+    cfg.auto_req_mode_pct = 0;
+    cfg.min_num_boot_reqs = 1;
+    cfg.max_num_boot_reqs = 4;
+    cfg.min_num_ep_reqs   = 4;
+    cfg.max_num_ep_reqs   = 4;
+    cfg.force_disable_pct = 100;
+
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+
+    cfg.num_endpoints = 1;
+
+    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_HIGH)
+  endfunction
+endclass : edn_disable_test

--- a/hw/ip/edn/dv/tests/edn_test.core
+++ b/hw/ip/edn/dv/tests/edn_test.core
@@ -16,6 +16,7 @@ filesets:
       - edn_stress_all_test.sv: {is_include_file: true}
       - edn_intr_test.sv: {is_include_file: true}
       - edn_alert_test.sv: {is_include_file: true}
+      - edn_disable_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/edn/dv/tests/edn_test_pkg.sv
+++ b/hw/ip/edn/dv/tests/edn_test_pkg.sv
@@ -23,5 +23,6 @@ package edn_test_pkg;
   `include "edn_stress_all_test.sv"
   `include "edn_intr_test.sv"
   `include "edn_alert_test.sv"
+  `include "edn_disable_test.sv"
 
 endpackage

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -6,7 +6,7 @@
 //
 //   does hardware-based csrng app interface command requests
 
-module edn_main_sm #(
+module edn_main_sm import edn_pkg::*; #(
   localparam int StateWidth = 9
 ) (
   input logic                   clk_i,
@@ -55,28 +55,6 @@ module edn_main_sm #(
 // Minimum Hamming weight: 2
 // Maximum Hamming weight: 7
 //
-
-  typedef enum logic [StateWidth-1:0] {
-    Idle              = 9'b110000101, // idle
-    BootLoadIns       = 9'b110110111, // boot: load the instantiate command
-    BootLoadGen       = 9'b000000011, // boot: load the generate command
-    BootInsAckWait    = 9'b011010010, // boot: wait for instantiate command ack
-    BootCaptGenCnt    = 9'b010111010, // boot: capture the gen fifo count
-    BootSendGenCmd    = 9'b011100100, // boot: send the generate command
-    BootGenAckWait    = 9'b101101100, // boot: wait for generate command ack
-    BootPulse         = 9'b100001010, // boot: signal a done pulse
-    BootDone          = 9'b011011111, // boot: stay in done state until reset
-    AutoLoadIns       = 9'b001110000, // auto: load the instantiate command
-    AutoFirstAckWait  = 9'b001001101, // auto: wait for first instantiate command ack
-    AutoAckWait       = 9'b101100011, // auto: wait for instantiate command ack
-    AutoDispatch      = 9'b110101110, // auto: determine next command to be sent
-    AutoCaptGenCnt    = 9'b000110101, // auto: capture the gen fifo count
-    AutoSendGenCmd    = 9'b111111000, // auto: send the generate command
-    AutoCaptReseedCnt = 9'b000100110, // auto: capture the reseed fifo count
-    AutoSendReseedCmd = 9'b101010110, // auto: send the reseed command
-    SWPortMode        = 9'b100111001, // swport: no hw request mode
-    Error             = 9'b010010001  // illegal state reached and hang
-  } state_e;
 
   state_e state_d, state_q;
 

--- a/hw/ip/edn/rtl/edn_pkg.sv
+++ b/hw/ip/edn/rtl/edn_pkg.sv
@@ -26,10 +26,26 @@ package edn_pkg;
   parameter edn_req_t EDN_REQ_DEFAULT = '0;
   parameter edn_rsp_t EDN_RSP_DEFAULT = '0;
 
-  // Sparse four-value signal type
-  parameter int EDN_MODE_WIDTH = 4;
-  typedef enum logic [EDN_MODE_WIDTH-1:0] {
-    EDN_FIELD_ON = 4'b1010
-  } edn_enb_e;
+  typedef enum logic [8:0] {
+    Idle              = 9'b110000101, // idle
+    BootLoadIns       = 9'b110110111, // boot: load the instantiate command
+    BootLoadGen       = 9'b000000011, // boot: load the generate command
+    BootInsAckWait    = 9'b011010010, // boot: wait for instantiate command ack
+    BootCaptGenCnt    = 9'b010111010, // boot: capture the gen fifo count
+    BootSendGenCmd    = 9'b011100100, // boot: send the generate command
+    BootGenAckWait    = 9'b101101100, // boot: wait for generate command ack
+    BootPulse         = 9'b100001010, // boot: signal a done pulse
+    BootDone          = 9'b011011111, // boot: stay in done state until reset
+    AutoLoadIns       = 9'b001110000, // auto: load the instantiate command
+    AutoFirstAckWait  = 9'b001001101, // auto: wait for first instantiate command ack
+    AutoAckWait       = 9'b101100011, // auto: wait for instantiate command ack
+    AutoDispatch      = 9'b110101110, // auto: determine next command to be sent
+    AutoCaptGenCnt    = 9'b000110101, // auto: capture the gen fifo count
+    AutoSendGenCmd    = 9'b111111000, // auto: send the generate command
+    AutoCaptReseedCnt = 9'b000100110, // auto: capture the reseed fifo count
+    AutoSendReseedCmd = 9'b101010110, // auto: send the reseed command
+    SWPortMode        = 9'b100111001, // swport: no hw request mode
+    Error             = 9'b010010001  // illegal state reached and hang
+  } state_e;
 
 endpackage : edn_pkg


### PR DESCRIPTION
Add edn_disable test/vseq/etc. Incomplete. Currently just focusing on boot_req_mode, disable occurring after endpoint req goes inactive, one endpoint. But it's a start...

Signed-off-by: Steve Nelson <steve.nelson@wdc.com>