### PR TITLE
[dv/pwrmgr] Fix recent unit test failures

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -97,7 +97,7 @@ class cip_base_vseq #(
     // Wait for alert init done, then start the sequence.
     foreach (cfg.list_of_alerts[i]) begin
       if (cfg.m_alert_agent_cfg[cfg.list_of_alerts[i]].is_active) begin
-        wait(cfg.m_alert_agent_cfg[cfg.list_of_alerts[i]].alert_init_done == 1);
+        `DV_WAIT(cfg.m_alert_agent_cfg[cfg.list_of_alerts[i]].alert_init_done == 1)
       end
     end
 

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -2,9 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+typedef class pwrmgr_scoreboard;
+
 class pwrmgr_env_cfg extends cip_base_env_cfg #(
   .RAL_T(pwrmgr_reg_block)
 );
+
+  // Handle to scoreboard to access cip_base for expected alert handling.
+  pwrmgr_scoreboard scoreboard;
 
   // disable fault csr read check from scoreboard
   bit disable_csr_rd_chk = 0;

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -27,6 +27,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
+    cfg.scoreboard = this;
   endfunction
 
   task run_phase(uvm_phase phase);

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
@@ -69,6 +69,9 @@ class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
       `uvm_info(`gfn, "Wait for Fast State NE FastPwrStateActive", UVM_MEDIUM)
       `DV_WAIT(cfg.pwrmgr_vif.fast_state != pwrmgr_pkg::FastPwrStateActive)
 
+      // For the cip scoreboard.
+      reset_start_for_cip();
+
       // Check fast state is not FastPwrStateActive for a while
       repeat (20) begin
         @cfg.slow_clk_rst_vif.cb;
@@ -83,6 +86,9 @@ class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
 
       wait_for_fast_fsm_active();
       `uvm_info(`gfn, "Back from reset", UVM_MEDIUM)
+
+      // For the cip scoreboard.
+      reset_end_for_cip();
 
       check_wake_info(.reasons('0), .fall_through(1'b0), .abort(1'b0));
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
@@ -24,8 +24,21 @@ class pwrmgr_esc_clk_rst_malfunc_vseq extends pwrmgr_base_vseq;
     // esc [clk|rst] malfunction
     add_noise();
 
+    // Expect to start reset.
+    `DV_WAIT(cfg.pwrmgr_vif.fast_state != pwrmgr_pkg::FastPwrStateActive)
+    `uvm_info(`gfn, "Started to process reset", UVM_MEDIUM)
+
+    // For the cip scoreboard.
+    reset_start_for_cip();
+
     // clear to end test gracfully
     clear_noise();
+
+    wait_for_fast_fsm_active();
+    `uvm_info(`gfn, "Back from reset", UVM_MEDIUM)
+    // For the cip scoreboard.
+    reset_end_for_cip();
+
   endtask : body
 
   task add_noise();

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
@@ -95,6 +95,11 @@ class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
     cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
     set_nvms_idle();
 
+    `DV_WAIT(cfg.pwrmgr_vif.fast_state != pwrmgr_pkg::FastPwrStateActive)
+
+    // For the cip scoreboard.
+    reset_start_for_cip();
+
     if (ral.control.main_pd_n.get_mirrored_value() == 1'b0) begin
       wait_for_reset_cause(pwrmgr_pkg::LowPwrEntry);
     end
@@ -110,6 +115,9 @@ class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
 
     wait_for_fast_fsm_active();
     `uvm_info(`gfn, "Back from wakeup", UVM_MEDIUM)
+
+    // For the cip scoreboard.
+    reset_end_for_cip();
   endtask : start_lowpower_transition
 
   function pwrmgr_pkg::fast_pwr_state_e dv2rtl_st(reset_index_e idx);

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
@@ -62,8 +62,14 @@ class pwrmgr_reset_vseq extends pwrmgr_base_vseq;
       `DV_WAIT(cfg.pwrmgr_vif.fast_state != pwrmgr_pkg::FastPwrStateActive)
       `uvm_info(`gfn, "Started to process reset", UVM_MEDIUM)
 
+      // For the cip scoreboard.
+      reset_start_for_cip();
+
       wait_for_fast_fsm_active();
       `uvm_info(`gfn, "Back from reset", UVM_MEDIUM)
+
+      // For the cip scoreboard.
+      reset_end_for_cip();
 
       check_wake_info(.reasons('0), .fall_through(1'b0), .abort(1'b0));
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
@@ -330,5 +330,4 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
     .q_o(slow_clr_req_o)
   );
 
-
 endmodule


### PR DESCRIPTION
Some of the fixes:

The change in clock for alert handling being clk_lc rather than clk (and the same change for reset) caused the cip scoreboard to loose track of alert expectations. Rather than changing cip, this creates a couple of functions that enable the pwrmgr to assist cip track resets, and adds calls to these in various test sequences.

The aborted_low_power test was unreliable, so this changes the test to rely on internal state machines to determine when to send stimulus and to predict expected results.

Signed-off-by: Guillermo Maturana <maturana@google.com>