### PR TITLE
[dv,test] add coremark test suite to DV

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1257,7 +1257,7 @@
     {
       name: chip_sw_coremark
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/benchmarks/coremark/coremark_top_earlgrey:1:external"]
+      sw_images: ["//third_party/coremark/top_earlgrey:coremark_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_uart_logger=1",
                  "+sw_test_timeout_ns=22_000_000"]

--- a/third_party/coremark/top_earlgrey/BUILD
+++ b/third_party/coremark/top_earlgrey/BUILD
@@ -22,7 +22,7 @@ opentitan_functest(
     copts = [
         "-Wno-implicit-fallthrough",
         "-Wno-strict-prototypes",
-        "-DITERATIONS=1",
+        "-DITERATIONS=8",
         "-DPERFORMANCE_RUN=1",
         "-DTOTAL_DATA_SIZE=2000",
         "-DMAIN_HAS_NOARGC=1",


### PR DESCRIPTION
This commit both:
1. fixes a runtime error with the coremark test suite that occurred because not enough test iterations were run, and
2. fixes the coremark test's DV configuration.

This fixes #14330.

Signed-off-by: Timothy Trippel <ttrippel@google.com>