### PR TITLE
[fpv/keymgr] Fix keymgr FPV error

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -278,6 +278,8 @@ module keymgr_kmac_if import keymgr_pkg::*;(
     // treated like fsm errors
     if (cnt_err) begin
       state_d = StError;
+      fsm_error_o = 1;
+      done_o = 1'b1;
     end
   end
 


### PR DESCRIPTION
This PR fixes a countercase regarding kmac_if counter error. Because FPV cut logic for `state_q` and `cnt_error`, so in my JasperGold run, the `state_d` went to `StError` but `state_q` is at `Idle` state. And eventually the `fsm_err_o` is not asserted.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>