### PR TITLE
[entropy_src, dv] Add test for CONFIG.REGWEN countermeasure

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_sec_cm_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_sec_cm_testplan.hjson
@@ -24,10 +24,7 @@
 {
   testpoints: [
     {
-      // TODO: We need to carefully check what points are covered by which test and how.
-      // At a first glance 1), 2) and 3b) should be covered by the automated entropy_src_csr_rw test.
-      // However, the SW_REGUPD and MODULE_ENABLE registers have exclusions for all automated CSR tests.
-      // Meaning we might need a directed test for 1) and 2).
+      // Since the SW_REGUPD and MODULE_ENABLE registers have exclusions for all automated CSR tests, 1) and 2) below are verified with a directed test.
       // 3 a) and b) are captured by the scoreboard.
       name: sec_cm_config_regwen
       desc: '''
@@ -38,7 +35,7 @@
             3) Only if MODULE_ENABLE is MuBi4False and SW_REGUPD is 1, a) REGWEN reads as 1 and b) associated control and threshold registers can be modified.
             '''
       stage: V2S
-      tests: ["entropy_src_rng"]
+      tests: ["entropy_src_rng", "entropy_src_cfg_regwen"]
     }
     {
       name: sec_cm_config_mubi

--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -95,6 +95,12 @@
     }
 
     {
+      name: entropy_src_cfg_regwen
+      uvm_test: entropy_src_cfg_regwen_test
+      uvm_test_seq: entropy_src_cfg_regwen_vseq
+    }
+
+    {
       name: entropy_src_functional_errors
       reseed: 1000
       uvm_test: entropy_src_functional_errors_test

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.core
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.core
@@ -36,6 +36,7 @@ filesets:
       - seq_lib/entropy_src_intr_vseq.sv: {is_include_file: true}
       - seq_lib/entropy_src_alert_vseq.sv: {is_include_file: true}
       - seq_lib/entropy_src_err_vseq.sv: {is_include_file: true}
+      - seq_lib/entropy_src_cfg_regwen_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_cfg_regwen_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_cfg_regwen_vseq.sv
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_cfg_regwen_vseq extends entropy_src_base_vseq;
+
+  `uvm_object_utils(entropy_src_cfg_regwen_vseq)
+
+  `uvm_object_new
+
+  bit ctrl_bit        = 0;
+  bit chk_bit         = 0;
+  int ctrl_mod_enable = 0;
+  int mod_enable_chk  = 0;
+
+  task body();
+
+    csr_wr(.ptr(ral.me_regwen), .value(ctrl_bit), .blocking(1));
+    csr_wr(.ptr(ral.me_regwen), .value(~ctrl_bit), .blocking(1));
+    csr_rd(.ptr(ral.me_regwen), .value(chk_bit), .blocking(1));
+
+    if (chk_bit != ctrl_bit) begin
+      `uvm_fatal(`gfn, $sformatf(" Was able to overwrite ME_REGWEN after being set to 0"))
+    end
+
+    csr_wr(.ptr(ral.sw_regupd), .value(ctrl_bit), .blocking(1));
+    csr_wr(.ptr(ral.sw_regupd), .value(~ctrl_bit), .blocking(1));
+    csr_rd(.ptr(ral.sw_regupd), .value(chk_bit), .blocking(1));
+
+    if (chk_bit != ctrl_bit) begin
+      `uvm_fatal(`gfn, $sformatf(" Was able to overwrite SW_REGUPD after being set to 0"))
+    end
+
+    csr_rd(.ptr(ral.module_enable), .value(ctrl_mod_enable), .blocking(1));
+    csr_wr(.ptr(ral.module_enable),
+           .value(ctrl_mod_enable ^ 1'b1),
+           .blocking(1));
+    csr_rd(.ptr(ral.module_enable), .value(mod_enable_chk), .blocking(1));
+
+    if (ctrl_mod_enable != mod_enable_chk) begin
+      `uvm_fatal(`gfn, $sformatf(" Was able to overwrite MOD_ENABLE with ME_REGWEN being set to 0"))
+    end
+  endtask // body
+
+endclass : entropy_src_cfg_regwen_vseq

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_vseq_list.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_vseq_list.sv
@@ -11,3 +11,4 @@
 `include "entropy_src_intr_vseq.sv"
 `include "entropy_src_alert_vseq.sv"
 `include "entropy_src_err_vseq.sv"
+`include "entropy_src_cfg_regwen_vseq.sv"

--- a/hw/ip/entropy_src/dv/tests/entropy_src_cfg_regwen_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_cfg_regwen_test.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_cfg_regwen_test extends entropy_src_base_test;
+
+  `uvm_component_utils(entropy_src_cfg_regwen_test)
+  `uvm_component_new
+
+  function void configure_env();
+    super.configure_env();
+
+  endfunction
+endclass : entropy_src_cfg_regwen_test

--- a/hw/ip/entropy_src/dv/tests/entropy_src_test.core
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_test.core
@@ -17,6 +17,7 @@ filesets:
       - entropy_src_stress_all_test.sv: {is_include_file: true}
       - entropy_src_functional_errors_test.sv: {is_include_file: true}
       - entropy_src_alert_test.sv: {is_include_file: true}
+      - entropy_src_cfg_regwen_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/entropy_src/dv/tests/entropy_src_test_pkg.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_test_pkg.sv
@@ -20,5 +20,6 @@ package entropy_src_test_pkg;
   `include "entropy_src_stress_all_test.sv"
   `include "entropy_src_functional_errors_test.sv"
   `include "entropy_src_alert_test.sv"
+  `include "entropy_src_cfg_regwen_test.sv"
 
 endpackage


### PR DESCRIPTION
Add test to verify the following:
  -ME REGWEN and SW_REGUPD cannot be set back to 1 after being set to 0 once
  -If ME_REGWEN is not set, MODULE_ENABLE cannot be modified

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>