### PR TITLE
[dv/top_earlgrey] lc ctrl register access acquisition for JTAG failure when in SCRAP state

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -662,6 +662,19 @@
       reseed: 15
     }
     {
+      name: chip_sw_lc_ctrl_scrap
+      uvm_test_seq: chip_sw_lc_ctrl_scrap_vseq
+      sw_images: ["//sw/device/tests/sim_dv:chip_sw_lc_ctrl_scrap_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      reseed: 1
+    }
+    {
+      name: chip_sw_lc_ctrl_kmac_reset
+      uvm_test_seq: chip_sw_lc_ctrl_kmac_reset_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_kmac_reset_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_lc_walkthrough_dev
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -83,6 +83,7 @@ filesets:
       - seq_lib/chip_sw_inject_scramble_seed_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_exit_test_unlocked_bootstrap_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
@@ -1,0 +1,84 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+class chip_sw_lc_ctrl_scrap_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_lc_ctrl_scrap_vseq)
+
+  `uvm_object_new
+
+  rand bit [7:0] lc_exit_token[TokenWidthByte];
+  rand bit [7:0] lc_unlock_token[TokenWidthByte];
+
+  virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
+    super.pre_start();
+  endtask
+
+  virtual function void backdoor_override_otp();
+    // Override the LC partition to TestLocked1 state.
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStTestLocked1);
+
+
+    // Override the test exit token to match SW test's input token.
+    cfg.mem_bkdr_util_h[Otp].otp_write_secret0_partition(
+        .unlock_token(dec_otp_token_from_lc_csrs(lc_unlock_token)),
+        .exit_token(dec_otp_token_from_lc_csrs(lc_exit_token)));
+  endfunction
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+    backdoor_override_otp();
+  endtask
+
+  virtual task body();
+    super.body();
+
+    `uvm_info(`gfn, $sformatf("Will run for %d iterations", num_trans), UVM_MEDIUM)
+    for (int trans_i = 1; trans_i <= num_trans; trans_i++) begin
+      // sw_symbol_backdoor_overwrite takes an array as the input.
+      bit [7:0] trans_i_array[] = {trans_i};
+      bit [TL_DW-1:0] ext_clock_en;
+      bit [BUS_DW-1:0] state;
+
+      if (trans_i > 1) begin
+        `uvm_info(`gfn, $sformatf("Applying reset and otp override for trans %d", trans_i),
+                  UVM_MEDIUM)
+        apply_reset();
+        backdoor_override_otp();
+      end
+
+      // In this test, LC_CTRL will enter the TestLocked state which only allows TAP selection once
+      // per boot. Because testbench does not know the exact time when TAP selection happens, we
+      // continuously issue LC JTAG read until it returns valid value.
+      // In the meantime, TAP selection could happen in between a transaction and might return an
+      // error. This error is permitted and can be ignored.
+      wait_lc_ready(.allow_err(1));
+
+      jtag_lc_state_transition(DecLcStTestLocked1, DecLcStScrap);
+
+      // LC state transition requires a chip reset.
+      `uvm_info(`gfn, $sformatf("Applying reset after lc transition for trans %d", trans_i),
+                UVM_MEDIUM)
+      apply_reset();
+
+      // acquire access for JTAG to LC CTRL
+       wait_lc_initialized(.allow_err(1));
+
+      // check LC state is indeed in SCRAP
+      jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.lc_state.get_offset(),
+                                          p_sequencer.jtag_sequencer_h,
+                                          state);
+
+      `DV_CHECK_EQ(state, DecLcStScrap)
+    end
+  endtask : body
+
+  task post_start();
+  	// once in SCRAP mode, the CPU can't execute any SW code, so
+  	// we don't expect the SW to be done
+  	// so we shutdown the device, and then override the test exit from here
+  	override_test_status_and_finish(.passed(1));
+
+  	super.post_start();
+  endtask : post_start
+endclass : chip_sw_lc_ctrl_scrap_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -35,6 +35,7 @@
 `include "chip_sw_flash_init_vseq.sv"
 `include "chip_sw_flash_rma_unlocked_vseq.sv"
 `include "chip_sw_lc_ctrl_transition_vseq.sv"
+`include "chip_sw_lc_ctrl_scrap_vseq.sv"
 `include "chip_sw_lc_walkthrough_vseq.sv"
 `include "chip_sw_lc_walkthrough_testunlocks_vseq.sv"
 `include "chip_sw_spi_device_tx_rx_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -332,6 +332,32 @@ opentitan_functest(
 )
 
 cc_library(
+    name = "chip_sw_lc_ctrl_scrap_impl",
+    srcs = ["chip_sw_lc_ctrl_scrap_impl.c"],
+    hdrs = ["chip_sw_lc_ctrl_scrap_impl.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+    ],
+)
+
+opentitan_functest(
+    name = "chip_sw_lc_ctrl_scrap_test",
+    srcs = ["chip_sw_lc_ctrl_scrap_test.c"],
+    targets = ["dv"],
+    deps = [
+        ":chip_sw_lc_ctrl_scrap_impl",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+cc_library(
     name = "lc_ctrl_transition_impl",
     srcs = ["lc_ctrl_transition_impl.c"],
     hdrs = ["lc_ctrl_transition_impl.h"],

--- a/sw/device/tests/sim_dv/chip_sw_lc_ctrl_scrap_impl.c
+++ b/sw/device/tests/sim_dv/chip_sw_lc_ctrl_scrap_impl.c
@@ -1,0 +1,108 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <stdbool.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/lc_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define LC_TOKEN_SIZE 16
+
+static dif_lc_ctrl_t lc;
+
+/**
+ * Track number of iterations of this C test.
+ *
+ * From the software / compiler's perspective, this is a constant (hence the
+ * `const` qualifier). However, the external DV testbench finds this symbol's
+ * address and modifies it via backdoor, to track how many transactions have
+ * been sent. Hence, we add the `volatile` keyword to prevent the compiler from
+ * optimizing it out.
+ * The `const` is needed to put it in the .rodata section, otherwise it gets
+ * placed in .data section in the main SRAM. We cannot backdoor write anything
+ * in SRAM at the start of the test because the CRT init code wipes it to 0s.
+ */
+static volatile const uint8_t kTestIterationCount = 0x0;
+
+// LC exit token value for LC state transition.
+static volatile const uint8_t kLcExitToken[LC_TOKEN_SIZE] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+};
+
+/**
+ * Tests the state transition request handshake between LC_CTRL and OTP_CTRL.
+ *
+ * 1). OTP pre-load image with lc_count = `8`.
+ * 2). Backdoor write OTP's LC partition to `TestLocked1` state, and backdoor
+ * write OTP's `test_exit` token and `test_unlock` token to match the rand
+ * patterns.
+ * 3). `TestLocked1` state disabled CPU, so external testbench will drive JTAG
+ * interface to transit to `TestUnlocked2` state and increment the LC_CNT.
+ * 4). When LC_CTRL is ready, check LC_CNT and LC_STATE register.
+ * 5). Program LC state transition request to advance to `Dev` state.
+ * 6). Issue hard reset.
+ * 7). Wait for LC_CTRL is ready, then check if LC_STATE advanced to `Dev`
+ * state, and lc_count advanced to `9`.
+ * 8). Issue hard reset and override OTP's LC partition, and reset LC state to
+ * `TestLocked1` state.
+ * 9). Repeat the steps above in a few iterations.
+ *
+ * In summary, this sequence walks through the following LC states:
+ * "TestLocked1" -> "TestUnlocked2" -> "Dev"
+ */
+
+bool execute_lc_ctrl_scrap_test(bool use_ext_clk) {
+  LOG_INFO("Start LC_CTRL scrap test");
+
+  mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
+  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
+
+  LOG_INFO("Read and check LC state.");
+  dif_lc_ctrl_state_t curr_state;
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc, &curr_state));
+
+  // The OTP preload image hardcodes the initial LC state transition count to 8.
+  // With each iteration of test, there are two LC_CTRL state transitions.
+  // And the first LC_CTRL state transition is done via external JTAG interface.
+  // `kTestIterationCount` starts with 1 in SystemVerilog.
+  const uint8_t kLcStateTransitionCount = 8 + 1 + (kTestIterationCount - 1) * 2;
+
+  if (curr_state == kDifLcCtrlStateTestUnlocked2) {
+    // LC TestUnlocked2 is the intial test state for this sequence.
+    // The sequence will check if lc_count matches the preload value.
+    lc_ctrl_testutils_check_transition_count(&lc, kLcStateTransitionCount);
+
+    // Request lc_state transfer to Dev state.
+    dif_lc_ctrl_token_t token;
+    for (int i = 0; i < LC_TOKEN_SIZE; i++) {
+      token.data[i] = kLcExitToken[i];
+    }
+    CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));
+    CHECK_DIF_OK(
+        dif_lc_ctrl_configure(&lc, kDifLcCtrlStateDev, use_ext_clk, &token),
+        "LC transition configuration failed!");
+    CHECK_DIF_OK(dif_lc_ctrl_transition(&lc), "LC transition failed!");
+
+    LOG_INFO("Waiting for LC transtition done and reboot.");
+    wait_for_interrupt();
+
+  } else {
+    // LC Dev is the requested state from previous lc_state transition request.
+    // Once the sequence checks current state and count via CSRs, the test can
+    // exit successfully.
+    CHECK(curr_state == kDifLcCtrlStateDev, "State transition failed!");
+    lc_ctrl_testutils_check_transition_count(&lc, kLcStateTransitionCount + 1);
+    return true;
+  }
+  return true;
+}

--- a/sw/device/tests/sim_dv/chip_sw_lc_ctrl_scrap_impl.h
+++ b/sw/device/tests/sim_dv/chip_sw_lc_ctrl_scrap_impl.h
@@ -1,0 +1,12 @@
+// Copyright Nuvoton contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_SIM_DV_LC_CTRL_SCRAP_IMPL_H_
+#define OPENTITAN_SW_DEVICE_TESTS_SIM_DV_LC_CTRL_SCRAP_IMPL_H_
+
+#include <stdbool.h>
+
+bool execute_lc_ctrl_scrap_test(bool use_ext_clk);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_SIM_DV_LC_CTRL_SCRAP_IMPL_H_

--- a/sw/device/tests/sim_dv/chip_sw_lc_ctrl_scrap_test.c
+++ b/sw/device/tests/sim_dv/chip_sw_lc_ctrl_scrap_test.c
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/tests/sim_dv/chip_sw_lc_ctrl_scrap_impl.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  return execute_lc_ctrl_scrap_test(/*use_ext_clk=*/false);
+}


### PR DESCRIPTION
Signed-off-by: Dror Kabely <dror.kabely@opentitan.org>

This test tries to perform the following LC state transition: TEST_LOCKED1->SCRAP.

The transition completes successfully, then a hard reset is issued.

After finishing the reset, we try to check that we indeed changed into SCRAP by trying to acquire access for LC_CTRL registers for the JTAG TAP, then reading the LC_STATE register in order to compare the read value to SCRAP.

However, the test gets stuck at the acquisition of the LC_CTRL access stage post reset. (hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv#65)