### PR TITLE
[top/dv] Fix address used for fault triggering.

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv
@@ -30,7 +30,7 @@ class chip_sw_flash_host_gnt_err_inj_vseq extends chip_sw_base_vseq;
   endtask // body
 
   task polling_host_gnt();
-    bit val;
+    bit val = 0;
     while (!val) begin
       `DV_CHECK(uvm_hdl_read(FLASH_BANK1_HOST_GNT_PATH, val));
       cfg.clk_rst_vif.wait_clks(1);

--- a/sw/device/tests/sim_dv/flash_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/flash_escalation_reset_test.c
@@ -42,8 +42,7 @@ enum {
   kEscalationPhase0Micros = 100,  // 100 us
   kEscalationPhase1Micros = 100,  // 100 us
   kMaxInterrupts = 30,
-  kRegionBaseBank1Page0Index = TOP_EARLGREY_EFLASH_SIZE_BYTES / 2,
-  kPageSize = FLASH_CTRL_PARAM_BYTES_PER_PAGE,
+  kRegionBaseBank1Page0Addr = FLASH_CTRL_PARAM_BYTES_PER_BANK,
   kNumTestWords = 16,
   kNumTestBytes = kNumTestWords * sizeof(uint32_t),
   kExpectedAlertNumber = 0,
@@ -223,8 +222,9 @@ bool test_main(void) {
 
   if (rst_info == kDifRstmgrResetInfoPor) {
     alert_handler_config();
-    LOG_INFO("host read start");
-    read_host_if(kPageSize * kRegionBaseBank1Page0Index);
+    LOG_INFO("host read start from 0x%x",
+             TOP_EARLGREY_EFLASH_BASE_ADDR + kRegionBaseBank1Page0Addr);
+    read_host_if(kRegionBaseBank1Page0Addr);
     // Set the timer value longer than escalation timeout.
     // 'static_assert' is added to check it.
     set_aon_timers(&aon_timer);


### PR DESCRIPTION
The current address used ends up being a "bad" out of range address that triggers the bus exception handler instead.

Signed-off-by: Timothy Chen <timothytim@google.com>