### PR TITLE
[top/dv] Ibex lockstep test fixes

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_core_ibex_lockstep_glitch_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_core_ibex_lockstep_glitch_vseq.sv
@@ -542,6 +542,8 @@ class chip_sw_rv_core_ibex_lockstep_glitch_vseq extends chip_sw_base_vseq;
     end
     // When glitching an input port, the delay until the effect is observable varies.
     case (port_name)
+      "data_gnt_i":         delay_clks += 1;
+      "data_rdata_i":       delay_clks += 1;
       "instr_gnt_i":        delay_clks += 1;
       "ic_scr_key_valid_i": delay_clks += 2;
       "instr_rvalid_i":     delay_clks += 3;


### PR DESCRIPTION
This is related to #15538 and contains two changes to fix the last two failures observed:
1. Make the test aware of the fact that even if Ibex isn't using the data on RF Read Port b, the returned and potentially glitched data may propagate through the LSU and into `data_wdata_o`. This may result in a mismatch even though the test previously assumed it wouldn't.
2. Increase the delay for expecting a failure when glitching `data_gnt_i` and `data_rdata_i` by one clock cycle.

In general, this waiting for a specific number of clock cycles looks error prone to me. For `data_gnt_i` mismatches should indeed always happen quickly:
- Glitching to 1: the glitched core moves forward and de-asserts `data_req_o` or changes `data_addr_o` (when doing back to back LD/ST).
- Glitching to 0: it doesn't de-assert `data_req_o` or change `data_addr_o`.

But when glitching e.g. `data_rdata_i` or other data input signals I can imagine it could also take more cycles. Should we increase the number of clock cycles for these just in general? What do you think @andreaskurth ?