### PR TITLE
[edn/rtl] enable bit 2 of ERR_CODE

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -371,6 +371,15 @@
                 This bit will stay set until the next reset.
                 '''
         }
+        { bits: "2",
+          name: "SFIFO_OUTPUT_ERR",
+          desc: '''
+                This bit will be set to one when an error has been detected for the
+                output FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until the next reset.
+                '''
+        }
         { bits: "20",
           name: "EDN_ACK_SM_ERR",
           desc: '''

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -57,6 +57,7 @@ module edn_core import edn_pkg::*;
     FatalErr,
     ReseedCmdErr,
     GenCmdErr,
+    OutputErr,
     FifoWrErr,
     FifoRdErr,
     FifoStErr,
@@ -341,6 +342,9 @@ module edn_core import edn_pkg::*;
 
   assign hw2reg.err_code.sfifo_gencmd_err.d = 1'b1;
   assign hw2reg.err_code.sfifo_gencmd_err.de = edn_enable_fo[GenCmdErr] && sfifo_gencmd_err_sum;
+
+  assign hw2reg.err_code.sfifo_output_err.d = 1'b1;
+  assign hw2reg.err_code.sfifo_output_err.de = edn_enable_fo[OutputErr] && sfifo_output_err_sum;
 
   assign hw2reg.err_code.edn_ack_sm_err.d = 1'b1;
   assign hw2reg.err_code.edn_ack_sm_err.de = edn_ack_sm_err_sum;

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -161,6 +161,10 @@ package edn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } sfifo_output_err;
+    struct packed {
+      logic        d;
+      logic        de;
     } edn_ack_sm_err;
     struct packed {
       logic        d;
@@ -207,10 +211,10 @@ package edn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    edn_hw2reg_intr_state_reg_t intr_state; // [43:40]
-    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [39:36]
-    edn_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [35:26]
-    edn_hw2reg_err_code_reg_t err_code; // [25:10]
+    edn_hw2reg_intr_state_reg_t intr_state; // [45:42]
+    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [41:38]
+    edn_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [37:28]
+    edn_hw2reg_err_code_reg_t err_code; // [27:10]
     edn_hw2reg_main_sm_state_reg_t main_sm_state; // [9:0]
   } edn_hw2reg_t;
 

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -182,6 +182,7 @@ module edn_reg_top (
   logic recov_alert_sts_edn_bus_cmp_alert_wd;
   logic err_code_sfifo_rescmd_err_qs;
   logic err_code_sfifo_gencmd_err_qs;
+  logic err_code_sfifo_output_err_qs;
   logic err_code_edn_ack_sm_err_qs;
   logic err_code_edn_main_sm_err_qs;
   logic err_code_edn_cntr_err_qs;
@@ -904,6 +905,32 @@ module edn_reg_top (
     .qs     (err_code_sfifo_gencmd_err_qs)
   );
 
+  //   F[sfifo_output_err]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_err_code_sfifo_output_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.sfifo_output_err.de),
+    .d      (hw2reg.err_code.sfifo_output_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (err_code_sfifo_output_err_qs)
+  );
+
   //   F[edn_ack_sm_err]: 20:20
   prim_subreg #(
     .DW      (1),
@@ -1337,6 +1364,7 @@ module edn_reg_top (
       addr_hit[14]: begin
         reg_rdata_next[0] = err_code_sfifo_rescmd_err_qs;
         reg_rdata_next[1] = err_code_sfifo_gencmd_err_qs;
+        reg_rdata_next[2] = err_code_sfifo_output_err_qs;
         reg_rdata_next[20] = err_code_edn_ack_sm_err_qs;
         reg_rdata_next[21] = err_code_edn_main_sm_err_qs;
         reg_rdata_next[22] = err_code_edn_cntr_err_qs;


### PR DESCRIPTION
Bit 2 of the ERR_CODE is defined as an error bit that when set will cause a fatal error.
This bit is associated with the Output FIFO.
Fixes #16218.