### PR TITLE
[entropy_src/rtl] Move `ack_sm` state definition into separate package

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
@@ -91,7 +91,7 @@ class entropy_src_err_vseq extends entropy_src_base_vseq;
         cov_vif.cg_sm_err_sample(fld_name == "es_ack_sm_err", fld_name == "es_main_sm_err");
       end
       es_cntr_err: begin
-        logic [entropy_src_pkg::AckSmStateWidth-1:0] sm_state;
+        logic [entropy_src_ack_sm_pkg::StateWidth-1:0] sm_state;
         string sm_state_path = cfg.entropy_src_path_vif.sm_err_path("ack_sm");
         fld = csr.get_field_by_name(fld_name);
         case (cfg.which_cntr)
@@ -121,7 +121,7 @@ class entropy_src_err_vseq extends entropy_src_base_vseq;
         // Check that the `entropy_src_ack_sm` FSM, which observes the errors of the faulted
         // counter, has entered the error state.
         `DV_CHECK(uvm_hdl_read(sm_state_path, sm_state))
-        `DV_CHECK_EQ(sm_state, entropy_src_pkg::AckSmError)
+        `DV_CHECK_EQ(sm_state, entropy_src_ack_sm_pkg::Error)
       end
       fifo_write_err, fifo_read_err, fifo_state_err: begin
         fifo_name = cfg.which_fifo.name();

--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -21,6 +21,7 @@ filesets:
       - lowrisc:ip:sha3
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:entropy_src_pkg
+      - lowrisc:ip:entropy_src_ack_sm_pkg
       - lowrisc:ip:entropy_src_main_sm_pkg
     files:
       - rtl/entropy_src_reg_pkg.sv

--- a/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
@@ -18,11 +18,11 @@ module entropy_src_ack_sm (
   output logic               ack_sm_err_o
 );
 
-  import entropy_src_pkg::*;
+  import entropy_src_ack_sm_pkg::*;
 
-  ack_sm_state_e state_d, state_q;
+  state_e state_d, state_q;
 
-  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, ack_sm_state_e, AckSmIdle)
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Idle)
 
   always_comb begin
     state_d = state_q;
@@ -30,34 +30,34 @@ module entropy_src_ack_sm (
     fifo_pop_o = 1'b0;
     ack_sm_err_o = 1'b0;
     unique case (state_q)
-      AckSmIdle: begin
+      Idle: begin
         if (enable_i) begin
           if (req_i) begin
-            state_d = AckSmWait;
+            state_d = Wait;
           end
         end
       end
-      AckSmWait: begin
+      Wait: begin
         if (!enable_i) begin
-          state_d = AckSmIdle;
+          state_d = Idle;
         end else begin
           if (fifo_not_empty_i) begin
             ack_o = 1'b1;
             fifo_pop_o = 1'b1;
-            state_d = AckSmIdle;
+            state_d = Idle;
           end
         end
       end
-      AckSmError: begin
+      Error: begin
         ack_sm_err_o = 1'b1;
       end
       default: begin
-        state_d = AckSmError;
+        state_d = Error;
         ack_sm_err_o = 1'b1;
       end
     endcase
     if (local_escalate_i) begin
-      state_d = AckSmError;
+      state_d = Error;
     end
   end
 

--- a/hw/ip/entropy_src/rtl/entropy_src_ack_sm_pkg.core
+++ b/hw/ip/entropy_src/rtl/entropy_src_ack_sm_pkg.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:ip:entropy_src_ack_sm_pkg:0.1"
+description: "entropy_src"
+filesets:
+  files_rtl:
+    files:
+      - entropy_src_ack_sm_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/entropy_src/rtl/entropy_src_ack_sm_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_ack_sm_pkg.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// State definitions for entropy_src_ack_sm, provided as a separate package for use in DV
+
+package entropy_src_ack_sm_pkg;
+
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 3 -n 6 \
+  //      -s 1236774883 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: |||||||||||||||||||| (33.33%)
+  //  4: |||||||||||||||||||| (33.33%)
+  //  5: |||||||||||||||||||| (33.33%)
+  //  6: --
+  //
+  // Minimum Hamming distance: 3
+  // Maximum Hamming distance: 5
+  // Minimum Hamming weight: 1
+  // Maximum Hamming weight: 4
+  //
+  localparam int StateWidth = 6;
+  typedef enum logic [StateWidth-1:0] {
+    Idle  = 6'b011101, // idle
+    Wait  = 6'b101100, // wait until the fifo has an entry
+    Error = 6'b000010  // illegal state reached and hang
+  } state_e;
+
+endpackage

--- a/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
@@ -82,32 +82,4 @@ package entropy_src_pkg;
   parameter entropy_src_xht_rsp_t ENTROPY_SRC_XHT_RSP_DEFAULT =
       '{test_cnt_lo: 16'hffff, default: '0};
 
-  // Sparse FSM state encodings
-
-  // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 3 -n 6 \
-  //      -s 1236774883 --language=sv
-  //
-  // Hamming distance histogram:
-  //
-  //  0: --
-  //  1: --
-  //  2: --
-  //  3: |||||||||||||||||||| (33.33%)
-  //  4: |||||||||||||||||||| (33.33%)
-  //  5: |||||||||||||||||||| (33.33%)
-  //  6: --
-  //
-  // Minimum Hamming distance: 3
-  // Maximum Hamming distance: 5
-  // Minimum Hamming weight: 1
-  // Maximum Hamming weight: 4
-  //
-  localparam int AckSmStateWidth = 6;
-  typedef enum logic [AckSmStateWidth-1:0] {
-    AckSmIdle  = 6'b011101, // idle
-    AckSmWait  = 6'b101100, // wait until the fifo has an entry
-    AckSmError = 6'b000010  // illegal state reached and hang
-  } ack_sm_state_e;
-
 endpackage : entropy_src_pkg


### PR DESCRIPTION
This is a follow-up on lowrisc/opentitan#16252 to be consistent with the existing `entropy_src_main_sm_pkg`.