### PR TITLE
[dv/edn] Fix disable auto_req_mode regression error

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_device_driver.sv
+++ b/hw/dv/sv/csrng_agent/csrng_device_driver.sv
@@ -38,6 +38,10 @@ class csrng_device_driver extends csrng_driver;
           cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
           cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= 1'b0;,
           wait (cfg.under_reset == 1);)
+
+      // Write ack bit again in case the race condition with `reset_signals`.
+      if (cfg.under_reset) cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
+
       `uvm_info(`gfn, cfg.under_reset ? "item sent during reset" : "item sent", UVM_HIGH)
       seq_item_port.item_done(rsp);
     end

--- a/hw/ip/edn/data/edn_testplan.hjson
+++ b/hw/ip/edn/data/edn_testplan.hjson
@@ -87,7 +87,7 @@
             Disable EDN in all states and verify proper operation when re-enabled.
             '''
       stage: V2
-      tests: ["edn_disable"]
+      tests: ["edn_disable", "edn_disable_auto_req_mode"]
     }
     {
       name: stress_all


### PR DESCRIPTION
The current version has a few errors:
1). CSRNG monitor did not handle reset.
2). EDN disable auto_req_mode sequence error: After the EDN is disaled,
  to re-enable EDN, we need to clear the FIFOs and rewrite all the
  previous FIFOs.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>