### PR TITLE
[bazel, test] Limit rom e2e tests to the RMA life cycle state in CI

### DIFF
--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -45,7 +45,7 @@ for tag in "${cw310_tags[@]}"; do
         xargs ci/bazelisk.sh test \
             --define DISABLE_VERILATOR_BUILD=true \
             --nokeep_going \
-            --test_tag_filters="${tag}",-broken,-manual \
+            --test_tag_filters="${tag}",-broken,-manual,-skip_in_ci \
             --test_timeout_filters=short,moderate \
             --test_output=all \
             --build_tests_only \

--- a/doc/getting_started/build_sw.md
+++ b/doc/getting_started/build_sw.md
@@ -131,6 +131,10 @@ We maintain or use the following tags to support this:
 * `manual` is a Bazel builtin that prevents targets from matching wildcards.
   Test suites are typically tagged manual so their contents match, but test suites don't get built or run unless they're intentionally invoked.
   Intermediate build artifacts may also be tagged with manual to prevent them from being unintentionally built if they cause other problems.
+* `skip_in_ci` is used to tag ROM end-to-end tests that we currently skip in CI.
+  ROM end-to-end tests are typically written for five life cycle states: TEST\_UNLOCKED0, DEV, PROD, PROD\_END, and RMA.
+  This tag allows us to limit the tests run in CI to a single life cycle state, allowing CW310 tests to finish in a reasonable timeframe.
+  We run tests for the remaining lifecycle states outside the CI in a less frequent manner.
 
 `ci/scripts/check-bazel-tags.sh` performs some useful queries to ensure these tags are applied.
 These tags can then be used to filter tests using `--build_tests_only --test_tag_filters=-cw310,-verilator,-vivado`.

--- a/rules/rom_e2e.bzl
+++ b/rules/rom_e2e.bzl
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:const.bzl", "CONST")
+load("@bazel_skylib//lib:structs.bzl", "structs")
+
+_ALL_LC_STATE_VALS = structs.to_dict(CONST.LCV).values()
+_SKIP_LC_STATE_VALS = [
+    CONST.LCV.TEST_UNLOCKED0,
+    CONST.LCV.PROD,
+    CONST.LCV.PROD_END,
+    CONST.LCV.DEV,
+]
+_REM_LC_STATE_VALS = [
+    lc_state_val
+    for lc_state_val in _ALL_LC_STATE_VALS
+    if lc_state_val not in _SKIP_LC_STATE_VALS
+]
+
+def maybe_skip_in_ci(lc_state_val):
+    if lc_state_val in _SKIP_LC_STATE_VALS:
+        return ["skip_in_ci"]
+    if lc_state_val in _REM_LC_STATE_VALS:
+        return []
+    fail("Life cycle state value {} is not in {}", lc_state_val, _ALL_LC_STATE_VALS)

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -186,21 +186,6 @@ opentitan_functest(
     ],
 )
 
-# Same as `:e2e_bootup_success`, but the Dev OTP image is spliced into the
-# bitstream before it's sent to the CW310 FPGA.
-opentitan_functest(
-    name = "e2e_bootup_success_otp_dev",
-    cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom_otp_dev",
-        # TODO(lowRISC/opentitan#13603): Remove this "manual" tag when the
-        # bitstream target can fetch pre-spliced bitstream from GCP.
-        tags = ["manual"],
-    ),
-    key = "test_key_0",
-    ot_flash_binary = ":empty_test_slot_a",
-    targets = ["cw310_rom"],
-)
-
 opentitan_functest(
     name = "e2e_bootstrap_entry",
     cw310 = cw310_params(

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -17,12 +17,10 @@ load(
     "opentitan_flash_binary",
     "opentitan_multislot_flash_binary",
 )
-load(
-    "//rules:manifest.bzl",
-    "manifest",
-)
+load("//rules:manifest.bzl", "manifest")
 load("//rules:opentitan_gdb_test.bzl", "opentitan_gdb_fpga_cw310_test")
 load("//rules:otp.bzl", "otp_image", "otp_json", "otp_partition")
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
 load("//rules:splice.bzl", "bitstream_splice")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@bazel_skylib//lib:structs.bzl", "structs")
@@ -389,30 +387,27 @@ opentitan_functest(
     targets = ["cw310_rom"],
 )
 
-LC_STATES_SHUTDOWN_OUTPUT = [k.lower() for k in structs.to_dict(CONST.LCV)]
-
 [otp_image(
-    name = "otp_img_shutdown_output_{}".format(lc_state),
-    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
+    name = "otp_img_shutdown_output_{}".format(lc_state.lower()),
+    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
     overlays = [
         "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
     ],
-    tags = ["vivado"],
-) for lc_state in LC_STATES_SHUTDOWN_OUTPUT]
+) for lc_state in structs.to_dict(CONST.LCV)]
 
 # Splice OTP images into bitstreams
 [
     bitstream_splice(
-        name = "bitstream_shutdown_output_{}".format(lc_state),
+        name = "bitstream_shutdown_output_{}".format(lc_state.lower()),
         src = "//hw/bitstream:rom",
-        data = ":otp_img_shutdown_output_{}".format(lc_state),
+        data = ":otp_img_shutdown_output_{}".format(lc_state.lower()),
         meminfo = "//hw/bitstream:otp_mmi",
         tags = ["vivado"],
         update_usr_access = True,
     )
-    for lc_state in LC_STATES_SHUTDOWN_OUTPUT
+    for lc_state in structs.to_dict(CONST.LCV)
 ]
 
 manifest({
@@ -422,29 +417,26 @@ manifest({
 })
 
 [opentitan_functest(
-    name = "shutdown_output_{}".format(lc_state),
+    name = "shutdown_output_{}".format(lc_state.lower()),
     cw310 = cw310_params(
-        bitstream = ":bitstream_shutdown_output_{}".format(lc_state),
+        bitstream = ":bitstream_shutdown_output_{}".format(lc_state.lower()),
         exit_failure = MSG_PASS,
         exit_success = MSG_TEMPLATE_BFV_LCV.format(
             hex(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
-            hex(getattr(
-                CONST.LCV,
-                lc_state.upper(),
-            )),
+            hex(lc_state_val),
         ),
-        tags = ["vivado"],
+        tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
     ),
     manifest = ":manifest_bad_identifier",
     ot_flash_binary = ":empty_test_slot_a",
     signed = False,
     targets = ["cw310_rom"],
-) for lc_state in LC_STATES_SHUTDOWN_OUTPUT]
+) for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()]
 
 test_suite(
     name = "shutdown_output",
     tags = ["manual"],
-    tests = ["shutdown_output_{}".format(lc_state) for lc_state in LC_STATES_SHUTDOWN_OUTPUT],
+    tests = ["shutdown_output_{}".format(lc_state.lower()) for lc_state in structs.to_dict(CONST.LCV)],
 )
 
 SEC_VERS = [
@@ -516,45 +508,39 @@ BOOT_POLICY_NEWER_CASES = [
     },
 ]
 
-LC_STATES_BOOT_POLICY_NEWER = [k.lower() for k in structs.to_dict(CONST.LCV)]
-
 [otp_image(
-    name = "otp_img_boot_policy_newer_{}".format(lc_state),
-    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
+    name = "otp_img_boot_policy_newer_{}".format(lc_state.lower()),
+    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
     overlays = [
         "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
     ],
-    tags = ["vivado"],
-) for lc_state in LC_STATES_BOOT_POLICY_NEWER]
+) for lc_state in structs.to_dict(CONST.LCV)]
 
 # Splice OTP images into bitstreams
 [
     bitstream_splice(
-        name = "bitstream_boot_policy_newer_{}".format(lc_state),
+        name = "bitstream_boot_policy_newer_{}".format(lc_state.lower()),
         src = "//hw/bitstream:rom",
-        data = ":otp_img_boot_policy_newer_{}".format(lc_state),
+        data = ":otp_img_boot_policy_newer_{}".format(lc_state.lower()),
         meminfo = "//hw/bitstream:otp_mmi",
         tags = ["vivado"],
         update_usr_access = True,
     )
-    for lc_state in LC_STATES_BOOT_POLICY_NEWER
+    for lc_state in structs.to_dict(CONST.LCV)
 ]
 
 [opentitan_functest(
     name = "boot_policy_newer_{}_a_{}_b_{}".format(
-        lc_state,
+        lc_state.lower(),
         t["a"],
         t["b"],
     ),
     cw310 = cw310_params(
-        bitstream = ":bitstream_boot_policy_newer_{}".format(lc_state),
-        exit_success = t["exit_success"].format(hex(getattr(
-            CONST.LCV,
-            lc_state.upper(),
-        ))),
-        tags = ["vivado"],
+        bitstream = ":bitstream_boot_policy_newer_{}".format(lc_state.lower()),
+        exit_success = t["exit_success"].format(hex(lc_state_val)),
+        tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
     ),
     key = "multislot",
     ot_flash_binary = ":sec_ver_{}_{}_image".format(
@@ -562,16 +548,16 @@ LC_STATES_BOOT_POLICY_NEWER = [k.lower() for k in structs.to_dict(CONST.LCV)]
         t["b"],
     ),
     targets = ["cw310_rom"],
-) for lc_state in LC_STATES_BOOT_POLICY_NEWER for t in BOOT_POLICY_NEWER_CASES]
+) for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items() for t in BOOT_POLICY_NEWER_CASES]
 
 test_suite(
     name = "boot_policy_newer",
     tags = ["manual"],
     tests = ["boot_policy_newer_{}_a_{}_b_{}".format(
-        lc_state,
+        lc_state.lower(),
         t["a"],
         t["b"],
-    ) for lc_state in LC_STATES_BOOT_POLICY_NEWER for t in BOOT_POLICY_NEWER_CASES],
+    ) for lc_state in structs.to_dict(CONST.LCV) for t in BOOT_POLICY_NEWER_CASES],
 )
 
 BOOT_POLICY_ROLLBACK_CASES = [
@@ -725,12 +711,12 @@ opentitan_flash_binary(
                 t["name"],
             ),
             exit_success = t["exit_success"][lc_state.lower()],
-            tags = ["vivado"],
+            tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         ot_flash_binary = ":empty_test_sigverify_mod_exp",
         targets = ["cw310_rom"],
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
     for t in SIGVERIFY_MOD_EXP_CASES
 ]
 
@@ -986,7 +972,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
                 t.get("sec_ver", 0),
             ),
             exit_success = t["exit_success"],
-            tags = ["vivado"],
+            tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         key = "multislot",
         ot_flash_binary = "boot_policy_bad_manifest_{}_{}_img".format(
@@ -998,7 +984,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "verilator",
         ],
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
     for t in BOOT_POLICY_BAD_MANIFEST_CASES
     for slot in SLOTS
 ]
@@ -1110,7 +1096,7 @@ BOOT_POLICY_VALID_CASES = [
             bitstream = "bitstream_boot_policy_valid_{}".format(lc_state.lower()),
             exit_failure = MSG_PASS if a["desc"] == b["desc"] and a["desc"] == "bad" else DEFAULT_TEST_FAILURE_MSG,
             exit_success = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG)) if a["desc"] == b["desc"] and a["desc"] == "bad" else MSG_PASS,
-            tags = ["vivado"],
+            tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         key = "multislot",
         ot_flash_binary = ":boot_policy_valid_img_a_{}_b_{}".format(
@@ -1119,7 +1105,7 @@ BOOT_POLICY_VALID_CASES = [
         ),
         targets = ["cw310_rom"],
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
     for a in BOOT_POLICY_VALID_CASES
     for b in BOOT_POLICY_VALID_CASES
 ]
@@ -1381,7 +1367,6 @@ REDACT.update({"INVALID": 0x0})
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             ":otp_json_{}_overlay".format(redact.lower()),
         ],
-        tags = ["vivado"],
         visibility = ["//visibility:private"],
     )
     for lc_state in structs.to_dict(CONST.LCV)
@@ -1426,9 +1411,7 @@ REDACT.update({"INVALID": 0x0})
                 lc_state_val,
                 redact_val,
             ))),
-            tags = [
-                "vivado",
-            ],
+            tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         signed = False,
         targets = ["cw310_rom"],


### PR DESCRIPTION
This change reduces the number of ROM e2e tests run in CI from 231 to 67.
The number of tests run in the CW310 ROM Tests step is reduced from 398 to 234.

![image](https://user-images.githubusercontent.com/57949550/199881394-e107683c-63a0-4850-9fb7-f99c9e05ed22.png)
