### PR TITLE
[top-level] Enable csrng_edn_concurrency_test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2307,7 +2307,8 @@
             X'ref'ed with each IP test that requsts entropy from EDN.
             '''
       stage: V2
-      tests: ["chip_sw_edn_entropy_reqs"]
+      tests: ["chip_sw_edn_entropy_reqs",
+              "chip_sw_csrng_edn_concurrency"]
     }
 
     // KEYMGR (pre-verified IP) integration tests:

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -629,13 +629,8 @@ opentitan_functest(
 opentitan_functest(
     name = "csrng_edn_concurrency_test",
     srcs = ["csrng_edn_concurrency_test.c"],
-    cw310 = cw310_params(
-        # FIXME #15980 Re-enable after EDN fatal alert is fixed.
-        tags = ["broken"],
-    ),
     verilator = verilator_params(
-        timeout = "long",
-        tags = ["broken"],
+        timeout = "eternal",
     ),
     deps = [
         ":otbn_randomness_impl",


### PR DESCRIPTION
* Removes broken tag from FPGA and Verilator targets after #16011.
* Maps test to test point in the chip level test plan.