### PR TITLE
[entropy_src/dv] More efficient config coverage

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -39,7 +39,7 @@ class entropy_src_env extends cip_base_env #(
     // tests which use a fixed (non-random) RNG sequence.  So the backpressure support is done
     // on a test by test basis.
     cfg.m_rng_agent_cfg.zero_delays = 0;
-    cfg.m_rng_agent_cfg.host_delay_min = 6;
+    cfg.m_rng_agent_cfg.host_delay_min = 1;
     cfg.m_rng_agent_cfg.host_delay_max = 12;
     cfg.m_rng_agent_cfg.ignore_push_host_backpressure = cfg.rng_ignores_backpressure;
 

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -24,7 +24,6 @@ class entropy_src_base_vseq extends cip_base_vseq #(
 
   virtual entropy_src_cov_if   cov_vif;
 
-  realtime default_cfg_pause = 50us;
 
   constraint do_check_ht_diag_c {
     do_check_ht_diag dist {
@@ -247,7 +246,7 @@ class entropy_src_base_vseq extends cip_base_vseq #(
   // Outputs REGWEN = 0, if the device coniguration was attempted when most registers
   // were locked. (Likely intentionally)
   virtual task entropy_src_init(entropy_src_dut_cfg newcfg=cfg.dut_cfg,
-                                realtime pause=default_cfg_pause,
+                                realtime pause=cfg.configuration_pause_time,
                                 output bit completed,
                                 output bit regwen);
     completed = 0;

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -50,6 +50,7 @@ class entropy_src_base_test extends cip_base_test #(
     // in one of the derived test classes.
     cfg.mean_rand_reconfig_time   = -1.0;
     cfg.mean_rand_csr_alert_time  = -1.0;
+    cfg.max_silent_reconfig_time  = -1.0;
     cfg.soft_mtbf                 = -1.0;
     cfg.hard_mtbf                 = -1.0;
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -21,6 +21,12 @@ class entropy_src_rng_test extends entropy_src_base_test;
     // The random alerts only need to happen frequently enough to
     // close coverage
     cfg.mean_rand_csr_alert_time    = 20ms;
+    // The following should be enough to confirm that OTP-silenced configurations are not
+    // outputting any seeds.
+    // TODO (V3/Enhancement): Add coverpoints (with sampling ifs) and assertions to
+    // confirm that data is actually being dropped in the DUT. (Silent configs are not counted
+    // by existing CP's as we only sample when seeds are generated)
+    cfg.max_silent_reconfig_time    = 100us;
     cfg.soft_mtbf                   = 7500us;
 
     // Apply standards ranging from strict to relaxed


### PR DESCRIPTION
This commit adds enhancments to the RNG vseq to perform more reconfigs per iteration and thus close more cover points with less simulation time.

- Identifies certain configurations as "Silent" meaning that they are blocked either by OTP or by inconsistent CSR configurations. These do not generate seeds and thus do not close any configuration CPs.
  - A new max_silent_reconfig_time parameter has been added to prompt a faster reconfig for these silent configurations.

- Identifies a bug in which random reconfigurations were not getting changed in Xcelium (it seems that if randomize() is called twice on the same object, the randomize routine is called, but the object
  is not updated in the calling task!).   This is fixed by creating a
  new copy of the dut_cfg object each time before randomizing.

- Removes long pauses when reconfiguring the DUT

- Removes the "Do NOT Disturb" flag in the RNG vseq. This debugging feature was incorrectly implemented and thus was preventing most reconfig trigger events it is also not needed anyway

- Includes a number of small constraint or knob changes to get more efficient coverage.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>