### PR TITLE
[rtl/edn] Move local_escalate_i and edn_enable_i out of case statement

### DIFF
--- a/hw/ip/edn/rtl/edn_ack_sm.sv
+++ b/hw/ip/edn/rtl/edn_ack_sm.sv
@@ -107,4 +107,9 @@ module edn_ack_sm (
     end
   end
 
+  // The `local_escalate_i` includes `ack_sm_err_o`.
+  // The following assertion ensures the Error state is stable until reset.
+  // With `FpvSecCm` prefix, this assertion will added to weekly FPV sec_cm regression.
+  `ASSERT(FpvSecCmErrorStStable_A, state_q == Error |-> local_escalate_i)
+
 endmodule


### PR DESCRIPTION
This PR moves the two common conditions:
1). local_escalate
2). edn_enable
Outside of each individual case statement to avoid duplications,
and improve: branch and conditional coverage.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>