### PR TITLE
[test] Extend chip_sw_data_integrity to also check ret SRAM and instruction faults

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -518,14 +518,29 @@
     {
       name: chip_sw_data_integrity
       desc: '''
-            Verify the alert signaling mechanism due to memory data integrity violation.
+            Verify the alert signaling mechanism due to integrity violations of load ops.
 
-            An SW test which performs the following on ret_sram to verify the memory end to end
-            integrity scheme.
+            An SW test which performs the following on main and retention SRAMs to verify the memory
+            end-to-end integrity scheme:
             - Corrupt a random data / integrity bit in the memory using SV force.
             - SW reads that address and the corrupted data is sent to ibex.
             - Verify that ibex detects the integrity violation and triggers an alert.
-            - Verify the alert upto the NMI stage or full reset, and alert cause is from ibex.
+            - Check the alert up to the NMI phase and make sure that the alert cause is from Ibex.
+            '''
+      stage: V2
+      tests: ["chip_sw_data_integrity_escalation"]
+    }
+    {
+      name: chip_sw_instruction_integrity
+      desc: '''
+            Verify the alert signaling mechanism due to integrity violations of instruction fetches.
+
+            An SW test which performs the following on main SRAM to verify the memory end-to-end
+            integrity scheme:
+            - Corrupt a data / integrity bit in a test function in the main SRAM using SV force.
+            - SW jumps to that test function in the main SRAM.
+            - Verify that ibex detects the integrity violation and triggers an alert.
+            - Check the alert up to the NMI phase and make sure that the alert cause is from Ibex.
             '''
       stage: V2
       tests: ["chip_sw_data_integrity_escalation"]

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2598,10 +2598,11 @@
             - Re-initialize the SRAMs and verify that they can now respond correctly to
               any further memory requests.
 
-            X-ref with chip_sw_all_escalation_resets.
+            X-ref with chip_sw_all_escalation_resets and chip_sw_data_integrity.
             '''
       stage: V2
-      tests: ["chip_sw_all_escalation_resets"]
+      tests: ["chip_sw_all_escalation_resets"
+              "chip_sw_data_integrity"]
     }
 
     // OTP (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -389,6 +389,7 @@
       sw_images: ["//sw/device/tests/sim_dv:data_integrity_escalation_reset_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
+      reseed: 6
     }
     {
       name: chip_sw_sleep_pin_mio_dio_val

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -173,7 +173,8 @@ package chip_env_pkg;
       string out_file = $sformatf("%0s.dat", symbol);
       string cmd = $sformatf(
           // use `--wide` to avoid truncating the output, in case of long symbol name
-          "/usr/bin/readelf -s --wide %0s | grep %0s | awk \'{print $2\" \"$3}\' > %0s",
+          // `\s%0s$` ensures we are looking for an exact match, with no pre- or postfixes.
+          "/usr/bin/readelf -s --wide %0s | grep \"\\s%0s$\" | awk \'{print $2\" \"$3}\' > %0s",
           elf_file, symbol, out_file);
 
       // TODO #3838: shell pipes are bad 'mkay?

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_data_integrity_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_data_integrity_vseq.sv
@@ -7,28 +7,88 @@ class chip_sw_data_integrity_vseq extends chip_sw_base_vseq;
 
   `uvm_object_new
 
+  typedef enum bit [31:0] {
+    FaultTargetMainSramData,
+    FaultTargetRetSramData,
+    FaultTargetMainSramInstr
+  } fault_target_e;
+
   virtual task body();
+    fault_target_e fault_target;
     bit [31:0] error_ram_address;
-    bit [ 7:0] sw_error_ram_address[];
+    bit [31:0] error_ram_base;
+    bit [31:0] error_ram_size;
+    bit [ 7:0] sw_error_ram_base[4];
+    bit [ 7:0] sw_error_ram_address[4];
+    bit [ 7:0] sw_fault_target[4];
 
     // This sequence will trigger a fatal sec_cm failure.
     super.body();
 
-    error_ram_address = ral.sram_ctrl_main_ram.default_map.get_base_addr() + 32'h0000_4000;
+    // Randomly select either the main or the retention SRAM.
+    `DV_CHECK_STD_RANDOMIZE_FATAL(fault_target)
+
+    // Memory blocks are always aligned to powers of 2, hence we can
+    // use the get_addr_mask() function of the RAL model to automatically infer the size.
+    if (fault_target == FaultTargetMainSramData) begin
+      `uvm_info(`gfn, "Injecting data error in main SRAM.", UVM_MEDIUM)
+      error_ram_size = ral.sram_ctrl_main_ram.get_addr_mask() + 1;
+      error_ram_base = ral.sram_ctrl_main_ram.default_map.get_base_addr();
+    end else if (fault_target == FaultTargetRetSramData) begin
+      `uvm_info(`gfn, "Injecting data error in retention SRAM.", UVM_MEDIUM)
+      error_ram_size = ral.sram_ctrl_ret_aon_ram.get_addr_mask() + 1;
+      error_ram_base = ral.sram_ctrl_ret_aon_ram.default_map.get_base_addr();
+    end else begin
+      `uvm_info(`gfn, "Injecting instruction error in main SRAM.", UVM_MEDIUM)
+      // Get the address of the first instruction of the test program in SRAM.
+      sw_symbol_backdoor_read("kSramFunctionTestAddress", sw_error_ram_base);
+      error_ram_address = {<<byte{sw_error_ram_base}};
+    end
+
+    if (fault_target != FaultTargetMainSramInstr) begin
+      // Choose a random address +-10 words around the midpoint of the SRAM so that
+      // we do not accidentally clobber data on the stack / heap.
+      error_ram_address = error_ram_base +
+                          error_ram_size/2 +
+                          (($urandom_range(0, 20) - 10) << $clog2(bus_params_pkg::BUS_DBW));
+    end
 
     // Disable scoreboard tl error checks since we will trigger faults which cannot be predicted.
     cfg.en_scb_tl_err_chk = 0;
 
-    // Let SW know the address thal will trigger an error when read.
+    // Let SW know the address that will trigger an error when read.
     sw_error_ram_address = {<<byte{error_ram_address}};
     `uvm_info(`gfn, $sformatf("address 0x%x as bytes %p", error_ram_address, sw_error_ram_address),
               UVM_MEDIUM)
     sw_symbol_backdoor_overwrite("kErrorRamAddress", sw_error_ram_address);
 
+    // Communicate the fault target to SW.
+    sw_fault_target = {<<byte{fault_target}};
+    `uvm_info(`gfn, $sformatf("fault_target 0x%x as bytes %p", fault_target, sw_fault_target),
+              UVM_MEDIUM)
+    sw_symbol_backdoor_overwrite("kFaultTarget", sw_fault_target);
+
+    // Wait until the test and associated data in SRAM have been loaded.
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Entered test_main")
+
     // And corrupt the data.
     `uvm_info(`gfn, $sformatf(
-              "Corrupting memory at address 0x%x, for alert %0d", error_ram_address, 63),
-              UVM_MEDIUM)
-    main_sram_bkdr_write32(.addr(error_ram_address), .data('0), .flip_bits(39'h1001));
+              "Corrupting memory at address 0x%x, for alert %0d", error_ram_address,
+              TopEarlgreyAlertIdRvCoreIbexFatalHwErr), UVM_MEDIUM)
+    if (fault_target == FaultTargetRetSramData) begin
+      // Double check again that the address range is correct.
+      error_ram_size = ral.sram_ctrl_ret_aon_ram.get_addr_mask() + 1;
+      error_ram_base = ral.sram_ctrl_ret_aon_ram.default_map.get_base_addr();
+      `DV_CHECK(error_ram_address >= error_ram_base)
+      `DV_CHECK(error_ram_address < error_ram_base + error_ram_size)
+      ret_sram_bkdr_write32(.addr(error_ram_address), .data('0), .flip_bits(39'h1001));
+    end else begin
+      // Double check again that the address range is correct.
+      error_ram_size = ral.sram_ctrl_main_ram.get_addr_mask() + 1;
+      error_ram_base = ral.sram_ctrl_main_ram.default_map.get_base_addr();
+      `DV_CHECK(error_ram_address >= error_ram_base)
+      `DV_CHECK(error_ram_address < error_ram_base + error_ram_size)
+      main_sram_bkdr_write32(.addr(error_ram_address), .data('0), .flip_bits(39'h1001));
+    end
   endtask
 endclass

--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -305,11 +305,14 @@ OT_SECTION(".non_volatile_counter_1")
 uint64_t nv_counter_1[kNonVolatileCounterFlashWords];
 OT_SECTION(".non_volatile_counter_2")
 uint64_t nv_counter_2[kNonVolatileCounterFlashWords];
+OT_SECTION(".non_volatile_counter_3")
+uint64_t nv_counter_3[kNonVolatileCounterFlashWords];
 
 static uint64_t *const kNvCounters[] = {
     nv_counter_0,
     nv_counter_1,
     nv_counter_2,
+    nv_counter_3,
 };
 
 uint32_t flash_ctrl_testutils_counter_get(size_t counter) {

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -253,6 +253,9 @@ SECTIONS {
    _non_volatile_counter_2_end = _non_volatile_counter_1_start;
    _non_volatile_counter_2_start = _non_volatile_counter_2_end - _non_volatile_counter_size;
 
+   _non_volatile_counter_3_end = _non_volatile_counter_2_start;
+   _non_volatile_counter_3_start = _non_volatile_counter_3_end - _non_volatile_counter_size;
+
   /**
    * Non-volatile scratch area in flash.
    */
@@ -286,6 +289,12 @@ SECTIONS {
   .non_volatile_counter_2 _non_volatile_counter_2_start (NOLOAD) : ALIGN(2048) {
     KEEP(*(.non_volatile_counter_2))
     KEEP(*(.non_volatile_counter_2.*))
+    . = _non_volatile_counter_size;
+  } > ottf_flash
+
+  .non_volatile_counter_3 _non_volatile_counter_3_start (NOLOAD) : ALIGN(2048) {
+    KEEP(*(.non_volatile_counter_3))
+    KEEP(*(.non_volatile_counter_3.*))
     . = _non_volatile_counter_size;
   } > ottf_flash
 

--- a/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
@@ -4,7 +4,10 @@
 
 // This test triggers a ram read uncorrectable error created from the SV side
 // for a specific address. The alert handler is programmed to trigger a specific
-// alert for the ibex.
+// alert for the ibex. The injection address is randomly selected by the SV
+// sequence and can either be in the main SRAM or in the retention SRAM. For the
+// main SRAM the SV sequence also randomly selects whether it injects a data
+// error, or an instruction error in a test function residing in the main SRAM.
 //
 // The test checks that the alert handler state indicates the correct alert
 // prior to reset, which is checked in the alert triggered interrupt. The
@@ -13,11 +16,55 @@
 // the interrupt, and it is also cleared after reset.
 //
 // As a backup the aon timer is programmed to bark and bite, but these are
-// expected not to happen since the escalation takes precedence.
+// expected not to happen since the escalation takes precedence. In particular,
+// the timeouts are set so that bark and bite happen during the escalation phase
+// where lc_escalate_en is asserted, which halts the watchdog timers.
 //
-// The alert_handler is programmed to escalate on the first interrupt, so the
-// regular ISR is not necessarily run and the load integrity error handler may
-// be beat by the NMI.
+// The alert_handler is programmed to escalate on the first alert event it
+// registers. It is also programmed to do nothing in its first escalation phase
+// so that the exception handlers and regular ISRs can execute before the NMI is
+// triggered in the subsequent escalation phase.
+//
+// In summary, the test comprises the following steps:
+//
+// 0) SV sequence waits until test is running and the test function has been
+// loaded to SRAM. It then randomly decides where to inject a fault, and
+// communicates this to the program via symbol overwrites.
+//
+// 1) Test sets up peripherals. Randomly choose the alert class to use for the
+// test.
+//
+// 2) Either read a corrupted memory location in main or retention SRAM, or
+// jump to a corrupted test function in SRAM.
+//
+// 3) Alert handler escalates right away when seeing the first alert
+// event. It enters phase 0 where it just waits for 200us without triggering any
+// actions so that regular exception handlers can execute (these would
+// otherwise be masked by the NMI).
+//
+// 4a) Regular ISR acknowledges alert handler has indeed escalated.
+//
+// 4b) Exception handler acknowledges either load integrity fault or instruction
+// access fault.
+//
+// 5) Alert handler moves on to the next escalation phase and triggers an NMI.
+//
+// 6) NMI handler executes and checks that NMI is not due to Wdog, due to alert
+// handler escalation. Since we do not clear the escalation, the NMI handler may
+// execute several times, which will be reflected by a > 1 NMI count in the
+// flash counters.
+//
+// 7) Alert handler moves on to the next escalation phase and asserts
+// lc_escalate_en, which renders the chip inert. The Wdog should stop running,
+// which is checked implicitly, since both bite and bark have been programmed to
+// trigger within this escalation phase.
+//
+// 8) Alert handler moves on to the last excalation phase and resets the chip.
+//
+// 9) The chip reboots, and the test checks the alert handler state and the
+// various interrupt counts maintained in flash.
+//
+// Throughout the entire test, we do not expect any Wdog bark or bite events.
 
 #include <assert.h>
 #include <limits.h>
@@ -30,13 +77,13 @@
 #include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/dif/dif_rv_plic.h"
-#include "sw/device/lib/dif/dif_sram_ctrl.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/irq.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/alert_handler_testutils.h"
 #include "sw/device/lib/testing/aon_timer_testutils.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/rand_testutils.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/rv_plic_testutils.h"
 #include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
@@ -51,9 +98,18 @@ OTTF_DEFINE_TEST_CONFIG();
 // trigger the fault on a read.
 static volatile const uint32_t kErrorRamAddress = 0;
 
-static const uint32_t kExpectedAlertNumber = 63;
+// This location will be update from SV to indicate the fault target for this
+// test. The SV side randomly selects between data errors on main and retention
+// SRAM, and instruction errors in a program that is loaded in the main SRAM.
+static volatile const uint32_t kFaultTarget = 0;
 
-uint32_t reset_count;
+static const uint32_t kExpectedAlertNumber =
+    kTopEarlgreyAlertIdRvCoreIbexFatalHwErr;
+
+// Alert class to use for the test. Will be chosen randomly by the test SW.
+static volatile dif_alert_handler_class_t alert_class_to_use;
+
+static volatile uint32_t reset_count;
 
 enum {
   // Counter for resets.
@@ -62,6 +118,17 @@ enum {
   kCounterInterrupt,
   // Counter for NMIs.
   kCounterNmi,
+  // Counter for exceptions
+  kCounterException
+};
+
+/**
+ * Enums for identifying the fault injection target.
+ */
+enum {
+  kFaultTargetMainSramData,
+  kFaultTargetRetSramData,
+  kFaultTargetMainSramInstr
 };
 
 /**
@@ -71,18 +138,64 @@ enum {
  * - bite after escalation reset, so we should not get timer reset.
  */
 enum {
-  kWdogBarkMicros = 600,          // 600 us
-  kWdogBiteMicros = 800,          // 800 us
-  kEscalationStartMicros = 200,   // 200 us
-  kEscalationPhase0Micros = 200,  // 200 us
-  kEscalationPhase1Micros = 200,  // 200 us
-  kMaxResets = 2,
+  // Note that the escalation phase times below define the length of each phase,
+  // not when they start.
+  // The starting time is given by the aggregate of previous phase lengths, and
+  // is noted with @ below.
+  // @0 us -> in this phase we will not do anything so that the exception
+  // handlers have time to execute.
+  kEscalationPhase0Micros = 200,
+  // @200 us -> in this phase we will raise an NMI
+  kEscalationPhase1Micros = 200,
+  // @400 us -> in this phase we will assert lc_escalate_en
+  kEscalationPhase2Micros = 200,
+  // @600 us -> in this phase we will reset the chip
+  kEscalationPhase3Micros = 200,
+  // These are set so that both events happen in Phase2 of the escalation
+  // protocol, which asserts lc_escalate_en. That should prevent the Wdog
+  // from running and sending out an NMI on its own (we check in the NMI
+  // handler below that this does not happen).
+  kWdogBarkMicros = 450,
+  kWdogBiteMicros = 500,
+  // We expect exactly one reset
+  kMaxResets = 1,
   kMaxInterrupts = 30,
 };
 
-static_assert(kWdogBarkMicros < kWdogBiteMicros &&
-                  kWdogBarkMicros > kEscalationPhase0Micros,
-              "The wdog bite shall happen only if escalation reset fails.");
+static_assert(
+    kWdogBarkMicros < kWdogBiteMicros &&
+        kWdogBarkMicros > (kEscalationPhase0Micros + kEscalationPhase1Micros),
+    "The wdog bite shall after the NMI phase when lc_escalate_en is asserted.");
+/**
+ * Main SRAM addresses used in the sram_function_test.
+ */
+enum {
+  kSramStart = TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR,
+  kSramEnd = TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR +
+             TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES,
+  kSramRetStart = TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR,
+};
+
+/**
+ * Program in main SRAM to jump to for testing corruption of instruction
+ * integrity.
+ *
+ * Using this program is convenient, since the sram_program.ld script ensures
+ * that the entry point will be mapped to the start of the main SRAM.
+ */
+OT_SECTION(".data.sram_function_test")
+OT_NOINLINE
+static void sram_function_test(void) {
+  uint32_t pc = 0;
+  uint32_t accum = 0;
+  asm("auipc %[pc], 0;" : [pc] "=r"(pc));
+  LOG_INFO("PC: %p, SRAM: [%p, %p)", pc, kSramStart, kSramEnd);
+  CHECK(pc >= kSramStart && pc < kSramEnd, "PC is outside the main SRAM");
+}
+// Make the address of this function available via a global constant that SV can
+// read.
+volatile static const uint32_t kSramFunctionTestAddress =
+    (uint32_t)sram_function_test;
 
 /**
  * Objects to access the peripherals used in this test via dif API.
@@ -145,48 +258,10 @@ void ottf_external_isr(void) {
     // We should not get aon timer interrupts since escalation suppresses them.
     CHECK(false, "Unexpected aon timer interrupt %d", irq);
   } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
-    CHECK(irq_id == kTopEarlgreyPlicIrqIdAlertHandlerClassa,
-          "Unexpected irq_id, expected %d, got %d",
-          kTopEarlgreyPlicIrqIdAlertHandlerClassa, irq_id);
-  }
-
-  // Complete the IRQ by writing the IRQ source to the Ibex specific CC
-  // register.
-  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kPlicTarget, irq_id));
-  LOG_INFO("Regular external ISR exiting");
-}
-
-void ottf_load_integrity_error_handler(void) {
-  dif_rv_plic_irq_id_t irq_id;
-
-  LOG_INFO("At load integrity error handler");
-
-  uint32_t mtval = ibex_mtval_read();
-  CHECK(mtval == kErrorRamAddress, "Unexpected mtval: expected 0x%x, got 0x%x",
-        kErrorRamAddress, mtval);
-
-  rv_core_ibex_fault_checker(true);
-
-  // There may be multiple interrupts due to the alert firing, so this keeps an
-  // interrupt counter and errors-out if there are too many interrupts.
-
-  // Increment the interrupt count and detect overflows.
-  uint32_t interrupt_count =
-      flash_ctrl_testutils_counter_get(kCounterInterrupt);
-  if (interrupt_count > kMaxInterrupts) {
-    CHECK(false, "Reset count %d got too many interrupts (%d)", reset_count,
-          interrupt_count);
-  }
-  flash_ctrl_testutils_counter_set_at_least(
-      &flash_ctrl_state, kCounterInterrupt, interrupt_count + 1);
-
-  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));
-
-  LOG_INFO("Got irq_id 0x%x (%d)", irq_id, irq_id);
-
-  top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
-      top_earlgrey_plic_interrupt_for_peripheral[irq_id];
-  if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
+    CHECK(
+        irq_id == kTopEarlgreyPlicIrqIdAlertHandlerClassa + alert_class_to_use,
+        "Unexpected irq_id, expected %d, got %d",
+        kTopEarlgreyPlicIrqIdAlertHandlerClassa + alert_class_to_use, irq_id);
     LOG_INFO("Got expected alert handler interrupt %d", irq_id);
 
     // Disable these interrupts from alert_handler so they don't keep happening
@@ -200,15 +275,69 @@ void ottf_load_integrity_error_handler(void) {
     // Disable this interrupt to prevent it from continuously firing. This
     // should not prevent escalation from continuing.
     CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(&plic, irq_id, kPlicTarget,
-                                             kDifToggleEnabled));
-  } else {
-    CHECK(false, "Unexpected peripheral %d for ISR", peripheral);
+                                             kDifToggleDisabled));
   }
 
   // Complete the IRQ by writing the IRQ source to the Ibex specific CC
   // register.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kPlicTarget, irq_id));
+  LOG_INFO("Regular external ISR exiting");
+}
+
+/**
+ * Load integrity error exception handler.
+ *
+ * Handles load integrity error exceptions on Ibex.
+ */
+void ottf_load_integrity_error_handler(void) {
+  LOG_INFO("At load integrity error handler");
+
+  CHECK(kFaultTarget != kFaultTargetMainSramInstr,
+        "Expected fault target 0 or 1, got %d", kFaultTarget);
+
+  uint32_t mtval = ibex_mtval_read();
+  CHECK(mtval == kErrorRamAddress, "Unexpected mtval: expected 0x%x, got 0x%x",
+        kErrorRamAddress, mtval);
+
+  // Increment the exception count.
+  uint32_t exception_count =
+      flash_ctrl_testutils_counter_get(kCounterException);
+  if (exception_count > kMaxInterrupts) {
+    LOG_INFO("Saturating exception counter at %d", exception_count);
+  } else {
+    flash_ctrl_testutils_counter_set_at_least(
+        &flash_ctrl_state, kCounterException, exception_count + 1);
+  }
+
+  rv_core_ibex_fault_checker(true);
+
   LOG_INFO("Load integrity error handler exiting");
+}
+
+/**
+ * Instruction access exception handler.
+ *
+ * Handles instruction access faults on Ibex.
+ */
+void ottf_instr_access_fault_handler(void) {
+  LOG_INFO("At instr access fault handler");
+
+  CHECK(kFaultTargetMainSramInstr == 2, "Expected fault target 2, got %d",
+        kFaultTarget);
+
+  // Increment the nmi interrupt count.
+  uint32_t exception_count =
+      flash_ctrl_testutils_counter_get(kCounterException);
+  if (exception_count > kMaxInterrupts) {
+    LOG_INFO("Saturating exception counter at %d", exception_count);
+  } else {
+    flash_ctrl_testutils_counter_set_at_least(
+        &flash_ctrl_state, kCounterException, exception_count + 1);
+  }
+
+  rv_core_ibex_fault_checker(true);
+
+  LOG_INFO("Instr access fault handler exiting");
 }
 
 /**
@@ -217,22 +346,36 @@ void ottf_load_integrity_error_handler(void) {
  * Handles NMI interrupts on Ibex for either escalation or watchdog.
  */
 void ottf_external_nmi_handler(void) {
+  dif_rv_core_ibex_nmi_state_t nmi_state = (dif_rv_core_ibex_nmi_state_t){0};
   LOG_INFO("At NMI handler");
 
   // Increment the nmi interrupt count.
-  uint32_t nmi_interrupt_count = flash_ctrl_testutils_counter_get(kCounterNmi);
-  if (nmi_interrupt_count > kMaxInterrupts) {
-    LOG_INFO("Saturating nmi interrupts at %d", nmi_interrupt_count);
+  uint32_t nmi_count = flash_ctrl_testutils_counter_get(kCounterNmi);
+  if (nmi_count > kMaxInterrupts) {
+    LOG_INFO("Saturating nmi interrupts at %d", nmi_count);
   } else {
     flash_ctrl_testutils_counter_set_at_least(&flash_ctrl_state, kCounterNmi,
-                                              nmi_interrupt_count + 1);
+                                              nmi_count + 1);
   }
+
+  // Check that this NMI was due to an alert handler escalation, and not due
+  // to a watchdog bark, since escalation suppresses the watchdog.
+  CHECK_DIF_OK(dif_rv_core_ibex_get_nmi_state(
+      &rv_core_ibex, (dif_rv_core_ibex_nmi_state_t *)&nmi_state));
+  CHECK(nmi_state.alert_enabled && nmi_state.alert_raised,
+        "Alert handler NMI state not expected:\n\t"
+        "alert_enable:%x\n\talert_raised:%x\n",
+        nmi_state.alert_enabled, nmi_state.alert_raised);
+  CHECK(nmi_state.wdog_enabled && !nmi_state.wdog_barked,
+        "Watchdog NMI state not expected:\n\t"
+        "wdog_enabled:%x\n\twdog_barked:%x\n",
+        nmi_state.wdog_enabled, nmi_state.wdog_barked);
 
   // Check the class.
   dif_alert_handler_class_state_t state;
-  CHECK_DIF_OK(dif_alert_handler_get_class_state(
-      &alert_handler, kDifAlertHandlerClassA, &state));
-  CHECK(state == kDifAlertHandlerClassStatePhase0, "Wrong phase %d", state);
+  CHECK_DIF_OK(dif_alert_handler_get_class_state(&alert_handler,
+                                                 alert_class_to_use, &state));
+  CHECK(state == kDifAlertHandlerClassStatePhase1, "Wrong phase %d", state);
 
   // Check this gets the expected alert.
   bool is_cause = false;
@@ -243,6 +386,7 @@ void ottf_external_nmi_handler(void) {
   // Acknowledge the cause, which doesn't affect escalation.
   CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(&alert_handler,
                                                    kExpectedAlertNumber));
+  LOG_INFO("NMI handler exiting");
 }
 
 /**
@@ -272,33 +416,40 @@ static void init_peripherals(void) {
 }
 
 /**
- * Program the alert handler to escalate on alerts and reset on phase 2,
- * and to start escalation after timing out due to an unacknowledged
- * interrupt.
+ * Program the alert handler to escalate on alerts and reset on phase 3,
+ * and to start escalation after observing 1 alert event.
  */
 static void alert_handler_config(void) {
+  alert_class_to_use = (dif_alert_handler_class_t)rand_testutils_gen32_range(
+      kDifAlertHandlerClassA, kDifAlertHandlerClassD);
   dif_alert_handler_alert_t alerts[] = {kExpectedAlertNumber};
-  dif_alert_handler_class_t alert_classes[] = {kDifAlertHandlerClassA};
+  dif_alert_handler_class_t alert_classes[] = {alert_class_to_use};
 
   dif_alert_handler_escalation_phase_t esc_phases[] = {
       {.phase = kDifAlertHandlerClassStatePhase0,
-       .signal = 0,
+       .signal = 0xFFFFFFFF,  // do not trigger any signal, just wait.
        .duration_cycles =
            alert_handler_testutils_get_cycles_from_us(kEscalationPhase0Micros)},
       {.phase = kDifAlertHandlerClassStatePhase1,
-       .signal = 1,
+       .signal = 0,  // NMI
        .duration_cycles =
            alert_handler_testutils_get_cycles_from_us(kEscalationPhase1Micros)},
       {.phase = kDifAlertHandlerClassStatePhase2,
-       .signal = 3,
+       .signal = 1,  // lc_escalate_en
+       .duration_cycles =
+           alert_handler_testutils_get_cycles_from_us(kEscalationPhase2Micros)},
+      {.phase = kDifAlertHandlerClassStatePhase3,
+       .signal = 3,  // reset
        .duration_cycles = alert_handler_testutils_get_cycles_from_us(
-           kEscalationPhase1Micros)}};
+           kEscalationPhase3Micros)}};
 
-  uint32_t deadline_cycles =
-      alert_handler_testutils_get_cycles_from_us(kEscalationStartMicros);
+  // This test does not leverage the IRQ timeout feature of the alert
+  // handler, hence deadline_cycles is set to zero. Rather, it triggers
+  // escalation right away if an alert event is seen, hence threshold = 0;
+  uint32_t deadline_cycles = 0;
   uint32_t threshold = 0;
-  LOG_INFO("Configuring class A with %d cycles and %d occurrences",
-           deadline_cycles, threshold);
+  LOG_INFO("Configuring class %d with %d cycles and %d occurrences",
+           alert_class_to_use, deadline_cycles, threshold);
   dif_alert_handler_class_config_t class_config[] = {{
       .auto_lock_accumulation_counter = kDifToggleDisabled,
       .accumulator_threshold = threshold,
@@ -308,7 +459,7 @@ static void alert_handler_config(void) {
       .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase3,
   }};
 
-  dif_alert_handler_class_t classes[] = {kDifAlertHandlerClassA};
+  dif_alert_handler_class_t classes[] = {alert_class_to_use};
   dif_alert_handler_config_t config = {
       .alerts = alerts,
       .alert_classes = alert_classes,
@@ -321,9 +472,17 @@ static void alert_handler_config(void) {
 
   alert_handler_testutils_configure_all(&alert_handler, config,
                                         kDifToggleEnabled);
-  // Enables alert handler irq.
+
+  // Enables all alert handler irqs. This allows us to implicitly check that
+  // we do not get spurious IRQs from the classes that are unused.
   CHECK_DIF_OK(dif_alert_handler_irq_set_enabled(
       &alert_handler, kDifAlertHandlerIrqClassa, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_alert_handler_irq_set_enabled(
+      &alert_handler, kDifAlertHandlerIrqClassb, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_alert_handler_irq_set_enabled(
+      &alert_handler, kDifAlertHandlerIrqClassc, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_alert_handler_irq_set_enabled(
+      &alert_handler, kDifAlertHandlerIrqClassd, kDifToggleEnabled));
 }
 
 static void set_aon_timers() {
@@ -351,27 +510,48 @@ static void set_aon_timers() {
 static void execute_test() {
   alert_handler_config();
 
-  // Enable NMI
+  // Make sure we can receive both the watchdog and alert NMIs.
   CHECK_DIF_OK(
       dif_rv_core_ibex_enable_nmi(&rv_core_ibex, kDifRvCoreIbexNmiSourceAlert));
+  CHECK_DIF_OK(
+      dif_rv_core_ibex_enable_nmi(&rv_core_ibex, kDifRvCoreIbexNmiSourceWdog));
 
   set_aon_timers();
 
-  LOG_INFO("Reading corrupted address 0x%x, expecting alert %d",
-           kErrorRamAddress, kExpectedAlertNumber);
+  // 2 is an instruction fault on main SRAM.
+  if (kFaultTarget == kFaultTargetMainSramInstr) {
+    LOG_INFO("Jump to corrupted SRAM test function at %x",
+             kSramFunctionTestAddress);
+    sram_function_test();
+    CHECK(false,
+          "Since the SRAM test function is corrupted, this should not be "
+          "reached");
+    // 0/1 are data faults on ret/main SRAM.
+  } else {
+    // We run this to make sure the program is callable and working correctly
+    // when no instruction faults are inserted.
+    LOG_INFO("Jump to SRAM test function at %x", kSramFunctionTestAddress);
+    sram_function_test();
+    LOG_INFO("Returned from the SRAM test function");
 
-  // The SV side injects error when test starts.
-  uint32_t data = *((uint32_t *)kErrorRamAddress);
+    LOG_INFO("Reading corrupted address 0x%x, expecting alert %d",
+             kErrorRamAddress, kExpectedAlertNumber);
 
-  // This normally should not run.
-  LOG_INFO("Read from address 0x%0x with expected error gets 0x%x",
-           kErrorRamAddress, data);
+    // The SV side injects error when test starts.
+    uint32_t data = *((uint32_t *)kErrorRamAddress);
+
+    // This normally should not run.
+    LOG_INFO("Read from address 0x%0x with expected error gets 0x%x",
+             kErrorRamAddress, data);
+  }
 
   wait_for_interrupt();
   CHECK(false, "This should not be reached");
 }
 
 bool test_main(void) {
+  LOG_INFO("Entered test_main");
+
   // Enable global and external IRQ at Ibex.
   irq_global_ctrl(true);
   irq_external_ctrl(true);
@@ -422,14 +602,26 @@ bool test_main(void) {
   } else if (rst_info == kDifRstmgrResetInfoEscalation) {
     LOG_INFO("Booting for the second time due to escalation reset");
 
+    // Get the counts from flash.
     int interrupt_count = flash_ctrl_testutils_counter_get(kCounterInterrupt);
-    // The interrupt count is informational only, since it is possible the NMI
-    // ends up taking precedence given the accumulator threshold is zero.
+    int nmi_count = flash_ctrl_testutils_counter_get(kCounterNmi);
+    int exception_count = flash_ctrl_testutils_counter_get(kCounterException);
+
     LOG_INFO("Interrupt count %d", interrupt_count);
+    LOG_INFO("NMI count %d", nmi_count);
+    LOG_INFO("Exception count %d", exception_count);
 
-    int nmi_interrupt_count = flash_ctrl_testutils_counter_get(kCounterNmi);
-    CHECK(nmi_interrupt_count > 0, "Expected at least one nmi");
-
+    CHECK(interrupt_count == 1, "Expected exactly one regular interrupt");
+    // The NMI handler may execute multiple times during the corresponding
+    // escalation phase since we do not clear/stop the escalation.
+    CHECK(nmi_count > 0, "Expected at least one nmi");
+    if (kFaultTarget == kFaultTargetMainSramInstr) {
+      // The instruction access fault keeps on triggering the ISR, hence
+      // the count can be greater thn 1 (similar to the NMI above).
+      CHECK(exception_count > 0, "Expected at least one exception");
+    } else {
+      CHECK(exception_count == 1, "Expected exactly one exception");
+    }
     // Check the alert handler cause is cleared.
     bool is_cause = true;
     CHECK_DIF_OK(dif_alert_handler_alert_is_cause(


### PR DESCRIPTION
This extends the chip_sw_data_integrity test so that it also injects errors in the retention SRAM and into instructions of a test program in the main SRAM.

The main test mechanism remains the same, but the ISRs and exception handlers are restructured in order to perform more strict checks. This also required to extend some of the test utilities on both the DV and SW side (initial commits).
    
Addresses part of #15970 and part of https://github.com/lowRISC/ibex/issues/1910.
    

