### PR TITLE
[kmac/lc_ctrl] Minor DV fixes

### DIFF
--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -188,7 +188,6 @@
     {
       name: "{variant}_lc_escalation"
       uvm_test_seq: kmac_lc_escalation_vseq
-      run_opts: ["+disable_lc_asserts=1"]
     }
     {
       name: kmac_stress_all

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -117,16 +117,4 @@ module tb;
     run_test();
   end
 
-  // This assertion only exists when en_masking parameter is set.
-  // This assertion will not be true if Kmac is interrupted by lc_escalate_en signal.
-  if (`EN_MASKING) begin : gen_assert_disable_for_masking_mode
-    initial begin
-      bit disable_lc_asserts;
-      void'($value$plusargs("disable_lc_asserts=%0b", disable_lc_asserts));
-      if (disable_lc_asserts) begin
-        $assertoff(0, tb.dut.u_sha3.u_keccak.u_keccak_p.gen_selperiod_chk.SelStayTwoCycleIfTrue_A);
-      end
-    end
-  end
-
 endmodule

--- a/hw/ip/kmac/rtl/keccak_2share.sv
+++ b/hw/ip/kmac/rtl/keccak_2share.sv
@@ -25,6 +25,8 @@ module keccak_2share
   input clk_i,
   input rst_ni,
 
+  input  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i, // Used to disable SVAs when escalating.
+
   input         [RndW-1:0] rnd_i, // Current round index
   input mubi4_t            phase_sel_i, // Output mux contol. Used when EnMasking := 1
   input              [1:0] cycle_i, // Current cycle index. Used when EnMasking := 1
@@ -415,10 +417,12 @@ module keccak_2share
   `ASSERT_INIT(ValidRound_A, MaxRound <= 24) // Keccak-f only
 
   // phase_sel_i shall stay for two cycle after change to 1.
+  lc_ctrl_pkg::lc_tx_t unused_lc_sig;
+  assign unused_lc_sig = lc_escalate_en_i;
   if (EnMasking) begin : gen_selperiod_chk
     `ASSUME(SelStayTwoCycleIfTrue_A,
         ($past(phase_sel_i) == MuBi4False) && (phase_sel_i == MuBi4True)
-        |=> phase_sel_i == MuBi4True, clk_i, !rst_ni)
+        |=> phase_sel_i == MuBi4True, clk_i, !rst_ni || lc_escalate_en_i != lc_ctrl_pkg::Off)
   end
 
   ///////////////

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -440,6 +440,8 @@ module keccak_round
     .clk_i,
     .rst_ni,
 
+    .lc_escalate_en_i,
+
     .rnd_i           (round),
     .phase_sel_i     (phase_sel),
     .cycle_i         (cycle),

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -114,7 +114,10 @@ package chip_env_pkg;
     LcTransitionError,
     LcTokenError,
     LcFlashRmaError,
-    LcOtpError
+    LcOtpError,
+    LcStateError,
+    LcBusIntegError,
+    LcOtpPartitionError
   } lc_ctrl_status_e;
 
   typedef enum bit[1:0] {


### PR DESCRIPTION
The KMAC assertion causes issues in top-level simulations as well when moving into `ScrapSt` or escalating, hence I changed this in the first commit so that the SVA is dynamically disabled in RTL based on escalation status.

The second commit just adds the missing error statuses to the enum in DV.