### PR TITLE
[PWRMGR|RANDOM_SLEEP] Adding chip_sw_pwrmgr_random_sleep_power_glitch…

### DIFF
--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
@@ -39,7 +39,10 @@ interface pwrmgr_rstmgr_sva_if
   // output reset cycle with a clk enable disable
   localparam int MIN_MAIN_RST_CYCLES = 0;
   localparam int MAX_MAIN_RST_CYCLES = 258;
+  localparam int MIN_GLITCH_RST_CYCLES = 450;
+  localparam int MAX_GLITCH_RST_CYCLES = 458;
   `define MAIN_RST_CYCLES ##[MIN_MAIN_RST_CYCLES:MAX_MAIN_RST_CYCLES]
+  `define GLITCH_RST_CYCLES ##[MIN_GLITCH_RST_CYCLES:MAX_GLITCH_RST_CYCLES]
 
   // The timing of the escalation reset is determined by the slow clock, but will not propagate if
   // the non-slow clock is off. We use the regular clock and multiply the clock cycles times the
@@ -122,7 +125,7 @@ interface pwrmgr_rstmgr_sva_if
   `ASSERT(MainPwrRstOff_A,
           $fell(
               main_rst_req_i
-          ) |-> `MAIN_RST_CYCLES !rstreqs[ResetMainPwrIdx], clk_slow_i,
+          ) |-> `GLITCH_RST_CYCLES !rstreqs[ResetMainPwrIdx], clk_slow_i,
           reset_or_disable || !check_rstreqs_en)
 
    // Signals in EscRstOn_A and EscRstOff_A are sampled with slow and fast clock.

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1144,7 +1144,7 @@
             state dependent corner cases with power glitch handling.
             '''
       stage: V2
-      tests: [""]
+      tests: ["chip_sw_pwrmgr_random_sleep_power_glitch_reset"]
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_power_glitch_reset

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -793,6 +793,13 @@
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
     }
     {
+      name: chip_sw_pwrmgr_random_sleep_power_glitch_reset
+      uvm_test_seq: chip_sw_random_power_glitch_vseq
+      sw_images: ["//sw/device/tests/sim_dv:pwrmgr_random_sleep_power_glitch_reset_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+bypass_alert_ready_to_end_check=1"]
+    }
+    {
       name: chip_sw_pwrmgr_sleep_disabled
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:pwrmgr_sleep_disabled_test:1"]

--- a/hw/top_earlgrey/dv/env/ast_supply_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_supply_if.sv
@@ -20,7 +20,7 @@ interface ast_supply_if (
   // The amount of time to hold the glitch. Should be enough to span more than one aon_clk cycles
   // so it is sampled.
   localparam time GlitchTimeSpan = 10us;
-  localparam int GlitchCycles = 3;
+  localparam int GlitchCycles = 6;
 
   // The number of cycles after stopping the glitch in vcmain before restarting
   // assertions in pwrmgr.
@@ -70,31 +70,16 @@ interface ast_supply_if (
   // Create glitch in vcmain_pok_h_o some cycles after core_sleeping trigger transitions high.
   // This is useful for non-deep sleep-related triggers.
   task automatic glitch_vcmain_pok_on_next_core_sleeping_trigger(int cycles);
-    `uvm_info("ast_supply_if", "normal sleep glitch 0", UVM_MEDIUM)
     @(posedge core_sleeping_trigger);
-    `uvm_info("ast_supply_if", "normal sleep glitch 1", UVM_MEDIUM)
     repeat (cycles) @(posedge clk);
-    `uvm_info("ast_supply_if", "normal sleep glitch 2", UVM_MEDIUM)
     `GLITCH_VCMAIN_POK;
-    `uvm_info("ast_supply_if", "normal sleep glitch 3", UVM_MEDIUM)
   endtask : glitch_vcmain_pok_on_next_core_sleeping_trigger
 
   // Create glitch in vcmain_pok_h_o once the fast fsm sets the reset cause to LowPwrEntry.
   task automatic glitch_vcmain_pok_on_next_low_power_trigger();
-    `uvm_info("ast_supply_if", "deep sleep glitch 0", UVM_MEDIUM)
     @(posedge low_power_trigger);
-    `uvm_info("ast_supply_if", "deep sleep glitch 1", UVM_MEDIUM)
     `GLITCH_VCMAIN_POK;
-    `uvm_info("ast_supply_if", "deep sleep glitch 2", UVM_MEDIUM)
   endtask : glitch_vcmain_pok_on_next_low_power_trigger
-
-  task automatic glitch_vcmain_pok_on(int cycles);
-    `uvm_info("ast_supply_if", "random sleep glitch 0", UVM_MEDIUM)
-    repeat (cycles) @(posedge clk);
-    `uvm_info("ast_supply_if", "random sleep glitch 1", UVM_MEDIUM)
-    `GLITCH_VCMAIN_POK;
-    `uvm_info("ast_supply_if", "random sleep glitch 2", UVM_MEDIUM)
-  endtask : glitch_vcmain_pok_on
 
 `undef GLITCH_VCMAIN_POK
 

--- a/hw/top_earlgrey/dv/env/ast_supply_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_supply_if.sv
@@ -20,7 +20,7 @@ interface ast_supply_if (
   // The amount of time to hold the glitch. Should be enough to span more than one aon_clk cycles
   // so it is sampled.
   localparam time GlitchTimeSpan = 10us;
-  localparam int GlitchCycles = 2;
+  localparam int GlitchCycles = 3;
 
   // The number of cycles after stopping the glitch in vcmain before restarting
   // assertions in pwrmgr.
@@ -70,16 +70,32 @@ interface ast_supply_if (
   // Create glitch in vcmain_pok_h_o some cycles after core_sleeping trigger transitions high.
   // This is useful for non-deep sleep-related triggers.
   task automatic glitch_vcmain_pok_on_next_core_sleeping_trigger(int cycles);
+    `uvm_info("ast_supply_if", "normal sleep glitch 0", UVM_MEDIUM)
     @(posedge core_sleeping_trigger);
+    `uvm_info("ast_supply_if", "normal sleep glitch 1", UVM_MEDIUM)
     repeat (cycles) @(posedge clk);
+    `uvm_info("ast_supply_if", "normal sleep glitch 2", UVM_MEDIUM)
     `GLITCH_VCMAIN_POK;
+    `uvm_info("ast_supply_if", "normal sleep glitch 3", UVM_MEDIUM)
   endtask : glitch_vcmain_pok_on_next_core_sleeping_trigger
 
   // Create glitch in vcmain_pok_h_o once the fast fsm sets the reset cause to LowPwrEntry.
   task automatic glitch_vcmain_pok_on_next_low_power_trigger();
+    `uvm_info("ast_supply_if", "deep sleep glitch 0", UVM_MEDIUM)
     @(posedge low_power_trigger);
+    `uvm_info("ast_supply_if", "deep sleep glitch 1", UVM_MEDIUM)
     `GLITCH_VCMAIN_POK;
+    `uvm_info("ast_supply_if", "deep sleep glitch 2", UVM_MEDIUM)
   endtask : glitch_vcmain_pok_on_next_low_power_trigger
+
+  task automatic glitch_vcmain_pok_on(int cycles);
+    `uvm_info("ast_supply_if", "random sleep glitch 0", UVM_MEDIUM)
+    repeat (cycles) @(posedge clk);
+    `uvm_info("ast_supply_if", "random sleep glitch 1", UVM_MEDIUM)
+    `GLITCH_VCMAIN_POK;
+    `uvm_info("ast_supply_if", "random sleep glitch 2", UVM_MEDIUM)
+  endtask : glitch_vcmain_pok_on
+
 `undef GLITCH_VCMAIN_POK
 
   // Create pulses in key0 after a trigger transitions high.

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -60,6 +60,7 @@ filesets:
       - seq_lib/chip_sw_full_aon_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_deep_power_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_main_power_glitch_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_random_power_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sysrst_ctrl_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_random_sleep_all_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_deep_sleep_all_reset_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_power_glitch_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_power_glitch_vseq.sv
@@ -1,0 +1,119 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_random_power_glitch_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_random_power_glitch_vseq)
+
+  `uvm_object_new
+
+  // NumRound = 12 is the number of resets in this test. It consists of one PoR
+  // reset (1st one) + 11 random reset. 11 random resets are 10 sleep mode
+  // (light sleep and deep sleep) and one normal mode. The reset array rst_idx has
+  // 12 (NumRound) reset elements where 11 (NumRound-1) random reset sequence is
+  // ordered using a random variable assa. The last reset does not have to set the next reset type.
+
+  parameter int NumSleepType = 2;
+  // (key rst + pad rst) x 2 (normal sleep/deep sleep)
+  parameter int NumPadRstEvent = 2 * NumSleepType;
+  // (sw_req + escalation rst + normal watchdog) x 2
+  parameter int NumWdogRstEvent = 3 * NumSleepType;
+  parameter int NumNormalMode = 1;
+  parameter int NumRound = NumPadRstEvent + NumWdogRstEvent + NumNormalMode + 1;
+
+  rand int cycles_after_trigger;
+  rand int cycles_till_reset;
+  rand int reset_delay;
+  int loop_num;
+
+  constraint cycles_after_trigger_c {cycles_after_trigger inside {[0 : 9]};}
+  constraint cycles_tll_reset_c {cycles_till_reset inside {[0 : 200]};}
+  constraint reset_delay_c {reset_delay inside {[0 : 10]};}
+
+  rand bit[7:0] assa[NumRound-1];
+  constraint assa_c {
+    foreach (assa[i]) assa[i] inside {[0:NumRound-2]};
+  }
+
+  virtual task cpu_init();
+    bit[7:0] rst_idx[NumRound];
+    loop_num = 0;
+    for (int i=0; i< NumRound; i = i+1) begin
+      if (i == (NumRound-1)) begin
+        rst_idx[i] = i;
+      end
+      else begin
+        //rst_idx[i] = assa[i]%2;
+        rst_idx[i] = 0;
+        if (rst_idx[i] inside {[0:3]}) begin
+          loop_num = loop_num + 1;
+        end
+      end
+    end
+
+    `uvm_info(`gfn, $sformatf("HW rst loop # : %d", loop_num), UVM_MEDIUM)
+
+    super.cpu_init();
+    sw_symbol_backdoor_overwrite("RST_IDX", rst_idx);
+  endtask
+
+  virtual task body();
+    super.body();
+    // Wait until we reach the SW test state.
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `uvm_info(`gfn, "SW test ready", UVM_MEDIUM)
+
+    repeat (loop_num) begin
+      `DV_WAIT(
+            cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by hw por" ||
+            cfg.sw_logger_vif.printed_log ==
+                "Booting and setting normal sleep followed by hw por" ||
+            cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by glitch reset" ||
+            cfg.sw_logger_vif.printed_log ==
+                "Booting and setting normal sleep followed by glitch reset" ||
+            cfg.sw_logger_vif.printed_log == "Last Booting" ||
+            cfg.sw_logger_vif.printed_log == "Test finish",
+            // 20ms
+            20_000_000)
+
+       if (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by glitch reset" ||
+           cfg.sw_logger_vif.printed_log == "Booting and setting normal sleep followed by glitch reset")
+           begin
+         `uvm_info(`gfn, "SW message delivered to TB", UVM_MEDIUM)
+         //repeat (10) @cfg.chip_vif.pwrmgr_low_power_if.cb;  //
+         //repeat (cycles_till_reset) @cfg.chip_vif.pwrmgr_low_power_if.cb;
+         if (cfg.sw_logger_vif.printed_log == "Booting and setting deep sleep followed by glitch reset") begin
+           `uvm_info(`gfn, "glitch for deep sleep", UVM_MEDIUM)
+           cfg.ast_supply_vif.glitch_vcmain_pok_on_next_low_power_trigger();
+         end
+         else begin
+           `uvm_info(`gfn, "glitch for normal sleep", UVM_MEDIUM)
+           cfg.ast_supply_vif.glitch_vcmain_pok_on_next_core_sleeping_trigger(cycles_after_trigger);
+         end
+       end
+       else if (cfg.sw_logger_vif.printed_log ==
+                "Booting and setting deep sleep followed by hw por" |
+                cfg.sw_logger_vif.printed_log ==
+                "Booting and setting normal sleep followed by hw por") begin
+         `uvm_info(`gfn, "SW message delivered to TB", UVM_MEDIUM)
+         repeat (10) @cfg.chip_vif.pwrmgr_low_power_if.cb;
+         repeat (cycles_till_reset) @cfg.chip_vif.pwrmgr_low_power_if.cb;
+         `uvm_info(`gfn, $sformatf("POR reset req set after fixed delay : %d + variable delay : %d",
+                                    10, cycles_till_reset), UVM_MEDIUM)
+         execute_reset();
+       end
+    end
+  endtask
+
+  virtual task pre_start();
+    super.pre_start();
+  endtask
+
+  task execute_reset();
+    `uvm_info(`gfn, "wait for low power entry", UVM_MEDIUM)
+    `DV_WAIT(cfg.chip_vif.pwrmgr_low_power_if.low_power == 1)
+    `uvm_info(`gfn, "reset after low power entry", UVM_MEDIUM)
+    assert_por_reset_deep_sleep (reset_delay);
+  endtask // execute_reset
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -18,6 +18,7 @@
 `include "chip_sw_full_aon_reset_vseq.sv"
 `include "chip_sw_deep_power_glitch_vseq.sv"
 `include "chip_sw_main_power_glitch_vseq.sv"
+`include "chip_sw_random_power_glitch_vseq.sv"
 `include "chip_sw_sysrst_ctrl_vseq.sv"
 `include "chip_sw_random_sleep_all_reset_vseq.sv"
 `include "chip_sw_deep_sleep_all_reset_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -654,6 +654,36 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "pwrmgr_random_sleep_power_glitch_reset_test",
+    srcs = ["pwrmgr_random_sleep_power_glitch_reset_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:rv_timer",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing:aon_timer_testutils",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "pwrmgr_usbdev_smoketest",
     srcs = ["pwrmgr_usbdev_smoketest.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
@@ -1,0 +1,577 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/dif_rv_timer.h"
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+static volatile const uint8_t RST_IDX[12] = {0, 1, 2, 3, 4,  5,
+                                             6, 7, 8, 9, 10, 11};
+static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
+
+/**
+ * Objects to access the peripherals used in this test via dif API.
+ */
+static dif_flash_ctrl_state_t flash_ctrl;
+static dif_rv_plic_t plic;
+static dif_alert_handler_t alert_handler;
+static dif_aon_timer_t aon_timer;
+static dif_pwrmgr_t pwrmgr;
+static dif_rstmgr_t rstmgr;
+
+/**
+ * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
+ * the phase 1 (i.e. wipe secrets) should occur and last during the time the
+ * wdog is programed to bark.
+ */
+enum {
+  kWdogBarkMicros = 3 * 100,          // 300 us
+  kWdogBiteMicros = 4 * 100,          // 400 us
+  kEscalationPhase0Micros = 1 * 100,  // 100 us
+  // The cpu value is slightly larger as the busy_spin_micros
+  // routine cycle count comes out slightly smaller due to the
+  // fact that it does not divide by exactly 1M
+  // see sw/device/lib/runtime/hart.c
+  kEscalationPhase0MicrosCpu = kEscalationPhase0Micros + 20,  // 120 us
+  kEscalationPhase1Micros = 5 * 100,                          // 500 us
+  kEscalationPhase2Micros = 50,                               // 50 us
+};
+
+uint32_t cycle_rescaling_factor() {
+  return kDeviceType == kDeviceSimDV ? 1 : 10;
+}
+
+static_assert(
+    kWdogBarkMicros < kWdogBiteMicros &&
+        kWdogBarkMicros > kEscalationPhase0Micros &&
+        kWdogBarkMicros < (kEscalationPhase0Micros + kEscalationPhase1Micros) &&
+        kWdogBiteMicros < (kEscalationPhase0Micros + kEscalationPhase1Micros),
+    "The wdog bark and bite shall happens during the escalation phase 1");
+
+/**
+ * External ISR.
+ *
+ * Handles all peripheral interrupts on Ibex. PLIC asserts an external interrupt
+ * line to the CPU, which results in a call to this OTTF ISR. This ISR
+ * overrides the default OTTF implementation.
+ */
+void ottf_external_isr(void) {
+  top_earlgrey_plic_peripheral_t peripheral;
+  dif_rv_plic_irq_id_t irq_id;
+  uint32_t irq = 0;
+  uint32_t alert = 0;
+
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));
+
+  peripheral = (top_earlgrey_plic_peripheral_t)
+      top_earlgrey_plic_interrupt_for_peripheral[irq_id];
+
+  if (peripheral == kTopEarlgreyPlicPeripheralAonTimerAon) {
+    irq =
+        (dif_aon_timer_irq_t)(irq_id -
+                              (dif_rv_plic_irq_id_t)
+                                  kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+
+    // Stops escalation process.
+    CHECK_DIF_OK(dif_alert_handler_escalation_clear(&alert_handler,
+                                                    kDifAlertHandlerClassA));
+    CHECK_DIF_OK(dif_aon_timer_irq_acknowledge(&aon_timer, irq));
+
+    CHECK(irq != kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark,
+          "AON Timer Wdog should not bark");
+
+  } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
+    irq = (dif_rv_plic_irq_id_t)(irq_id -
+                                 (dif_rv_plic_irq_id_t)
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassa);
+
+    CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(&alert_handler, alert));
+
+    dif_alert_handler_class_state_t state;
+    CHECK_DIF_OK(dif_alert_handler_get_class_state(
+        &alert_handler, kDifAlertHandlerClassA, &state));
+
+    CHECK(state == kDifAlertHandlerClassStatePhase0, "Wrong phase %d", state);
+
+    CHECK_DIF_OK(dif_alert_handler_irq_acknowledge(&alert_handler, irq));
+  }
+
+  // Complete the IRQ by writing the IRQ source to the Ibex specific CC
+  // register.
+  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kPlicTarget, irq_id));
+}
+
+/**
+ * Initialize the peripherals used in this test.
+ */
+void init_peripherals(void) {
+  // Initialize pwrmgr.
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+
+  // Initialize rstmgr to check the reset reason.
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  // Initialize aon timer to use the wdog.
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+
+  // Initialize flash_ctrl
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash_ctrl,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+
+  // Initialize plic.
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
+
+  rv_plic_testutils_irq_range_enable(
+      &plic, kPlicTarget, kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired,
+      kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark);
+
+  // Initialize alert handler.
+  CHECK_DIF_OK(dif_alert_handler_init(
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
+      &alert_handler));
+}
+
+/**
+ * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
+ * the phase 1 (i.e. wipe secrets) should occur and last during the time the
+ * wdog is programed to bark.
+ */
+static void alert_handler_config(void) {
+  dif_alert_handler_alert_t alerts[] = {kTopEarlgreyAlertIdPwrmgrAonFatalFault};
+  dif_alert_handler_class_t alert_classes[] = {kDifAlertHandlerClassA};
+
+  dif_alert_handler_escalation_phase_t esc_phases[] = {
+      {.phase = kDifAlertHandlerClassStatePhase0,
+       .signal = 0,
+       .duration_cycles =
+           udiv64_slow(kEscalationPhase0Micros * kClockFreqPeripheralHz,
+                       1000000, NULL) *
+           cycle_rescaling_factor()},
+      {.phase = kDifAlertHandlerClassStatePhase1,
+       .signal = 1,
+       .duration_cycles =
+           udiv64_slow(kEscalationPhase1Micros * kClockFreqPeripheralHz,
+                       1000000, NULL) *
+           cycle_rescaling_factor()},
+      {.phase = kDifAlertHandlerClassStatePhase2,
+       .signal = 3,
+       .duration_cycles =
+           udiv64_slow(kEscalationPhase2Micros * kClockFreqPeripheralHz,
+                       1000000, NULL) *
+           cycle_rescaling_factor()}};
+
+  dif_alert_handler_class_config_t class_config[] = {{
+      .auto_lock_accumulation_counter = kDifToggleDisabled,
+      .accumulator_threshold = 0,
+      .irq_deadline_cycles =
+          udiv64_slow(10 * kClockFreqPeripheralHz, 1000000, NULL) *
+          cycle_rescaling_factor(),
+      .escalation_phases = esc_phases,
+      .escalation_phases_len = ARRAYSIZE(esc_phases),
+      .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase3,
+  }};
+
+  dif_alert_handler_class_t classes[] = {kDifAlertHandlerClassA};
+  dif_alert_handler_config_t config = {
+      .alerts = alerts,
+      .alert_classes = alert_classes,
+      .alerts_len = ARRAYSIZE(alerts),
+      .classes = classes,
+      .class_configs = class_config,
+      .classes_len = ARRAYSIZE(class_config),
+      .ping_timeout = 0,
+  };
+
+  alert_handler_testutils_configure_all(&alert_handler, config,
+                                        kDifToggleEnabled);
+  // Enables alert handler irq.
+  CHECK_DIF_OK(dif_alert_handler_irq_set_enabled(
+      &alert_handler, kDifAlertHandlerIrqClassa, kDifToggleEnabled));
+}
+
+/**
+ * Execute the aon timer interrupt test.
+ */
+static void config_escalate(dif_aon_timer_t *aon_timer,
+                            const dif_pwrmgr_t *pwrmgr) {
+  uint64_t bark_cycles =
+      udiv64_slow(kWdogBarkMicros * kClockFreqAonHz, 1000000, NULL) *
+      cycle_rescaling_factor();
+  uint64_t bite_cycles =
+      udiv64_slow(kWdogBiteMicros * kClockFreqAonHz, 1000000, NULL) *
+      cycle_rescaling_factor();
+
+  CHECK(bite_cycles < UINT32_MAX,
+        "The value %u can't fit into the 32 bits timer counter.", bite_cycles);
+
+  LOG_INFO(
+      "Wdog will bark after %u/%u us/cycles and bite after %u/%u us/cycles",
+      (uint32_t)kWdogBarkMicros, (uint32_t)bark_cycles,
+      (uint32_t)kWdogBiteMicros, (uint32_t)bite_cycles);
+
+  // Setup the wdog bark and bite timeouts.
+  aon_timer_testutils_watchdog_config(aon_timer, bark_cycles, bite_cycles,
+                                      false);
+
+  // Trigger the alert handler to escalate.
+  dif_pwrmgr_alert_t alert = kDifPwrmgrAlertFatalFault;
+  CHECK_DIF_OK(dif_pwrmgr_alert_force(pwrmgr, alert));
+}
+
+static void low_power_glitch_reset(const dif_pwrmgr_t *pwrmgr) {
+  // Program the pwrmgr to go to deep sleep state (clocks off).
+  pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceFive,
+                                    0);
+  // Enter in low power mode.
+  wait_for_interrupt();
+}
+
+static void normal_sleep_glitch_reset(const dif_pwrmgr_t *pwrmgr) {
+  // Place device into low power and immediately wake.
+  dif_pwrmgr_domain_config_t config;
+  config = kDifPwrmgrDomainOptionUsbClockInLowPower |
+           kDifPwrmgrDomainOptionCoreClockInLowPower |
+           kDifPwrmgrDomainOptionIoClockInLowPower |
+           kDifPwrmgrDomainOptionMainPowerInLowPower;
+  pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceFive,
+                                    config);
+  // Enter in low power mode.
+  wait_for_interrupt();
+}
+
+static void timer_on(uint32_t usec) {
+  busy_spin_micros(usec);
+  // If we arrive here the test must fail.
+  CHECK(false, "Timeout waiting for reset!");
+}
+
+/**
+ * Configure the wdog.
+ */
+static void config_wdog(const dif_aon_timer_t *aon_timer,
+                        const dif_pwrmgr_t *pwrmgr, uint64_t bark_time_us,
+                        uint64_t bite_time_us) {
+  uint32_t bark_cycles =
+      aon_timer_testutils_get_aon_cycles_from_us(bark_time_us);
+  uint32_t bite_cycles =
+      aon_timer_testutils_get_aon_cycles_from_us(bite_time_us);
+
+  LOG_INFO("Wdog will bark after %u us and bite after %u us",
+           (uint32_t)bark_time_us, (uint32_t)bite_time_us);
+  // Setup the wdog bark and bite timeouts.
+
+  aon_timer_testutils_watchdog_config(aon_timer, bark_cycles, bite_cycles,
+                                      false);
+  // Set wdog as a reset source.
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
+                                              kDifPwrmgrResetRequestSourceTwo,
+                                              kDifToggleEnabled));
+}
+
+/**
+ * Execute the aon timer wdog bite reset test.
+ */
+static void wdog_bite_test(const dif_aon_timer_t *aon_timer,
+                           const dif_pwrmgr_t *pwrmgr, uint64_t bark_time_us) {
+  uint64_t bite_time_us = bark_time_us * 2;
+  config_wdog(aon_timer, pwrmgr, bark_time_us, bite_time_us);
+
+  // The `intr_state` takes 3 aon clock cycles to rise plus 2 extra cycles as a
+  // precaution.
+  uint32_t wait_us =
+      bark_time_us +
+      udiv64_slow(5 * 1000000 + kClockFreqAonHz - 1, kClockFreqAonHz, NULL);
+
+  // Wait bark time and check that the bark interrupt requested.
+  busy_spin_micros(wait_us);
+  bool is_pending = false;
+  CHECK_DIF_OK(dif_aon_timer_irq_is_pending(
+      aon_timer, kDifAonTimerIrqWdogTimerBark, &is_pending));
+  CHECK(is_pending, "Wdog bark irq did not rise after %u microseconds",
+        wait_us);
+
+  // Wait for the remaining time to the wdog bite.
+  busy_spin_micros(wait_us);
+  // If we arrive here the test must fail.
+  CHECK(false, "Timeout waiting for Wdog bite reset!");
+}
+
+/**
+ * Execute the aon timer wdog bite reset during sleep test.
+ */
+static void sleep_wdog_bite_test(const dif_aon_timer_t *aon_timer,
+                                 const dif_pwrmgr_t *pwrmgr,
+                                 uint64_t bark_time_us) {
+  uint64_t bite_time_us = bark_time_us * 2;
+  config_wdog(aon_timer, pwrmgr, bark_time_us, bite_time_us);
+}
+
+static void low_power_wdog(const dif_pwrmgr_t *pwrmgr) {
+  // Program the pwrmgr to go to deep sleep state (clocks off).
+  // Enter in low power mode.
+  pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceTwo,
+                                    0);
+  LOG_INFO("Low power set for watch dog");
+  wait_for_interrupt();
+  // If we arrive here the test must fail.
+  CHECK(false, "Fail to enter in low power mode!");
+}
+
+static void normal_sleep_wdog(const dif_pwrmgr_t *pwrmgr) {
+  // Place device into low power and immediately wake.
+  dif_pwrmgr_domain_config_t config;
+  config = kDifPwrmgrDomainOptionUsbClockInLowPower |
+           kDifPwrmgrDomainOptionCoreClockInLowPower |
+           kDifPwrmgrDomainOptionIoClockInLowPower |
+           kDifPwrmgrDomainOptionMainPowerInLowPower;
+
+  // Enter in low power mode.
+  pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceTwo,
+                                    config);
+  LOG_INFO("Normal sleep set for watchdog");
+  wait_for_interrupt();
+}
+
+static void low_power_por(const dif_pwrmgr_t *pwrmgr) {
+  // Set por as a reset source.
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
+                                              kDifPwrmgrResetRequestSourceTwo,
+                                              kDifToggleEnabled));
+
+  // Program the pwrmgr to go to deep sleep state (clocks off).
+  pwrmgr_testutils_enable_low_power(
+      pwrmgr,
+      (kDifPwrmgrWakeupRequestSourceOne | kDifPwrmgrWakeupRequestSourceTwo |
+       kDifPwrmgrWakeupRequestSourceThree | kDifPwrmgrWakeupRequestSourceFour |
+       kDifPwrmgrWakeupRequestSourceFive | kDifPwrmgrWakeupRequestSourceSix),
+      0);
+  // Enter in low power mode.
+  wait_for_interrupt();
+  // If we arrive here the test must fail.
+  CHECK(false, "Fail to enter in low power mode!");
+}
+
+static void normal_sleep_por(const dif_pwrmgr_t *pwrmgr) {
+  // Set por as a reset source.
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
+                                              kDifPwrmgrResetRequestSourceTwo,
+                                              kDifToggleEnabled));
+
+  // Place device into low power and immediately wake.
+  dif_pwrmgr_domain_config_t config;
+  config = kDifPwrmgrDomainOptionUsbClockInLowPower |
+           kDifPwrmgrDomainOptionCoreClockInLowPower |
+           kDifPwrmgrDomainOptionIoClockInLowPower |
+           kDifPwrmgrDomainOptionMainPowerInLowPower;
+
+  // Program the pwrmgr to go to deep sleep state (clocks off).
+  pwrmgr_testutils_enable_low_power(
+      pwrmgr,
+      (kDifPwrmgrWakeupRequestSourceOne | kDifPwrmgrWakeupRequestSourceTwo |
+       kDifPwrmgrWakeupRequestSourceThree | kDifPwrmgrWakeupRequestSourceFour |
+       kDifPwrmgrWakeupRequestSourceFive | kDifPwrmgrWakeupRequestSourceSix),
+      config);
+  // Enter in low power mode.
+  wait_for_interrupt();
+}
+
+bool test_main(void) {
+  // Enable global and external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  init_peripherals();
+
+  // Enable all the AON interrupts used in this test.
+  rv_plic_testutils_irq_range_enable(&plic, kPlicTarget,
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassa,
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassd);
+
+  alert_handler_config();
+
+  // First check the flash stored value
+  uint32_t event_idx = flash_ctrl_testutils_counter_get(0);
+
+  // Enable flash access
+  flash_ctrl_testutils_default_region_access(&flash_ctrl,
+                                             /*rd_en*/ true,
+                                             /*prog_en*/ true,
+                                             /*erase_en*/ true,
+                                             /*scramble_en*/ false,
+                                             /*ecc_en*/ false,
+                                             /*he_en*/ false);
+
+  // Increment flash counter to know where we are
+  flash_ctrl_testutils_counter_increment(&flash_ctrl, 0);
+
+  LOG_INFO("Test round %d", event_idx);
+  LOG_INFO("RST_IDX[%d] = %d", event_idx, RST_IDX[event_idx]);
+
+  // Check if there was a HW reset caused by expected cases
+  dif_rstmgr_reset_info_bitfield_t rst_info;
+  rst_info = rstmgr_testutils_reason_get();
+  rstmgr_testutils_reason_clear();
+  LOG_INFO("reset info = %02X", rst_info);
+
+  CHECK(rst_info == kDifRstmgrResetInfoPor ||
+            rst_info == kDifRstmgrResetInfoSysRstCtrl ||
+            rst_info == kDifRstmgrResetInfoWatchdog ||
+            rst_info == kDifRstmgrResetInfoEscalation ||
+            rst_info == kDifRstmgrResetInfoLowPowerExit ||
+            rst_info == (kDifRstmgrResetInfoSysRstCtrl |
+                         kDifRstmgrResetInfoLowPowerExit) ||
+            rst_info == (kDifRstmgrResetInfoPowerUnstable | 
+                         kDifRstmgrResetInfoLowPowerExit) ||
+            rst_info == kDifRstmgrResetInfoPowerUnstable || 
+            rst_info ==
+                (kDifRstmgrResetInfoPor | kDifRstmgrResetInfoLowPowerExit) ||
+            rst_info == (kDifRstmgrResetInfoWatchdog |
+                         kDifRstmgrResetInfoLowPowerExit) ||
+            rst_info == (kDifRstmgrResetInfoEscalation |
+                         kDifRstmgrResetInfoLowPowerExit) ||
+            rst_info == kDifRstmgrResetInfoSw,
+        "Wrong reset reason %02X", rst_info);
+
+  switch (RST_IDX[event_idx] / 2) {
+    case 0:
+      if (RST_IDX[event_idx] % 2) {
+        LOG_INFO("Booting and setting normal sleep followed by glitch reset");
+        normal_sleep_glitch_reset(&pwrmgr);
+        timer_on(kWdogBiteMicros);
+      } else {
+        LOG_INFO("Booting and setting deep sleep followed by glitch reset");
+        low_power_glitch_reset(&pwrmgr);
+      }
+      break;
+    case 1:
+      if (RST_IDX[event_idx] % 2) {
+        LOG_INFO("Booting and setting normal sleep followed by hw por");
+        normal_sleep_por(&pwrmgr);
+        timer_on(kWdogBiteMicros);
+      } else {
+        LOG_INFO("Booting and setting deep sleep followed by hw por");
+        low_power_por(&pwrmgr);
+      }
+      break;
+    case 2:
+      if (RST_IDX[event_idx] % 2) {
+        LOG_INFO(
+            "Booting and setting normal sleep mode followed for low_power "
+            "entry reset");
+        LOG_INFO("Let SV wait timer reset");
+        // actually the same test as normal sleep + watchdog
+        rstmgr_testutils_pre_reset(&rstmgr);
+        sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
+        normal_sleep_wdog(&pwrmgr);
+        timer_on(kEscalationPhase0MicrosCpu);
+      } else {
+        LOG_INFO(
+            "Booting and setting deep sleep mode followed for low_power entry "
+            "reset");
+        LOG_INFO("Let SV wait timer reset");
+        // Executing the wdog bite reset during sleep test.
+        // actually the same test as deep sleep + watchdog
+        rstmgr_testutils_pre_reset(&rstmgr);
+        sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
+        low_power_wdog(&pwrmgr);
+      }
+      break;
+
+    case 3:
+      if (RST_IDX[event_idx] % 2) {
+        LOG_INFO(
+            "Booting and setting normal sleep followed by watchdog reset "
+            "combined "
+            "with sw_req");
+        LOG_INFO("Let SV wait timer reset");
+        // Executing the wdog bite reset during sleep test.
+        rstmgr_testutils_pre_reset(&rstmgr);
+        CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+        LOG_INFO("Device reset from sw");
+        sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
+        normal_sleep_wdog(&pwrmgr);
+        timer_on(kEscalationPhase0MicrosCpu);
+      } else {
+        LOG_INFO(
+            "Booting and setting deep sleep followed by watchdog reset "
+            "combined "
+            "with sw_req");
+        LOG_INFO("Let SV wait timer reset");
+        // Executing the wdog bite reset during sleep test.
+        rstmgr_testutils_pre_reset(&rstmgr);
+        CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+        LOG_INFO("Device reset from sw");
+        sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
+        low_power_wdog(&pwrmgr);
+      }
+      break;
+    case 4:
+      if (RST_IDX[event_idx] % 2) {
+        LOG_INFO("Booting and setting normal sleep followed by watchdog reset");
+        LOG_INFO("Let SV wait timer reset");
+        // Executing the wdog bite reset during sleep test.
+        rstmgr_testutils_pre_reset(&rstmgr);
+        sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
+        normal_sleep_wdog(&pwrmgr);
+        timer_on(kEscalationPhase0MicrosCpu);
+      } else {
+        LOG_INFO("Booting and setting deep sleep followed by watchdog reset");
+        LOG_INFO("Let SV wait timer reset");
+        // Executing the wdog bite reset during sleep test.
+        rstmgr_testutils_pre_reset(&rstmgr);
+        sleep_wdog_bite_test(&aon_timer, &pwrmgr, 200);
+        low_power_wdog(&pwrmgr);
+      }
+      break;
+    case 5:
+      if (RST_IDX[event_idx] % 2) {
+        LOG_INFO("Last Booting");
+      } else {
+        LOG_INFO(
+            "Booting and running normal sleep followed by escalation reset");
+        config_escalate(&aon_timer, &pwrmgr);
+        timer_on(kEscalationPhase0MicrosCpu);
+      }
+      break;
+    default:
+      LOG_INFO("Booting for undefined case");
+  }
+
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
+  return true;
+}


### PR DESCRIPTION
- Each glitch is generated right after putting the chip in a normal sleep or deep sleep state. 
- 11 random sleep events where 2 normal sleep followed by a glitch and 2 deep sleep followed by a glitch + 7 random resets such as PoR, Escalation reset, Watchdog, and low power entry. 
- DV file updates come from assertion failures to be reviewed further. 

Signed-off-by: Joshua Park <jeoong@google.com>