### PR TITLE
[keymgr/dv] Fix 2 regression failures

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -616,10 +616,11 @@ interface keymgr_if(input clk, input rst_n);
   // consider async handshaking and a few cycles to start the req. allow no more than 20 tolerance
   // error on the cnt
   `ASSERT(CheckEdn1stReq, $rose(edn_req_sync) && edn_req_cnt == 0 && start_edn_req |->
-          (edn_wait_cnt > edn_interval) && (edn_wait_cnt - edn_interval < 20), clk, !rst_n)
+          (edn_wait_cnt > edn_interval) && (edn_wait_cnt - edn_interval < 20),
+          clk, !rst_n || !en_chk)
 
   `ASSERT(CheckEdn2ndReq, $rose(edn_req_sync) && edn_req_cnt == 1 |-> edn_wait_cnt < 20,
-          clk, !rst_n)
+          clk, !rst_n || !en_chk)
 
   `undef ASSERT_IFF_KEYMGR_LEGAL
 endinterface

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -856,7 +856,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     keymgr_invalid_hw_input_type_e invalid_hw_input_type;
 
     // if it's an invalid op, kmac key and data are random value, they shouldn't be all 0s/1s
-    if (get_invalid_op()) return 0;
+    if (get_invalid_op() || get_operation() == keymgr_pkg::OpDisable) return 0;
 
     if ((current_internal_key[current_cdi][0] inside {0, '1} ||
          current_internal_key[current_cdi][1] inside {0, '1}) &&

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
@@ -26,6 +26,9 @@ class keymgr_common_vseq extends keymgr_base_vseq;
 
   virtual task pre_start();
     do_keymgr_init = 1'b0;
+    // randomly changing edn interval value makes EDN req unpredictable,
+    // disable the EDN SVA in the keymgr_if.
+    cfg.keymgr_vif.en_chk = 0;
     super.pre_start();
   endtask
 


### PR DESCRIPTION
1. Fixed scb for direct_to_disable test
2. Disabled EDN SVA for CSR tests

Signed-off-by: Weicai Yang <weicai@google.com>