### PR TITLE
[spi_host] Bug fix for spi_host_speed

### DIFF
--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -22,7 +22,7 @@ class spi_device_driver extends spi_driver;
   `uvm_component_utils(spi_device_driver)
   `uvm_component_new
 
-  bit [CSB_WIDTH-1:0] active_csb;
+  bit [CSB_WIDTH-1:0] active_csb = 0;
 
   virtual task reset_signals();
     forever begin
@@ -43,7 +43,6 @@ class spi_device_driver extends spi_driver;
       seq_item_port.get_next_item(req);
       `DV_CHECK_EQ(cfg.vif.disconnected, 0)
 
-      active_csb = req.csb_sel;
       $cast(rsp, req.clone());
       rsp.set_id_info(req);
       // The response should read the payload actually consumed, not start with

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -198,7 +198,7 @@ class spi_monitor extends dv_base_monitor#(
           `uvm_info(`gfn, $sformatf("spi_monitor: cmdtmp \n%0h", cmdtmp), UVM_DEBUG)
         end
         cmd_byte++;
-        if (cmd_byte == cfg.num_bytes_per_trans_in_mon)begin
+        if (cmd_byte == cfg.spi_cmd_width)begin
           cmd = cmdtmp;
           `uvm_info(`gfn, $sformatf("spi_monitor: cmd \n%0h", cmd), UVM_DEBUG)
         end

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -299,6 +299,8 @@ class spi_host_base_vseq extends cip_base_vseq #(
     cfg.m_spi_agent_cfg.csid              = spi_host_ctrl_reg.csid;
     cfg.m_spi_agent_cfg.spi_mode          = spi_host_command_reg.mode;
     cfg.m_spi_agent_cfg.decode_commands   = 1'b1;
+    cfg.m_spi_agent_cfg.vif.sck_polarity  = spi_config_regs.cpol[0];
+    cfg.m_spi_agent_cfg.vif.sck_phase     = spi_config_regs.cpha[0];
     print_spi_host_regs();
   endfunction : update_spi_agent_regs
 

--- a/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
@@ -59,9 +59,6 @@ class spi_host_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_host_reg_block));
     m_spi_agent_cfg.byte_order = SPI_HOST_BYTEORDER;
     // make spi behave as realistic spi. (set to 1 byte per transaction)
     m_spi_agent_cfg.num_bytes_per_trans_in_mon = 1;
-    // set the number of bytes in first segment
-    // needed for the agent to know when to take control of the bus
-    m_spi_agent_cfg.spi_cmd_width = num_cmd_bytes;
     // create the seq_cfg
     seq_cfg = spi_host_seq_cfg::type_id::create("seq_cfg");
 

--- a/hw/ip/spi_host/dv/tb.sv
+++ b/hw/ip/spi_host/dv/tb.sv
@@ -99,7 +99,8 @@ module tb;
   for (genvar i = 0; i < 4; i++) begin : gen_tri_state
     pullup (weak1) pd_in_i (si_pulldown[i]);
     pullup (weak1) pd_out_i (so_pulldown[i]);
-    assign spi_if.sio[i]  = (cio_sd_en_o[i]) ? cio_sd_o[i] : so_pulldown[i];
+    assign spi_if.sio[i]  = (cio_sd_en_o[i]) ? cio_sd_o[i] : 'z;
+    assign (highz0, pull1) spi_if.sio[i] = !cio_sd_en_o[i];
     assign si_pulldown[i] = spi_if.sio[i];
 
     assign spi_if.csb[i] = (i < NumCS && cio_csb_en_o[i]) ? cio_csb_o[i] : 1'b1;


### PR DESCRIPTION
spi_host_speed regression tests are failing for a long time with a zero pass rate. This PR includes 3 commits / fixes and increases pass rate to 100%.

In spi_monitor.sv, cmd value gets updated after first byte transmitted during command segment. But it should be updated at the end of the segment. First commit fixes that.

spi_host_speed test fails when a weak pull-up and an assign to zero concur, the signal becomes `x`. Second commit fixes that.

sck_polarity and sck_phase in vif do not have the correct value and this leads to sampling data on wrong edge of sck. Third commit fixes this error.

Fourth commit fixes drive conflict when spi_agent responsing read requests.

Signed-off-by: Abdullah Varici <abdullah.varici@lowrisc.org>