### PR TITLE
[entropy_src,dv] Add test and coverage for `INTERSIG.MUBI` countermeasure

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_sec_cm_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_sec_cm_testplan.hjson
@@ -63,16 +63,13 @@
       tests: ["entropy_src_rng"]
     }
     {
-      // TODO: It seems we currently always drive either MuBi8True or MuBi8False values to these signals.
-      // Similar to CONFIG.MUBI and CONFIG.REDUN we should probably also with a certain probability drive invalid MuBi values to these signals.
-      // The DUT isn't expected to signal an alert though in case of invalid encodings for these two signals.
       name: sec_cm_intersig_mubi
       desc: '''
             Verify the countermeasure(s) INTERSIG.MUBI.
             Verify that unless the otp_en_entropy_src_fw_read or otp_en_entropy_src_fw_over input signals are equal to MuBi8True the DUT doesn't allow reading entropy from the ENTROPY_DATA register or from the FW_OV_RD_DATA register, respectively.
             '''
       stage: V2S
-      tests: ["entropy_src_rng"]
+      tests: ["entropy_src_rng", "entropy_src_fw_ov"]
     }
     {
       name: sec_cm_main_sm_fsm_sparse

--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -118,6 +118,7 @@ interface entropy_src_cov_if
                                                      mubi4_t   entropy_data_reg_enable,
                                                      bit [7:0] otp_en_es_fw_read,
                                                      mubi4_t   fw_ov_mode,
+                                                     bit [7:0] otp_en_es_fw_over,
                                                      mubi4_t   entropy_insert,
                                                      bit       full_seed);
 
@@ -177,6 +178,14 @@ interface entropy_src_cov_if
       bins        mubi_false = { MuBi4False };
     }
 
+    // Sample the otp_en_entropy_src_fw_over_i input, just to be sure that it
+    // does not interfere with the entropy_data interface.
+    cp_otp_en_es_fw_over: coverpoint otp_en_es_fw_over {
+      bins         mubi_true  = { MuBi8True };
+      bins         mubi_false = { MuBi8False };
+      bins         mubi_inval = {[0:$]} with (!(item inside {MuBi8True, MuBi8False}));
+    }
+
     cp_entropy_insert: coverpoint entropy_insert {
       bins        mubi_true  = { MuBi4True };
       bins        mubi_false = { MuBi4False };
@@ -213,6 +222,7 @@ interface entropy_src_cov_if
                                               bit [3:0] entropy_data_reg_enable,
                                               bit [7:0] otp_en_es_fw_read,
                                               bit [3:0] fw_ov_mode,
+                                              bit [7:0] otp_en_es_fw_over,
                                               bit [3:0] entropy_insert);
 
     option.name         = "csrng_hw_cg";
@@ -269,6 +279,14 @@ interface entropy_src_cov_if
       bins        mubi_false = { MuBi4False };
     }
 
+    // Sample the otp_en_entropy_src_fw_over_i input, just to be sure that it
+    // does not interfere with the entropy_data interface.
+    cp_otp_en_es_fw_over: coverpoint otp_en_es_fw_over {
+      bins         mubi_true  = { MuBi8True };
+      bins         mubi_false = { MuBi8False };
+      bins         mubi_inval = {[0:$]} with (!(item inside {MuBi8True, MuBi8False}));
+    }
+
     cp_entropy_insert: coverpoint entropy_insert {
       bins        mubi_true  = { MuBi4True };
       bins        mubi_false = { MuBi4False };
@@ -278,22 +296,24 @@ interface entropy_src_cov_if
 
     // CSRNG HW interface is tested with all valid configurations
     cr_config: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit, cp_es_type,
-                     cp_entropy_data_reg_enable, cp_otp_en_es_fw_read;
+                     cp_entropy_data_reg_enable, cp_otp_en_es_fw_read, cp_otp_en_es_fw_over;
 
     // Smaller crosses
     cr_fips_scope_type: cross cp_fips_enable, cp_threshold_scope, cp_es_type;
     cr_fips_scope_data_enable: cross cp_fips_enable, cp_threshold_scope, cp_entropy_data_reg_enable;
-    cr_fips_scope_otp: cross cp_fips_enable, cp_threshold_scope, cp_otp_en_es_fw_read;
+    cr_fips_scope_otp: cross cp_fips_enable, cp_threshold_scope, cp_otp_en_es_fw_read,
+                             cp_otp_en_es_fw_over;
     cr_fips_scope_fw_ov: cross cp_fips_enable, cp_threshold_scope, cp_fw_ov_mode, cp_entropy_insert;
 
     cr_fips_bit_type: cross cp_fips_enable, cp_rng_bit, cp_es_type;
     cr_fips_bit_data_enable: cross cp_fips_enable, cp_rng_bit, cp_entropy_data_reg_enable;
-    cr_fips_bit_otp: cross cp_fips_enable, cp_rng_bit, cp_otp_en_es_fw_read;
+    cr_fips_bit_otp: cross cp_fips_enable, cp_rng_bit, cp_otp_en_es_fw_read, cp_otp_en_es_fw_over;
     cr_fips_bit_fw_ov: cross cp_fips_enable, cp_rng_bit, cp_fw_ov_mode, cp_entropy_insert;
 
     cr_scope_bit_type:  cross cp_threshold_scope, cp_rng_bit, cp_es_type;
     cr_scope_bit_data_enable:  cross cp_threshold_scope, cp_rng_bit, cp_entropy_data_reg_enable;
-    cr_scope_bit_otp:  cross cp_threshold_scope, cp_rng_bit, cp_otp_en_es_fw_read;
+    cr_scope_bit_otp:  cross cp_threshold_scope, cp_rng_bit, cp_otp_en_es_fw_read,
+                             cp_otp_en_es_fw_over;
     cr_scope_bit_fw_ov:  cross cp_threshold_scope, cp_rng_bit, cp_fw_ov_mode, cp_entropy_insert;
 
     // CSRNG HW interface functions despite any changes to the fw_ov settings
@@ -312,6 +332,7 @@ interface entropy_src_cov_if
                                                         mubi4_t   entropy_data_reg_enable,
                                                         bit [7:0] otp_en_es_fw_read,
                                                         mubi4_t   fw_ov_mode,
+                                                        bit [7:0] otp_en_es_fw_over,
                                                         mubi4_t   entropy_insert);
 
     option.name         = "seed_observe_fifo_event_cg";
@@ -373,6 +394,13 @@ interface entropy_src_cov_if
       illegal_bins mubi_false = { MuBi4False };
     }
 
+    // No data should emerge from the Observe FIFO if OTP does not allow it.
+    cp_otp_en_es_fw_over: coverpoint otp_en_es_fw_over {
+      bins         mubi_true  = { MuBi8True };
+      illegal_bins mubi_false = { MuBi8False };
+      illegal_bins mubi_inval = {[0:$]} with (!(item inside {MuBi8True, MuBi8False}));
+    }
+
     cp_entropy_insert: coverpoint entropy_insert {
       bins        mubi_true  = { MuBi4True };
       bins        mubi_false = { MuBi4False };
@@ -382,7 +410,7 @@ interface entropy_src_cov_if
 
     // Entropy data interface is tested with all valid configurations
     cr_config: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit, cp_es_route, cp_es_type,
-                     cp_entropy_data_reg_enable, cp_otp_en_es_fw_read;
+                     cp_entropy_data_reg_enable, cp_otp_en_es_fw_read, cp_otp_en_es_fw_over;
 
     // Smaller cross-points
     cr_rng_insert_fips: cross cp_rng_bit, cp_entropy_insert, cp_fips_enable;
@@ -390,7 +418,8 @@ interface entropy_src_cov_if
     cr_rng_insert_route: cross cp_rng_bit, cp_entropy_insert, cp_es_route;
     cr_rng_insert_type: cross cp_rng_bit, cp_entropy_insert, cp_es_type;
     cr_rng_insert_reg_en: cross cp_rng_bit, cp_entropy_insert, cp_entropy_data_reg_enable;
-    cr_rng_insert_otp: cross cp_rng_bit, cp_entropy_insert, cp_otp_en_es_fw_read;
+    cr_rng_insert_otp: cross cp_rng_bit, cp_entropy_insert, cp_otp_en_es_fw_read,
+                             cp_otp_en_es_fw_over;
 
   endgroup : observe_fifo_event_cg
 
@@ -778,12 +807,14 @@ interface entropy_src_cov_if
                                                     mubi4_t   entropy_data_reg_enable,
                                                     bit [7:0] otp_en_es_fw_read,
                                                     mubi4_t   fw_ov_mode,
+                                                    bit [7:0] otp_en_es_fw_over,
                                                     mubi4_t   entropy_insert,
                                                     bit       full_seed);
     seed_output_csr_cg_inst.sample(fips_enable, threshold_scope, rng_bit_enable,
                                    rng_bit_sel, es_route, es_type,
                                    entropy_data_reg_enable, otp_en_es_fw_read,
-                                   fw_ov_mode, entropy_insert, full_seed);
+                                   fw_ov_mode, otp_en_es_fw_over, entropy_insert,
+                                   full_seed);
   endfunction
 
   function automatic void cg_csrng_hw_sample(bit [3:0] fips_enable,
@@ -795,11 +826,12 @@ interface entropy_src_cov_if
                                              bit [3:0] entropy_data_reg_enable,
                                              bit [7:0] otp_en_es_fw_read,
                                              bit [3:0] fw_ov_mode,
+                                             bit [7:0] otp_en_es_fw_over,
                                              bit [3:0] entropy_insert);
     csrng_hw_cg_inst.sample(fips_enable, threshold_scope, rng_bit_enable,
                             rng_bit_sel, es_route, es_type,
                             entropy_data_reg_enable, otp_en_es_fw_read,
-                            fw_ov_mode, entropy_insert);
+                            fw_ov_mode, otp_en_es_fw_over, entropy_insert);
   endfunction
 
   function automatic void cg_observe_fifo_event_sample(mubi4_t   fips_enable,
@@ -811,11 +843,12 @@ interface entropy_src_cov_if
                                                        mubi4_t   entropy_data_reg_enable,
                                                        bit [7:0] otp_en_es_fw_read,
                                                        mubi4_t   fw_ov_mode,
+                                                       bit [7:0] otp_en_es_fw_over,
                                                        mubi4_t   entropy_insert);
     observe_fifo_event_cg_inst.sample(fips_enable, threshold_scope, rng_bit_enable,
                                       rng_bit_sel, es_route, es_type,
                                       entropy_data_reg_enable, otp_en_es_fw_read,
-                                      fw_ov_mode, entropy_insert);
+                                      fw_ov_mode, otp_en_es_fw_over, entropy_insert);
   endfunction
 
   function automatic void cg_sw_update_sample(uvm_pkg::uvm_reg_addr_t offset,
@@ -907,6 +940,7 @@ interface entropy_src_cov_if
                          tb.dut.reg2hw.conf.entropy_data_reg_enable.q,
                          otp_en_entropy_src_fw_read_i,
                          tb.dut.reg2hw.fw_ov_control.fw_ov_mode.q,
+                         otp_en_entropy_src_fw_over_i,
                          tb.dut.reg2hw.fw_ov_control.fw_ov_entropy_insert.q);
     end
   end

--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -161,12 +161,13 @@ interface entropy_src_cov_if
       illegal_bins mubi_false = { MuBi4False };
     }
 
-    // Signal an error if data is observed when otp_en_es_fw_read is false.
+    // Signal an error if data is observed when otp_en_es_fw_read is not true.
     // Sample this even if we don't have a full seed, to detect partial seed
     // leakage.
     cp_otp_en_es_fw_read: coverpoint otp_en_es_fw_read {
       bins         mubi_true  = { MuBi8True };
       illegal_bins mubi_false = { MuBi8False };
+      illegal_bins mubi_inval = {[0:$]} with (!(item inside {MuBi8True, MuBi8False}));
     }
 
     // Sample the FW_OV parameters, just to be sure that they

--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -259,6 +259,7 @@ interface entropy_src_cov_if
     cp_otp_en_es_fw_read: coverpoint otp_en_es_fw_read {
       bins         mubi_true  = { MuBi8True };
       bins         mubi_false = { MuBi8False };
+      bins         mubi_inval = {[0:$]} with (!(item inside {MuBi8True, MuBi8False}));
     }
 
     // Sample the FW_OV parameters, just to be sure that they
@@ -363,6 +364,7 @@ interface entropy_src_cov_if
     cp_otp_en_es_fw_read: coverpoint otp_en_es_fw_read {
       bins         mubi_true  = { MuBi8True };
       bins         mubi_false = { MuBi8False };
+      bins         mubi_inval = {[0:$]} with (!(item inside {MuBi8True, MuBi8False}));
     }
 
     // No data should emerge from the Observe FIFO when disabled

--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -116,7 +116,7 @@ interface entropy_src_cov_if
                                                      mubi4_t   es_route,
                                                      mubi4_t   es_type,
                                                      mubi4_t   entropy_data_reg_enable,
-                                                     mubi8_t   otp_en_es_fw_read,
+                                                     bit [7:0] otp_en_es_fw_read,
                                                      mubi4_t   fw_ov_mode,
                                                      mubi4_t   entropy_insert,
                                                      bit       full_seed);
@@ -308,7 +308,7 @@ interface entropy_src_cov_if
                                                         mubi4_t   es_route,
                                                         mubi4_t   es_type,
                                                         mubi4_t   entropy_data_reg_enable,
-                                                        mubi8_t   otp_en_es_fw_read,
+                                                        bit [7:0] otp_en_es_fw_read,
                                                         mubi4_t   fw_ov_mode,
                                                         mubi4_t   entropy_insert);
 
@@ -773,7 +773,7 @@ interface entropy_src_cov_if
                                                     mubi4_t   es_route,
                                                     mubi4_t   es_type,
                                                     mubi4_t   entropy_data_reg_enable,
-                                                    mubi8_t   otp_en_es_fw_read,
+                                                    bit [7:0] otp_en_es_fw_read,
                                                     mubi4_t   fw_ov_mode,
                                                     mubi4_t   entropy_insert,
                                                     bit       full_seed);
@@ -806,7 +806,7 @@ interface entropy_src_cov_if
                                                        mubi4_t   es_route,
                                                        mubi4_t   es_type,
                                                        mubi4_t   entropy_data_reg_enable,
-                                                       mubi8_t   otp_en_es_fw_read,
+                                                       bit [7:0] otp_en_es_fw_read,
                                                        mubi4_t   fw_ov_mode,
                                                        mubi4_t   entropy_insert);
     observe_fifo_event_cg_inst.sample(fips_enable, threshold_scope, rng_bit_enable,

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -104,7 +104,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   ///////////////////////
 
   // OTP variables.
-  rand prim_mubi_pkg::mubi8_t   otp_en_es_fw_read, otp_en_es_fw_over;
+  rand logic [7:0]              otp_en_es_fw_read, otp_en_es_fw_over;
 
   rand bit                      spurious_inject_entropy;
 
@@ -233,10 +233,10 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
 
     str = {
         str,
-        $sformatf("\n\t |***** otp_en_es_fw_read           : %12s *****| \t",
-                  otp_en_es_fw_read.name()),
-        $sformatf("\n\t |***** otp_en_es_fw_over           : %12s *****| \t",
-                  otp_en_es_fw_over.name()),
+        $sformatf("\n\t |***** otp_en_es_fw_read           :         'h%02h *****| \t",
+                  otp_en_es_fw_read),
+        $sformatf("\n\t |***** otp_en_es_fw_over           :         'h%02h *****| \t",
+                  otp_en_es_fw_over),
         $sformatf("\n\t |***** seed_cnt                    : %12d *****| \t",
                   seed_cnt),
         $sformatf("\n\t |***** sim_duration                : %9.2f ms *****| \t",

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -73,7 +73,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   uint          spurious_inject_entropy_pct;
 
   // Constraint knobs for OTP-driven inputs
-  uint          otp_en_es_fw_read_pct, otp_en_es_fw_over_pct;
+  uint          otp_en_es_fw_read_pct, otp_en_es_fw_read_inval_pct,
+                otp_en_es_fw_over_pct, otp_en_es_fw_over_inval_pct;
 
   // Behavioral constrint knob: dictates how often each sequence
   // performs a survey of the health test diagnostics.
@@ -127,13 +128,17 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // Constraints //
   /////////////////
 
-  constraint otp_en_es_fw_read_c {otp_en_es_fw_read dist {
-      prim_mubi_pkg::MuBi8True  :/ otp_en_es_fw_read_pct,
-      prim_mubi_pkg::MuBi8False :/ (100 - otp_en_es_fw_read_pct) };}
+  constraint otp_en_es_fw_read_c {
+    `DV_MUBI8_DIST(otp_en_es_fw_read, otp_en_es_fw_read_pct,
+                                      100 - otp_en_es_fw_read_pct - otp_en_es_fw_read_inval_pct,
+                                      otp_en_es_fw_read_inval_pct)
+  }
 
-  constraint otp_en_es_fw_over_c {otp_en_es_fw_over dist {
-      prim_mubi_pkg::MuBi8True  :/ otp_en_es_fw_over_pct,
-      prim_mubi_pkg::MuBi8False :/ (100 - otp_en_es_fw_over_pct) };}
+  constraint otp_en_es_fw_over_c {
+    `DV_MUBI8_DIST(otp_en_es_fw_over, otp_en_es_fw_over_pct,
+                                      100 - otp_en_es_fw_over_pct - otp_en_es_fw_over_inval_pct,
+                                      otp_en_es_fw_over_inval_pct)
+  }
 
   constraint spurious_inject_entropy_c {spurious_inject_entropy dist {
       1                         :/ spurious_inject_entropy_pct,
@@ -249,8 +254,12 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
         str,
         $sformatf("\n\t |***** otp_en_es_fw_read_pct       : %12d *****| \t",
                   otp_en_es_fw_read_pct),
+        $sformatf("\n\t |***** otp_en_es_fw_read_inval_pct : %12d *****| \t",
+                  otp_en_es_fw_read_inval_pct),
         $sformatf("\n\t |***** otp_en_es_fw_over_pct       : %12d *****| \t",
-                  otp_en_es_fw_over_pct)
+                  otp_en_es_fw_over_pct),
+        $sformatf("\n\t |***** otp_en_es_fw_over_inval_pct : %12d *****| \t",
+                  otp_en_es_fw_over_inval_pct)
     };
 
     str = {str, "\n\t |******************************************************| \t"};
@@ -272,6 +281,10 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   function void check_knob_vals();
     `DV_CHECK(spurious_inject_entropy_pct <= 100);
     `DV_CHECK(otp_en_es_fw_read_pct <= 100);
+    `DV_CHECK(otp_en_es_fw_read_inval_pct <= 100);
+    `DV_CHECK((otp_en_es_fw_read_pct + otp_en_es_fw_read_inval_pct) <= 100);
+    `DV_CHECK(otp_en_es_fw_over_inval_pct <= 100);
+    `DV_CHECK((otp_en_es_fw_over_pct + otp_en_es_fw_over_inval_pct) <= 100);
     `DV_CHECK(otp_en_es_fw_over_pct <= 100);
     `DV_CHECK(do_check_ht_diag_pct <= 100);
     `DV_CHECK(induce_targeted_transition_pct <= 100);

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -952,6 +952,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
               prim_mubi_pkg::mubi4_t'(ral.conf.entropy_data_reg_enable.get_mirrored_value()),
               prim_mubi_pkg::mubi8_t'(cfg.otp_en_es_fw_read),
               prim_mubi_pkg::mubi4_t'(ral.fw_ov_control.fw_ov_mode.get_mirrored_value()),
+              prim_mubi_pkg::mubi8_t'(cfg.otp_en_es_fw_over),
               prim_mubi_pkg::mubi4_t'(ral.fw_ov_control.fw_ov_entropy_insert.get_mirrored_value()),
               full_seed_found
           );
@@ -2312,6 +2313,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
               prim_mubi_pkg::mubi4_t'(ral.conf.entropy_data_reg_enable.get_mirrored_value()),
               prim_mubi_pkg::mubi8_t'(cfg.otp_en_es_fw_read),
               prim_mubi_pkg::mubi4_t'(ral.fw_ov_control.fw_ov_mode.get_mirrored_value()),
+              prim_mubi_pkg::mubi8_t'(cfg.otp_en_es_fw_over),
               prim_mubi_pkg::mubi4_t'(ral.fw_ov_control.fw_ov_entropy_insert.get_mirrored_value())
           );
           msg = $sformatf("Match found: %d\n", observe_fifo_words);

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -31,7 +31,9 @@ class entropy_src_base_test extends cip_base_test #(
     // so there is no need to randomize it.
     cfg.seed_cnt                       = 1;
     cfg.otp_en_es_fw_read_pct          = 100;
+    cfg.otp_en_es_fw_read_inval_pct    = 0;
     cfg.otp_en_es_fw_over_pct          = 100;
+    cfg.otp_en_es_fw_over_inval_pct    = 0;
     cfg.dut_cfg.en_intr_pct            = 75;
     cfg.dut_cfg.me_regwen_pct          = 100;
     cfg.dut_cfg.sw_regupd_pct          = 100;

--- a/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
@@ -40,6 +40,7 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
     cfg.dut_cfg.entropy_data_reg_enable_pct = 50;
     cfg.dut_cfg.route_software_pct          = 50;
     cfg.otp_en_es_fw_read_pct               = 50;
+    cfg.otp_en_es_fw_read_inval_pct         = 25;
     // Always allow FW override for this test
     cfg.otp_en_es_fw_over_pct               = 100;
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -56,9 +56,9 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.dut_cfg.fips_enable_pct             = 25;
     cfg.dut_cfg.type_bypass_pct             = 75;
 
-    // Sometimes read data from the Observe FIFO (but always take entropy from RNG)
+    // Sometimes read data from the Observe FIFO (but almost always take entropy from RNG)
     cfg.dut_cfg.fw_read_pct                 = 50;
-    cfg.dut_cfg.fw_over_pct                 = 0;
+    cfg.dut_cfg.fw_over_pct                 = 10;
     // Sometimes inject data, even if not configured
     cfg.spurious_inject_entropy_pct = 50;
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -45,6 +45,7 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.dut_cfg.route_software_pct          = 50;
     cfg.otp_en_es_fw_read_pct               = 50;
     cfg.otp_en_es_fw_over_pct               = 50;
+    cfg.otp_en_es_fw_over_inval_pct         = 25;
 
     cfg.dut_cfg.ht_threshold_scope_pct      = 50;
     cfg.dut_cfg.default_ht_thresholds_pct   = 0;


### PR DESCRIPTION
This extends and tunes the `entropy_src` DV environment to also drive invalid MuBi values to the `otp_en_entropy_src_fw_read` and `otp_en_entropy_src_fw_over` input signals. It also extends the coverage interface to track those values.

This PR contributes to resolving #16065.