### PR TITLE
[lc_ctrl] Fix FSM behavior in SCRAP state and expose initialized status in CSRs

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -501,13 +501,20 @@
               "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "0"
-          name: "READY"
+          name: "INITIALIZED"
           desc: '''
                 This bit is set to 1 if the life cycle controller has successfully initialized and the
                 state exposed in !!LC_STATE and !!LC_TRANSITION_CNT is valid.
                 '''
         }
         { bits: "1"
+          name: "READY"
+          desc: '''
+                This bit is set to 1 if the life cycle controller has successfully initialized and is
+                ready to accept a life cycle transition command.
+                '''
+        }
+        { bits: "2"
           name: "TRANSITION_SUCCESSFUL"
           desc: '''
                 This bit is set to 1 if the last life cycle transition request was successful.
@@ -515,7 +522,7 @@
                 moves the life cycle state into POST_TRANSITION.
                 '''
         }
-        { bits: "2"
+        { bits: "3"
           name: "TRANSITION_COUNT_ERROR"
           desc: '''
                 This bit is set to 1 if the !!LC_TRANSITION_CNT has reached its maximum.
@@ -524,7 +531,7 @@
                 moves the life cycle state into POST_TRANSITION.
                 '''
         }
-        { bits: "3"
+        { bits: "4"
           name: "TRANSITION_ERROR"
           desc: '''
                 This bit is set to 1 if the last transition command requested an invalid state transition
@@ -532,7 +539,7 @@
                 moves the life cycle state into POST_TRANSITION.
                 '''
         }
-        { bits: "4"
+        { bits: "5"
           name: "TOKEN_ERROR"
           desc: '''
                 This bit is set to 1 if the token supplied for a conditional transition was invalid.
@@ -540,7 +547,7 @@
                 moves the life cycle state into POST_TRANSITION.
                 '''
         }
-        { bits: "5"
+        { bits: "6"
           name: "FLASH_RMA_ERROR"
           desc: '''
                 This bit is set to 1 if flash failed to correctly respond to an RMA request.
@@ -548,7 +555,7 @@
                 moves the life cycle state into POST_TRANSITION.
                 '''
         }
-        { bits: "6"
+        { bits: "7"
           name: "OTP_ERROR"
           desc: '''
                 This bit is set to 1 if an error occurred during an OTP programming operation.
@@ -556,7 +563,7 @@
                 fatal_prog_error alert.
                 '''
         }
-        { bits: "7"
+        { bits: "8"
           name: "STATE_ERROR"
           desc: '''
                 This bit is set to 1 if either the controller FSM state or the life cycle state is invalid or
@@ -564,14 +571,14 @@
                 automatically to INVALID and raise a fatal_state_error alert.
                 '''
         }
-        { bits: "8"
+        { bits: "9"
           name: "BUS_INTEG_ERROR"
           desc: '''
                 This bit is set to 1 if a fatal bus integrity fault is detected.
                 This error triggers a fatal_bus_integ_error alert.
                 '''
         }
-        { bits: "9"
+        { bits: "10"
           name: "OTP_PARTITION_ERROR"
           desc: '''
                 This bit is set to 1 if the life cycle partition in OTP is in error state.

--- a/hw/ip/lc_ctrl/doc/_index.md
+++ b/hw/ip/lc_ctrl/doc/_index.md
@@ -652,7 +652,7 @@ The TAP isolation and multiplexing is implemented in the pinmux IP as [described
 The register layout and offsets shown in the [register table]{{< relref "#register-table" >}} below are identical for both the CSR and JTAG TAP interfaces.
 Hence the following programming sequence applies to both SW running on the device and SW running on the test appliance that accesses life cycle through the TAP.
 
-1. In order to perform a life cycle transition, SW should first check whether the life cycle controller has successfully initialized by making sure that the {{< regref "STATUS.READY" >}} bit is set to 1, and that all other status and error bits in {{< regref "STATUS" >}} are set to 0.
+1. In order to perform a life cycle transition, SW should first check whether the life cycle controller has successfully initialized and is ready to accept a transition command by making sure that the {{< regref "STATUS.READY" >}} bit is set to 1, and that all other status and error bits in {{< regref "STATUS" >}} are set to 0.
 
 2. Read the {{< regref "LC_STATE" >}} and {{< regref "LC_TRANSITION_CNT" >}} registers to determine which life cycle state the device currently is in, and how many transition attempts are still available.
 

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -50,7 +50,11 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
 
     for (int i = 1; i <= num_trans; i++) begin
       cfg.set_test_phase(LcCtrlIterStart);
-      if (i != 1) dut_init();
+      if (i != 1) begin
+        dut_init();
+        // We expect initialized to be set to 1 after dut_init
+        csr_rd_check(.ptr(ral.status.initialized), .compare_value(1));
+      end
       `DV_CHECK_RANDOMIZE_FATAL(this)
       `uvm_info(`gfn, $sformatf(
                 "starting seq %0d/%0d, init LC_state is %0s, LC_cnt is %0s",
@@ -138,4 +142,3 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
   endfunction
 
 endclass : lc_ctrl_smoke_vseq
-

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
@@ -18,5 +18,3 @@
 `include "lc_ctrl_sec_token_mux_vseq.sv"
 `include "lc_ctrl_sec_token_digest_vseq.sv"
 `include "lc_ctrl_stress_all_vseq.sv"
-
-

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -291,7 +291,7 @@ module lc_ctrl
   dec_lc_cnt_t       dec_lc_cnt;
   dec_lc_id_state_e  dec_lc_id_state;
 
-  logic lc_idle_d;
+  logic lc_idle_d, lc_done_d;
 
   // Assign hardware revision output
   assign hw_rev_o = '{chip_gen: ChipGen, chip_rev: ChipRev};
@@ -303,6 +303,7 @@ module lc_ctrl
 
   always_comb begin : p_csr_assign_outputs
     hw2reg = '0;
+    hw2reg.status.initialized            = lc_done_d;
     hw2reg.status.ready                  = lc_idle_d;
     hw2reg.status.transition_successful  = trans_success_q;
     hw2reg.status.transition_count_error = trans_cnt_oflw_error_q;
@@ -589,7 +590,7 @@ module lc_ctrl
     .q_o(lc_init)
   );
 
-  logic lc_done_d, lc_done_q;
+  logic lc_done_q;
   logic lc_idle_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_sync_regs

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -73,6 +73,9 @@ package lc_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
+    } initialized;
+    struct packed {
+      logic        d;
     } ready;
     struct packed {
       logic        d;
@@ -173,7 +176,7 @@ package lc_ctrl_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    lc_ctrl_hw2reg_status_reg_t status; // [852:843]
+    lc_ctrl_hw2reg_status_reg_t status; // [853:843]
     lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [842:835]
     lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [834:834]
     lc_ctrl_hw2reg_transition_ctrl_reg_t transition_ctrl; // [833:833]
@@ -229,7 +232,7 @@ package lc_ctrl_reg_pkg;
   parameter logic [0:0] LC_CTRL_ALERT_TEST_FATAL_PROG_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] LC_CTRL_ALERT_TEST_FATAL_STATE_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] LC_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_RESVAL = 1'h 0;
-  parameter logic [9:0] LC_CTRL_STATUS_RESVAL = 10'h 0;
+  parameter logic [10:0] LC_CTRL_STATUS_RESVAL = 11'h 0;
   parameter logic [7:0] LC_CTRL_CLAIM_TRANSITION_IF_RESVAL = 8'h 69;
   parameter logic [7:0] LC_CTRL_CLAIM_TRANSITION_IF_MUTEX_RESVAL = 8'h 69;
   parameter logic [0:0] LC_CTRL_TRANSITION_REGWEN_RESVAL = 1'h 0;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -129,6 +129,7 @@ module lc_ctrl_reg_top (
   logic alert_test_fatal_state_error_wd;
   logic alert_test_fatal_bus_integ_error_wd;
   logic status_re;
+  logic status_initialized_qs;
   logic status_ready_qs;
   logic status_transition_successful_qs;
   logic status_transition_count_error_qs;
@@ -274,7 +275,22 @@ module lc_ctrl_reg_top (
 
 
   // R[status]: V(True)
-  //   F[ready]: 0:0
+  //   F[initialized]: 0:0
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_status_initialized (
+    .re     (status_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.status.initialized.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .ds     (),
+    .qs     (status_initialized_qs)
+  );
+
+  //   F[ready]: 1:1
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_ready (
@@ -289,7 +305,7 @@ module lc_ctrl_reg_top (
     .qs     (status_ready_qs)
   );
 
-  //   F[transition_successful]: 1:1
+  //   F[transition_successful]: 2:2
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_transition_successful (
@@ -304,7 +320,7 @@ module lc_ctrl_reg_top (
     .qs     (status_transition_successful_qs)
   );
 
-  //   F[transition_count_error]: 2:2
+  //   F[transition_count_error]: 3:3
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_transition_count_error (
@@ -319,7 +335,7 @@ module lc_ctrl_reg_top (
     .qs     (status_transition_count_error_qs)
   );
 
-  //   F[transition_error]: 3:3
+  //   F[transition_error]: 4:4
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_transition_error (
@@ -334,7 +350,7 @@ module lc_ctrl_reg_top (
     .qs     (status_transition_error_qs)
   );
 
-  //   F[token_error]: 4:4
+  //   F[token_error]: 5:5
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_token_error (
@@ -349,7 +365,7 @@ module lc_ctrl_reg_top (
     .qs     (status_token_error_qs)
   );
 
-  //   F[flash_rma_error]: 5:5
+  //   F[flash_rma_error]: 6:6
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_flash_rma_error (
@@ -364,7 +380,7 @@ module lc_ctrl_reg_top (
     .qs     (status_flash_rma_error_qs)
   );
 
-  //   F[otp_error]: 6:6
+  //   F[otp_error]: 7:7
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_otp_error (
@@ -379,7 +395,7 @@ module lc_ctrl_reg_top (
     .qs     (status_otp_error_qs)
   );
 
-  //   F[state_error]: 7:7
+  //   F[state_error]: 8:8
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_state_error (
@@ -394,7 +410,7 @@ module lc_ctrl_reg_top (
     .qs     (status_state_error_qs)
   );
 
-  //   F[bus_integ_error]: 8:8
+  //   F[bus_integ_error]: 9:9
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_bus_integ_error (
@@ -409,7 +425,7 @@ module lc_ctrl_reg_top (
     .qs     (status_bus_integ_error_qs)
   );
 
-  //   F[otp_partition_error]: 9:9
+  //   F[otp_partition_error]: 10:10
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_otp_partition_error (
@@ -1212,16 +1228,17 @@ module lc_ctrl_reg_top (
       end
 
       addr_hit[1]: begin
-        reg_rdata_next[0] = status_ready_qs;
-        reg_rdata_next[1] = status_transition_successful_qs;
-        reg_rdata_next[2] = status_transition_count_error_qs;
-        reg_rdata_next[3] = status_transition_error_qs;
-        reg_rdata_next[4] = status_token_error_qs;
-        reg_rdata_next[5] = status_flash_rma_error_qs;
-        reg_rdata_next[6] = status_otp_error_qs;
-        reg_rdata_next[7] = status_state_error_qs;
-        reg_rdata_next[8] = status_bus_integ_error_qs;
-        reg_rdata_next[9] = status_otp_partition_error_qs;
+        reg_rdata_next[0] = status_initialized_qs;
+        reg_rdata_next[1] = status_ready_qs;
+        reg_rdata_next[2] = status_transition_successful_qs;
+        reg_rdata_next[3] = status_transition_count_error_qs;
+        reg_rdata_next[4] = status_transition_error_qs;
+        reg_rdata_next[5] = status_token_error_qs;
+        reg_rdata_next[6] = status_flash_rma_error_qs;
+        reg_rdata_next[7] = status_otp_error_qs;
+        reg_rdata_next[8] = status_state_error_qs;
+        reg_rdata_next[9] = status_bus_integ_error_qs;
+        reg_rdata_next[10] = status_otp_partition_error_qs;
       end
 
       addr_hit[2]: begin

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
@@ -195,9 +195,8 @@ module lc_ctrl_signal_decode
       end
       ///////////////////////////////////////////////////////////////////
       // Post-transition state. Behaves similarly to the virtual scrap
-      // states below, with the exception that escalate_en, since that
-      // could trigger unwanted alerts / escalations and system resets.
-      // is NOT asserted.
+      // states below, with the exception that escalate_en is NOT asserted,
+      // since that could trigger unwanted alerts / escalations and system resets.
       PostTransSt: ;
       ///////////////////////////////////////////////////////////////////
       // Virtual scrap states, make sure the escalation signal is

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_decode.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_decode.sv
@@ -62,6 +62,7 @@ module lc_ctrl_state_decode
       EscalateSt:  dec_lc_state = {DecLcStateNumRep{DecLcStEscalate}};
       PostTransSt: dec_lc_state = {DecLcStateNumRep{DecLcStPostTrans}};
       InvalidSt:   dec_lc_state = {DecLcStateNumRep{DecLcStInvalid}};
+      ScrapSt:     dec_lc_state = {DecLcStateNumRep{DecLcStScrap}};
       // Otherwise check and decode the life cycle state continously.
       default: begin
         // Note that we require that the valid signal from OTP is

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -94,6 +94,7 @@ package chip_env_pkg;
 
   // Two status for LC JTAG to identify if LC state transition is successful.
   typedef enum int {
+    LcInitialized,
     LcReady,
     LcTransitionSuccessful,
     LcTransitionCntError,

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -598,6 +598,12 @@ class chip_sw_base_vseq extends chip_base_vseq;
     end
   endtask
 
+  virtual task wait_lc_initialized(bit allow_err = 1);
+    cfg.m_jtag_riscv_agent_cfg.allow_errors = allow_err;
+    wait_lc_status(LcInitialized);
+    cfg.m_jtag_riscv_agent_cfg.allow_errors = 0;
+  endtask
+
   virtual task wait_lc_ready(bit allow_err = 1);
     cfg.m_jtag_riscv_agent_cfg.allow_errors = allow_err;
     wait_lc_status(LcReady);

--- a/sw/device/lib/dif/dif_lc_ctrl.c
+++ b/sw/device/lib/dif/dif_lc_ctrl.c
@@ -126,6 +126,11 @@ dif_result_t dif_lc_ctrl_get_status(const dif_lc_ctrl_t *lc,
 
   dif_lc_ctrl_status_t status_word = 0;
 
+  if (bitfield_bit32_read(reg, LC_CTRL_STATUS_INITIALIZED_BIT)) {
+    status_word = bitfield_bit32_write(status_word,
+                                       kDifLcCtrlStatusCodeInitialized, true);
+  }
+
   if (bitfield_bit32_read(reg, LC_CTRL_STATUS_READY_BIT)) {
     status_word =
         bitfield_bit32_write(status_word, kDifLcCtrlStatusCodeReady, true);

--- a/sw/device/lib/dif/dif_lc_ctrl.h
+++ b/sw/device/lib/dif/dif_lc_ctrl.h
@@ -33,6 +33,11 @@ typedef enum dif_lc_ctrl_status_code {
   /**
    * Indicates that the controller has been successfully initialized.
    */
+  kDifLcCtrlStatusCodeInitialized,
+  /**
+   * Indicates that the controller has been successfully initialized
+   * and is ready to accept a life cycle transition command.
+   */
   kDifLcCtrlStatusCodeReady,
   /**
    * Indicates that the last lifecycle transition succeeded.

--- a/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
@@ -96,11 +96,14 @@ TEST_F(StateTest, GetAttempts) {
 TEST_F(StateTest, GetStatus) {
   dif_lc_ctrl_status_t status;
 
-  EXPECT_READ32(LC_CTRL_STATUS_REG_OFFSET, {
-                                               {LC_CTRL_STATUS_READY_BIT, true},
-                                           });
+  EXPECT_READ32(LC_CTRL_STATUS_REG_OFFSET,
+                {
+                    {LC_CTRL_STATUS_INITIALIZED_BIT, true},
+                    {LC_CTRL_STATUS_READY_BIT, true},
+                });
   EXPECT_DIF_OK(dif_lc_ctrl_get_status(&lc_, &status));
-  EXPECT_EQ(status, bitfield_bit32_write(0, kDifLcCtrlStatusCodeReady, true));
+  EXPECT_TRUE(bitfield_bit32_read(status, kDifLcCtrlStatusCodeInitialized));
+  EXPECT_TRUE(bitfield_bit32_read(status, kDifLcCtrlStatusCodeReady));
 
   EXPECT_READ32(LC_CTRL_STATUS_REG_OFFSET,
                 {


### PR DESCRIPTION
Once we are in scrap we should stop decoding the life cycle vector from OTP, as this otherwise causes the life cycle fsm to flip over to InvalidSt after a few cycles, since the vector from OTP is invalidated.

This was discovered by @dkabely-ot in https://github.com/lowRISC/opentitan/pull/15938, where a busy loop on the READY register via JTAG timed out after rebooting the chip in SCRAP.

EDIT: this now also implements the INITIALIZED status register discussed in https://github.com/lowRISC/opentitan/issues/15963, together with required SW and DV updates.

Signed-off-by: Michael Schaffner <msf@google.com>