### PR TITLE
[csrng/rtl] Fix FSM alerts

### DIFF
--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -396,7 +396,10 @@ module csrng_cmd_stage import csrng_pkg::*; #(
       Error: begin
         cmd_stage_sm_err_o = 1'b1;
       end
-      default: state_d = Error;
+      default: begin
+        state_d = Error;
+        cmd_stage_sm_err_o = 1'b1;
+      end
     endcase // unique case (state_q)
 
     // if disable, cycle back to Idle

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -493,16 +493,17 @@ module csrng_core import csrng_pkg::*; #(
          ctr_drbg_gen_sfifo_gadstage_err_sum ||
          ctr_drbg_gen_sfifo_ggenbits_err_sum ||
          block_encrypt_sfifo_blkenc_err_sum ||
+         fifo_write_err_sum ||
+         fifo_read_err_sum ||
+         fifo_status_err_sum)) ||
+         // errs not gated by cs_enable
          cmd_stage_sm_err_sum ||
          main_sm_err_sum ||
          drbg_gen_sm_err_sum ||
          drbg_updbe_sm_err_sum ||
          drbg_updob_sm_err_sum ||
          aes_cipher_sm_err_sum ||
-         fifo_write_err_sum ||
-         fifo_read_err_sum ||
-         fifo_status_err_sum)) ||
-         cmd_gen_cnt_err_sum; // err not gated by cs_enable
+         cmd_gen_cnt_err_sum;
 
   // set fifo errors that are single instances of source
   assign ctr_drbg_cmd_sfifo_cmdreq_err_sum = (|ctr_drbg_cmd_sfifo_cmdreq_err) ||

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -368,7 +368,10 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
       ReqError: begin
         ctr_drbg_gen_sm_err_o = 1'b1;
       end
-      default: state_d = ReqError;
+      default: begin
+        state_d = ReqError;
+        ctr_drbg_gen_sm_err_o = 1'b1;
+      end
     endcase
   end
 

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -360,7 +360,10 @@ module csrng_ctr_drbg_upd #(
       BEError: begin
         ctr_drbg_updbe_sm_err_o = 1'b1;
       end
-      default: blk_enc_state_d = BEError;
+      default: begin
+        blk_enc_state_d = BEError;
+        ctr_drbg_updbe_sm_err_o = 1'b1;
+      end
     endcase // case (blk_enc_state_q)
   end
 
@@ -549,7 +552,10 @@ module csrng_ctr_drbg_upd #(
       OBError: begin
         ctr_drbg_updob_sm_err_o = 1'b1;
       end
-      default: outblk_state_d = OBError;
+      default: begin
+        outblk_state_d = OBError;
+        ctr_drbg_updob_sm_err_o = 1'b1;
+      end
     endcase
   end
 

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -240,7 +240,10 @@ module csrng_main_sm import csrng_pkg::*; #(
       Error: begin
         main_sm_err_o = 1'b1;
       end
-      default: state_d = Error;
+      default: begin
+        state_d = Error;
+        main_sm_err_o = 1'b1;
+      end
     endcase
   end
 

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
@@ -64,7 +64,7 @@
                fusesoc_core: lowrisc:dv:csrng_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/csrng/{sub_flow}/{tool}"
-               stopats: ["*u_state_regs.state_o"]
+               stopats: ["*u_*state_regs.state_o"]
                task: "FpvSecCm"
              }
              {


### PR DESCRIPTION
An FSM state error must trigger an alert, regardless of the corresponding FSM being enabled or not. Additionally, the default item of an FSM case statement must signal an FSM state error. This PR fixes both.

These bugs were identified by FPV, see https://github.com/lowRISC/opentitan/issues/16112#issuecomment-1312005184. This PR additionally tweaks the FPV configuration for CSRNG to include two FSMs (which were unreachable for FPV before).

With this PR, all assertions of CSRNG get proven. Therefore, this PR resolves https://github.com/lowRISC/opentitan/issues/16112. (The dashboard will be used for sign-off, so we can close that issue and create a new one should FPV drop below 100% again.)

A quick regression run with `-i all -r 10` gave pass rates that are not significantly different from those in today's nightly run (i.e., `csrng_cmds` and `csrng_stress_all_with_rand_reset` 0%, `csrng_stress_all` 20%, rest 100%).