### PR TITLE
[entropy_src/rtl] Consistent core enable masking

### DIFF
--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -35,6 +35,7 @@ filesets:
       - rtl/entropy_src_adaptp_ht.sv
       - rtl/entropy_src_bucket_ht.sv
       - rtl/entropy_src_markov_ht.sv
+      - rtl/entropy_src_enable_delay.sv
       - rtl/entropy_src_core.sv
       - rtl/entropy_src.sv
     file_type: systemVerilogSource

--- a/hw/ip/entropy_src/rtl/entropy_src_enable_delay.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_enable_delay.sv
@@ -1,0 +1,107 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description: Logic module indicate ongoing activity of after disablement of entropy_src_core
+//
+// The entropy_src has a great deal of internal state, and when shutting down most of this internal
+// state should be cleared.  (The two notable exceptions are the health test statistics, which are
+// only cleared at the next enable, and the SHA3 conditioning sponge which accumulates unused
+// entropy until a seed is generated).  There are delays as incoming RNG data is processed, and for
+// ease of verification we insist all elements of the data pipeline are cleared consistently.  This
+// means that once an RNG sample enters the pipeline, that sample should be reflected in the health
+// tests. The SHA3 conditioner is also assumed to successfully absorb every 64-bits that enters the
+// module.
+//
+// To acheive this consistency goal the entropy_src delays the clearing of internal data buffers
+// and the state machine until:
+// 1. Any unprocessed data has been counted at the health checks (regardless of the mode)
+// 2. Any RNG data bound for the SHA conditioner has been received at the conditioner.
+// 3. Any ongoing SHA processing operations have completed, and the main FSM has been forced
+//    back to idle.
+//
+// This block creates a modified version of the enable pulse which:
+// 1. Postpones the disable event until any flowing data has passed through the RNG, ESBIT and
+//    POSTHT FIFOs.  If packpressure is encountered at the Precon FIFO, the stalled data can
+//    be discarded, and so a has a maximum time limit of MaxFifoWait=3 clocks is given for this
+//    check.
+// 2. Once the disable signal is received, the rising edge does not occur until:
+//    2a. One clock after the falling edge OR
+//    2b. One clock after the SHA engine completes,
+//    Whichever comes later.
+
+module entropy_src_enable_delay import prim_mubi_pkg::*; (
+  input logic  clk_i,
+  input logic  rst_ni,
+
+  input logic  enable_i,
+
+  // Unconsumed FIFO inputs
+  input logic esrng_fifo_not_empty_i,
+  input logic esbit_fifo_not_empty_i,
+  input logic postht_fifo_not_empty_i,
+
+  // SHA3 conditioner inputs
+  input logic   cs_aes_halt_req_i,
+  input mubi4_t sha3_done_i,
+
+  input logic bypass_mode_i,
+
+  output logic enable_o
+);
+
+  // Maximum number of cycles to wait for FIFOs to clear out.
+  // Set to 3 to allow one cycle for each FIFO in the pipeline.
+  localparam int MaxFifoWait = 3;
+
+  logic suppress_reenable;
+  logic extend_enable;
+
+  logic data_in_flight;
+  logic [2:0] fifos_not_empty;
+
+  // Flops
+  logic [MaxFifoWait - 1:0] fifo_timer_d, fifo_timer_q;
+  logic                     sha3_active_post_en_d, sha3_active_post_en_q;
+  mubi4_t                   sha3_done_q;
+  logic                     extend_enable_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      sha3_active_post_en_q   <= 1'b0;
+      fifo_timer_q            <= '0;
+      sha3_done_q             <= prim_mubi_pkg::MuBi4False;
+      extend_enable_q         <= 1'b0;
+    end else begin
+      sha3_active_post_en_q   <= sha3_active_post_en_d;
+      fifo_timer_q            <= fifo_timer_d;
+      sha3_done_q             <= sha3_done_i;
+      extend_enable_q         <= extend_enable;
+    end
+  end
+
+  // Output definition
+  assign enable_o = (enable_i & ~suppress_reenable) | extend_enable;
+
+  // In flight data monitoring.
+  // The `fifo_timer` is a small shift register to count out the maximum number of cycles to wait
+  // for the FIFOs to drain. Since this timer is very small (3 cycles), it is implemented as a shift
+  // register to keep the logic simple, though it could easily be implemented as a counter as well.
+  assign fifo_timer_d = enable_i ? {MaxFifoWait{1'b1}} : {fifo_timer_q[MaxFifoWait-2:0], 1'b0};
+  assign fifos_not_empty = {esrng_fifo_not_empty_i, esbit_fifo_not_empty_i,
+                            !bypass_mode_i & postht_fifo_not_empty_i};
+  assign data_in_flight = |fifo_timer_q && |fifos_not_empty;
+
+  assign extend_enable = (data_in_flight & ~enable_i);
+
+  // Pulse to extend from the falling edge of the incoming enable pulse
+  // until one cycle after the SHA is done.
+  assign sha3_active_post_en_d = cs_aes_halt_req_i && !enable_i ? 1'b1 :
+                                 mubi4_test_true_strict(sha3_done_q) ? 1'b0 :
+                                 sha3_active_post_en_q;
+
+  // Force the output to be low until sha3_active_post_en_q falls or
+  // for one more cycle after the falling each of extend_enable
+  assign suppress_reenable = sha3_active_post_en_q | extend_enable_q;
+
+endmodule


### PR DESCRIPTION
The entropy_src core module has many activities that persist after disablement, notably the closing of health_test statistics data and the processing of SHA conditioning outputs.  Prior to this commit there have been many ad-hoc signals to allow these individual processes to finish before clearing the relavant fifos or state machines.  This lack of consistency makes it hard to track how these delays interact.

Ideally the external module interfaces (CSR locks and RNG inputs) would also be closed during these shutdown period to prevent the admission of new RNG data (bad for verification) or new CSR commands (which can cause spurious events due to poorly timed changes in configuration).

This commit creates a new delayed copy of the module enable signals.  The falling edge of this delayed copy signals when it is safe to clear the last few internal FIFOs, and the rising edge signals when the FSM has actually received a pending idle request.

This new enable signal is generated by a new module in order to cleanly encapulate and document the logic and motivation for the delay calculations.

Github Note: This PR requires #16095 for proper DV.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>