### PR TITLE
[bazel] Avoid riscv32 transition in otp_alert_digest

### DIFF
--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -137,6 +137,7 @@ otp_alert_digest = rule(
         "_opentitantool": attr.label(
             default = "//sw/host/opentitantool:opentitantool",
             allow_single_file = True,
+            cfg = "exec",
         ),
     },
 )


### PR DESCRIPTION
If we do not set `cfg = "exec"`, we could incorrectly build opentitantool for riscv32 instead of the host platform whenever.

For instance, I got the following error when I built //sw/device/silicon_creator/rom/e2e:rom_e2e_asm_watchdog_bark_fpga_cw310_test_otp_dev:

```
    error[E0463]: can't find crate for `std`
    |
    = note: the `riscv32imc-unknown-none-elf` target may not support the standard library
    = note: `std` is required by `humantime` because it does not declare `#![no_std]`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`
```

Signed-off-by: Dan McArdle <dmcardle@google.com>