### PR TITLE
[edn/doc] Update rw0c register description

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -70,7 +70,7 @@
       desc: "A mismatch detected inside any EDN counter moves the main state machine into a terminal error state."
     }
     { name: "CS_RDATA.BUS.CONSISTENCY"
-      desc: "Comparison on successive bus values for genbits returned from csrng that will destribute over the endpoint buses."
+      desc: "Comparison on successive bus values for genbits returned from csrng that will distribute over the endpoint buses."
     }
     { name: "TILE_LINK.BUS.INTEGRITY"
       desc: "Tilelink end-to-end bus integrity scheme."
@@ -87,7 +87,7 @@
         { bits: "0",
           desc: '''
                 When true, the CTRL can be written by software.
-                When false, this field read-only. Defaults true, write one to clear.
+                When false, this field read-only. Defaults true, write zero to clear.
                 Note that this needs to be cleared after initial configuration at boot in order to
                 lock in the listed register settings.
                 '''


### PR DESCRIPTION
Fix a small typo in regwen. The RW0C should be write value zero to set the regwen.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>