### PR TITLE
[dv/edn] Random write reserved value to err_code_test reg

### DIFF
--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -74,6 +74,18 @@ package edn_env_pkg;
   } err_code_e;
 
   typedef enum int {
+    EdnSfifoRescmdErrTest = 0,
+    EdnSfifoGencmdErrTest = 1,
+    EdnErrTest            = 2, // TODO: issue #16218
+    EdnAckSmErrTest       = 20,
+    EdnMainSmErrTest      = 21,
+    EdnCntrErrTest        = 22,
+    EdnFifoWriteErrTest   = 28,
+    EdnFifoReadErrTest    = 29,
+    EdnFifoStateErrTest   = 30
+  } err_code_test_e;
+
+  typedef enum int {
     sfifo_rescmd = 0,
     sfifo_gencmd = 1
   } which_fifo_e;

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -20,6 +20,7 @@ class edn_base_vseq extends cip_base_vseq #(
   bit [csrng_pkg::CSRNG_CMD_WIDTH - 1:0]        cmd_data;
 
   rand bit                                      set_regwen;
+  rand bit                                      write_reserved_err_code_test_reg;
   virtual edn_cov_if                            cov_vif;
 
   constraint regwen_c {
@@ -123,6 +124,15 @@ class edn_base_vseq extends cip_base_vseq #(
     if ($urandom_range(0, 19) == 19 || set_regwen) begin
       bit [TL_DW-1:0] val;
       csr_rd(.ptr(ral.ctrl), .value(val));
+    end
+
+    if (write_reserved_err_code_test_reg) begin
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.err_code_test.err_code_test,
+          !(value inside
+          {EdnSfifoRescmdErrTest, EdnSfifoGencmdErrTest, EdnErrTest, EdnAckSmErrTest,
+           EdnMainSmErrTest, EdnCntrErrTest, EdnFifoWriteErrTest, EdnFifoReadErrTest,
+           EdnFifoStateErrTest});)
+      csr_update(ral.err_code_test);
     end
   endtask
 


### PR DESCRIPTION
This PR randomly writes reserved value to err_code_test reg in all tests. And sequence ensures no alert or error will be triggered.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>