### PR TITLE
[csrng,dv] Delete predicted genbits after checking them

### DIFF
--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -362,7 +362,6 @@ class csrng_scoreboard extends cip_base_scoreboard #(
                                   bit [18:0] glen,
                                   bit [CSRNG_BUS_WIDTH-1:0] additional_input = 'h0);
 
-    uint                          requested_bits;
     bit [GENBITS_BUS_WIDTH-1:0]   genbits, hw_genbits;
     bit [CTR_LEN-1:0]             inc;
     bit [BLOCK_LEN-1:0]           output_block;
@@ -371,7 +370,6 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     if (additional_input) begin
       ctr_drbg_update(app, additional_input);
     end
-    requested_bits = glen * GENBITS_BUS_WIDTH;
     for (int i = 0; i < glen; i++) begin
       if (CTR_LEN < BLOCK_LEN) begin
         inc = (cfg.v[app][CTR_LEN-1:0] + 1);


### PR DESCRIPTION
The predicted genbits were being deleted for the software app, but not for the two hardware apps, which caused an immediate mismatch on the second generate call. It would compare the newly generated genbits with the old ones, which would not be the same. This fixes the fact that nearly all `csrng_cmds` tests were failing, which is mentioned in: https://github.com/lowRISC/opentitan/issues/15748

In essence, I replicated this line: https://github.com/lowRISC/opentitan/blob/f7274bf22ddc644706b5998207112f859189bb4e/hw/ip/csrng/dv/env/csrng_scoreboard.sv#L226

Also, I removed an unused variable that I came across during my debugging.