### PR TITLE
[chip dv] Fix chip_sw_rom_ctrl_integrity_check test

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
@@ -69,7 +69,7 @@ endfunction
 
 
 virtual function void rom_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1:0] addr,
-                                                logic [31:0]                       data,
+                                                logic [38:0]                       data,
                                                 logic [SRAM_KEY_WIDTH-1:0]         key,
                                                 logic [SRAM_BLOCK_WIDTH-1:0]       nonce,
                                                 bit                                scramble_data,
@@ -94,7 +94,7 @@ virtual function void rom_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1:
   // Calculate the scrambled address
   scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(rom_addr, addr_width, nonce_arr);
 
-  if(scramble_data) begin
+  if (scramble_data) begin
     // Calculate the integrity constant
     integ_data = prim_secded_pkg::prim_secded_inv_39_32_enc(data);
 

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -620,7 +620,9 @@ interface chip_if;
   clk_rst_if io_div4_clk_rst_if(.clk(io_div4_clk), .rst_n(io_div4_rst_n));
 
   wire pwrmgr_low_power = `PWRMGR_HIER.low_power_o;
-  wire rom_ctrl_done = `PWRMGR_HIER.rom_ctrl_i.done;
+
+  wire rom_ctrl_done = `PWRMGR_HIER.rom_ctrl_i.done == prim_mubi_pkg::MuBi4True;
+  wire rom_ctrl_good = `PWRMGR_HIER.rom_ctrl_i.good == prim_mubi_pkg::MuBi4True;
 
   // alert_esc_if alert_if[NUM_ALERTS](.clk  (`ALERT_HANDLER_HIER.clk_i),
   //                                   .rst_n(`ALERT_HANDLER_HIER.rst_ni));

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
@@ -4,67 +4,84 @@
 
 class chip_sw_rom_ctrl_integrity_check_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_rom_ctrl_integrity_check_vseq)
-
   `uvm_object_new
 
-  localparam uint TimeoutNs = 1_000_000;  // 1ms
+  localparam uint TimeoutNs = 5_000_000;  // 5ms
 
-  // Overwrite the last expected digest word in the ROM which is
-  // sufficient to cause an integrity failure.
-  virtual task rom_digest_overwrite();
-    int retval;
-    string rom_nonce_hdl_path = "tb.dut.top_earlgrey.u_rom_ctrl.RndCnstScrNonce";
-    bit [sram_scrambler_pkg::SRAM_BLOCK_WIDTH-1:0] rom_nonce;
-    uint32_t addr = (cfg.mem_bkdr_util_h[Rom].get_depth() * 4) - 4;  // digest at last ROM location.
+  bit rom_ctrl_done_checker_stop;
 
-    // Get ROM nonce directly from rom_ctrl instance rather
-    // than using a hard coded value.
-    retval = uvm_hdl_check_path(rom_nonce_hdl_path);
-    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
-                       "Hierarchical path %0s appears to be invalid.", rom_nonce_hdl_path))
-    retval = uvm_hdl_read(rom_nonce_hdl_path, rom_nonce);
-    `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", rom_nonce_hdl_path))
-
-    // Write to ROM at last digest location with random data (which can be unscrambled).
-    cfg.mem_bkdr_util_h[Rom].rom_encrypt_write32_integ(
-        addr, $urandom(), sram_scrambler_pkg::SRAM_KEY_WIDTH'('b0), rom_nonce, 1'b0);
+  virtual task pre_start();
+    rom_ctrl_done_checker();
+    super.pre_start();
   endtask
 
-  virtual task test_state_monitor();
-    // wait for the test to boot and issue the WFI status
+  virtual task cpu_init();
+    super.cpu_init();
+    corrupt_rom_image();
+  endtask
+
+  virtual task body();
+    super.body();
+
+    // Wait for the test to boot and reach WFI.
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
 
-    // update the lc state to a production state and do a reset
+    // Update the lc state to a production state and reboot the chip.
     cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(lc_ctrl_state_pkg::LcStProd);
     apply_reset();
 
-    // At this point, a successful boot would be an error. We will start a
-    // parallel timeout thread which will be expected to complete as the boot
-    // process should be locked up.
-    fork
-      begin
-        `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
-        `uvm_error(`gfn, "Unexpected successful boot in PROD LC_STATE.")
-      end
-      begin
-        #(TimeoutNs * 1ns);
-        override_test_status_and_finish(.passed(1'b 1));
-      end
-    join_any
-    disable fork;
+    // At this point, a successful boot would be an error. We will start a parallel timeout thread
+    // which will be expected to complete as the boot process should be locked up.
+    `DV_WAIT(cfg.chip_vif.rom_ctrl_done)
+    `DV_SPINWAIT_EXIT(
+      // ~wait~ condition.
+      #(TimeoutNs * 1ns);,
+      // ~exit~ condition.
+      wait (cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+      `uvm_error(`gfn, "CPU unexpectedly booted and reached the ROM stage")
+    )
+    rom_ctrl_done_checker_stop = 1'b1;
+    override_test_status_and_finish(.passed(1'b1));
   endtask
 
-  // The test will do the standard setup and then overwrite the
-  // expected ROM digest via the backdoor which is a condition
-  // that when in non production LC state (the default) should still boot.
-  // We then launch a task to monitor the test state and make changes
-  // following the successful boot to change the lc state to a production
-  // state then do a reset after which it should be expected not to boot.
-  virtual task body();
-    super.body();
-    rom_digest_overwrite();
-    test_state_monitor();
+  // ROM ctrl should always report a not-good image for this test.
+  //
+  // This non-blocking task spawns off a thread that can be disabled using the
+  // rom_ctrl_done_checker_stop bit.
+  virtual task rom_ctrl_done_checker();
+    fork
+      forever @(cfg.chip_vif.rom_ctrl_done or rom_ctrl_done_checker_stop) begin
+        if (rom_ctrl_done_checker_stop) break;
+        if (cfg.chip_vif.rom_ctrl_done) begin
+          `DV_CHECK(!cfg.chip_vif.rom_ctrl_good)
+        end
+      end
+    join_none
   endtask
+
+  // Corrupt the preloaded ROM image by flipping a single bit in the digest portion.
+  virtual function void corrupt_rom_image();
+    bit [bus_params_pkg::BUS_AW-1:0]                addr;
+    bit [38:0]                                      data;
+    bit [38:0]                                      flip_bit;
+    bit [sram_scrambler_pkg::SRAM_BLOCK_WIDTH-1:0]  nonce;
+    bit [sram_scrambler_pkg::SRAM_KEY_WIDTH-1:0]    key;
+
+    // Pick any random addr and corrupt a single bit. We limit the addr selection to the digest
+    // portion, since we need the ROM code to execute properly to completion in the first phase of
+    // the test. The upper 32 bytes of the ROM is reserved for storing the digest.
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(
+        addr,
+        addr inside {[cfg.mem_bkdr_util_h[Rom].get_size_bytes()-32:
+                      cfg.mem_bkdr_util_h[Rom].get_size_bytes()-1]};
+        (addr % cfg.mem_bkdr_util_h[Rom].get_bytes_per_word()) == 0;
+    )
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flip_bit, $onehot(flip_bit);)
+    nonce = top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrNonce;
+    key = top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrKey;
+    data = cfg.mem_bkdr_util_h[Rom].rom_encrypt_read32(addr, key, nonce, 0) ^ flip_bit;
+    cfg.mem_bkdr_util_h[Rom].rom_encrypt_write32_integ(addr, data, key, nonce, 0);
+  endfunction
 
 endclass : chip_sw_rom_ctrl_integrity_check_vseq

--- a/sw/device/tests/sim_dv/rom_ctrl_integrity_check_test.c
+++ b/sw/device/tests/sim_dv/rom_ctrl_integrity_check_test.c
@@ -46,10 +46,8 @@ bool test_main(void) {
   dif_rom_ctrl_digest_t expected_digest;
   CHECK_DIF_OK(dif_rom_ctrl_get_digest(&rom_ctrl, &computed_digest));
   CHECK_DIF_OK(dif_rom_ctrl_get_expected_digest(&rom_ctrl, &expected_digest));
-  CHECK(expected_digest.digest[ROM_CTRL_DIGEST_MULTIREG_COUNT - 1] !=
-            computed_digest.digest[ROM_CTRL_DIGEST_MULTIREG_COUNT - 1],
-        "Expected and computed digests match. Digests = %08x",
-        expected_digest.digest[ROM_CTRL_DIGEST_MULTIREG_COUNT - 1]);
+  CHECK_ARRAYS_NE(expected_digest.digest, computed_digest.digest,
+                  ROM_CTRL_DIGEST_MULTIREG_COUNT);
 
   // set test_status to wfi and call wait_for_interrupt to make
   // the cpu idle, the testbench sequence will wait for this test


### PR DESCRIPTION
- Check rom_ctrl is reporting bad intg with an internal probe
- Pick a digest addr randomly to indroduce corruption, rather the only the last digest word.
- Corrupt the digest with only a single bit-flip in the digest word, including the integrity bits, rather than corrupting the whole word.
- In the second phase of the test, wait for the ROM operation to be completed first (this is the main issue described in #16013).

Fixed #16013.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>