### PR TITLE
[ci] Split FPGA tests into two batches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -511,9 +511,30 @@ jobs:
         gcpKeyFile: "gcpkey.json"
         bucketURI: "gs://opentitan-bitstreams/master"
 
-- job: execute_fpga_tests_cw310
-  displayName: CW310 Tests
-  # Execute tests on ChipWhisperer CW310 FPGA board
+- job: execute_test_rom_fpga_tests_cw310
+  displayName: CW310 Test ROM Tests
+  pool: FPGA
+  timeoutInMinutes: 45
+  dependsOn:
+    - chip_earlgrey_cw310
+    - sw_build
+  condition: succeeded( 'chip_earlgrey_cw310', 'sw_build' )
+  steps:
+  - template: ci/checkout-template.yml
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_earlgrey_cw310
+        - sw_build
+  - bash: |
+      set -e
+      . util/build_consts.sh
+      ci/scripts/run-fpga-cw310-tests.sh cw310_test_rom || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+    displayName: Execute tests
+
+- job: execute_rom_fpga_tests_cw310
+  displayName: CW310 ROM Tests
   pool: FPGA
   timeoutInMinutes: 45
   dependsOn:
@@ -532,7 +553,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-cw310-tests.sh cw310_rom || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
 
 - job: deploy_release_artifacts
@@ -557,9 +578,7 @@ jobs:
         - chip_englishbreakfast_verilator
   - bash: |
       . util/build_consts.sh
-
       ci/scripts/make_distribution.sh
-
       tar --list -f $BIN_DIR/opentitan-*.tar.xz
       # Put the resulting tar file into a directory the |publish| step below can reference.
       mkdir "$BUILD_ROOT/dist-final"
@@ -577,7 +596,6 @@ jobs:
       addChangeLog: false
       assets: |
           $(Build.ArtifactStagingDirectory)/dist-final/*
-
 
 - job: build_docker_containers
   displayName: "Build Docker Containers"

--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -11,6 +11,14 @@ set -e
 SHA=$(git rev-parse HEAD)
 readonly SHA
 
+if [ $# == 0 ]; then
+    echo >&2 "Usage: run-fpga-cw310-tests.sh <cw310_tags>"
+    echo >&2 "E.g. ./run-fpga-cw310-tests.sh cw310_rom"
+    echo >&2 "E.g. ./run-fpga-cw310-tests.sh cw310_rom cw310_test_rom"
+    exit 1
+fi
+cw310_tags=("$@")
+
 # Copy bitstreams and related files into the cache directory so Bazel will have
 # the corresponding targets in the @bitstreams workspace.
 #
@@ -32,7 +40,6 @@ export BITSTREAM="--offline --list ${SHA}"
 # in case we've crashed the UART handler on the CW310's SAM3U
 trap 'ci/bazelisk.sh run //sw/host/opentitantool -- --interface=cw310 fpga reset' EXIT
 
-cw310_tags=( "cw310_test_rom" "cw310_rom" )
 for tag in "${cw310_tags[@]}"; do
     ./bazelisk.sh query 'rdeps(//..., @bitstreams//...)' |
         xargs ci/bazelisk.sh test \


### PR DESCRIPTION
The recent addition of new tests pushed the CW310 tests over the time limit. To reduce test time and get better utilization of the FPGAs, we've decided to split the CW310 tests into two jobs that run either the `cw310_rom` or `cw310_test_rom` tests.