### PR TITLE
[i2c] Various target mode fixes 

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -44,7 +44,7 @@
     { name: "trans_complete"
       desc: '''
         host and target mode interrupt.
-        In host mode, raised if the host terminates the transaction by issuing STOP or repeated START.
+        In host mode, raised if the host issues a repated START or terminates the transaction by issuing STOP.
         In target mode, raised if the external host issues a STOP or repeated START.
       '''
     }

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -15,52 +15,56 @@
   // INTERRUPT pins
   interrupt_list: [
     { name: "fmt_watermark"
-      desc: "raised when the FMT FIFO depth falls below the low watermark."
+      desc: "host mode interrupt: raised when the FMT FIFO depth falls below the low watermark."
     }
     { name: "rx_watermark"
-      desc: "raised if the RX FIFO is past the high watermark."
+      desc: "host mode interrupt: raised if the RX FIFO is past the high watermark."
     }
     { name: "fmt_overflow"
-      desc: "raised if the FMT FIFO has overflowed."
+      desc: "host mode interrupt: raised if the FMT FIFO has overflowed."
     }
     { name: "rx_overflow"
-      desc: "raised if the RX FIFO has overflowed."
+      desc: "host mode interrupt: raised if the RX FIFO has overflowed."
     }
     { name: "nak"
-      desc: "raised if there is no ACK in response to an address or data write"
+      desc: "host mode interrupt: raised if there is no ACK in response to an address or data write"
     }
     { name: "scl_interference"
-      desc: "raised if the SCL line drops early (not supported without clock synchronization)."
+      desc: "host mode interrupt: raised if the SCL line drops early (not supported without clock synchronization)."
     }
     { name: "sda_interference"
-      desc: "raised if the SDA line goes low when host is trying to assert high"
+      desc: "host mode interrupt: raised if the SDA line goes low when host is trying to assert high"
     }
     { name: "stretch_timeout"
-      desc: "raised if target stretches the clock beyond the allowed timeout period"
+      desc: "host mode interrupt: raised if target stretches the clock beyond the allowed timeout period"
     }
     { name: "sda_unstable"
-      desc: "raised if the target does not assert a constant value of SDA during transmission."
+      desc: "host mode interrupt: raised if the target does not assert a constant value of SDA during transmission."
     }
     { name: "trans_complete"
-      desc: "raised if the host terminates the transaction by issuing STOP or repeated START."
+      desc: '''
+        host and target mode interrupt.
+        In host mode, raised if the host terminates the transaction by issuing STOP or repeated START.
+        In target mode, raised if the external host issues a STOP or repeated START.
+      '''
     }
     { name: "tx_empty"
-      desc: "raised if the target needs data to transmit and TX FIFO is empty."
+      desc: "target mode interrupt: raised if the target needs data to transmit and TX FIFO is empty."
     }
     { name: "tx_nonempty"
-      desc: "raised if there are extra bytes left in TX FIFO at the end of a read."
+      desc: "target mode interrupt: raised if there are extra bytes left in TX FIFO at the end of a read."
     }
     { name: "tx_overflow"
-      desc: "raised if TX FIFO has overflowed."
+      desc: "target mode interrupt: raised if TX FIFO has overflowed."
     }
     { name: "acq_overflow"
-      desc: "raised if ACQ FIFO has overflowed."
+      desc: "target mode interrupt: raised if ACQ FIFO has overflowed."
     }
     { name: "ack_stop"
-      desc: "raised if STOP is received after ACK (host sends both signals)."
+      desc: "target mode interrupt: raised if STOP is received after ACK instead of NACK from an external host read."
     }
     { name: "host_timeout"
-      desc: "raised if the host stops sending the clock during an ongoing transaction."
+      desc: "target mode interrupt: raised if the host stops sending the clock during an ongoing transaction."
     }
   ],
   alert_list: [

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -738,6 +738,10 @@ module i2c_fsm (
       end
       // AcquireSrP: target acquires repeated Start or Stop
       AcquireSrP : begin
+        // Since this is either a re-start or a stop, indicate transaction
+        // complete.
+        event_trans_complete_o = 1'b1;
+
         if (start_det) acq_fifo_wdata_o = {1'b1, 1'b1, input_byte};
         else acq_fifo_wdata_o = {1'b1, 1'b0, input_byte};
         acq_fifo_wvalid_o = 1'b1;

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -789,7 +789,6 @@ module i2c_fsm (
   end
 
   // Conditional state transition
-  logic idle;
   always_comb begin : state_functions
     state_d = state_q;
     load_tcount = 1'b0;
@@ -809,12 +808,10 @@ module i2c_fsm (
     en_sda_interf_det = 1'b0;
     start_det_clr = 1'b0;
     stop_det_clr = 1'b0;
-    idle = 1'b0;
 
     unique case (state_q)
       // Idle: initial state, SDA and SCL are released (high)
       Idle : begin
-        idle = 1'b1;
         if (!host_enable_i && !target_enable_i) state_d = Idle; // Idle unless host is enabled
         else if (host_enable_i) begin
           if (fmt_fifo_rvalid_i) state_d = Active;
@@ -1277,7 +1274,8 @@ module i2c_fsm (
     // instead of being dependent on a specific state, which may lead to
     // certain corner cases.
     if (target_enable_i &&
-       ((start_det && !idle) || stop_det)) begin
+       ((start_det && !start_det_clr) ||
+        (stop_det && !stop_det_clr))) begin
       state_d = AcquireSrP;
     end
   end

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.h
@@ -75,70 +75,79 @@ dif_result_t dif_i2c_alert_force(const dif_i2c_t *i2c, dif_i2c_alert_t alert);
  */
 typedef enum dif_i2c_irq {
   /**
-   * Raised when the FMT FIFO depth falls below the low watermark.
+   * Host mode interrupt: raised when the FMT FIFO depth falls below the low
+   * watermark.
    */
   kDifI2cIrqFmtWatermark = 0,
   /**
-   * Raised if the RX FIFO is past the high watermark.
+   * Host mode interrupt: raised if the RX FIFO is past the high watermark.
    */
   kDifI2cIrqRxWatermark = 1,
   /**
-   * Raised if the FMT FIFO has overflowed.
+   * Host mode interrupt: raised if the FMT FIFO has overflowed.
    */
   kDifI2cIrqFmtOverflow = 2,
   /**
-   * Raised if the RX FIFO has overflowed.
+   * Host mode interrupt: raised if the RX FIFO has overflowed.
    */
   kDifI2cIrqRxOverflow = 3,
   /**
-   * Raised if there is no ACK in response to an address or data write
+   * Host mode interrupt: raised if there is no ACK in response to an address or
+   * data write
    */
   kDifI2cIrqNak = 4,
   /**
-   * Raised if the SCL line drops early (not supported without clock
-   * synchronization).
+   * Host mode interrupt: raised if the SCL line drops early (not supported
+   * without clock synchronization).
    */
   kDifI2cIrqSclInterference = 5,
   /**
-   * Raised if the SDA line goes low when host is trying to assert high
+   * Host mode interrupt: raised if the SDA line goes low when host is trying to
+   * assert high
    */
   kDifI2cIrqSdaInterference = 6,
   /**
-   * Raised if target stretches the clock beyond the allowed timeout period
+   * Host mode interrupt: raised if target stretches the clock beyond the
+   * allowed timeout period
    */
   kDifI2cIrqStretchTimeout = 7,
   /**
-   * Raised if the target does not assert a constant value of SDA during
-   * transmission.
+   * Host mode interrupt: raised if the target does not assert a constant value
+   * of SDA during transmission.
    */
   kDifI2cIrqSdaUnstable = 8,
   /**
-   * Raised if the host terminates the transaction by issuing STOP or repeated
-   * START.
+   * Host and target mode interrupt. In host mode, raised if the host terminates
+   * the transaction by issuing STOP or repeated START. In target mode, raised
+   * if the external host issues a STOP or repeated START.
    */
   kDifI2cIrqTransComplete = 9,
   /**
-   * Raised if the target needs data to transmit and TX FIFO is empty.
+   * Target mode interrupt: raised if the target needs data to transmit and TX
+   * FIFO is empty.
    */
   kDifI2cIrqTxEmpty = 10,
   /**
-   * Raised if there are extra bytes left in TX FIFO at the end of a read.
+   * Target mode interrupt: raised if there are extra bytes left in TX FIFO at
+   * the end of a read.
    */
   kDifI2cIrqTxNonempty = 11,
   /**
-   * Raised if TX FIFO has overflowed.
+   * Target mode interrupt: raised if TX FIFO has overflowed.
    */
   kDifI2cIrqTxOverflow = 12,
   /**
-   * Raised if ACQ FIFO has overflowed.
+   * Target mode interrupt: raised if ACQ FIFO has overflowed.
    */
   kDifI2cIrqAcqOverflow = 13,
   /**
-   * Raised if STOP is received after ACK (host sends both signals).
+   * Target mode interrupt: raised if STOP is received after ACK instead of NACK
+   * from an external host read.
    */
   kDifI2cIrqAckStop = 14,
   /**
-   * Raised if the host stops sending the clock during an ongoing transaction.
+   * Target mode interrupt: raised if the host stops sending the clock during an
+   * ongoing transaction.
    */
   kDifI2cIrqHostTimeout = 15,
 } dif_i2c_irq_t;

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.h
@@ -117,9 +117,9 @@ typedef enum dif_i2c_irq {
    */
   kDifI2cIrqSdaUnstable = 8,
   /**
-   * Host and target mode interrupt. In host mode, raised if the host terminates
-   * the transaction by issuing STOP or repeated START. In target mode, raised
-   * if the external host issues a STOP or repeated START.
+   * Host and target mode interrupt. In host mode, raised if the host issues a
+   * repated START or terminates the transaction by issuing STOP. In target
+   * mode, raised if the external host issues a STOP or repeated START.
    */
   kDifI2cIrqTransComplete = 9,
   /**


### PR DESCRIPTION
- don't always assume its a re-start
- distinguish between host / target stretch
- fix 1-off error for bit_idx
- drop bit_ack qualification in AckHold state