### PR TITLE
[csrng,dv] Check drbg_upd ctr/gen redun

### DIFF
--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -41,6 +41,7 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   rand which_fifo_e     which_fifo;
   rand which_fifo_err_e which_fifo_err;
   rand invalid_mubi_e   which_invalid_mubi;
+  rand which_cnt_e      which_cnt;
 
   bit                                    compliance[NUM_HW_APPS + 1], status[NUM_HW_APPS + 1];
   bit [csrng_env_pkg::KEY_LEN-1:0]       key[NUM_HW_APPS + 1];

--- a/hw/ip/csrng/dv/env/csrng_env_pkg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_pkg.sv
@@ -161,6 +161,12 @@ package csrng_env_pkg;
     fifo_state = 2
   } which_fifo_err_e;
 
+  typedef enum int {
+    cmd_gen_cnt_sel  = 0,
+    drbg_upd_cnt_sel = 1,
+    drbg_gen_cnt_sel = 2
+  } which_cnt_e;
+
   // functions
 
   // package sources

--- a/hw/ip/csrng/dv/env/csrng_path_if.sv
+++ b/hw/ip/csrng/dv/env/csrng_path_if.sv
@@ -54,6 +54,14 @@ interface csrng_path_if
 
   function automatic string cmd_gen_cnt_err_path(int NHwApps);
     return {core_path, $sformatf(".gen_cmd_stage[%0d]", NHwApps),
-            ".u_csrng_cmd_stage.u_prim_count_cmd_gen_cntr.err_o"};
+            ".u_csrng_cmd_stage.u_prim_count_cmd_gen_cntr.cnt_q[1]"};
   endfunction // cmd_gen_cnt_err_path
+
+  function automatic string drbg_upd_cnt_err_path();
+    return {core_path, ".u_csrng_ctr_drbg_upd.u_prim_count_ctr_drbg.cnt_q[1]"};
+  endfunction // drbg_upd_cnt_err_path
+
+  function automatic string drbg_gen_cnt_err_path();
+    return {core_path, ".u_csrng_ctr_drbg_gen.u_prim_count_ctr_drbg.cnt_q[1]"};
+  endfunction // drbg_gen_cnt_err_path
 endinterface // csrng_path_if

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_err_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_err_vseq.sv
@@ -107,9 +107,23 @@ class csrng_err_vseq extends csrng_base_vseq;
         end
       end
       cmd_gen_cnt_err: begin
-        fld = csr.get_field_by_name(fld_name);
-        path = cfg.csrng_path_vif.cmd_gen_cnt_err_path(cfg.NHwApps);
-        force_path_err(path, 8'h01, fld, 1'b1);
+        case(cfg.which_cnt) inside
+          cmd_gen_cnt_sel: begin
+            fld = csr.get_field_by_name(fld_name);
+            path = cfg.csrng_path_vif.cmd_gen_cnt_err_path(cfg.which_hw_inst_exc);
+            force_cnt_err(path, fld, 1'b1, 13);
+          end
+          drbg_upd_cnt_sel: begin
+            fld = csr.get_field_by_name(fld_name);
+            path = cfg.csrng_path_vif.drbg_upd_cnt_err_path();
+            force_cnt_err(path, fld, 1'b1, 32);
+          end
+          drbg_gen_cnt_sel: begin
+            fld = csr.get_field_by_name(fld_name);
+            path = cfg.csrng_path_vif.drbg_gen_cnt_err_path();
+            force_cnt_err(path, fld, 1'b1, 32);
+          end
+        endcase
       end
       fifo_write_err, fifo_read_err, fifo_state_err: begin
         fld = csr.get_field_by_name(fld_name);


### PR DESCRIPTION
Check the redundancy of the counters in drbg_upd and drbg_gen:
- Randomly select cmd_gen_cnt, drbg_upd_cnt or drbg_gen_cnt
- Create function force_cnt_err which inverts one of the counters
- Check that any one of these cause a cmd_gen_cnt_err

As part of this issue: https://github.com/lowRISC/opentitan/issues/16238