### PR TITLE
[sw/sca/sha3] Edited and added necessary files for SHA3 TVLA on cw310 (issue #15470)

### DIFF
--- a/sw/device/sca/BUILD
+++ b/sw/device/sca/BUILD
@@ -34,6 +34,22 @@ opentitan_flash_binary(
 )
 
 opentitan_flash_binary(
+    name = "kmac_serial",
+    srcs = ["kmac_serial.c"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/dif:kmac",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/sca/lib:prng",
+        "//sw/device/sca/lib:sca",
+        "//sw/device/sca/lib:simple_serial",
+    ],
+)
+
+opentitan_flash_binary(
     name = "sha3_serial",
     srcs = ["sha3_serial.c"],
     deps = [


### PR DESCRIPTION
This PR adds the SCA device software for SHA3 TVLA:

- It separates the sha3 and kmac into two serial files / targets for better distinctiveness
- Further, the sha3 target implements a handler function to enable/disable masks via a simpleserial command