### PR TITLE
[entropy_src/rtl] No SHA disable alerts in bypass mode

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -2421,7 +2421,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
          fw_ov_fifo_wr_pulse && fw_ov_wr_fifo_full;
 
   assign es_fw_ov_disable_alert = fw_ov_mode && fw_ov_mode_entropy_insert &&
-         fw_ov_sha3_disable_pulse && fw_ov_wr_fifo_full;
+         !es_bypass_mode && fw_ov_sha3_disable_pulse && fw_ov_wr_fifo_full;
 
   //--------------------------------------------
   // entropy conditioner


### PR DESCRIPTION
There is no reason to signal an alert for disabling the SHA3 conditioner in fw_ov mode if the the conditioner is not active, when all the data is flowing through the bypass path.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>