### PR TITLE
[bazel/manifest] Pass manifest attrs as strings

### DIFF
--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -51,7 +51,7 @@ def _manifest_impl(ctx):
     if ctx.attr.binding_value:
         if len(ctx.attr.binding_value) != 8:
             fail("The binding_value must be exactly 8 words.")
-        mf["binding_value"] = _hex(ctx.attr.binding_value)
+        mf["binding_value"] = [_hex(v) for v in ctx.attr.binding_value]
 
     # The selector_bits are set based on the values of the usage_constraints.
     uc = {}

--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -10,6 +10,9 @@ _SEL_MANUF_STATE_OWNER = (1 << 9)
 _SEL_LIFE_CYCLE_STATE = (1 << 10)
 
 def _hex(v):
+    """Expects v to be an int or a hex-encoded string."""
+    if type(v) == "string":
+        v = int(v, base = 16)
     return "0x{}".format(hex(v))
 
 def _manifest_impl(ctx):
@@ -93,7 +96,7 @@ def _manifest_impl(ctx):
     if ctx.attr.selector_bits:
         # If they don't match, fail unless explicitly permitted to set a
         # bad value.
-        if ctx.attr.selector_bits != selector_bits and ctx.attr.selector_mismatch_is_failure:
+        if int(ctx.attr.selector_bits, base = 16) != selector_bits and ctx.attr.selector_mismatch_is_failure:
             fail("User provided selector_bits don't match computed selector_bits")
         uc["selector_bits"] = _hex(ctx.attr.selector_bits)
     else:
@@ -110,27 +113,28 @@ def _manifest_impl(ctx):
 
 _manifest = rule(
     implementation = _manifest_impl,
+    # Manifest attrs are supplied as strings due to Bazel limiting int types to 32-bit signed integers
     attrs = {
         "signature": attr.string(doc = "Image signature as a hex-encoded string"),
         "modulus": attr.string(doc = "Signing key modulus as a hex-encoded string"),
-        "selector_bits": attr.int(doc = "Usage constraint selector bits"),
+        "selector_bits": attr.string(doc = "Usage constraint selector bits as a hex-encoded string"),
         "selector_mismatch_is_failure": attr.bool(default = True, doc = "A mismatch in computed selector bits is a failure"),
-        "device_id": attr.int_list(doc = "Usage constraint device ID"),
-        "manuf_state_creator": attr.int(doc = "Usage constraint for silicon creator manufacturing status"),
-        "manuf_state_owner": attr.int(doc = "Usage constraint for silicon owner manufacturing status"),
-        "life_cycle_state": attr.int(doc = "Usage constraint for life cycle status"),
-        "address_translation": attr.int(doc = "Whether this image uses address translation"),
-        "identifier": attr.int(doc = "Manifest identifier"),
-        "length": attr.int(doc = "Length of this image"),
-        "version_major": attr.int(doc = "Image major version"),
-        "version_minor": attr.int(doc = "Image minor version"),
-        "security_version": attr.int(doc = "Security version for anti-rollback protection"),
-        "timestamp": attr.int(doc = "Unix timestamp of the image"),
-        "binding_value": attr.int_list(doc = "Binding value used by key manager to derive secrets"),
-        "max_key_version": attr.int(doc = "Maximum allowed version for keys generated at the next boot stage"),
-        "code_start": attr.int(doc = "Start offset of the executable region in the image"),
-        "code_end": attr.int(doc = "End offset of the executable region in the image"),
-        "entry_point": attr.int(doc = "Offset of the first instruction in the image"),
+        "device_id": attr.string_list(doc = "Usage constraint device ID as a hex-encoded string"),
+        "manuf_state_creator": attr.string(doc = "Usage constraint for silicon creator manufacturing status as a hex-encoded string"),
+        "manuf_state_owner": attr.string(doc = "Usage constraint for silicon owner manufacturing status as a hex-encoded string"),
+        "life_cycle_state": attr.string(doc = "Usage constraint for life cycle status as a hex-encoded string"),
+        "address_translation": attr.string(doc = "Whether this image uses address translation as a hex-encoded string"),
+        "identifier": attr.string(doc = "Manifest identifier as a hex-encoded string"),
+        "length": attr.string(doc = "Length of this image as a hex-encoded string"),
+        "version_major": attr.string(doc = "Image major version as a hex-encoded string"),
+        "version_minor": attr.string(doc = "Image minor version as a hex-encoded string"),
+        "security_version": attr.string(doc = "Security version for anti-rollback protection as a hex-encoded string"),
+        "timestamp": attr.string(doc = "Unix timestamp of the image as a hex-encoded string"),
+        "binding_value": attr.string_list(doc = "Binding value used by key manager to derive secrets as a hex-encoded string"),
+        "max_key_version": attr.string(doc = "Maximum allowed version for keys generated at the next boot stage as a hex-encoded string"),
+        "code_start": attr.string(doc = "Start offset of the executable region in the image as a hex-encoded string"),
+        "code_end": attr.string(doc = "End offset of the executable region in the image as a hex-encoded string"),
+        "entry_point": attr.string(doc = "Offset of the first instruction in the image as a hex-encoded string"),
     },
 )
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -468,8 +468,8 @@ opentitan_functest(
 
 manifest({
     "name": "manifest_bad_identifier",
-    "address_translation": CONST.FALSE,
-    "identifier": 0,
+    "address_translation": hex(CONST.FALSE),
+    "identifier": "0",
 })
 
 [opentitan_functest(
@@ -503,9 +503,9 @@ SEC_VERS = [
 
 [manifest({
     "name": "manifest_sec_ver_{}".format(sec_ver),
-    "address_translation": CONST.FALSE,
-    "identifier": CONST.ROM_EXT,
-    "security_version": sec_ver,
+    "address_translation": hex(CONST.FALSE),
+    "identifier": hex(CONST.ROM_EXT),
+    "security_version": hex(sec_ver),
 }) for sec_ver in SEC_VERS]
 
 [opentitan_flash_binary(
@@ -830,23 +830,23 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
     {
         "name": "bad_identifier",
         "manifest": {
-            "identifier": 0,
+            "identifier": "0",
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER)),
     },
     {
         "name": "too_small",
         "manifest": {
-            "identifier": CONST.ROM_EXT,
-            "length": CONST.ROM_EXT_SIZE_MIN - 1,
+            "identifier": hex(CONST.ROM_EXT),
+            "length": hex(CONST.ROM_EXT_SIZE_MIN - 1),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.BOOT_POLICY.BAD_LENGTH)),
     },
     {
         "name": "too_large",
         "manifest": {
-            "identifier": CONST.ROM_EXT,
-            "length": CONST.ROM_EXT_SIZE_MAX + 1,
+            "identifier": hex(CONST.ROM_EXT),
+            "length": hex(CONST.ROM_EXT_SIZE_MAX + 1),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.BOOT_POLICY.BAD_LENGTH)),
     },
@@ -854,90 +854,90 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
         "name": "empty_code",
         "manifest": {
             # Note: `length` is filled automatically unless overriden here.
-            "identifier": CONST.ROM_EXT,
-            "code_start": CONST.MANIFEST_SIZE + 12,
-            "code_end": CONST.MANIFEST_SIZE + 12,
+            "identifier": hex(CONST.ROM_EXT),
+            "code_start": hex(CONST.MANIFEST_SIZE + 12),
+            "code_end": hex(CONST.MANIFEST_SIZE + 12),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
     },
     {
         "name": "code_in_manifest",
         "manifest": {
-            "identifier": CONST.ROM_EXT,
-            "code_start": CONST.MANIFEST_SIZE - 4,
-            "code_end": CONST.MANIFEST_SIZE + 12,
-            "entry_point": CONST.MANIFEST_SIZE + 8,
+            "identifier": hex(CONST.ROM_EXT),
+            "code_start": hex(CONST.MANIFEST_SIZE - 4),
+            "code_end": hex(CONST.MANIFEST_SIZE + 12),
+            "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
     },
     {
         "name": "code_outside_image",
         "manifest": {
-            "identifier": CONST.ROM_EXT,
-            "code_start": CONST.ROM_EXT_SIZE_MAX,
-            "code_end": CONST.MANIFEST_SIZE + 12,
-            "entry_point": CONST.MANIFEST_SIZE + 8,
+            "identifier": hex(CONST.ROM_EXT),
+            "code_start": hex(CONST.ROM_EXT_SIZE_MAX),
+            "code_end": hex(CONST.MANIFEST_SIZE + 12),
+            "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
     },
     {
         "name": "code_start_unaligned",
         "manifest": {
-            "identifier": CONST.ROM_EXT,
-            "code_start": CONST.MANIFEST_SIZE + 6,
-            "code_end": CONST.MANIFEST_SIZE + 12,
-            "entry_point": CONST.MANIFEST_SIZE + 8,
+            "identifier": hex(CONST.ROM_EXT),
+            "code_start": hex(CONST.MANIFEST_SIZE + 6),
+            "code_end": hex(CONST.MANIFEST_SIZE + 12),
+            "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
     },
     {
         "name": "code_end_unaligned",
         "manifest": {
-            "identifier": CONST.ROM_EXT,
-            "code_start": CONST.MANIFEST_SIZE + 8,
-            "code_end": CONST.MANIFEST_SIZE + 10,
-            "entry_point": CONST.MANIFEST_SIZE + 8,
+            "identifier": hex(CONST.ROM_EXT),
+            "code_start": hex(CONST.MANIFEST_SIZE + 8),
+            "code_end": hex(CONST.MANIFEST_SIZE + 10),
+            "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
     },
     {
         "name": "entry_before_code_start",
         "manifest": {
-            "identifier": CONST.ROM_EXT,
-            "code_start": CONST.MANIFEST_SIZE + 8,
-            "code_end": CONST.MANIFEST_SIZE + 12,
-            "entry_point": CONST.MANIFEST_SIZE + 4,
+            "identifier": hex(CONST.ROM_EXT),
+            "code_start": hex(CONST.MANIFEST_SIZE + 8),
+            "code_end": hex(CONST.MANIFEST_SIZE + 12),
+            "entry_point": hex(CONST.MANIFEST_SIZE + 4),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
     },
     {
         "name": "entry_at_code_end",
         "manifest": {
-            "identifier": CONST.ROM_EXT,
-            "code_start": CONST.MANIFEST_SIZE + 8,
-            "code_end": CONST.MANIFEST_SIZE + 12,
-            "entry_point": CONST.MANIFEST_SIZE + 12,
+            "identifier": hex(CONST.ROM_EXT),
+            "code_start": hex(CONST.MANIFEST_SIZE + 8),
+            "code_end": hex(CONST.MANIFEST_SIZE + 12),
+            "entry_point": hex(CONST.MANIFEST_SIZE + 12),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
     },
     {
         "name": "entry_unaligned",
         "manifest": {
-            "identifier": CONST.ROM_EXT,
-            "code_start": CONST.MANIFEST_SIZE + 8,
-            "code_end": CONST.MANIFEST_SIZE + 12,
-            "entry_point": CONST.MANIFEST_SIZE + 10,
+            "identifier": hex(CONST.ROM_EXT),
+            "code_start": hex(CONST.MANIFEST_SIZE + 8),
+            "code_end": hex(CONST.MANIFEST_SIZE + 12),
+            "entry_point": hex(CONST.MANIFEST_SIZE + 10),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
     },
     {
         "name": "rollback",
         "manifest": {
-            "identifier": CONST.ROM_EXT,
-            "code_start": CONST.MANIFEST_SIZE + 8,
-            "code_end": CONST.MANIFEST_SIZE + 12,
-            "entry_point": CONST.MANIFEST_SIZE + 8,
-            "security_version": 0,
+            "identifier": hex(CONST.ROM_EXT),
+            "code_start": hex(CONST.MANIFEST_SIZE + 8),
+            "code_end": hex(CONST.MANIFEST_SIZE + 12),
+            "entry_point": hex(CONST.MANIFEST_SIZE + 8),
+            "security_version": "0",
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.BOOT_POLICY.ROLLBACK)),
         "sec_ver": 1,

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:const.bzl", "CONST")
+load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
 load("//rules:opentitan.bzl", "opentitan_flash_binary")
 load("//rules:linker.bzl", "ld_library")
@@ -142,15 +142,15 @@ cc_library(
 
 manifest({
     "name": "manifest_standard",
-    "address_translation": CONST.FALSE,
-    "identifier": CONST.ROM_EXT,
+    "address_translation": hex(CONST.FALSE),
+    "identifier": hex(CONST.ROM_EXT),
     "visibility": ["//visibility:public"],
 })
 
 manifest({
     "name": "manifest_virtual",
-    "address_translation": CONST.TRUE,
-    "identifier": CONST.ROM_EXT,
+    "address_translation": hex(CONST.TRUE),
+    "identifier": hex(CONST.ROM_EXT),
 })
 
 opentitan_flash_binary(
@@ -194,8 +194,8 @@ opentitan_flash_binary(
 
 manifest({
     "name": "manifest_bad_address_translation",
-    "address_translation": 0,
-    "identifier": CONST.ROM_EXT,
+    "address_translation": "0",
+    "identifier": hex(CONST.ROM_EXT),
 })
 
 opentitan_flash_binary(

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:const.bzl", "CONST")
+load("//rules:const.bzl", "CONST", "hex")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:manifest.bzl", "manifest")
 load(
@@ -65,14 +65,14 @@ cc_library(
 
 manifest({
     "name": "manifest_standard",
-    "address_translation": CONST.FALSE,
-    "identifier": CONST.OWNER,
+    "address_translation": hex(CONST.FALSE),
+    "identifier": hex(CONST.OWNER),
 })
 
 manifest({
     "name": "manifest_virtual",
-    "address_translation": CONST.TRUE,
-    "identifier": CONST.OWNER,
+    "address_translation": hex(CONST.TRUE),
+    "identifier": hex(CONST.OWNER),
 })
 
 opentitan_flash_binary(


### PR DESCRIPTION
Bazel only supports passing 32-bit signed integers as attrs into rules. However, most manifest fields are uint32_t. This PR changes the manifest rule to accept hex-encoded strings instead.

Another option is to do something similar to what we do in the OTP and serialize a dictionary to pass in all the parameters.