### PR TITLE
[chip dv] Fixes for failing CSR tests

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -322,9 +322,9 @@
     {
       // Reused from hw/dv/tools/dvsim/tests/csr_tests.hjson.
       name: "chip_csr_bit_bash"
-      // Don't test over 512 randomly picked CSRs at a time.
-      run_opts: ["+test_timeout_ns=120_000_000", "+num_test_csrs=400"]
-      run_timeout_mins: 120
+      // Don't test over 200 randomly picked CSRs at a time.
+      run_opts: ["+test_timeout_ns=120_000_000", "+num_test_csrs=200"]
+      run_timeout_mins: 180
     }
     {
       // Reused from hw/dv/tools/dvsim/tests/csr_tests.hjson.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -34,6 +34,8 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
     // pinmux may inadvertently connect the chip IOs to peripherals, causing Xs to propagate, if
     // the chip MIOs are not initialized. Hence, we weakly pull down ALL MIOs for these tests.
     cfg.chip_vif.mios_if.pins_pd = '1;
+    cfg.chip_vif.dios_if.pins_pd[top_earlgrey_pkg::DioPadSpiDevD3:
+                                 top_earlgrey_pkg::DioPadSpiHostD0] = '1;
 
     super.pre_start();
     // Disable assertions failed due to CSR random write value.
@@ -50,6 +52,8 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
     $asserton(0,
         "tb.dut.top_earlgrey.u_adc_ctrl_aon.u_adc_ctrl_core.u_adc_ctrl_fsm.NpSampleCntCfg_M");
     cfg.chip_vif.mios_if.pins_pd = '0;
+    cfg.chip_vif.dios_if.pins_pd[top_earlgrey_pkg::DioPadSpiDevD3:
+                                 top_earlgrey_pkg::DioPadSpiHostD0] = '0;
   endtask
 
 endclass


### PR DESCRIPTION
Fixes chip_csr_hw_reset test with failure signature:
```
  UVM_ERROR @ 2823.589889 us: (chip_if.sv:146) [tb.dut.chip_if] Detected an X on MioPadIor13
```
- Added weak pulls on DIOs for this test, since it randomly writes pinmux pad attr and wake up registers and inadvertently creates a combination that ends up spewing Xs.

Fixes chip_csr_bit_bash test with failure signature:
```
Job chip_earlgrey_asic-sim-vcs_run_cover_reg_top killed due to: Exit reason: User job exceeded
runlimit: User job timed out has 1 failures:
```
- Limited the number of CSRs tested for bit bash to 200 at a time, increased test timeout to 180 minutes.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>