### PR TITLE
[i2c,dv] change default en_monitor to 0.

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -4,7 +4,7 @@
 
 class i2c_agent_cfg extends dv_base_agent_cfg;
 
-  bit en_monitor = 1'b1; // enable monitor
+  bit en_monitor = 1'b0; // enable monitor
 
   // this parameters can be set by test to slow down the agent's responses
   int host_latency_cycles = 0;

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -34,50 +34,10 @@ class i2c_monitor extends dv_base_monitor #(
 
   virtual task run_phase(uvm_phase phase);
     wait(cfg.vif.rst_ni);
+    // expecting 'en_monitor is set by env or sequence.
+    wait(cfg.en_monitor);
     if (cfg.if_mode == Host) begin
-      bit r_bit = 1'b0;
-      i2c_item full_item;
-      forever begin
-        if (mon_dut_item.stop ||
-            (!mon_dut_item.stop && !mon_dut_item.start && !mon_dut_item.rstart)) begin
-          cfg.vif.wait_for_host_start(cfg.timing_cfg);
-          `uvm_info(`gfn, "\nmonitor, detect HOST START", UVM_MEDIUM)
-        end else begin
-          mon_dut_item.rstart = 1'b1;
-        end
-        num_dut_tran++;
-        mon_dut_item.start = 1'b1;
-        // collecting address
-        for (int i = cfg.target_addr_mode - 1; i >= 0; i--) begin
-          cfg.vif.p_edge_scl();
-          mon_dut_item.addr[i] = cfg.vif.cb.sda_i;
-          `uvm_info(`gfn, $sformatf("\nmonitor, address[%0d] %b", i, mon_dut_item.addr[i]),
-                    UVM_HIGH)
-        end
-        `uvm_info(`gfn, $sformatf("\nmonitor, address %0x", mon_dut_item.addr), UVM_MEDIUM)
-        cfg.vif.p_edge_scl();
-        r_bit = cfg.vif.cb.sda_i;
-        `uvm_info(`gfn, $sformatf("\nmonitor, rw %d", r_bit), UVM_MEDIUM)
-        mon_dut_item.bus_op = (r_bit) ? BusOpRead : BusOpWrite;
-
-        // expect target ack
-        cfg.vif.p_edge_scl();
-        r_bit = cfg.vif.cb.sda_i;
-        `DV_CHECK_CASE_EQ(r_bit, 1'b0)
-
-        if (mon_dut_item.bus_op == BusOpRead)
-          target_read();
-        else target_write();
-
-        // send rsp_item to scoreboard
-        `downcast(full_item, mon_dut_item.clone());
-        full_item.stop = 1'b1;
-        if (mon_dut_item.bus_op == BusOpRead) begin
-          full_item.read = 1;
-          analysis_port.write(full_item);
-        end
-        mon_dut_item.clear_data();
-      end
+      collect_trans(phase);
     end else begin
       forever begin
         fork
@@ -99,10 +59,55 @@ class i2c_monitor extends dv_base_monitor #(
     end
   endtask : run_phase
 
+  task collect_trans(uvm_phase phase);
+    bit r_bit = 1'b0;
+    i2c_item full_item;
+    forever begin
+      if (mon_dut_item.stop ||
+          (!mon_dut_item.stop && !mon_dut_item.start && !mon_dut_item.rstart)) begin
+        cfg.vif.wait_for_host_start(cfg.timing_cfg);
+        `uvm_info(`gfn, "\nmonitor, detect HOST START", UVM_MEDIUM)
+      end else begin
+        mon_dut_item.rstart = 1'b1;
+      end
+      num_dut_tran++;
+      mon_dut_item.start = 1'b1;
+      // collecting address
+      for (int i = cfg.target_addr_mode - 1; i >= 0; i--) begin
+        cfg.vif.p_edge_scl();
+        mon_dut_item.addr[i] = cfg.vif.cb.sda_i;
+        `uvm_info(`gfn, $sformatf("\nmonitor, address[%0d] %b", i, mon_dut_item.addr[i]),
+                  UVM_HIGH)
+      end
+      `uvm_info(`gfn, $sformatf("\nmonitor, address %0x", mon_dut_item.addr), UVM_MEDIUM)
+      cfg.vif.p_edge_scl();
+      r_bit = cfg.vif.cb.sda_i;
+      `uvm_info(`gfn, $sformatf("\nmonitor, rw %d", r_bit), UVM_MEDIUM)
+      mon_dut_item.bus_op = (r_bit) ? BusOpRead : BusOpWrite;
+
+      // expect target ack
+      cfg.vif.p_edge_scl();
+      r_bit = cfg.vif.cb.sda_i;
+      `DV_CHECK_CASE_EQ(r_bit, 1'b0)
+
+      if (mon_dut_item.bus_op == BusOpRead)
+        target_read();
+      else target_write();
+
+      // send rsp_item to scoreboard
+      `downcast(full_item, mon_dut_item.clone());
+      full_item.stop = 1'b1;
+      if (mon_dut_item.bus_op == BusOpRead) begin
+        full_item.read = 1;
+        analysis_port.write(full_item);
+      end
+      mon_dut_item.clear_data();
+    end
+  endtask // collect_trans
+
   // Collect transactions forever
   virtual protected task collect_thread(uvm_phase phase);
     i2c_item full_item;
-    wait(cfg.en_monitor);
     if (mon_dut_item.stop ||
        (!mon_dut_item.stop && !mon_dut_item.start && !mon_dut_item.rstart)) begin
       cfg.vif.wait_for_host_start(cfg.timing_cfg);

--- a/hw/ip/i2c/dv/env/i2c_env.sv
+++ b/hw/ip/i2c/dv/env/i2c_env.sv
@@ -19,6 +19,7 @@ class i2c_env extends cip_base_env #(
     m_i2c_agent = i2c_agent::type_id::create("m_i2c_agent", this);
     uvm_config_db#(i2c_agent_cfg)::set(this, "m_i2c_agent*", "cfg", cfg.m_i2c_agent_cfg);
     cfg.m_i2c_agent_cfg.en_cov = cfg.en_cov;
+    cfg.m_i2c_agent_cfg.en_monitor = 1;
   endfunction : build_phase
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -131,7 +131,7 @@
   regressions: [
     {
        name: smoke
-       tests: ["i2c_host_smoke"]
+       tests: ["i2c_host_smoke", "i2c_target_smoke"]
     }
   ]
 }


### PR DESCRIPTION
Address first issue of #16208 
In block tb, it will be set in env, and chip tb will be set this in individual sequence.

The other one will be addressed separately.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>