### PR TITLE
[test] Use fake prod key instead of test key in rom e2e tests

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -390,15 +390,15 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
           // suffix to the image name.
           if ("signed" inside {sw_image_flags[i]}) begin
             // Options match DEFAULT_SIGNING_KEYS in `rules/opentitan.bzl`.
-            if ("dev_key_0" inside {sw_image_flags[i]}) begin
-              sw_images[i] = $sformatf("%0s.dev_key_0.signed", sw_images[i]);
-            end else if ("prod_key_0" inside {sw_image_flags[i]}) begin
-              sw_images[i] = $sformatf("%0s.prod_key_0.signed", sw_images[i]);
+            if ("fake_dev_key_0" inside {sw_image_flags[i]}) begin
+              sw_images[i] = $sformatf("%0s.fake_dev_key_0.signed", sw_images[i]);
+            end else if ("fake_prod_key_0" inside {sw_image_flags[i]}) begin
+              sw_images[i] = $sformatf("%0s.fake_prod_key_0.signed", sw_images[i]);
             end else begin
-              // We default to "test_key_0" if no key name is provided in the
-              // SW image tags (or if the key name provided is "test_key_0"),
+              // We default to "fake_test_key_0" if no key name is provided in the
+              // SW image tags (or if the key name provided is "fake_test_key_0"),
               // as this works in the RMA LC state, which is the default OTP image.
-              sw_images[i] = $sformatf("%0s.test_key_0.signed", sw_images[i]);
+              sw_images[i] = $sformatf("%0s.fake_test_key_0.signed", sw_images[i]);
             end
           end
         end else if (i == SwTypeOtp) begin

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -44,9 +44,9 @@ PER_DEVICE_DEPS = {
 
 # Default keys used to sign ROM_EXT and BL0 images for testing.
 DEFAULT_SIGNING_KEYS = {
-    "test_key_0": "@//sw/device/silicon_creator/rom/keys/fake:test_private_key_0",
-    "dev_key_0": "@//sw/device/silicon_creator/rom/keys/fake:dev_private_key_0",
-    "prod_key_0": "@//sw/device/silicon_creator/rom/keys/fake:prod_private_key_0",
+    "fake_test_key_0": "@//sw/device/silicon_creator/rom/keys/fake:test_private_key_0",
+    "fake_dev_key_0": "@//sw/device/silicon_creator/rom/keys/fake:dev_private_key_0",
+    "fake_prod_key_0": "@//sw/device/silicon_creator/rom/keys/fake:prod_private_key_0",
     "unauthorized_0": "@//sw/device/silicon_creator/rom/keys:unauthorized_private_key_0",
 }
 

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -249,7 +249,7 @@ def opentitan_functest(
         manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
         slot = "silicon_creator_a",
         test_harness = "@//sw/host/opentitantool",
-        key = "test_key_0",
+        key = "prod_key_0",
         logging = "info",
         dv = None,
         verilator = None,

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -249,7 +249,7 @@ def opentitan_functest(
         manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
         slot = "silicon_creator_a",
         test_harness = "@//sw/host/opentitantool",
-        key = "prod_key_0",
+        key = "fake_prod_key_0",
         logging = "info",
         dv = None,
         verilator = None,

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -58,18 +58,18 @@ SLOTS = {
 
 LC_KEY_TYPES = {
     CONST.LCV.TEST_UNLOCKED0: [
-        "test_key_0",
-        "prod_key_0",
+        "fake_test_key_0",
+        "fake_prod_key_0",
     ],
     CONST.LCV.DEV: [
-        "dev_key_0",
-        "prod_key_0",
+        "fake_dev_key_0",
+        "fake_prod_key_0",
     ],
-    CONST.LCV.PROD: ["prod_key_0"],
-    CONST.LCV.PROD_END: ["prod_key_0"],
+    CONST.LCV.PROD: ["fake_prod_key_0"],
+    CONST.LCV.PROD_END: ["fake_prod_key_0"],
     CONST.LCV.RMA: [
-        "test_key_0",
-        "prod_key_0",
+        "fake_test_key_0",
+        "fake_prod_key_0",
     ],
 }
 
@@ -146,7 +146,7 @@ opentitan_functest(
     dv = dv_params(
         rom = "//sw/device/silicon_creator/rom",
     ),
-    key = "test_key_0",
+    key = "fake_test_key_0",
     ot_flash_binary = ":empty_test_slot_a",
     targets = [
         "cw310_rom",
@@ -245,7 +245,7 @@ opentitan_functest(
         # bitstream target can fetch pre-spliced bitstream from GCP.
         tags = ["manual"],
     ),
-    key = "test_key_0",
+    key = "fake_test_key_0",
     ot_flash_binary = ":empty_test_slot_a",
     targets = ["cw310_rom"],
 )
@@ -369,7 +369,7 @@ opentitan_multislot_flash_binary(
     name = "rom_ext_b_flash_b_image",
     srcs = {
         "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": {
-            "key": "test_key_0",
+            "key": "fake_test_key_0",
             "offset": SLOTS["b"],
         },
     },
@@ -390,7 +390,7 @@ opentitan_multislot_flash_binary(
     name = "rom_ext_a_flash_b_image",
     srcs = {
         "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a": {
-            "key": "test_key_0",
+            "key": "fake_test_key_0",
             "offset": SLOTS["b"],
         },
     },
@@ -411,7 +411,7 @@ opentitan_multislot_flash_binary(
     name = "rom_ext_b_flash_a_image",
     srcs = {
         "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": {
-            "key": "test_key_0",
+            "key": "fake_test_key_0",
             "offset": SLOTS["a"],
         },
     },
@@ -442,7 +442,7 @@ opentitan_multislot_flash_binary(
     name = "rom_ext_v_flash_b_image",
     srcs = {
         "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": {
-            "key": "test_key_0",
+            "key": "fake_test_key_0",
             "offset": SLOTS["b"],
         },
     },
@@ -585,11 +585,11 @@ SEC_VERS = [
     name = "sec_ver_{}_{}_image".format(sec_ver_a, sec_ver_b),
     srcs = {
         ":empty_test_slot_a_sec_ver_{}".format(sec_ver_a): {
-            "key": "prod_key_0",
+            "key": "fake_prod_key_0",
             "offset": SLOTS["a"],
         },
         ":empty_test_slot_b_sec_ver_{}".format(sec_ver_b): {
-            "key": "prod_key_0",
+            "key": "fake_prod_key_0",
             "offset": SLOTS["b"],
         },
     },
@@ -948,7 +948,7 @@ ALERT_LC_STATES = {
             bitstream = ":bitstream_alert_{}".format(lc_state.lower()),
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
-        key = "prod_key_0",
+        key = "fake_prod_key_0",
         ot_flash_binary = ":rom_e2e_alert_config_test_{}".format(lc_state.lower()),
         signed = True,
         targets = [
@@ -1238,7 +1238,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             t["name"],
             slot,
         ): {
-            "key": "test_key_0",
+            "key": "fake_test_key_0",
             "offset": offset,
         },
     },
@@ -1483,9 +1483,9 @@ test_suite(
 )
 
 SIGVERIFY_LC_KEYS = [
-    "test_key_0",
-    "dev_key_0",
-    "prod_key_0",
+    "fake_test_key_0",
+    "fake_dev_key_0",
+    "fake_prod_key_0",
 ]
 
 [
@@ -1559,11 +1559,11 @@ BOOT_POLICY_VALID_CASES = [
         ),
         srcs = {
             ":empty_test_slot_a{}".format(a["suffix"]): {
-                "key": "prod_key_0",
+                "key": "fake_prod_key_0",
                 "offset": SLOTS["a"],
             },
             ":empty_test_slot_b{}".format(b["suffix"]): {
-                "key": "prod_key_0",
+                "key": "fake_prod_key_0",
                 "offset": SLOTS["b"],
             },
         },
@@ -2319,9 +2319,9 @@ test_suite(
         ],
     )
     for key in [
-        "test_key_0",
-        "dev_key_0",
-        "prod_key_0",
+        "fake_test_key_0",
+        "fake_dev_key_0",
+        "fake_prod_key_0",
     ]
 ]
 
@@ -2368,11 +2368,11 @@ SIGVERIFY_BAD_CASES = [
 ]
 
 SIGVERIFY_LCS_2_VALID_KEY = {
-    "test_unlocked0": "test_key_0",
-    "dev": "dev_key_0",
-    "prod": "prod_key_0",
-    "prod_end": "prod_key_0",
-    "rma": "prod_key_0",
+    "test_unlocked0": "fake_test_key_0",
+    "dev": "fake_dev_key_0",
+    "prod": "fake_prod_key_0",
+    "prod_end": "fake_prod_key_0",
+    "rma": "fake_prod_key_0",
 }
 
 [
@@ -2452,9 +2452,9 @@ test_suite(
 ]
 
 SIGVERIFY_KEY_TYPE_KEYS = [
-    "test_key_0",
-    "dev_key_0",
-    "prod_key_0",
+    "fake_test_key_0",
+    "fake_dev_key_0",
+    "fake_prod_key_0",
 ]
 
 [

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1559,11 +1559,11 @@ BOOT_POLICY_VALID_CASES = [
         ),
         srcs = {
             ":empty_test_slot_a{}".format(a["suffix"]): {
-                "key": "test_key_0",
+                "key": "prod_key_0",
                 "offset": SLOTS["a"],
             },
             ":empty_test_slot_b{}".format(b["suffix"]): {
-                "key": "test_key_0",
+                "key": "prod_key_0",
                 "offset": SLOTS["b"],
             },
         },

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -121,11 +121,11 @@ opentitan_multislot_flash_binary(
     name = "rom_ext_virtual_bare_metal_virtual",
     srcs = {
         "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": {
-            "key": "test_key_0",
+            "key": "fake_test_key_0",
             "offset": "0x0",
         },
         ":bare_metal_slot_virtual": {
-            "key": "test_key_0",
+            "key": "fake_test_key_0",
             "offset": "0x10000",
         },
     },
@@ -162,11 +162,11 @@ opentitan_multislot_flash_binary(
     name = "rom_ext_virtual_ottf_bl0_virtual",
     srcs = {
         "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": {
-            "key": "test_key_0",
+            "key": "fake_test_key_0",
             "offset": "0x0",
         },
         ":ottf_test_bl0_slot_virtual": {
-            "key": "test_key_0",
+            "key": "fake_test_key_0",
             "offset": "0x10000",
         },
     },


### PR DESCRIPTION
Noticed while running e2e tests for all life cycle states on my machine. Since test keys are only valid in test and rma states, we should use (fake) prod keys to be able to run a test in all life cycle states.

Signed-off-by: Alphan Ulusoy <alphan@google.com>