### PR TITLE
[rtl] EDN remove unreachable logic

### DIFF
--- a/hw/ip/edn/rtl/edn_ack_sm.sv
+++ b/hw/ip/edn/rtl/edn_ack_sm.sv
@@ -99,7 +99,7 @@ module edn_ack_sm (
     // clear out everything and return to default.
     if (local_escalate_i) begin
       state_d = Error;
-    end else if (!enable_i && !ack_sm_err_o) begin
+    end else if (!enable_i) begin
       state_d = Disabled;
       ack_o = 1'b0;
       fifo_pop_o = 1'b0;


### PR DESCRIPTION
This PR removes an unreachable condition:
The signal `local_escalate_i` is a super set of `ack_sm_err_o`. So the following case will never happen:
local_escalate_i = 0 but ack_sm_err_o = 1.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>