### PR TITLE
[rules] Fix OTP digest rule to use execution platform

### DIFF
--- a/rules/host.bzl
+++ b/rules/host.bzl
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transition rules for accessing the host platform
+
+This file contains transition rules for accessing the host platform's
+configuration. Primarily, this provides transitions for rules where a tool runs
+on the host but the target configuration is not the host. For rules where
+the host configuration is not adequate, toolchains should be used instead.
+"""
+
+def _host_tools_transition_impl(settings, attr):
+    """Returns a dictionary with the platforms command line option set to host.
+
+    This transition is used for building host tools, passing through all build
+    settings specified on the command line.
+    """
+    return {"//command_line_option:platforms": "@local_config_platform//:host"}
+
+host_tools_transition = transition(
+    implementation = _host_tools_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:platforms"],
+)

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -37,6 +37,7 @@ format expected by the image generation tool.
 """
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("//rules:host.bzl", "host_tools_transition")
 
 def get_otp_images():
     """Returns a list of (otp_name, img_target) tuples.
@@ -115,7 +116,7 @@ def _otp_alert_digest_impl(ctx):
     ]
 
     args = ctx.actions.args()
-    args.add_all(("otp", "alert-digest", ctx.file.otp_img))
+    args.add_all(("--rcfile=", "otp", "alert-digest", ctx.file.otp_img))
     args.add("--output", file)
 
     ctx.actions.run(
@@ -137,6 +138,11 @@ otp_alert_digest = rule(
         "_opentitantool": attr.label(
             default = "//sw/host/opentitantool:opentitantool",
             allow_single_file = True,
+            executable = True,
+            cfg = host_tools_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
 )


### PR DESCRIPTION
Use the execution platform's config for opentitantool, so it does not build an RV32 variant when we want to run on the host.