### PR TITLE
[chip_if] Update sysrst_ctrl DIO assignments 

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -274,12 +274,12 @@ interface chip_if;
 
   // Functional (dedicated) interface (inout): EC reset.
   pins_if #(.Width(1), .PullStrength("Weak")) ec_rst_l_if(
-    .pins(mios[top_earlgrey_pkg::DioPadIor8])
+    .pins(dios[top_earlgrey_pkg::DioPadIor8])
   );
 
   // Functional (dedicated) interface (inout): flash write protect.
   pins_if #(.Width(1), .PullStrength("Weak")) flash_wp_l_if(
-    .pins(mios[top_earlgrey_pkg::DioPadIor9])
+    .pins(dios[top_earlgrey_pkg::DioPadIor9])
   );
 
   // Functional (dedicated) interface (inout): power button.


### PR DESCRIPTION
This fixes #16025 and #16026

It also aligns some names, adds more comments, checks and debug printouts to `chip_sw_sysrst_ctrl_ec_rst_l`.