### PR TITLE
[keymgr] use sparse_fsm for sideload FSM

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
@@ -102,8 +102,8 @@ class keymgr_common_vseq extends keymgr_base_vseq;
           exp[keymgr_pkg::FaultKmacFsm] = 1;
           if (cfg.en_cov) cov.fault_status_cg.sample(keymgr_pkg::FaultKmacFsm);
         end else if (!uvm_re_match("*.u_sideload_ctrl*", if_proxy.path)) begin
-          exp[keymgr_pkg::FaultSideSel] = 1;
-          if (cfg.en_cov) cov.fault_status_cg.sample(keymgr_pkg::FaultSideSel);
+          exp[keymgr_pkg::FaultSideFsm] = 1;
+          if (cfg.en_cov) cov.fault_status_cg.sample(keymgr_pkg::FaultSideFsm);
         end else begin
           exp[keymgr_pkg::FaultCtrlFsm] = 1;
           if (cfg.en_cov) cov.fault_status_cg.sample(keymgr_pkg::FaultCtrlFsm);

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -755,6 +755,8 @@ module keymgr
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlOpFsmCheck_A,
       u_ctrl.u_op_state.u_state_regs, alert_tx_o[1])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(KmacIfFsmCheck_A, u_kmac_if.u_state_regs, alert_tx_o[1])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(SideloadCtrlFsmCheck_A,
+      u_sideload_ctrl.u_state_regs, alert_tx_o[1])
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[1])

--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -199,9 +199,13 @@ module keymgr_kmac_if import keymgr_pkg::*;(
           end else if (gen_en_i) begin
             rounds = LastGenRound;
           end
-
-          // we are sending only 1 entry
-          state_d = (rounds == 0) ? StTxLast : StTx;
+          // simplify the transition when rounds can never be zero, so that we don't have
+          // the unreachable transition StIdle -> StTxLast.
+          if (0 inside {LastAdvRound, LastIdRound, LastGenRound}) begin : gen_zero_rounds
+            state_d = (rounds == 0) ? StTxLast : StTx;
+          end else begin : gen_no_zero_rounds
+            state_d = StTx;
+          end
         end
       end
 

--- a/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
@@ -62,17 +62,7 @@ module keymgr_sideload_key_ctrl import keymgr_pkg::*;(
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = keymgr_sideload_e'(state_raw_q);
-  prim_flop #(
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StSideloadReset))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .d_i ( state_d     ),
-    .q_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, keymgr_sideload_e, StSideloadReset)
 
   logic keys_en;
   logic [Shares-1:0][KeyWidth-1:0] data_truncated;


### PR DESCRIPTION
Also removed an unreachable transition and update vseq to the right CSR field.

Addressed #16046

Signed-off-by: Weicai Yang <weicai@google.com>