### PR TITLE
[opentitantool] Comprehensive list of HyperDebug pins

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
@@ -2,25 +2,216 @@
   "includes": ["/__builtin__/opentitan.json"],
   "interface": "hyperdebug",
   "pins": [
-      {
-          "name": "RESET",
-          "mode": "OpenDrain",
-          "level": true,
-          "pull_mode": "PullUp",
-          "alias_of": "CN10_29"
-      },
-      {
-          "name": "SW_STRAP0",
-          "alias_of": "CN9_13"
-      },
-      {
-          "name": "SW_STRAP1",
-          "alias_of": "CN9_15"
-      },
-      {
-          "name": "SW_STRAP2",
-          "alias_of": "CN9_17"
-      }
+    {
+      "name": "RESET",
+      "mode": "OpenDrain",
+      "pull_mode": "PullUp"
+      "alias_of": "CN10_29"
+    },
+    {
+      "name": "IOA0",
+      "alias_of": "CN8_6"
+    },
+    {
+      "name": "IOA1",
+      "alias_of": "CN8_8"
+    },
+    {
+      "name": "IOA2",
+      "alias_of": "CN9_29"
+    },
+    {
+      "name": "IOA3",
+      "alias_of": "CN7_18"
+    },
+    {
+      "name": "IOA4",
+      "alias_of": "CN8_10"
+    },
+    {
+      "name": "IOA5",
+      "alias_of": "CN8_12"
+    },
+    {
+      "name": "IOA6",
+      "alias_of": "CN7_20"
+    },
+    {
+      "name": "IOA7",
+      "alias_of": "CN7_4"
+    },
+    {
+      "name": "IOA8",
+      "alias_of": "CN7_2"
+    },
+    {
+      "name": "IOB0",
+      "alias_of": "CN9_25"
+    },
+    {
+      "name": "IOB1",
+      "alias_of": "CN9_8"
+    },
+    {
+      "name": "IOB2",
+      "alias_of": "CN9_10"
+    },
+    {
+      "name": "IOB3",
+      "alias_of": "CN9_27"
+    },
+    {
+      "name": "IOB4",
+      "alias_of": "CN10_14"
+    },
+    {
+      "name": "IOB5",
+      "alias_of": "CN10_16"
+    },
+    {
+      "name": "IOB6",
+      "alias_of": "CN9_5"
+    },
+    {
+      "name": "IOB7",
+      "alias_of": "CN8_4"
+    },
+    {
+      "name": "IOB8",
+      "alias_of": "CN9_2"
+    },
+    {
+      "name": "IOB9",
+      "alias_of": "CN9_11"
+    },
+    {
+      "name": "IOB10",
+      "alias_of": "CN9_9"
+    },
+    {
+      "name": "IOB11",
+      "alias_of": "CN9_19"
+    },
+    {
+      "name": "IOB12",
+      "alias_of": "CN9_21"
+    },
+    {
+      "name": "IOC0",
+      "alias_of": "CN9_13"
+    },
+    {
+      "name": "IOC1",
+      "alias_of": "CN9_15"
+    },
+    {
+      "name": "IOC2",
+      "alias_of": "CN9_17"
+    },
+    {
+      "name": "IOC3",
+      "alias_of": "CN9_6"
+    },
+    {
+      "name": "IOC4",
+      "alias_of": "CN9_4"
+    },
+    {
+      "name": "IOC5",
+      "alias_of": "CN8_14"
+    },
+    {
+      "name": "IOC6",
+      "alias_of": "CN10_7"
+    },
+    {
+      "name": "IOC7",
+      "alias_of": "CN10_18"
+    },
+    {
+      "name": "IOC8",
+      "alias_of": "CN8_16"
+    },
+    {
+      "name": "IOC9",
+      "alias_of": "CN10_31"
+    },
+    {
+      "name": "IOC10",
+      "alias_of": "CN10_33"
+    },
+    {
+      "name": "IOC11",
+      "alias_of": "CN10_2"
+    },
+    {
+      "name": "IOC12",
+      "alias_of": "CN10_4"
+    },
+    {
+      "name": "IOR0",
+      "alias_of": "CN7_7"
+    },
+    {
+      "name": "IOR1",
+      "alias_of": "CN7_5"
+    },
+    {
+      "name": "IOR2",
+      "alias_of": "CN7_3"
+    },
+    {
+      "name": "IOR3",
+      "alias_of": "CN7_1"
+    },
+    {
+      "name": "IOR4",
+      "alias_of": "CN7_16"
+    },
+    {
+      "name": "IOR5",
+      "alias_of": "CN9_14"
+    },
+    {
+      "name": "IOR6",
+      "alias_of": "CN9_16"
+    },
+    {
+      "name": "IOR7",
+      "alias_of": "CN9_18"
+    },
+    {
+      "name": "IOR8",
+      "alias_of": "CN9_20"
+    },
+    {
+      "name": "IOR9",
+      "alias_of": "CN9_22"
+    },
+    {
+      "name": "IOR10",
+      "alias_of": "CN9_24"
+    },
+    {
+      "name": "IOR11",
+      "alias_of": "CN9_26"
+    },
+    {
+      "name": "IOR12",
+      "alias_of": "CN9_28"
+    },
+    {
+      "name": "IOR13",
+      "alias_of": "CN9_30"
+    },
+    {
+      "name": "CC1",
+      "alias_of": "CN7_9"
+    },
+    {
+      "name": "CC2",
+      "alias_of": "CN7_10"
+    }
   ],
   "uarts": [
     {

--- a/sw/host/opentitanlib/src/app/config/opentitan.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan.json
@@ -2,27 +2,28 @@
   "pins": [
     {
       "name": "RESET",
-      "mode": "PushPull",
-      "level": true,
-      "pull_mode": "None"
+      "level": true
     },
     {
       "name": "SW_STRAP0",
       "mode": "PushPull",
       "level": false,
-      "pull_mode": "None"
+      "pull_mode": "None",
+      "alias_of": "IOC0"
     },
     {
       "name": "SW_STRAP1",
       "mode": "PushPull",
       "level": false,
-      "pull_mode": "None"
+      "pull_mode": "None",
+      "alias_of": "IOC1"
     },
     {
       "name": "SW_STRAP2",
       "mode": "PushPull",
       "level": false,
-      "pull_mode": "None"
+      "pull_mode": "None",
+      "alias_of": "IOC2"
     },
     {
       "name": "TAP_STRAP0",

--- a/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
@@ -4,18 +4,20 @@
   "pins": [
     {
       "name": "RESET",
-      "alias_of": "USB_A14"
+      "mode": "PushPull",
+      "alias_of": "USB_A14",
+      "pull_mode": "None"
     },
     {
-      "name": "SW_STRAP0",
+      "name": "IOC0",
       "alias_of": "USB_A15"
     },
     {
-      "name": "SW_STRAP1",
+      "name": "IOC1",
       "alias_of": "USB_A16"
     },
     {
-      "name": "SW_STRAP2",
+      "name": "IOC2",
       "alias_of": "USB_A17"
     },
     {


### PR DESCRIPTION
This PR attempts to declare all the OpenTitan pin names, such that when using HyperDebug, one can run a command like the below for any pin of OpenTitan:
```
opentitantool gpio read IOR7
```

I imagine that end users of OpenTitan and HyperDebug will define an additional configuration file matching their firmware, to declare that e.g. IOA0 should be OpenDrain with pull up, called "CHASSIS_INTRUSION" or whatever.  They can do so knowing only the OpenTitan pin naming, without having to refer to the HyperDebug names.