### PR TITLE
cw310_rom_variant tag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -516,9 +516,9 @@ jobs:
         bucketURI: "gs://opentitan-bitstreams/master"
 
 - job: execute_test_rom_fpga_tests_cw310
-  displayName: CW310 Test ROM Tests
+  displayName: CW310 Tests
   pool: FPGA
-  timeoutInMinutes: 45
+  timeoutInMinutes: 60
   dependsOn:
     - chip_earlgrey_cw310
     - sw_build
@@ -534,13 +534,13 @@ jobs:
   - bash: |
       set -e
       . util/build_consts.sh
-      ci/scripts/run-fpga-cw310-tests.sh cw310_test_rom || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-cw310-tests.sh cw310_test_rom cw310_rom || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
 
 - job: execute_rom_fpga_tests_cw310
-  displayName: CW310 ROM Tests
+  displayName: CW310 Spliced Tests
   pool: FPGA
-  timeoutInMinutes: 45
+  timeoutInMinutes: 60
   dependsOn:
     - chip_earlgrey_cw310
     - sw_build
@@ -557,7 +557,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh cw310_rom || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-cw310-tests.sh cw310_other || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
 
 - job: deploy_release_artifacts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -557,7 +557,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh cw310_other || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-cw310-tests.sh cw310_rom_variant || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
 
 - job: deploy_release_artifacts

--- a/ci/scripts/check-bazel-tags.sh
+++ b/ci/scripts/check-bazel-tags.sh
@@ -6,14 +6,37 @@
 
 set -e
 
-untagged=$(./bazelisk.sh query "rdeps(//..., //hw:verilator) except attr(tags, '[\\[ ](verilator|manual)[,\\]]', //...)")
+untagged=$(./bazelisk.sh query "rdeps(//..., //hw:verilator) except attr(tags, '[\\[ ](verilator|manual)[,\\]]', //...)" --output=label_kind)
 if [[ ${untagged} ]]; then # Check that all targets that depend on verilator are tagged
-  echo "Target(s): ${untagged} depend(s) on //hw:verilator, please tag it with verilator or manual";
+  echo "Error:";
+  echo "${untagged}"|sed 's/^/    /';
+  echo "Target(s) above depend(s) on //hw:verilator, please tag it with verilator or manual.";
   exit 1
 fi
 
-untagged=$(./bazelisk.sh query "rdeps(//..., kind('bitstream_splice', //...)) except attr(tags, '[\\[ ](cw310_rom|cw310_test_rom|vivado|manual)[,\\]]', //...)")
+untagged=$(./bazelisk.sh query "rdeps(//..., kind('bitstream_splice', //...)) except attr(tags, '[\\[ ](cw310_rom|cw310_test_rom|vivado|manual)[,\\]]', //...)" --output=label_kind)
 if [[ ${untagged} ]]; then # Check that all targets that depend on vivado are tagged
-  echo "Target(s): ${untagged} depend(s) on a bitstream_splice but isn't tagged with vivado or manual";
+  echo "Error:";
+  echo "${untagged}"|sed 's/^/    /';
+  echo "Target(s) above depend(s) on a bitstream_splice and isn't available in a cache."
+  echo "Please tag it with vivado or manual.";
+  exit 1
+fi
+
+mistagged=$(./bazelisk.sh query "rdeps(attr(tags, '[\\[ ]cw310_test_rom[,\\]]',//...), kind('bitstream_splice', //...) except deps(//hw/bitstream:test_rom))" --output=label_kind)
+if [[ ${mistagged} ]]; then # Check that all cw310_test_rom tagged targets don't depend on other bistream_splices
+  echo "Error:";
+  echo "${mistagged}"|sed 's/^/    /';
+  echo "Target(s) above depend(s) on a bitstream_splice other than those used to generate the test_rom.";
+  echo "Please tag as cw310_other if you intended to use another bitstream_splice.";
+  exit 1
+fi
+
+mistagged=$(./bazelisk.sh query "rdeps(attr(tags, '[\\[ ]cw310_rom[,\\]]',//...), kind('bitstream_splice', //...) except deps(//hw/bitstream:rom))" --output=label_kind)
+if [[ ${mistagged} ]]; then # Check that all cw310_rom tagged targets don't depend on other bitstream_splices
+  echo "Error:";
+  echo "${mistagged}"|sed 's/^/    /';
+  echo "Above target(s) depend(s) on a bitstream_splice other than those used to generate the rom.";
+  echo "Please tag as cw310_other if you intend to use another bitstream_splice.";
   exit 1
 fi

--- a/ci/scripts/check-bazel-tags.sh
+++ b/ci/scripts/check-bazel-tags.sh
@@ -94,7 +94,11 @@ generate the cached bitstream with the test_ROM, but is tagged with cw310_test_r
 Please either:
 -Correct the dependencies to exclude other bitstream_splices,
 -Correct the target by setting it to something other than cw310_test_rom,
--Remove the cw310_test_rom tag."
+-Remove the cw310_test_rom tag.
+NOTE: test_suites that contain targets with different tags should almost
+universally use the manual tag."
+
+
 
 # This check ensures cw310 users may group tests that depend on the cached
 # cw310_rom bitstream.
@@ -121,4 +125,6 @@ generate the cached bitstream with the ROM, but is tagged with cw310_rom.
 Please either:
 -Correct the dependencies to exclude other bitstream_splices,
 -Correct the target by setting it to something like cw310_rom_variant,
--Correct the tag by setting it to cw310_rom_variant."
+-Correct the tag by setting it to cw310_rom_variant.
+NOTE: test_suites that contain targets with different tags should almost
+universally use the manual tag."

--- a/ci/scripts/check-bazel-tags.sh
+++ b/ci/scripts/check-bazel-tags.sh
@@ -63,22 +63,24 @@ Please tag it with vivado or manual."
 # This check ensures cw310 users may group tests that depend on the cached
 # cw310_test_rom bitstream.
 mistagged=$(./bazelisk.sh query \
-  "rdeps(
-      attr(
-          tags,
-          '$(exact_regex cw310_test_rom)',
-          //...
-      ),
-      kind(
-          'bitstream_splice',
-          //...
-      )
-      except
-      deps(
-          //hw/bitstream:test_rom
-      )
-  )" \
-  --output=label_kind)
+    "tests(
+        rdeps(
+            attr(
+                tags,
+                '$(exact_regex cw310_test_rom)',
+                tests(//...)
+            ),
+            kind(
+                'bitstream_splice',
+                //...
+            )
+            except
+            deps(
+                //hw/bitstream:test_rom
+            )
+        )
+    )" \
+    --output=label_kind)
 check_empty "${mistagged}" \
 "Target(s) above depend(s) on a bitstream_splice other than those used to generate the test_rom.
 Please tag as cw310_*_variant if you intended to use another bitstream."
@@ -86,20 +88,22 @@ Please tag as cw310_*_variant if you intended to use another bitstream."
 # This check ensures cw310 users may group tests that depend on the cached
 # cw310_rom bitstream.
 mistagged=$(./bazelisk.sh query \
-    "rdeps(
-        attr(
-            tags,
-            '$(exact_regex cw310_rom)',
-            //...
-        ),
-        kind(
-            'bitstream_splice',
-            //...
+    "tests(
+        rdeps(
+            attr(
+                tags,
+                '$(exact_regex cw310_rom)',
+                //...
+            ),
+            kind(
+                'bitstream_splice',
+                //...
+            )
+            except
+            deps(//hw/bitstream:rom)
         )
-        except
-        deps(//hw/bitstream:rom)
-  )" \
-  --output=label_kind)
+    )" \
+    --output=label_kind)
 check_empty "${mistagged}" \
 "Above target(s) depend(s) on a bitstream_splice other than those used to generate the rom.
 Please tag as cw310_*_variant if you intend to use another bitstream."

--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -40,15 +40,17 @@ export BITSTREAM="--offline --list ${SHA}"
 # in case we've crashed the UART handler on the CW310's SAM3U
 trap 'ci/bazelisk.sh run //sw/host/opentitantool -- --interface=cw310 fpga reset' EXIT
 
+# Tags help control which tests run in CI and when.
+# The cw310_tags used here are described at https://docs.opentitan.org/doc/getting_started/build_sw/#tags-and-wildcards
 for tag in "${cw310_tags[@]}"; do
-    ./bazelisk.sh query 'rdeps(//..., @bitstreams//...)' |
-        xargs ci/bazelisk.sh test \
-            --define DISABLE_VERILATOR_BUILD=true \
-            --nokeep_going \
-            --test_tag_filters="${tag}",-broken,-manual,-skip_in_ci \
-            --test_timeout_filters=short,moderate \
-            --test_output=all \
-            --build_tests_only \
-            --define cw310=lowrisc \
-            --flaky_test_attempts=2
+    ci/bazelisk.sh test \
+        --define DISABLE_VERILATOR_BUILD=true \
+        --nokeep_going \
+        --test_tag_filters="${tag}",-broken,-skip_in_ci \
+        --test_timeout_filters=short,moderate \
+        --test_output=all \
+        --build_tests_only \
+        --define cw310=lowrisc \
+        --flaky_test_attempts=2 \
+        //...
 done

--- a/doc/getting_started/build_sw.md
+++ b/doc/getting_started/build_sw.md
@@ -121,8 +121,8 @@ You may find it useful to use wildcards to build/test all targets in the OpenTit
 If a a target (a test or build artifact) relies on optional parts of the "Getting Started" guide they should be tagged so they can be filtered out and users can `bazelisk.sh test //...` once they filter out the appropriate tags.
 We maintain or use the following tags to support this:
 * `broken` is used to tag tests that are committed but should not be expected by CI or others to pass.
-* `cw310_test_rom`, `cw310_rom`, and `cw310_other` are used to tag tests that depend on a correctly setup cw310 "Bergen Board" to emulate OpenTitan.
-  The `cw310` prefix may be used in `--test_tag_filters` to enable concise filtering.
+* `cw310`, `cw310_test_rom`, `cw310_rom`, and `cw310_rom_variant` are used to tag tests that depend on a correctly setup cw310 "Bergen Board" to emulate OpenTitan.
+  `cw310` may be used in `--test_tag_filters` to enable concise filtering.
   Loading the bitstream is the slowest part of the test, so these tags can group tests with common bitstreams to accelerate the tests.
 * `verilator` is used to tag tests that depend on a verilated model of OpenTitan that can take a significant time to build.
   Verilated tests can still be built with `--define DISABLE_VERILATOR_BUILD`, but they will skip the invocation of Verilator and cannot be run.

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -7,7 +7,7 @@ load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@bazel_skylib//lib:collections.bzl", "collections")
 
 DEFAULT_TARGETS = ["dv", "verilator", "cw310_rom", "cw310_test_rom"]
-VALID_TARGETS = ["dv", "verilator", "cw310_rom", "cw310_test_rom", "cw310_other"]
+VALID_TARGETS = ["dv", "verilator", "cw310_rom", "cw310_test_rom", "cw310_rom_variant"]
 
 OTTF_SUCCESS_MSG = r"PASS.*\n"
 OTTF_FAILURE_MSG = r"(FAIL|FAULT).*\n"
@@ -309,7 +309,7 @@ def opentitan_functest(
         elif target == "verilator":
             devices_to_build_for.append("sim_verilator")
             target_params["sim_verilator"] = verilator_params() if not verilator else verilator
-        elif target in ["cw310_rom", "cw310_test_rom", "cw310_other"]:
+        elif target in ["cw310_rom", "cw310_test_rom", "cw310_rom_variant"]:
             devices_to_build_for.append("fpga_cw310")
 
             # Copy `cw310` for each `target`. This is not a deep copy, thus we
@@ -323,7 +323,6 @@ def opentitan_functest(
             DEFAULT_BITSTREAM = {
                 "cw310_test_rom": "@//hw/bitstream:test_rom",
                 "cw310_rom": "@//hw/bitstream:rom",
-                "cw310_other": "@//hw/bitstream:rom",
             }
             if (cw310 == None) or (cw310.get("bitstream") == None):
                 cw310_["bitstream"] = DEFAULT_BITSTREAM[target]
@@ -339,12 +338,12 @@ def opentitan_functest(
                 cw310_["rom_kind"] = "rom"
                 cw310_["tags"].append("cw310_rom")
                 target_params["fpga_cw310_rom"] = cw310_
-            elif target == "cw310_other":
+            elif target == "cw310_rom_variant":
                 cw310_["rom_kind"] = "rom"
-                cw310_["tags"].append("cw310_other")
-                target_params["fpga_cw310_other"] = cw310_
+                cw310_["tags"].append("cw310_rom_variant")
+                target_params["fpga_cw310_rom_variant"] = cw310_
             else:
-                fail("Expected `cw310_test_rom`, `cw310_rom`, and/or `cw310_other` as the target name")
+                fail("Expected `cw310_test_rom`, `cw310_rom`, and/or `cw310_rom_variant` as the target name")
         else:
             fail("Invalid target. Target must be in {}".format(VALID_TARGETS))
     devices_to_build_for = collections.uniq(devices_to_build_for)
@@ -431,7 +430,7 @@ def opentitan_functest(
         # Set flash image.
         if target in ["sim_dv", "sim_verilator"]:
             flash = "{}_{}_scr_vmem64".format(ot_flash_binary, target)
-        elif target in ["fpga_cw310_rom", "fpga_cw310_test_rom", "fpga_cw310_other"]:
+        elif target in ["fpga_cw310_rom", "fpga_cw310_test_rom", "fpga_cw310_rom_variant"]:
             flash = "{}_fpga_cw310_bin".format(ot_flash_binary)
         else:
             fail("Unexpected target: {}".format(target))
@@ -452,7 +451,7 @@ def opentitan_functest(
             flash = rom
         else:
             target_data.append(flash)
-            if target in ["fpga_cw310_rom", "fpga_cw310_test_rom", "fpga_cw310_other"]:
+            if target in ["fpga_cw310_rom", "fpga_cw310_test_rom", "fpga_cw310_rom_variant"]:
                 target_data.append("{}_fpga_cw310".format(ot_flash_binary))
             else:
                 target_data.append("{}_{}".format(ot_flash_binary, target))
@@ -478,7 +477,7 @@ def opentitan_functest(
         # Set success/failure strings for target platforms that print test
         # results over the UART (e.g., Verilator and FPGA).
         exit_strings_kwargs = {}
-        if target in ["fpga_cw310_rom", "fpga_cw310_test_rom", "fpga_cw310_other", "sim_verilator"]:
+        if target in ["fpga_cw310_rom", "fpga_cw310_test_rom", "fpga_cw310_rom_variant", "sim_verilator"]:
             exit_strings_kwargs = {
                 "exit_success": shell.quote(params.pop("exit_success")),
                 "exit_failure": shell.quote(params.pop("exit_failure")),
@@ -512,7 +511,7 @@ def opentitan_functest(
         target_test_cmds = [s.format(**format_dict) for s in target_test_cmds]
         env["TEST_CMDS"] = " ".join(target_test_cmds)
 
-        if target in ["fpga_cw310_rom", "fpga_cw310_test_rom", "fpga_cw310_other"]:
+        if target in ["fpga_cw310_rom", "fpga_cw310_test_rom", "fpga_cw310_rom_variant"]:
             # We attach the UART configuration to the front of the command line
             # so that they'll be parsed as global options rather than
             # command-specific options.

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -221,13 +221,11 @@ opentitan_functest(
     name = "e2e_bootup_success_otp_dev",
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_dev",
-        # TODO(lowRISC/opentitan#13603): Remove this "manual" tag when the
-        # bitstream target can fetch pre-spliced bitstream from GCP.
-        tags = ["manual"],
+        tags = ["vivado"],
     ),
     key = "test_key_0",
     ot_flash_binary = ":empty_test_slot_a",
-    targets = ["cw310_rom"],
+    targets = ["cw310_rom_variant"],
 )
 
 opentitan_functest(
@@ -704,7 +702,7 @@ otp_json(
         t["a"],
         t["b"],
     ),
-    targets = ["cw310_rom"],
+    targets = ["cw310_rom_variant"],
 ) for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items() for t in BOOT_POLICY_ROLLBACK_CASES]
 
 test_suite(
@@ -1228,7 +1226,7 @@ SHUTDOWN_WATCHDOG_CASES = [
         local_defines = [
             "HANG_SECS=1",
         ],
-        targets = ["cw310_rom"],
+        targets = ["cw310_rom_variant"],
         deps = [
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1870,6 +1870,7 @@ SIGVERIFY_BAD_CASES = [
 
 test_suite(
     name = "sigverify_always",
+    tags = ["manual"],
     tests = [
         "sigverify_always_a_{}_b_{}".format(
             a["desc"],
@@ -1878,5 +1879,4 @@ test_suite(
         for a in SIGVERIFY_BAD_CASES
         for b in SIGVERIFY_BAD_CASES
     ],
-    tags = ["manual"],
 )

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -264,7 +264,7 @@ opentitan_functest(
     # binary target.  We'll build an unsigned do-nothing binary.
     ot_flash_binary = ":empty_test_slot_a",
     signed = False,
-    targets = ["cw310_other"],
+    targets = ["cw310_rom_variant"],
     test_harness = "//sw/host/tests/rom/e2e_bootstrap_disabled",
 )
 
@@ -493,7 +493,7 @@ manifest({
     ot_flash_binary = ":empty_test_slot_a",
     signed = False,
     targets = [
-        "cw310_other",
+        "cw310_rom_variant",
         "dv",
     ],
 ) for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()]
@@ -613,7 +613,7 @@ BOOT_POLICY_NEWER_CASES = [
         t["a"],
         t["b"],
     ),
-    targets = ["cw310_other"],
+    targets = ["cw310_rom_variant"],
 ) for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items() for t in BOOT_POLICY_NEWER_CASES]
 
 test_suite(
@@ -823,7 +823,7 @@ opentitan_flash_binary(
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         ot_flash_binary = ":empty_test_sigverify_mod_exp",
-        targets = ["cw310_other"],
+        targets = ["cw310_rom_variant"],
     )
     for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
     for t in SIGVERIFY_MOD_EXP_CASES
@@ -1090,7 +1090,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             slot,
         ),
         targets = [
-            "cw310_other",
+            "cw310_rom_variant",
             "verilator",
         ],
         verilator = verilator_params(
@@ -1333,7 +1333,7 @@ BOOT_POLICY_VALID_CASES = [
             a["desc"],
             b["desc"],
         ),
-        targets = ["cw310_other"],
+        targets = ["cw310_rom_variant"],
     )
     for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
     for a in BOOT_POLICY_VALID_CASES
@@ -1803,7 +1803,7 @@ REDACT.update({"INVALID": 0x0})
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         signed = False,
-        targets = ["cw310_other"],
+        targets = ["cw310_rom_variant"],
         deps = [
             "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
             "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -823,7 +823,7 @@ opentitan_flash_binary(
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         ot_flash_binary = ":empty_test_sigverify_mod_exp",
-        targets = ["cw310_rom"],
+        targets = ["cw310_other"],
     )
     for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
     for t in SIGVERIFY_MOD_EXP_CASES
@@ -1090,7 +1090,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             slot,
         ),
         targets = [
-            "cw310_rom",
+            "cw310_other",
             "verilator",
         ],
         verilator = verilator_params(
@@ -1333,7 +1333,7 @@ BOOT_POLICY_VALID_CASES = [
             a["desc"],
             b["desc"],
         ),
-        targets = ["cw310_rom"],
+        targets = ["cw310_other"],
     )
     for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
     for a in BOOT_POLICY_VALID_CASES

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1878,4 +1878,5 @@ test_suite(
         for a in SIGVERIFY_BAD_CASES
         for b in SIGVERIFY_BAD_CASES
     ],
+    tags = ["manual"],
 )

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -264,7 +264,7 @@ opentitan_functest(
     # binary target.  We'll build an unsigned do-nothing binary.
     ot_flash_binary = ":empty_test_slot_a",
     signed = False,
-    targets = ["cw310_rom"],
+    targets = ["cw310_other"],
     test_harness = "//sw/host/tests/rom/e2e_bootstrap_disabled",
 )
 
@@ -493,7 +493,7 @@ manifest({
     ot_flash_binary = ":empty_test_slot_a",
     signed = False,
     targets = [
-        "cw310_rom",
+        "cw310_other",
         "dv",
     ],
 ) for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()]
@@ -613,7 +613,7 @@ BOOT_POLICY_NEWER_CASES = [
         t["a"],
         t["b"],
     ),
-    targets = ["cw310_rom"],
+    targets = ["cw310_other"],
 ) for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items() for t in BOOT_POLICY_NEWER_CASES]
 
 test_suite(
@@ -1803,7 +1803,7 @@ REDACT.update({"INVALID": 0x0})
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         signed = False,
-        targets = ["cw310_rom"],
+        targets = ["cw310_other"],
         deps = [
             "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
             "//sw/device/lib/testing/test_framework:ottf_main",


### PR DESCRIPTION
Add a check for a cw310_other tag to be added to tests that require bitstreams other than the ones we cache for the cw310. This lets us group the cw310_rom and cw310_test_rom tests to avoid loading bitstreams when we run those tests.

I also increased the timeouts to make it less likely to encounter problems.