### PR TITLE
[keymgr/dv] Update scb to check debug CSR

### DIFF
--- a/hw/ip/keymgr/data/keymgr_testplan.hjson
+++ b/hw/ip/keymgr/data/keymgr_testplan.hjson
@@ -247,13 +247,6 @@
             - Cross with the corresponding regwen.'''
     }
     {
-      name: control_w_regwen_cg
-      desc: '''
-            - Similar to keymgr_sw_input_cg, create a separate cg as there are some reserved fields
-              scattered in the CSR.
-            '''
-    }
-    {
       name: err_code_cg
       desc: '''
             - Cover `err_codes` values except `invalid_shadow_update` as that is tested in a common
@@ -283,12 +276,6 @@
       desc: '''
             - Cover `fault_status` values except `REGFILE_INTG` and `SHADOW` as they are tested in
               a common direct test.
-            - This is sampled when `fault_status` is read.'''
-    }
-    {
-      name: csr_debug_cg
-      desc: '''
-            - Cover all field in `debug`, which indicates different kinds of invalid inputs.
             - This is sampled when `fault_status` is read.'''
     }
     {

--- a/hw/ip/keymgr/dv/env/keymgr_env_cov.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cov.sv
@@ -157,15 +157,6 @@ class keymgr_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_env_cfg));
     key_ver_x_state_x_op_cross: cross key_version_cmp_cp, state_cp, op_cp;
   endgroup
 
-  covergroup control_w_regwen_cg with function sample(bit [14:0] control, bit regwen);
-    // There are some reserved fields, to simply it, just create 4 auto-bin
-    control_cp: coverpoint control {
-      option.auto_bin_max = 4;
-    }
-    regwen_cp: coverpoint regwen;
-    control_x_regwen_cr: cross control_cp, regwen_cp;
-  endgroup
-
   function new(string name, uvm_component parent);
     super.new(name, parent);
 
@@ -178,7 +169,6 @@ class keymgr_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_env_cfg));
     sync_async_fault_cross_cg = new();
     reseed_interval_cg = new();
     key_version_compare_cg = new();
-    control_w_regwen_cg = new();
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -78,28 +78,6 @@ interface keymgr_if(input clk, input rst_n);
   bit edn_req_ack_sync;
   bit edn_req_ack_sync_done;
 
-  localparam int CtrlCntCopies  = 2;
-  localparam int CtrlCntWitdh   = 3;
-  localparam int KmacIfCntWitdh = 5;
-  localparam int StateWidth = 10;
-  localparam bit [StateWidth-1:0] KmacIfValidStates = {10'b1110100010,
-                                                       10'b0010011011,
-                                                       10'b0101000000,
-                                                       10'b1000101001,
-                                                       10'b1111111101,
-                                                       10'b0011101110};
-  localparam bit [StateWidth-1:0] CtrlValidStates = {10'b1101100001,
-                                                     10'b1110010010,
-                                                     10'b0011110100,
-                                                     10'b0110101111,
-                                                     10'b0100000100,
-                                                     10'b1000011101,
-                                                     10'b0001001010,
-                                                     10'b1101111110,
-                                                     10'b1010101000,
-                                                     10'b0000110011,
-                                                     10'b1011000111};
-
   // If we need to wait for internal signal to be certain value, we may not be able to get that
   // when the sim is close to end. Define a cnt and MaxWaitCycle to avoid sim hang
   int cnt_to_wait_for_internal_value;

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -180,7 +180,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
                               current_state.name, cast_operation.name, is_good_op), UVM_MEDIUM)
 
     // wait for status to get out of OpWip and check
-    csr_spinwait(.ptr(ral.op_status.status), .exp_data(keymgr_pkg::OpWip), .timeout_ns(1000_000),
+    csr_spinwait(.ptr(ral.op_status.status), .exp_data(keymgr_pkg::OpWip),
                  .compare_op(CompareOpNe), .spinwait_delay_ns($urandom_range(0, 100)));
 
     exp_status = is_good_op ? keymgr_pkg::OpDoneSuccess : keymgr_pkg::OpDoneFail;
@@ -210,6 +210,12 @@ class keymgr_base_vseq extends cip_base_vseq #(
     csr_rd(.ptr(ral.intr_state), .value(rd_val));
     if (rd_val != 0) begin
       csr_wr(.ptr(ral.intr_state), .value(rd_val));
+    end
+    // read and clear debug CSRs, check is done in scb
+    csr_rd(.ptr(ral.debug), .value(rd_val));
+    if (rd_val != 0) begin
+      // this CSR is w0c
+      csr_wr(.ptr(ral.debug), .value(~rd_val));
     end
   endtask : wait_op_done
 


### PR DESCRIPTION
1. Update scb and sequence to check `debug` CSR
2. Remove regwen coverage as it's done in the base lib
3. Remove debug_csr_cg as we have alread had a fcov for that
4. small clean-up in keymgr_if

depends on #16167
Signed-off-by: Weicai Yang <weicai@google.com>