### PR TITLE
[otp/tests] Clean up OTP generation in E2E tests

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:autogen.bzl", "autogen_hjson_header")
-load("//rules:otp.bzl", "otp_alert_digest", "otp_image", "otp_json", "otp_partition")
+load("//rules:otp.bzl", "STD_OTP_OVERLAYS", "otp_alert_digest", "otp_image", "otp_json", "otp_partition")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@bazel_skylib//rules:common_settings.bzl", "int_flag")
 
@@ -364,67 +364,37 @@ otp_alert_digest(
 otp_image(
     name = "img_dev",
     src = ":otp_json_dev",
-    overlays = [
-        ":otp_json_creator_sw_cfg",
-        ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
-        ":otp_json_hw_cfg",
-    ],
+    overlays = STD_OTP_OVERLAYS,
 )
 
 otp_image(
     name = "img_prod",
     src = ":otp_json_prod",
-    overlays = [
-        ":otp_json_creator_sw_cfg",
-        ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
-        ":otp_json_hw_cfg",
-    ],
+    overlays = STD_OTP_OVERLAYS,
 )
 
 otp_image(
     name = "img_prod_end",
     src = ":otp_json_prod_end",
-    overlays = [
-        ":otp_json_creator_sw_cfg",
-        ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
-        ":otp_json_hw_cfg",
-    ],
+    overlays = STD_OTP_OVERLAYS,
 )
 
 otp_image(
     name = "img_raw",
     src = ":otp_json_raw",
-    overlays = [
-        ":otp_json_creator_sw_cfg",
-        ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
-        ":otp_json_hw_cfg",
-    ],
+    overlays = STD_OTP_OVERLAYS,
 )
 
 otp_image(
     name = "img_rma",
     src = ":otp_json_rma",
-    overlays = [
-        ":otp_json_creator_sw_cfg",
-        ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
-        ":otp_json_hw_cfg",
-    ],
+    overlays = STD_OTP_OVERLAYS,
 )
 
 otp_image(
     name = "img_test_unlocked0",
     src = ":otp_json_test_unlocked0",
-    overlays = [
-        ":otp_json_creator_sw_cfg",
-        ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
-        ":otp_json_hw_cfg",
-    ],
+    overlays = STD_OTP_OVERLAYS,
 )
 
 # Create an execution-disabling overlay
@@ -441,13 +411,7 @@ otp_json(
 otp_image(
     name = "img_exec_disabled",
     src = ":otp_json_rma",
-    overlays = [
-        ":otp_json_creator_sw_cfg",
-        ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
-        ":otp_json_hw_cfg",
-        ":otp_json_exec_disabled",
-    ],
+    overlays = STD_OTP_OVERLAYS + [":otp_json_exec_disabled"],
 )
 
 # Create a bootstrap-disabling overlay
@@ -464,13 +428,7 @@ otp_json(
 otp_image(
     name = "img_bootstrap_disabled",
     src = ":otp_json_rma",
-    overlays = [
-        ":otp_json_creator_sw_cfg",
-        ":otp_json_owner_sw_cfg",
-        ":otp_json_alert_digest_cfg",
-        ":otp_json_hw_cfg",
-        ":otp_json_bootstrap_disabled",
-    ],
+    overlays = STD_OTP_OVERLAYS + [":otp_json_bootstrap_disabled"],
 )
 
 filegroup(

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -208,3 +208,12 @@ otp_image = rule(
         ),
     },
 )
+
+# This is a set of overlays to generate a generic, standard OTP image.
+# Additional overlays can be applied on top to further customize the OTP.
+STD_OTP_OVERLAYS = [
+    "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
+    "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+    "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
+    "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
+]

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -18,7 +18,7 @@ load(
 )
 load("//rules:manifest.bzl", "manifest")
 load("//rules:opentitan_gdb_test.bzl", "opentitan_gdb_fpga_cw310_test")
-load("//rules:otp.bzl", "otp_image", "otp_json", "otp_partition")
+load("//rules:otp.bzl", "STD_OTP_OVERLAYS", "otp_image", "otp_json", "otp_partition")
 load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
 load("//rules:splice.bzl", "bitstream_splice")
 load("@bazel_skylib//lib:shell.bzl", "shell")
@@ -446,12 +446,7 @@ opentitan_functest(
 [otp_image(
     name = "otp_img_shutdown_output_{}".format(lc_state.lower()),
     src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
-    overlays = [
-        "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
-    ],
+    overlays = STD_OTP_OVERLAYS,
 ) for lc_state in structs.to_dict(CONST.LCV)]
 
 # Splice OTP images into bitstreams
@@ -576,12 +571,7 @@ BOOT_POLICY_NEWER_CASES = [
 [otp_image(
     name = "otp_img_boot_policy_newer_{}".format(lc_state.lower()),
     src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
-    overlays = [
-        "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
-    ],
+    overlays = STD_OTP_OVERLAYS,
 ) for lc_state in structs.to_dict(CONST.LCV)]
 
 # Splice OTP images into bitstreams
@@ -664,13 +654,7 @@ otp_json(
 [otp_image(
     name = "otp_img_boot_policy_rollback_{}".format(lc_state.lower()),
     src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
-    overlays = [
-        "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
-        ":otp_json_boot_policy_rollback",
-    ],
+    overlays = STD_OTP_OVERLAYS + [":otp_json_boot_policy_rollback"],
     visibility = ["//visibility:private"],
 ) for lc_state in structs.to_dict(CONST.LCV)]
 
@@ -743,12 +727,7 @@ otp_json(
 [otp_image(
     name = "otp_img_watchdog_enable_{}".format(lc_state.lower()),
     src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
-    overlays = [
-        "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-        "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
-        ":otp_json_watchdog_enable",
-    ],
+    overlays = STD_OTP_OVERLAYS + [":otp_json_watchdog_enable"],
 ) for lc_state in structs.to_dict(CONST.LCV)]
 
 # Bitstreams with the watchdog-enable OTP images spliced in.
@@ -917,13 +896,7 @@ opentitan_flash_binary(
             t["name"],
         ),
         src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
-        overlays = [
-            "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
-            ":otp_json_sigverify_mod_exp_{}".format(t["name"]),
-        ],
+        overlays = STD_OTP_OVERLAYS + [":otp_json_sigverify_mod_exp_{}".format(t["name"])],
         visibility = ["//visibility:private"],
     )
     for lc_state in structs.to_dict(CONST.LCV)
@@ -1172,13 +1145,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             sec_ver,
         ),
         src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
-        overlays = [
-            "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
-            ":otp_json_sec_ver_{}".format(sec_ver),
-        ],
+        overlays = STD_OTP_OVERLAYS + [":otp_json_sec_ver_{}".format(sec_ver)],
         visibility = ["//visibility:private"],
     )
     for lc_state in structs.to_dict(CONST.LCV)
@@ -1316,11 +1283,7 @@ SHUTDOWN_WATCHDOG_CASES = [
             t["bite_threshold"],
         ),
         src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(t["lc_state"]),
-        overlays = [
-            "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
+        overlays = STD_OTP_OVERLAYS + [
             ":otp_json_shutdown_watchdog_{}_{}".format(
                 t["lc_state"],
                 t["bite_threshold"],
@@ -1434,12 +1397,7 @@ BOOT_POLICY_VALID_CASES = [
     otp_image(
         name = "otp_img_boot_policy_valid_{}".format(lc_state.lower()),
         src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
-        overlays = [
-            "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
-        ],
+        overlays = STD_OTP_OVERLAYS,
     )
     for lc_state in structs.to_dict(CONST.LCV)
 ]
@@ -1510,13 +1468,7 @@ OTP_CFGS_EXEC_DISABLED = [
     otp_image(
         name = "img_{}_exec_disabled".format(otp_name),
         src = "//hw/ip/otp_ctrl/data:otp_json_" + otp_name,
-        overlays = [
-            "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_exec_disabled",
-        ],
+        overlays = STD_OTP_OVERLAYS + ["//hw/ip/otp_ctrl/data:otp_json_exec_disabled"],
         visibility = ["//visibility:private"],
     )
     for otp_name in OTP_CFGS_EXEC_DISABLED
@@ -1891,13 +1843,7 @@ REDACT.update({"INVALID": 0x0})
             redact.lower(),
         ),
         src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
-        overlays = [
-            "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
-            "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
-            ":otp_json_{}_overlay".format(redact.lower()),
-        ],
+        overlays = STD_OTP_OVERLAYS + [":otp_json_{}_overlay".format(redact.lower())],
         visibility = ["//visibility:private"],
     )
     for lc_state in structs.to_dict(CONST.LCV)


### PR DESCRIPTION
This PR cleans up the custom OTP splicing workflow for E2E tests:
1. Create a new `STANDARD_OTP_OVERLAYS` variable that contains the 4 overlays we apply to create a "default" OTP image
2. Add `PROD_END` to the list of available OTP images (this corrects a small oversight from when we created the PROD_END image)
3. Remove extraneous custom bitstream splices in E2E tests. There are 3 E2E tests that re-splice bitstreams just to cycle through the LC states (with no other overlays). We already generate these in `//hw/bitstream`. This commit removes these re-splices and just points to the existing bitstreams.