### PR TITLE
[ci] Remove unecessary query from fpga test script

### DIFF
--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -41,14 +41,14 @@ export BITSTREAM="--offline --list ${SHA}"
 trap 'ci/bazelisk.sh run //sw/host/opentitantool -- --interface=cw310 fpga reset' EXIT
 
 for tag in "${cw310_tags[@]}"; do
-    ./bazelisk.sh query 'rdeps(//..., @bitstreams//...)' |
-        xargs ci/bazelisk.sh test \
-            --define DISABLE_VERILATOR_BUILD=true \
-            --nokeep_going \
-            --test_tag_filters="${tag}",-broken,-manual,-skip_in_ci \
-            --test_timeout_filters=short,moderate \
-            --test_output=all \
-            --build_tests_only \
-            --define cw310=lowrisc \
-            --flaky_test_attempts=2
+    ci/bazelisk.sh test //...\
+        --define DISABLE_VERILATOR_BUILD=true \
+        --nokeep_going \
+        --test_tag_filters="${tag}",-broken,-skip_in_ci \
+        --test_timeout_filters=short,moderate \
+        --test_output=all \
+        --build_tests_only \
+        --define cw310=lowrisc \
+        --flaky_test_attempts=2
+
 done


### PR DESCRIPTION
the rdeps(bitstream) query was finding all the tagged cw310 targets including ones tagged "manual" so we can drop that filter as well.

Signed-off-by: Drew Macrae <drewmacrae@google.com>