### PR TITLE
[alert_handler] Demonstrate potential hmac fatal_alert misbehavior

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -998,7 +998,7 @@
       uvm_test_seq: chip_sw_alert_handler_shorten_ping_wait_cycle_vseq
       sw_images: ["//sw/device/tests:alert_handler_lpg_clkoff_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000"]
+      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000", "+bypass_alert_ready_to_end_check=1"]
       run_timeout_mins: 240
     }
     {

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv
@@ -19,4 +19,59 @@ class chip_sw_alert_handler_shorten_ping_wait_cycle_vseq extends chip_sw_base_vs
     super.pre_start();
   endtask
 
+  string signal_forced;
+  virtual task body();
+
+    super.body();
+
+///*
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Trigger fatal alert AES")
+    signal_forced = "tb.dut.top_earlgrey.u_aes.gen_alert_tx[1].u_prim_alert_sender.alert_req_i";
+    `DV_CHECK(uvm_hdl_force(signal_forced, 1'b1))
+    #200ns;
+    `DV_CHECK(uvm_hdl_release(signal_forced))
+
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Trigger fatal alert HMAC")
+    signal_forced = "tb.dut.top_earlgrey.u_hmac.gen_alert_tx[0].u_prim_alert_sender.alert_req_i";
+    `DV_CHECK(uvm_hdl_force(signal_forced, 1'b1))
+    #200ns;
+    `DV_CHECK(uvm_hdl_release(signal_forced))
+
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Trigger fatal alert KMAC")
+    signal_forced = "tb.dut.top_earlgrey.u_kmac.gen_alert_tx[1].u_prim_alert_sender.alert_req_i";
+    `DV_CHECK(uvm_hdl_force(signal_forced, 1'b1))
+    #200ns;
+    `DV_CHECK(uvm_hdl_release(signal_forced))
+
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Trigger fatal alert OTBN")
+    signal_forced = "tb.dut.top_earlgrey.u_otbn.gen_alert_tx[0].u_prim_alert_sender.alert_req_i";
+    `DV_CHECK(uvm_hdl_force(signal_forced, 1'b1))
+    #200ns;
+    `DV_CHECK(uvm_hdl_release(signal_forced))
+
+   `DV_WAIT(cfg.sw_logger_vif.printed_log == "Trigger fatal alert SPI_HOST0")
+    signal_forced = "tb.dut.top_earlgrey.u_spi_host0.gen_alert_tx[0].u_prim_alert_sender.alert_req_i";
+    `DV_CHECK(uvm_hdl_force(signal_forced, 1'b1))
+    #200ns;
+    `DV_CHECK(uvm_hdl_release(signal_forced))
+
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Trigger fatal alert SPI_HOST1")
+    signal_forced = "tb.dut.top_earlgrey.u_spi_host1.gen_alert_tx[0].u_prim_alert_sender.alert_req_i";
+    `DV_CHECK(uvm_hdl_force(signal_forced, 1'b1))
+    #200ns;
+    `DV_CHECK(uvm_hdl_release(signal_forced))
+
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Trigger fatal alert USB")
+    signal_forced = "tb.dut.top_earlgrey.u_usbdev.gen_alert_tx[0].u_prim_alert_sender.alert_req_i";
+    `DV_CHECK(uvm_hdl_force(signal_forced, 1'b1))
+    #200ns;
+    `DV_CHECK(uvm_hdl_release(signal_forced))
+
+  endtask
+
+  //task post_start();
+   // expect_fatal_alerts = 1;
+  //  super.post_start();
+ // endtask
+
 endclass

--- a/sw/device/tests/alert_handler_lpg_clkoff_test.c
+++ b/sw/device/tests/alert_handler_lpg_clkoff_test.c
@@ -589,8 +589,9 @@ bool test_main(void) {
     peri_idx = test_step_cnt - (test_phase)*ARRAYSIZE(kPeripherals);
 
     // Wait for a random time <= 1024us
-    get_rand_words(&ibex, /*number of words*/ 1, &rnd_wait_time,
-                   /*max*/ 1 << 10);
+    //get_rand_words(&ibex, /*number of words*/ 1, &rnd_wait_time,
+    //               /*max*/ 1 << 10);
+/*
     busy_spin_micros(rnd_wait_time);
 
     // Disable the clock of the peripheral
@@ -607,10 +608,109 @@ bool test_main(void) {
 
     // Enable the clock of the peripheral again
     set_peripheral_clock(&kPeripherals[peri_idx], kDifToggleEnabled);
-
+*/
     // Increment the test counter
     test_step_cnt++;
   }
+
+   /* TEST PHASE #2: TEST THE FATAL ALERTS (DV-only)
+    Use the same alert handler config from the previous phase:
+      - The timeout value is set to 256.
+      - All peripherals' alerts are enabled and locked.
+      - None of the alerts should trigger ping_timeout_alert
+    TEST:
+    for_each_peripheral
+      1- Wait for random time
+      2- Enable the peripheral's clock
+      3- Trigger the peripheral's fatal alert
+      4- Disable the peripheral's clock
+      5- Wait for 1ms
+      6- Enable the peripheral's clock
+      7- Confirm that fatal_alert is still there
+  */
+
+
+  while (test_step_cnt < 3 * ARRAYSIZE(kPeripherals)) {
+    // Run this test phase only in DV sim
+    if (kDeviceType == kDeviceSimDV) {
+      // Read the test_step_cnt and compute the test phase
+      // amd the peripheral ID to test
+      test_phase = test_step_cnt / ARRAYSIZE(kPeripherals);
+      peri_idx = test_step_cnt - (test_phase)*ARRAYSIZE(kPeripherals);
+
+      // Wait for a random time <= 1024 cycles
+      //get_rand_words(&ibex, /*number of words*/ 1, &rnd_wait_time,
+      //              /*max*/ 1 << 10);
+      //busy_spin_micros(rnd_wait_time);
+
+      // Enable the clock of the peripheral just in case
+      set_peripheral_clock(&kPeripherals[peri_idx], kDifToggleEnabled);
+      // Wait for 100us
+      busy_spin_micros(100 * 1);
+
+      // THIS PART SHOULD BE IMPLEMENTED BY SystemVerilog
+      // bilgiday: I KEEP THE FOLLOWING CODE 
+      // bilgiday: TO ILLUSTRATE WHAT I AM TRYING TO ACHIVE.
+      // SEE THIS DISCUSSION
+      // https://github.com/lowRISC/opentitan/pull/14858#discussion_r993874235
+      // Trigger the fatal alert via ALERT_TEST_REG of the peripheral
+/*
+      uint32_t alert_test_reg = bitfield_bit32_write(
+          0, kPeripherals[peri_idx].fatal_alert_bit, kDifToggleEnabled);
+      mmio_region_t base_addr =
+          mmio_region_from_addr(kPeripherals[peri_idx].base);
+      mmio_region_write32(base_addr, kPeripherals[peri_idx].offset,
+                          alert_test_reg);
+*/
+      LOG_INFO("Trigger fatal alert %s", kPeripherals[peri_idx].name);
+      // Wait for 100us
+      // busy_spin_micros(100 * 1);
+      // Check if the alert is really triggered
+      is_cause = false;
+      while(!is_cause) {
+        CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
+          &alert_handler, kPeripherals[peri_idx].alert_ids[0], &is_cause));
+      }
+
+      // Disable the clock of the peripheral
+      set_peripheral_clock(&kPeripherals[peri_idx], kDifToggleDisabled);
+
+      // Clear the alert_handler.ALERT_CAUSE bit before re-enabling the clocks
+      CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
+          &alert_handler, kPeripherals[peri_idx].alert_ids[0]));
+      // Verify that ALERT_CAUSE is actually cleared
+/*
+      CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
+          &alert_handler, kPeripherals[peri_idx].alert_ids[0], &is_cause));
+      CHECK(!is_cause, "is_cause for alert[%d] should be 0 but we got 1",
+            kPeripherals[peri_idx].alert_ids[0]);
+*/
+      // Wait for 100us
+      busy_spin_micros(100 * 1);
+
+      // Enable the clock of the peripheral
+      set_peripheral_clock(&kPeripherals[peri_idx], kDifToggleEnabled);
+      // Wait for 100us
+      busy_spin_micros(100 * 1);
+
+
+      // Check if the fatal alert is still there
+      CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
+          &alert_handler, kPeripherals[peri_idx].alert_ids[0], &is_cause));
+      // CHECK(is_cause, "is_cause should be 1 but we got %d", is_cause);
+      // Increment the test counter
+      test_step_cnt++;
+    } else {
+      // TODO: This is only for testing the counters on the FPGA. 
+      // TODO: Remove it in the final version.  
+      // Increment the test counter
+      test_phase = test_step_cnt / ARRAYSIZE(kPeripherals);
+      peri_idx = test_step_cnt - (test_phase)*ARRAYSIZE(kPeripherals);
+      test_step_cnt++;
+      LOG_INFO("step_cnt = %d, phase = %d, peri_idx = %d", test_step_cnt, test_phase, peri_idx);
+    }
+  }
+  LOG_INFO("Test END");
 
   return true;
 }


### PR DESCRIPTION
According to top_earlgrey.v, hmac's alert should be a fatal alert. However, while implementing phase #3 of chip_sw_alert_handler_lpg_clkoff test, I noticed it misbehaves.

This commit provides the C and SV files to reproduce the behavior:
   - Drive u_hmac.gen_alert_tx[0].u_prim_alert_sender.alert_req_i to 1 for 200ns.
   - Put the hmac into clock-gating mode
   - Clear the hmac_alert_cause register (cause_reg_44) of the alert handler
   - Wait for 100us
   - Enable the clock again

Expected behavior: alert_req_trigger to be 1 after re-enabling the clock Observed behavior: alert_req_trigger is 0 after re-enabling the clock

Signed-off-by: Bilgiday Yuce <bilgiday@google.com>