### PR TITLE
[chip dv] Complete the SV part of chip_sw_alert_handler_lpg_clkoff test

### DIFF
--- a/hw/dv/sv/sec_cm/sec_cm_pkg.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_pkg.sv
@@ -30,13 +30,22 @@ package sec_cm_pkg;
   //
   // This function matches the first instance whose `path` matches the input argument `path`.
   // A fatal error is thrown if there is no instance in the queue that matches the path.
-  // TODO: Allow partial path matching with `uvm_re_match`.
-  function automatic sec_cm_base_if_proxy find_sec_cm_if_proxy(string path);
+  // The argument `is_regex` indicates that the `path` is not a full path, but a regular expression.
+  function automatic sec_cm_base_if_proxy find_sec_cm_if_proxy(string path, bit is_regex = 0);
     sec_cm_base_if_proxy proxies[$];
-    // Search singleton queue of proxies in sec_cm_pkg
-    proxies = sec_cm_pkg::sec_cm_if_proxy_q.find_first() with (item.path == path);
-    if (proxies.size > 0) return proxies[0];
+    if (is_regex) begin
+      proxies = sec_cm_pkg::sec_cm_if_proxy_q.find_first() with (!uvm_re_match(path, item.path));
+    end else begin
+      proxies = sec_cm_pkg::sec_cm_if_proxy_q.find_first() with (item.path == path);
+    end
+    if (proxies.size()) begin
+      `uvm_info(msg_id, $sformatf({"find_sec_cm_if_proxy: found proxy instance for path %s: ",
+                                   "type = %0d, full path = %0s"}, path, proxies[0].sec_cm_type,
+                                  proxies[0].path), UVM_MEDIUM)
+      return proxies[0];
+    end
     else `uvm_fatal(msg_id, $sformatf("find_sec_cm_if_proxy: no proxy with path %s", path))
+    return null;
   endfunction
 
 endpackage

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1018,7 +1018,7 @@
     }
     {
       name: chip_sw_alert_handler_lpg_clkoff
-      uvm_test_seq: chip_sw_alert_handler_shorten_ping_wait_cycle_vseq
+      uvm_test_seq: chip_sw_alert_handler_lpg_clkoff_vseq
       sw_images: ["//sw/device/tests:alert_handler_lpg_clkoff_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -55,6 +55,7 @@ filesets:
       - seq_lib/chip_sw_alert_handler_entropy_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_alert_handler_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_alert_handler_lpg_clkoff_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_all_escalation_resets_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_data_integrity_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_full_aon_reset_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -646,6 +646,18 @@ interface chip_if;
                                             == pwrmgr_pkg::FastPwrStateLowPower;
   assign pwrmgr_low_power_if.deep_powerdown = ~`PWRMGR_HIER.pwr_ast_i.main_pok;
 
+  // clkmgr related: SW controlled clock gating contol signals reflecting the actual status
+  // of these clocks.
+  wire aes_clk_is_enabled = `CLKMGR_HIER.u_reg.hw2reg.clk_hints_status.clk_main_aes_val.d;
+  wire hmac_clk_is_enabled = `CLKMGR_HIER.u_reg.hw2reg.clk_hints_status.clk_main_hmac_val.d;
+  wire kmac_clk_is_enabled = `CLKMGR_HIER.u_reg.hw2reg.clk_hints_status.clk_main_kmac_val.d;
+  wire otbn_clk_is_enabled = `CLKMGR_HIER.u_reg.hw2reg.clk_hints_status.clk_main_otbn_val.d;
+
+  wire usbdev_clk_is_enabled = `CLKMGR_HIER.u_reg.reg2hw.clk_enables.clk_usb_peri_en.q;
+  wire io_clk_is_enabled = `CLKMGR_HIER.u_reg.reg2hw.clk_enables.clk_io_peri_en.q;
+  wire io_div2_clk_is_enabled = `CLKMGR_HIER.u_reg.reg2hw.clk_enables.clk_io_div2_peri_en.q;
+  wire io_div4_clk_is_enabled = `CLKMGR_HIER.u_reg.reg2hw.clk_enables.clk_io_div4_peri_en.q;
+
   // Stub CPU envorinment.
   //
   // The initial value is sought from a plusarg. It can however, be set by the sequence on the fly

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_lpg_clkoff_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_lpg_clkoff_vseq.sv
@@ -1,0 +1,100 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_alert_handler_lpg_clkoff_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_alert_handler_lpg_clkoff_vseq)
+
+  `uvm_object_new
+
+  // The list of IPs tested in this test. This enumeration must match the array in
+  // sw/device/tests/alert_handler_lpg_clkoff_test.c::kPeripherals[].
+  typedef enum {
+    Aes,
+    Hmac,
+    Kmac,
+    Otbn,
+    SpiHost0,
+    SpiHost1,
+    Usbdev,
+    IpCount
+  } ips_tested_e;
+
+  typedef struct {
+    string if_proxy_regex;
+    sec_cm_pkg::sec_cm_base_if_proxy if_proxy;
+    int unsigned fatal_alert_id;
+  } ip_fatal_alert_t;
+
+  ip_fatal_alert_t ip_fatal_alerts[] = '{
+    '{"*aes*prim_reg_we_check*", null, TopEarlgreyAlertIdAesFatalFault},
+    '{"*hmac*prim_reg_we_check*", null, TopEarlgreyAlertIdHmacFatalFault},
+    '{"*kmac*prim_reg_we_check*", null, TopEarlgreyAlertIdKmacFatalFaultErr},
+    '{"*otbn*prim_reg_we_check*", null, TopEarlgreyAlertIdOtbnFatal},
+    '{"*spi_host0*prim_reg_we_check*", null, TopEarlgreyAlertIdSpiHost0FatalFault},
+    '{"*spi_host1*prim_reg_we_check*", null, TopEarlgreyAlertIdSpiHost1FatalFault},
+    '{"*usbdev*prim_reg_we_check*", null, TopEarlgreyAlertIdUsbdevFatalFault}
+  };
+
+  virtual task pre_start();
+    // The wait-time between two ping requests is a 16-bit value, coming from an LFSR.
+    // In DV, we force the wait-time to known fixed value so that the alert handler's ping mechanism
+    // is able to hit all blocks within a reasonable amount of simulated / wall clock time. We pick
+    // 7 which is the minimum-allowed value.
+    void'(cfg.chip_vif.signal_probe_alert_handler_ping_timer_wait_cyc_mask_i(SignalProbeForce, 7));
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    string anchor = "Peripheral %0d ready for fault injection";
+
+    super.body();
+
+    // Construct the ip_fatal_alerts data structure.
+    for (int i = 0; i < IpCount; i++) begin
+      ip_fatal_alerts[i].if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(
+          .path(ip_fatal_alerts[i].if_proxy_regex), .is_regex(1));
+    end
+
+    // In test phase 2, we inject a fault in peripherals whose clocks are turned off, to ensure that
+    // the fatal alert continues to fire after the clock is turned back on.
+    // Loop through the IPs, injecting a fault as expected by the SW test.
+    for (int i = 0; i < IpCount; i++) begin
+      ips_tested_e ip = ips_tested_e'(i);
+      `DV_WAIT(string'(cfg.sw_logger_vif.printed_log) == $sformatf(anchor, i))
+      cfg.chip_vif.cpu_clk_rst_if.wait_clks($urandom_range(200, 500));
+      `uvm_info(`gfn, $sformatf("Injecting a fatal alert in %0s", ip.name()), UVM_LOW)
+      ip_fatal_alerts[i].if_proxy.inject_fault();
+      // Verify that the alert triggered (the SW does the same via frontdoor CSR read).
+      // By virtue of automation, the cfg.list_of_alerts string names follow the same enumeration as
+      // the alert indices in top_earlgrey_pkg::alert_id_e.
+      wait_alert_trigger(cfg.list_of_alerts[ip_fatal_alerts[i].fatal_alert_id], .max_wait_cycle(2));
+      // The SW turns the clock to the peripheral off and then back on. Wait for those events.
+      wait_clk_status(ip, 0);
+      wait_clk_status(ip, 1);
+    end
+  endtask
+
+  // Waits for the clock to the chosen IP to be enabled or gated.
+  task wait_clk_status(ips_tested_e ip, bit is_enabled);
+    case(ip)
+      Aes:      `DV_WAIT(cfg.chip_vif.aes_clk_is_enabled == is_enabled)
+      Hmac:     `DV_WAIT(cfg.chip_vif.hmac_clk_is_enabled == is_enabled)
+      Kmac:     `DV_WAIT(cfg.chip_vif.kmac_clk_is_enabled == is_enabled)
+      Otbn:     `DV_WAIT(cfg.chip_vif.otbn_clk_is_enabled == is_enabled)
+      SpiHost0: `DV_WAIT(cfg.chip_vif.io_clk_is_enabled == is_enabled)
+      SpiHost1: `DV_WAIT(cfg.chip_vif.io_div2_clk_is_enabled == is_enabled)
+      Usbdev:   `DV_WAIT(cfg.chip_vif.usbdev_clk_is_enabled == is_enabled)
+      default:  `uvm_fatal(`gfn, $sformatf("Invalid IP: %0d", ip))
+    endcase
+  endtask
+
+  virtual task post_start();
+    // Wait for the SW test to finsh.
+    super.post_start();
+
+    // Restore the DUT back to a clean state.
+    apply_reset();
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -772,7 +772,6 @@ class chip_sw_base_vseq extends chip_base_vseq;
     end
   endtask : jtag_otp_program32
 
-
   // End the test with status.
   //
   // SW test code finishes the test sequence usually by returing true or false

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -60,6 +60,7 @@
 `include "chip_rv_dm_ndm_reset_vseq.sv"
 `include "chip_rv_dm_lc_disabled_vseq.sv"
 `include "chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv"
+`include "chip_sw_alert_handler_lpg_clkoff_vseq.sv"
 `include "chip_sw_alert_handler_escalation_vseq.sv"
 `include "chip_sw_alert_handler_entropy_vseq.sv"
 `include "chip_sw_lc_ctrl_program_error_vseq.sv"

--- a/sw/device/lib/testing/alert_handler_testutils.c
+++ b/sw/device/lib/testing/alert_handler_testutils.c
@@ -147,3 +147,11 @@ uint32_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds) {
 uint32_t alert_handler_testutils_cycle_rescaling_factor() {
   return kDeviceType == kDeviceSimDV ? 1 : 10;
 }
+
+bool alert_handler_testutils_is_alert_active(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_alert_t alert) {
+  bool is_cause;
+  CHECK_DIF_OK(
+      dif_alert_handler_alert_is_cause(alert_handler, alert, &is_cause));
+  return is_cause;
+}

--- a/sw/device/lib/testing/alert_handler_testutils.h
+++ b/sw/device/lib/testing/alert_handler_testutils.h
@@ -89,4 +89,14 @@ uint32_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds);
  */
 uint32_t alert_handler_testutils_cycle_rescaling_factor();
 
+/**
+ * Returns whether an alert is active.
+ *
+ * @param alert_handler An alert handler handle.
+ * @param alert The given alert.
+ * @return The status of the given alert as boolean.
+ */
+bool alert_handler_testutils_is_alert_active(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_alert_t alert);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_ALERT_HANDLER_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -176,7 +176,6 @@ opentitan_functest(
         "//sw/device/lib/dif:kmac",
         "//sw/device/lib/dif:otbn",
         "//sw/device/lib/dif:rstmgr",
-        "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/dif:spi_host",
         "//sw/device/lib/dif:usbdev",
@@ -186,6 +185,7 @@ opentitan_functest(
         "//sw/device/lib/testing:alert_handler_testutils",
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -841,6 +841,7 @@ opentitan_functest(
     name = "example_test_from_flash",
     srcs = ["example_test_from_flash.c"],
     deps = [
+        "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )


### PR DESCRIPTION
The PR builds on top of @bilgiday's work on chip_sw_alert_handler_lpg_clkoff test, descrived in #14126. It was originally implemented in #14858, and later updated by @bilgiday in #15950.
 
This PR implements the SV portion of the test in the last commit. 
The first 4 bisectable commits are helper changes to other parts of the codebase that eventually help effectively write the test. 

The test is currently failing due to #16190.