### PR TITLE
[dv/edn] edn_sec_cm enhancement

### DIFF
--- a/hw/ip/edn/data/edn_sec_cm_testplan.hjson
+++ b/hw/ip/edn/data/edn_sec_cm_testplan.hjson
@@ -31,9 +31,14 @@
     }
     {
       name: sec_cm_config_mubi
-      desc: "Verify the countermeasure(s) CONFIG.MUBI."
+      desc: '''Verify the countermeasure(s) CONFIG.MUBI.
+
+            Write non-Mubi4True or Mubi4False value to the ctrl register's mubi fields.
+            Verify that design triggers the corresponding recoverable alerts and error status.
+            Verify that design categorizes the value as Mubi4False.
+            '''
       stage: V2S
-      tests: []
+      tests: ["edn_alert"]
     }
     {
       name: sec_cm_main_sm_fsm_sparse
@@ -55,21 +60,33 @@
     }
     {
       name: sec_cm_main_sm_ctr_local_esc
-      desc: "Verify the countermeasure(s) MAIN_SM.CTR.LOCAL_ESC."
+      desc: '''Verify the countermeasure(s) MAIN_SM.CTR.LOCAL_ESC.
+
+            Verify that after the local escalation:
+            - The atal alert is firing continuously.
+            - Register `main_sm_state` goes to error state.
+            - No valid EDN responses.
+            '''
       stage: V2S
-      tests: []
+      tests: ["edn_sec_cm"]
     }
     {
       name: sec_cm_cs_rdata_bus_consistency
-      desc: "Verify the countermeasure(s) CS_RDATA.BUS.CONSISTENCY."
+      desc: '''Verify the countermeasure(s) CS_RDATA.BUS.CONSISTENCY.
+
+            Load randomly generated but constant fips and genbits data from the CSRNG host driver
+            to create the consistency error.
+            Check the corresponding recoverable alert is fired and check the recov_alert_sts
+            register.
+             '''
       stage: V2S
-      tests: []
+      tests: ["edn_alert"]
     }
     {
       name: sec_cm_tile_link_bus_integrity
       desc: "Verify the countermeasure(s) TILE_LINK.BUS.INTEGRITY."
       stage: V2S
-      tests: []
+      tests: ["edn_tl_intg_err"]
     }
   ]
 }

--- a/hw/ip/edn/dv/env/seq_lib/edn_common_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_common_vseq.sv
@@ -20,6 +20,13 @@ class edn_common_vseq extends edn_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+  // For each round, randomly enable EDN to make sure the EDN won't provide valid response during
+  // fatal alerts.
+  virtual task sec_cm_inject_fault(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
+    if ($urandom_range(0, 4) == 4) csr_wr(.ptr(ral.ctrl.edn_enable), .value(MuBi4True));
+    super.sec_cm_inject_fault(if_proxy);
+  endtask : sec_cm_inject_fault
+
   virtual task check_sec_cm_fi_resp(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
     if (!uvm_re_match("*.cnt_q*", if_proxy.path)) begin
       csr_rd_check(.ptr(ral.err_code.edn_cntr_err), .compare_value(1'b1));
@@ -28,6 +35,39 @@ class edn_common_vseq extends edn_base_vseq;
     end else if (!uvm_re_match("*.u_edn_main_sm*", if_proxy.path)) begin
       csr_rd_check(.ptr(ral.err_code.edn_main_sm_err), .compare_value(1'b1));
     end
-    // TODO: check local escalation and check other EDN request will be blocked.
+
+    // Check main_sm_state goes to error st.
+    csr_rd_check(.ptr(ral.main_sm_state), .compare_value(edn_pkg::Error));
+
+    // Check no EDN responses.
+    send_edn_requests_during_fatal_alerts();
   endtask
+
+  virtual task send_edn_requests_during_fatal_alerts();
+    push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH) m_endpoint_pull_seq[MAX_NUM_ENDPOINTS];
+
+    // TODO: can only send one request due to TB errors. Fix it.
+    bit [MAX_NUM_ENDPOINTS-1:0] send_edn_reqs = 1;
+    `uvm_info(`gfn, $sformatf("Send %0h EDN reqs during fatal alert", send_edn_reqs), UVM_HIGH)
+
+    foreach (send_edn_reqs[i]) begin
+      if (send_edn_reqs[i]) begin
+        automatic int index = i;
+        m_endpoint_pull_seq[index] = push_pull_host_seq#(FIPS_ENDPOINT_BUS_WIDTH)::
+            type_id::create($sformatf("m_endpoint_pull_seq[%0d]", index));
+        // TODO: investigate why agent will hang if this is set to value > 1.
+        m_endpoint_pull_seq[index].num_trans = 1;
+        `uvm_info(`gfn, $sformatf("Send EDN_%0d req during fatal alert", index), UVM_LOW)
+
+        // Assertion in design will check EDN should not response during fatal alert.
+        fork
+          m_endpoint_pull_seq[index].start(p_sequencer.endpoint_sequencer_h[index]);
+        join_none
+      end
+    end
+
+    // TODO: add fcov.
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 100));
+  endtask
+
 endclass

--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -117,9 +117,12 @@ module edn
   // Endpoint Asserts
   for (genvar i = 0; i < NumEndPoints; i = i+1) begin : gen_edn_if_asserts
     `ASSERT_KNOWN(EdnEndPointOut_A, edn_o[i])
+
     // This assertion checks that EDN data will be stable from edn_ack until the next edn request.
     `ASSERT(EdnDataStable_A, edn_o[i].edn_ack |=>
             $stable(edn_o[i].edn_bus) throughout edn_i[i].edn_req[->1])
+
+    `ASSERT(EdnFatalAlertNoRsp_A, alert[1] |-> edn_o[i].edn_ack == 0)
   end : gen_edn_if_asserts
 
   // CSRNG Asserts


### PR DESCRIPTION
This PR enhance the v2s task:
1). Map and add more descriptions to the sec_cm testplan
2). Enhance the edn_sec_cm test by adding more register 
     and interface checking after the fatal alerts occurred.
3). In design, add an assertion to check when fatal alert happens,
     EDN response should always be 0.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>