### PR TITLE
[rom_e2e] Add rom_e2e_alert_config tests

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -870,6 +870,84 @@ test_suite(
     ],
 )
 
+# Alert Handler configuration test cases.
+#
+# These test cases verify the ROM correctly configures the alert_handler in each
+# life cycle state.
+
+# Alert handler configuration is not checked in the TEST LC state.
+ALERT_LC_STATES = {
+    k: structs.to_dict(CONST.LCV)[k]
+    for k in [
+        "PROD",
+        "PROD_END",
+        "DEV",
+        "RMA",
+    ]
+}
+
+[otp_image(
+    name = "otp_img_alert_{}".format(lc_state.lower()),
+    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+    overlays = STD_OTP_OVERLAYS,
+) for lc_state in ALERT_LC_STATES]
+
+[bitstream_splice(
+    name = "bitstream_alert_{}".format(lc_state.lower()),
+    src = "//hw/bitstream:rom",
+    data = ":otp_img_alert_{}".format(lc_state.lower()),
+    meminfo = "//hw/bitstream:otp_mmi",
+    tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
+    update_usr_access = True,
+) for lc_state, lc_state_val in ALERT_LC_STATES.items()]
+
+[opentitan_flash_binary(
+    name = "rom_e2e_alert_config_test_{}".format(lc_state.lower()),
+    srcs = ["rom_e2e_alert_config_test.c"],
+    devices = [
+        "fpga_cw310",
+    ],
+    local_defines = [
+        "OTP_ALERT_DIGEST=OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_DIGEST_{}_OFFSET".format(lc_state.upper()),
+    ],
+    deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/drivers:alert",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:otp",
+    ],
+) for lc_state in ALERT_LC_STATES]
+
+[
+    opentitan_functest(
+        name = "alert_{}".format(
+            lc_state.lower(),
+        ),
+        cw310 = cw310_params(
+            bitstream = ":bitstream_alert_{}".format(lc_state.lower()),
+            tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
+        ),
+        key = "prod_key_0",
+        ot_flash_binary = ":rom_e2e_alert_config_test_{}".format(lc_state.lower()),
+        signed = True,
+        targets = [
+            "cw310_rom",
+        ],
+    )
+    for lc_state, lc_state_val in ALERT_LC_STATES.items()
+]
+
+test_suite(
+    name = "rom_e2e_alert_config",
+    tags = ["manual"],
+    tests = [
+        "alert_{}".format(lc_state.lower())
+        for lc_state in ALERT_LC_STATES
+    ],
+)
+
 SIGVERIFY_MOD_EXP_CASES = [
     {
         "name": "sw",

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_alert_config_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_alert_config_test.c
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/alert.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+
+#include "otp_ctrl_regs.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+/**
+ * Check that the alert_handler register CRC32 matches OTP value.
+ *
+ * The `OWNER_SW_CFG_ROM_ALERT_DIGEST_<LC_STATE>` OTP word should match the
+ * digest computed by XORing the CRC32 of the alert_handler registers with the
+ * current lifecycle state and kErrorOk, as done in
+ * `sw/device/silicon_creator/lib/shutdown.c:shutdown_init`.
+ */
+static void alert_cfg_test(void) {
+  uint32_t digest = alert_config_crc32() ^ lifecycle_state_get() ^ kErrorOk;
+
+  // `OTP_ALERT_DIGEST` in configured for each test to reference the digest for
+  // the current LC state.
+  CHECK(digest == otp_read32(OTP_ALERT_DIGEST));
+}
+
+bool test_main(void) {
+  alert_cfg_test();
+  return true;
+}


### PR DESCRIPTION
Adds tests to verify alert_handler is configured correctly in each lifecycle state.

Fixes #14499