### PR TITLE
[dv/edn] Enhance edn_disablement test to hit all boot mode st.

### DIFF
--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -102,6 +102,8 @@
       name: edn_disable
       uvm_test: edn_disable_test
       uvm_test_seq: edn_disable_vseq
+      // For debug purpose, this test is very short.
+      run_opts: ["+test_timeout_ns=100_000"]
     }
 
     // TODO: add more tests here


### PR DESCRIPTION
This PR enhances the current edn_disablement test so it tries to hit all Boot mode related states.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>