### PR TITLE
[chip-test] Update the description of chip_sw_alert_handler_lpg_clkoff

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1491,8 +1491,6 @@
 
             - Configure clkmgr to randomly turn off one of the IP's clock and check alert_handler
               won't trigger a ping timeout error on that block.
-            - Trigger fatal alerts in an IP then configure clkmgr to turn off the IP clock. Check
-              the IP's fatal alert resumes after clock is turned back on.
             '''
       stage: V2
       tests: ["chip_sw_alert_handler_lpg_clkoff"]


### PR DESCRIPTION
Reduce the scope of the chip_sw_alert_lpg_clkoff test such that it will verifies that the alert-ping mechanism is stable accross LPG clock gating events.

Remove the part regarding fatal alerts because this part shall be covered by "chip_sw_alert_handler_lpg_sleep_mode_alerts" test.

Resolves the issue #14126.

Signed-off-by: Bilgiday Yuce <bilgiday@google.com>