### PR TITLE
[dv] enable tests to specify a custom OTP image built by Bazel

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -302,7 +302,8 @@
   // to know what type of image is it:
   // - 0 for Boot ROM,
   // - 1 for SW test (loaded in flash),
-  // - 2 for OTBN test,
+  // - 2 for OTBN test, and
+  // - 3 for OTP.
   // This allows an arbitrary number of SW images to be supplied to the TB.
   //
   // For example, if the Bazel label for a test is:
@@ -380,7 +381,7 @@
       sw_images: ["//sw/device/tests/sim_dv:sleep_pin_mio_dio_val_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       // Starting the chip in prod LC state frees up all MIOs for this test.
-      run_opts: ["+use_otp_image=LcStProd"]
+      run_opts: ["+use_otp_image=OtpTypeLcStProd"]
     }
     {
       name: chip_sw_sleep_pin_wake
@@ -388,7 +389,7 @@
       sw_images: ["//sw/device/tests/sim_dv:sleep_pin_wake_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       // Starting the chip in prod LC state frees up all MIOs for this test.
-      run_opts: ["+use_otp_image=LcStProd"]
+      run_opts: ["+use_otp_image=OtpTypeLcStProd"]
     }
     {
       name: chip_sw_sleep_pin_retention
@@ -608,7 +609,7 @@
       en_run_modes: ["sw_test_mode_test_rom"],
       // Use the image as basis, but clear provitioning state of the SECRET2
       // partition so that the test can make front-door accesses to that partition.
-      run_opts: ["+use_otp_image=LcStTestUnlocked0", "+otp_clear_secret2=1"]
+      run_opts: ["+use_otp_image=OtpTypeLcStTestUnlocked0", "+otp_clear_secret2=1"]
     }
     {
       name: chip_sw_otp_ctrl_lc_signals_dev
@@ -617,7 +618,7 @@
       en_run_modes: ["sw_test_mode_test_rom"],
       // Use the image as basis, but clear provitioning state of the SECRET2
       // partition so that the test can make front-door accesses to that partition.
-      run_opts: ["+use_otp_image=LcStDev", "+otp_clear_secret2=1"]
+      run_opts: ["+use_otp_image=OtpTypeLcStDev", "+otp_clear_secret2=1"]
     }
     {
       name: chip_sw_otp_ctrl_lc_signals_prod
@@ -626,7 +627,7 @@
       en_run_modes: ["sw_test_mode_test_rom"],
       // Use the image as basis, but clear provitioning state of the SECRET2
       // partition so that the test can make front-door accesses to that partition.
-      run_opts: ["+use_otp_image=LcStProd", "+otp_clear_secret2=1"]
+      run_opts: ["+use_otp_image=OtpTypeLcStProd", "+otp_clear_secret2=1"]
     }
     {
       name: chip_sw_otp_ctrl_lc_signals_rma
@@ -635,7 +636,7 @@
       en_run_modes: ["sw_test_mode_test_rom"],
       // Use the image as basis, but clear provitioning state of the SECRET2
       // partition so that the test can make front-door accesses to that partition.
-      run_opts: ["+use_otp_image=LcStRma", "+otp_clear_secret2=1"]
+      run_opts: ["+use_otp_image=OtpTypeLcStRma", "+otp_clear_secret2=1"]
     }
     {
       // Set higher reseed value to reach all kmac_data to lc_ctrl toggle coverage.
@@ -657,7 +658,7 @@
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+flash_program_latency=5",
-                 "+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStDev",
+                 "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStDev",
                  // The test takes long time because it will transit to RMA state
                  "+sw_test_timeout_ns=200_000_000"]
       run_timeout_mins: 240
@@ -668,7 +669,7 @@
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+flash_program_latency=5",
-                 "+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProd",
+                 "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProd",
                  // The test takes long time because it will transit to RMA state
                  "+sw_test_timeout_ns=200_000_000"]
       run_timeout_mins: 240
@@ -679,14 +680,14 @@
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+flash_program_latency=5",
-                 "+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProdEnd"]
+                 "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProdEnd"]
     }
     {
       name: chip_sw_lc_walkthrough_rma
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStRma",
+      run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStRma",
                  "+flash_program_latency=5",
                  // The test takes long time because it will transit to RMA state
                  "+sw_test_timeout_ns=200_000_000"]
@@ -697,7 +698,7 @@
       uvm_test_seq: chip_sw_lc_walkthrough_testunlocks_vseq
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_testunlocks_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStTestUnlock7"]
+      run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStTestUnlock7"]
     }
     {
       name: chip_sw_rstmgr_sw_req
@@ -1046,7 +1047,7 @@
       sw_images: ["//sw/device/tests/sim_dv:csrng_lc_hw_debug_en_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=15_000_000", "+rng_srate_value_min=15",
-                 "+use_otp_image=LcStTestUnlocked0"]
+                 "+use_otp_image=OtpTypeLcStTestUnlocked0"]
       run_timeout_mins: 60
     }
     {
@@ -1430,7 +1431,7 @@
       name: chip_tap_straps_dev
       uvm_test_seq: chip_tap_straps_vseq
       en_run_modes: ["strap_tests_mode"]
-      run_opts: ["+use_otp_image=LcStDev"]
+      run_opts: ["+use_otp_image=OtpTypeLcStDev"]
       run_timeout_mins: 120
     }
     {
@@ -1490,7 +1491,7 @@
       uvm_test_seq: chip_padctrl_attributes_vseq
       en_run_modes: ["stub_cpu_mode"]
       // Starting the chip in prod LC state frees up all MIOs for this test.
-      run_opts: ["+use_otp_image=LcStProd"]
+      run_opts: ["+use_otp_image=OtpTypeLcStProd"]
       reseed: 10
     }
   ]

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -29,7 +29,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Creator SW config region in OTP that holds the AST config data. Randomized for open source.
   //
   // These are written via backdoor to the OTP region that starts at
-  // otp_ctrl_reg_pkg::CreatorSwCfgAstCfgOffset. SW based tests (via test ROM or the production mask
+  // otp_ctrl_reg_pkg::CreatorSwCfgAstCfgOffset. SW based tests (via test ROM or the production
   // ROM) will read out from this OTP region and write blindly to AST at the start. Non-SW based
   // tests will do the same, prior to the test starting, see
   // chip_stub_cpu_base_vseq::dut_init().
@@ -65,8 +65,8 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   string sw_image_flags[sw_type_e][$];
 
   // Maintain a list of generated OTP images.
-  lc_ctrl_state_pkg::lc_state_e use_otp_image = lc_ctrl_state_pkg::LcStRma;
-  string otp_images[lc_ctrl_state_pkg::lc_state_e];
+  otp_type_e use_otp_image = OtpTypeLcStRma;
+  string otp_images[otp_type_e];
 
   uint               sw_test_timeout_ns = 12_000_000; // 12ms
   sw_logger_vif      sw_logger_vif;
@@ -180,11 +180,13 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     end
 
     // By default, assume these OTP image paths.
-    otp_images[lc_ctrl_state_pkg::LcStRaw] = "otp_ctrl_img_raw.vmem";
-    otp_images[lc_ctrl_state_pkg::LcStDev] = "otp_ctrl_img_dev.vmem";
-    otp_images[lc_ctrl_state_pkg::LcStProd] = "otp_ctrl_img_prod.vmem";
-    otp_images[lc_ctrl_state_pkg::LcStRma] = "otp_ctrl_img_rma.vmem";
-    otp_images[lc_ctrl_state_pkg::LcStTestUnlocked0] = "otp_ctrl_img_test_unlocked0.vmem";
+    // A customized OTP image may be specified loaded via the `sw_images` plusarg.
+    otp_images[OtpTypeLcStRaw] = "otp_ctrl_img_raw.vmem";
+    otp_images[OtpTypeLcStDev] = "otp_ctrl_img_dev.vmem";
+    otp_images[OtpTypeLcStProd] = "otp_ctrl_img_prod.vmem";
+    otp_images[OtpTypeLcStRma] = "otp_ctrl_img_rma.vmem";
+    otp_images[OtpTypeLcStTestUnlocked0] = "otp_ctrl_img_test_unlocked0.vmem";
+    otp_images[OtpTypeCustom] = "";
 
     `DV_CHECK_LE_FATAL(num_ram_main_tiles, 16)
     `DV_CHECK_LE_FATAL(num_ram_ret_tiles, 16)
@@ -391,6 +393,8 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
             // `rules/opentitan.bzl` for options.
             sw_images[i] = $sformatf("%0s.test_key_0.signed", sw_images[i]);
           end
+        end else if (i == SwTypeOtp) begin
+          otp_images[OtpTypeCustom] = $sformatf("%0s.24.vmem", sw_images[i]);
         end
       end
     end

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -89,8 +89,21 @@ package chip_env_pkg;
   typedef enum {
     SwTypeRom,  // Ibex SW - first stage boot ROM.
     SwTypeTest, // Ibex SW - actual test SW.
-    SwTypeOtbn  // Otbn SW.
+    SwTypeOtbn, // Otbn SW
+    SwTypeOtp   // Customized OTP image
   } sw_type_e;
+
+  // Our dvsim.py configuration always generates five base OTP images (in various lifecycle states)
+  // to allow tests configurations to choose from. Additionally, we support specifying a custom OTP
+  // image, via the `sw_images` plusarg, that is built by the SW build system.
+  typedef enum {
+    OtpTypeLcStRaw,           // Base OTP image in Raw lifecycle state.
+    OtpTypeLcStDev,           // Base OTP image in Dev lifecycle state.
+    OtpTypeLcStProd,          // Base OTP image in Prod lifecycle state.
+    OtpTypeLcStRma,           // Base OTP image in RMA lifecycle state.
+    OtpTypeLcStTestUnlocked0, // Base OTP image in TestUnlocked0 lifecycle state.
+    OtpTypeCustom             // Custom OTP image specified via `sw_images` plusarg.
+  } otp_type_e;
 
   // Two status for LC JTAG to identify if LC state transition is successful.
   typedef enum int {

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -45,7 +45,9 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     // Initialize the sw logger interface.
     foreach (cfg.sw_images[i]) begin
-      cfg.sw_logger_vif.add_sw_log_db(cfg.sw_images[i]);
+      if (i != SwTypeOtp) begin
+        cfg.sw_logger_vif.add_sw_log_db(cfg.sw_images[i]);
+      end
     end
     cfg.sw_logger_vif.sw_log_addr = SW_DV_LOG_ADDR;
     cfg.sw_logger_vif.write_sw_logs_to_file = cfg.write_sw_logs_to_file;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
@@ -25,6 +25,13 @@ class chip_tap_straps_vseq extends chip_sw_base_vseq;
 
   lc_ctrl_state_pkg::lc_state_e cur_lc_state;
 
+  lc_ctrl_state_pkg::lc_state_e otp_type_2_lc_state[otp_type_e] = '{
+    OtpTypeLcStRaw: LcStRaw,
+    OtpTypeLcStDev: LcStDev,
+    OtpTypeLcStProd: LcStProd,
+    OtpTypeLcStRma: LcStRma,
+    OtpTypeLcStTestUnlocked0: LcStTestUnlocked0};
+
   local uvm_reg lc_csrs[$];
   chip_jtag_tap_e select_jtag;
 
@@ -50,7 +57,7 @@ class chip_tap_straps_vseq extends chip_sw_base_vseq;
     if (lc_at_prod) begin
       cur_lc_state = LcStProd;
     end else begin
-      cur_lc_state = cfg.use_otp_image;
+      cur_lc_state = otp_type_2_lc_state[cfg.use_otp_image];
     end
 
     super.pre_start();

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -84,7 +84,7 @@ class chip_base_test extends cip_base_test #(
     end
 
     // Knob to select the OTP image based on LC state.
-    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::lc_state_e, cfg.use_otp_image, use_otp_image)
+    `DV_GET_ENUM_PLUSARG(otp_type_e, cfg.use_otp_image, use_otp_image)
     `DV_CHECK_FATAL(cfg.otp_images.exists(cfg.use_otp_image),
                     $sformatf({"Unsupported plusarg value: +use_otp_image=%0s. An image associated",
                                "with this LC state needs to be created first."}, cfg.use_otp_image))

--- a/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
@@ -88,7 +88,7 @@
   // - 0 for Boot ROM,
   // - 1 for SW test (loaded in flash),
   // - 2 for OTBN test,
-  // - 3 for OTP and so on
+  // - 3 for OTP.
   // This allows an arbitrary number of SW images to be supplied to the TB.
   //
   // For example, if the Bazel label for a test is:


### PR DESCRIPTION
Previously, only a specific set of five different OTP images (built by dvsim during the pre-run phase) were avaiable for tests to use. If a test required specific OTP fields to be different than what was provided in any of these base image, the test needed to backdoor overwrite said field.

To enable running ROM E2E tests in DV, which have their own Bazel infrastructure to generate OTP images as part of the test build process, this enhances the DV testbench to enable passing a custom OTP image (which is automatically built by Bazel when the SW images are built for a test during the dvsim run phase). This allows ROM E2E tests to use the same OTP image across all platforms (FPGA, Verilator, and DV), with the exception of the img- and otp-seed values which may be specified on the command line when Bazel is invoked to build the OTP image (thanks to the previous PR this depends on).

This partially addresses #14634.

**_This depends on #16052. Please only review the last commit._**