### PR TITLE
[entropy_src_ast_rng_req_test] Wait 6ms for entropy to become available

### DIFF
--- a/sw/device/tests/entropy_src_ast_rng_req_test.c
+++ b/sw/device/tests/entropy_src_ast_rng_req_test.c
@@ -57,7 +57,7 @@ bool test_main() {
 
   // Verify that the FIFO depth is non-zero via SW - indicating the reception of
   // data over the AST RNG interface.
-  IBEX_SPIN_FOR(read_fifo_depth(&entropy_src) > 0, 1000);
+  IBEX_SPIN_FOR(read_fifo_depth(&entropy_src) > 0, 6000);
 
   return true;
 }


### PR DESCRIPTION
in a verilated model of OpenTitan the ICache makes the code check for entropy sooner and have to wait longer before it's available to this test about 4ms later.

Fixes: #15934
Signed-off-by: Drew Macrae <drewmacrae@google.com>