### PR TITLE
[otbn] Do not error in otbn_busy_wait_for_done

### DIFF
--- a/sw/device/lib/runtime/otbn.c
+++ b/sw/device/lib/runtime/otbn.c
@@ -37,8 +37,8 @@ otbn_result_t otbn_busy_wait_for_done(otbn_t *ctx) {
     return kOtbnError;
   }
   if (err_bits != kDifOtbnErrBitsNoError) {
-    LOG_ERROR("otbn err_bits got: 0x%x, want: 0x%x", err_bits,
-              kDifOtbnErrBitsNoError);
+    LOG_INFO("otbn err_bits got: 0x%x, want: 0x%x", err_bits,
+             kDifOtbnErrBitsNoError);
     return kOtbnOperationFailed;
   }
   return kOtbnOk;


### PR DESCRIPTION
The status of this function should be checked by the caller, hence the message is demoted from ERRO to INFO.

See also discussion on #16030.

This fixes #16030.

Signed-off-by: Michael Schaffner <msf@google.com>