### PR TITLE
[rdc] Add `waves` option to RDC flow.

### DIFF
--- a/hw/rdc/tools/dvsim/common_rdc_cfg.hjson
+++ b/hw/rdc/tools/dvsim/common_rdc_cfg.hjson
@@ -67,6 +67,7 @@
     { BUILD_DIR:    "{build_dir}" },
     { DUT:          "{dut}" },
     { PARAMS:       "{params}" },
+    { WAVES:        "{waves}"},
     { SV_FLIST:     "{sv_flist}" }
   ]
 }

--- a/hw/rdc/tools/meridianrdc/run-rdc.tcl
+++ b/hw/rdc/tools/meridianrdc/run-rdc.tcl
@@ -31,8 +31,9 @@ set RESET_SCENARIO_FILE [get_env_var "RESET_SCENARIO_FILE"]
 
 # WAVES is optional
 set WAVES ""
-if {[info exists ::env("WAVES")]} {
+if {[info exists ::env(WAVES)]} {
   set WAVES "$::env(WAVES)"
+  puts "::env(WAVES) = ${WAVES}"
 }
 
 # Used to disable some SDC constructs that are not needed by RDC.

--- a/util/dvsim/RdcCfg.py
+++ b/util/dvsim/RdcCfg.py
@@ -15,6 +15,8 @@ class RdcCfg(LintCfg):
 
     def __init__(self, flow_cfg_file, hjson_data, args, mk_config):
 
+        self.waves = args.waves or ""
+
         super().__init__(flow_cfg_file, hjson_data, args, mk_config)
 
         self.results_title = f'{self.name.upper()} RDC Results'


### PR DESCRIPTION
RDC flow checks `args.waves` then setting `WAVES` env. var with the value. RDC tcl script `hw/rdc/tools/meridianrdc/run-rdc.tcl` uses the env. variable to set internal configs to dump all violation waveforms.
