### PR TITLE
[bazel, topgen] Add topgen-related bazel py_* pacakges

### DIFF
--- a/util/ipgen/BUILD
+++ b/util/ipgen/BUILD
@@ -1,0 +1,33 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("@ot_python_deps//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "ipgen",
+    srcs = [
+        "__init__.py",
+        "lib.py",
+        "renderer.py",
+    ],
+    deps = [
+        "//util/reggen:gen_rtl",
+        "//util/reggen:lib",
+        "//util/reggen:params",
+        requirement("hjson"),
+        requirement("mako"),
+    ],
+)
+
+py_test(
+    name = "test_render",
+    srcs = ["tests/test_render.py"],
+    deps = [
+        ":ipgen",
+        requirement("pytest"),
+    ],
+)

--- a/util/reggen/BUILD
+++ b/util/reggen/BUILD
@@ -323,3 +323,8 @@ py_library(
     name = "version",
     srcs = ["version.py"],
 )
+
+filegroup(
+    name = "tpl_files",
+    srcs = glob(["**/*.tpl"]),
+)

--- a/util/tlgen/BUILD
+++ b/util/tlgen/BUILD
@@ -1,0 +1,32 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("@ot_python_deps//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "tlgen",
+    srcs = [
+        "__init__.py",
+        "doc.py",
+        "elaborate.py",
+        "generate.py",
+        "generate_tb.py",
+        "item.py",
+        "lib.py",
+        "validate.py",
+        "xbar.py",
+    ],
+    deps = [
+        "//util/reggen:validate",
+        requirement("mako"),
+    ],
+)
+
+filegroup(
+    name = "tpl_files",
+    srcs = glob(["**/*.tpl"]),
+)

--- a/util/topgen/BUILD
+++ b/util/topgen/BUILD
@@ -1,0 +1,78 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("@ot_python_deps//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "topgen",
+    srcs = [
+        "__init__.py",
+        "gen_top_docs.py",
+        "validate.py",
+    ],
+    deps = [
+        ":merge",
+        requirement("tabulate"),
+    ],
+)
+
+py_library(
+    name = "c_test",
+    srcs = ["c_test.py"],
+    deps = [
+        ":lib",
+    ],
+)
+
+py_library(
+    name = "gen_dv",
+    srcs = [
+        "gen_dv.py",
+        "top.py",
+    ],
+    deps = [
+        "//util/reggen:gen_dv",
+        "//util/reggen:ip_block",
+        "//util/reggen:params",
+        "//util/reggen:window",
+        requirement("mako"),
+    ],
+)
+
+py_library(
+    name = "lib",
+    srcs = [
+        "c.py",
+        "intermodule.py",
+        "lib.py",
+        "resets.py",
+    ],
+    deps = [
+        "//util/reggen:inter_signal",
+        "//util/reggen:ip_block",
+        "//util/reggen:validate",
+        requirement("hjson"),
+        requirement("mako"),
+    ],
+)
+
+py_library(
+    name = "merge",
+    srcs = [
+        "clocks.py",
+        "merge.py",
+    ],
+    deps = [
+        ":lib",
+        "//util/reggen:params",
+    ],
+)
+
+filegroup(
+    name = "tpl_files",
+    srcs = glob(["**/*.tpl"]),
+)


### PR DESCRIPTION
Add the bazel BUILD fils to support py_binary for calling topgen-depedendency modules out of tree.

Signed-off-by: Cindy Liu <hcindyl@google.com>