### PR TITLE
[top, dv] Enable spi_monitor for bootstrap

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -431,8 +431,8 @@ class chip_sw_base_vseq extends chip_base_vseq;
       .backdoor(1),
       .spinwait_delay_ns(5000));
 
-    // sdo from chip is unknown, ignore checking that
-    cfg.m_spi_host_agent_cfg.en_monitor_checks = 0;
+    // Enable monitor to check the SPI interface.
+    cfg.m_spi_host_agent_cfg.en_monitor = 1;
 
     read_sw_frames(sw_image, sw_byte_q);
 


### PR DESCRIPTION
No need to disable the monitor since we switch to flash mode for bootstrap

Test this with the bootstrap test and it's passing.
Signed-off-by: Weicai Yang <weicai@google.com>