### PR TITLE
[fpga] Add SRST delay option to OpenOCD args

### DIFF
--- a/rules/scripts/gdb_test_coordinator.py
+++ b/rules/scripts/gdb_test_coordinator.py
@@ -142,7 +142,12 @@ def main(rom_kind: str = typer.Option(...),
         "-f",
         openocd_jtag_adapter_config,
         "-c",
-        "adapter speed 0; transport select jtag; reset_config trst_and_srst",
+        "; ".join([
+            "adapter speed 200",
+            "transport select jtag",
+            "reset_config trst_and_srst",
+            "adapter srst delay 10",
+        ]),
         "-f",
         openocd_earlgrey_config,
     ]


### PR DESCRIPTION
This commit increases the SRST delay from the default of zero to 10 ms. Now, OpenOCD will wait after deasserting SRST before it issues JTAG commands. This is necessary to give the chip time to boot, since the SRST signal is interpreted as POR.

The additional SRST delay eliminates these warnings from the log:

    [OPENOCD] Error: JTAG scan chain interrogation failed: all ones
    [OPENOCD] Error: Check JTAG interface, timings, target power, etc.

This commit also disables adaptive clock speed (RCLK) because we do not support that feature. I don't have a great justification for the value of 200 KHz, but it's less than the ARM-USB-TINY-H's max of 500 KHz and it appears to work.

Signed-off-by: Dan McArdle <dmcardle@google.com>