### PR TITLE
[dv/edn] Fix auto_req_mode regression error

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -104,6 +104,7 @@ class csrng_monitor extends dv_base_monitor #(
   virtual protected task collect_request();
     csrng_item   cs_item;
     forever begin
+      wait(cfg.under_reset == 0);
       @(cfg.vif.cmd_push_if.mon_cb);
       if ((cfg.vif.cmd_push_if.mon_cb.valid) && (cfg.vif.cmd_push_if.mon_cb.ready)) begin
         // TODO: sample any covergroups

--- a/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
@@ -39,7 +39,7 @@ class edn_disable_auto_req_mode_vseq extends edn_base_vseq;
       `DV_SPINWAIT(
           while (state_val != auto_req_sts[rand_st_idx]) begin
             uvm_hdl_read(main_sm_d_path, state_val);
-            cfg.clk_rst_vif.wait_clks(1);
+            cfg.clk_rst_vif.wait_n_clks(1);
           end)
     end
 
@@ -110,7 +110,15 @@ class edn_disable_auto_req_mode_vseq extends edn_base_vseq;
     // Otherwise the testbench will hanging at waiting for more EDN requests.
     `DV_WAIT(edn_enable_toggle_done == 1);
     `DV_WAIT(edn_done == edn_reqs);
+    `uvm_info(`gfn, "The body of the sequence ended", UVM_HIGH);
+  endtask
+
+  virtual task post_start();
+    super.post_start();
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
+    // Add a EDN disablement to terminate all the pending transactions in auto_req_mode.
     cfg.edn_vif.drive_edn_disable(1);
+    csr_wr(.ptr(ral.ctrl.edn_enable), .value(MuBi4False));
   endtask
 
 endclass


### PR DESCRIPTION
This PR fixes auto_req_mode regression error.
1). The auto-req mode will always request another CSRNG entropy, and waiting for another EDN request to read out the FIFO (after it is full). For CSRNG agent, this will be a forever non-ending request.

To resolve this issue without disabling the EDN again, we can consider issue a reset.

2). The probing for state_q is not very accurate right at the posedge of
  the clock cycle. So this PR change the sampling to the negedge to
  avoid race conditions.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>