### PR TITLE
[chip dv] Fix pin mio_dio_val and pin wakeup tests

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -833,8 +833,9 @@ interface chip_if;
     return path;
   endfunction
 
-  // Disable SVAs for padctrl attributes test.
+  // Disable SVAs in certain hierarchies specific to tests.
   bit chip_padctrl_attributes_test_sva_disable;
+  bit chip_sw_sleep_pin_mio_dio_val_sva_disable;
 
   /*
    * Helper methods for forcing internal signals.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_padctrl_attributes_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_padctrl_attributes_vseq.sv
@@ -164,7 +164,11 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
   }
 
   virtual task body();
+    // The chip_padctrl_attributes test verifies the input / output connections of the pads to
+    // peripherals and fully verifies all pad attributes. In doing so, Xs may end up propagating
+    // into the peripheral. We hence, disable SVAs in these blocks while the test is running.
     cfg.chip_vif.chip_padctrl_attributes_test_sva_disable = 1;
+
     // TODO: remove later, once default pulls on straps are refactored.
     cfg.chip_vif.tap_straps_if.disconnect();
     // TODO: remove later, once default pulls on JTAG IOs are refactored.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
@@ -178,6 +178,15 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
     // Release any driver interfaces.
     cfg.chip_vif.disconnect_all_interfaces(.disconnect_default_pulls(0));
 
+    // The SW test randomizes between deep and light sleep. The SW test also randomizes the
+    // retention values of DIOs during sleep. If the SW ends up picking up the CLK or CSB ports of
+    // the SPI peripherals (that have dedicated pads) for example, then setting the values
+    // ends up triggering unexpected SVA errors. So we disable SVAs in those peripherals for this
+    // test. It may also be an artifact of having external weak pulls on DIOs. TODO: revisit this
+    // once we eliminate all weak pulls on all IOs (in chip_if.sv).
+    // TODO: deassert the below bit to reenable SVAs once we are back in active power.
+    cfg.chip_vif.chip_sw_sleep_pin_mio_dio_val_sva_disable = 1;
+
     @(cfg.chip_vif.pwrmgr_low_power_if.cb);
 
     `uvm_info(`gfn, "Chip Entered Deep Powerdown mode.", UVM_LOW)
@@ -186,6 +195,7 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
 
     // If `chech_pad_retention_type()` runs without uvm_error and reach this point, the test passed
     // full check
+    // TODO: Cleanly exit the test with idle CPU.
     override_test_status_and_finish(.passed(1'b 1));
 
   endtask : body

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -361,24 +361,32 @@ module tb;
 `endif
 
   initial begin
-    // The chip_padctrl_attributes test verifies the input / output connections of the pads to
-    // peripherals and fully verifies all pad attributes. In doing so, Xs may end up propagating
-    // into the peripheral. We hence, disable SVAs in these blocks while the test is running.
-    forever @dut.chip_if.chip_padctrl_attributes_test_sva_disable begin
-      if (dut.chip_if.chip_padctrl_attributes_test_sva_disable) begin
-        $assertoff(0, dut.top_earlgrey.u_pinmux_aon);
-        $assertoff(0, dut.top_earlgrey.u_spi_device);
-        $assertoff(0, dut.top_earlgrey.u_spi_host0);
-        $assertoff(0, dut.top_earlgrey.u_sysrst_ctrl_aon);
-        $assertoff(0, dut.top_earlgrey.u_usbdev);
-      end else begin
-        $asserton(0, dut.top_earlgrey.u_pinmux_aon);
-        $asserton(0, dut.top_earlgrey.u_spi_device);
-        $asserton(0, dut.top_earlgrey.u_spi_host0);
-        $asserton(0, dut.top_earlgrey.u_sysrst_ctrl_aon);
-        $asserton(0, dut.top_earlgrey.u_usbdev);
+    fork
+      // See chip_padctrl_attributes_vseq for more details.
+      forever @dut.chip_if.chip_padctrl_attributes_test_sva_disable begin
+        if (dut.chip_if.chip_padctrl_attributes_test_sva_disable) begin
+          $assertoff(0, dut.top_earlgrey.u_pinmux_aon);
+          $assertoff(0, dut.top_earlgrey.u_spi_device);
+          $assertoff(0, dut.top_earlgrey.u_spi_host0);
+          $assertoff(0, dut.top_earlgrey.u_sysrst_ctrl_aon);
+          $assertoff(0, dut.top_earlgrey.u_usbdev);
+        end else begin
+          $asserton(0, dut.top_earlgrey.u_pinmux_aon);
+          $asserton(0, dut.top_earlgrey.u_spi_device);
+          $asserton(0, dut.top_earlgrey.u_spi_host0);
+          $asserton(0, dut.top_earlgrey.u_sysrst_ctrl_aon);
+          $asserton(0, dut.top_earlgrey.u_usbdev);
+        end
       end
-    end
+      // See chip_sw_sleep_pin_mio_dio_val_vseq for more details.
+      forever @dut.chip_if.chip_sw_sleep_pin_mio_dio_val_sva_disable begin
+        if (dut.chip_if.chip_sw_sleep_pin_mio_dio_val_sva_disable) begin
+          $assertoff(0, dut.top_earlgrey.u_spi_device);
+        end else begin
+          $asserton(0, dut.top_earlgrey.u_spi_device);
+        end
+      end
+    join
   end
 
   // Control assertions in the DUT with UVM resource string "dut_assert_en".


### PR DESCRIPTION
This commit makes some fixes and enhancements to these 2 tests:

chip_sw_sleep_pin_wake:
- randomize wakeup detector in C test - no need of SW symbol override
- Monitor sleep / sleep exit events using probes rather than SW logs
- Avoid subtraction of 2 in chosen MIOs for wakeup (its a SW programming artifact that SV does not need to know)
- Disconnect the pin chosen for wakeup once we are back in active power
- Drive the SW strap pins again after sleep reset (since we disconnected all interfaces before sleep)

chip_sw_sleep_pin_mio_dio_val:
- Disable assertions in spi_device - setting sleep retention values in light sleep messes up the SPI device in unexpected ways.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>