### PR TITLE
[keymgr/dv] Add keymgr_sideload_protect test

### DIFF
--- a/hw/ip/keymgr/data/keymgr_sec_cm_testplan.hjson
+++ b/hw/ip/keymgr/data/keymgr_sec_cm_testplan.hjson
@@ -105,9 +105,16 @@
     }
     {
       name: sec_cm_output_keys_ctrl_redun
-      desc: "Verify the countermeasure(s) OUTPUT_KEYS.CTRL.REDUN."
+      desc: '''Verify the countermeasure(s) OUTPUT_KEYS.CTRL.REDUN.
+
+            1. Randomly advance to a functional state and start a sideload operation.
+            2. Flip either data_sw_en or data_valid.
+            3. Read sw_share* for check:
+              - if hw_key_sel is flipped but data_sw_en is not, it doesn't match either the
+                previously flopped value or the sideload value.
+              - if hw_key_sel is not flipped but data_en is, you should see the previous value.'''
       stage: V2S
-      tests: ["keymgr_custom_cm"]
+      tests: ["keymgr_sideload_protect"]
     }
     {
       name: sec_cm_ctrl_fsm_sparse

--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -34,6 +34,7 @@ filesets:
       - seq_lib/keymgr_hwsw_invalid_input_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_kmac_rsp_err_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_custom_cm_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_sideload_protect_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_sync_async_fault_cross_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/keymgr/dv/env/keymgr_env.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env.sv
@@ -25,6 +25,7 @@ class keymgr_env extends cip_base_env #(
     if (!uvm_config_db#(keymgr_vif)::get(this, "", "keymgr_vif", cfg.keymgr_vif)) begin
       `uvm_fatal(`gfn, "failed to get keymgr_vif from uvm_config_db")
     end
+    cfg.scb = scoreboard;
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -6,6 +6,7 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
 
   rand kmac_app_agent_cfg m_keymgr_kmac_agent_cfg;
 
+  keymgr_scoreboard scb;
   // interface for input data from LC, OTP and flash
   keymgr_vif keymgr_vif;
 

--- a/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
@@ -79,6 +79,8 @@ package keymgr_env_pkg;
     end
   endfunction
 
+  // forward declaration
+  typedef class keymgr_scoreboard;
   // package sources
   `include "keymgr_env_cfg.sv"
   `include "keymgr_env_cov.sv"

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_protect_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_protect_vseq.sv
@@ -1,0 +1,70 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test KEYMGR.OUTPUT_KEYS.CTRL.REDUN
+// 1. randomly advance to a functional state and start a sideload operation
+// 2. flip either data_sw_en or data_valid,
+// 3. read sw_share* for check
+//  - if hw_key_sel is flipped but data_sw_en is not, it doesn't match either the
+//    previously flopped value or the sideload value.
+//  - if hw_key_sel is not flipped but data_en is, you should see the previous value.
+class keymgr_sideload_protect_vseq extends keymgr_random_vseq;
+  `uvm_object_utils(keymgr_sideload_protect_vseq)
+  `uvm_object_new
+
+  // don'd advance any of the 3 functonal states
+  constraint num_adv_c {
+    num_adv inside {[2:4]};
+  }
+
+  task body();
+    bit force_hw_key_sel_or_data_en;
+    bit [keymgr_pkg::Shares-1:0][DIGEST_SHARE_WORD_NUM-1:0][TL_DW-1:0] sw_share_output;
+    keymgr_pkg::hw_key_req_t hw_key;
+    super.body();
+
+    // update key_version to a valid value
+    update_key_version();
+    // read sw_shares to clear the output (these are w0c CSRs)
+    read_sw_shares(sw_share_output);
+
+    repeat ($urandom_range(2, 5)) begin
+      force_hw_key_sel_or_data_en = $urandom_range(0, 1);
+      $assertoff(0, "tb.dut.u_ctrl.DataEn_A");
+      $assertoff(0, "tb.dut.u_ctrl.DataEnDis_A");
+      `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(key_dest, key_dest != keymgr_pkg::None;)
+      fork
+        keymgr_generate(.operation(keymgr_pkg::OpGenHwOut), .key_dest(key_dest), .wait_done(1));
+        cfg.keymgr_vif.inject_sideload_fault(force_hw_key_sel_or_data_en);
+      join
+
+      case (key_dest)
+        keymgr_pkg::Aes:  hw_key = cfg.keymgr_vif.aes_key.key;
+        keymgr_pkg::Kmac: hw_key = cfg.keymgr_vif.kmac_key.key;
+        keymgr_pkg::Otbn: begin
+          // truncate otbn key from 386 to 256 bits
+          foreach (hw_key.key[i]) hw_key.key[i] = cfg.keymgr_vif.otbn_key.key[i];
+        end
+        default: `uvm_fatal(`gfn, "invalid value")
+      endcase
+
+      // Let scb know sw output is random value
+      if (force_hw_key_sel_or_data_en) cfg.scb.is_sw_share_corrupted = 1;
+
+      read_sw_shares(sw_share_output);
+      // force on data_sw_en, sw output remains 0
+      // force hw_key_sel, random value is assigned to sw output
+      if (force_hw_key_sel_or_data_en) begin
+        `DV_CHECK_NE(sw_share_output, 0)
+      end else begin
+        `DV_CHECK_EQ(sw_share_output, 0)
+      end
+      `DV_CHECK_NE(sw_share_output, hw_key.key)
+
+      $asserton(0, "tb.dut.u_ctrl.DataEn_A");
+      $asserton(0, "tb.dut.u_ctrl.DataEnDis_A");
+    end
+  endtask : body
+
+endclass : keymgr_sideload_protect_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
@@ -15,5 +15,6 @@
 `include "keymgr_hwsw_invalid_input_vseq.sv"
 `include "keymgr_kmac_rsp_err_vseq.sv"
 `include "keymgr_custom_cm_vseq.sv"
+`include "keymgr_sideload_protect_vseq.sv"
 `include "keymgr_sync_async_fault_cross_vseq.sv"
 `include "keymgr_stress_all_vseq.sv"

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -124,6 +124,11 @@
     }
 
     {
+      name: keymgr_sideload_protect
+      uvm_test_seq: keymgr_sideload_protect_vseq
+    }
+
+    {
       name: keymgr_sync_async_fault_cross
       uvm_test_seq: keymgr_sync_async_fault_cross_vseq
     }


### PR DESCRIPTION
1. Randomly advance to a functional state and start a sideload operation.
2. Flip either data_sw_en or data_valid.
3. Read sw_share* for check:
 - if hw_key_sel is flipped but data_sw_en is not, it doesn't match either the previously flopped value or the sideload value.
 - if hw_key_sel is not flipped but data_en is, you should see the previous value.

Signed-off-by: Weicai Yang <weicai@google.com>