### PR TITLE
[rom] Add missing dependency for otp image generation.

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -746,6 +746,7 @@ otp_json(
     overlays = [
         "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+        "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
         "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
         ":otp_json_watchdog_enable",
     ],


### PR DESCRIPTION
Thanks to moidx for tracking this down.

Signed-off-by: Timothy Chen <timothytim@google.com>