### PR TITLE
[i2c] Patch handling of clock stretching for target mode

### DIFF
--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -377,7 +377,7 @@ module  i2c_core #(
     .rst_ni,
     .clr_i   (i2c_fifo_acqrst),
     .wvalid_i(acq_fifo_wvalid),
-    .wready_o(acq_fifo_wready),
+    .wready_o(),
     .wdata_i (acq_fifo_wdata),
     .depth_o (acq_fifo_depth),
     .rvalid_o(acq_fifo_rvalid),
@@ -443,7 +443,7 @@ module  i2c_core #(
     .tx_fifo_rready_o        (tx_fifo_rready),
     .tx_fifo_rdata_i         (tx_fifo_rdata),
 
-    .acq_fifo_wready_i       (acq_fifo_wready),
+    .acq_fifo_wready_o       (acq_fifo_wready),
     .acq_fifo_wvalid_o       (acq_fifo_wvalid),
     .acq_fifo_wdata_o        (acq_fifo_wdata),
     .acq_fifo_depth_i        (acq_fifo_depth),

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -408,7 +408,9 @@ module  i2c_core #(
     .q_o (sda_sync)
   );
 
-  i2c_fsm u_i2c_fsm (
+  i2c_fsm #(
+    .FifoDepth(FifoDepth)
+  ) u_i2c_fsm (
     .clk_i,
     .rst_ni,
 
@@ -444,6 +446,7 @@ module  i2c_core #(
     .acq_fifo_wready_i       (acq_fifo_wready),
     .acq_fifo_wvalid_o       (acq_fifo_wvalid),
     .acq_fifo_wdata_o        (acq_fifo_wdata),
+    .acq_fifo_depth_i        (acq_fifo_depth),
 
     .host_idle_o             (host_idle),
     .target_idle_o           (target_idle),


### PR DESCRIPTION
While Hs mode/nack are not currently supported, the previous stretching
organization made it difficult to support them in the long run.
Minor tweaks to addr and acq stretching flows to better support this.

The stretching scheme works as follows:
For data input (address / write operations), the stretch is always done
after the data is ack'd.  For data output (read operations), the stretch
is done before the data is sent.

This means for address / write operations, we always receive the byte,
acknowledge the byte and then look to see if space is available in the FIFO.
If space is not available, the clock is stretched until software makes space.
Acq full interrupt is used to notify software.

For read operations, we always look to see if there is a byte to send first
(functionally after the last ack from the host).  If there is nothing to send,
the clock is stretched until software provides data.
Tx empty interrupt is used to notify software.