### PR TITLE
[draft] [csrng/dv] Exclude AES module from coverage

### DIFF
--- a/hw/ip/csrng/dv/cov/excl_aes.vRefine
+++ b/hw/ip/csrng/dv/cov/excl_aes.vRefine
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    Copyright lowRISC contributors.
+    Licensed under the Apache License, Version 2.0, see LICENSE for details.
+    SPDX-License-Identifier: Apache-2.0
+-->
+<refinement-file-root>
+  <information comment-version="1" creation-time="Mon 14 Nov 2022 14:28:34 GMT" creator="ctopal" csCheck="false" save-ref-method="seq" tool-version="Cadence vManager21.09" rules-signature-c="2c5828d6c83283c1705c1c9ea543761">
+    <ucm-files>
+    </ucm-files>
+    <ccf-files>
+    </ccf-files>
+  </information>
+  <rules>
+    <rule ccType="inst" comment="AES Cipher is verified in its own block level verification framework. Hence, it's excluded from CSRNG block level verification coverage." domain="icc" entityName="csrng/u_csrng_core/u_csrng_block_encrypt/u_aes_cipher_core" entityType="inst" excTime="1668436105" name="exclude" recursiveMetrics="overall" reviewer="ctopal" user="0" vscope="default"></rule>
+  </rules>
+  <cache-map>
+  </cache-map>
+</refinement-file-root>

--- a/hw/ip/csrng/dv/csrng_sim_cfg.hjson
+++ b/hw/ip/csrng/dv/csrng_sim_cfg.hjson
@@ -43,6 +43,8 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  xcelium_cov_refine_files: ["{proj_root}/hw/ip/csrng/dv/cov/excl_aes.vRefine"]
+
   // Update all builds to add options specific to AES C model compilation.
   en_build_modes: ["{tool}_aes_model_build_opts"]
 


### PR DESCRIPTION
DRAFT: This PR will only become relevant if the corresponding exclusion is approved.

The `aes_cipher_core` module that is instantiated within `csrng_block_encrypt` has already been verified at the block level.  As only a limited set of features and code of `aes_cipher_core` are used within CSRNG, its coverage is not representative for CSRNG.  To avoid the hassle of having to maintain UNR rules that depend on AES code within CSRNG, this commit excludes the entire `aes_cipher_core` instance from CSRNG coverage measures.