### PR TITLE
[bazel] Cleanup rom_e2e_pmp_init test suite

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1838,8 +1838,7 @@ test_suite(
 test_suite(
     name = "rom_e2e_epmp_init",
     tags = [
-        "cw310",
-        "vivado",
+        "manual",
     ],
     tests = [
         "epmp_init_otp_" + lc_state.lower()


### PR DESCRIPTION
Changed the tag to manual so the rom_e2e_epmp_init test suite wouldn't build and prevent verilator tests from running. There's nothing in the name to indicate the exclusion was intentional.

Signed-off-by: Drew Macrae <drewmacrae@google.com>