### PR TITLE
[test] Implement rom_e2e_debug_disallowed_in_prod

### DIFF
--- a/rules/opentitan_gdb_test.bzl
+++ b/rules/opentitan_gdb_test.bzl
@@ -34,6 +34,9 @@ def _opentitan_gdb_fpga_cw310_test(ctx):
         args.append(("--gdb-expect-output-sequence", output))
 
     arg_lines = ["{}={}".format(flag, shell.quote(value)) for flag, value in args]
+    if ctx.attr.expect_debug_disallowed:
+        arg_lines.append("--expect-debug-disallowed")
+
     test_script += " \\\n".join(arg_lines)
 
     ctx.actions.write(output = gdb_script_file, content = ctx.attr.gdb_script)
@@ -84,6 +87,7 @@ opentitan_gdb_fpga_cw310_test = rv_rule(
         ),
         "rom_kind": attr.string(mandatory = True, values = ["Rom", "TestRom"]),
         "gdb_expect_output_sequence": attr.string_list(),
+        "expect_debug_disallowed": attr.bool(default = False),
         "_coordinator": attr.label(
             default = "//rules/scripts:gdb_test_coordinator",
             cfg = "exec",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1355,6 +1355,14 @@ test_suite(
     ],
 )
 
+ALL_OTP_CFGS_EXEC_DISABLED = [
+    "test_unlocked0",
+    "dev",
+    "rma",
+    "prod",
+    "prod_end",
+]
+
 # Names of OTP configs shared by tests that require execution to be disabled.
 OTP_CFGS_EXEC_DISABLED = [
     "test_unlocked0",
@@ -1363,7 +1371,7 @@ OTP_CFGS_EXEC_DISABLED = [
 ]
 
 # Apply an overlay that disables ROM execution on top of the base OTP configs
-# derived from `OTP_CFGS_EXEC_DISABLED`.
+# derived from `ALL_OTP_CFGS_EXEC_DISABLED`.
 [
     otp_image(
         name = "img_{}_exec_disabled".format(otp_name),
@@ -1377,7 +1385,7 @@ OTP_CFGS_EXEC_DISABLED = [
         ],
         visibility = ["//visibility:private"],
     )
-    for otp_name in OTP_CFGS_EXEC_DISABLED
+    for otp_name in ALL_OTP_CFGS_EXEC_DISABLED
 ]
 
 # Splice each execution-disabled OTP image into the ROM bitstream.
@@ -1394,7 +1402,7 @@ OTP_CFGS_EXEC_DISABLED = [
         update_usr_access = True,
         visibility = ["//visibility:private"],
     )
-    for otp_name in OTP_CFGS_EXEC_DISABLED
+    for otp_name in ALL_OTP_CFGS_EXEC_DISABLED
 ]
 
 SRAM_JTAG_INJECTION_GDB_SCRIPT = """
@@ -1513,6 +1521,44 @@ test_suite(
         "vivado",
     ],
     tests = ["sram_program_fpga_cw310_test_otp_" + otp_name for otp_name in OTP_CFGS_EXEC_DISABLED],
+)
+
+[
+    opentitan_gdb_fpga_cw310_test(
+        name = "debug_disallowed_in_prod_fpga_cw310_test_otp_" + otp_name,
+        timeout = "short",
+        expect_debug_disallowed = otp_name in ("prod", "prod_end"),
+        gdb_script = """
+            target extended-remote :3333
+
+            echo :::: Send OpenOCD the 'reset halt' command.\\n
+            monitor reset halt
+
+            echo :::: Load ROM symbols into GDB.\\n
+            file rom.elf
+
+            print $pc
+        """,
+        gdb_script_symlinks = {
+            "//sw/device/silicon_creator/rom:rom_fpga_cw310.elf": "rom.elf",
+        },
+        rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
+        rom_kind = "Rom",
+        tags = [
+            "cw310",
+            "vivado",
+        ],
+    )
+    for otp_name in ("prod", "prod_end", "rma")
+]
+
+test_suite(
+    name = "rom_e2e_debug_disallowed_in_prod_tests",
+    tags = ["manual"],
+    tests = [
+        "debug_disallowed_in_prod_fpga_cw310_test_otp_" + otp_name
+        for otp_name in ("prod", "prod_end", "rma")
+    ],
 )
 
 [


### PR DESCRIPTION
These tests infer that debugging is disabled when OpenOCD fails to print "Examined RISC-V core; found 1 harts" after 5 seconds. For good measure, I'm testing on "rma" as well as the required "prod" and "prod_end". The "rma" variant will fail if OpenOCD someday stops printing that line.

Fixes #14485

Caveats:
* These tests are currently broken due to issue #16067. I started writing the tests on top of f3da3f66ef03e2485f51e7626d5dc46a93273ac5, then rebased onto master.
* The tests will fail to build due to an unrelated bug, which will be fixed by #16086.