### PR TITLE
[i2c,dv] target mode clock stretch tests

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -15,7 +15,24 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
 
   bit     host_scl_start;
   bit     host_scl_stop;
-  event   got_stop;
+
+  // In i2c test, between every transaction, assuming a new timing
+  // parameter is programmed. This means during a transaction,
+  // test should not update timing parameter.
+  // This variable indicates target DUT receives the end of the transaction
+  // and allow tb to program a new timing parameter.
+  bit     got_stop = 0;
+
+  // In target mode i2c test, sequence finishes when all host transactions are fetched.
+  // However, test has to wait until all read data transferred from DUT to test bench.
+  // If test create a scinario to trigger clock stretch, TB has to wait indefinte time
+  // (because clock stretch froze transmit clock).
+  // This varialbe to indicate all read / write data fetch and trasmitted.
+  // Used only for stretched mode test.
+  bit     use_seq_term = 0;
+
+  int     sent_rd_byte = 0;
+  int     rcvd_rd_byte = 0;
 
   // this variables can be configured from host test
   uint i2c_host_min_data_rw = 1;

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -37,7 +37,7 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
     i2c_item req;
     @(posedge cfg.vif.rst_ni);
     forever begin
-      release_bus();
+      if (cfg.if_mode == Device) release_bus();
       // driver drives bus per mode
       seq_item_port.get_next_item(req);
       fork

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -351,11 +351,10 @@
 
             Checking:
               - During read transaction, ensure tx_empty interrupt is asserted when no data left
-                in tx_fifo
-                otherwise tx_empty interrupt must be asserted
+                in tx_fifo otherwise tx_empty interrupt must be de-asserted
             '''
       stage: V2
-      tests: []
+      tests: ["i2c_target_stress_rd"]
     }
     {
       name: target_fifo_reset
@@ -387,7 +386,7 @@
               - Check fifo full states by reading status register
             '''
       stage: V2
-      tests: [""]
+      tests: ["i2c_target_stress_wr"]
     }
     {
       name: target_timeout
@@ -405,6 +404,22 @@
             '''
       stage: V2
       tests: [""]
+    }
+    {
+      name: target_clock_stretch
+      desc: '''
+            Test clock stretch feature of DUT Target mode.
+            For the write and address transaction, when acq fifo is full, DUT starts to stretch clock.
+            For the read transaction, when dut receives read command, the tx fifo is empty,
+            DUT starts to stretch clock.
+            Using read / write mixed traffic, trigger stretch condition by slowing down acq / tx
+            fifo process.
+
+            Checking:
+            Ensure all read /write data received correct on the other side without dropping any data.
+            '''
+      stage: V2
+      tests: ["i2c_target_stretch"]
     }
   ]
 }

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -38,6 +38,9 @@ filesets:
       - seq_lib/i2c_host_error_intr_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_stress_wr_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_stress_rd_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_stretch_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env.sv
+++ b/hw/ip/i2c/dv/env/i2c_env.sv
@@ -19,6 +19,7 @@ class i2c_env extends cip_base_env #(
     m_i2c_agent = i2c_agent::type_id::create("m_i2c_agent", this);
     uvm_config_db#(i2c_agent_cfg)::set(this, "m_i2c_agent*", "cfg", cfg.m_i2c_agent_cfg);
     cfg.m_i2c_agent_cfg.en_cov = cfg.en_cov;
+    cfg.m_i2c_agent_cfg.en_monitor = 1'b1;
   endfunction : build_phase
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -16,6 +16,7 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
 
   tran_type_e trans_type = ReadWrite;
 
+  int        spinwait_timeout_ns = 10_000_000; // 10ms
   int        sent_acq_cnt;
   int        rcvd_acq_cnt;
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -7,6 +7,43 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
   `uvm_object_utils(i2c_target_smoke_vseq)
   `uvm_object_new
 
+  constraint timing_val_c {
+    thigh   inside {[cfg.seq_cfg.i2c_min_timing : cfg.seq_cfg.i2c_max_timing]};
+    t_r     inside {[cfg.seq_cfg.i2c_min_timing : cfg.seq_cfg.i2c_max_timing]};
+    t_f     inside {[cfg.seq_cfg.i2c_min_timing : cfg.seq_cfg.i2c_max_timing]};
+    thd_sta inside {[cfg.seq_cfg.i2c_min_timing : cfg.seq_cfg.i2c_max_timing]};
+    tsu_sto inside {[cfg.seq_cfg.i2c_min_timing : cfg.seq_cfg.i2c_max_timing]};
+    tsu_dat inside {[cfg.seq_cfg.i2c_min_timing : cfg.seq_cfg.i2c_max_timing]};
+    thd_dat inside {[cfg.seq_cfg.i2c_min_timing : cfg.seq_cfg.i2c_max_timing]};
+
+    solve t_r, tsu_dat, thd_dat before tlow;
+    solve t_r                   before t_buf;
+    solve t_f, thigh            before t_sda_unstable, t_sda_interference;
+    if (program_incorrect_regs) {
+      // force derived timing parameters to be negative (incorrect DUT config)
+      tsu_sta == t_r + t_buf + 1;  // negative tHoldStop
+      tlow    == 2;                // negative tClockLow
+      t_buf   == 2;
+      t_sda_unstable     == 0;
+      t_sda_interference == 0;
+      t_scl_interference == 0;
+    } else {
+      tsu_sta inside {[cfg.seq_cfg.i2c_min_timing : cfg.seq_cfg.i2c_max_timing]};
+      // force derived timing parameters to be positive (correct DUT config)
+      // tlow must be at least 2 greater than the sum of t_r + tsu_dat + thd_dat
+      // because the flopped clock (see #15003 below) reduces tClockLow by 1.
+      thigh == (thd_sta + tsu_sta + t_r);
+      tlow    inside {[(t_r + tsu_dat + thd_dat + 5) :
+                       (t_r + tsu_dat + thd_dat + 5) + cfg.seq_cfg.i2c_time_range]};
+      t_buf   inside {[(tsu_sta - t_r + 1) :
+                       (tsu_sta - t_r + 1) + cfg.seq_cfg.i2c_time_range]};
+      t_sda_unstable     inside {[0 : t_r + thigh + t_f - 1]};
+      t_sda_interference inside {[0 : t_r + thigh + t_f - 1]};
+      t_scl_interference inside {[0 : t_r + thigh + t_f - 1]};
+    }
+  }
+
+
   virtual task body();
     i2c_target_base_seq m_i2c_host_seq;
     i2c_item txn_q[$];
@@ -23,7 +60,8 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
           get_timing_values();
           if (i > 0) begin
             // wait for previous stop before program a new timing param.
-            @(cfg.m_i2c_agent_cfg.got_stop);
+            `DV_WAIT(cfg.m_i2c_agent_cfg.got_stop,, cfg.spinwait_timeout_ns, "target_smoke_vseq")
+            cfg.m_i2c_agent_cfg.got_stop = 0;
           end
           program_registers();
 
@@ -31,13 +69,14 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
           create_txn(txn_q);
           fetch_txn(txn_q, m_i2c_host_seq.req_q);
           m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
+          sent_txn_cnt++;
         end
       end
       begin
         process_acq();
       end
       begin
-        process_txq();
+        if (cfg.rd_pct != 0) process_txq();
       end
     join_none
   endtask : body

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_rd_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_rd_vseq.sv
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class i2c_target_stress_rd_vseq extends i2c_target_smoke_vseq;
+  `uvm_object_utils(i2c_target_stress_rd_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c { num_trans inside {[1 : 5]}; }
+
+  virtual task body();
+    `uvm_info(`gfn, $sformatf("num_trans:%0d", num_trans), UVM_MEDIUM)
+
+    cfg.min_data = 100;
+    cfg.max_data = 200;
+    cfg.wr_pct = 0;
+    cfg.m_i2c_agent_cfg.use_seq_term = 1;
+
+    // Since read test use tx_empty interrupt,
+    // interrupt read / clear will be handle in the test sequence.
+    do_clear_all_interrupts = 0;
+
+    super.body();
+  endtask // body
+
+  task process_txq();
+    process_slow_txq();
+    cfg.m_i2c_agent_cfg.use_seq_term = 0;
+  endtask
+
+endclass

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_wr_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_wr_vseq.sv
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class i2c_target_stress_wr_vseq extends i2c_target_smoke_vseq;
+  `uvm_object_utils(i2c_target_stress_wr_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c { num_trans inside {[1 : 5]}; }
+
+  virtual task body();
+    `uvm_info(`gfn, $sformatf("num_trans:%0d", num_trans), UVM_MEDIUM)
+
+    cfg.min_data = 80;
+    cfg.max_data = 200;
+    cfg.rd_pct = 0;
+    cfg.m_i2c_agent_cfg.use_seq_term = 1;
+
+    super.body();
+  endtask // body
+
+  // slow acq fifo read to create acq_fifo full
+  task process_acq();
+    process_slow_acq();
+    cfg.m_i2c_agent_cfg.use_seq_term = 0;
+  endtask
+endclass

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_stretch_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_stretch_vseq.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class i2c_target_stretch_vseq extends i2c_target_smoke_vseq;
+  `uvm_object_utils(i2c_target_stretch_vseq)
+  `uvm_object_new
+
+  bit wr_end = 0;
+
+  constraint num_trans_c { num_trans inside {[1 : 5]}; }
+
+  virtual task body();
+    `uvm_info(`gfn, $sformatf("num_trans:%0d", num_trans), UVM_MEDIUM)
+
+    cfg.min_data = 100;
+    cfg.max_data = 200;
+    cfg.m_i2c_agent_cfg.use_seq_term = 1;
+    do_clear_all_interrupts = 0;
+
+    super.body();
+  endtask // body
+
+  task process_acq();
+    process_slow_acq();
+    wr_end = 1;
+  endtask
+
+  task process_txq();
+    process_slow_txq();
+    wait (wr_end == 1);
+    cfg.m_i2c_agent_cfg.use_seq_term = 0;
+  endtask
+
+endclass // i2c_target_stretch_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -21,3 +21,6 @@
 `include "i2c_host_error_intr_vseq.sv"
 `include "i2c_host_stress_all_vseq.sv"
 `include "i2c_target_smoke_vseq.sv"
+`include "i2c_target_stress_wr_vseq.sv"
+`include "i2c_target_stress_rd_vseq.sv"
+`include "i2c_target_stretch_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -125,6 +125,21 @@
       uvm_test_seq: i2c_target_smoke_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=10_000_000"]
     }
+    {
+      name: i2c_target_stress_wr
+      uvm_test_seq: i2c_target_stress_wr_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=200_000_000"]
+    }
+    {
+      name: i2c_target_stress_rd
+      uvm_test_seq: i2c_target_stress_rd_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=10_000_000"]
+    }
+    {
+      name: i2c_target_stretch
+      uvm_test_seq: i2c_target_stretch_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=80_000_000"]
+    }
   ]
 
   // List of regressions.
@@ -132,6 +147,11 @@
     {
        name: smoke
        tests: ["i2c_host_smoke"]
+    }
+    {
+      name: target_sanity
+      tests: ["i2c_target_smoke", "i2c_target_stress_wr",
+              "i2c_target_stress_rd", "i2c_target_stretch"]
     }
   ]
 }


### PR DESCRIPTION
This PR has 3 tests.
- i2c_target_stress_wr: clock stretch test with write only traffic
- i2c_target_stress_rd: clock stretch test with read only traffic
- i2c_target_stertch: clock stretch test with read/write mixed traffic

For the write transaction, when acq fifo is full, DUT starts to stretch clock.
For the read transaction, when dut receives read command, the tx fifo is empty,
DUT starts to stretch clock.
Using read / write mixed traffic, trigger stretch conditino by slowing down acq / tx fifo process.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>