### PR TITLE
[keymgr/dv] Update exclusion

### DIFF
--- a/hw/ip/keymgr/dv/cov/keymgr_cov_excl.el
+++ b/hw/ip/keymgr/dv/cov/keymgr_cov_excl.el
@@ -3,19 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 ANNOTATION: "[LOWRISK] non-idle -> error"
-CHECKSUM: "117487336 1278423873"
-INSTANCE: tb.dut.u_ctrl
-Fsm state_q "1382639396"
-Transition StCtrlOwnerKey->StCtrlWipe "894->51"
-
-ANNOTATION: "[LOWRISK] non-idle -> error"
-CHECKSUM: "2519441784 2391940402"
 INSTANCE: tb.dut.u_kmac_if
-Fsm state_q "3597806508"
-Transition StClean->StError "1021->238"
 Fsm state_q "3597806508"
 Transition StTxLast->StError "320->238"
 Fsm state_q "3597806508"
 Transition StTx->StError "155->238"
 Fsm state_q "3597806508"
 Transition StOpWait->StError "553->238"
+Fsm state_q "3597806508"
+Transition StClean->StError "1021->238"
+ANNOTATION: "[UNR]"
+Fsm state_q "3597806508"
+Transition StIdle->StTxLast "930->320"


### PR DESCRIPTION
1. decided not to keep this unreachable transition. #16285
 - StIdle->StTxLast
2. The Transition to StCtrlWipe is covered because of recent design fix

Signed-off-by: Weicai Yang <weicai@google.com>