### PR TITLE
[bazel,dvsim] enable generating OTP images with Bazel in dvsim

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -90,6 +90,10 @@ ifneq (${sw_images},)
 		else \
 			echo "Building SW image \"$${bazel_label}\"."; \
 			bazel_opts="${sw_build_opts} --define DISABLE_VERILATOR_BUILD=true"; \
+			bazel_opts+=" --//hw/ip/otp_ctrl/data:img_seed=${seed}"; \
+			if [[ "${build_seed}" != "None" ]]; then \
+				bazel_opts+=" --//hw/ip/otp_ctrl/data:otp_seed=${build_seed}"; \
+			fi; \
 			if [[ -z $${BAZEL_PYTHON_WHEELS_REPO} ]]; then \
 				echo "Building \"$${bazel_label}\" on network connected machine."; \
 				bazel_cmd="./bazelisk.sh"; \

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -5,8 +5,24 @@
 load("//rules:autogen.bzl", "autogen_hjson_header")
 load("//rules:otp.bzl", "otp_image", "otp_json", "otp_partition")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@bazel_skylib//rules:common_settings.bzl", "int_flag")
 
 package(default_visibility = ["//visibility:public"])
+
+# These configurations expose the OTP image generation tool's seed override
+# command line arguments to enable dvsim to pass this through Bazel to the
+# underlying OTP image generation tool. This is required to enable dvsim to
+# invoke OTP image generation as part of the Bazel build process, while still
+# enabling the use of multiple seeds needed to achieve DV coverage.
+int_flag(
+    name = "img_seed",
+    build_setting_default = 0,
+)
+
+int_flag(
+    name = "otp_seed",
+    build_setting_default = 0,
+)
 
 # This package must be kept in sync with get_otp_images() from //rules:otp.bzl.
 # That is, each OTP image referenced by the macro should have a definition in

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -36,6 +36,8 @@ list of dicts, each of the form {"name": key, "value": value}, which is the
 format expected by the image generation tool.
 """
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
 def get_otp_images():
     """Returns a list of (otp_name, img_target) tuples.
 
@@ -109,6 +111,10 @@ def _otp_image(ctx):
         args.add("--quiet")
     args.add("--lc-state-def", ctx.file.lc_state_def)
     args.add("--mmap-def", ctx.file.mmap_def)
+    if ctx.attr.img_seed:
+        args.add("--img-seed", ctx.attr.img_seed[BuildSettingInfo].value)
+    if ctx.attr.otp_seed:
+        args.add("--otp-seed", ctx.attr.otp_seed[BuildSettingInfo].value)
     args.add("--img-cfg", ctx.file.src)
     args.add_all(ctx.files.overlays, before_each = "--add-cfg")
     args.add("--out", "{}/{}.BITWIDTH.vmem".format(output.dirname, ctx.attr.name))
@@ -144,6 +150,14 @@ otp_image = rule(
             allow_single_file = True,
             default = "//hw/ip/otp_ctrl/data:otp_ctrl_mmap.hjson",
             doc = "OTP Controller memory map file in Hjson format.",
+        ),
+        "img_seed": attr.label(
+            default = "//hw/ip/otp_ctrl/data:img_seed",
+            doc = "Configuration override seed used to randomize field values in an OTP image.",
+        ),
+        "otp_seed": attr.label(
+            default = "//hw/ip/otp_ctrl/data:otp_seed",
+            doc = "Configuration override seed used to randomize OTP netlist constants.",
         ),
         "verbose": attr.bool(
             default = False,

--- a/util/design/gen-otp-img.py
+++ b/util/design/gen-otp-img.py
@@ -13,6 +13,7 @@ import re
 from pathlib import Path
 
 import hjson
+
 from lib.common import wrapped_docstring
 from lib.OtpMemImg import OtpMemImg
 
@@ -30,6 +31,8 @@ MEMORY_MEM_FILE = 'otp-img.BITWIDTH.vmem'
 def _override_seed(args, name, config):
     '''Override the seed key in config with value specified in args'''
     arg_seed = getattr(args, name)
+    # An override seed of 0 will not trigger the override, which is intended, as
+    # the OTP-generation Bazel rule sets the default seed values to 0.
     if arg_seed:
         log.warning('Commandline override of {} with {}.'.format(
             name, arg_seed))

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -465,6 +465,7 @@ class RunTest(Deploy):
     def __init__(self, index, test, build_job, sim_cfg):
         self.test_obj = test
         self.index = index
+        self.build_seed = sim_cfg.build_seed
         self.seed = RunTest.get_seed()
         self.simulated_time = JobTime()
         super().__init__(sim_cfg)
@@ -492,6 +493,8 @@ class RunTest(Deploy):
             "run_cmd": False,
             "run_opts": False,
             "post_run_cmds": False,
+            "build_seed": True,  # Already set in the constructor.
+            "seed": True,  # Already set in the constructor.
         })
 
         self.mandatory_misc_attrs.update({


### PR DESCRIPTION
This PR contains two commits that enable generating OTP images with Bazel in dvsim, using both build and test seeds provided by dvsim. Sepcifically:

**Commit 1:** add Bazel command line flags to enable OTP seed overrides during OTP img generation (kicked off by Bazel).

**Commit 2:** configures dvsim to pass the OTP image seed command line build flags to Bazel (so that Bazel can generate the correct OTP image needed by the simulation). Note, this does not disturb the existing mechanism for generating the (five) base OTP images within the dvsim configuration file (`chip_sim_cfg.hjson`). Rather, it simply makes it possible to **_also_** allow Bazel to generate custom OTP images (with dvsim provided build and test seeds) during the run phase, where Bazel is currently invoked to generate other SW images (i.e., ROM and flash images).

Both of these commits contain infrastructure tweaks that are required to enable ROM E2E tests to run in DV, and therefore, partially address #14634.