### PR TITLE
[top/dv] Add variant of SPI passthrough test that incorporates the use of filtered opcodes.

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -149,11 +149,14 @@
       desc: '''Verify the pass through mode from an end-to-end perspective.
 
             - Configure the SPI device and host in pass through mode.
+            - Program the cmd_filter_* CSRs to filter out random commands.
             - Configure and enable both spi_host0 and spi_host1
             - Send a random flash commands over the SPI device interface (chip IOs) from the
               testbench.
             - Verify the flash commands which pass through spi_host0, are received on chip IOs.
-            - Verify spi_host1 doesn't send out any data from spi_device
+            - Verify that only the payloads that are not filtered show up on the SPI host interface
+              at chip IOs.
+	    - Verify spi_host1 doesn't send out any data from spi_device
             - Run with min (6MHz), typical (24Mhz) and max (30MHz) SPI clk frequencies.
             - Run with single, dual and quad SPI modes.
             - Testbench should test the following commands:
@@ -163,27 +166,12 @@
       stage: V2
       tests: ["chip_sw_spi_device_pass_through"]
     }
-    {
-      name: chip_sw_spi_device_pass_through_filter
-      desc: '''Verify the command filtering mechanism in passthrough mode.
-
-            - Extend the chip_spi_device_pass_through test.
-            - Program the cmd_filter_* CSRs to filter out certain commands. a one byte command (such
-              as Chip Erase) and a multi-bytes command (such as Program or Sector/Block Erase) must
-              be added to filter
-            - Verify that only the payloads that are not filtered show up on the SPI host interface
-              at chip IOs.
-            '''
-      stage: V2
-      tests: []
-    }
 
     {
       name: chip_sw_spi_device_pass_through_flash_model
       desc: '''Verify the command filtering mechanism in passthrough mode.
 
-            - Extend the chip_spi_device_pass_through and chip_spi_device_pass_through_filter
-              tests.
+            - Extend the chip_spi_device_pass_through test.
             - Connect with a real flash model on spi_host
             - Verify that the flash commands are received and interpreted correctly in the flash
               model

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
@@ -17,6 +17,8 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
     33_000, // 30 MHz
     167_000 // 6 MHz
   };
+  // A bit map of command slots that will have passthrough filters enabled.
+  rand bit [spi_device_pkg::NumTotalCmdInfo-1:0] passthrough_filters;
 
   // Generate a random permutation of the following opcodes, and place them in
   // the test_opcodes queue:
@@ -47,6 +49,30 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
       "Observed SPI transaction on spi_host1, which should be inactive"));
   endtask
 
+  task get_filtered_commands(output bit [255:0] filter_map);
+    filter_map = '0;
+    for (int i = 0; i < spi_device_pkg::NumTotalCmdInfo; i++) begin
+      uvm_object csr;
+      uvm_reg_data_t opcode;
+      case (spi_device_pkg::cmd_info_index_e'(i))
+        spi_device_pkg::CmdInfoEn4B:
+            csr = ral.spi_device.cmd_info_en4b.opcode;
+        spi_device_pkg::CmdInfoEx4B:
+            csr = ral.spi_device.cmd_info_ex4b.opcode;
+        spi_device_pkg::CmdInfoWrEn:
+            csr = ral.spi_device.cmd_info_wren.opcode;
+        spi_device_pkg::CmdInfoWrDi:
+            csr = ral.spi_device.cmd_info_wrdi.opcode;
+        default:
+            csr = ral.spi_device.cmd_info[i].opcode;
+      endcase
+      if (passthrough_filters[i]) begin
+        csr_rd(.ptr(csr), .value(opcode), .backdoor(1));
+        filter_map[opcode] = 1'b1;
+      end
+    end
+  endtask
+
   // Send the sequence of commands indicated by the `test_opcodes` member.
   // These commands must be registered with the host and device agents, as the
   // command info determines the actions takes for each opcode. Random data of
@@ -56,38 +82,60 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
     spi_device_flash_seq m_spi_device_seq;
     spi_host_flash_seq m_spi_host_seq;
     spi_item host_rsp, device_rsp;
+    spi_item device_rsp_q[$];
     spi_agent_cfg agent_cfg = cfg.m_spi_host_agent_cfg;
+    bit [255:0] filter_map;
+    get_filtered_commands(filter_map);
 
-    while (test_opcodes.size() > 0) begin
-      bit [7:0] opcode = test_opcodes.pop_front();
-
-      `uvm_create_on(m_spi_device_seq, p_sequencer.spi_device_sequencer_hs[0]);
-      `uvm_create_on(m_spi_host_seq, p_sequencer.spi_host_sequencer_h);
-      // Prepare for specific opcode. The address_q is kept empty, which will
-      // trigger m_spi_host_seq to do the lookup and supply a random value.
-      `DV_CHECK_RANDOMIZE_WITH_FATAL(m_spi_host_seq,
-                                     opcode == local::opcode;
-                                     address_q.size() == 0;
-                                     payload_q.size() <= local::max_payload_size;
-                                     read_size == payload_q.size(););
+    fork begin : isolation_fork
+      // The device agent handles the incoming command, if it is not filtered.
       fork
-        begin
+        forever begin
+          `uvm_create_on(m_spi_device_seq, p_sequencer.spi_device_sequencer_hs[0]);
           `uvm_send(m_spi_device_seq);
+          device_rsp_q.push_back(m_spi_device_seq.rsp);
         end
-        begin
-          `uvm_send(m_spi_host_seq);
-        end
-      join
+      join_none
 
-      // Check that the command, address, and data sent matches on both sides.
-      host_rsp = m_spi_host_seq.rsp;
-      device_rsp = m_spi_device_seq.rsp;
-      `DV_CHECK_EQ(host_rsp.opcode, device_rsp.opcode);
-      `DV_CHECK_Q_EQ(host_rsp.address_q, device_rsp.address_q);
-      `DV_CHECK_EQ(host_rsp.dummy_cycles, device_rsp.dummy_cycles);
-      `DV_CHECK_EQ(host_rsp.num_lanes, device_rsp.num_lanes);
-      `DV_CHECK_Q_EQ(host_rsp.payload_q, device_rsp.payload_q);
-    end
+      while (test_opcodes.size() > 0) begin
+        bit [7:0] opcode = test_opcodes.pop_front();
+
+        `uvm_create_on(m_spi_host_seq, p_sequencer.spi_host_sequencer_h);
+        // Prepare for specific opcode. The address_q is kept empty, which will
+        // trigger m_spi_host_seq to do the lookup and supply a random value.
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(m_spi_host_seq,
+                                       opcode == local::opcode;
+                                       address_q.size() == 0;
+                                       payload_q.size() <= local::max_payload_size;
+                                       read_size == payload_q.size(););
+        `uvm_send(m_spi_host_seq);
+        // Wait for a small delay to allow the device agent to push the response
+        // into the queue.
+        #1ps;
+        if (!filter_map[opcode]) begin
+          // Check that the command, address, and data sent matches on both sides.
+          `DV_CHECK_EQ(device_rsp_q.size(), 1);
+          host_rsp = m_spi_host_seq.rsp;
+          device_rsp = device_rsp_q.pop_front();
+          `DV_CHECK_EQ(host_rsp.opcode, device_rsp.opcode);
+          `DV_CHECK_Q_EQ(host_rsp.address_q, device_rsp.address_q);
+          `DV_CHECK_EQ(host_rsp.dummy_cycles, device_rsp.dummy_cycles);
+          `DV_CHECK_EQ(host_rsp.num_lanes, device_rsp.num_lanes);
+          `DV_CHECK_Q_EQ(host_rsp.payload_q, device_rsp.payload_q);
+        end else begin
+          `DV_CHECK_EQ(device_rsp_q.size(), 0);
+        end
+      end
+      disable fork;
+    end join
+  endtask
+
+  virtual task cpu_init();
+    bit [7:0] sw_filter_config[4];
+    super.cpu_init();
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(passthrough_filters);
+    sw_filter_config = {<<byte{passthrough_filters}};
+    sw_symbol_backdoor_overwrite("kFilteredCommands", sw_filter_config);
   endtask
 
   virtual task body();

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -825,6 +825,7 @@ opentitan_functest(
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:spi_device",


### PR DESCRIPTION
Also merge the test with filters into the one without. Random filter values will cover both cases.

Resolves #14154