### PR TITLE
[pinmux] Remove overly strict SVA

### DIFF
--- a/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
@@ -298,8 +298,8 @@ module pinmux_strap_sampling
   `ASSERT(PwrMgrStrapSampleOnce_A, strap_en_i |=> ##0 !strap_en_i [*])
 
   `ASSERT(RvTapOff0_A,  lc_hw_debug_en_i == lc_ctrl_pkg::Off |-> ##2 rv_jtag_o == '0)
-  `ASSUME(RvTapOff1_A,  lc_hw_debug_en_i == lc_ctrl_pkg::Off |-> ##2 rv_jtag_i == '0)
   `ASSERT(DftTapOff0_A, lc_dft_en_i == lc_ctrl_pkg::Off |-> ##2 dft_jtag_o == '0)
-  `ASSUME(DftTapOff1_A, lc_dft_en_i == lc_ctrl_pkg::Off |-> ##2 dft_jtag_i == '0)
-
+  // These assumptions are only used in FPV. They will cause failures in simulations.
+  `ASSUME_FPV(RvTapOff1_A,  lc_hw_debug_en_i == lc_ctrl_pkg::Off |-> ##2 rv_jtag_i == '0)
+  `ASSUME_FPV(DftTapOff1_A, lc_dft_en_i == lc_ctrl_pkg::Off |-> ##2 dft_jtag_i == '0)
 endmodule : pinmux_strap_sampling

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
@@ -200,9 +200,6 @@ class chip_tap_straps_vseq extends chip_sw_base_vseq;
     jtag_pkg::jtag_req_t exp_jtag_req, act_jtag_req;
     jtag_pkg::jtag_rsp_t exp_jtag_rsp;
 
-    // forcing the internal jtag tdo causes this check to fail.
-    $assertoff(1, "tb.dut.top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.DftTapOff1_A");
-
     `uvm_info(`gfn, $sformatf("Testing DFT tap with dft_tap_en: %0d", dft_tap_en), UVM_LOW)
     repeat ($urandom_range(10, 5)) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(exp_jtag_req)
@@ -234,8 +231,6 @@ class chip_tap_straps_vseq extends chip_sw_base_vseq;
     `DV_CHECK_FATAL(uvm_hdl_release(path_tb_jtag_tms))
     `DV_CHECK_FATAL(uvm_hdl_release(path_tb_jtag_tdi))
     `DV_CHECK_FATAL(uvm_hdl_release(path_dft_tap_rsp))
-
-    $asserton(1, "tb.dut.top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.DftTapOff1_A");
 
     // The random force/release toggling above means trst_n could be left in an active state.
     // Wiggle the trst_n pin and make sure it returns to an inactive value.


### PR DESCRIPTION
We can't guarantee inside the pinmux that the JTAG TAP inputs are not toggling, since we only have control over the JTAG TAP outputs.

Fixes #15897

Signed-off-by: Michael Schaffner <msf@google.com>