### PR TITLE
[keymgr/dv] Test fsm_consistency

### DIFF
--- a/hw/ip/keymgr/data/keymgr_sec_cm_testplan.hjson
+++ b/hw/ip/keymgr/data/keymgr_sec_cm_testplan.hjson
@@ -109,9 +109,14 @@
     }
     {
       name: sec_cm_ctrl_fsm_consistency
-      desc: "Verify the countermeasure(s) CTRL.FSM.CONSISTENCY."
+      desc: '''Verify the countermeasure(s) CTRL.FSM.CONSISTENCY.
+
+            - Set `ral.control_shadowed` to OpDisable, so that no Advance or Generate operation
+             is selected.
+            - Force internal `tb.dut.u_ctrl.adv_en_o` or `tb.dut.u_ctrl.gen_en_o` to 1.
+            - Check the fatal alert is triggered and `fault_status.ctrl_fsm_chk` is set.'''
       stage: V2S
-      tests: []
+      tests: ["keymgr_sec_cm"]
     }
     {
       name: sec_cm_ctrl_fsm_global_esc

--- a/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
@@ -59,6 +59,7 @@ package keymgr_env_pkg;
   typedef enum int {
     FaultOpNotOnehot,
     FaultOpNotConsistent,
+    FaultOpNotExist,
     FaultKmacDoneError,
     FaultSideloadNotConsistent,
     FaultKeyIntgError


### PR DESCRIPTION
Test one more custom countermeasure
 - Set `ral.control_shadowed` to OpDisable, so that no Advance or Generate operation is selected.
 - Force internal `tb.dut.u_ctrl.adv_en_o` or `tb.dut.u_ctrl.gen_en_o` to 1

Signed-off-by: Weicai Yang <weicai@google.com>