### PR TITLE
[ottf,bugfix] Fix the flow control test to work on the fpga

### DIFF
--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -139,7 +139,7 @@ def verilator_params(
     """
     default_args = [
         "--rcfile=",
-        "--logging=info",
+        "--logging={logging}",
     ]
     required_test_cmds = [
         "--interface=verilator",
@@ -213,7 +213,7 @@ def cw310_params(
     """
     default_args = [
         "--rcfile=",
-        "--logging=info",
+        "--logging={logging}",
     ]
     required_test_cmds = [
         "--interface=cw310",
@@ -250,6 +250,7 @@ def opentitan_functest(
         slot = "silicon_creator_a",
         test_harness = "@//sw/host/opentitantool",
         key = "test_key_0",
+        logging = "info",
         dv = None,
         verilator = None,
         cw310 = None,
@@ -498,6 +499,7 @@ def opentitan_functest(
             "dvsim_config": dvsim_config,
             "bitstream": bitstream,
             "rom_kind": rom_kind,
+            "logging": params.pop("logging", logging),
         }
         format_dict.update(exit_strings_kwargs)
         target_args = [a.format(**format_dict) for a in target_args]

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -272,11 +272,10 @@ opentitan_functest(
     name = "ottf_flow_control_functest",
     srcs = ["ottf_flow_control_functest.c"],
     cw310 = cw310_params(
-        tags = ["broken"],  # TODO(#15487): failing on CI
         test_cmds = [
             "--exec=\"fpga load-bitstream --rom-kind={rom_kind} $(location {bitstream})\"",
             "--exec=\"bootstrap --clear-uart=true $(location {flash})\"",
-            "--exec \"console --quiet --exit-success=BUSY --exit-failure=PASS|FAIL\"",
+            "--exec=\"console --quiet --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control\"",
             "console",
             "--flow-control",
             "--send=\"{}\"".format(_FLOW_CONTROL_MESSAGE),
@@ -290,7 +289,7 @@ opentitan_functest(
     ],
     verilator = verilator_params(
         test_cmds = [
-            "--exec \"console --quiet --exit-success=BUSY --exit-failure=PASS|FAIL\"",
+            "--exec \"console --quiet --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control\"",
             "console",
             "--flow-control",
             "--send=\"{}\"".format(_FLOW_CONTROL_MESSAGE),

--- a/sw/device/lib/testing/test_framework/ottf_flow_control.c
+++ b/sw/device/lib/testing/test_framework/ottf_flow_control.c
@@ -20,7 +20,8 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 #define FLOW_CONTROL_LOW_WATERMARK 4
-#define FLOW_CONTROL_HIGH_WATERMARK 16
+#define FLOW_CONTROL_HIGH_WATERMARK 8
+#define FLOW_CONRTOL_WATERMARK_CONFIG kDifUartWatermarkByte8
 const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
 
 // The flow_control_state and ottf_flow_control_intr varibles are shared between
@@ -33,7 +34,7 @@ void ottf_flow_control_enable(void) {
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &ottf_plic));
 
   dif_uart_t *uart = ottf_console();
-  CHECK_DIF_OK(dif_uart_watermark_rx_set(uart, kDifUartWatermarkByte16));
+  CHECK_DIF_OK(dif_uart_watermark_rx_set(uart, FLOW_CONRTOL_WATERMARK_CONFIG));
   CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
                                         kDifToggleEnabled));
 

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -30,6 +30,7 @@ impl UartParams {
         if let Some(baudrate) = self.baudrate {
             uart.set_baudrate(baudrate)?;
         }
+        log::info!("set_flow_control to {}", self.flow_control);
         uart.set_flow_control(self.flow_control)?;
         Ok(uart)
     }

--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -4,16 +4,21 @@
 
 use anyhow::{Context, Result};
 use serialport::ClearBuffer;
-use serialport::{FlowControl, SerialPort};
-use std::cell::RefCell;
+//use serialport::{FlowControl, SerialPort};
+use serialport::SerialPort;
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::io::ErrorKind;
 use std::time::Duration;
 
-use crate::io::uart::{Uart, UartError};
+//use crate::io::uart::{Uart, UartError};
+use crate::io::uart::{FlowControl, Uart, UartError};
 
 /// Implementation of the `Uart` trait on top of a serial device, such as `/dev/ttyUSB0`.
 pub struct SerialPortUart {
+    flow_control: Cell<FlowControl>,
     port: RefCell<Box<dyn SerialPort>>,
+    rxbuf: RefCell<VecDeque<u8>>,
 }
 
 impl SerialPortUart {
@@ -27,12 +32,56 @@ impl SerialPortUart {
     /// Open the given serial device, such as `/dev/ttyUSB0`.
     pub fn open(port_name: &str) -> Result<Self> {
         Ok(SerialPortUart {
+            flow_control: Cell::new(FlowControl::None),
             port: RefCell::new(
                 serialport::new(port_name, 115200)
                     .open()
                     .map_err(|e| UartError::OpenError(e.to_string()))?,
             ),
+            rxbuf: RefCell::default(),
         })
+    }
+
+    fn read_worker(&self, timeout: Duration) -> Result<()> {
+        let mut buf = [0u8; 256];
+        let mut port = self.port.borrow_mut();
+
+        port.set_timeout(timeout).context("UART read error")?;
+        let result = port.read(&mut buf);
+        let len = match result {
+            Ok(n) => n,
+            Err(ioerr) if ioerr.kind() == ErrorKind::TimedOut => 0,
+            Err(e) => return Err(e.into()),
+        };
+        for &ch in &buf[..len] {
+            if self.flow_control.get() != FlowControl::None {
+                if ch == FlowControl::Resume as u8 {
+                    log::debug!("Got RESUME");
+                    self.flow_control.set(FlowControl::Resume);
+                    continue;
+                } else if ch == FlowControl::Pause as u8 {
+                    log::debug!("Got PAUSE");
+                    self.flow_control.set(FlowControl::Pause);
+                    continue;
+                }
+            }
+            self.rxbuf.borrow_mut().push_back(ch);
+        }
+        port.set_timeout(Self::FOREVER).context("UART read error")?;
+        Ok(())
+    }
+
+    fn read_buffer(&self, buf: &mut [u8]) -> Result<usize> {
+        let mut rxbuf = self.rxbuf.borrow_mut();
+        let mut i = 0;
+        for byte in buf.iter_mut() {
+            let Some(rx) = rxbuf.pop_front() else {
+                break;
+            };
+            *byte = rx;
+            i += 1;
+        }
+        Ok(i)
     }
 }
 
@@ -52,51 +101,58 @@ impl Uart for SerialPortUart {
     }
 
     fn set_flow_control(&self, flow_control: bool) -> Result<()> {
-        if flow_control {
-            self.port
-                .borrow_mut()
-                .set_flow_control(FlowControl::Software)?;
-        } else {
-            self.port.borrow_mut().set_flow_control(FlowControl::None)?;
-        }
+        self.flow_control.set(match flow_control {
+            false => FlowControl::None,
+            // When flow-control is enabled, assume we're haven't
+            // already been put into a pause state.
+            true => FlowControl::Resume,
+        });
         Ok(())
-    }
-
-    /// Reads UART receive data into `buf`, returning the number of bytes read.
-    /// This function _may_ block.
-    fn read(&self, buf: &mut [u8]) -> Result<usize> {
-        self.port.borrow_mut().read(buf).context("UART read error")
     }
 
     /// Reads UART receive data into `buf`, returning the number of bytes read.
     /// The `timeout` may be used to specify a duration to wait for data.
     fn read_timeout(&self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
-        let mut port = self.port.borrow_mut();
-        port.set_timeout(timeout).context("UART read error")?;
-        let result = port.read(buf);
-        let len = match result {
-            Err(ioerr) if ioerr.kind() == ErrorKind::TimedOut => Ok(0),
-            _ => result,
-        };
-        port.set_timeout(Self::FOREVER).context("UART read error")?;
-        len.context("UART read error")
+        if self.rxbuf.borrow().is_empty() {
+            self.read_worker(timeout)?;
+        }
+        self.read_buffer(buf)
+    }
+
+    /// Reads UART receive data into `buf`, returning the number of bytes read.
+    /// This function _may_ block.
+    fn read(&self, buf: &mut [u8]) -> Result<usize> {
+        self.read_timeout(buf, Self::FOREVER)
     }
 
     /// Writes data from `buf` to the UART.
-    fn write(&self, mut buf: &[u8]) -> Result<()> {
-        while !buf.is_empty() {
-            let written = self
-                .port
+    fn write(&self, buf: &[u8]) -> Result<()> {
+        // The constant of 10 is approximately 10 uart bit times per byte.
+        let pacing = Duration::from_nanos(10 * 1_000_000_000u64 / (self.get_baudrate()? as u64));
+        log::debug!("pacing = {:?}", pacing);
+
+        for b in buf.iter() {
+            // If flow control is enabled, read data from the input stream and
+            // process the flow control chars.
+            while self.flow_control.get() != FlowControl::None {
+                self.read_worker(pacing)?;
+                // If we're ok to send, then break out of the flow-control loop and send the data.
+                if self.flow_control.get() == FlowControl::Resume {
+                    break;
+                }
+            }
+            self.port
                 .borrow_mut()
-                .write(buf)
+                .write_all(std::slice::from_ref(b))
                 .context("UART write error")?;
-            buf = &buf[written..];
         }
         Ok(())
     }
 
     /// Clears the UART RX buffer.
     fn clear_rx_buffer(&self) -> Result<()> {
-        Ok(self.port.borrow_mut().clear(ClearBuffer::Input)?)
+        self.rxbuf.borrow_mut().clear();
+        self.port.borrow_mut().clear(ClearBuffer::Input)?;
+        Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/transport/verilator/uart.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/uart.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{Context, Result};
 use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io;
@@ -20,6 +21,7 @@ pub struct VerilatorUart {
     baudrate: Cell<u32>,
     flow_control: Cell<FlowControl>,
     file: RefCell<File>,
+    rxbuf: RefCell<VecDeque<u8>>,
 }
 
 impl VerilatorUart {
@@ -38,7 +40,59 @@ impl VerilatorUart {
                     .open(path)
                     .map_err(|e| TransportError::OpenError(path.to_string(), e.to_string()))?,
             ),
+            rxbuf: RefCell::default(),
         })
+    }
+
+    fn read_worker(&self, timeout: Duration) -> Result<()> {
+        let mut buf = [0u8; 256];
+        let mut file = self.file.borrow_mut();
+
+        if timeout != Duration::MAX {
+            let ready = file::wait_read_timeout(&*file, timeout);
+            match ready {
+                Ok(_) => {}
+                Err(e) => {
+                    // A timeout from the simulated UART is not an error.  Let all other errors propagate.
+                    if let Some(ioerr) = e.downcast_ref::<io::Error>() {
+                        if ioerr.kind() == ErrorKind::TimedOut {
+                            return Ok(());
+                        }
+                    }
+                    return Err(e).context("UART read error");
+                }
+            }
+        }
+
+        let len = file.read(&mut buf)?;
+        for &ch in &buf[..len] {
+            if self.flow_control.get() != FlowControl::None {
+                if ch == FlowControl::Resume as u8 {
+                    log::debug!("Got RESUME");
+                    self.flow_control.set(FlowControl::Resume);
+                    continue;
+                } else if ch == FlowControl::Pause as u8 {
+                    log::debug!("Got PAUSE");
+                    self.flow_control.set(FlowControl::Pause);
+                    continue;
+                }
+            }
+            self.rxbuf.borrow_mut().push_back(ch);
+        }
+        Ok(())
+    }
+
+    fn read_buffer(&self, buf: &mut [u8]) -> Result<usize> {
+        let mut rxbuf = self.rxbuf.borrow_mut();
+        let mut i = 0;
+        for byte in buf.iter_mut() {
+            let Some(rx) = rxbuf.pop_front() else {
+                break;
+            };
+            *byte = rx;
+            i += 1;
+        }
+        Ok(i)
     }
 }
 
@@ -64,46 +118,14 @@ impl Uart for VerilatorUart {
     }
 
     fn read_timeout(&self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
-        let ready = file::wait_read_timeout(&*self.file.borrow(), timeout);
-        match ready {
-            Ok(()) => self.read(buf),
-            Err(e) => {
-                // If we got a timeout from the uart, return 0 as per convention.
-                // Let all other errors propagate.
-                if let Some(ioerr) = e.downcast_ref::<io::Error>() {
-                    if ioerr.kind() == ErrorKind::TimedOut {
-                        return Ok(0);
-                    }
-                }
-                Err(e).context("UART read error")
-            }
+        if self.rxbuf.borrow().is_empty() {
+            self.read_worker(timeout)?;
         }
+        self.read_buffer(buf)
     }
 
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
-        let mut n = self
-            .file
-            .borrow_mut()
-            .read(buf)
-            .context("UART read error")?;
-        if self.flow_control.get() != FlowControl::None {
-            // Eliminate flow control characters from the buffer
-            let mut i = 0;
-            while i < n {
-                if buf[i] == FlowControl::Resume as u8 {
-                    self.flow_control.set(FlowControl::Resume);
-                    buf.copy_within((i + 1)..n, i);
-                    n -= 1;
-                } else if buf[i] == FlowControl::Pause as u8 {
-                    self.flow_control.set(FlowControl::Pause);
-                    buf.copy_within((i + 1)..n, i);
-                    n -= 1;
-                } else {
-                    i += 1;
-                }
-            }
-        }
-        Ok(n)
+        self.read_timeout(buf, Duration::MAX)
     }
 
     fn write(&self, buf: &[u8]) -> Result<()> {
@@ -111,11 +133,10 @@ impl Uart for VerilatorUart {
         let pacing = Duration::from_nanos(10 * 1_000_000_000u64 / (self.baudrate.get() as u64));
 
         for b in buf.iter() {
-            // If flow control is enabled, read and discard data from the input stream,
-            // which will process the flow control chars.
+            // If flow control is enabled, read data from the input stream and
+            // process the flow control chars.
             while self.flow_control.get() != FlowControl::None {
-                let mut byte = 0;
-                self.read_timeout(std::slice::from_mut(&mut byte), pacing)?;
+                self.read_worker(pacing)?;
                 // If we're ok to send, then break out of the flow-control loop and send the data.
                 if self.flow_control.get() == FlowControl::Resume {
                     break;

--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -118,7 +118,9 @@ impl UartConsole {
                 if len == 1 && buf[0] == UartConsole::CTRL_C {
                     return Ok(ExitStatus::CtrlC);
                 }
-                uart.write(&buf[..len])?;
+                if len > 0 {
+                    uart.write(&buf[..len])?;
+                }
             }
         }
         Ok(ExitStatus::None)


### PR DESCRIPTION
1. Refactor UART flow control in opentitanlib.  Most notably, (a) we no longer discard RX data during a send and (b) the `common` UART code implements manual flow control and pacing.
2. Fix the test by giving more time in the `WAIT` loop.  Use a delay rather than UART output to control the time spent in the
   `WAIT` loop.