### PR TITLE
[entropy_src/dv] Check for error state when faulting counter

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_sec_cm_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_sec_cm_testplan.hjson
@@ -114,10 +114,6 @@
       tests: ["entropy_src_sec_cm", "entropy_src_functional_errors"]
     }
     {
-      // TODO: It seems that this is currently not being verified.
-      // The entropy_src_functional_errors test verifies that if there is any mismatch in the redundant counters this is reported in the ERR_CODE register.
-      // But a check that the main FSM indeed enters a terminal error state seems to be missing.
-      // The scoreboard captures that setting ERR_CODE_TEST.ES_CNTR_ERR causes the DUT to signal a fatal alert and ERR_CODE.ES_CNTR_ERR as well as ERR_CODE.ES_MAIN_SM_ERR to get set.
       name: sec_cm_ctr_local_esc
       desc: '''
             Verify the countermeasure(s) CTR.LOCAL_ESC.

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
@@ -91,6 +91,8 @@ class entropy_src_err_vseq extends entropy_src_base_vseq;
         cov_vif.cg_sm_err_sample(fld_name == "es_ack_sm_err", fld_name == "es_main_sm_err");
       end
       es_cntr_err: begin
+        logic [entropy_src_pkg::AckSmStateWidth-1:0] sm_state;
+        string sm_state_path = cfg.entropy_src_path_vif.sm_err_path("ack_sm");
         fld = csr.get_field_by_name(fld_name);
         case (cfg.which_cntr)
           window_cntr: begin // window counter
@@ -116,6 +118,10 @@ class entropy_src_err_vseq extends entropy_src_base_vseq;
           end
         endcase // case (cfg.which_cntr)
         cov_vif.cg_cntr_err_sample(cfg.which_cntr, cfg.which_cntr_replicate, cfg.which_bin);
+        // Check that the `entropy_src_ack_sm` FSM, which observes the errors of the faulted
+        // counter, has entered the error state.
+        `DV_CHECK(uvm_hdl_read(sm_state_path, sm_state))
+        `DV_CHECK_EQ(sm_state, entropy_src_pkg::AckSmError)
       end
       fifo_write_err, fifo_read_err, fifo_state_err: begin
         fifo_name = cfg.which_fifo.name();

--- a/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
@@ -18,37 +18,11 @@ module entropy_src_ack_sm (
   output logic               ack_sm_err_o
 );
 
-// Encoding generated with:
-// $ ./util/design/sparse-fsm-encode.py -d 3 -m 3 -n 6 \
-//      -s 1236774883 --language=sv
-//
-// Hamming distance histogram:
-//
-//  0: --
-//  1: --
-//  2: --
-//  3: |||||||||||||||||||| (33.33%)
-//  4: |||||||||||||||||||| (33.33%)
-//  5: |||||||||||||||||||| (33.33%)
-//  6: --
-//
-// Minimum Hamming distance: 3
-// Maximum Hamming distance: 5
-// Minimum Hamming weight: 1
-// Maximum Hamming weight: 4
-//
+  import entropy_src_pkg::*;
 
+  ack_sm_state_e state_d, state_q;
 
-  localparam int StateWidth = 6;
-  typedef enum logic [StateWidth-1:0] {
-    Idle     = 6'b011101, // idle
-    AckWait  = 6'b101100, // wait until the fifo has an entry
-    Error    = 6'b000010  // illegal state reached and hang
-  } state_e;
-
-  state_e state_d, state_q;
-
-  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Idle)
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, ack_sm_state_e, AckSmIdle)
 
   always_comb begin
     state_d = state_q;
@@ -56,34 +30,34 @@ module entropy_src_ack_sm (
     fifo_pop_o = 1'b0;
     ack_sm_err_o = 1'b0;
     unique case (state_q)
-      Idle: begin
+      AckSmIdle: begin
         if (enable_i) begin
           if (req_i) begin
-            state_d = AckWait;
+            state_d = AckSmWait;
           end
         end
       end
-      AckWait: begin
+      AckSmWait: begin
         if (!enable_i) begin
-          state_d = Idle;
+          state_d = AckSmIdle;
         end else begin
           if (fifo_not_empty_i) begin
             ack_o = 1'b1;
             fifo_pop_o = 1'b1;
-            state_d = Idle;
+            state_d = AckSmIdle;
           end
         end
       end
-      Error: begin
+      AckSmError: begin
         ack_sm_err_o = 1'b1;
       end
       default: begin
-        state_d = Error;
+        state_d = AckSmError;
         ack_sm_err_o = 1'b1;
       end
     endcase
     if (local_escalate_i) begin
-      state_d = Error;
+      state_d = AckSmError;
     end
   end
 

--- a/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
@@ -82,4 +82,32 @@ package entropy_src_pkg;
   parameter entropy_src_xht_rsp_t ENTROPY_SRC_XHT_RSP_DEFAULT =
       '{test_cnt_lo: 16'hffff, default: '0};
 
+  // Sparse FSM state encodings
+
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 3 -n 6 \
+  //      -s 1236774883 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: |||||||||||||||||||| (33.33%)
+  //  4: |||||||||||||||||||| (33.33%)
+  //  5: |||||||||||||||||||| (33.33%)
+  //  6: --
+  //
+  // Minimum Hamming distance: 3
+  // Maximum Hamming distance: 5
+  // Minimum Hamming weight: 1
+  // Maximum Hamming weight: 4
+  //
+  localparam int AckSmStateWidth = 6;
+  typedef enum logic [AckSmStateWidth-1:0] {
+    AckSmIdle  = 6'b011101, // idle
+    AckSmWait  = 6'b101100, // wait until the fifo has an entry
+    AckSmError = 6'b000010  // illegal state reached and hang
+  } ack_sm_state_e;
+
 endpackage : entropy_src_pkg


### PR DESCRIPTION
The `CTR.LOCAL_ESC` CM implies that an `entropy_src` FSM must enter its terminal error state upon a counter mismatch. The `entropy_src_functional_errors` already does this faulting, but it does not yet check if the FSM enters the error state. This PR fills that gap, thereby contributing to resolving #16065. This is the second commit.

To make this check possible without duplicating the sparse state encoding, the declarations required for the sparse state of the `entropy_src_ack_sm` module have been moved into the `entropy_src_pkg` (as is common practice for other modules in OT). This is the first commit.

Pass rate of `entropy_src_functional_errors` remains 100%.