### PR TITLE
[rv_core_ibex] Fix a fetch enable assertion

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -908,6 +908,7 @@ module rv_core_ibex
   `ASSERT(IbexFetchEnable3_A,
       lc_ctrl_pkg::lc_tx_test_true_strict(lc_cpu_en_i) &&
       lc_ctrl_pkg::lc_tx_test_true_strict(pwrmgr_cpu_en_i) ##1
+      lc_ctrl_pkg::lc_tx_test_true_strict(local_fetch_enable_q) &&
       !fatal_core_err
       |=>
       lc_ctrl_pkg::lc_tx_test_true_strict(fetch_enable))


### PR DESCRIPTION
The SVA failed because it did not take the latched fetch disable state into account.

Fixes #15899

Signed-off-by: Michael Schaffner <msf@google.com>