### PR TITLE
[keymgr] Fix alert disable

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -571,8 +571,8 @@ module keymgr
       .NumCopies(2),
       .AsyncOn(0)
     ) u_mubi_buf (
-      .clk_i('0),
-      .rst_ni('0),
+      .clk_i,
+      .rst_ni,
       .mubi_i(hw_key_sel),
       .mubi_o(hw_key_sel_buf)
     );


### PR DESCRIPTION
- keymgr's usage of certain prim_mubi4_sync is only for buffered copies.  This means inside the module the clock/reset is not actually used by any real logic.  This led to lint errors. Previously, this was worked around by tying clock and reset to 0, but this had the unintentional side effect of also disabling alerts and leading to coverage issues.

- The lint issue has now been addressed by the presence of dummy logic, so it is safe to just connect the clocks and resets normally and allow the assertions to properly function.

Signed-off-by: Timothy Chen <timothytim@google.com>