### PR TITLE
[i2c,dv] target 1 write WIP

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -609,3 +609,8 @@
     return SIGNAL_PATH_;                                                                      \
   endfunction
 `endif
+`ifndef JDBG
+  `define JDBG(x) \
+  $write($sformatf("%t:JDBG:",$time));\
+  $display($sformatf x);
+`endif

--- a/hw/dv/sv/i2c_agent/i2c_agent.core
+++ b/hw/dv/sv/i2c_agent/i2c_agent.core
@@ -22,6 +22,7 @@ filesets:
       - seq_lib/i2c_seq_list.sv: {is_include_file: true}
       - seq_lib/i2c_base_seq.sv: {is_include_file: true}
       - seq_lib/i2c_device_response_seq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_base_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -13,14 +13,19 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;
 
   timing_cfg_t    timing_cfg;
-  bit mon_start = 0;
+
+  // This has to be set after if_mode is set. 
+  bit agent_init_done = 0;
    
   virtual i2c_if  vif;
-
+  bit 	  host_scl_start;
+  bit 	  host_scl_stop;
+ 
   // this variables can be configured from test
   uint i2c_host_min_data_rw = 1;
   uint i2c_host_max_data_rw = 10;
 
+   
   `uvm_object_utils_begin(i2c_agent_cfg)
     `uvm_field_int(en_monitor,                                UVM_DEFAULT)
     `uvm_field_enum(i2c_target_addr_mode_e, target_addr_mode, UVM_DEFAULT)

--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -14,9 +14,6 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
 
   timing_cfg_t    timing_cfg;
 
-  // This has to be set after if_mode is set. 
-  bit agent_init_done = 0;
-   
   virtual i2c_if  vif;
   bit 	  host_scl_start;
   bit 	  host_scl_stop;

--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -13,7 +13,8 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;
 
   timing_cfg_t    timing_cfg;
-
+  bit mon_start = 0;
+   
   virtual i2c_if  vif;
 
   // this variables can be configured from test

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -28,7 +28,6 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
       reset_signals();
       get_and_drive();
       begin
-	 wait(cfg.agent_init_done);	 
 	 if (cfg.if_mode == Host) drive_scl();		
       end
     join

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -52,6 +52,7 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
 
   // TODO: drive_host_item is WiP
   virtual task drive_host_item(i2c_item req);
+     `JDBG(("drv: %s", req.drv_type.name))
      unique case (req.drv_type)
       HostStart: begin
         cfg.vif.host_start(cfg.timing_cfg);

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -61,9 +61,13 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
         cfg.vif.host_rstart(cfg.timing_cfg);
       end
       HostData: begin
-        for (int i = $bits(wr_data) -1; i >= 0; i--) begin
-          cfg.vif.host_data(cfg.timing_cfg, wr_data[i]);
+        `uvm_info(`gfn, $sformatf("Driving host item h%x", req.wdata), UVM_MEDIUM)
+        for (int i = $bits(req.wdata) -1; i >= 0; i--) begin
+          cfg.vif.host_data(cfg.timing_cfg, req.wdata[i]);
         end
+
+        // drive one more bit for ack
+        cfg.vif.host_data(cfg.timing_cfg, 1);
       end
       HostNAck: begin
         cfg.vif.host_nack(cfg.timing_cfg);

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -238,6 +238,7 @@ interface i2c_if(
   endtask: host_rstart
 
   task automatic host_data(ref timing_cfg_t tc, input bit bit_i);
+      scl_o = 1'b0;
       sda_o = bit_i;
       wait_for_dly(tc.tClockLow);
       wait_for_dly(tc.tSetupBit);

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -25,6 +25,9 @@ interface i2c_if(
 
   string msg_id = "i2c_if";
 
+  clocking cb @(posedge clk_i);
+     input scl_i;     
+  endclocking
   //---------------------------------
   // common tasks
   //---------------------------------
@@ -224,7 +227,7 @@ interface i2c_if(
       sda_o = 1'b0;
       wait_for_dly(tc.tHoldStart);
       scl_o = 1'b0;
-      wait_for_dly(tc.tClockStart);
+     wait_for_dly(tc.tClockStart);
   endtask: host_start
 
   task automatic host_rstart(ref timing_cfg_t tc);
@@ -238,13 +241,14 @@ interface i2c_if(
   endtask: host_rstart
 
   task automatic host_data(ref timing_cfg_t tc, input bit bit_i);
-      scl_o = 1'b0;
+//      scl_o = 1'b0;
       sda_o = bit_i;
       wait_for_dly(tc.tClockLow);
       wait_for_dly(tc.tSetupBit);
-      scl_o = 1'b1;
+     wait(cb.scl_i === 1'b1);
+//      scl_o = 1'b1;
       wait_for_dly(tc.tClockPulse);
-      scl_o = 1'b0;
+//      scl_o = 1'b0;
       wait_for_dly(tc.tHoldBit);
   endtask: host_data
 
@@ -268,4 +272,14 @@ interface i2c_if(
       wait_for_dly(tc.tHoldBit);
   endtask: host_nack
 
+   task automatic wait_scl(int iter = 1, timing_cfg_t tc);
+      repeat(iter) begin
+	 wait_for_dly(tc.tClockLow);
+	 wait_for_dly(tc.tSetupBit);
+	 wait(cb.scl_i === 1'b1);
+	 wait_for_dly(tc.tClockPulse);
+	 wait_for_dly(tc.tHoldBit);
+      end      
+   endtask // wait_scl
+   
 endinterface : i2c_if

--- a/hw/dv/sv/i2c_agent/i2c_item.sv
+++ b/hw/dv/sv/i2c_agent/i2c_item.sv
@@ -56,7 +56,7 @@ class i2c_item extends uvm_sequence_item;
     `uvm_field_int(read,                    UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
     `uvm_field_int(rcont,                   UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
     `uvm_field_int(nakok,                   UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
-    `uvm_field_enum(drv_type_e,  drv_type,  UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
+    `uvm_field_enum(drv_type_e,  drv_type,  UVM_DEFAULT | UVM_NOCOMPARE)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -33,7 +33,10 @@ class i2c_monitor extends dv_base_monitor #(
   endtask : wait_for_reset_and_drop_item
 
   virtual task run_phase(uvm_phase phase);
-    wait(cfg.vif.rst_ni);
+//    wait(cfg.vif.rst_ni);
+     wait(cfg.mon_start);
+     
+     `JDBG(("MON: ifmode:%s", cfg.if_mode.name))
     forever begin
       fork
         begin: iso_fork
@@ -56,7 +59,7 @@ class i2c_monitor extends dv_base_monitor #(
 
   // collect transactions for 'target mode' dut.
   virtual protected task collect_host_item(uvm_phase phase);
-    //TBD
+     cfg.vif.wait_for_host_start(cfg.timing_cfg);
   endtask
 
   // collect transactions for 'host mode' dut.
@@ -74,6 +77,7 @@ class i2c_monitor extends dv_base_monitor #(
     mon_dut_item.start = 1'b1;
     // monitor address for non-chained reads
     address_thread();
+
     // monitor read/write data
     if (mon_dut_item.bus_op == BusOpRead) read_thread();
     else                                  write_thread();
@@ -86,6 +90,7 @@ class i2c_monitor extends dv_base_monitor #(
       `uvm_info(`gfn, $sformatf("\nmonitor, send full item to scb\n%s",
           full_item.sprint()), UVM_DEBUG)
     end
+
     mon_dut_item.clear_data();
   endtask: collect_device_item
 

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -33,15 +33,14 @@ class i2c_monitor extends dv_base_monitor #(
   endtask : wait_for_reset_and_drop_item
 
   virtual task run_phase(uvm_phase phase);
-//    wait(cfg.vif.rst_ni);
-     wait(cfg.mon_start);
-     
-     `JDBG(("MON: ifmode:%s", cfg.if_mode.name))
+     wait(cfg.vif.rst_ni);
     forever begin
       fork
         begin: iso_fork
           fork
             begin
+	       wait(cfg.agent_init_done);     
+	       `JDBG(("MON: ifmode:%s", cfg.if_mode.name))
               if (cfg.if_mode == Device) collect_device_item(phase);
               else collect_host_item(phase);
             end

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -34,13 +34,12 @@ class i2c_monitor extends dv_base_monitor #(
 
   virtual task run_phase(uvm_phase phase);
      wait(cfg.vif.rst_ni);
+     `JDBG(("MON: ifmode:%s", cfg.if_mode.name))
     forever begin
       fork
         begin: iso_fork
           fork
             begin
-	       wait(cfg.agent_init_done);     
-	       `JDBG(("MON: ifmode:%s", cfg.if_mode.name))
               if (cfg.if_mode == Device) collect_device_item(phase);
               else collect_host_item(phase);
             end

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
@@ -14,7 +14,7 @@ class i2c_base_seq extends dv_base_seq #(
   REQ req_q[$];
 
   // data to be sent to target dut
-  bit [7:0] data_q[$];
+  rand bit [7:0] data_q[$];
 
   // Stops running this sequence
   protected bit stop;

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_seq_list.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_seq_list.sv
@@ -4,3 +4,4 @@
 
 `include "i2c_base_seq.sv"
 `include "i2c_device_response_seq.sv"
+`include "i2c_target_base_seq.sv"

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_target_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_target_base_seq.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class i2c_target_base_seq extends i2c_base_seq;
+  `uvm_object_utils(i2c_target_base_seq)
+  `uvm_object_new
+
+  virtual task body();
+    // i2c_item needs more test specific parameters for proper randomization.
+    // Rather than keeping duplicate parameters in i2c_agent_cfg and i2c_seq_cfg,
+    // use i2c_seq_cfg parameters to simplify implementation.
+    // So, instead of randomizing i2c_item here, assuming i2c_item is randomized in
+    // vseq and fed to req_q here.
+    fork
+      begin: isolation_thread
+        fork
+           begin
+	      wait (req_q.size() > 0);
+	      while (req_q.size() > 0) begin
+		 req = req_q.pop_front();
+		 start_item(req);
+		 finish_item(req);
+	      end
+          end
+          wait (stop);
+        join_any
+        #0;
+        disable fork;
+      end
+    join
+  endtask : body
+
+endclass : i2c_target_base_seq

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -37,6 +37,7 @@ filesets:
       - seq_lib/i2c_host_stretch_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_error_intr_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_smoke_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env.sv
+++ b/hw/ip/i2c/dv/env/i2c_env.sv
@@ -29,6 +29,9 @@ class i2c_env extends cip_base_env #(
     end
 
     virtual_sequencer.i2c_sequencer_h = m_i2c_agent.sequencer;
+    if (cfg.m_i2c_agent_cfg.if_mode == Host) begin
+       virtual_sequencer.target_mode_wr_exp_port.connect(scoreboard.target_mode_wr_exp_fifo.analysis_export);
+    end
   endfunction
 
 endclass : i2c_env

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -15,7 +15,7 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   bit [7:0]  lastbyte;
 
   tran_type_e trans_type = ReadWrite;
-
+   
   `uvm_object_utils_begin(i2c_env_cfg)
     `uvm_field_object(m_i2c_agent_cfg, UVM_DEFAULT)
   `uvm_object_utils_end

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -55,6 +55,20 @@ package i2c_env_pkg;
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
 
+   function automatic i2c_item acq2item(bit[9:0] data);
+      i2c_item item;
+      `uvm_create_obj(i2c_item, item);
+
+      item.wdata = data[7:0];
+      if (data[9:8] == 2'b11) begin
+	 // TODO Re start support
+      end else begin
+	 item.start = data[8];
+	 item.stop = data[9];	 
+      end
+      return item;      
+   endfunction // acq2item
+   
   // package sources
   `include "i2c_seq_cfg.sv"
   `include "i2c_env_cfg.sv"

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -31,6 +31,9 @@ class i2c_scoreboard extends cip_base_scoreboard #(
   uvm_tlm_analysis_fifo #(i2c_item) rd_item_fifo;
   uvm_tlm_analysis_fifo #(i2c_item) wr_item_fifo;
 
+  // Target mode transactions
+  uvm_tlm_analysis_fifo #(i2c_item) target_mode_wr_exp_fifo;
+   
   // interrupt bit vector
   local bit [NumI2cIntr-1:0] intr_exp;
 
@@ -43,10 +46,22 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     rd_pending_item = new("rd_pending_item" );
     exp_rd_item = new("exp_rd_item");
     exp_wr_item = new("exp_wr_item");
+
+     target_mode_wr_exp_fifo = new("target_mode_wr_exp_fifo", this);
+     
   endfunction : build_phase
 
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
+    if (cfg.m_i2c_agent_cfg.if_mode == Host) begin
+       fork begin
+	  forever begin
+	     target_mode_wr_exp_fifo.get(exp_wr_item);
+	     `JDBG(("exp_tn%0d\n %s", exp_wr_item.tran_id, exp_wr_item.sprint()))
+	     process_target_write(exp_wr_item);	     
+	  end
+       end join_none
+    end else begin 
     forever begin
       `DV_SPINWAIT_EXIT(
         fork
@@ -55,6 +70,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
         join,
         @(negedge cfg.clk_rst_vif.rst_n),
       )
+    end
     end
   endtask : run_phase
 
@@ -394,4 +410,31 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     `DV_EOT_PRINT_TLM_FIFO_CONTENTS(i2c_item, wr_item_fifo)
   endfunction
 
+   task process_target_write(i2c_item exp);
+      uvm_reg_data_t read_data;
+      i2c_item obs;
+      
+      // polling status.acqempty == 0
+      csr_spinwait(.ptr(ral.status.acqempty), .exp_data(1'b0),
+		   .timeout_ns(10_000));
+      
+      // read one entry and compare
+      csr_rd(.ptr(ral.acqdata), .value(read_data));
+      `uvm_create_obj(i2c_item, obs);
+      obs = acq2item(read_data);
+      obs.tran_id = this.tran_id++;
+      target_txn_comp(obs, exp);
+      
+   endtask // process_target_write
+
+   // Compare start, stop and wdata only
+   function void target_txn_comp(i2c_item obs, i2c_item exp);
+      `uvm_info(`gfn, $sformatf("comp:target wr_txn %0d", obs.tran_id), UVM_MEDIUM)
+      `DV_CHECK_EQ(obs.start, exp.start)
+      `DV_CHECK_EQ(obs.stop, exp.stop)
+      if (obs.stop == 0) begin
+	 `DV_CHECK_EQ(obs.wdata, exp.wdata)
+      end
+   endfunction // target_txn_comp
+   
 endclass : i2c_scoreboard

--- a/hw/ip/i2c/dv/env/i2c_seq_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_seq_cfg.sv
@@ -53,6 +53,10 @@ class i2c_seq_cfg extends uvm_object;
   // set en_sda_interference to allow sda_interference irq is triggered
   bit en_sda_interference        = 1'b0;
 
+  // dut target mode parameters
+   int min_data = 1;
+   int max_data = 1;
+      
   `uvm_object_new
 
 endclass : i2c_seq_cfg

--- a/hw/ip/i2c/dv/env/i2c_virtual_sequencer.sv
+++ b/hw/ip/i2c/dv/env/i2c_virtual_sequencer.sv
@@ -5,8 +5,13 @@
 class i2c_virtual_sequencer extends cip_base_virtual_sequencer #(.CFG_T(i2c_env_cfg),
                                                                  .COV_T(i2c_env_cov));
   i2c_sequencer    i2c_sequencer_h;
-
+  uvm_analysis_port #(i2c_item) target_mode_wr_exp_port;
+   
   `uvm_component_utils(i2c_virtual_sequencer)
   `uvm_component_new
 
+    function void build_phase(uvm_phase phase);
+       super.build_phase(phase);
+       target_mode_wr_exp_port = new("target_mode_wr_exp_port", this);
+    endfunction
 endclass : i2c_virtual_sequencer

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -200,8 +200,9 @@ class i2c_base_vseq extends cip_base_vseq #(
     print_seq_cfg_vars("post-start");
   endtask : post_start
 
+  // TODO remove input arguments 
   virtual task initialization(if_mode_e mode = Host);
-    wait(cfg.m_i2c_agent_cfg.vif.rst_ni);
+    wait(cfg.m_i2c_agent_cfg.vif.rst_ni);         
     if (mode == Host) begin
       i2c_init(Host);
       agent_init(Device);
@@ -213,12 +214,11 @@ class i2c_base_vseq extends cip_base_vseq #(
         (mode == Host) ? "Host/Target" : "Target/Host"), UVM_LOW)
   endtask : initialization
 
+  // 'cfg.m_i2c_agent_cfg.if_mode' is set by plusarg.
+  // default value of if_mode in block level is 'Device'
   virtual task agent_init(if_mode_e mode = Device);
     i2c_base_seq m_base_seq;
 
-    cfg.m_i2c_agent_cfg.if_mode = mode;
-    cfg.m_i2c_agent_cfg.agent_init_done = 1;
-     
     `uvm_info(`gfn, $sformatf("\n  initialize agent in mode %s", mode.name()), UVM_DEBUG)
     if (mode == Host) begin
 //      // stop re-active seq when the agent switches to Host mode

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -214,10 +214,12 @@ class i2c_base_vseq extends cip_base_vseq #(
     i2c_base_seq m_base_seq;
 
     cfg.m_i2c_agent_cfg.if_mode = mode;
+    cfg.m_i2c_agent_cfg.mon_start = 1;
+     
     `uvm_info(`gfn, $sformatf("\n  initialize agent in mode %s", mode.name()), UVM_DEBUG)
     if (mode == Host) begin
-      // stop re-active seq when the agent switches to Host mode
-      p_sequencer.i2c_sequencer_h.stop_sequences();
+//      // stop re-active seq when the agent switches to Host mode
+//      p_sequencer.i2c_sequencer_h.stop_sequences();
     end else begin
       m_base_seq = i2c_base_seq::type_id::create("m_base_seq");
       `uvm_info(`gfn, $sformatf("\n  start i2c_sequence %s",
@@ -356,7 +358,7 @@ class i2c_base_vseq extends cip_base_vseq #(
     // configure i2c_agent_cfg
     cfg.m_i2c_agent_cfg.timing_cfg = timing_cfg;
     `uvm_info(`gfn, $sformatf("\n  cfg.m_i2c_agent_cfg.timing_cfg\n%p",
-        cfg.m_i2c_agent_cfg.timing_cfg), UVM_DEBUG)
+        cfg.m_i2c_agent_cfg.timing_cfg), UVM_MEDIUM)
 
     //*** program ilvl
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fmtilvl)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -57,6 +57,9 @@ class i2c_base_vseq extends cip_base_vseq #(
   rand uint                   prob_sda_interference;
   rand uint                   prob_scl_interference;
 
+  // host timeout ctrl value
+   bit [31:0] 		      host_timeout_ctrl = 32'hffff;
+   
   // constraints
   constraint addr_c {
     addr inside {[cfg.seq_cfg.i2c_min_addr : cfg.seq_cfg.i2c_max_addr]};
@@ -214,7 +217,7 @@ class i2c_base_vseq extends cip_base_vseq #(
     i2c_base_seq m_base_seq;
 
     cfg.m_i2c_agent_cfg.if_mode = mode;
-    cfg.m_i2c_agent_cfg.mon_start = 1;
+    cfg.m_i2c_agent_cfg.agent_init_done = 1;
      
     `uvm_info(`gfn, $sformatf("\n  initialize agent in mode %s", mode.name()), UVM_DEBUG)
     if (mode == Host) begin
@@ -254,6 +257,9 @@ class i2c_base_vseq extends cip_base_vseq #(
       ral.target_id.address1.set(target_addr1);
       ral.target_id.mask1.set(7'h3f);
       csr_update(ral.target_id);
+      // Host timeout control
+      ral.host_timeout_ctrl.set(this.host_timeout_ctrl);
+      csr_update(ral.host_timeout_ctrl);
     end
 
     // clear fifos

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -8,14 +8,14 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
   `uvm_object_new
 
   int trans_id;
-   
+
   virtual task body();
     i2c_target_base_seq m_i2c_host_seq;
     // Intialize dut in device mode and agent in host mode
     initialization(Device);
      print_time_property();
- 
-    get_timing_values();     
+
+    get_timing_values();
     program_registers();
 
     `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
@@ -24,7 +24,7 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
 //    `uvm_create_obj(i2c_item, item)
 //    `DV_CHECK_RANDOMIZE_FATAL(item)
 //    m_i2c_host_seq.req_q.push_back(item);
-     create_write_txn(m_i2c_host_seq);     
+     create_write_txn(m_i2c_host_seq);
     m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
     `JDBG(("ASSA"))
 
@@ -51,37 +51,38 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
       `JDBG(("error intrs probability"))
       `JDBG(("prob_sda_unstable:%0d    ", prob_sda_unstable));
       `JDBG(("prob_sda_interference:%0d", prob_sda_interference));
-      `JDBG(("prob_scl_interference:%0d", prob_scl_interference));      
+      `JDBG(("prob_scl_interference:%0d", prob_scl_interference));
    endfunction // print_timing
 
    task create_write_txn(ref i2c_target_base_seq seq);
-      bit [7:0] wdata_q[$];      
+      bit [7:0] wdata_q[$];
       i2c_item txn;
-      
+
       int txn_size;
-      
+
       `uvm_create_obj(i2c_item, txn)
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(wdata_q,
 				     wdata_q.size() inside {
                                      [cfg.seq_cfg.min_data : cfg.seq_cfg.max_data]};)
       // data + address
-      `JDBG(("byte0:%x (addr:%x) wdataq:%p", {target_addr0, 1'b0}, target_addr0, wdata_q))
+      `JDBG(("byte0:0x%x (addr:0x%x) wdataq:%p", {target_addr0, 1'b0}, target_addr0, wdata_q))
       txn_size = wdata_q.size() + 1;
 
       txn.drv_type = HostStart;
-      seq.req_q.push_back(txn);      
-      for (int i = 0; i < txn_size; i++) begin	 
+      seq.req_q.push_back(txn);
+      for (int i = 0; i < txn_size; i++) begin
 	 `uvm_create_obj(i2c_item, txn)
-	 txn.drv_type = HostData;	 
+	 txn.drv_type = HostData;
 	 if (i == 0) begin
-	    txn.wdata[7:1] = target_addr0;
+	   txn.wdata[7:1] = target_addr0;
+           txn.wdata[0] = 1'b0;
 	 end else begin
-	    txn.wdata = wdata_q[i-1];	    
-	 end	 
-	 seq.req_q.push_back(txn); 
+	   txn.wdata = wdata_q[i-1];
+	 end
+	 seq.req_q.push_back(txn);
       end
       `uvm_create_obj(i2c_item, txn)
       txn.drv_type = HostStop;
-      seq.req_q.push_back(txn);      
-   endtask 
+      seq.req_q.push_back(txn);
+   endtask
 endclass : i2c_target_smoke_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -19,11 +19,7 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
     program_registers();
 
     `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
-//    m_i2c_host_seq.cfg = cfg.m_i2c_agent_cfg;
 
-//    `uvm_create_obj(i2c_item, item)
-//    `DV_CHECK_RANDOMIZE_FATAL(item)
-//    m_i2c_host_seq.req_q.push_back(item);
      create_write_txn(m_i2c_host_seq);
     m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
     `JDBG(("ASSA"))

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -1,0 +1,87 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Basic smoke test vseq
+class i2c_target_smoke_vseq extends i2c_base_vseq;
+  `uvm_object_utils(i2c_target_smoke_vseq)
+  `uvm_object_new
+
+  int trans_id;
+   
+  virtual task body();
+    i2c_target_base_seq m_i2c_host_seq;
+    // Intialize dut in device mode and agent in host mode
+    initialization(Device);
+     print_time_property();
+ 
+    get_timing_values();     
+    program_registers();
+
+    `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
+//    m_i2c_host_seq.cfg = cfg.m_i2c_agent_cfg;
+
+//    `uvm_create_obj(i2c_item, item)
+//    `DV_CHECK_RANDOMIZE_FATAL(item)
+//    m_i2c_host_seq.req_q.push_back(item);
+     create_write_txn(m_i2c_host_seq);     
+    m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
+    `JDBG(("ASSA"))
+
+  endtask : body
+
+   function void print_time_property();
+      `JDBG(("timing_prop"))
+      `JDBG(("thigh:%0d	     ", thigh));	     // high period of the SCL in clock units
+      `JDBG(("tlow:%0d		     ", tlow));		     // low period of the SCL in clock units
+      `JDBG(("t_r:%0d		     ", t_r));		     // rise time of both SDA and SCL in clock units
+      `JDBG(("t_f:%0d		     ", t_f));		     // fall time of both SDA and SCL in clock units
+      `JDBG(("thd_sta:%0d	     ", thd_sta));	     // hold time for (repeated) START in clock units
+      `JDBG(("tsu_sta:%0d	     ", tsu_sta));	     // setup time for repeated START in clock units
+      `JDBG(("tsu_sto:%0d	     ", tsu_sto));	     // setup time for STOP in clock units
+      `JDBG(("tsu_dat:%0d	     ", tsu_dat));	     // data setup time in clock units
+      `JDBG(("thd_dat:%0d	     ", thd_dat));	     // data hold time in clock units
+      `JDBG(("t_buf:%0d	     ", t_buf));	     // bus free time between STOP and START in clock units
+      `JDBG(("t_timeout:%0d	     ", t_timeout));	     // max time target may stretch the clock
+      `JDBG(("e_timeout:%0d	     ", e_timeout));	     // max time target may stretch the clock
+      `JDBG(("t_sda_unstable:%0d    ", t_sda_unstable));    // sda unstable time during the posedge_clock
+      `JDBG(("t_sda_interference:%0d", t_sda_interference)); // sda interference time during the posedge_clock
+      `JDBG(("t_scl_interference:%0d", t_scl_interference)); // scl interference time during the posedge_clock
+
+      `JDBG(("error intrs probability"))
+      `JDBG(("prob_sda_unstable:%0d    ", prob_sda_unstable));
+      `JDBG(("prob_sda_interference:%0d", prob_sda_interference));
+      `JDBG(("prob_scl_interference:%0d", prob_scl_interference));      
+   endfunction // print_timing
+
+   task create_write_txn(ref i2c_target_base_seq seq);
+      bit [7:0] wdata_q[$];      
+      i2c_item txn;
+      
+      int txn_size;
+      
+      `uvm_create_obj(i2c_item, txn)
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(wdata_q,
+				     wdata_q.size() inside {
+                                     [cfg.seq_cfg.min_data : cfg.seq_cfg.max_data]};)
+      // data + address
+      `JDBG(("byte0:%x (addr:%x) wdataq:%p", {target_addr0, 1'b0}, target_addr0, wdata_q))
+      txn_size = wdata_q.size() + 1;
+
+      txn.drv_type = HostStart;
+      seq.req_q.push_back(txn);      
+      for (int i = 0; i < txn_size; i++) begin	 
+	 `uvm_create_obj(i2c_item, txn)
+	 txn.drv_type = HostData;	 
+	 if (i == 0) begin
+	    txn.wdata[7:1] = target_addr0;
+	 end else begin
+	    txn.wdata = wdata_q[i-1];	    
+	 end	 
+	 seq.req_q.push_back(txn); 
+      end
+      `uvm_create_obj(i2c_item, txn)
+      txn.drv_type = HostStop;
+      seq.req_q.push_back(txn);      
+   endtask 
+endclass : i2c_target_smoke_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -7,23 +7,26 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
   `uvm_object_utils(i2c_target_smoke_vseq)
   `uvm_object_new
 
-  int trans_id;
+  int tran_id;
 
   virtual task body();
     i2c_target_base_seq m_i2c_host_seq;
+     
     // Intialize dut in device mode and agent in host mode
     initialization(Device);
-     print_time_property();
+//    print_time_property();
+//    `JDBG(("agtcfg: %s", cfg.m_i2c_agent_cfg.sprint()))
 
+     for (int i = 0; i < 2; i++) begin 
     get_timing_values();
     program_registers();
 
     `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
 
      create_write_txn(m_i2c_host_seq);
-    m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
+     m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
     `JDBG(("ASSA"))
-
+     end
   endtask : body
 
    function void print_time_property();
@@ -53,7 +56,8 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
    task create_write_txn(ref i2c_target_base_seq seq);
       bit [7:0] wdata_q[$];
       i2c_item txn;
-
+      i2c_item exp_txn;
+      
       int txn_size;
 
       `uvm_create_obj(i2c_item, txn)
@@ -65,20 +69,36 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
       txn_size = wdata_q.size() + 1;
 
       txn.drv_type = HostStart;
-      seq.req_q.push_back(txn);
+      // skip the first transaction to pass sb because
+      // start and address are coalescing in acq fifo.
+      seq.req_q.push_back(txn);      
       for (int i = 0; i < txn_size; i++) begin
 	 `uvm_create_obj(i2c_item, txn)
+	 `uvm_create_obj(i2c_item, exp_txn)
 	 txn.drv_type = HostData;
+	 txn.stop = 0;	
+         txn.tran_id = this.tran_id++; 
 	 if (i == 0) begin
+	   txn.start = 1;	    
 	   txn.wdata[7:1] = target_addr0;
            txn.wdata[0] = 1'b0;
+	    
 	 end else begin
+	   txn.start = 0;	    
 	   txn.wdata = wdata_q[i-1];
 	 end
+
+	 `downcast(exp_txn, txn.clone());	 
 	 seq.req_q.push_back(txn);
+	 p_sequencer.target_mode_wr_exp_port.write(exp_txn);	 
       end
       `uvm_create_obj(i2c_item, txn)
+      `uvm_create_obj(i2c_item, exp_txn)
+      txn.tran_id = this.tran_id++;   
+      txn.stop = 1;   
       txn.drv_type = HostStop;
+      `downcast(exp_txn, txn.clone());	 
       seq.req_q.push_back(txn);
+      p_sequencer.target_mode_wr_exp_port.write(exp_txn);	 
    endtask
 endclass : i2c_target_smoke_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -20,3 +20,4 @@
 `include "i2c_host_stretch_timeout_vseq.sv"
 `include "i2c_host_error_intr_vseq.sv"
 `include "i2c_host_stress_all_vseq.sv"
+`include "i2c_target_smoke_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -123,7 +123,7 @@
     {
       name: i2c_target_smoke
       uvm_test_seq: i2c_target_smoke_vseq
-      run_opts: ["+test_timeout_ns=50_000"]
+      run_opts: ["+test_timeout_ns=100_000"]
     }
   ]
 

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -120,6 +120,11 @@
       name: i2c_host_stress_all
       uvm_test_seq: i2c_host_stress_all_vseq
     }
+    {
+      name: i2c_target_smoke
+      uvm_test_seq: i2c_target_smoke_vseq
+      run_opts: ["+test_timeout_ns=50_000"]
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -123,7 +123,7 @@
     {
       name: i2c_target_smoke
       uvm_test_seq: i2c_target_smoke_vseq
-      run_opts: ["+test_timeout_ns=100_000"]
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=100_000"]
     }
   ]
 

--- a/hw/ip/i2c/dv/tb/tb.sv
+++ b/hw/ip/i2c/dv/tb/tb.sv
@@ -136,4 +136,11 @@ module tb;
     run_test();
   end
 
+//  initial begin
+//     #8.62us;
+//     force tb.dut.i2c_core.scl_o = 0;
+//     repeat(20) @(posedge clk);
+//     release tb.dut.i2c_core.scl_o;
+//     
+//  end
 endmodule : tb

--- a/hw/ip/i2c/dv/tests/i2c_base_test.sv
+++ b/hw/ip/i2c/dv/tests/i2c_base_test.sv
@@ -15,9 +15,15 @@ class i2c_base_test extends cip_base_test #(.ENV_T(i2c_env),
   // run that seq in the run_phase; as such, nothing more needs to be done
   
   virtual function void build_phase(uvm_phase phase);
+    if_mode_e mode = Device;
     max_quit_count  = 50;
     test_timeout_ns = 600_000_000; // 600ms
     super.build_phase(phase);
+    
+    `DV_GET_ENUM_PLUSARG(if_mode_e, mode, i2c_agent_mode)
+    `uvm_info(`gfn, $sformatf("set i2c agent mode to %s", mode.name), UVM_MEDIUM)
+    cfg.m_i2c_agent_cfg.if_mode = mode;
+   
   endfunction : build_phase
 
 endclass : i2c_base_test


### PR DESCRIPTION
cmd:
./util/dvsim/dvsim.py ./hw/ip/i2c/dv/i2c_sim_cfg.hjson -i target_smoke -r 1 -v m -s 1 -w fsdb

Test send 1 data 8'hE7 to target_address0 : 0x32

Start is detected by dut but state goes to 'AcquireSrP' which makes 1st data of acq_fifo[9:8] = 'h3
instead of 'h1. (https://docs.opentitan.org/hw/ip/i2c/doc/index.html#acquired-formatted-data)

Also please double check driver doesn't honor 1/f_scl . (TB need to fix this).

timing parameters in this test
cfg.m_i2c_agent_cfg.timing_cfg
'{tSetupStart:'h2, tHoldStart:'h6, tClockStart:'h5, tClockLow:'h4, tSetupBit:'h3, tClockPulse:'h8, tHoldBit:'h8, tClockStop:'hb, tSetupStop:'h4, tHoldStop:'h3, enbTimeOut:'h0, tTimeOut:'h4, tStretchHostClock:'h0, tSdaUnstable:'h0, tSclInterference:'h0, tSdaInterference:'h0}
thigh:4	     
tlow:13		     
t_r:1		     
t_f:3		     
thd_sta:3	     
tsu_sta:1	     
tsu_sto:3	     
tsu_dat:2	     
thd_dat:5	     
t_buf:3	     
t_timeout:4	     
e_timeout:0	     
t_sda_unstable:4    
t_sda_interference:2
t_scl_interference:0



Signed-off-by: Jaedon Kim <jdonjdon@google.com>