### PR TITLE
[dv,test] fix unmapped tests and test timeouts

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1277,6 +1277,7 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_uart_logger=1",
                  "+sw_test_timeout_ns=22_000_000"]
+      run_timeout_mins: 180
     }
     {
       name: chip_sw_pwrmgr_b2b_sleep_reset_req

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -39,7 +39,7 @@
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2
-      tests: []
+      tests: ["rom_e2e_shutdown_output"]
     }
 
     {


### PR DESCRIPTION
This fixes an unmapped ROM E2E test and increases the timeout of the coremark test.