### PR TITLE
[clkmgr] Add MUBI Synchronizer to Idle

### DIFF
--- a/hw/ip/clkmgr/dv/sva/clkmgr_trans_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_trans_sva_if.sv
@@ -18,7 +18,7 @@ interface clkmgr_trans_sva_if (
   localparam int MAX_START_CYCLES = 3;
 
   localparam int MIN_STOP_CYCLES = 2;
-  localparam int MAX_STOP_CYCLES = 12;
+  localparam int MAX_STOP_CYCLES = 15;
 
   `ASSERT(TransStart_A,
           $rose(

--- a/hw/ip/clkmgr/rtl/clkmgr_trans.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_trans.sv
@@ -54,6 +54,20 @@ module clkmgr_trans
     .q_o(sw_hint_synced)
   );
 
+  // Idle sync: Idle signal comes from IP module. The reset of the Idle signal
+  // may differ from the reset here. Adding mubi sync to synchronize.
+  prim_mubi_pkg::mubi4_t [0:0] idle;
+  prim_mubi4_sync #(
+    .NumCopies      ( 1     ),
+    .AsyncOn        ( 1'b 1 ),
+    .StabilityCheck ( 1'b 1 )
+  ) u_idle_sync (
+    .clk_i,
+    .rst_ni,
+    .mubi_i (idle_i),
+    .mubi_o (idle)
+  );
+
   // SEC_CM: IDLE.CTR.REDUN
   logic cnt_err;
   prim_count #(
@@ -62,10 +76,10 @@ module clkmgr_trans
     .clk_i(clk_i),
     .rst_ni(rst_ni),
     // the default condition is to keep the clock enabled
-    .clr_i(mubi4_test_false_loose(idle_i)),
+    .clr_i(mubi4_test_false_loose(idle[0])),
     .set_i('0),
     .set_cnt_i('0),
-    .incr_en_i(mubi4_test_true_strict(idle_i) & ~idle_valid),
+    .incr_en_i(mubi4_test_true_strict(idle[0]) & ~idle_valid),
     .decr_en_i(1'b0),
     .step_i(IdleCntWidth'(1'b1)),
     .cnt_o(idle_cnt),

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -101,14 +101,14 @@ set_reset_scenario { \
 # RSTMGR SW Resets
 #set_reset_scenario { {{top_earlgrey.u_rstmgr_aon.u_ndm_sync.u_sync_2.gen_generic.u_impl_generic.q_o[0]} {reset  { @t0 1 } { #10 0}} }} -name Scenario8 -comment "functional reset"
 set_reset_scenario { \
-  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_0.q[0]} {reset  { @t0 0 } { #10 1}} } \
-  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_1.q[0]} {reset  { @t0 0 } { #10 1}} } \
-  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_2.q[0]} {reset  { @t0 0 } { #10 1}} } \
-  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_3.q[0]} {reset  { @t0 0 } { #10 1}} } \
-  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_4.q[0]} {reset  { @t0 0 } { #10 1}} } \
-  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_5.q[0]} {reset  { @t0 0 } { #10 1}} } \
-  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_6.q[0]} {reset  { @t0 0 } { #10 1}} } \
-  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_7.q[0]} {reset  { @t0 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_0.q[0]} {reset  { @t0 1 } { #2 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_1.q[0]} {reset  { @t0 1 } { #2 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_2.q[0]} {reset  { @t0 1 } { #2 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_3.q[0]} {reset  { @t0 1 } { #2 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_4.q[0]} {reset  { @t0 1 } { #2 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_5.q[0]} {reset  { @t0 1 } { #2 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_6.q[0]} {reset  { @t0 1 } { #2 0 } { #10 1}} } \
+  {{top_earlgrey.u_rstmgr_aon.u_reg.u_sw_rst_ctrl_n_7.q[0]} {reset  { @t0 1 } { #2 0 } { #10 1}} } \
   { POR_N                               { constraint { @t0 1 } } } \
   { u_ast.u_rglts_pdm_3p3v.vcmain_pok_h { constraint { @t0 1 } } } \
   { u_ast.u_rglts_pdm_3p3v.vcaon_pok_h  { constraint { @t0 1 } } } \


### PR DESCRIPTION

Idle comes from other peripherals as mubi4_t type. When other modules
are reset, there's chance the idle signal abruptly changes, which
results in the meta stability issue in the idle counter inside clkmgr.

This commit adds mubi synchronizers to not create metastability issue.