### PR TITLE
[dv, flash_rma] Link the `chip_sw_flash_rma_unlocked` in the testplan

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2786,7 +2786,7 @@
               testplan.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_flash_rma_unlocked"]
     }
     {
       name: chip_sw_flash_scramble


### PR DESCRIPTION
Fix #15911