### PR TITLE
[keymgr] Adjust keymgr_en handling

### DIFF
--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -281,8 +281,18 @@
     }
     { name: "OUTPUT_KEYS.CTRL.REDUN",
       desc: '''
-        Software and sideload keys are redundantly controlled. One valid controls the write enable,
-        the other controls the input data (muxed to random).
+        Software and sideload keys are redundantly controlled. Each generate operation
+        creates a valid and a data enable (software and sideload specific).
+
+        In order for a key to be populated into the software register, both the software valid
+        and the software data enable must be asserted.  The same is true for sideload.
+
+        This makes it more difficult for an attack to fault a sideload key into the software key slot.
+        An attacker would need to fault both the software valid and the software data enable.
+
+        During a sideload operation, if an attacker manages to fault the valid but not the data enable,
+        the software key is populated with random data.  If an atacker manages to fault the data enable but
+        not the valid, then the software key retains its previous value.
       '''
     }
     { name: "CTRL.FSM.SPARSE",

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -247,7 +247,8 @@ module keymgr
   logic op_done;
   logic init;
   logic data_valid;
-  logic data_en;
+  logic data_hw_en;
+  logic data_sw_en;
   logic kmac_done;
   logic kmac_input_invalid;
   logic kmac_cmd_err;
@@ -294,7 +295,8 @@ module keymgr
     .status_o(hw2reg.op_status.d),
     .fault_o(fault_code),
     .error_o(err_code),
-    .data_en_o(data_en),
+    .data_hw_en_o(data_hw_en),
+    .data_sw_en_o(data_sw_en),
     .data_valid_o(data_valid),
     .working_state_o(hw2reg.working_state.d),
     .root_key_i(otp_key_i),
@@ -552,7 +554,7 @@ module keymgr
     .dest_sel_i(dest_sel),
     .hw_key_sel_i(hw_key_sel),
     // SEC_CM: OUTPUT_KEYS.CTRL.REDUN
-    .data_en_i(data_en),
+    .data_en_i(data_hw_en),
     .data_valid_i(data_valid),
     .key_i(kmac_key),
     .data_i(kmac_data),
@@ -581,14 +583,14 @@ module keymgr
     prim_sec_anchor_buf #(
      .Width(32)
     ) u_prim_buf_share0_d (
-      .in_i(~data_en | wipe_key ? data_rand[0] : kmac_data[0][i*32 +: 32]),
+      .in_i(~data_sw_en | wipe_key ? data_rand[0] : kmac_data[0][i*32 +: 32]),
       .out_o(hw2reg.sw_share0_output[i].d)
     );
 
     prim_sec_anchor_buf #(
      .Width(32)
     ) u_prim_buf_share1_d (
-      .in_i(~data_en | wipe_key ? data_rand[1] : kmac_data[1][i*32 +: 32]),
+      .in_i(~data_sw_en | wipe_key ? data_rand[1] : kmac_data[1][i*32 +: 32]),
       .out_o(hw2reg.sw_share1_output[i].d)
     );
 


### PR DESCRIPTION
- addresses https://github.com/lowRISC/opentitan/issues/16234
- The disable control was not correctly handled in the init states or
  in when an operation is completed on exactly the same cycle.

- Address both scenarios by allowing "early" disable error and not
  always wait for the fsm to transition.