### PR TITLE
[entropy_src/dv] Functional Coverage Improvements

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -61,6 +61,7 @@
 
     {
       name: entropy_src_rng
+      reseed: 300
       uvm_test: entropy_src_rng_test
       uvm_test_seq: entropy_src_rng_vseq
     }
@@ -73,6 +74,7 @@
 
     {
       name: entropy_src_fw_ov
+      reseed: 300
       uvm_test: entropy_src_fw_ov_test
       uvm_test_seq: entropy_src_rng_vseq
     }

--- a/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
@@ -15,7 +15,7 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
     cfg.rng_ignores_backpressure            = 1;
 
     cfg.dut_cfg.boot_mode_retry_limit       = 10;
-    cfg.sim_duration                        = 10ms;
+    cfg.sim_duration                        = 5ms;
     cfg.hard_mtbf                           = 100s;
     cfg.mean_rand_reconfig_time             = 1ms;
     cfg.mean_rand_csr_alert_time            = 2ms;
@@ -40,8 +40,8 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
 
     cfg.dut_cfg.entropy_data_reg_enable_pct = 50;
     cfg.dut_cfg.route_software_pct          = 50;
-    cfg.otp_en_es_fw_read_pct               = 50;
-    cfg.otp_en_es_fw_read_inval_pct         = 25;
+    cfg.otp_en_es_fw_read_pct               = 33;
+    cfg.otp_en_es_fw_read_inval_pct         = 33;
     // Always allow FW override for this test
     cfg.otp_en_es_fw_over_pct               = 100;
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -15,7 +15,7 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.rng_ignores_backpressure    = 1;
 
     cfg.dut_cfg.boot_mode_retry_limit       = 10;
-    cfg.sim_duration                = 20ms;
+    cfg.sim_duration                = 10ms;
     cfg.hard_mtbf                   = 3ms;
     cfg.mean_rand_reconfig_time     = 3ms;
     // The random alerts only need to happen frequently enough to
@@ -50,9 +50,10 @@ class entropy_src_rng_test extends entropy_src_base_test;
 
     cfg.dut_cfg.entropy_data_reg_enable_pct = 50;
     cfg.dut_cfg.route_software_pct          = 50;
-    cfg.otp_en_es_fw_read_pct               = 50;
-    cfg.otp_en_es_fw_over_pct               = 50;
-    cfg.otp_en_es_fw_over_inval_pct         = 25;
+    cfg.otp_en_es_fw_read_pct               = 33;
+    cfg.otp_en_es_fw_read_inval_pct         = 33;
+    cfg.otp_en_es_fw_over_pct               = 33;
+    cfg.otp_en_es_fw_over_inval_pct         = 33;
 
     cfg.dut_cfg.ht_threshold_scope_pct      = 50;
     cfg.dut_cfg.default_ht_thresholds_pct   = 0;


### PR DESCRIPTION
This commit modifies the regression parameters to deal with the recent OTP coverpoint changes added by @andreaskurth (support for both OTP inputs, coverage of Invalid Mubi8's as well as True and False)

In general the `entropy_src_rng` and `entropy_src_fw_ov` tests have been halved in duration, but with 6x more tests.  The simulated time is now roughly 3x of the original, to account for the fact that the size of the largest cross-coverage points have grown by somewhere between 3x and 4.5x (depending on the crosspoint).

The tradeoff in performing more numerous shorter sims is important because the OTP settings are fixed through out a run, and so any gaps or imbalances in OTP coverage have to come from more runs.

This commit also adjusts the constraints so that (where-applicable) there are equal numbers of all three types of MuBi values.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>