### PR TITLE
[rom_e2e,dv] build `sigverify_always` test for DV

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -14,8 +14,10 @@ load(
 load("//rules:const.bzl", "CONST", "error_redact", "hex", "lc_hw_to_sw")
 load(
     "//rules:opentitan.bzl",
+    "bin_to_vmem",
     "opentitan_flash_binary",
     "opentitan_multislot_flash_binary",
+    "scramble_flash_vmem",
 )
 load("//rules:manifest.bzl", "manifest")
 load("//rules:opentitan_gdb_test.bzl", "opentitan_gdb_fpga_cw310_test")
@@ -1395,7 +1397,7 @@ SIGVERIFY_LC_KEYS = [
     genrule(
         name = "empty_test_slot_{}_corrupted_{}_bin_signed_{}".format(slot, device, key),
         srcs = ["empty_test_slot_{}_{}_bin_signed_{}".format(slot, device, key)],
-        outs = ["empty_test_slot_{}_bad_signature_{}_bin_signed_{}".format(slot, device, key)],
+        outs = ["empty_test_slot_{}_corrupted_{}.{}.signed.bin".format(slot, device, key)],
         cmd_bash = "cat $(SRCS) > $(OUTS) && dd if=/dev/zero of=$(OUTS) bs=4 seek=7 count=1 conv=notrunc status=none".format(slot),
     )
     for slot in SLOTS
@@ -1404,6 +1406,43 @@ SIGVERIFY_LC_KEYS = [
         "fpga_cw310",
     ]
     for key in SIGVERIFY_LC_KEYS
+]
+
+# The below three rule sets (bin_to_vmem, scramble_flash_vmem, and filegroup)
+# are needed to run `sigverify_always` test in DV.
+[
+    bin_to_vmem(
+        name = "empty_test_slot_{}_corrupted_sim_dv_vmem64_signed_{}".format(slot, key),
+        bin = "empty_test_slot_{}_corrupted_sim_dv_bin_signed_{}".format(slot, key),
+        word_size = 64,  # Backdoor-load VMEM image uses 64-bit words
+    )
+    for slot in SLOTS
+    for key in SIGVERIFY_LC_KEYS
+]
+
+[
+    scramble_flash_vmem(
+        name = "empty_test_slot_{}_corrupted_sim_dv_scr_vmem64_signed_{}".format(slot, key),
+        vmem = "empty_test_slot_{}_corrupted_sim_dv_vmem64_signed_{}".format(slot, key),
+    )
+    for slot in SLOTS
+    for key in SIGVERIFY_LC_KEYS
+]
+
+[
+    filegroup(
+        name = "empty_test_slot_{}_corrupted_sim_dv".format(slot),
+        srcs = [
+            "empty_test_slot_{}_corrupted_sim_dv_{}_signed_{}".format(slot, file_type, key)
+            for file_type in [
+                "bin",
+                "vmem64",
+                "scr_vmem64",
+            ]
+            for key in SIGVERIFY_LC_KEYS
+        ],
+    )
+    for slot in SLOTS
 ]
 
 BOOT_POLICY_VALID_CASES = [

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1399,7 +1399,10 @@ SIGVERIFY_LC_KEYS = [
         cmd_bash = "cat $(SRCS) > $(OUTS) && dd if=/dev/zero of=$(OUTS) bs=4 seek=7 count=1 conv=notrunc status=none".format(slot),
     )
     for slot in SLOTS
-    for device in ["fpga_cw310"]
+    for device in [
+        "sim_dv",
+        "fpga_cw310",
+    ]
     for key in SIGVERIFY_LC_KEYS
 ]
 
@@ -2014,7 +2017,10 @@ test_suite(
                 "offset": offset,
             },
         },
-        devices = ["fpga_cw310"],
+        devices = [
+            "sim_dv",
+            "fpga_cw310",
+        ],
     )
     for slot, offset in SLOTS.items()
     for key in SIGVERIFY_LC_KEYS
@@ -2033,7 +2039,10 @@ test_suite(
                 "offset": SLOTS["b"],
             },
         },
-        devices = ["fpga_cw310"],
+        devices = [
+            "sim_dv",
+            "fpga_cw310",
+        ],
     )
     for key in SIGVERIFY_LC_KEYS
 ]
@@ -2049,7 +2058,10 @@ test_suite(
         cmd_bash = "touch $(OUTS)",
     )
     for slot in SLOTS
-    for device in ["fpga_cw310"]
+    for device in [
+        "sim_dv",
+        "fpga_cw310",
+    ]
     for key in SIGVERIFY_LC_KEYS
 ]
 
@@ -2066,7 +2078,10 @@ test_suite(
                 "offset": SLOTS["b"],
             },
         },
-        devices = ["fpga_cw310"],
+        devices = [
+            "sim_dv",
+            "fpga_cw310",
+        ],
     )
     for key in [
         "test_key_0",
@@ -2142,13 +2157,20 @@ SIGVERIFY_LCS_2_VALID_KEY = {
             otp = ":otp_img_sigverify_always_{}".format(lc_state.lower()),
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
+        dv = dv_params(
+            otp = ":otp_img_sigverify_always_{}".format(lc_state.lower()),
+            rom = "//sw/device/silicon_creator/rom",
+        ),
         key = "multislot",
         ot_flash_binary = ":sigverify_always_img_a_{}_b_{}_{}".format(
             case["a"],
             case["b"],
             SIGVERIFY_LCS_2_VALID_KEY[lc_state.lower()],
         ),
-        targets = ["cw310_rom"],
+        targets = [
+            "dv",
+            "cw310_rom",
+        ],
     )
     for case in SIGVERIFY_BAD_CASES
     for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()


### PR DESCRIPTION
This PR contains two commits that add the necessary build targets to bring up the `sigverify_always` ROM E2E test in DV (as required by #14634). Specifically, this builds the SW artifacts for the DV "device" and also builds VMEM files for corrupted images (previously only BIN files were generated for the FPGA). While we could load uncorrupted VMEM images (that already exist for the `empty_test_slot_{a,b}` flash binaries) in DV and backdoor overwrite a portion to "corrupt" the image in the SV testbench, doing so would make it difficult to keep the exact corruption point in sync with the same used on FPGA, so this method was chosen instead.

**_Note: this depends on #16185, only review last two commits._**