### PR TITLE
[rdc] out-of-clockedge for MainPok reset

### DIFF
--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -59,8 +59,8 @@ set_reset_scenario { \
 # This scenario is entering low power mode (not brownout) in that case the
 # clocks other than clk_aon are gated prior to turn off main power.
 set_reset_scenario { \
-  { u_ast.u_rglts_pdm_3p3v.vcmain_pok_h { reset { @t0 0 } { #10 1}}} \
-  { u_ast.u_rglts_pdm_3p3v.vcaon_pok_h  { constraint {@t0 1} } } \
+  { u_ast.u_rglts_pdm_3p3v.vcmain_pok_h { reset { @t0 1 } { #2 0 } { #10 1 } } } \
+  { u_ast.u_rglts_pdm_3p3v.vcaon_pok_h  { constraint { @t0 1} } } \
   { top_earlgrey.u_spi_device.cio_sck_i { constraint { @t0 0 } } } \
   { top_earlgrey.clkmgr_aon_clocks.clk_io_div4_powerup { constraint { @t0 0 } } } \
   { top_earlgrey.clkmgr_aon_clocks.clk_main_powerup    { constraint { @t0 0 } } } \


### PR DESCRIPTION
This commit shifts the timing of the main pok reset. Previously, main_pok asserts at `t0` time at the same time as clock. Now, main_pok remains high for two cycles then is asserted.

