### PR TITLE
[csrng] Add test to verify CONFIG.REGWEN countermeasre

### DIFF
--- a/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
@@ -24,8 +24,7 @@
 {
   testpoints: [
     {
-      // TODO: Unlike the REGWEN register, the CTRL and ERR_CODE_TEST registers are excluded from some automated CSRs tests (CsrExclWrite).
-      // We need to ensure write-read checks are happening or alternatively test point 2) explicitly, e.g., with a directed test.
+      // Since CTRL and ERR_CODE_TEST registers are excluded from some automated CSRs tests (CsrExclWrite), test points 1) and 2) are verified using a directed test.
       name: sec_cm_config_regwen
       desc: '''
             Verify the countermeasure(s) CONFIG.REGWEN.
@@ -34,7 +33,7 @@
             2) If REGWEN is not set, the CTRL and ERR_CODE_TEST registers cannot be modified.
             '''
       stage: V2S
-      tests: ["csrng_csr_rw"]
+      tests: ["csrng_csr_rw", "csrng_regwen"]
     }
     {
       name: sec_cm_config_mubi

--- a/hw/ip/csrng/dv/csrng_sim_cfg.hjson
+++ b/hw/ip/csrng/dv/csrng_sim_cfg.hjson
@@ -88,6 +88,12 @@
       uvm_test_seq: csrng_err_vseq
     }
 
+    {
+      name: csrng_regwen
+      uvm_test: csrng_regwen_test
+      uvm_test_seq: csrng_regwen_vseq
+    }
+
     // TODO: add more tests here
   ]
 

--- a/hw/ip/csrng/dv/env/csrng_env.core
+++ b/hw/ip/csrng/dv/env/csrng_env.core
@@ -33,6 +33,7 @@ filesets:
       - seq_lib/csrng_intr_vseq.sv: {is_include_file: true}
       - seq_lib/csrng_alert_vseq.sv: {is_include_file: true}
       - seq_lib/csrng_err_vseq.sv: {is_include_file: true}
+      - seq_lib/csrng_regwen_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_regwen_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_regwen_vseq.sv
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Verify the countermeasure(s) CONFIG.REGWEN.
+
+class csrng_regwen_vseq extends csrng_base_vseq;
+  `uvm_object_utils(csrng_regwen_vseq)
+
+  `uvm_object_new
+
+  bit ctrl_bit        = 0;
+  bit chk_bit         = 0;
+  int ctrl_int        = 0;
+  int chk_int         = 0;
+
+  task body();
+
+    csr_wr(.ptr(ral.regwen), .value(ctrl_bit), .blocking(1));
+    csr_wr(.ptr(ral.regwen), .value(~ctrl_bit), .blocking(1));
+    csr_rd(.ptr(ral.regwen), .value(chk_bit), .blocking(1));
+
+    if (chk_bit != ctrl_bit) begin
+      `uvm_fatal(`gfn, $sformatf(" Was able to overwrite REGWEN after being set to 0"))
+    end
+
+    csr_rd(.ptr(ral.ctrl), .value(ctrl_int), .blocking(1));
+    csr_wr(.ptr(ral.ctrl),
+           .value(ctrl_int ^ 1'b1),
+           .blocking(1));
+    csr_rd(.ptr(ral.ctrl), .value(chk_int), .blocking(1));
+
+    if (ctrl_int != chk_int) begin
+      `uvm_fatal(`gfn, $sformatf(" Was able to overwrite CTRL with REGWEN being set to 0"))
+    end
+
+    csr_rd(.ptr(ral.err_code_test), .value(ctrl_int), .blocking(1));
+    csr_wr(.ptr(ral.err_code_test),
+           .value(ctrl_int ^ 1'b1),
+           .blocking(1));
+    csr_rd(.ptr(ral.err_code_test), .value(chk_int), .blocking(1));
+
+    if (ctrl_int != chk_int) begin
+      `uvm_fatal(`gfn, $sformatf(" Was able to overwrite ERR_CODE_TEST with REGWEN being set to 0"))
+    end
+
+  endtask : body
+
+endclass : csrng_regwen_vseq

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_vseq_list.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_vseq_list.sv
@@ -10,3 +10,4 @@
 `include "csrng_intr_vseq.sv"
 `include "csrng_alert_vseq.sv"
 `include "csrng_err_vseq.sv"
+`include "csrng_regwen_vseq.sv"

--- a/hw/ip/csrng/dv/tests/csrng_regwen_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_regwen_test.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class csrng_regwen_test extends csrng_base_test;
+
+  `uvm_component_utils(csrng_regwen_test)
+  `uvm_component_new
+
+  function void configure_env();
+    super.configure_env();
+
+  endfunction
+endclass : csrng_regwen_test

--- a/hw/ip/csrng/dv/tests/csrng_test.core
+++ b/hw/ip/csrng/dv/tests/csrng_test.core
@@ -16,6 +16,7 @@ filesets:
       - csrng_stress_all_test.sv: {is_include_file: true}
       - csrng_intr_test.sv: {is_include_file: true}
       - csrng_alert_test.sv: {is_include_file: true}
+      - csrng_regwen_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/csrng/dv/tests/csrng_test_pkg.sv
+++ b/hw/ip/csrng/dv/tests/csrng_test_pkg.sv
@@ -19,5 +19,6 @@ package csrng_test_pkg;
   `include "csrng_stress_all_test.sv"
   `include "csrng_intr_test.sv"
   `include "csrng_alert_test.sv"
+  `include "csrng_regwen_test.sv"
 
 endpackage


### PR DESCRIPTION
Add test to verify the following:
  -REGWEN cannot be set back to 1 after being set to 0
  -If REGWEN is not set, the CTRL and ERR_CODE_TEST registers
   cannot be modified

This PR contributes to resolving #16238

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>