### PR TITLE
[top-level] Explicitly check for entropy alerts

### DIFF
--- a/sw/device/lib/testing/entropy_testutils.h
+++ b/sw/device/lib/testing/entropy_testutils.h
@@ -5,6 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_ENTROPY_TESTUTILS_H_
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_ENTROPY_TESTUTILS_H_
 
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_edn.h"
 #include "sw/device/lib/dif/dif_entropy_src.h"
 
 /**
@@ -62,5 +64,23 @@ void entropy_testutils_wait_for_state(const dif_entropy_src_t *entropy_src,
  * Stops EDN and CSRNG instances before stopping the entropy source.
  */
 void entropy_testutils_stop_all(void);
+
+/**
+ * Throws test assertion if there are any errors detected in any of the entropy
+ * blocks.
+ *
+ * Note that the encoding of the error codes printed in the log follow the
+ * respective DIF error enum mapping, which may be different to the bit mapping
+ * in the error registers.
+ *
+ * @param entropy_src Entropy source handle.
+ * @param csrng CSRNG handle.
+ * @param edn0 EDN0 handle.
+ * @param edn1 EDN1 handle.
+ */
+void entropy_testutils_error_check(const dif_entropy_src_t *entropy_src,
+                                   const dif_csrng_t *csrng,
+                                   const dif_edn_t *edn0,
+                                   const dif_edn_t *edn1);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_ENTROPY_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -629,8 +629,13 @@ opentitan_functest(
 opentitan_functest(
     name = "csrng_edn_concurrency_test",
     srcs = ["csrng_edn_concurrency_test.c"],
+    cw310 = cw310_params(
+        # FIXME #15980 Re-enable after EDN fatal alert is fixed.
+        tags = ["broken"],
+    ),
     verilator = verilator_params(
         timeout = "long",
+        tags = ["broken"],
     ),
     deps = [
         ":otbn_randomness_impl",

--- a/sw/device/tests/csrng_edn_concurrency_test.c
+++ b/sw/device/tests/csrng_edn_concurrency_test.c
@@ -335,8 +335,9 @@ static void main_task(void *task_parameters) {
         execution_state_update(kTestStateTearDown);
         break;
       }
-      execution_state_update(kTestStateSetup);
       csrng_testutils_recoverable_alerts_check(&csrng);
+      entropy_testutils_error_check(&entropy_src, &csrng, &edn0, &edn1);
+      execution_state_update(kTestStateSetup);
     }
     // The rest of this code block is executed when
     // `execute_state == kTestStateSetup`.

--- a/sw/device/tests/entropy_src_csrng_test.c
+++ b/sw/device/tests/entropy_src_csrng_test.c
@@ -205,22 +205,6 @@ static void edn_ready_wait(const dif_edn_t *edn) {
 }
 
 /**
- * Throws test assertion if there are any errors detected in the EDN blocks.
- */
-static void edn_errors_check(void) {
-  uint32_t fifo_errors;
-  uint32_t edn_errors;
-
-  CHECK_DIF_OK(dif_edn_get_errors(&edn0, &fifo_errors, &edn_errors));
-  CHECK(edn_errors == 0, "edn0 unexpected err: 0x%x", edn_errors);
-  CHECK(fifo_errors == 0, "edn0 unexpected fifo err: 0x%x", fifo_errors);
-
-  CHECK_DIF_OK(dif_edn_get_errors(&edn1, &fifo_errors, &edn_errors));
-  CHECK(edn_errors == 0, "edn1 unexpected err: 0x%x", edn_errors);
-  CHECK(fifo_errors == 0, "edn1 unexpected fifo err: 0x%x", fifo_errors);
-}
-
-/**
  * Configures the `edn` instance.
  *
  * Verifies that the entropy req interrupt is triggered on EDN instantiate and
@@ -281,7 +265,7 @@ static void test_edn_cmd_done(const dif_edn_seed_material_t *seed_material) {
   CHECK_DIF_OK(dif_edn_generate_start(&edn1, /*len=*/1));
   edn_ready_wait(&edn0);
   edn_ready_wait(&edn1);
-  edn_errors_check();
+  entropy_testutils_error_check(&entropy_src, &csrng, &edn0, &edn1);
 
   LOG_INFO("OTBN:START");
   otbn_randomness_test_start(&otbn);
@@ -322,7 +306,7 @@ static void test_edn_cmd_done(const dif_edn_seed_material_t *seed_material) {
   irq_block_wait(kTestIrqFlagIdEdn1CmdDone);
 
   csrng_testutils_recoverable_alerts_check(&csrng);
-  edn_errors_check();
+  entropy_testutils_error_check(&entropy_src, &csrng, &edn0, &edn1);
 }
 
 void ottf_external_isr(void) {


### PR DESCRIPTION
This commit adds explicit alert checks so that issues can be thrown in non-DV environments.
