### PR TITLE
[ci] Fix a missing manual tag found by ci/scripts/check-bazel-tags.sh

### DIFF
--- a/ci/scripts/check-bazel-tags.sh
+++ b/ci/scripts/check-bazel-tags.sh
@@ -53,11 +53,17 @@ untagged=$(./bazelisk.sh query \
           'bitstream_splice',
           //...
       )
+      except`# Other than those used to build cached bitstreams`
+      (
+          deps(//hw/bitstream:rom)
+          union
+          deps(//hw/bitstream:test_rom)
+      )
   )
   except
   attr(
       tags,
-      '$(exact_regex "(cw310_rom|cw310_test_rom|vivado|manual)")',
+      '$(exact_regex "(vivado|manual)")',
       //...
   )" \
   --output=label_kind)

--- a/ci/scripts/check-bazel-tags.sh
+++ b/ci/scripts/check-bazel-tags.sh
@@ -6,14 +6,63 @@
 
 set -e
 
-untagged=$(./bazelisk.sh query "rdeps(//..., //hw:verilator) except attr(tags, '[\\[ ](verilator|manual)[,\\]]', //...)")
-if [[ ${untagged} ]]; then # Check that all targets that depend on verilator are tagged
-  echo "Target(s): ${untagged} depend(s) on //hw:verilator, please tag it with verilator or manual";
-  exit 1
-fi
+# The list of bazel tags is represented as a string and checked with a regex
+# https://bazel.build/query/language#attr
+# This function takes a tag(or regex component) and wraps it so attr can query
+# for exact matches.
+exact_regex () {
+  echo "[\\[ ]${1}[,\\]]"
+}
 
-untagged=$(./bazelisk.sh query "rdeps(//..., kind('bitstream_splice', //...)) except attr(tags, '[\\[ ](cw310_rom|cw310_test_rom|vivado|manual)[,\\]]', //...)")
-if [[ ${untagged} ]]; then # Check that all targets that depend on vivado are tagged
-  echo "Target(s): ${untagged} depend(s) on a bitstream_splice but isn't tagged with vivado or manual";
-  exit 1
-fi
+check_empty () {
+    if [[ ${1} ]]; then
+        echo "Error:"
+        echo "$1"|sed 's/^/    /';
+        echo "$2"
+        exit 1
+    fi
+}
+
+# This check ensures OpenTitan software can be built with a wildcard without
+# waiting for Verilator using --build_tag_filters=-verilator
+untagged=$(./bazelisk.sh query \
+  "rdeps(
+      //...,
+      //hw:verilator
+  )
+  except
+  attr(
+      tags,
+      '$(exact_regex "(verilator|manual)")',
+      //...
+  )" \
+  --output=label_kind)
+check_empty "${untagged}" \
+"Target(s) above depend(s) on //hw:verilator; please tag it with verilator or
+(to prevent matching any wildcards) manual.
+NOTE: test_suites that contain bazel tests with different tags should almost
+universally use the manual tag."
+
+# This check ensures OpenTitan software can be built with wildcards in
+# environments that don't have vivado or vivado tools installed by using
+# --build_tag_filters=-vivado.
+untagged=$(./bazelisk.sh query \
+  "rdeps(
+      //...,
+      kind(
+          'bitstream_splice',
+          //...
+      )
+  )
+  except
+  attr(
+      tags,
+      '$(exact_regex "(cw310_rom|cw310_test_rom|vivado|manual)")',
+      //...
+  )" \
+  --output=label_kind)
+check_empty "${untagged}" \
+"Target(s) above depend(s) on a bitstream_splice that isn't cached.
+Please tag it with vivado or (to prevent matching any wildcards) manual.
+NOTE: test_suites that contain tests with different sets of tags should almost
+universally use the manual tag."

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1695,8 +1695,7 @@ SRAM_JTAG_INJECTION_GDB_SCRIPT = """
 test_suite(
     name = "rom_e2e_jtag_inject_tests",
     tags = [
-        "cw310_rom",
-        "vivado",
+        "manual",
     ],
     tests = ["sram_program_fpga_cw310_test_otp_" + otp_name for otp_name in OTP_CFGS_EXEC_DISABLED],
 )
@@ -1786,8 +1785,7 @@ test_suite(
 test_suite(
     name = "rom_e2e_asm_interrupt_handler",
     tags = [
-        "cw310",
-        "vivado",
+        "manual",
     ],
     tests = ["asm_interrupt_handler_fpga_cw310_test_otp_" + otp_name for otp_name in OTP_CFGS_EXEC_DISABLED],
 )
@@ -1938,8 +1936,7 @@ REDACT = structs.to_dict(CONST.SHUTDOWN.REDACT)
 test_suite(
     name = "rom_e2e_asm_watchdog",
     tags = [
-        "cw310",
-        "vivado",
+        "manual",
     ],
     tests = [
         "rom_e2e_asm_watchdog_" + type + "_fpga_cw310_test_otp_" + otp_name


### PR DESCRIPTION
The missing tag may break builds that filter out the vivado tag because it's not available.
The behavior of ci/scripts/check-bazel-tags.sh is unchanged but it's been made more verbose and clearer with language and patterns from #16010 

Signed-off-by: Drew Macrae <drewmacrae@google.com>