### PR TITLE
[dv,test] fix `rom_e2e_shutdown_exception_c` test

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -17,10 +17,14 @@
     }
     {
       name: rom_e2e_shutdown_exception_c
-      uvm_test_seq: chip_sw_base_vseq
+      uvm_test_seq: chip_sw_rom_e2e_shutdown_exception_c_vseq
       sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_shutdown_exception_c:1:signed"]
       en_run_modes: ["sw_test_mode_rom"]
-      run_opts: ["+sw_test_timeout_ns=20000000"]
+      run_opts: [
+        "+sw_test_timeout_ns=20000000",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      run_timeout_mins: 120
     }
     {
       name: rom_e2e_shutdown_output

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -115,6 +115,7 @@ filesets:
       - seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv: {is_include_file: true}
       - seq_lib/chip_padctrl_attributes_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_shutdown_output_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rom_e2e_shutdown_exception_c_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - alerts_if.sv
       - ast_ext_clk_if.sv

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_shutdown_exception_c_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_shutdown_exception_c_vseq.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_rom_e2e_shutdown_exception_c_vseq extends chip_sw_rom_e2e_shutdown_output_vseq;
+  `uvm_object_utils(chip_sw_rom_e2e_shutdown_exception_c_vseq)
+  `uvm_object_new
+
+  // This matches the expected value in `sw/device/silicon_creator/rom/e2e/BUILD`. Note,
+  // SystemVerilog does not support "\r" carriage return in a string literal, so we use the hex code
+  // of "\x0d" instead.
+  string exp_boot_fault_msg = "BFV:01495202\x0d\nLCV:2739ce73\x0d\n";
+
+  virtual task check_rom_console_messages();
+    // Wait for SRAM initialization to be done before hooking up the UART agent to prevent
+    // X's propagating as a result of multiple drivers on pins IOC3 and IOC4 (due to DFT strap
+    // sampling in TestUnlocked* and RMA lifecycel states).
+    `DV_WAIT(sram_init_done_event.triggered)
+
+    check_uart_output_msg(exp_boot_fault_msg);
+  endtask
+
+endclass : chip_sw_rom_e2e_shutdown_exception_c_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -76,3 +76,4 @@
 `include "chip_sw_flash_host_gnt_err_inj_vseq.sv"
 `include "chip_padctrl_attributes_vseq.sv"
 `include "chip_sw_rom_e2e_shutdown_output_vseq.sv"
+`include "chip_sw_rom_e2e_shutdown_exception_c_vseq.sv"


### PR DESCRIPTION
This PR contains two commits that fix the `rom_e2e_shutdown_exception_c` test (in DV).

Commit 1: refactors the `chip_sw_rom_e2e_shutdown_output_vseq` sequence to allow reuse of some of the code for writing additional ROM E2E test sequences that also check UART output.

Commit 2: Implements sequence to check the UART output for a specific boot fault message, since the ROM does not allow use of the DV backdoor logging mechanism.

**Note: this depends on #16054.**