### PR TITLE
[rom_e2e] fix sigverify_always test

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1385,12 +1385,23 @@ test_suite(
     ],
 )
 
-[genrule(
-    name = "empty_test_slot_{}_corrupted_{}_bin_signed_{}".format(slot, device, key),
-    srcs = ["empty_test_slot_{}_{}_bin_signed_{}".format(slot, device, key)],
-    outs = ["empty_test_slot_{}_bad_signature_{}_bin_signed_{}".format(slot, device, key)],
-    cmd_bash = "cat $(SRCS) > $(OUTS) && dd if=/dev/zero of=$(OUTS) bs=4 seek=7 count=1 conv=notrunc status=none".format(slot),
-) for slot in SLOTS for device in ["fpga_cw310"] for key in ["test_key_0"]]
+SIGVERIFY_LC_KEYS = [
+    "test_key_0",
+    "dev_key_0",
+    "prod_key_0",
+]
+
+[
+    genrule(
+        name = "empty_test_slot_{}_corrupted_{}_bin_signed_{}".format(slot, device, key),
+        srcs = ["empty_test_slot_{}_{}_bin_signed_{}".format(slot, device, key)],
+        outs = ["empty_test_slot_{}_bad_signature_{}_bin_signed_{}".format(slot, device, key)],
+        cmd_bash = "cat $(SRCS) > $(OUTS) && dd if=/dev/zero of=$(OUTS) bs=4 seek=7 count=1 conv=notrunc status=none".format(slot),
+    )
+    for slot in SLOTS
+    for device in ["fpga_cw310"]
+    for key in SIGVERIFY_LC_KEYS
+]
 
 BOOT_POLICY_VALID_CASES = [
     {
@@ -1992,60 +2003,77 @@ test_suite(
 
 [
     opentitan_multislot_flash_binary(
-        name = "sigverify_always_img_a_{}_b_{}".format(
+        name = "sigverify_always_img_a_{}_b_{}_{}".format(
             "nothing" if slot == "b" else "bad",
             "nothing" if slot == "a" else "bad",
+            key,
         ),
         srcs = {
             ":empty_test_slot_{}_corrupted".format(slot): {
-                "key": "test_key_0",
+                "key": key,
                 "offset": offset,
             },
         },
         devices = ["fpga_cw310"],
     )
     for slot, offset in SLOTS.items()
+    for key in SIGVERIFY_LC_KEYS
 ]
 
-opentitan_multislot_flash_binary(
-    name = "sigverify_always_img_a_bad_b_bad",
-    srcs = {
-        ":empty_test_slot_a_corrupted": {
-            "key": "test_key_0",
-            "offset": SLOTS["a"],
+[
+    opentitan_multislot_flash_binary(
+        name = "sigverify_always_img_a_bad_b_bad_{}".format(key),
+        srcs = {
+            ":empty_test_slot_a_corrupted": {
+                "key": key,
+                "offset": SLOTS["a"],
+            },
+            ":empty_test_slot_b_corrupted": {
+                "key": key,
+                "offset": SLOTS["b"],
+            },
         },
-        ":empty_test_slot_b_corrupted": {
-            "key": "test_key_0",
-            "offset": SLOTS["b"],
-        },
-    },
-    devices = ["fpga_cw310"],
-)
+        devices = ["fpga_cw310"],
+    )
+    for key in SIGVERIFY_LC_KEYS
+]
 
 # Since we cannot feed the `assemble_flash_image` rule that is instantiated by
 # the `opentitan_multislot_flash_binary` macro an empty dictionary, we create
 # two images with "nothing" in them by created files of all ones, and stitching
 # them together.
-[genrule(
-    name = "sigverify_always_img_{}_nothing_{}_bin_signed_{}".format(slot, device, key),
-    outs = ["sigverify_always_img_all_ones_{}_bin_signed_{}".format(slot, device, key)],
-    cmd_bash = "touch $(OUTS)",
-) for slot in SLOTS for device in ["fpga_cw310"] for key in ["test_key_0"]]
+[
+    genrule(
+        name = "sigverify_always_img_{}_nothing_{}_bin_signed_{}".format(slot, device, key),
+        outs = ["sigverify_always_img_{}_all_ones_{}_bin_signed_{}".format(slot, device, key)],
+        cmd_bash = "touch $(OUTS)",
+    )
+    for slot in SLOTS
+    for device in ["fpga_cw310"]
+    for key in SIGVERIFY_LC_KEYS
+]
 
-opentitan_multislot_flash_binary(
-    name = "sigverify_always_img_a_nothing_b_nothing",
-    srcs = {
-        ":sigverify_always_img_a_nothing": {
-            "key": "test_key_0",
-            "offset": SLOTS["a"],
+[
+    opentitan_multislot_flash_binary(
+        name = "sigverify_always_img_a_nothing_b_nothing_{}".format(key),
+        srcs = {
+            ":sigverify_always_img_a_nothing": {
+                "key": key,
+                "offset": SLOTS["a"],
+            },
+            ":sigverify_always_img_b_nothing": {
+                "key": key,
+                "offset": SLOTS["b"],
+            },
         },
-        ":sigverify_always_img_b_nothing": {
-            "key": "test_key_0",
-            "offset": SLOTS["b"],
-        },
-    },
-    devices = ["fpga_cw310"],
-)
+        devices = ["fpga_cw310"],
+    )
+    for key in [
+        "test_key_0",
+        "dev_key_0",
+        "prod_key_0",
+    ]
+]
 
 [otp_image(
     name = "otp_img_sigverify_always_{}".format(lc_state.lower()),
@@ -2089,6 +2117,14 @@ SIGVERIFY_BAD_CASES = [
     },
 ]
 
+SIGVERIFY_LCS_2_VALID_KEY = {
+    "test_unlocked0": "test_key_0",
+    "dev": "dev_key_0",
+    "prod": "prod_key_0",
+    "prod_end": "prod_key_0",
+    "rma": "prod_key_0",
+}
+
 [
     opentitan_functest(
         name = "sigverify_always_{}_a_{}_b_{}".format(
@@ -2107,9 +2143,10 @@ SIGVERIFY_BAD_CASES = [
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         key = "multislot",
-        ot_flash_binary = ":sigverify_always_img_a_{}_b_{}".format(
+        ot_flash_binary = ":sigverify_always_img_a_{}_b_{}_{}".format(
             case["a"],
             case["b"],
+            SIGVERIFY_LCS_2_VALID_KEY[lc_state.lower()],
         ),
         targets = ["cw310_rom"],
     )

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -2007,6 +2007,21 @@ test_suite(
     for slot, offset in SLOTS.items()
 ]
 
+opentitan_multislot_flash_binary(
+    name = "sigverify_always_img_a_bad_b_bad",
+    srcs = {
+        ":empty_test_slot_a_corrupted": {
+            "key": "test_key_0",
+            "offset": SLOTS["a"],
+        },
+        ":empty_test_slot_b_corrupted": {
+            "key": "test_key_0",
+            "offset": SLOTS["b"],
+        },
+    },
+    devices = ["fpga_cw310"],
+)
+
 # Since we cannot feed the `assemble_flash_image` rule that is instantiated by
 # the `opentitan_multislot_flash_binary` macro an empty dictionary, we create
 # two images with "nothing" in them by created files of all ones, and stitching
@@ -2054,6 +2069,7 @@ opentitan_multislot_flash_binary(
 SIGVERIFY_BAD_CASES = [
     ("nothing", "bad"),
     ("bad", "nothing"),
+    ("bad", "bad"),
     ("nothing", "nothing"),
 ]
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -2032,6 +2032,25 @@ opentitan_multislot_flash_binary(
     devices = ["fpga_cw310"],
 )
 
+[otp_image(
+    name = "otp_img_sigverify_always_{}".format(lc_state.lower()),
+    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+    overlays = STD_OTP_OVERLAYS,
+) for lc_state in structs.to_dict(CONST.LCV)]
+
+# Splice OTP images into bitstreams
+[
+    bitstream_splice(
+        name = "bitstream_sigverify_always_{}".format(lc_state.lower()),
+        src = "//hw/bitstream:rom",
+        data = ":otp_img_sigverify_always_{}".format(lc_state.lower()),
+        meminfo = "//hw/bitstream:otp_mmi",
+        tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
+        update_usr_access = True,
+    )
+    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+]
+
 SIGVERIFY_BAD_CASES = [
     ("nothing", "bad"),
     ("bad", "nothing"),
@@ -2040,29 +2059,37 @@ SIGVERIFY_BAD_CASES = [
 
 [
     opentitan_functest(
-        name = "sigverify_always_a_{}_b_{}".format(
-            a,
-            b,
+        name = "sigverify_always_{}_a_{}_b_{}".format(
+            lc_state.lower(),
+            case["a"],
+            case["b"],
         ),
         cw310 = cw310_params(
+            bitstream = ":bitstream_sigverify_always_{}".format(lc_state.lower()),
             exit_failure = MSG_PASS,
             exit_success = DEFAULT_TEST_FAILURE_MSG,
+            otp = ":otp_img_sigverify_always_{}".format(lc_state.lower()),
+            tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         key = "multislot",
         ot_flash_binary = ":sigverify_always_img_a_{}_b_{}".format(a, b),
         targets = ["cw310_rom"],
     )
     for a, b in SIGVERIFY_BAD_CASES
+    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
 ]
 
 test_suite(
     name = "sigverify_always",
+    tags = ["manual"],
     tests = [
-        "sigverify_always_a_{}_b_{}".format(
-            a,
-            b,
+        "sigverify_always_{}_a_{}_b_{}".format(
+            lc_state.lower(),
+            case["a"],
+            case["b"],
         )
         for a, b in SIGVERIFY_BAD_CASES
+        for lc_state in structs.to_dict(CONST.LCV)
     ],
 )
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1990,61 +1990,79 @@ test_suite(
     ) for lc_state in structs.to_dict(CONST.LCV) for redact in REDACT],
 )
 
-[opentitan_multislot_flash_binary(
-    name = "boot_policy_valid_img_a_{}_b_{}".format(
-        "empty" if offset == "0x0" else "bad",
-        "empty" if offset != "0x0" else "bad",
-    ),
+[
+    opentitan_multislot_flash_binary(
+        name = "sigverify_always_img_a_{}_b_{}".format(
+            "nothing" if slot == "b" else "bad",
+            "nothing" if slot == "a" else "bad",
+        ),
+        srcs = {
+            ":empty_test_slot_{}_corrupted".format(slot): {
+                "key": "test_key_0",
+                "offset": offset,
+            },
+        },
+        devices = ["fpga_cw310"],
+    )
+    for slot, offset in SLOTS.items()
+]
+
+# Since we cannot feed the `assemble_flash_image` rule that is instantiated by
+# the `opentitan_multislot_flash_binary` macro an empty dictionary, we create
+# two images with "nothing" in them by created files of all ones, and stitching
+# them together.
+[genrule(
+    name = "sigverify_always_img_{}_nothing_{}_bin_signed_{}".format(slot, device, key),
+    outs = ["sigverify_always_img_all_ones_{}_bin_signed_{}".format(slot, device, key)],
+    cmd_bash = "touch $(OUTS)",
+) for slot in SLOTS for device in ["fpga_cw310"] for key in ["test_key_0"]]
+
+opentitan_multislot_flash_binary(
+    name = "sigverify_always_img_a_nothing_b_nothing",
     srcs = {
-        ":empty_test_slot_{}_corrupted".format(slot): {
+        ":sigverify_always_img_a_nothing": {
             "key": "test_key_0",
-            "offset": offset,
+            "offset": SLOTS["a"],
+        },
+        ":sigverify_always_img_b_nothing": {
+            "key": "test_key_0",
+            "offset": SLOTS["b"],
         },
     },
     devices = ["fpga_cw310"],
-) for slot, offset in SLOTS.items()]
+)
 
 SIGVERIFY_BAD_CASES = [
-    {
-        "desc": "bad",
-        "suffix": "_corrupted",
-    },
-    {
-        "desc": "empty",
-        "suffix": "_empty",
-    },
+    ("nothing", "bad"),
+    ("bad", "nothing"),
+    ("nothing", "nothing"),
 ]
 
 [
     opentitan_functest(
         name = "sigverify_always_a_{}_b_{}".format(
-            a["desc"],
-            b["desc"],
+            a,
+            b,
         ),
         cw310 = cw310_params(
             exit_failure = MSG_PASS,
             exit_success = DEFAULT_TEST_FAILURE_MSG,
         ),
         key = "multislot",
-        ot_flash_binary = ":boot_policy_valid_img_a_{}_b_{}".format(
-            a["desc"],
-            b["desc"] if a != b and b != "empty" else "bad",
-        ),
+        ot_flash_binary = ":sigverify_always_img_a_{}_b_{}".format(a, b),
         targets = ["cw310_rom"],
     )
-    for a in SIGVERIFY_BAD_CASES
-    for b in SIGVERIFY_BAD_CASES
+    for a, b in SIGVERIFY_BAD_CASES
 ]
 
 test_suite(
     name = "sigverify_always",
     tests = [
         "sigverify_always_a_{}_b_{}".format(
-            a["desc"],
-            b["desc"],
+            a,
+            b,
         )
-        for a in SIGVERIFY_BAD_CASES
-        for b in SIGVERIFY_BAD_CASES
+        for a, b in SIGVERIFY_BAD_CASES
     ],
 )
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -2067,10 +2067,26 @@ opentitan_multislot_flash_binary(
 ]
 
 SIGVERIFY_BAD_CASES = [
-    ("nothing", "bad"),
-    ("bad", "nothing"),
-    ("bad", "bad"),
-    ("nothing", "nothing"),
+    {
+        "a": "nothing",
+        "b": "bad",
+        "expected_bfv": hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG),
+    },
+    {
+        "a": "bad",
+        "b": "nothing",
+        "expected_bfv": hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG),
+    },
+    {
+        "a": "bad",
+        "b": "bad",
+        "expected_bfv": hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG),
+    },
+    {
+        "a": "nothing",
+        "b": "nothing",
+        "expected_bfv": hex(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
+    },
 ]
 
 [
@@ -2083,15 +2099,21 @@ SIGVERIFY_BAD_CASES = [
         cw310 = cw310_params(
             bitstream = ":bitstream_sigverify_always_{}".format(lc_state.lower()),
             exit_failure = MSG_PASS,
-            exit_success = DEFAULT_TEST_FAILURE_MSG,
+            exit_success = MSG_TEMPLATE_BFV_LCV.format(
+                case["expected_bfv"],
+                hex(lc_state_val),
+            ),
             otp = ":otp_img_sigverify_always_{}".format(lc_state.lower()),
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         key = "multislot",
-        ot_flash_binary = ":sigverify_always_img_a_{}_b_{}".format(a, b),
+        ot_flash_binary = ":sigverify_always_img_a_{}_b_{}".format(
+            case["a"],
+            case["b"],
+        ),
         targets = ["cw310_rom"],
     )
-    for a, b in SIGVERIFY_BAD_CASES
+    for case in SIGVERIFY_BAD_CASES
     for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
 ]
 
@@ -2104,7 +2126,7 @@ test_suite(
             case["a"],
             case["b"],
         )
-        for a, b in SIGVERIFY_BAD_CASES
+        for case in SIGVERIFY_BAD_CASES
         for lc_state in structs.to_dict(CONST.LCV)
     ],
 )


### PR DESCRIPTION
# Summary
@engdoreis @alphan I came across some issues with the `sigverify_always` test when I went to try to add this test to the DV environment. This PR contains a few commits that refactor said test to:
1. fix some issues with the the sigverify_always test
2. enhance the test to:
    a. test across multiple lifecycle states (as requested by the [test plan](https://github.com/lowRISC/opentitan/issues/14477)),
    b. check the BFVs, instead of just checking if there was a boot fault, and
4. make the Bazel test code easier to read.

Below I explain in more detail what I changed, but please correct me if my "corrections" are wrong hehe.

# Commit Details

### Commit 1:
Refactors the sigverify_always ROM E2E test to correct its implementation, and make it easier to read. Specifically, the old test suite, shown below,
<img width="1066" alt="old-test-suite" src="https://user-images.githubusercontent.com/5633066/200961224-bd6f7c06-dbca-4214-8e38-987cc14cec0a.png">
contained a test to test both slots being "empty" (`*_a_empty_b_empty`). However, it was incorrectly using the two "empty_test" images to create a scenario where "no slots are filled". Unfortunately, the "empty_test_*" images are not empty in the sense that they are all ones, rather they are a "empty test" that returns true, i.e. the test performs no actions. As a result, the `*_a_empty_b_empty` test image was not all ones:
<img width="610" alt="non-empty-test" src="https://user-images.githubusercontent.com/5633066/200961556-c8cad279-87b6-4614-9f9f-c0ef81413e91.png">.

After refactoring, we can confirm that the `*_a_nothing_b_nothing` test now is indeed empty (all ones):
<img width="543" alt="Screen Shot 2022-11-09 at 2 59 15 PM" src="https://user-images.githubusercontent.com/5633066/200962081-1bc9a9f3-7399-4f41-aafc-5a534ee5ea2d.png">

### Commit 2:
Enhances the test to iterate over all required LC states.

### Commit 3:
Adds back in the `*_a_bad_b_bad` test that was originally tested, and was one of the scenarios requested [here](https://github.com/lowRISC/opentitan/pull/15553#issuecomment-1287774364).

### Commit 4:
Check the BFVs are the value expected, instead of just checking if there was a boot fault.

# Other

After all commits, the test suite now contains tests for the following scenarios:
<img width="792" alt="Screen Shot 2022-11-09 at 3 44 23 PM" src="https://user-images.githubusercontent.com/5633066/200965818-aa0a72ac-3b46-4e46-81b3-2c25624d9d27.png">

Lastly, note I used the term "nothing" here instead of "empty" since the term "empty" in the `../rom/e2e/BUILD` file seems to have a double meaning.