### PR TITLE
[spi_host/dv] Fix spi_host_stress_all test

### DIFF
--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -119,6 +119,19 @@ class spi_host_base_vseq extends cip_base_vseq #(
     join
   endtask // start_reactive_seq
 
+  // Call this function to cleanup the above started reactive-sequences, such as if we
+  // exit early, or are running sequences back-to-back.
+  virtual task cleanup_reactive_seq();
+    p_sequencer.spi_sequencer_h.stop_sequences();
+    if (cfg.m_spi_agent_cfg.has_req_fifo) p_sequencer.spi_sequencer_h.req_analysis_fifo.flush();
+    if (cfg.m_spi_agent_cfg.has_rsp_fifo) p_sequencer.spi_sequencer_h.rsp_analysis_fifo.flush();
+  endtask // cleanup_reactive_seq
+
+  task post_start();
+    super.post_start();
+    cleanup_reactive_seq();
+  endtask
+
   function void transaction_init();
     transaction = new();
 

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_stress_all_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_stress_all_vseq.sv
@@ -7,9 +7,13 @@ class spi_host_stress_all_vseq extends spi_host_tx_rx_vseq;
   `uvm_object_utils(spi_host_stress_all_vseq)
   `uvm_object_new
 
-  constraint num_trans_c {
-    num_trans inside {[3:6]};
-  }
+  task pre_randomize();
+    super.pre_randomize();
+    cfg.seq_cfg.host_spi_min_trans = 2;
+    cfg.seq_cfg.host_spi_max_trans = 3;
+    cfg.seq_cfg.host_spi_min_runs = 2;
+    cfg.seq_cfg.host_spi_max_runs = 5;
+  endtask
 
 
   virtual task body();

--- a/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson
+++ b/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson
@@ -117,6 +117,7 @@
     {
       name: spi_host_stress_all
       uvm_test_seq: spi_host_stress_all_vseq
+      run_opts: ["+test_timeout_ns=1_000_000_000"]
     }
     // TODO: add more tests here
   ]


### PR DESCRIPTION
Before starting sequences running back to back in spi_host_stress_all test, the req fifos were not empty and this was causing misbehaviours. Stop previously started reactive-sequences and flush fifos. Increase test time-out.

closes #16014

Signed-off-by: Abdullah Varici <abdullah.varici@lowrisc.org>