### PR TITLE
[syn/upf] Add file that defines iso values for LC signals

### DIFF
--- a/hw/top_earlgrey/syn/chip_earlgrey_asic_nonzero_upf_vals.tcl
+++ b/hw/top_earlgrey/syn/chip_earlgrey_asic_nonzero_upf_vals.tcl
@@ -1,0 +1,17 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Defines paths to signals that require non-zero isolation values in UPF.
+
+# The LC OFF value is set to 0x1010 in RTL. Note that changing this encoding has
+# implications on isolation cell values in RTL. Do not change this unless
+# absolutely needed. See #4244 for the audit / discussion about which ports
+# should have nonzero values.
+set UPF_ISO_LC_OFF_PORTS_CLAMP1 {
+  top_earlgrey/u_aon_timer_aon/lc_escalate_en_i[3] \
+  top_earlgrey/u_aon_timer_aon/lc_escalate_en_i[1] \
+  top_earlgrey/u_pinmux_aon/lc_escalate_en_i[3]    \
+  top_earlgrey/u_pinmux_aon/lc_escalate_en_i[1]    \
+  top_earlgrey/u_pinmux_aon/lc_check_byp_en_i[3]   \
+  top_earlgrey/u_pinmux_aon/lc_check_byp_en_i[1]   }


### PR DESCRIPTION
Fixes #4244.

@arnonsha let me know if this is an acceptable format or not.

Signed-off-by: Michael Schaffner <msf@google.com>