### PR TITLE
[dv] some small fix on spi_agent to enable item comparison

### DIFF
--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -113,6 +113,7 @@ class spi_device_driver extends spi_driver;
           logic [7:0] byte_data;
           cfg.read_byte(item.num_lanes, !item.write_command, byte_data);
           rsp.payload_q.push_back(byte_data);
+          if (!item.write_command) rsp.read_size++;
         end
       end : thread_collect_payload
 

--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -257,7 +257,7 @@ class spi_host_driver extends spi_driver;
   endtask
 
   task drive_sck_no_csb_item();
-    repeat (req.dummy_clk_cnt) begin
+    repeat (req.dummy_sck_cnt) begin
       #($urandom_range(1, 100) * 1ns);
       cfg.vif.sck <= ~cfg.vif.sck;
     end
@@ -266,7 +266,7 @@ class spi_host_driver extends spi_driver;
 
   task drive_csb_no_sck_item();
     cfg.vif.csb[active_csb] <= 1'b0;
-    #(req.dummy_sck_length_ns * 1ns);
+    #(req.dummy_csb_length_ns * 1ns);
   endtask
 
   function uint get_rand_extra_delay_ns_btw_sck();

--- a/hw/dv/sv/spi_agent/spi_item.sv
+++ b/hw/dv/sv/spi_agent/spi_item.sv
@@ -21,8 +21,8 @@ class spi_item extends uvm_sequence_item;
   rand int dummy_cycles;
 
   // for dummy transaction
-  rand uint dummy_clk_cnt;
-  rand uint dummy_sck_length_ns;
+  rand uint dummy_sck_cnt;
+  rand uint dummy_csb_length_ns;
 
   // indicate the active csb
   rand bit [CSB_WIDTH-1:0] csb_sel;
@@ -35,9 +35,19 @@ class spi_item extends uvm_sequence_item;
   // constrain size of data sent / received to be at most 64kB
   constraint data_size_c { data.size() inside {[0:65536]}; }
 
-  constraint dummy_clk_cnt_c { dummy_clk_cnt inside {[1:1000]}; }
+  constraint dummy_sck_cnt_c {
+    if (item_type == SpiTransSckNoCsb) {
+      dummy_sck_cnt inside {[1:1000]};
+    } else {
+      dummy_sck_cnt == 0;
+    }}
 
-  constraint dummy_sck_length_c { dummy_sck_length_ns inside {[1:1000]}; }
+  constraint dummy_csb_length_ns_c {
+    if (item_type == SpiTransCsbNoSck) {
+      dummy_csb_length_ns inside {[1:1000]};
+    } else {
+      dummy_csb_length_ns == 0;
+    }}
 
   constraint num_lanes_c {
     write_command -> num_lanes == 1;
@@ -48,8 +58,8 @@ class spi_item extends uvm_sequence_item;
     `uvm_field_enum(spi_trans_type_e, item_type, UVM_DEFAULT)
     `uvm_field_queue_int(data,                   UVM_DEFAULT)
     `uvm_field_int(first_byte,                   UVM_DEFAULT)
-    `uvm_field_int(dummy_clk_cnt,                UVM_DEFAULT)
-    `uvm_field_int(dummy_sck_length_ns,          UVM_DEFAULT)
+    `uvm_field_int(dummy_sck_cnt,                UVM_DEFAULT)
+    `uvm_field_int(dummy_csb_length_ns,          UVM_DEFAULT)
     `uvm_field_int(read_size,                    UVM_DEFAULT)
     `uvm_field_int(write_command,                UVM_DEFAULT)
     `uvm_field_int(opcode,                       UVM_DEFAULT)
@@ -71,8 +81,8 @@ class spi_item extends uvm_sequence_item;
 
     txt = "\n \t ----| SPI ITEM |----";
     txt = {txt, $sformatf("\n ----| Item Type: \t%s", item_type.name()) };
-    txt = {txt, $sformatf("\n ----| Dummy Clk Cnt: \t%0d",  dummy_clk_cnt) };
-    txt = {txt, $sformatf("\n ----| Dummy Sck Lengtht: \t%0d ns",  dummy_sck_length_ns) };
+    txt = {txt, $sformatf("\n ----| Dummy Clk Cnt: \t%0d",  dummy_sck_cnt) };
+    txt = {txt, $sformatf("\n ----| Dummy Sck Lengtht: \t%0d ns",  dummy_csb_length_ns) };
     txt = {txt, $sformatf("\n ----| First Byte: \t%b ",  first_byte) };
     txt = {txt, $sformatf("\n ----| Data:") };
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
@@ -117,11 +117,10 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
           `DV_CHECK_EQ(device_rsp_q.size(), 1);
           host_rsp = m_spi_host_seq.rsp;
           device_rsp = device_rsp_q.pop_front();
-          `DV_CHECK_EQ(host_rsp.opcode, device_rsp.opcode);
-          `DV_CHECK_Q_EQ(host_rsp.address_q, device_rsp.address_q);
-          `DV_CHECK_EQ(host_rsp.dummy_cycles, device_rsp.dummy_cycles);
-          `DV_CHECK_EQ(host_rsp.num_lanes, device_rsp.num_lanes);
-          `DV_CHECK_Q_EQ(host_rsp.payload_q, device_rsp.payload_q);
+          if (!host_rsp.compare(device_rsp)) begin
+            `uvm_error(`gfn, $sformatf("Compare mismatch\nhost_rsp:\n%sdevice_rsp:\n%s",
+                                       host_rsp.sprint(), device_rsp.sprint()))
+          end
         end else begin
           `DV_CHECK_EQ(device_rsp_q.size(), 0);
         end


### PR DESCRIPTION
1. Constrain dummy_* to random value only in the related mode
2. Update read_size in device_driver
3. Update top-level vseq to compare SPI items directly

Also rename dummy_*

Signed-off-by: Weicai Yang <weicai@google.com>