### PR TITLE
[ci] Build verilator model with 4 cores

### DIFF
--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -15,7 +15,7 @@ ci/bazelisk.sh test \
     --test_tag_filters=verilator,-broken \
     --test_output=errors \
     --//hw:verilator_options=--threads,1 \
-    --//hw:make_options=-j,1 \
+    --//hw:make_options=-j,4 \
     //sw/device/tests:aes_smoketest_sim_verilator \
     //sw/device/tests:uart_smoketest_sim_verilator \
     //sw/device/tests:crt_test_sim_verilator \


### PR DESCRIPTION
This should parallelize the compilation of the verilated model which accounts for ~30m of the build and run verilator tests. I'd like to get a sense of how this impacts memory usage, but I don't expect any problems.

Signed-off-by: Drew Macrae <drewmacrae@google.com>