### PR TITLE
[entropy_src/dv] Require `cs_aes_halt` handshake in scoreboard

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -103,6 +103,7 @@ class entropy_src_env extends cip_base_env #(
     m_rng_agent.monitor.analysis_port.connect(scoreboard.rng_fifo.analysis_export);
     m_csrng_agent.monitor.analysis_port.connect(scoreboard.csrng_fifo.analysis_export);
     m_xht_agent.monitor.analysis_port.connect(scoreboard.xht_fifo.analysis_export);
+    m_aes_halt_agent.monitor.analysis_port.connect(scoreboard.cs_aes_halt_fifo.analysis_export);
 
     scoreboard.interrupt_vif = cfg.interrupt_vif;
 


### PR DESCRIPTION
This commit forces the scoreboard to confirm that every FIPS seed generated is preceded by a `cs_aes_halt` handshake.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>