### PR TITLE
[csrng/dv] Add test and coverage for `INTERSIG.MUBI` and `CONSTANTS.LC_GATED` CMs

### DIFF
--- a/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
@@ -48,16 +48,13 @@
       tests: ["csrng_alert"]
     }
     {
-      // TODO: This is currently untested.
-      // The environment has support for randomly driving MuBi8False to otp_en_csrng_sw_app_read but always MuBi8True is driven.
-      // In addition, the environment needs to be extended to drive also non-valid encodings (see entropy_src).
       name: sec_cm_intersig_mubi
       desc: '''
             Verify the countermeasure(s) INTERSIG.MUBI.
             Verify that unless the otp_en_csrng_sw_app_read input signal is equal to MuBi8True and CTRL.SW_APP_ENABLE or CTRL.READ_INT_STATE is set to kMultiBitBool4True the DUT doesn't allow reading the genbits or the internal state from the GENBITS or INT_STATE_VAL register, respectively.
             '''
       stage: V2S
-      tests: []
+      tests: ["csrng_stress_all"]
     }
     {
       name: sec_cm_main_sm_fsm_sparse
@@ -166,7 +163,6 @@
       tests: ["csrng_intr", "csrng_err"]
     }
     {
-      // TODO: The environment needs to be extended to drive also non-valid encodings (see INTERSIG.MUBI).
       name: sec_cm_constants_lc_gated
       desc: '''
             Verify the countermeasure(s) CONSTANTS.LC_GATED.

--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -23,7 +23,7 @@ interface csrng_cov_if (
   bit en_intg_cov_loc;
   assign en_intg_cov_loc = en_full_cov | en_intg_cov;
 
-  covergroup csrng_cfg_cg with function sample(mubi8_t   otp_en_cs_sw_app_read,
+  covergroup csrng_cfg_cg with function sample(bit [7:0] otp_en_cs_sw_app_read,
                                                mubi4_t   sw_app_enable,
                                                mubi4_t   read_int_state
                                               );

--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -24,6 +24,7 @@ interface csrng_cov_if (
   assign en_intg_cov_loc = en_full_cov | en_intg_cov;
 
   covergroup csrng_cfg_cg with function sample(bit [7:0] otp_en_cs_sw_app_read,
+                                               bit [3:0] lc_hw_debug_en,
                                                mubi4_t   sw_app_enable,
                                                mubi4_t   read_int_state
                                               );
@@ -34,6 +35,11 @@ interface csrng_cov_if (
       bins mubi_true  = { MuBi8True };
       bins mubi_false = { MuBi8False };
       bins mubi_inval = {[0:$]} with (!(item inside {MuBi8True, MuBi8False}));
+    }
+    cp_lc_hw_debug_en: coverpoint lc_hw_debug_en {
+      bins lc_on    = { lc_ctrl_pkg::On };
+      bins lc_off   = { lc_ctrl_pkg::Off };
+      bins lc_inval = {[0:$]} with (!(item inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off}));
     }
     cp_sw_app_enable:  coverpoint sw_app_enable;
     cp_read_int_state: coverpoint read_int_state;
@@ -138,6 +144,7 @@ interface csrng_cov_if (
   // Sample functions needed for xcelium
   function automatic void cg_cfg_sample(csrng_env_cfg cfg);
     csrng_cfg_cg_inst.sample(cfg.otp_en_cs_sw_app_read,
+                              cfg.lc_hw_debug_en,
                               cfg.sw_app_enable,
                               cfg.read_int_state
                              );

--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -30,7 +30,11 @@ interface csrng_cov_if (
     option.name         = "csrng_cfg_cg";
     option.per_instance = 1;
 
-    cp_sw_app_read:    coverpoint otp_en_cs_sw_app_read;
+    cp_sw_app_read:    coverpoint otp_en_cs_sw_app_read {
+      bins mubi_true  = { MuBi8True };
+      bins mubi_false = { MuBi8False };
+      bins mubi_inval = {[0:$]} with (!(item inside {MuBi8True, MuBi8False}));
+    }
     cp_sw_app_enable:  coverpoint sw_app_enable;
     cp_read_int_state: coverpoint read_int_state;
 

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -23,7 +23,7 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   virtual csrng_path_if csrng_path_vif; // handle to csrng path interface
 
   // Knobs & Weights
-  uint   otp_en_cs_sw_app_read_pct, lc_hw_debug_en_pct, regwen_pct,
+  uint   otp_en_cs_sw_app_read_pct, otp_en_cs_sw_app_read_inval_pct, lc_hw_debug_en_pct, regwen_pct,
          enable_pct, sw_app_enable_pct, read_int_state_pct, force_state_pct,
          check_int_state_pct, num_cmds_min, num_cmds_max, aes_halt_pct,
          min_aes_halt_clks, max_aes_halt_clks;
@@ -58,9 +58,12 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   rand uint  which_sp2v;
   constraint which_sp2v_c { which_sp2v inside {[0:Sp2VWidth-1]};}
 
-  constraint otp_en_cs_sw_app_read_c { otp_en_cs_sw_app_read dist {
-                                       MuBi8True  :/ otp_en_cs_sw_app_read_pct,
-                                       MuBi8False :/ (100 - otp_en_cs_sw_app_read_pct) };}
+  constraint otp_en_cs_sw_app_read_c {
+    `DV_MUBI8_DIST(otp_en_cs_sw_app_read,
+                   otp_en_cs_sw_app_read_pct,
+                   100 - otp_en_cs_sw_app_read_pct - otp_en_cs_sw_app_read_inval_pct,
+                   otp_en_cs_sw_app_read_inval_pct)
+  }
 
   constraint lc_hw_debug_en_c { `DV_LC_TX_DIST(lc_hw_debug_en, lc_hw_debug_en_pct,
                                 (100 - lc_hw_debug_en_pct) / 2,  (100 - lc_hw_debug_en_pct) / 2)}
@@ -198,45 +201,47 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   virtual function string convert2string();
     string str = "";
     str = {str, "\n"};
-    str = {str,  $sformatf("\n\t |**************** csrng_env_cfg *******************| \t")};
-    str = {str,  $sformatf("\n\t |***** otp_en_cs_sw_app_read     :       'h%02h *****| \t",
+    str = {str,  $sformatf("\n\t |**************** csrng_env_cfg *************************| \t")};
+    str = {str,  $sformatf("\n\t |***** otp_en_cs_sw_app_read           :       'h%02h *****| \t",
            otp_en_cs_sw_app_read)};
-    str = {str,  $sformatf("\n\t |***** lc_hw_debug_en            :       'h%02h *****| \t",
+    str = {str,  $sformatf("\n\t |***** lc_hw_debug_en                  :       'h%02h *****| \t",
            lc_hw_debug_en)};
-    str = {str,  $sformatf("\n\t |***** enable                    : %10s *****| \t",
+    str = {str,  $sformatf("\n\t |***** enable                          : %10s *****| \t",
            enable.name())};
-    str = {str,  $sformatf("\n\t |***** sw_app_enable             : %10s *****| \t",
+    str = {str,  $sformatf("\n\t |***** sw_app_enable                   : %10s *****| \t",
            sw_app_enable.name())};
-    str = {str,  $sformatf("\n\t |***** read_int_state            : %10s *****| \t",
+    str = {str,  $sformatf("\n\t |***** read_int_state                  : %10s *****| \t",
            read_int_state.name())};
-    str = {str,  $sformatf("\n\t |***** regwen                    : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** regwen                          : %10d *****| \t",
            regwen)};
-    str = {str,  $sformatf("\n\t |***** check_int_state           : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** check_int_state                 : %10d *****| \t",
            check_int_state)};
-    str = {str,  $sformatf("\n\t |---------------- knobs ---------------------------| \t")};
-    str = {str,  $sformatf("\n\t |***** otp_en_cs_sw_app_read_pct : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |---------------- knobs ---------------------------------| \t")};
+    str = {str,  $sformatf("\n\t |***** otp_en_cs_sw_app_read_pct       : %10d *****| \t",
            otp_en_cs_sw_app_read_pct) };
-    str = {str,  $sformatf("\n\t |***** lc_hw_debug_en_pct        : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** otp_en_cs_sw_app_read_inval_pct : %10d *****| \t",
+           otp_en_cs_sw_app_read_pct) };
+    str = {str,  $sformatf("\n\t |***** lc_hw_debug_en_pct              : %10d *****| \t",
            lc_hw_debug_en_pct) };
-    str = {str,  $sformatf("\n\t |***** enable_pct                : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** enable_pct                      : %10d *****| \t",
            enable_pct)};
-    str = {str,  $sformatf("\n\t |***** sw_app_enable_pct         : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** sw_app_enable_pct               : %10d *****| \t",
            sw_app_enable_pct)};
-    str = {str,  $sformatf("\n\t |***** read_int_state_pct        : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** read_int_state_pct              : %10d *****| \t",
            read_int_state_pct)};
-    str = {str,  $sformatf("\n\t |***** regwen_pct                : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** regwen_pct                      : %10d *****| \t",
            regwen_pct)};
-    str = {str,  $sformatf("\n\t |***** check_int_state_pct       : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** check_int_state_pct             : %10d *****| \t",
            check_int_state_pct)};
-    str = {str,  $sformatf("\n\t |***** num_cmds_min              : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** num_cmds_min                    : %10d *****| \t",
            num_cmds_min)};
-    str = {str,  $sformatf("\n\t |***** num_cmds_max              : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** num_cmds_max                    : %10d *****| \t",
            num_cmds_max)};
-    str = {str,  $sformatf("\n\t |***** min_aes_halt_clks         : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** min_aes_halt_clks               : %10d *****| \t",
            min_aes_halt_clks)};
-    str = {str,  $sformatf("\n\t |***** max_aes_halt_clks         : %10d *****| \t",
+    str = {str,  $sformatf("\n\t |***** max_aes_halt_clks               : %10d *****| \t",
            max_aes_halt_clks)};
-    str = {str,  $sformatf("\n\t |**************************************************| \t")};
+    str = {str,  $sformatf("\n\t |********************************************************| \t")};
     str = {str, "\n"};
     return str;
   endfunction

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -33,8 +33,8 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   rand bit       check_int_state, regwen, hw_app[NUM_HW_APPS],
                  sw_app, aes_halt;
   rand mubi4_t   enable, sw_app_enable, read_int_state;
-  rand lc_tx_t   lc_hw_debug_en;
-  rand mubi8_t   otp_en_cs_sw_app_read;
+  rand bit [3:0] lc_hw_debug_en;
+  rand bit [7:0] otp_en_cs_sw_app_read;
 
   rand fatal_err_e      which_fatal_err;
   rand err_code_e       which_err_code;
@@ -199,10 +199,10 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
     string str = "";
     str = {str, "\n"};
     str = {str,  $sformatf("\n\t |**************** csrng_env_cfg *******************| \t")};
-    str = {str,  $sformatf("\n\t |***** otp_en_cs_sw_app_read     : %10s *****| \t",
-           otp_en_cs_sw_app_read.name())};
-    str = {str,  $sformatf("\n\t |***** lc_hw_debug_en            : %10s *****| \t",
-           lc_hw_debug_en.name())};
+    str = {str,  $sformatf("\n\t |***** otp_en_cs_sw_app_read     :       'h%02h *****| \t",
+           otp_en_cs_sw_app_read)};
+    str = {str,  $sformatf("\n\t |***** lc_hw_debug_en            :       'h%02h *****| \t",
+           lc_hw_debug_en)};
     str = {str,  $sformatf("\n\t |***** enable                    : %10s *****| \t",
            enable.name())};
     str = {str,  $sformatf("\n\t |***** sw_app_enable             : %10s *****| \t",

--- a/hw/ip/csrng/dv/tests/csrng_alert_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_alert_test.sv
@@ -10,10 +10,11 @@ class csrng_alert_test extends csrng_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.en_scb                    = 0;
-    cfg.otp_en_cs_sw_app_read_pct = 100;
-    cfg.sw_app_enable_pct         = 100;
-    cfg.use_invalid_mubi          = 1;
+    cfg.en_scb                          = 0;
+    cfg.otp_en_cs_sw_app_read_pct       = 100;
+    cfg.otp_en_cs_sw_app_read_inval_pct = 0;
+    cfg.sw_app_enable_pct               = 100;
+    cfg.use_invalid_mubi                = 1;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 

--- a/hw/ip/csrng/dv/tests/csrng_base_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_base_test.sv
@@ -24,13 +24,14 @@ class csrng_base_test extends cip_base_test #(
   // the run_phase; as such, nothing more needs to be done
 
   virtual function void configure_env();
-    cfg.otp_en_cs_sw_app_read_pct = 90;
-    cfg.lc_hw_debug_en_pct        = 50;
-    cfg.regwen_pct                = 100;
-    cfg.enable_pct                = 100;
-    cfg.sw_app_enable_pct         = 90;
-    cfg.read_int_state_pct        = 90;
-    cfg.check_int_state_pct       = 100;
+    cfg.otp_en_cs_sw_app_read_pct       = 90;
+    cfg.otp_en_cs_sw_app_read_inval_pct = 0;
+    cfg.lc_hw_debug_en_pct              = 50;
+    cfg.regwen_pct                      = 100;
+    cfg.enable_pct                      = 100;
+    cfg.sw_app_enable_pct               = 90;
+    cfg.read_int_state_pct              = 90;
+    cfg.check_int_state_pct             = 100;
   endfunction
 
 endclass : csrng_base_test

--- a/hw/ip/csrng/dv/tests/csrng_base_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_base_test.sv
@@ -24,8 +24,8 @@ class csrng_base_test extends cip_base_test #(
   // the run_phase; as such, nothing more needs to be done
 
   virtual function void configure_env();
-    cfg.otp_en_cs_sw_app_read_pct       = 90;
-    cfg.otp_en_cs_sw_app_read_inval_pct = 0;
+    cfg.otp_en_cs_sw_app_read_pct       = 80;
+    cfg.otp_en_cs_sw_app_read_inval_pct = 10;
     cfg.lc_hw_debug_en_pct              = 50;
     cfg.regwen_pct                      = 100;
     cfg.enable_pct                      = 100;

--- a/hw/ip/csrng/dv/tests/csrng_intr_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_intr_test.sv
@@ -10,10 +10,11 @@ class csrng_intr_test extends csrng_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.en_scb                    = 0;
-    cfg.otp_en_cs_sw_app_read_pct = 100;
-    cfg.sw_app_enable_pct         = 100;
-    cfg.use_invalid_mubi          = 0;
+    cfg.en_scb                          = 0;
+    cfg.otp_en_cs_sw_app_read_pct       = 100;
+    cfg.otp_en_cs_sw_app_read_inval_pct = 0;
+    cfg.sw_app_enable_pct               = 100;
+    cfg.use_invalid_mubi                = 0;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 


### PR DESCRIPTION
This extends and tunes the CSRNG DV environment to also drive invalid MuBi and LC values to `otp_en_csrng_sw_app_read_i` and `lc_hw_debug_en`, respectively. It also extends the coverage interface to track those values.

The invalid bins get hit according to the coverage report. The pass rate of the existing tests is comparable to before this PR.

This PR contributes to resolving #16238.

(This PR is much easier to review if you hide whitespace changes, which can be ticked under :gear: in the diff view.)

## Open questions
- [x] In the CM testplan, which tests should be mapped to the `INTERSIG.MUBI` CM? Currently, all tests except `alert_test` and `intr_test` drive false or invalid MuBi value to that input. For `CONSTANTS.LC_GATED`, `stress_all` is mapped.