### PR TITLE
[top] Various fixes for ndm_reset test

### DIFF
--- a/hw/ip/prim/lint/prim_flop_2sync.waiver
+++ b/hw/ip/prim/lint/prim_flop_2sync.waiver
@@ -9,3 +9,6 @@ waive -rules {IFDEF_CODE} -location {prim_flop_2sync.sv} -regexp {.*contained wi
 
 waive -rules {PARAM_NOT_USED} -location {prim_flop_2sync.sv} -regexp {Parameter 'EnablePrimCdcRand' not used in module.*} \
       -comment "This parameter is used when cdc instrumentation is enabled."
+
+waive -rules {SAME_NAME_TYPE} -location {prim_flop_2sync.sv} -regexp {'ResetValue' is used as a parameter here, and as an enumeration value at prim.*} \
+      -comment "Parameter name reuse."

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
@@ -8,26 +8,27 @@
 interface pwrmgr_rstmgr_sva_if
   import pwrmgr_pkg::*, pwrmgr_reg_pkg::NumRstReqs;
 (
-  input logic                            clk_i,
-  input logic                            rst_ni,
-  input logic                            clk_slow_i,
-  input logic                            rst_slow_ni,
+  input logic                    clk_i,
+  input logic                    rst_ni,
+  input logic                    clk_slow_i,
+  input logic                    rst_slow_ni,
   // Input resets.
-  input logic         [  NumRstReqs-1:0] rstreqs_i,
-  input logic         [  NumRstReqs-1:0] reset_en,
-  input logic                            sw_rst_req_i,
-  input logic                            main_rst_req_i,
-  input logic                            esc_rst_req_i,
-  input logic                            ndm_req_i,
+  input logic [ NumRstReqs-1:0]  rstreqs_i,
+  input logic [ NumRstReqs-1:0]  reset_en,
+  input logic                    sw_rst_req_i,
+  input logic                    main_rst_req_i,
+  input logic                    esc_rst_req_i,
+  // TODO: Add ndm_reset on/off testing
+  input logic                    ndm_rst_req_i,
   // The inputs from pwrmgr.
-  input logic         [PowerDomains-1:0] rst_lc_req,
-  input logic         [PowerDomains-1:0] rst_sys_req,
-  input logic         [HwResetWidth-1:0] rstreqs,
-  input logic                            main_pd_n,
-  input reset_cause_e                    reset_cause,
+  input logic [PowerDomains-1:0] rst_lc_req,
+  input logic [PowerDomains-1:0] rst_sys_req,
+  input logic [HwResetWidth-1:0] rstreqs,
+  input logic                    main_pd_n,
+  input                          reset_cause_e reset_cause,
   // The inputs from rstmgr.
-  input logic         [PowerDomains-1:0] rst_lc_src_n,
-  input logic         [PowerDomains-1:0] rst_sys_src_n
+  input logic [PowerDomains-1:0] rst_lc_src_n,
+  input logic [PowerDomains-1:0] rst_sys_src_n
 );
 
   // Number of cycles for the LC/SYS reset handshake.

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
@@ -23,7 +23,6 @@ interface pwrmgr_rstmgr_sva_if
   input logic         [PowerDomains-1:0] rst_sys_req,
   input logic         [HwResetWidth-1:0] rstreqs,
   input logic                            main_pd_n,
-  input logic                            ndm_sys_req,
   input reset_cause_e                    reset_cause,
   // The inputs from rstmgr.
   input logic         [PowerDomains-1:0] rst_lc_src_n,

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
@@ -18,6 +18,7 @@ interface pwrmgr_rstmgr_sva_if
   input logic                            sw_rst_req_i,
   input logic                            main_rst_req_i,
   input logic                            esc_rst_req_i,
+  input logic                            ndm_req_i,
   // The inputs from pwrmgr.
   input logic         [PowerDomains-1:0] rst_lc_req,
   input logic         [PowerDomains-1:0] rst_sys_req,

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_unit_bind.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_unit_bind.sv
@@ -19,14 +19,13 @@ module pwrmgr_unit_bind;
     .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(sw_rst_req_i)),
     .main_rst_req_i(!rst_main_ni),
     .esc_rst_req_i(esc_rst_req_q),
+    .ndm_req_i(ndmreset_req_i),
     // The outputs from pwrmgr.
     .rst_lc_req(pwr_rst_o.rst_lc_req),
     .rst_sys_req(pwr_rst_o.rst_sys_req),
     .rstreqs(pwr_rst_o.rstreqs),
     .main_pd_n(pwr_ast_o.main_pd_n),
     .reset_cause(pwr_rst_o.reset_cause),
-    // This goes directly to rstmgr and can trigger rst_sys_src_n.
-    .ndm_sys_req(1'b0),
     // The inputs from rstmgr.
     .rst_lc_src_n(pwr_rst_i.rst_lc_src_n),
     .rst_sys_src_n(pwr_rst_i.rst_sys_src_n)

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_unit_bind.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_unit_bind.sv
@@ -19,7 +19,7 @@ module pwrmgr_unit_bind;
     .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(sw_rst_req_i)),
     .main_rst_req_i(!rst_main_ni),
     .esc_rst_req_i(esc_rst_req_q),
-    .ndm_req_i(ndmreset_req_i),
+    .ndm_rst_req_i(ndmreset_req_i),
     // The outputs from pwrmgr.
     .rst_lc_req(pwr_rst_o.rst_lc_req),
     .rst_sys_req(pwr_rst_o.rst_sys_req),

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -311,9 +311,8 @@ module pwrmgr
   // The main power domain glitch automatically causes a reset, so regsitering
   // an alert is functionally pointless.  However, if an attacker somehow manages/
   // to silence the reset, this gives us one potential back-up path through alert_handler.
-  logic en_main_pd_glitch_status;
-  assign en_main_pd_glitch_status = clr_hint;
-  assign hw2reg.fault_status.main_pd_glitch.de  = en_main_pd_glitch_status;
+  // Allow capture of main_pd fault status whenever the system is live.
+  assign hw2reg.fault_status.main_pd_glitch.de  = pwr_clk_o.main_ip_clk_en;
   assign hw2reg.fault_status.main_pd_glitch.d   = peri_reqs_masked.rstreqs[ResetMainPwrIdx];
 
   // Check that the clock enables are deasserted in the next slow clock cycle if a power glitch is

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -315,15 +315,6 @@ module pwrmgr
   assign hw2reg.fault_status.main_pd_glitch.de  = pwr_clk_o.main_ip_clk_en;
   assign hw2reg.fault_status.main_pd_glitch.d   = peri_reqs_masked.rstreqs[ResetMainPwrIdx];
 
-  // Check that the clock enables are deasserted in the next slow clock cycle if a power glitch is
-  // detected.
-  `ASSERT(PwrmgrMainPowerGlitchMainClkVld, $rose(hw2reg.fault_status.main_pd_glitch.de)
-                                           |=> !pwr_clk_o.main_ip_clk_en, clk_slow_i, !rst_slow_ni)
-  `ASSERT(PwrmgrMainPowerGlitchIOClkVld, $rose(hw2reg.fault_status.main_pd_glitch.de)
-                                         |=> !pwr_clk_o.io_ip_clk_en, clk_slow_i, !rst_slow_ni)
-  `ASSERT(PwrmgrMainPowerGlitchUSBClkVld, $rose(hw2reg.fault_status.main_pd_glitch.de)
-                                          |=> !pwr_clk_o.usb_ip_clk_en, clk_slow_i, !rst_slow_ni)
-
 
   ////////////////////////////
   ///  alerts

--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -73,7 +73,7 @@ package pwrmgr_pkg;
   typedef enum logic [1:0] {
     ResetNone = 0,     // there is no reset
     LowPwrEntry = 1,   // reset is caused by low power entry
-    HwReq = 2,         // reset is caused by peripheral reset requests (no ndm)
+    HwReq = 2,         // reset is caused by peripheral reset requests
     ResetUndefined = 3 // this should never happen outside of POR
   } reset_cause_e;
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -73,7 +73,7 @@ package pwrmgr_pkg;
   typedef enum logic [1:0] {
     ResetNone = 0,     // there is no reset
     LowPwrEntry = 1,   // reset is caused by low power entry
-    HwReq = 2,         // reset is caused by peripheral reset requests
+    HwReq = 2,         // reset is caused by peripheral reset requests (no ndm)
     ResetUndefined = 3 // this should never happen outside of POR
   } reset_cause_e;
 
@@ -201,8 +201,8 @@ package pwrmgr_pkg;
 
   // fast fsm state enum
   // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 18 -n 12 \
-  //      -s 2594078347 --language=sv
+  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 19 -n 12 \
+  //      -s 3096160381 --language=sv
   //
   // Hamming distance histogram:
   //
@@ -211,40 +211,41 @@ package pwrmgr_pkg;
   //  2: --
   //  3: --
   //  4: --
-  //  5: ||||||||||||||||| (30.72%)
-  //  6: |||||||||||||||||||| (35.95%)
-  //  7: ||||||||| (16.99%)
-  //  8: |||| (8.50%)
-  //  9: || (4.58%)
-  // 10: | (1.96%)
-  // 11:  (0.65%)
-  // 12:  (0.65%)
+  //  5: ||||||||||||||||| (30.99%)
+  //  6: |||||||||||||||||||| (35.09%)
+  //  7: ||||||||| (15.79%)
+  //  8: |||||| (10.53%)
+  //  9: ||| (5.85%)
+  // 10: | (1.75%)
+  // 11: --
+  // 12: --
   //
   // Minimum Hamming distance: 5
-  // Maximum Hamming distance: 12
-  // Minimum Hamming weight: 3
+  // Maximum Hamming distance: 10
+  // Minimum Hamming weight: 2
   // Maximum Hamming weight: 10
   //
   localparam int FastPwrStateWidth = 12;
   typedef enum logic [FastPwrStateWidth-1:0] {
-    FastPwrStateLowPower     = 12'b101000110011,
-    FastPwrStateEnableClocks = 12'b001011101000,
-    FastPwrStateReleaseLcRst = 12'b110111110111,
-    FastPwrStateOtpInit      = 12'b000110011001,
-    FastPwrStateLcInit       = 12'b001100001110,
-    FastPwrStateStrap        = 12'b110000011000,
-    FastPwrStateAckPwrUp     = 12'b100001001101,
-    FastPwrStateRomCheckDone = 12'b011010100111,
-    FastPwrStateRomCheckGood = 12'b011101000011,
-    FastPwrStateActive       = 12'b100101101010,
-    FastPwrStateDisClks      = 12'b000001010010,
-    FastPwrStateFallThrough  = 12'b111110111100,
-    FastPwrStateNvmIdleChk   = 12'b010111001100,
-    FastPwrStateLowPowerPrep = 12'b101010000100,
-    FastPwrStateNvmShutDown  = 12'b000010111110,
-    FastPwrStateResetPrep    = 12'b001101111101,
-    FastPwrStateReqPwrDn     = 12'b111011010001,
-    FastPwrStateInvalid      = 12'b110110000010
+    FastPwrStateLowPower     = 12'b000000110111,
+    FastPwrStateEnableClocks = 12'b101011001110,
+    FastPwrStateReleaseLcRst = 12'b100111000000,
+    FastPwrStateOtpInit      = 12'b111110100010,
+    FastPwrStateLcInit       = 12'b101001010011,
+    FastPwrStateStrap        = 12'b110000111010,
+    FastPwrStateAckPwrUp     = 12'b000010101000,
+    FastPwrStateRomCheckDone = 12'b010111110011,
+    FastPwrStateRomCheckGood = 12'b010000000100,
+    FastPwrStateActive       = 12'b001101100100,
+    FastPwrStateDisClks      = 12'b001110010101,
+    FastPwrStateFallThrough  = 12'b011011010000,
+    FastPwrStateNvmIdleChk   = 12'b100101111001,
+    FastPwrStateLowPowerPrep = 12'b010110001111,
+    FastPwrStateNvmShutDown  = 12'b001100001010,
+    FastPwrStateResetPrep    = 12'b011001101111,
+    FastPwrStateResetWait    = 12'b111111111100,
+    FastPwrStateReqPwrDn     = 12'b111010001001,
+    FastPwrStateInvalid      = 12'b110101010110
   } fast_pwr_state_e;
 
   // Encoding generated with:

--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -232,7 +232,8 @@
           resval: "0"
         },
 
-        // reset requests include escalation reset + peripheral requests
+        // reset requests include escalation reset, main power glitch,
+        // ndm reset request + other peripheral requests
         { bits: "${3 + total_hw_resets - 1}:3",
           hwaccess: "hrw",
           name: "HW_REQ",

--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -143,12 +143,6 @@
       package: "rstmgr_pkg", // Origin package (only needs for the req)
     },
 
-    { struct:  "logic",
-      type:    "uni",
-      name:    "ndmreset_req",
-      act:     "rcv",
-    },
-
     { struct:  "alert_crashdump",
       type:    "uni",
       name:    "alert_dump",
@@ -230,14 +224,6 @@
         },
 
         { bits: "2",
-          name: "NDM_RESET",
-          desc: '''
-            Indicates when a device has reset due to non-debug-module request.
-            '''
-          resval: "0"
-        },
-
-        { bits: "3",
           hwaccess: "hrw",
           name: "SW_RESET",
           desc: '''
@@ -247,7 +233,7 @@
         },
 
         // reset requests include escalation reset + peripheral requests
-        { bits: "${4 + total_hw_resets - 1}:4",
+        { bits: "${3 + total_hw_resets - 1}:3",
           hwaccess: "hrw",
           name: "HW_REQ",
           desc: '''

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -47,9 +47,6 @@ module rstmgr
   // software initiated reset request
   output mubi4_t sw_rst_req_o,
 
-  // cpu related inputs
-  input logic ndmreset_req_i,
-
   // Interface to alert handler
   input alert_pkg::alert_crashdump_t alert_dump_i,
 
@@ -239,25 +236,6 @@ module rstmgr
   end
 
   ////////////////////////////////////////////////////
-  // Input handling                                 //
-  ////////////////////////////////////////////////////
-
-  logic ndmreset_req_q;
-  logic ndm_req_valid;
-
-  prim_flop_2sync #(
-    .Width(1),
-    .ResetValue('0)
-  ) u_ndm_sync (
-    .clk_i,
-    .rst_ni,
-    .d_i(ndmreset_req_i),
-    .q_o(ndmreset_req_q)
-  );
-
-  assign ndm_req_valid = ndmreset_req_q & (pwr_i.reset_cause == pwrmgr_pkg::ResetNone);
-
-  ////////////////////////////////////////////////////
   // Source resets in the system                    //
   // These are hardcoded and not directly used.     //
   // Instead they act as async reset roots.         //
@@ -388,7 +366,6 @@ module rstmgr
 
   logic rst_hw_req;
   logic rst_low_power;
-  logic rst_ndm;
   logic pwrmgr_rst_req;
 
   // there is a valid reset request from pwrmgr
@@ -399,7 +376,6 @@ module rstmgr
   // must be updated to account for each individual core.
   assign rst_hw_req    = pwrmgr_rst_req &
                          (pwr_i.reset_cause == pwrmgr_pkg::HwReq);
-  assign rst_ndm       = ndm_req_valid;
   assign rst_low_power = pwrmgr_rst_req &
                          (pwr_i.reset_cause == pwrmgr_pkg::LowPwrEntry);
 
@@ -414,9 +390,6 @@ module rstmgr
   // Only sw is allowed to clear a reset reason, hw is only allowed to set it.
   assign hw2reg.reset_info.low_power_exit.d  = 1'b1;
   assign hw2reg.reset_info.low_power_exit.de = rst_low_power;
-
-  assign hw2reg.reset_info.ndm_reset.d  = 1'b1;
-  assign hw2reg.reset_info.ndm_reset.de = rst_ndm;
 
   // software issued request triggers the same response as hardware, although it is
   // accounted for differently.
@@ -435,7 +408,7 @@ module rstmgr
   ////////////////////////////////////////////////////
 
   logic dump_capture;
-  assign dump_capture =  rst_hw_req | rst_ndm | rst_low_power;
+  assign dump_capture =  rst_hw_req | rst_low_power;
 
   // halt dump capture once we hit particular conditions
   logic dump_capture_halt;

--- a/hw/ip/rstmgr/dv/env/rstmgr_if.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_if.sv
@@ -53,7 +53,6 @@ interface rstmgr_if (
     reset_info = {
       `PATH_TO_DUT.u_reg.reset_info_hw_req_qs,
       `PATH_TO_DUT.u_reg.reset_info_sw_reset_qs,
-      `PATH_TO_DUT.u_reg.reset_info_ndm_reset_qs,
       `PATH_TO_DUT.u_reg.reset_info_low_power_exit_qs,
       `PATH_TO_DUT.u_reg.reset_info_por_qs
     };

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -19,6 +19,7 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
   endtask
 
   task body();
+    uvm_reg_data_t exp_reg;
     bit is_standalone = is_running_sequence("rstmgr_smoke_vseq");
     // Expect reset info to be POR when running the sequence standalone.
     if (is_standalone) begin
@@ -43,7 +44,10 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
 
     // Send low power entry reset.
     send_reset(pwrmgr_pkg::LowPwrEntry, '0);
-    check_reset_info(2, "expected reset_info to indicate low power");
+    exp_reg = csr_utils_pkg::get_csr_val_with_updated_field(
+              ral.reset_info.low_power_exit, '0, 1);
+    check_reset_info(exp_reg,
+                     "expected reset_info to indicate low power");
     check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b1);
     wait_between_resets();
 
@@ -55,7 +59,10 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
     set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
 
     send_reset(pwrmgr_pkg::HwReq, rstreqs);
-    check_reset_info({rstreqs, 4'h0}, $sformatf("expected reset_info to match 0x%x", {rstreqs, 4'h0}
+    exp_reg = csr_utils_pkg::get_csr_val_with_updated_field(
+              ral.reset_info.hw_req, '0, rstreqs);
+    check_reset_info(exp_reg,
+                     $sformatf("expected reset_info to match 0x%x", exp_reg
                      ));
     check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b0);
     wait_between_resets();
@@ -65,20 +72,15 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
     `DV_CHECK_RANDOMIZE_FATAL(this)
     set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
 
-    // Send debug reset.
-    send_ndm_reset();
-    check_reset_info(4, "Expected reset_info to indicate ndm reset");
-    check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b1);
-    wait_between_resets();
-
-    csr_wr(.ptr(ral.reset_info), .value('1));
-
     `DV_CHECK_RANDOMIZE_FATAL(this)
     set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
 
     // Send sw reset.
     send_sw_reset(MuBi4True);
-    check_reset_info(8, "Expected reset_info to indicate sw reset");
+    exp_reg = csr_utils_pkg::get_csr_val_with_updated_field(
+              ral.reset_info.sw_reset, '0, 1);
+    check_reset_info(exp_reg,
+                     "Expected reset_info to indicate sw reset");
     check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 0);
     wait_between_resets();
 

--- a/hw/ip/rstmgr/dv/sva/rstmgr_unit_only_bind.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_unit_only_bind.sv
@@ -26,7 +26,6 @@ module rstmgr_unit_only_bind;
     .rst_lc_req(pwr_i.rst_lc_req),
     .rst_sys_req(pwr_i.rst_sys_req),
     .main_pd_n('1),
-    .ndm_sys_req(ndmreset_req_i),
     .reset_cause(pwr_i.reset_cause),
     // The inputs from rstmgr.
     .rst_lc_src_n(pwr_o.rst_lc_src_n),

--- a/hw/ip/rstmgr/dv/sva/rstmgr_unit_only_bind.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_unit_only_bind.sv
@@ -21,6 +21,7 @@ module rstmgr_unit_only_bind;
     .sw_rst_req_i('0),
     .main_rst_req_i('0),
     .esc_rst_req_i('0),
+    .ndm_rst_req_i('0),
     .rstreqs('0),
     // These are actually used for checks.
     .rst_lc_req(pwr_i.rst_lc_req),

--- a/hw/ip/rstmgr/dv/tb.sv
+++ b/hw/ip/rstmgr/dv/tb.sv
@@ -103,7 +103,6 @@ module tb;
     .pwr_o(rstmgr_if.pwr_o),
 
     .sw_rst_req_o  (rstmgr_if.sw_rst_req_o),
-    .ndmreset_req_i(rstmgr_if.cpu_i.ndmreset_req),
 
     .alert_dump_i(rstmgr_if.alert_dump_i),
     .cpu_dump_i  (rstmgr_if.cpu_dump_i),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3040,18 +3040,6 @@
           index: -1
         }
         {
-          name: ndmreset_req
-          struct: logic
-          type: uni
-          act: rcv
-          width: 1
-          inst_name: rstmgr_aon
-          default: ""
-          package: ""
-          top_signame: rv_dm_ndmreset_req
-          index: -1
-        }
-        {
           name: alert_dump
           struct: alert_crashdump
           package: alert_pkg
@@ -8215,7 +8203,6 @@
       ]
       rv_dm.ndmreset_req:
       [
-        rstmgr_aon.ndmreset_req
         pwrmgr_aon.ndmreset_req
       ]
       rstmgr_aon.sw_rst_req:
@@ -16552,18 +16539,6 @@
         inst_name: rstmgr_aon
         default: ""
         top_signame: rstmgr_aon_rst_en
-        index: -1
-      }
-      {
-        name: ndmreset_req
-        struct: logic
-        type: uni
-        act: rcv
-        width: 1
-        inst_name: rstmgr_aon
-        default: ""
-        package: ""
-        top_signame: rv_dm_ndmreset_req
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -1025,8 +1025,8 @@
       // spi passthrough connection
       'spi_device.passthrough'     : ['spi_host0.passthrough']
 
-      // Debug module reset request to reset manager
-      'rv_dm.ndmreset_req' : ['rstmgr_aon.ndmreset_req', 'pwrmgr_aon.ndmreset_req'],
+      // Debug module reset request to power manager
+      'rv_dm.ndmreset_req' : ['pwrmgr_aon.ndmreset_req'],
 
       // Reset manager software reset request to pwrmgr
       'rstmgr_aon.sw_rst_req' : ['pwrmgr_aon.sw_rst_req'],

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -437,6 +437,7 @@ interface chip_if;
   jtag_if flash_ctrl_jtag_if();
 
   // TODO: Revisit this logic.
+  wire lc_ready = `LC_CTRL_HIER.u_reg.u_status_ready.qs;
   wire lc_hw_debug_en = (`LC_CTRL_HIER.lc_hw_debug_en_o == lc_ctrl_pkg::On);
   assign flash_ctrl_jtag_enabled = enable_flash_ctrl_jtag && lc_hw_debug_en;
   assign mios[top_earlgrey_pkg::MioPadIob0] = flash_ctrl_jtag_enabled ?

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_base_vseq.sv
@@ -33,26 +33,16 @@ class chip_jtag_base_vseq extends chip_sw_base_vseq;
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(1));
 
     // spin wait on reset completion
-    csr_spinwait(.ptr(ral.lc_ctrl.status.ready), .exp_data(0), .backdoor(1),
-                 .spinwait_delay_ns(1000));
-    `uvm_info(`gfn, $sformatf("saw lc ready"),
-              UVM_LOW)
+    `DV_WAIT(cfg.chip_vif.lc_ready == '0)
+    `uvm_info(`gfn, "LC controller reset", UVM_MEDIUM)
 
-    csr_spinwait(.ptr(ral.lc_ctrl.status.ready), .exp_data(1), .backdoor(1),
-                 .spinwait_delay_ns(1000), .timeout_ns(5000000));
-    `uvm_info(`gfn, $sformatf("saw lc ready again"),
-              UVM_LOW)
+    `DV_WAIT(cfg.chip_vif.lc_ready == 1'b1)
+    `uvm_info(`gfn, "LC controller initialized", UVM_MEDIUM)
+
+    #10us;
   endtask
 
    task ndm_reset_off();
-     // Temporary workaround until pinmux/rv_dm fixes are in
-    `uvm_info(`gfn, $sformatf("issue reset"),
-              UVM_LOW)
-     cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.do_trst_n(2);
-    `uvm_info(`gfn, $sformatf("reset done"),
-              UVM_LOW)
-     cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.in_reset = 1'b0;
-
      csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(0));
      cfg.clk_rst_vif.wait_clks(5);
    endtask

--- a/hw/top_earlgrey/dv/sva/top_earlgrey_bind.sv
+++ b/hw/top_earlgrey/dv/sva/top_earlgrey_bind.sv
@@ -17,6 +17,7 @@ module top_earlgrey_bind;
     .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(u_pwrmgr_aon.sw_rst_req_i)),
     .main_rst_req_i(!u_pwrmgr_aon.rst_main_ni),
     .esc_rst_req_i(u_pwrmgr_aon.esc_rst_req_q),
+    .ndm_rst_req_i(u_pwrmgr_aon.ndmreset_req_i),
     // The outputs from pwrmgr.
     .rst_lc_req(u_pwrmgr_aon.pwr_rst_o.rst_lc_req),
     .rst_sys_req(u_pwrmgr_aon.pwr_rst_o.rst_sys_req),

--- a/hw/top_earlgrey/dv/sva/top_earlgrey_bind.sv
+++ b/hw/top_earlgrey/dv/sva/top_earlgrey_bind.sv
@@ -23,8 +23,6 @@ module top_earlgrey_bind;
     .rstreqs(u_pwrmgr_aon.pwr_rst_o.rstreqs),
     .main_pd_n(u_pwrmgr_aon.pwr_ast_o.main_pd_n),
     .reset_cause(u_pwrmgr_aon.pwr_rst_o.reset_cause),
-    // This goes directly to rstmgr and can trigger rst_sys_src_n.
-    .ndm_sys_req(u_rstmgr_aon.ndmreset_req_i),
     // The inputs from rstmgr.
     .rst_lc_src_n(u_pwrmgr_aon.pwr_rst_i.rst_lc_src_n),
     .rst_sys_src_n(u_pwrmgr_aon.pwr_rst_i.rst_sys_src_n)

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -147,12 +147,6 @@
       package: "rstmgr_pkg", // Origin package (only needs for the req)
     },
 
-    { struct:  "logic",
-      type:    "uni",
-      name:    "ndmreset_req",
-      act:     "rcv",
-    },
-
     { struct:  "alert_crashdump",
       type:    "uni",
       name:    "alert_dump",
@@ -226,14 +220,6 @@
         },
 
         { bits: "2",
-          name: "NDM_RESET",
-          desc: '''
-            Indicates when a device has reset due to non-debug-module request.
-            '''
-          resval: "0"
-        },
-
-        { bits: "3",
           hwaccess: "hrw",
           name: "SW_RESET",
           desc: '''
@@ -243,7 +229,7 @@
         },
 
         // reset requests include escalation reset + peripheral requests
-        { bits: "8:4",
+        { bits: "7:3",
           hwaccess: "hrw",
           name: "HW_REQ",
           desc: '''

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -228,7 +228,8 @@
           resval: "0"
         },
 
-        // reset requests include escalation reset + peripheral requests
+        // reset requests include escalation reset, main power glitch,
+        // ndm reset request + other peripheral requests
         { bits: "7:3",
           hwaccess: "hrw",
           name: "HW_REQ",

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
@@ -91,10 +91,6 @@ package rstmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } ndm_reset;
-    struct packed {
-      logic        d;
-      logic        de;
     } sw_reset;
     struct packed {
       logic [4:0]  d;
@@ -160,8 +156,8 @@ package rstmgr_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    rstmgr_hw2reg_reset_req_reg_t reset_req; // [98:94]
-    rstmgr_hw2reg_reset_info_reg_t reset_info; // [93:82]
+    rstmgr_hw2reg_reset_req_reg_t reset_req; // [96:92]
+    rstmgr_hw2reg_reset_info_reg_t reset_info; // [91:82]
     rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [81:80]
     rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [79:76]
     rstmgr_hw2reg_alert_info_reg_t alert_info; // [75:44]
@@ -250,7 +246,7 @@ package rstmgr_reg_pkg;
   parameter logic [3:0] RSTMGR_PERMIT [28] = '{
     4'b 0001, // index[ 0] RSTMGR_ALERT_TEST
     4'b 0001, // index[ 1] RSTMGR_RESET_REQ
-    4'b 0011, // index[ 2] RSTMGR_RESET_INFO
+    4'b 0001, // index[ 2] RSTMGR_RESET_INFO
     4'b 0001, // index[ 3] RSTMGR_ALERT_REGWEN
     4'b 0001, // index[ 4] RSTMGR_ALERT_INFO_CTRL
     4'b 0001, // index[ 5] RSTMGR_ALERT_INFO_ATTR

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -137,8 +137,6 @@ module rstmgr_reg_top (
   logic reset_info_por_wd;
   logic reset_info_low_power_exit_qs;
   logic reset_info_low_power_exit_wd;
-  logic reset_info_ndm_reset_qs;
-  logic reset_info_ndm_reset_wd;
   logic reset_info_sw_reset_qs;
   logic reset_info_sw_reset_wd;
   logic [4:0] reset_info_hw_req_qs;
@@ -341,34 +339,7 @@ module rstmgr_reg_top (
     .qs     (reset_info_low_power_exit_qs)
   );
 
-  //   F[ndm_reset]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_reset_info_ndm_reset (
-    // sync clock and reset required for this register
-    .clk_i   (clk_por_i),
-    .rst_ni  (rst_por_ni),
-
-    // from register interface
-    .we     (reset_info_we),
-    .wd     (reset_info_ndm_reset_wd),
-
-    // from internal hardware
-    .de     (hw2reg.reset_info.ndm_reset.de),
-    .d      (hw2reg.reset_info.ndm_reset.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (reset_info_ndm_reset_qs)
-  );
-
-  //   F[sw_reset]: 3:3
+  //   F[sw_reset]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -395,7 +366,7 @@ module rstmgr_reg_top (
     .qs     (reset_info_sw_reset_qs)
   );
 
-  //   F[hw_req]: 8:4
+  //   F[hw_req]: 7:3
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1295,11 +1266,9 @@ module rstmgr_reg_top (
 
   assign reset_info_low_power_exit_wd = reg_wdata[1];
 
-  assign reset_info_ndm_reset_wd = reg_wdata[2];
+  assign reset_info_sw_reset_wd = reg_wdata[2];
 
-  assign reset_info_sw_reset_wd = reg_wdata[3];
-
-  assign reset_info_hw_req_wd = reg_wdata[8:4];
+  assign reset_info_hw_req_wd = reg_wdata[7:3];
   assign alert_regwen_we = addr_hit[3] & reg_we & !reg_error;
 
   assign alert_regwen_wd = reg_wdata[0];
@@ -1418,9 +1387,8 @@ module rstmgr_reg_top (
       addr_hit[2]: begin
         reg_rdata_next[0] = reset_info_por_qs;
         reg_rdata_next[1] = reset_info_low_power_exit_qs;
-        reg_rdata_next[2] = reset_info_ndm_reset_qs;
-        reg_rdata_next[3] = reset_info_sw_reset_qs;
-        reg_rdata_next[8:4] = reset_info_hw_req_qs;
+        reg_rdata_next[2] = reset_info_sw_reset_qs;
+        reg_rdata_next[7:3] = reset_info_hw_req_qs;
       end
 
       addr_hit[3]: begin

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1732,7 +1732,6 @@ module top_earlgrey #(
       .pwr_o(pwrmgr_aon_pwr_rst_rsp),
       .resets_o(rstmgr_aon_resets),
       .rst_en_o(rstmgr_aon_rst_en),
-      .ndmreset_req_i(rv_dm_ndmreset_req),
       .alert_dump_i(alert_handler_crashdump),
       .cpu_dump_i(rv_core_ibex_crash_dump),
       .sw_rst_req_o(rstmgr_aon_sw_rst_req),

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -610,9 +610,6 @@
       // spi passthrough connection
       'spi_device.passthrough'     : ['spi_host0.passthrough']
 
-      // Debug module reset request to reset manager
-      'rv_dm.ndmreset_req' : ['rstmgr_aon.ndmreset_req']
-
       // Reset manager software reset request to pwrmgr
       'rstmgr_aon.sw_rst_req' : ['pwrmgr_aon.sw_rst_req'],
     }

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -24,7 +24,6 @@
 
 RSTMGR_RESET_INFO_CHECK(Por, INFO_POR);
 RSTMGR_RESET_INFO_CHECK(LowPowerExit, INFO_LOW_POWER_EXIT);
-RSTMGR_RESET_INFO_CHECK(Ndm, INFO_NDM_RESET);
 
 static_assert(kDifRstmgrResetInfoHwReq == (RSTMGR_RESET_INFO_HW_REQ_MASK
                                            << RSTMGR_RESET_INFO_HW_REQ_OFFSET),

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -75,34 +75,34 @@ typedef enum dif_rstmgr_reset_info {
    */
   kDifRstmgrResetInfoLowPowerExit = (0x1 << 1),
   /**
-   * Device has reset due to non-debug-module request.
-   */
-  kDifRstmgrResetInfoNdm = (0x1 << 2),
-  /**
    * Device has reset due to software request.
    */
-  kDifRstmgrResetInfoSw = (0x1 << 3),
+  kDifRstmgrResetInfoSw = (0x1 << 2),
   /**
    * Device has reset due to a peripheral request. This can be an alert
    * escalation, watchdog or anything else.
    */
-  kDifRstmgrResetInfoHwReq = (0x1f << 4),
+  kDifRstmgrResetInfoHwReq = (0x1f << 3),
   /**
    * Device has reset due to the peripheral system reset control request.
    */
-  kDifRstmgrResetInfoSysRstCtrl = (0x1 << 4),
+  kDifRstmgrResetInfoSysRstCtrl = (1 << 3),
   /**
    * Device has reset due to watchdog bite.
    */
-  kDifRstmgrResetInfoWatchdog = (1 << 5),
+  kDifRstmgrResetInfoWatchdog = (1 << 4),
   /**
    * Device has reset due to power unstable.
    */
-  kDifRstmgrResetInfoPowerUnstable = (1 << 6),
+  kDifRstmgrResetInfoPowerUnstable = (1 << 5),
   /**
    * Device has reset due to alert escalation.
    */
-  kDifRstmgrResetInfoEscalation = (1 << 7),
+  kDifRstmgrResetInfoEscalation = (1 << 6),
+  /**
+   * Device has reset due to non-debug-module request.
+   */
+  kDifRstmgrResetInfoNdm = (1 << 7),
 } dif_rstmgr_reset_info_t;
 
 /**

--- a/sw/device/lib/dif/dif_rstmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_rstmgr_unittest.cc
@@ -111,13 +111,12 @@ class ResetCausesGetTest : public RstmgrTest {
 
     // Number of reset reasons between test and the peripheral match at the
     // time of writing this test.
-    EXPECT_EQ(reset_info_reasons_.size(), 4);
+    EXPECT_EQ(reset_info_reasons_.size(), 3);
   }
 
   const std::vector<bitfield_field32_t> reset_info_reasons_{
       bitfield_bit32_to_field32(RSTMGR_RESET_INFO_POR_BIT),
       bitfield_bit32_to_field32(RSTMGR_RESET_INFO_LOW_POWER_EXIT_BIT),
-      bitfield_bit32_to_field32(RSTMGR_RESET_INFO_NDM_RESET_BIT),
       RSTMGR_RESET_INFO_HW_REQ_FIELD,
   };
 };

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.c
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.c
@@ -46,7 +46,6 @@ uint32_t rstmgr_reason_get(void) {
   REASON_ASSERT(kRstmgrReasonPowerOn, RSTMGR_RESET_INFO_POR_BIT);
   REASON_ASSERT(kRstmgrReasonLowPowerExit,
                 RSTMGR_RESET_INFO_LOW_POWER_EXIT_BIT);
-  REASON_ASSERT(kRstmgrReasonNonDebugModule, RSTMGR_RESET_INFO_NDM_RESET_BIT);
   REASON_ASSERT(kRstmgrReasonSysrstCtrl,
                 RSTMGR_RESET_INFO_HW_REQ_OFFSET +
                     kTopEarlgreyPowerManagerResetRequestsSysrstCtrlAonRstReq);

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.h
@@ -46,27 +46,26 @@ typedef enum rstmgr_reason {
   kRstmgrReasonLowPowerExit = 1,
 
   /**
-   * Non-debug module (NDM).
-   */
-  kRstmgrReasonNonDebugModule = 2,
-
-  /**
    * Software issued request (SW).
    */
-  kRstmgrReasonSoftwareRequest = 3,
+  kRstmgrReasonSoftwareRequest = 2,
 
   /**
    * Hardware requests (HW_REQ).
    */
-  kRstmgrReasonSysrstCtrl = 4,
-  kRstmgrReasonWatchdog = 5,
-  kRstmgrReasonPowerUnstable = 6,
-  kRstmgrReasonEscalation = 7,
+  kRstmgrReasonSysrstCtrl = 3,
+  kRstmgrReasonWatchdog = 4,
+  kRstmgrReasonPowerUnstable = 5,
+  kRstmgrReasonEscalation = 6,
+  /**
+   * Non-debug module (NDM).
+   */
+  kRstmgrReasonNonDebugModule = 7,
 
   /**
    * Last used bit index (inclusive).
    */
-  kRstmgrReasonLast = 8,
+  kRstmgrReasonLast = 7,
 } rstmgr_reason_t;
 
 /**

--- a/sw/device/tests/sim_dv/rv_dm_ndm_reset_req.c
+++ b/sw/device/tests/sim_dv/rv_dm_ndm_reset_req.c
@@ -93,7 +93,6 @@ static dif_keymgr_t keymgr;
 enum {
   OTP_CTRL,
   PINMUX,
-  SRAM_CTRL_RET,
   ADC_CTRL,
   SYSRST_CTRL,
   KEYMGR,
@@ -107,7 +106,7 @@ static test_register_t kReg[] = {
             .base = TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR,
             .offset = OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET,
             .write_val = 0x06092022,
-            .exp_read_val = 0x06092022,
+            .exp_read_val = OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_RESVAL,
         },
     [PINMUX] =
         {
@@ -115,17 +114,8 @@ static test_register_t kReg[] = {
             .base = TOP_EARLGREY_PINMUX_AON_BASE_ADDR,
             .offset = PINMUX_WKUP_DETECTOR_CNT_TH_1_REG_OFFSET,
             .write_val = 0x44,
-            .exp_read_val = 0x44,
+            .exp_read_val = PINMUX_WKUP_DETECTOR_CNT_TH_1_REG_RESVAL,
 
-        },
-    [SRAM_CTRL_RET] =
-        {
-            .name = "SRAM_CTRL_RET",
-            .base = TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR,
-            .offset =
-                8 * sizeof(uint32_t), /* Random location of retention ram */
-            .write_val = 0xddAA55bb,
-            .exp_read_val = 0xddAA55bb,
         },
     [ADC_CTRL] =
         {
@@ -133,7 +123,7 @@ static test_register_t kReg[] = {
             .base = TOP_EARLGREY_ADC_CTRL_AON_BASE_ADDR,
             .offset = ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET,
             .write_val = 0x37,
-            .exp_read_val = 0x9b,
+            .exp_read_val = ADC_CTRL_ADC_SAMPLE_CTL_REG_RESVAL,
 
         },
     [SYSRST_CTRL] =
@@ -142,7 +132,7 @@ static test_register_t kReg[] = {
             .base = TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR,
             .offset = SYSRST_CTRL_EC_RST_CTL_REG_OFFSET,
             .write_val = 0x567,
-            .exp_read_val = 0x7d0,
+            .exp_read_val = SYSRST_CTRL_EC_RST_CTL_REG_RESVAL,
 
         },
     [KEYMGR] =
@@ -151,7 +141,7 @@ static test_register_t kReg[] = {
             .base = TOP_EARLGREY_KEYMGR_BASE_ADDR,
             .offset = KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET,
             .write_val = 0x1600ABBA,
-            .exp_read_val = 0x0,
+            .exp_read_val = KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_RESVAL,
 
         },
     [FLASH_CTRL] =
@@ -160,7 +150,7 @@ static test_register_t kReg[] = {
             .base = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR,
             .offset = FLASH_CTRL_SCRATCH_REG_OFFSET,
             .write_val = 0x3927,
-            .exp_read_val = 0x0,
+            .exp_read_val = FLASH_CTRL_SCRATCH_REG_RESVAL,
         },
 };
 


### PR DESCRIPTION
- minor fixes on `pwrmgr` side.
- updated reset reason information, since `ndm reset` is now treated like a hardware reset.
- related software and test updates. 

This PR is not complete, and needs to be combined with #15998.  Hopefully this one is enough to pass CI standalone right now, and we can do the merge separately. 