### PR TITLE
[dv/edn] Allow randomly select a EDN endpoint to enable

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_driver_lib.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_driver_lib.sv
@@ -133,6 +133,10 @@ class push_host_driver #(
         `CB.valid_int <= 1'b0;
         if (!cfg.hold_h_data_until_next_req) `CB.h_data_int <= 'x;,
         wait (cfg.in_reset);)
+    // In case there is race condition between the logic above and reset_signals task.
+    // We always set the valid_int again to 0 to make sure the data comes out of reset is not
+    // valid.
+    if (cfg.in_reset) `CB.valid_int <= '0;
   endtask
 
   `undef CB

--- a/hw/ip/edn/dv/env/edn_env.sv
+++ b/hw/ip/edn/dv/env/edn_env.sv
@@ -56,7 +56,7 @@ class edn_env extends cip_base_env #(
       m_csrng_agent.m_cmd_push_agent.monitor.analysis_port.connect
           (scoreboard.cs_cmd_fifo.analysis_export);
 
-      for (int i = 0; i < cfg.num_endpoints; i++) begin
+      for (int i = 0; i < MAX_NUM_ENDPOINTS; i++) begin
         m_endpoint_agent[i].monitor.analysis_port.connect
             (scoreboard.endpoint_fifo[i].analysis_export);
       end
@@ -65,7 +65,7 @@ class edn_env extends cip_base_env #(
           (scoreboard.rsp_sts_fifo.analysis_export);
     end
 
-    for (int i = 0; i < cfg.num_endpoints; i++) begin
+    for (int i = 0; i < MAX_NUM_ENDPOINTS; i++) begin
       if (cfg.m_endpoint_agent_cfg[i].is_active) begin
         virtual_sequencer.endpoint_sequencer_h[i] = m_endpoint_agent[i].sequencer;
       end

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -35,7 +35,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
     cs_cmd_fifo  = new("cs_cmd_fifo", this);
     rsp_sts_fifo = new("cs_rsp_sts_fifo", this);
 
-    for (int i = 0; i < cfg.num_endpoints; i++) begin
+    for (int i = 0; i < MAX_NUM_ENDPOINTS; i++) begin
       endpoint_fifo[i] = new($sformatf("endpoint_fifo[%0d]", i), this);
     end
 
@@ -56,7 +56,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
       process_rsp_sts_fifo();
     join_none
 
-    for (int i = 0; i < cfg.num_endpoints; i++) begin
+    for (int i = 0; i < MAX_NUM_ENDPOINTS; i++) begin
       automatic int j = i;
       fork
         begin


### PR DESCRIPTION
The current logic will always enable EDN endpoint 0 because cfg.num_endpoint = 1.
This PR allows testbench to randomly pick an EDN endpoint instead of fixing the index to 0.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>