### PR TITLE
[rv_core_ibex] Check that side loaded scramble key is correctly used

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -960,6 +960,15 @@ module rv_core_ibex
       )
     end
 
+    // Ensure that when a FENCE.I is executed, a new icache scramble key is requested.
+    `ASSERT(IbexIcacheScrambleKeyRequestAfterFenceI_A,
+        u_core.u_ibex_core.id_stage_i.instr_valid_i
+        && u_core.u_ibex_core.id_stage_i.decoder_i.opcode == ibex_pkg::OPCODE_MISC_MEM
+        && u_core.u_ibex_core.id_stage_i.decoder_i.instr[14:12] == 3'b001 // FENCE.I
+        |-> ##[0:10] // upper bound is not exact, but it should not take more than a few cycles
+        icache_otp_key_o.req
+    )
+
   end
 `endif // ifdef INC_ASSERT
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1472,6 +1472,12 @@
       run_opts: ["+disable_assert_final_checks"]
     }
     {
+      name: chip_sw_rv_core_ibex_icache_invalidate
+      uvm_test_seq: chip_sw_rv_core_ibex_icache_invalidate_vseq
+      sw_images: ["//sw/device/tests:rv_core_ibex_icache_invalidate_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_usb_ast_clk_calib
       uvm_test_seq: "chip_sw_usb_ast_clk_calib_vseq"
       sw_images: ["//sw/device/tests/sim_dv:ast_usb_clk_calib:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -111,6 +111,7 @@ filesets:
       - seq_lib/chip_sw_spi_device_tpm_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_patt_ios_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rv_core_ibex_lockstep_glitch_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rv_core_ibex_icache_invalidate_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_aes_masking_off_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv: {is_include_file: true}
       - seq_lib/chip_padctrl_attributes_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -624,6 +624,9 @@ interface chip_if;
   wire rom_ctrl_done = `PWRMGR_HIER.rom_ctrl_i.done == prim_mubi_pkg::MuBi4True;
   wire rom_ctrl_good = `PWRMGR_HIER.rom_ctrl_i.good == prim_mubi_pkg::MuBi4True;
 
+  wire rv_core_ibex_icache_otp_key_req = `RV_CORE_IBEX_HIER.icache_otp_key_o.req;
+  wire rv_core_ibex_icache_otp_key_ack = `RV_CORE_IBEX_HIER.icache_otp_key_i.ack;
+
   // alert_esc_if alert_if[NUM_ALERTS](.clk  (`ALERT_HANDLER_HIER.clk_i),
   //                                   .rst_n(`ALERT_HANDLER_HIER.rst_ni));
   // for (genvar i = 0; i < NUM_ALERTS; i++) begin : gen_alert_rx_conn

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_core_ibex_icache_invalidate_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_core_ibex_icache_invalidate_vseq.sv
@@ -7,19 +7,65 @@ class chip_sw_rv_core_ibex_icache_invalidate_vseq extends chip_sw_base_vseq;
 
   `uvm_object_new
 
-  virtual task body();
-    super.body();
+  // Randomize number of expected icache invalidations: at least two but not more than a dozen
+  // (otherwise the test takes overly long).
+  rand bit [7:0] exp_num_icache_invals;
+  constraint num_icache_invals_c {
+    exp_num_icache_invals >=  2;
+    exp_num_icache_invals <= 12;
+  }
 
-    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+  // Tell the CPU how many times it should invalidate the icache.
+  virtual task cpu_init();
+    bit [7:0] byte_arr[1];
+    super.cpu_init();
+    byte_arr[0] = exp_num_icache_invals;
+    sw_symbol_backdoor_overwrite("kNumIcacheInvals", byte_arr);
+  endtask
 
+  task await_icache_inval();
     // Wait for rv_core_ibex.icache_otp_key_o.req then rv_core_ibex.icache_otp_key_i.ack to become
     // high, which indicates a completed icache scramble key exchange.
     `DV_WAIT(cfg.chip_vif.rv_core_ibex_icache_otp_key_req == 1'b1)
     `DV_WAIT(cfg.chip_vif.rv_core_ibex_icache_otp_key_ack == 1'b1)
 
-    // Wait for the core to signal completion of the icache invalidation by completing the test
-    // program.
-    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusPassed)
+    // Wait for both signals to become low again, so the next key exchange can be observed.
+    `DV_WAIT(cfg.chip_vif.rv_core_ibex_icache_otp_key_req == 1'b0)
+    `DV_WAIT(cfg.chip_vif.rv_core_ibex_icache_otp_key_ack == 1'b0)
+  endtask
+
+  virtual task body();
+    int unsigned num_icache_invals = 0;
+
+    super.body();
+
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+
+    `uvm_info(`gfn, $sformatf("Running test with %0d expected icache invalidations",
+                              exp_num_icache_invals), UVM_LOW)
+
+    fork
+      begin
+        // Count number of completed icache invalidations.  This thread is meant to not stop until
+        // it is killed after the completion of the second thread (which can time out, so this is
+        // never an infinite loop).
+        forever begin
+          await_icache_inval();
+          num_icache_invals++;
+        end
+      end
+      begin
+        // Wait for the core to signal completion of the icache invalidations by completing the test
+        // program.  If the core does not signal completion, the enclosing fork will not join and
+        // the test will time out.
+        `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusPassed)
+      end
+    join_any
+    disable fork;
+
+    // Check that the number of actual icache invalidations matches the expectation.
+    `DV_CHECK_EQ(num_icache_invals, exp_num_icache_invals,
+                 "Unexpected number of icache invalidations")
 
     // Give assertions a few cycles to conclude.  If they don't fail until then, the test passes.
     cfg.chip_vif.cpu_clk_rst_if.wait_n_clks(100);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_core_ibex_icache_invalidate_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_core_ibex_icache_invalidate_vseq.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_rv_core_ibex_icache_invalidate_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_rv_core_ibex_icache_invalidate_vseq)
+
+  `uvm_object_new
+
+  virtual task body();
+    super.body();
+
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+
+    // Wait for rv_core_ibex.icache_otp_key_o.req then rv_core_ibex.icache_otp_key_i.ack to become
+    // high, which indicates a completed icache scramble key exchange.
+    `DV_WAIT(cfg.chip_vif.rv_core_ibex_icache_otp_key_req == 1'b1)
+    `DV_WAIT(cfg.chip_vif.rv_core_ibex_icache_otp_key_ack == 1'b1)
+
+    // Wait for the core to signal completion of the icache invalidation by completing the test
+    // program.
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusPassed)
+
+    // Give assertions a few cycles to conclude.  If they don't fail until then, the test passes.
+    cfg.chip_vif.cpu_clk_rst_if.wait_n_clks(100);
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -68,6 +68,7 @@
 `include "chip_sw_usb_ast_clk_calib_vseq.sv"
 `include "chip_sw_i2c_host_tx_rx_vseq.sv"
 `include "chip_sw_rv_core_ibex_lockstep_glitch_vseq.sv"
+`include "chip_sw_rv_core_ibex_icache_invalidate_vseq.sv"
 `include "chip_sw_inject_scramble_seed_vseq.sv"
 `include "chip_sw_exit_test_unlocked_bootstrap_vseq.sv"
 `include "chip_sw_patt_ios_vseq.sv"

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1758,6 +1758,15 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "rv_core_ibex_icache_invalidate_test",
+    srcs = ["rv_core_ibex_icache_invalidate_test.c"],
+    deps = [
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "ast_clk_outs_test",
     srcs = ["ast_clk_outs_test.c"],
     cw310 = cw310_params(

--- a/sw/device/tests/rv_core_ibex_icache_invalidate_test.c
+++ b/sw/device/tests/rv_core_ibex_icache_invalidate_test.c
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+// Initialize OTTF.
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  // Invalidate instruction cache.
+  icache_invalidate();
+
+  return true;
+}

--- a/sw/device/tests/rv_core_ibex_icache_invalidate_test.c
+++ b/sw/device/tests/rv_core_ibex_icache_invalidate_test.c
@@ -2,15 +2,34 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 // Initialize OTTF.
 OTTF_DEFINE_TEST_CONFIG();
 
+// Number of instruction cache invalidations.  This gets overwritten by the
+// vseq via the backdoor symbol overwrite mechanism and thus must be declared
+// `static volatile`.  The default value applies to non-DV runs, though.
+static volatile const uint8_t kNumIcacheInvals = 7;
+
 bool test_main(void) {
-  // Invalidate instruction cache.
-  icache_invalidate();
+  // Ensure that the instruction cache will get invalidated at least two times.
+  CHECK(kNumIcacheInvals >= 2);
+
+  // Invalidate instruction cache multiple times.
+  for (unsigned i = 0; i < kNumIcacheInvals; i++) {
+    icache_invalidate();
+
+    // Wait for the icache scramble key to become valid before requesting the
+    // next invalidation.
+    uint32_t cpuctrlsts;
+    do {
+      CSR_READ(CSR_REG_CPUCTRL, &cpuctrlsts);
+    } while ((cpuctrlsts & (1 << 8)) == 0);
+  }
 
   return true;
 }


### PR DESCRIPTION
This resolves #16117 by adding two assertions:
1. Ensure that when a scramble key is received, it is correctly applied to the icache scrambled memory primitives.
2. Ensure that when a `FENCE.I` is executed, a new icache scramble key is requested.

Additionally, this PR adds a top-level test (since we don't have block-level DV for `rv_core_ibex` within OT) to cover the added assertions. I have locally verified that the assertions fail when the RTL is manipulated so that the icache scramble key is not requested on a `FENCE.I` or the returned key is not applied at the scrambled memory primitives.

## Feedback requested / open questions
- [x] Is it okay to put the assertions into an `` `ifdef INC_ASSERT`` section (to prevent synthesis from including the scramble key sample FFs) into `rv_core_ibex.sv`? Or should they go into a new interface or module that will be bound to `rv_core_ibex` in the DV environment?
- [x] When `FENCE.I` reaches the ID stage, that instruction is architecturally being executed -- is that assumption correct?
- [ ] The newly added test covers the `sec_cm_icache_mem_scramble` testpoint in the `rv_core_ibex` CM testplan. It's a top-level test, though, since we don't have block-level DV for `rv_core_ibex` within OT. Should this relation nonetheless be noted?