### PR TITLE
[aes, dv] V2S coverage improvements - Part 2

### DIFF
--- a/hw/ip/aes/dv/err_injection_if/fi_cipher_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_cipher_if.sv
@@ -50,6 +50,18 @@ interface fi_cipher_if
     $sformatf("%s.%s", par_hier, "round_key_sel_o")
   };
 
+  // check whether the given hier_name ends with signal_name
+  function automatic int check_target_name(string hier_name, string signal_name);
+    int hier_len = hier_name.len();
+    int signal_len = signal_name.len();
+    if (str_utils_pkg::str_rfind(hier_name, signal_name,
+                                 hier_len - signal_len - 1, -1) == -1) begin
+      return 0;
+    end else begin
+      return 1;
+    end
+  endfunction
+
   function automatic int get_if_size();
     return intf_array.size() + intf_mul_array.size();
   endfunction // get_if_size
@@ -69,18 +81,35 @@ interface fi_cipher_if
 
   function automatic void force_single_bit(int target);
     bit  read;
+    bit  value;
     $assertoff(0, "tb.dut");
     $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscDataOut");
     $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscIv");
     if (!uvm_hdl_check_path(intf_array[target])) begin
       `uvm_fatal("fi_cipher_if", $sformatf("PATH NOT EXISTING %m"))
     end
-    // read the value currently
-    uvm_hdl_read(intf_array[target], read);
+    if (check_target_name(intf_array[target], "out_ready_i") ||
+        check_target_name(intf_array[target], "sub_bytes_out_req_i") ||
+        check_target_name(intf_array[target], "key_expand_out_req_i")) begin
+      // The cipher core is only ever reading out_ready_i when its FSM is ready to advance. Forcing
+      // the signal to 1 is thus not sufficient to make the cipher core advance faster.
+      //
+      // Similarly, faulting sub_bytes_out_req_i and key_expand_out_req_i to 1 doesn't suffice to
+      // make the cipher core advance faster (also depends on cyc_ctr_q).
+      //
+      // Therefore, this test only attemps to stall the cipher core by forcing these signals to 0.
+      // For reference, see https://github.com/lowRISC/opentitan/issues/13572 .
+      value = 0;
+    end else begin
+      // Read the current value.
+      uvm_hdl_read(intf_array[target], read);
+      value = !read;
+    end
     // always announce we are forcing something
     `uvm_info("if_cipher_if",
-       $sformatf(" I am forcing target %d %s, value %b",target, intf_array[target], !read),UVM_LOW);
-    if (!uvm_hdl_force(intf_array[target],!read)) begin
+       $sformatf(" I am forcing target %d %s, value %b",target, intf_array[target], value),
+       UVM_LOW);
+    if (!uvm_hdl_force(intf_array[target], value)) begin
       `uvm_error("fi_cipher_if", $sformatf("Was not able to force %s", intf_array[target]))
     end
   endfunction
@@ -93,7 +122,7 @@ interface fi_cipher_if
 
 
   function automatic void force_multi_bit(int target, bit [31:0] value);
-    bit  read;
+    bit [31:0] read;
     $assertoff(0, "tb.dut");
     $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscDataOut");
     $asserton(0, "tb.dut.u_aes_core.AesSecCmDataRegLocalEscIv");
@@ -103,10 +132,28 @@ interface fi_cipher_if
     if (!uvm_hdl_check_path(intf_mul_array[target])) begin
       `uvm_fatal("fi_cipher_if", $sformatf("PATH NOT EXISTING %m"))
     end
-    // read the value currently of bit 0
-    uvm_hdl_read(intf_mul_array[target], read);
-    // flip bit to make sure we don't force the value currently on bus
-    value[0] = !read;
+    if (check_target_name(intf_mul_array[target], "cyc_ctr_q")) begin
+      // Faulting cyc_ctr_q to greater values alone doesn't suffice to make the cipher core advance
+      // faster (also depends on sub_bytes_out_req_i and key_expand_out_req_i). Therfore, this test
+      // attemps to stall the cipher core.
+      value = value & 2'h3;
+    end else begin
+      // Read the current value.
+      uvm_hdl_read(intf_mul_array[target], read);
+      if (check_target_name(intf_mul_array[target], "sel_o")) begin
+        // The selector signals are OR-combined. Flipping one bit in one rail to zero doesn't have
+        // an effect and cannot be detected. Therefore, this test forces a least one additional bit
+        // to 1.
+        for (int i = 0; i < 32; ++i) begin
+          if (!read[i]) begin
+            value[i] = 1'b1;
+            break;
+          end
+        end
+      end
+      // Make sure to at least flip one bit compared to the current value.
+      value[0] = !read[0];
+    end
     if (!uvm_hdl_force(intf_mul_array[target], value)) begin
       `uvm_error("fi_cipher_if", $sformatf("Was not able to force %s", intf_mul_array[target]))
     end

--- a/hw/ip/aes/dv/tests/aes_fi_test.sv
+++ b/hw/ip/aes/dv/tests/aes_fi_test.sv
@@ -27,8 +27,8 @@ class aes_fi_test extends aes_base_test;
     cfg.cfb_weight               = 5;
     cfg.ctr_weight               = 80;
 
-    cfg.message_len_min          = 7;    // one block (16bytes=128bits)
-    cfg.message_len_max          = 300;
+    cfg.message_len_min          = 1;    // one block (16bytes=128bits)
+    cfg.message_len_max          = 65;
     cfg.manual_operation_pct     = 0;
     cfg.use_key_mask             = 0;
 


### PR DESCRIPTION
This is a follow-up of #15907. The main changes are:
- Set constraints that are more useful for the FI tests, i.e., trigger more interesting state transitions and handshakes (e.g. with CTR mode FSM) and operations (decryption key generation) more frequently.
- Don't drive signal values that are less useful. More precisely, some handshake signals are backed up with a counter, driving these to 1 earlier doesn't have any effect. This resolves #13572.

The main result of this PR is that less FI tests timeout/fail which we need to reach the coverage goal and pass criteria for AES V2S.