### PR TITLE
[ci] Exclude non-JTAG tests in experimental job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -557,7 +557,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh cw310_rom,jtag || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-cw310-tests.sh jtag || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
     # TODO(lowRISC/opentitan#16067) Fail CI when JTAG tests fail.
     continueOnError: True


### PR DESCRIPTION
The job for running experimental JTAG tests was accidentally pulling in more tests than intended. The semantics of --test_tag_filters are logical OR for positive tags and logical AND for negative tags. As a result, "cw310_rom,jtag" selected any tests tagged "cw310_rom" OR "jtag".

This commit drops the "cw310_rom" requirement so we only select "jtag" tests. Longer term, we could make run-fpga-cw310-tests.sh's interface more expressive.

Signed-off-by: Dan McArdle <dmcardle@google.com>