### PR TITLE
[dv/edn] support csrng agent disablement

### DIFF
--- a/hw/ip/edn/dv/env/edn_env.core
+++ b/hw/ip/edn/dv/env/edn_env.core
@@ -13,7 +13,7 @@ filesets:
       - lowrisc:dv:csrng_agent
     files:
       - edn_env_pkg.sv
-      - edn_path_if.sv
+      - edn_if.sv
       - edn_env_cfg.sv: {is_include_file: true}
       - edn_env_cov.sv: {is_include_file: true}
       - edn_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/edn/dv/env/edn_env.sv
+++ b/hw/ip/edn/dv/env/edn_env.sv
@@ -39,8 +39,8 @@ class edn_env extends cip_base_env #(
     end
 
     // config edn path virtual interface
-    if (!uvm_config_db#(virtual edn_path_if)::get(this, "", "edn_path_vif", cfg.edn_path_vif)) begin
-      `uvm_fatal(`gfn, "failed to get edn_path_vif from uvm_config_db")
+    if (!uvm_config_db#(virtual edn_if)::get(this, "", "edn_vif", cfg.edn_vif)) begin
+      `uvm_fatal(`gfn, "failed to get edn_vif from uvm_config_db")
     end
   endfunction
 

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -20,7 +20,7 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
   // handle to edn assert interface
   virtual edn_assert_if edn_assert_vif;
   // handle to edn path interface
-  virtual edn_path_if edn_path_vif;
+  virtual edn_if edn_vif;
 
   // Variables
   uint   reseed_cnt, generate_cnt, generate_between_reseeds_cnt;

--- a/hw/ip/edn/dv/env/edn_if.sv
+++ b/hw/ip/edn/dv/env/edn_if.sv
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This interface deals with the force paths in EDN interrupt and error tests
+// This is an EDN interface.
+// It deals with the force paths in EDN interrupt and error tests,
+// and helps pass the disable signal to the csrng agent.
 
-interface edn_path_if
+interface edn_if
 (
   input edn_i
 );
@@ -12,6 +14,7 @@ interface edn_path_if
   import uvm_pkg::*;
 
   string core_path = "tb.dut.u_edn_core";
+  logic edn_disable_o;
 
   function automatic string fifo_err_path(string fifo_name, string which_path);
     return {core_path, ".", fifo_name, "_", which_path};
@@ -21,11 +24,16 @@ interface edn_path_if
     case (which_sm)
       "edn_ack_sm": return {core_path, ".gen_ep_blk[0].u_edn_ack_sm_ep.state_q"};
       "edn_main_sm": return {core_path, ".u_edn_main_sm.state_q"};
-      default: `uvm_fatal("edn_path_if", "Invalid sm name!")
+      default: `uvm_fatal("edn_if", "Invalid sm name!")
     endcase // case (which_sm)
   endfunction // sm_err_path
 
   function automatic string cntr_err_path();
     return {core_path, ".u_prim_count_max_reqs_cntr.err_o"};
   endfunction // cntr_err_path
-endinterface // edn_path_if
+
+  function automatic drive_edn_disable(bit val);
+    edn_disable_o = val;
+  endfunction
+
+endinterface // edn_if

--- a/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
@@ -77,19 +77,19 @@ class edn_err_vseq extends edn_base_vseq;
         fifo_base_path = fld_name.substr(0, last_index-1);
 
         foreach (path_exts[i]) begin
-          fifo_forced_paths[i] = cfg.edn_path_vif.fifo_err_path(fifo_base_path, path_exts[i]);
+          fifo_forced_paths[i] = cfg.edn_vif.fifo_err_path(fifo_base_path, path_exts[i]);
         end
         force_all_fifo_errs(fifo_forced_paths, fifo_forced_values, path_exts, fld,
                             1'b1, cfg.which_fifo_err);
       end
       edn_ack_sm_err, edn_main_sm_err: begin
         fld = csr.get_field_by_name(fld_name);
-        path = cfg.edn_path_vif.sm_err_path(fld_name.substr(0, last_index-1));
+        path = cfg.edn_vif.sm_err_path(fld_name.substr(0, last_index-1));
         force_path_err(path, 6'b0, fld, 1'b1);
       end
       edn_cntr_err: begin
         fld = csr.get_field_by_name(fld_name);
-        path = cfg.edn_path_vif.cntr_err_path();
+        path = cfg.edn_vif.cntr_err_path();
         force_path_err(path, 6'b000001, fld, 1'b1);
         // Verify EDN.MAIN_SM.CTR.LOCAL_ESC
         csr_rd_check(.ptr(ral.err_code.edn_main_sm_err), .compare_value(1'b1));
@@ -99,8 +99,8 @@ class edn_err_vseq extends edn_base_vseq;
         fifo_name = cfg.which_fifo.name();
         path_key = fld_name.substr(first_index+1, last_index-1);
 
-        path1 = cfg.edn_path_vif.fifo_err_path(fifo_name, fifo_err_path[0][path_key]);
-        path2 = cfg.edn_path_vif.fifo_err_path(fifo_name, fifo_err_path[1][path_key]);
+        path1 = cfg.edn_vif.fifo_err_path(fifo_name, fifo_err_path[0][path_key]);
+        path2 = cfg.edn_vif.fifo_err_path(fifo_name, fifo_err_path[1][path_key]);
         value1 = fifo_err_value[0][path_key];
         value2 = fifo_err_value[1][path_key];
         force_fifo_err(path1, path2, value1, value2, fld, 1'b1);

--- a/hw/ip/edn/dv/env/seq_lib/edn_intr_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_intr_vseq.sv
@@ -60,17 +60,17 @@ class edn_intr_vseq extends edn_base_vseq;
       sfifo_rescmd_error, sfifo_gencmd_error: begin
         fifo_base_path = fld_name.substr(0, last_index-1);
         foreach (path_exts[i]) begin
-          fifo_forced_paths[i] = cfg.edn_path_vif.fifo_err_path(fifo_base_path, path_exts[i]);
+          fifo_forced_paths[i] = cfg.edn_vif.fifo_err_path(fifo_base_path, path_exts[i]);
         end
         force_all_fifo_errs(fifo_forced_paths, fifo_forced_values, path_exts,
                             ral.intr_state.edn_fatal_err, 1'b1, cfg.which_fifo_err);
       end
       edn_ack_sm_error, edn_main_sm_error: begin
-        path = cfg.edn_path_vif.sm_err_path(fld_name.substr(0, last_index-1));
+        path = cfg.edn_vif.sm_err_path(fld_name.substr(0, last_index-1));
         force_path_err(path, 6'b0, ral.intr_state.edn_fatal_err, 1'b1);
       end
       edn_cntr_error: begin
-        path = cfg.edn_path_vif.cntr_err_path();
+        path = cfg.edn_vif.cntr_err_path();
         force_path_err(path, 6'b000001, ral.intr_state.edn_fatal_err, 1'b1);
       end
       default: begin


### PR DESCRIPTION
When the EDN is disabled, we expect the CSRNG to also disable. The current CSRNG agent does not know that the CSRNG is disabled, and will still try to response to the current CSRNG request (dropped due to disablement).
So I connect the csrng agent's reset. This will help drop the CSRNG request.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>