### PR TITLE
[lib,testutils] Round up divisions for cycle computations

### DIFF
--- a/sw/device/lib/testing/alert_handler_testutils.c
+++ b/sw/device/lib/testing/alert_handler_testutils.c
@@ -136,8 +136,9 @@ void alert_handler_testutils_configure_all(
 }
 
 uint32_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds) {
-  uint64_t cycles = udiv64_slow(microseconds * kClockFreqPeripheralHz, 1000000,
-                                /*rem_out=*/NULL);
+  uint64_t cycles =
+      udiv64_slow(microseconds * kClockFreqPeripheralHz + 1000000 - 1, 1000000,
+                  /*rem_out=*/NULL);
   CHECK(cycles < UINT32_MAX,
         "The value 0x%08x%08x can't fit into the 32 bits timer counter.",
         (cycles >> 32), (uint32_t)cycles);

--- a/sw/device/lib/testing/alert_handler_testutils.h
+++ b/sw/device/lib/testing/alert_handler_testutils.h
@@ -68,6 +68,8 @@ void alert_handler_testutils_configure_all(
 
 /**
  * Returns the number of cycles corresponding to the given microseconds.
+ *
+ * This rounds up if there is a fractional part.
  */
 uint32_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds);
 

--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -16,8 +16,9 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 uint32_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds) {
-  uint64_t cycles = udiv64_slow(microseconds * kClockFreqAonHz, 1000000,
-                                /*rem_out=*/NULL);
+  uint64_t cycles =
+      udiv64_slow(microseconds * kClockFreqAonHz + 1000000 - 1, 1000000,
+                  /*rem_out=*/NULL);
   CHECK(cycles < UINT32_MAX,
         "The value 0x%08x%08x can't fit into the 32 bits timer counter.",
         (cycles >> 32), (uint32_t)cycles);
@@ -25,8 +26,9 @@ uint32_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds) {
 }
 
 uint32_t aon_timer_testutils_get_us_from_aon_cycles(uint64_t cycles) {
-  uint64_t uss = udiv64_slow(cycles * 1000000, kClockFreqAonHz,
-                             /*rem_out=*/NULL);
+  uint64_t uss =
+      udiv64_slow(cycles * 1000000 + kClockFreqAonHz - 1, kClockFreqAonHz,
+                  /*rem_out=*/NULL);
   CHECK(uss < UINT32_MAX,
         "The value 0x%08x%08x can't fit into the 32 bits timer counter.",
         (uss >> 32), (uint32_t)uss);

--- a/sw/device/lib/testing/aon_timer_testutils.h
+++ b/sw/device/lib/testing/aon_timer_testutils.h
@@ -11,11 +11,15 @@
 
 /**
  * Returns the number of AON cycles corresponding to the given microseconds.
+ *
+ * This rounds up if there is a fractional part.
  */
 uint32_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds);
 
 /**
  * Returns the number of microseconds corresponding to the given AON cycles.
+ *
+ * This rounds up if there is a fractional part.
  */
 uint32_t aon_timer_testutils_get_us_from_aon_cycles(uint64_t cycles);
 


### PR DESCRIPTION
When computing the number of cycles for a given number of microseconds it is best to round-up if there is any fractional part. Also handle the reverse computation this way.

Signed-off-by: Guillermo Maturana <maturana@google.com>