### PR TITLE
[top] Audit tests that make use of reset reason

### DIFF
--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -130,9 +130,10 @@ bool test_main(void) {
   } else if (rst_info ==
              (kDifRstmgrResetInfoWatchdog | kDifRstmgrResetInfoLowPowerExit)) {
     LOG_INFO("Booting for the third time due to wdog bite reset during sleep");
+    // Turn off the AON timer hardware completely before exiting.
+    aon_timer_testutils_shutdown(&aon_timer);
+    return true;
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
-  return true;
+  return false;
 }

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -247,12 +247,12 @@ bool test_main(void) {
     execute_test(&aon_timer);
   } else if (rst_info == kDifRstmgrResetInfoEscalation) {
     LOG_INFO("Booting for the second time due to escalation reset");
+
+    // Turn off the AON timer hardware completely before exiting.
+    aon_timer_testutils_shutdown(&aon_timer);
+    return true;
   } else {
     LOG_ERROR("Unexpected rst_info=0x%x", rst_info);
-    return false;
   }
-
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
-  return true;
+  return false;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
@@ -510,12 +510,13 @@ bool test_main(void) {
       break;
     case 6:
       LOG_INFO("Last Booting");
+      // Turn off the AON timer hardware completely before exiting.
+      aon_timer_testutils_shutdown(&aon_timer);
+      return true;
       break;
     default:
       LOG_INFO("Booting for undefined case");
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
-  return true;
+  return false;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -522,12 +522,13 @@ bool test_main(void) {
       break;
     case 6:
       LOG_INFO("Last Booting");
+      // Turn off the AON timer hardware completely before exiting.
+      aon_timer_testutils_shutdown(&aon_timer);
+      return true;
       break;
     default:
       LOG_INFO("Booting for undefined case");
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
-  return true;
+  return false;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
@@ -601,6 +601,10 @@ bool test_main(void) {
     case 5:
       if (RST_IDX[event_idx] % 2) {
         LOG_INFO("Last Booting");
+
+        // Turn off the AON timer hardware completely before exiting.
+        aon_timer_testutils_shutdown(&aon_timer);
+        return true;
       } else {
         LOG_INFO(
             "Booting and running normal sleep followed by escalation reset");
@@ -611,8 +615,5 @@ bool test_main(void) {
     default:
       LOG_INFO("Booting for undefined case");
   }
-
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
-  return true;
+  return false;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
@@ -556,6 +556,10 @@ bool test_main(void) {
     case 5:
       if (RST_IDX[event_idx] % 2) {
         LOG_INFO("Last Booting");
+
+        // Turn off the AON timer hardware completely before exiting.
+        aon_timer_testutils_shutdown(&aon_timer);
+        return true;
       } else {
         LOG_INFO(
             "Booting and running normal sleep followed by escalation reset");
@@ -567,7 +571,5 @@ bool test_main(void) {
       LOG_INFO("Booting for undefined case");
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
-  return true;
+  return false;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
@@ -194,10 +194,12 @@ bool test_main(void) {
   } else if (rst_info == kDifRstmgrResetInfoWatchdog) {
     LOG_INFO("Booting for the third time due to wdog bite reset");
     LOG_INFO("Last Booting");
+    // Turn off the AON timer hardware completely before exiting.
+    aon_timer_testutils_shutdown(&aon_timer);
+    LOG_INFO("Test finish");
+    return true;
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
-  LOG_INFO("Test finish");
-  return true;
+  // Reset reason is also checked above, so this is not strictly necessary.
+  return false;
 }

--- a/sw/device/tests/sim_dv/rv_dm_ndm_reset_req.c
+++ b/sw/device/tests/sim_dv/rv_dm_ndm_reset_req.c
@@ -213,6 +213,7 @@ bool test_main(void) {
     // Register value check after reset.
     LOG_INFO("Check registers");
     check_test_reg();
+    return true;
   }
-  return true;
+  return false;
 }

--- a/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
@@ -385,7 +385,8 @@ bool test_main(void) {
 
     execute_retention_sram_test();
     CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+    return true;
   }
 
-  return true;
+  return false;
 }

--- a/sw/device/tests/sim_dv/sysrst_ctrl_reset_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_reset_test.c
@@ -176,10 +176,11 @@ bool test_main(void) {
     case kTestPhaseFinalCheck:
       CHECK(rstmgr_reset_info ==
             (kDifRstmgrResetInfoSysRstCtrl | kDifRstmgrResetInfoLowPowerExit));
+      return true;
       break;
     default:
       LOG_ERROR("Unexpected test phase : %d", kTestPhase);
       break;
   }
-  return true;
+  return false;
 }


### PR DESCRIPTION
- addresses #13307
- some tests did have actual issues where an undefined reset reason did not cause a failures.
- Other tests did have some kind of mechanism, but it was done before the reset info conditionals and are potentially vulnerable to accidental changes later.

Signed-off-by: Timothy Chen <timothytim@google.com>