### PR TITLE
[dv, sw] Introduce rand_testuils_shuffle

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -263,6 +263,7 @@ cc_library(
         ":rv_core_ibex_testutils",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/lib/testing/rand_testutils.h
+++ b/sw/device/lib/testing/rand_testutils.h
@@ -100,4 +100,14 @@ uint32_t rand_testutils_gen32(void);
  */
 uint32_t rand_testutils_gen32_range(uint32_t min, uint32_t max);
 
+/** Shuffles an arbitrary array of elements.
+ *
+ * The shuffling occurs in-place. The reseeding of the LFSR is temporarily
+ * turned off to allow faster runtime performance.
+ * @param array Pointer to the array being shuffled.
+ * @param size The size of each element in the array.
+ * @param length The number of elements in the array.
+ */
+void rand_testutils_shuffle(void *array, size_t size, size_t length);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_RAND_TESTUTILS_H_


### PR DESCRIPTION
Enables shuffling of arbitrary array data strtuctures to facilitate more robust testing in SW. This is a work in progress - the shuffle is not working correctly yet.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>