### PR TITLE
[CI] Increase the timeout of the FPGA jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -518,7 +518,7 @@ jobs:
 - job: execute_test_rom_fpga_tests_cw310
   displayName: CW310 Test ROM Tests
   pool: FPGA
-  timeoutInMinutes: 45
+  timeoutInMinutes: 75
   dependsOn:
     - chip_earlgrey_cw310
     - sw_build
@@ -540,7 +540,7 @@ jobs:
 - job: execute_rom_fpga_tests_cw310
   displayName: CW310 ROM Tests
   pool: FPGA
-  timeoutInMinutes: 45
+  timeoutInMinutes: 75
   dependsOn:
     - chip_earlgrey_cw310
     - sw_build


### PR DESCRIPTION
We've seen FPGA jobs failing due to timeout.
As a temporary solution, until we figure out the correct solution, increasing jobs timeout should stop those errors.