### PR TITLE
[entropy_src/dv] Cumulative constraint and knob changes

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_dut_cfg.sv
@@ -231,14 +231,14 @@ class entropy_src_dut_cfg extends uvm_object;
           [6  : 10] :/ 1,
           [11 : 20] :/ 1,
           [21 : 40] :/ 1,
-          41        :/ 0
+          [41 : 80] :/ 0
         };
       } else {
         repcnt_thresh_bypass dist {
           [6  : 10] :/ 0,
           [11 : 20] :/ 0,
           [21 : 40] :/ 0,
-          41        :/ 1
+          [41 : 80] :/ 1
         };
       }
     }
@@ -250,14 +250,14 @@ class entropy_src_dut_cfg extends uvm_object;
           [6  : 10] :/ 1,
           [11 : 20] :/ 1,
           [21 : 40] :/ 1,
-          41        :/ 0
+          [41 : 80] :/ 0
         };
       } else {
         repcnt_thresh_fips dist {
           [6  : 10] :/ 0,
           [11 : 20] :/ 0,
           [21 : 40] :/ 0,
-          41        :/ 1
+          [41 : 80] :/ 1
         };
       }
     }

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -21,7 +21,6 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   virtual pins_if#(8)   otp_en_es_fw_read_vif;
   virtual pins_if#(8)   otp_en_es_fw_over_vif;
 
-
   // Configuration for DUT CSRs (held in a separate object for easy re-randomization)
   entropy_src_dut_cfg dut_cfg;
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
@@ -17,7 +17,7 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
     cfg.sim_duration                        = 10ms;
     cfg.hard_mtbf                           = 100s;
     cfg.mean_rand_reconfig_time             = 1ms;
-    cfg.mean_rand_csr_alert_time            = 5ms;
+    cfg.mean_rand_csr_alert_time            = 2ms;
     cfg.soft_mtbf                           = 7500us;
 
     // Apply truly impossible standards, to confirm that HT's don't matter here
@@ -35,15 +35,22 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
     cfg.dut_cfg.markov_sigma_max_tight      = 0.0;
 
     cfg.dut_cfg.sw_regupd_pct               = 50;
+    cfg.dut_cfg.preconfig_disable_pct       = 50;
 
     cfg.dut_cfg.entropy_data_reg_enable_pct = 50;
     cfg.dut_cfg.route_software_pct          = 50;
-    // TODO: Randomize@90%
-    cfg.otp_en_es_fw_read_pct               = 100;
+    cfg.otp_en_es_fw_read_pct               = 50;
+    // Always allow FW override for this test
     cfg.otp_en_es_fw_over_pct               = 100;
 
-    cfg.dut_cfg.type_bypass_pct             = 0;
+    cfg.dut_cfg.ht_threshold_scope_pct      = 50;
     cfg.dut_cfg.default_ht_thresholds_pct   = 0;
+
+    // Preferentially generate non-fips data, with the understanding that this test
+    // will automatically switch the DUT from non-fips to fips mode once a seed
+    // is observed, or else will otherwise reconfigure
+    cfg.dut_cfg.fips_enable_pct             = 25;
+    cfg.dut_cfg.type_bypass_pct             = 75;
 
     // Always read data from the Observe FIFO
     cfg.dut_cfg.fw_read_pct                 = 100;
@@ -52,12 +59,15 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
     cfg.spurious_inject_entropy_pct = 50;
 
     // RNG bit Enable shouldn't matter for this test. Randomize anyway
-    cfg.dut_cfg.rng_bit_enable_pct          = 50;
+    cfg.dut_cfg.rng_bit_enable_pct          = 80;
 
     // TODO: Randomize@50%
-    cfg.dut_cfg.fips_enable_pct             = 100;
+    cfg.dut_cfg.fips_enable_pct             = 50;
     cfg.dut_cfg.module_enable_pct           = 100;
+    cfg.induce_targeted_transition_pct      = 75;
+
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
+
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction
 endclass : entropy_src_fw_ov_test

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -15,9 +15,8 @@ class entropy_src_rng_test extends entropy_src_base_test;
 
     cfg.dut_cfg.boot_mode_retry_limit       = 10;
     cfg.sim_duration                = 20ms;
-    // On average two hard failures per simulation
-    cfg.hard_mtbf                   = 10ms;
-    cfg.mean_rand_reconfig_time     = 1ms;
+    cfg.hard_mtbf                   = 3ms;
+    cfg.mean_rand_reconfig_time     = 3ms;
     // The random alerts only need to happen frequently enough to
     // close coverage
     cfg.mean_rand_csr_alert_time    = 20ms;
@@ -47,9 +46,14 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.otp_en_es_fw_read_pct               = 50;
     cfg.otp_en_es_fw_over_pct               = 50;
 
-    cfg.dut_cfg.type_bypass_pct             = 75;
     cfg.dut_cfg.ht_threshold_scope_pct      = 50;
     cfg.dut_cfg.default_ht_thresholds_pct   = 0;
+
+    // Preferentially generate non-fips data, with the understanding that this test
+    // will automatically switch the DUT from non-fips to fips mode once a seed
+    // is observed, or else will otherwise reconfigure
+    cfg.dut_cfg.fips_enable_pct             = 25;
+    cfg.dut_cfg.type_bypass_pct             = 75;
 
     // Sometimes read data from the Observe FIFO (but always take entropy from RNG)
     cfg.dut_cfg.fw_read_pct                 = 50;
@@ -57,13 +61,12 @@ class entropy_src_rng_test extends entropy_src_base_test;
     // Sometimes inject data, even if not configured
     cfg.spurious_inject_entropy_pct = 50;
 
-    cfg.dut_cfg.rng_bit_enable_pct          = 50;
+    cfg.dut_cfg.rng_bit_enable_pct          = 80;
 
-    cfg.dut_cfg.fips_enable_pct             = 25;
-    cfg.dut_cfg.module_enable_pct           = 100;
+    cfg.dut_cfg.module_enable_pct           = 0;
     cfg.dut_cfg.bad_mubi_cfg_pct            = 50;
-    cfg.induce_targeted_transition_pct      = 25;
-    cfg.dut_cfg.tight_thresholds_pct        = 75;
+    cfg.dut_cfg.tight_thresholds_pct        = 50;
+    cfg.induce_targeted_transition_pct      = 75;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 


### PR DESCRIPTION
This commit contains the a number of changes to the knobs used in the RNG and FW_OV tests as wells as some updates to the constraints, which should cumulatively bring entropy_src to the 90% coverage levels.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>