### PR TITLE
[spi_host] Decrease num_trans and num_runs for spi_host_sw_reset

### DIFF
--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_sw_reset_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_sw_reset_vseq.sv
@@ -12,6 +12,14 @@ class spi_host_sw_reset_vseq extends spi_host_tx_rx_vseq;
   bit rxempty;
   bit txempty;
 
+  task pre_randomize();
+    super.pre_randomize();
+    cfg.seq_cfg.host_spi_min_trans = 1;
+    cfg.seq_cfg.host_spi_max_trans = 2;
+    cfg.seq_cfg.host_spi_min_runs = 2;
+    cfg.seq_cfg.host_spi_max_runs = 5;
+  endtask
+
   virtual task body();
     for (int i = 0; i < num_runs; i++) begin
       fork


### PR DESCRIPTION
A large default number of transactions-per-run, combined with many runs was causing this test to run for a long time, and frequently timeout.

Goes towards #15075

Signed-off-by: Harry Callahan <hcallahan@lowrisc.org>