### PR TITLE
[dv,flash_ctrl,escalation] Expect ISR should not run

### DIFF
--- a/sw/device/tests/sim_dv/all_escalation_resets_test.c
+++ b/sw/device/tests/sim_dv/all_escalation_resets_test.c
@@ -953,7 +953,14 @@ bool test_main(void) {
     LOG_INFO("The regular interrupt count is %d", interrupt_count);
 
     int nmi_interrupt_count = flash_ctrl_testutils_counter_get(kCounterNmi);
-    if (kExpectedAlertNumber != kTopEarlgreyAlertIdFlashCtrlFatalStdErr) {
+    if (kExpectedAlertNumber == kTopEarlgreyAlertIdFlashCtrlFatalStdErr) {
+      // ISRs should not run if flash_ctrl gets a fault because it should
+      // block flash accesses.
+      CHECK(interrupt_count == 0,
+            "Expected regular ISR should not run for flash_ctrl faults");
+      CHECK(nmi_interrupt_count == 0,
+            "Expected nmi should not run for flash_ctrl faults");
+    } else {
       CHECK(nmi_interrupt_count > 0, "Expected at least one nmi");
     }
 


### PR DESCRIPTION
Check that when the flash_ctrl gets a fatal fault it should block flash accesses. The chip_sw_all_escalation_resets test was allowing ISR not to run when flash_ctrl faults occur, this change causes a failure if an ISR actually runs.

Fixes #15971

Signed-off-by: Guillermo Maturana <maturana@google.com>