### PR TITLE
[doc/EDN] Update description of errors that can trigger fatal alert

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -359,7 +359,7 @@
                 This bit will be set to one when an error has been detected for the
                 reseed command FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until the next reset.
+                This error will signal a fatal alert. This bit will stay set until the next reset.
                 '''
         }
         { bits: "1",
@@ -368,7 +368,7 @@
                 This bit will be set to one when an error has been detected for the
                 generate command FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until the next reset.
+                This error will signal a fatal alert. This bit will stay set until the next reset.
                 '''
         }
         { bits: "20",


### PR DESCRIPTION
From the RTL, looks like `sfifo_rescmd_err_sum` and `sfifo_gencmd_err_sum` can also trigger fatal alerts. Update the hjson to reflect that.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>