### PR TITLE
[chip dv] Fixes for chip_csr_aliasing and outstanding tests

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -324,6 +324,13 @@
       // Reused from hw/dv/tools/dvsim/tests/csr_tests.hjson.
       name: "chip_csr_aliasing"
       run_timeout_mins: 180
+      run_opts: ["+test_timeout_ns=120_000_000"]
+    }
+    {
+      // Reused from hw/dv/tools/dvsim/tests/csr_tests.hjson.
+      name: "chip_same_csr_outstanding"
+      run_timeout_mins: 120
+      run_opts: ["+test_timeout_ns=120_000_000"]
     }
     {
       name: chip_sw_example_flash


### PR DESCRIPTION
Increase the simulated time and wall clock time timeouts.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>