### PR TITLE
[entropy_src/rtl] Minor core timing tweaks

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -1050,7 +1050,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   // select source for health testing
 
   assign health_test_esbus     = pfifo_postht_wdata;
-  assign health_test_esbus_vld = pfifo_postht_push & pfifo_postht_not_full;
+  assign health_test_esbus_vld = pfifo_postht_push & pfifo_postht_not_full & ~pfifo_postht_clr;
 
   // Health test any data that comes in on the RNG interface.
   assign repcnt_active = 1'b1;


### PR DESCRIPTION
- Prevent sprurious `health_test_esbus_vld` pulses when FIFOs are being cleared.
- Keep main_fsm enabled for one more cycle (even if no data in flight) to capture any final HT results.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>