### PR TITLE
[top-test] Switch otbn tests to edn auto mode

### DIFF
--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -95,7 +95,7 @@ bool sign_then_verify_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  entropy_testutils_boot_mode_init();
+  entropy_testutils_auto_mode_init();
 
   CHECK(compute_digest() == kHmacOk);
 

--- a/sw/device/tests/otbn_irq_test.c
+++ b/sw/device/tests/otbn_irq_test.c
@@ -158,7 +158,7 @@ void ottf_external_isr(void) {
 }
 
 bool test_main(void) {
-  entropy_testutils_boot_mode_init();
+  entropy_testutils_auto_mode_init();
   plic_init_with_irqs();
 
   // Enable the external IRQ (so that we see the interrupt from the PLIC)

--- a/sw/device/tests/otbn_rsa_test.c
+++ b/sw/device/tests/otbn_rsa_test.c
@@ -692,7 +692,7 @@ static void test_rsa4096_roundtrip(void) {
 }
 
 bool test_main(void) {
-  entropy_testutils_boot_mode_init();
+  entropy_testutils_auto_mode_init();
 
   test_rsa512_roundtrip();
   test_rsa1024_roundtrip();

--- a/sw/device/tests/otbn_smoketest.c
+++ b/sw/device/tests/otbn_smoketest.c
@@ -163,7 +163,7 @@ static void test_sec_wipe(otbn_t *otbn_ctx) {
 }
 
 bool test_main(void) {
-  entropy_testutils_boot_mode_init();
+  entropy_testutils_auto_mode_init();
 
   otbn_t otbn_ctx;
   CHECK(otbn_init(&otbn_ctx, mmio_region_from_addr(


### PR DESCRIPTION
We want to use OTBN with EDN in auto mode for production use cases. This commit updates top-level tests to use EDN auto mode configuration.
