### PR TITLE
[entropy_src/rtl] Fix FSM alerts

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
@@ -77,7 +77,10 @@ module entropy_src_ack_sm (
       Error: begin
         ack_sm_err_o = 1'b1;
       end
-      default: state_d = Error;
+      default: begin
+        state_d = Error;
+        ack_sm_err_o = 1'b1;
+      end
     endcase
     if (local_escalate_i) begin
       state_d = Error;

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -816,9 +816,9 @@ module entropy_src_core import entropy_src_pkg::*; #(
                                  (sfifo_esrng_err_sum   ||
                                   sfifo_observe_err_sum ||
                                   sfifo_esfinal_err_sum ||
-                                  sfifo_test_err_sum    ||
-                                  es_ack_sm_err_sum ) ) ||
-                              (main_sm_enable && es_main_sm_err_sum) ||
+                                  sfifo_test_err_sum) ) ||
+                              es_ack_sm_err_sum ||
+                              es_main_sm_err_sum ||
                               es_cntr_err_sum || // prim_count err is always active
                               sha3_rst_storage_err_sum ||
                               sha3_state_error_sum;

--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -274,7 +274,10 @@ module entropy_src_main_sm
       Error: begin
         main_sm_err_o = 1'b1;
       end
-      default: state_d = Error;
+      default: begin
+        state_d = Error;
+        main_sm_err_o = 1'b1;
+      end
     endcase
     if (local_escalate_i) begin
       state_d = Error;


### PR DESCRIPTION
An FSM state error must trigger an alert, regardless of the corresponding FSM being enabled or not. Additionally, the `default` item of an FSM `case` statement must signal an FSM state error. This PR fixes both.

These bugs were identified by FPV (CEX on `FpvSecCmCtrlMainFsmCheck_A` and `FpvSecCmCtrlAckFsmCheck_A`). With this PR, all assertions of `entropy_src` get proven. Therefore, this PR resolves #16113. (The dashboard will be used for sign-off, so we can close that issue and create a new one should FPV drop below 100% again.)

A quick regression run with `-i all -r 10` gave 100% pass rate.