### PR TITLE
Revert "[bazel] Add rule for OTP alert_hander digests"

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:autogen.bzl", "autogen_hjson_header")
-load("//rules:otp.bzl", "otp_alert_digest", "otp_image", "otp_json", "otp_partition")
+load("//rules:otp.bzl", "otp_image", "otp_json", "otp_partition")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@bazel_skylib//rules:common_settings.bzl", "int_flag")
 
@@ -137,6 +137,10 @@ otp_json(
                     "0x0",
                     "0x0",
                 ],
+                "OWNER_SW_CFG_ROM_ALERT_DIGEST_DEV": "0xf23b13fb",
+                "OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD": "0x9c933414",
+                "OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_END": "0x68d8d091",
+                "OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA": "0x36ed9cb0",
             },
         ),
     ],
@@ -355,19 +359,12 @@ otp_json(
     seed = "01931961561863975174",
 )
 
-# Create an overlay for the alert_handler digest.
-otp_alert_digest(
-    name = "otp_json_alert_digest_cfg",
-    otp_img = ":otp_json_owner_sw_cfg",
-)
-
 otp_image(
     name = "img_dev",
     src = ":otp_json_dev",
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -378,7 +375,6 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -389,7 +385,6 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -400,7 +395,6 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -411,7 +405,6 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -422,7 +415,6 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
     ],
 )
@@ -444,7 +436,6 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
         ":otp_json_exec_disabled",
     ],
@@ -467,7 +458,6 @@ otp_image(
     overlays = [
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
         ":otp_json_hw_cfg",
         ":otp_json_bootstrap_disabled",
     ],

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -104,43 +104,6 @@ otp_json = rule(
     },
 )
 
-def _otp_alert_digest_impl(ctx):
-    file = ctx.actions.declare_file("{}.json".format(ctx.attr.name))
-
-    outputs = [file]
-
-    inputs = [
-        ctx.file._opentitantool,
-        ctx.file.otp_img,
-    ]
-
-    args = ctx.actions.args()
-    args.add_all(("otp", "alert-digest", ctx.file.otp_img))
-    args.add("--output", file)
-
-    ctx.actions.run(
-        outputs = outputs,
-        inputs = inputs,
-        arguments = [args],
-        executable = ctx.file._opentitantool.path,
-    )
-
-    return [DefaultInfo(files = depset([file]))]
-
-otp_alert_digest = rule(
-    implementation = _otp_alert_digest_impl,
-    attrs = {
-        "otp_img": attr.label(
-            allow_single_file = [".json", ".hjson"],
-            doc = "The OTP image file containing alert_handler values.",
-        ),
-        "_opentitantool": attr.label(
-            default = "//sw/host/opentitantool:opentitantool",
-            allow_single_file = True,
-        ),
-    },
-)
-
 def _otp_image(ctx):
     output = ctx.actions.declare_file(ctx.attr.name + ".24.vmem")
     args = ctx.actions.args()

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -449,7 +449,6 @@ opentitan_functest(
     overlays = [
         "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
     ],
 ) for lc_state in structs.to_dict(CONST.LCV)]
@@ -571,7 +570,6 @@ BOOT_POLICY_NEWER_CASES = [
     overlays = [
         "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
     ],
 ) for lc_state in structs.to_dict(CONST.LCV)]
@@ -659,7 +657,6 @@ otp_json(
     overlays = [
         "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
         ":otp_json_boot_policy_rollback",
     ],
@@ -770,7 +767,6 @@ opentitan_flash_binary(
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             ":otp_json_sigverify_mod_exp_{}".format(t["name"]),
         ],
@@ -1025,7 +1021,6 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             ":otp_json_sec_ver_{}".format(sec_ver),
         ],
@@ -1169,7 +1164,6 @@ SHUTDOWN_WATCHDOG_CASES = [
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             ":otp_json_shutdown_watchdog_{}_{}".format(
                 t["lc_state"],
@@ -1287,7 +1281,6 @@ BOOT_POLICY_VALID_CASES = [
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
         ],
     )
@@ -1363,7 +1356,6 @@ OTP_CFGS_EXEC_DISABLED = [
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_exec_disabled",
         ],
@@ -1587,7 +1579,6 @@ REDACT.update({"INVALID": 0x0})
         overlays = [
             "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
             "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
             ":otp_json_{}_overlay".format(redact.lower()),
         ],


### PR DESCRIPTION
This reverts commit b0e0bf8b8a3429fdc7e6dbce1eb7f216fa2c0b87. Which breaks the bazel build for some targets

Signed-off-by: Drew Macrae <drewmacrae@google.com>