### PR TITLE
[pwrmgr] Do not clear strap_sampled upon lc reset

### DIFF
--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -193,7 +193,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       strap_sampled <= 1'b0;
-    end else if (&rst_lc_req_q || &rst_sys_req_q) begin
+    end else if (&rst_sys_req_q) begin
       strap_sampled <= 1'b0;
     end else if (strap_o) begin
       strap_sampled <= 1'b1;

--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -348,6 +348,11 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
         end
       end
 
+      FastPwrStateStrap: begin
+        strap_o = ~strap_sampled;
+        state_d =  FastPwrStateRomCheck;
+      end
+
       FastPwrStateRomCheck: begin
         // zero outgoing low power indication
         low_power_d = '0;
@@ -356,11 +361,6 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
         if (mubi4_test_true_strict(rom_intg_chk_ok)) begin
           state_d = FastPwrStateActive;
         end
-      end
-
-      FastPwrStateStrap: begin
-        strap_o = ~strap_sampled;
-        state_d =  FastPwrStateRomCheck;
       end
 
       FastPwrStateActive: begin


### PR DESCRIPTION
Lc reset is triggered by NDM reset and this should not clear the strap sampled indication inside the FSM so that the straps are not sampled again after an NDM reset.

Fix https://github.com/lowRISC/opentitan/issues/15759