### PR TITLE
[dv,chip] add chip_sw_ast_clk_rst_inputs test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2947,7 +2947,15 @@
       name: chip_sw_ast_clk_rst_inputs
       desc: '''Verify the clk and rst inputs to AST (from `clkmgr`).
 
-            Details TBD.
+            Create different scenarios that affect the clocks and resets and see that the AST features
+            (RNG, entropy, alert, ADC) that use those clocks/resets behave correctly.
+            sequence:
+            1. Check that AST RNG generates data and fills the entropy source fifo
+            2. Create AST alerts
+            3. Activate ADC conversion
+            4. EDN entropy supply to AST
+            Enter sleep/deep sleep/ stop IO/USB clocks
+            Repeat 1-4 to check it is ok.
             '''
       stage: V2
       tests: []

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1494,6 +1494,14 @@
       run_opts: ["+use_otp_image=OtpTypeLcStProd"]
       reseed: 10
     }
+    
+     {
+      name: chip_sw_ast_clk_rst_inputs
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:chip_sw_ast_clk_rst_inputs:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=60_000_000"]
+    } 
   ]
 
   // List of regressions.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -757,6 +757,36 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "chip_sw_ast_clk_rst_inputs",
+    srcs = ["chip_sw_ast_clk_rst_inputs.c"],
+    deps = [
+        "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing:aon_timer_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/dif:sensor_ctrl",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/dif:clkmgr",
+        "//sw/device/lib/testing:clkmgr_testutils",
+    ],
+)
+
+
+opentitan_functest(
     name = "entropy_src_csrng_test",
     srcs = ["entropy_src_csrng_test.c"],
     verilator = verilator_params(

--- a/sw/device/tests/chip_sw_ast_clk_rst_inputs.c
+++ b/sw/device/tests/chip_sw_ast_clk_rst_inputs.c
@@ -1,0 +1,498 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/dif/dif_sensor_ctrl.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/testing/clkmgr_testutils.h"
+
+
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include "sensor_ctrl_regs.h"  // Generated.
+
+
+
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
+
+static  dif_sensor_ctrl_t sensor_ctrl;
+static  dif_alert_handler_t alert_handler;
+static  dif_aon_timer_t aon_timer;
+static  dif_rv_plic_t rv_plic;
+static  dif_rv_plic_t plic;
+static  dif_pwrmgr_t pwrmgr;
+static  dif_rstmgr_t rstmgr;
+static  dif_entropy_src_t entropy_src;
+static  dif_pwrmgr_wakeup_reason_t wakeup_reason;
+
+static  dif_clkmgr_t clkmgr;
+
+
+static plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
+                                  .hart_id = kTopEarlgreyPlicTargetIbex0};
+
+
+static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
+    .pwrmgr = &pwrmgr,
+    .plic_pwrmgr_start_irq_id = kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+    .expected_irq = kDifPwrmgrIrqWakeup,
+    .is_only_irq = true};
+
+enum {
+  /**
+   * The size of the buffer used in firmware to process the entropy bits in
+   * firmware override mode.
+   */
+  kEntropyFifoBufferSize = 32,
+};
+
+enum {
+  kAstRngAfterLp,
+  kAstAlertAfterLp,
+};
+
+/**
+ * External interrupt handler.
+ */
+void ottf_external_isr(void) {
+  dif_pwrmgr_irq_t irq_id;
+  top_earlgrey_plic_peripheral_t peripheral;
+
+  isr_testutils_pwrmgr_isr(plic_ctx, pwrmgr_isr_ctx, &peripheral, &irq_id);
+
+  // Check that both the peripheral and the irq id is correct
+  CHECK(peripheral == kTopEarlgreyPlicPeripheralPwrmgrAon,
+        "IRQ peripheral: %d is incorrect", peripheral);
+  CHECK(irq_id == kDifPwrmgrIrqWakeup, "IRQ ID: %d is incorrect", irq_id);
+}
+
+static uint32_t read_fifo_depth(dif_entropy_src_t *entropy) {
+  uint32_t fifo_depth = 0;
+  CHECK_DIF_OK(dif_entropy_src_get_fifo_depth(entropy, &fifo_depth));
+  return fifo_depth;
+}
+
+
+static uint32_t get_events(dif_toggle_t fatal) {
+  dif_sensor_ctrl_events_t events = 0;
+  if (dif_toggle_to_bool(fatal)) {
+    CHECK_DIF_OK(dif_sensor_ctrl_get_fatal_events(&sensor_ctrl, &events));
+  } else {
+    CHECK_DIF_OK(dif_sensor_ctrl_get_recov_events(&sensor_ctrl, &events));
+  }
+  return events;
+}
+
+/**
+ *  Clear event trigger and recoverable status.
+ */
+static void clear_event(uint32_t idx, dif_toggle_t fatal) {
+  CHECK_DIF_OK(dif_sensor_ctrl_set_ast_event_trigger(&sensor_ctrl, idx,
+                                                     kDifToggleDisabled));
+
+  if (!dif_toggle_to_bool(fatal)) {
+    CHECK_DIF_OK(dif_sensor_ctrl_clear_recov_event(&sensor_ctrl, idx));
+  }
+}
+
+
+/**
+ *  Check alert cause registers are correctly set
+ */
+static void check_alert_state(dif_toggle_t fatal) {
+  bool fatal_cause = false;
+  bool recov_cause = false;
+
+  CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
+      &alert_handler, kTopEarlgreyAlertIdSensorCtrlFatalAlert, &fatal_cause));
+
+  CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
+      &alert_handler, kTopEarlgreyAlertIdSensorCtrlRecovAlert, &recov_cause));
+
+  if (dif_toggle_to_bool(fatal)) {
+    CHECK(fatal_cause & !recov_cause,
+          "Fatal alert not correctly observed in alert handler");
+  } else {
+    CHECK(recov_cause & !fatal_cause,
+          "Recov alert not correctly observed in alert handler");
+  }
+
+  CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
+      &alert_handler, kTopEarlgreyAlertIdSensorCtrlRecovAlert));
+  CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
+      &alert_handler, kTopEarlgreyAlertIdSensorCtrlFatalAlert));
+};
+
+
+/**
+ *  First configure fatality of the desired event.
+ *  Then trigger the event from sensor_ctrl to ast.
+ *  Next poll for setting of correct events inside sensor_ctrl status.
+ *  When a recoverable event is triggerd, make sure only recoverable
+ *  status is seen, likewise for fatal events.
+ *  Finally, check for correct capture of cause in alert handler.
+ */
+static void test_event(uint32_t idx, dif_toggle_t fatal, bool set_event) {
+
+  if(set_event)
+  {
+
+    // Configure event fatality
+    CHECK_DIF_OK(dif_sensor_ctrl_set_alert_fatal(&sensor_ctrl, idx, fatal));
+
+    // Trigger event
+    CHECK_DIF_OK(dif_sensor_ctrl_set_ast_event_trigger(&sensor_ctrl, idx,
+                                                       kDifToggleEnabled));
+
+    // wait for events to set
+    IBEX_SPIN_FOR(get_events(fatal) > 0, 1);
+
+    // Check for the event in ast sensor_ctrl
+    // if the event is not set, error
+    CHECK(((get_events(fatal) >> idx) & 0x1) == 1, "Event %d not observed in AST",
+          idx);
+
+    // check the opposite fatality setting, should not be set
+    CHECK(((get_events(!fatal) >> idx) & 0x1) == 0,
+          "Event %d observed in AST when it should not be", idx);
+  }
+  else
+  {
+
+    // clear event trigger
+    clear_event(idx, fatal);
+
+    // check whether alert handler captured the event
+    check_alert_state(fatal);
+  }
+};
+
+void init_units(){
+
+
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  CHECK_DIF_OK(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &rv_plic));
+
+  CHECK_DIF_OK(dif_sensor_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SENSOR_CTRL_BASE_ADDR), &sensor_ctrl));
+  CHECK_DIF_OK(dif_alert_handler_init(
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),&alert_handler));
+
+      // Initialize plic.
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
+
+  CHECK_DIF_OK(dif_clkmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+}
+
+
+void test_ast_functionality_after_different_sleep_modes(int test_idx, dif_pwrmgr_domain_config_t pwrmgr_config, dif_entropy_src_config_t entropy_src_config, uint32_t alert_idx)
+{
+
+  bool deepsleep;
+  int read_fifo_depth_val;
+  bool clock_check_status;  
+
+  const dif_edn_t edn0 = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
+  const dif_edn_t edn1 = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR)};
+
+
+  if((pwrmgr_config&(~kDifPwrmgrDomainOptionUsbClockInActivePower))==0)
+  {
+    LOG_INFO("\ntest in deep sleep mode\n");
+    deepsleep = true;
+  }
+  else
+  {
+    LOG_INFO("\ntest in sleep mode\n");
+    deepsleep = false;
+  }
+
+
+if (pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0)) {
+
+  CHECK_DIF_OK(dif_entropy_src_set_enabled(&entropy_src, kDifToggleDisabled));
+
+  const dif_entropy_src_fw_override_config_t fw_override_config = {
+      .entropy_insert_enable = true,
+      .buffer_threshold = kEntropyFifoBufferSize,
+  };
+
+  CHECK_DIF_OK(dif_entropy_src_fw_override_configure(
+      &entropy_src, fw_override_config, kDifToggleEnabled));
+
+  CHECK_DIF_OK(
+      dif_entropy_src_configure(&entropy_src, entropy_src_config, kDifToggleEnabled));
+
+  // Verify that the FIFO depth is non-zero via SW - indicating the reception of
+  // data over the AST RNG interface.
+  IBEX_SPIN_FOR(read_fifo_depth(&entropy_src) > 0, 1000);
+
+
+  if(test_idx==kAstAlertAfterLp)
+  {
+    // test recoverable event
+  test_event(alert_idx, kDifToggleDisabled, true);
+  }
+
+  //config wakeup
+  uint32_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 1000 : 100;
+  aon_timer_testutils_wakeup_config(&aon_timer, wakeup_threshold);
+
+  // Enable all the AON interrupts used in this test.
+  rv_plic_testutils_irq_range_enable(&rv_plic, kTopEarlgreyPlicTargetIbex0,
+                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+  CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, 0, kDifToggleEnabled));
+
+
+  // Enter low power mode.
+  LOG_INFO("Issued WFI to enter sleep.");
+  // Setup low power.
+  rstmgr_testutils_pre_reset(&rstmgr);
+
+  if(!deepsleep)
+  {
+    read_fifo_depth_val=read_fifo_depth(&entropy_src);
+  }
+
+  //set idle
+  LOG_INFO("set idle power state");
+  pwrmgr_testutils_enable_low_power(&pwrmgr, kDifPwrmgrWakeupRequestSourceFive, pwrmgr_config);
+
+  wait_for_interrupt();
+
+  } 
+  else if (pwrmgr_testutils_is_wakeup_reason( &pwrmgr, kDifPwrmgrWakeupRequestSourceFive)) 
+  {
+
+
+  if(deepsleep)
+  {
+    if(read_fifo_depth(&entropy_src)!=0)
+      LOG_ERROR("read_fifo_depth after reset=%0d should be 0",read_fifo_depth(&entropy_src));
+  }
+
+  CHECK_DIF_OK(dif_entropy_src_set_enabled(&entropy_src, kDifToggleDisabled));
+
+  const dif_entropy_src_fw_override_config_t fw_override_config = {
+      .entropy_insert_enable = true,
+      .buffer_threshold = kEntropyFifoBufferSize,
+  };
+
+  CHECK_DIF_OK(dif_entropy_src_fw_override_configure(
+      &entropy_src, fw_override_config, kDifToggleEnabled));
+
+  CHECK_DIF_OK(
+      dif_entropy_src_configure(&entropy_src, entropy_src_config, kDifToggleEnabled));
+
+  IBEX_SPIN_FOR(read_fifo_depth(&entropy_src) > 0, 1000);
+
+}
+
+  // Turn off the AON timer hardware completely before exiting.
+  aon_timer_testutils_shutdown(&aon_timer);
+
+
+  if(!deepsleep)
+  {
+    if(read_fifo_depth_val>=read_fifo_depth(&entropy_src))
+      LOG_ERROR("read_fifo_depth after exit from idle=%0d should be equal/greater than previous read value (%0d)",read_fifo_depth(&entropy_src), read_fifo_depth_val);
+  }
+
+  IBEX_SPIN_FOR(read_fifo_depth(&entropy_src) > 0, 1000);
+
+  if(test_idx==kAstAlertAfterLp)
+  {
+    // test recoverable event
+    test_event(alert_idx, kDifToggleDisabled,false);
+  }
+  
+  CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_clear(&pwrmgr)); 
+
+  // test event after exit from low power
+  if(test_idx==kAstAlertAfterLp)
+  {
+  test_event(alert_idx, kDifToggleDisabled,true);
+  test_event(alert_idx, kDifToggleDisabled,false);
+  }                            
+}
+
+
+
+
+void set_edn_auto_mode()
+{
+
+  const dif_edn_t edn0 = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
+  const dif_edn_t edn1 = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR)};
+
+  //entropy_testutils_stop_all();
+  CHECK_DIF_OK(dif_edn_stop(&edn0));
+  CHECK_DIF_OK(dif_edn_stop(&edn1));
+
+  // re-eanble entropy src and csrng
+  //setup_entropy_src(&entropy_src);
+  //CHECK_DIF_OK(dif_csrng_configure(&csrng));
+
+  // Re-enable EDN0 in auto mode.
+  const dif_edn_auto_params_t edn0_params = {
+      // EDN0 provides lower-quality entropy.  Let one generate command return 8
+      // blocks, and reseed every 32 generates.
+      .instantiate_cmd =
+          {
+              .cmd = 0x00000001 |  // Reseed from entropy source only.
+                     kMultiBitBool4False << 8,
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
+          },
+      .reseed_cmd =
+          {
+              .cmd = 0x00008002 |  // One generate returns 8 blocks, reseed
+                                   // from entropy source only.
+                     kMultiBitBool4False << 8,
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
+          },
+      .generate_cmd =
+          {
+              .cmd = 0x00008003,  // One generate returns 8 blocks.
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
+          },
+      .reseed_interval = 32,  // Reseed every 32 generates.
+  };
+  CHECK_DIF_OK(dif_edn_set_auto_mode(&edn0, edn0_params));
+
+  // Re-enable EDN1 in auto mode.
+  const dif_edn_auto_params_t edn1_params = {
+      // EDN1 provides highest-quality entropy.  Let one generate command
+      // return 1 block, and reseed after every generate.
+      .instantiate_cmd =
+          {
+              .cmd = 0x00000001 |  // Reseed from entropy source only.
+                     kMultiBitBool4False << 8,
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
+          },
+      .reseed_cmd =
+          {
+              .cmd = 0x00001002 |  // One generate returns 1 block, reseed
+                                   // from entropy source only.
+                     kMultiBitBool4False << 8,
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
+          },
+      .generate_cmd =
+          {
+              .cmd = 0x00001003,  // One generate returns 1 block.
+              .seed_material =
+                  {
+                      .len = 0,
+                  },
+          },
+      .reseed_interval = 4,  // Reseed after every 4 generates.
+  };
+  CHECK_DIF_OK(dif_edn_set_auto_mode(&edn1, edn1_params));
+}
+
+bool test_main() {
+
+  uint32_t event_idx;
+  int idx=1;
+  int read_fifo_depth_val;
+
+  bool deepsleep;
+  dif_pwrmgr_domain_config_t pwrmgr_config;
+
+    const dif_entropy_src_config_t entropy_src_config = {
+      .fips_enable = true,
+      // Route the entropy data received from RNG to the FIFO.
+      .route_to_firmware = true,
+      .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+      .health_test_threshold_scope = false, /*default*/
+      .health_test_window_size = 0x0200,    /*default*/
+      .alert_threshold = 2,                 /*default*/
+  };
+
+
+  // Enable global and external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+  
+  init_units();
+
+  set_edn_auto_mode();
+  CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr, kDifToggleEnabled));
+
+  // Enable both recoverable and fatal alerts
+  CHECK_DIF_OK(dif_alert_handler_configure_alert(
+      &alert_handler, kTopEarlgreyAlertIdSensorCtrlRecovAlert,
+      kDifAlertHandlerClassA, kDifToggleEnabled, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_alert_handler_configure_alert(
+      &alert_handler, kTopEarlgreyAlertIdSensorCtrlFatalAlert,
+      kDifAlertHandlerClassA, kDifToggleEnabled, kDifToggleEnabled));
+
+  LOG_INFO("test alert/rng after Deep sleep 1");
+  pwrmgr_config =kDifPwrmgrDomainOptionUsbClockInActivePower;
+  test_ast_functionality_after_different_sleep_modes(kAstAlertAfterLp, pwrmgr_config, entropy_src_config, 7);
+
+
+  LOG_INFO("test alert/rng after regular sleep 2 (io clk & core clk enabled)");
+  pwrmgr_config = kDifPwrmgrDomainOptionUsbClockInLowPower | 
+         kDifPwrmgrDomainOptionUsbClockInActivePower|
+         kDifPwrmgrDomainOptionMainPowerInLowPower;
+  test_ast_functionality_after_different_sleep_modes(kAstAlertAfterLp, pwrmgr_config, entropy_src_config, 8);
+
+
+  LOG_INFO("test alert/rng after regular sleep 3 (all clk disabled)");
+  pwrmgr_config=kDifPwrmgrDomainOptionMainPowerInLowPower| kDifPwrmgrDomainOptionUsbClockInActivePower;
+  test_ast_functionality_after_different_sleep_modes(kAstAlertAfterLp, pwrmgr_config, entropy_src_config, 7);
+
+
+  return true;
+}


### PR DESCRIPTION
Signed-off-by: arielc <ariel.cohen@nuvoton.com>
This is a draft pr for issue #14132.
Please ignore lint errors and comments, this is just for reviewing the test content.

By the way when pulling the latest repository version, it fails with the following error:
_INFO: From Running Cargo build script libftdi1_sys:
Build Script Warning: Config for libftdi1 not found, falling back to default search path: `"pkg-config" "--libs" "--cflags" "libftdi1" "libftdi1 >= 1.4"` did not exit successfully: exit status: 1
[928 / 1,306] Action hw/top_earlgrey/ip/ast/data/ast_regs.h; 47s processwrapper-sandbox ... (24 actions, 23 running)
[1,024 / 1,306] Compiling Rust rlib serde v1.0.145 (21 files); 41s processwrapper-sandbox ... (24 actions running)
ERROR: /tanap1/proj_cd14/opentitan/arcohen/chip_clk_rst_pr/opentitan/sw/host/opentitanlib/bindgen/BUILD:33:21: Generating bindings for sw/host/opentitanlib/bindgen/difs.h.. failed: (Exit 101): bindgen__bin failed: error executing command bazel-out/k8-opt-exec-2B5CBBC6-ST-e846b08c7501/bin/external/rules_rust_bindgen__bindgen-0.60.1/bindgen__bin --no-rustfmt-bindings '--allowlist-type=dif_lc_ctrl_state' ... (remaining 32 arguments skipped)_

Any idea what is the reason for this error?
