### PR TITLE
[fpv/edn] Fix EDN FPV errors

### DIFF
--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -293,7 +293,10 @@ module edn_main_sm import edn_pkg::*; #(
       Error: begin
         main_sm_err_o = 1'b1;
       end
-      default: state_d = Error;
+      default: begin
+        state_d = Error;
+        main_sm_err_o = 1'b1;
+      end
     endcase
   end
 


### PR DESCRIPTION
There is a countercase in FPV run regarding main_sm error. Looks like the simple solution is to report error immediately after the state machine went to default state.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>