### PR TITLE
[ci] Move SW Build and Test job to ci-public

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -195,8 +195,7 @@ jobs:
   timeoutInMinutes: 120
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
-  pool:
-    vmImage: ubuntu-20.04
+  pool: ci-public
   variables:
     - name: bazelCacheGcpKeyPath
       value: ''


### PR DESCRIPTION
The public Azure Pipelines ubuntu-20.04 pool is slightly overtaxed, causing the ci-public pool to be underutilized over the past few days. We can move the SW Build and Test step (which normally takes about 30-40 min on Azure-hosted runners) to the ci-public machine. This job would also benefit from the increased parallelization.

Signed-off-by: Miles Dai <milesdai@google.com>