### PR TITLE
[csrng,dv] Coverage improvements around errors

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_agent_cov.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_cov.sv
@@ -43,6 +43,7 @@ covergroup host_cmd_cg with function sample(csrng_item item, bit sts);
     bins res = {RES};
     bins gen = {GEN};
     bins upd = {UPD};
+    bins uni = {UNI};
     bins genb = {GENB};
     bins genu = {GENU};
     illegal_bins il = default;

--- a/hw/ip/csrng/data/csrng_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_testplan.hjson
@@ -109,18 +109,22 @@
             '''
     }
     {
-      name: err_test_cg
+      name: csrng_err_code_cg
       desc: '''
-            Covers that all fatal errors, all fifo errors, all state machine errors and
-            all error codes of csrng have been tested.
-            Individual config settings that will be covered include:
-            - which_hw_inst_exc (0 to NHwApps-1), NHwApps possible hw instance exceptions
-            - which_sp2v (0 to Sp2VWidth-1), SP2V_HIGH_LOGIC width
-            - which_fatal_err (0 to 25), 26 possible fatal errors
-            - which_fifo (0 to 15), 16 different fifos
-            - which_err_code (0 to 51), 26 possible fatal errors, plus 26 ERR_CODE_TEST bits test
-            - which_fifo_err (0 to 2), fifo write/read/state errors
-            - which_invalid_mubi (0 to 2), 3 possible invalid mubi4 fields
+            Covers all possible fatal errors, possible AES FSM errors inside CSRNG and all possible
+            hw_exc_sts responses from each HW instance.
+            '''
+    }
+    {
+      name: csrng_err_code_test_cg
+      desc: '''
+            Covers ERR_CODE_TEST register values for setting up fatal errors.
+            '''
+    }
+    {
+      name: csrng_recov_alert_sts_cg
+      desc: '''
+            Covers all possible recoverable alert cases.
             '''
     }
   ]

--- a/hw/ip/csrng/dv/env/csrng_env_pkg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_pkg.sv
@@ -137,6 +137,44 @@ package csrng_env_pkg;
   } err_code_e;
 
   typedef enum int {
+    SFIFO_CMD_ERR      = 0,
+    SFIFO_GENBITS_ERR  = 1,
+    SFIFO_CMDREQ_ERR   = 2,
+    SFIFO_RCSTAGE_ERR  = 3,
+    SFIFO_KEYVRC_ERR   = 4,
+    SFIFO_UPDREQ_ERR   = 5,
+    SFIFO_BENCREQ_ERR  = 6,
+    SFIFO_BENCACK_ERR  = 7,
+    SFIFO_PDATA_ERR    = 8,
+    SFIFO_FINAL_ERR    = 9,
+    SFIFO_GBENCACK_ERR = 10,
+    SFIFO_GRCSTAGE_ERR = 11,
+    SFIFO_GGENREQ_ERR  = 12,
+    SFIFO_GADSTAGE_ERR = 13,
+    SFIFO_GGENBITS_ERR = 14,
+    SFIFO_BLKENC_ERR   = 15,
+    CMD_STAGE_SM_ERR   = 20,
+    MAIN_SM_ERR        = 21,
+    DRBG_GEN_SM_ERR    = 22,
+    DRBG_UPDBE_SM_ERR  = 23,
+    DRBG_UPDOB_SM_ERR  = 24,
+    AES_CIPHER_SM_ERR  = 25,
+    CMD_GEN_CNT_ERR    = 26,
+    FIFO_WRITE_ERR     = 28,
+    FIFO_READ_ERR      = 29,
+    FIFO_STATE_ERR     = 30
+  } err_code_bit_e;
+
+  typedef enum int {
+    ENABLE_FIELD_ALERT         = 0,
+    SW_APP_ENABLE_FIELD_ALERT  = 1,
+    READ_INT_STATE_FIELD_ALERT = 2,
+    ACMD_FLAG0_FIELD_ALERT     = 3,
+    CS_BUS_CMP_ALERT           = 12,
+    CS_MAIN_SM_ALERT           = 13
+  } recov_alert_bit_e;
+
+  typedef enum int {
     sfifo_blkenc   = 0,
     sfifo_ggenbits = 1,
     sfifo_gadstage = 2,

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
@@ -19,7 +19,9 @@ class csrng_alert_vseq extends csrng_base_vseq;
     uvm_reg       csr;
     uvm_reg_field fld;
 
-     `uvm_info(`gfn, $sformatf("Testing enable_field_alert"), UVM_MEDIUM)
+    super.body();
+
+    `uvm_info(`gfn, $sformatf("Testing enable_field_alert"), UVM_MEDIUM)
 
     // Initiate with invalid mubi data
     csrng_init();
@@ -39,6 +41,8 @@ class csrng_alert_vseq extends csrng_base_vseq;
     exp_recov_alert_sts = 32'b0;
     exp_recov_alert_sts[fld.get_lsb_pos()] = 1;
     csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
+    // Since we already did a backdoor check, sampling with this value is sufficient.
+    cov_vif.cg_recov_alert_sample(.recov_alert(exp_recov_alert_sts));
 
     cfg.clk_rst_vif.wait_clks(100);
 
@@ -103,6 +107,8 @@ class csrng_alert_vseq extends csrng_base_vseq;
     exp_recov_alert_sts = 32'b0;
     exp_recov_alert_sts[ral.recov_alert_sts.cs_bus_cmp_alert.get_lsb_pos()] = 1;
     csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
+    // Since we already did a backdoor check, sampling with this value is sufficient.
+    cov_vif.cg_recov_alert_sample(.recov_alert(ral.recov_alert_sts.get_mirrored_value()));
 
     // Clear recov_alert_sts register
     csr_wr(.ptr(ral.recov_alert_sts), .value(32'b0));

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
@@ -61,6 +61,11 @@ class csrng_intr_vseq extends csrng_base_vseq;
   endtask // test_cs_entropy_req
 
   task test_cs_hw_inst_exc();
+    // TODO: Instead of forcing ack_sts, find a way to actually generate the csrng_rsp_sts
+    // response as described in the documentation
+    // 1. Failure of the entropy source
+    // 2. Attempts to use an instance which has not been properly instantiated, or
+    // 3. Attempts to generate data when an instance has exceeded its maximum seed life.
     path1 = cfg.csrng_path_vif.cs_hw_inst_exc_path("ack", cfg.which_hw_inst_exc);
     path2 = cfg.csrng_path_vif.cs_hw_inst_exc_path("ack_sts", cfg.which_hw_inst_exc);
 
@@ -71,6 +76,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     `DV_CHECK(uvm_hdl_release(path1));
     `DV_CHECK(uvm_hdl_release(path2));
 
+    cov_vif.cg_err_code_sample(.err_code(ral.err_code.get_mirrored_value()));
     // Expect/Clear interrupt bit
     check_interrupts(.interrupts((1 << HwInstExc)), .check_set(1'b1));
     cfg.clk_rst_vif.wait_clks(100);
@@ -173,9 +179,11 @@ class csrng_intr_vseq extends csrng_base_vseq;
         `uvm_fatal(`gfn, "Invalid case! (bug in environment)")
       end
     endcase // case (cfg.which_fatal_err)
+    cov_vif.cg_err_code_sample(.err_code(ral.err_code.get_mirrored_value()));
   endtask // test_cs_fatal_err
 
   task body();
+    super.body();
     // Turn off fatal alert check
     expect_fatal_alerts = 1'b1;
 


### PR DESCRIPTION
First two commits are related with the title, last commit is a fix in csrng_agent_cov as it was counting UNI mode as illegal before.

Resolves https://github.com/lowRISC/opentitan/issues/16201
Resolves https://github.com/lowRISC/opentitan/issues/15742