### PR TITLE
[entropy_src/dv] No backpressure on AST RNG agent

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
@@ -45,6 +45,9 @@ class push_pull_agent_cfg #(parameter int HostDataWidth = 32,
   // Enable starting the device sequence by default if configured in Device mode.
   bit start_default_device_seq = 1;
 
+  // Ignore backpressure (ready signal) if configured as a Push Host
+  bit ignore_push_host_backpressure = 0;
+
   // These data queues allows users to specify data to be driven by the sequence at a higher level.
   //
   // To specify some Host data to be sent, `set_h_user_data()` should be called from a higher layer

--- a/hw/dv/sv/push_pull_agent/push_pull_driver_lib.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_driver_lib.sv
@@ -129,7 +129,7 @@ class push_host_driver #(
         repeat (req.host_delay) @(`CB);
         `CB.valid_int <= 1'b1;
         `CB.h_data_int <= req.h_data;
-        do @(`CB); while (!`CB.ready);
+        do @(`CB); while (!cfg.ignore_push_host_backpressure && !`CB.ready);
         `CB.valid_int <= 1'b0;
         if (!cfg.hold_h_data_until_next_req) `CB.h_data_int <= 'x;,
         wait (cfg.in_reset);)

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -35,9 +35,13 @@ class entropy_src_env extends cip_base_env #(
     cfg.m_rng_agent_cfg.en_cov     = cfg.en_cov;
 
     // To correctly model ast/rng behavior, back-to-back entropy is not allowed
+    // The actual AST/RNG ingores ready-signal backpressure, but this can be inconvenient for
+    // tests which use a fixed (non-random) RNG sequence.  So the backpressure support is done
+    // on a test by test basis.
     cfg.m_rng_agent_cfg.zero_delays = 0;
     cfg.m_rng_agent_cfg.host_delay_min = 6;
     cfg.m_rng_agent_cfg.host_delay_max = 12;
+    cfg.m_rng_agent_cfg.ignore_push_host_backpressure = cfg.rng_ignores_backpressure;
 
     m_csrng_agent = push_pull_agent#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))::
                     type_id::create("m_csrng_agent", this);

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -66,6 +66,12 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
 
   int      seed_cnt;
 
+  // The AST/RNG does not pay attention to the entropy_src `ready` backpressure signal on the RNG
+  // entropy_src interface.  We mimic this behavior in the RNG and FW_OV tests, which expect random
+  // RNG data.  For other tests (which rely on fixed RNG sequences) we leave handshaking enabled.
+  bit      rng_ignores_backpressure = 0;
+
+
   /////////////////////
   // Knobs & Weights //
   /////////////////////

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -98,6 +98,10 @@ module tb;
     // Drive clk and rst_n from clk_if
     // Set interfaces in config_db
     clk_rst_if.set_active();
+    // The rng_if (which mimics the AST RNG) is expected to drop RNG inputs even if the
+    // DUT is not ready.
+    $assertoff(0, tb.rng_if.H_DataStableWhenValidAndNotReady_A);
+    $assertoff(0, tb.rng_if.ValidHighUntilReady_A);
     csrng_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "csrng_rst_vif", csrng_rst_if);

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -30,6 +30,7 @@ class entropy_src_base_test extends cip_base_test #(
     // seed_cnt only used by smoke test
     // so there is no need to randomize it.
     cfg.seed_cnt                       = 1;
+    cfg.rng_ignores_backpressure       = 0;
     cfg.otp_en_es_fw_read_pct          = 100;
     cfg.otp_en_es_fw_over_pct          = 100;
     cfg.dut_cfg.en_intr_pct            = 75;
@@ -53,6 +54,7 @@ class entropy_src_base_test extends cip_base_test #(
     cfg.dut_cfg.bad_mubi_cfg_pct       = 0;
     cfg.induce_targeted_transition_pct = 0;
     cfg.dut_cfg.tight_thresholds_pct   = 0;
+
 
   endfunction
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
@@ -12,6 +12,7 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
 
     cfg.en_scb                              = 1;
     cfg.alert_max_delay                     = 5;
+    cfg.rng_ignores_backpressure            = 1;
 
     cfg.dut_cfg.boot_mode_retry_limit       = 10;
     cfg.sim_duration                        = 10ms;

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -12,6 +12,7 @@ class entropy_src_rng_test extends entropy_src_base_test;
 
     cfg.en_scb                      = 1;
     cfg.alert_max_delay             = 5;
+    cfg.rng_ignores_backpressure    = 1;
 
     cfg.dut_cfg.boot_mode_retry_limit       = 10;
     cfg.sim_duration                = 20ms;


### PR DESCRIPTION
The Raw RNG source used by the top-level AST top is expected to not respect the `ready` output from the `entropy_src`.  This commit modifies the host/push variant of the `push_pull_driver`, to optionially mimic such an external device.

This change is helpful in in closing the `main_sm` transition coverage. The transition StartupHTStart->Idle transition can be blocked if there is always an RNG sample waiting at the RNG IF, as many parts of the DUT, including the FSM, wait for the state of the internal FIFOs to self-clear before fully shutting down.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>