### PR TITLE
[rom_e2e] fix rom_e2e_keymgr_init test in DV

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -29,6 +29,14 @@
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
     }
+    {
+      name: rom_e2e_keymgr_init
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_keymgr_init:1:signed"]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: ["+sw_test_timeout_ns=20000000"]
+      run_timeout_mins: 120
+    }
 
     // Signed chip-level tests to be run with ROM, instead of test ROM.
     {
@@ -45,13 +53,6 @@
       name: rom_keymgr_functest
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/silicon_creator/lib/drivers:keymgr_functest:1"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=10000000"]
-    }
-    {
-      name: rom_keymgr_init
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/silicon_creator/rom/e2e:e2e_keymgr_init:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=10000000"]
     }

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -1109,9 +1109,9 @@
               - sealing sw binding equals the `binding_value` field of the manifest, and
               - max creator key version equals the `max_key_version` field of the manifest,
             '''
-      tags: ["rom", "no_dv", "fpga", "silicon"]
+      tags: ["rom", "dv", "verilator", "fpga", "silicon"]
       stage: V2
-      tests: ["rom_keymgr_init"]
+      tests: ["rom_e2e_keymgr_init"]
     }
 
     {

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -5,7 +5,6 @@
 load(
     "//rules:opentitan_test.bzl",
     "DEFAULT_TEST_FAILURE_MSG",
-    "DEFAULT_TEST_SUCCESS_MSG",
     "cw310_params",
     "dv_params",
     "opentitan_functest",
@@ -165,11 +164,15 @@ opentitan_functest(
 )
 
 opentitan_functest(
-    name = "e2e_keymgr_init",
+    name = "rom_e2e_keymgr_init",
     srcs = ["rom_e2e_keymgr_init_test.c"],
+    dv = dv_params(
+        rom = "//sw/device/silicon_creator/rom",
+    ),
     signed = True,
     targets = [
         "cw310_rom",
+        "dv",
         "verilator",
     ],
     verilator = verilator_params(


### PR DESCRIPTION
The test configuration was slightly incorrect (it was running with test ROM instead of ROM) and the testplan had the "no_dv" tag.

Signed-off-by: Timothy Trippel <ttrippel@google.com>