### PR TITLE
[ci] Enable remaining RMA variants of JTAG tests

### DIFF
--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -71,6 +71,18 @@ CONST = struct(
     ),
 )
 
+def get_lc_items(*want_lc_values):
+    """Return a list of key-value pairs from CONST.LCV with lowercased keys.
+
+    If `want_lc_values` is empty, returns an unfiltered dict. Otherwise, only
+    key-value pairs where the value is in `want_lc_values` are returned.
+    """
+    lcv_dict = structs.to_dict(CONST.LCV)
+    out = [(k.lower(), v) for k, v in lcv_dict.items() if not want_lc_values or v in want_lc_values]
+    if want_lc_values and len(out) != len(want_lc_values):
+        fail("get_lc_items would produce list with incorrect length")
+    return out
+
 def lc_hw_to_sw(hw_lc_state):
     """Converts any TEST_* LC states to TEST"""
     if hw_lc_state.startswith("TEST_"):

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1848,9 +1848,12 @@ test_suite(
 
 [
     opentitan_gdb_fpga_cw310_test(
-        name = "debug_disallowed_in_prod_fpga_cw310_test_otp_" + otp_name,
+        name = "debug_disallowed_in_prod_fpga_cw310_test_otp_" + lc_state,
         timeout = "short",
-        expect_debug_disallowed = otp_name in ("prod", "prod_end"),
+        expect_debug_disallowed = lc_state_val in [
+            CONST.LCV.PROD,
+            CONST.LCV.PROD_END,
+        ],
         gdb_script = """
             target extended-remote :3333
 
@@ -1865,23 +1868,30 @@ test_suite(
         gdb_script_symlinks = {
             "//sw/device/silicon_creator/rom:rom_fpga_cw310.elf": "rom.elf",
         },
-        rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
+        rom_bitstream = ":rom_otp_{}_exec_disabled".format(lc_state),
         rom_kind = "Rom",
         tags = [
             "cw310_rom",
-            "skip_in_ci",
             "vivado",
-        ],
+        ] + maybe_skip_in_ci(lc_state_val),
     )
-    for otp_name in ("prod", "prod_end", "rma")
+    for lc_state, lc_state_val in get_lc_items(
+        CONST.LCV.PROD,
+        CONST.LCV.PROD_END,
+        CONST.LCV.RMA,
+    )
 ]
 
 test_suite(
     name = "rom_e2e_debug_disallowed_in_prod_tests",
     tags = ["manual"],
     tests = [
-        "debug_disallowed_in_prod_fpga_cw310_test_otp_" + otp_name
-        for otp_name in ("prod", "prod_end", "rma")
+        "debug_disallowed_in_prod_fpga_cw310_test_otp_" + lc_state
+        for lc_state, _ in get_lc_items(
+            CONST.LCV.PROD,
+            CONST.LCV.PROD_END,
+            CONST.LCV.RMA,
+        )
     ],
 )
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1989,9 +1989,6 @@ test_suite(
     tests = ["shutdown_exception_asm_otp_" + otp_name for otp_name in OTP_CFGS_EXEC_DISABLED],
 )
 
-# Dict that also includes an invalid redaction value for test purposes.
-REDACT = structs.to_dict(CONST.SHUTDOWN.REDACT)
-
 # Ensure that the watchdog restarts the ROM even when the bite threshold has
 # been artificially inflated.
 [
@@ -2145,6 +2142,9 @@ test_suite(
 )
 
 # Shutdown Redact Test
+
+# Dict that also includes an invalid redaction value for test purposes.
+REDACT = structs.to_dict(CONST.SHUTDOWN.REDACT)
 
 REDACT.update({"INVALID": 0x0})
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -11,7 +11,7 @@ load(
     "opentitan_functest",
     "verilator_params",
 )
-load("//rules:const.bzl", "CONST", "error_redact", "hex", "lc_hw_to_sw")
+load("//rules:const.bzl", "CONST", "error_redact", "get_lc_items", "hex", "lc_hw_to_sw")
 load(
     "//rules:opentitan.bzl",
     "bin_to_vmem",
@@ -1887,7 +1887,7 @@ test_suite(
 
 [
     opentitan_gdb_fpga_cw310_test(
-        name = "asm_interrupt_handler_fpga_cw310_test_otp_" + otp_name,
+        name = "asm_interrupt_handler_fpga_cw310_test_otp_" + lc_state,
         timeout = "short",
         gdb_script = """
             target extended-remote :3333
@@ -1917,23 +1917,31 @@ test_suite(
         gdb_script_symlinks = {
             "//sw/device/silicon_creator/rom:rom_fpga_cw310.elf": "rom.elf",
         },
-        rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
+        rom_bitstream = ":rom_otp_{}_exec_disabled".format(lc_state),
         rom_kind = "Rom",
         tags = [
             "cw310_rom",
-            "skip_in_ci",
             "vivado",
-        ],
+        ] + maybe_skip_in_ci(lc_state_val),
     )
-    for otp_name in OTP_CFGS_EXEC_DISABLED
+    for lc_state, lc_state_val in get_lc_items(
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.DEV,
+        CONST.LCV.RMA,
+    )
 ]
 
 test_suite(
     name = "rom_e2e_asm_interrupt_handler",
-    tags = [
-        "manual",
+    tags = ["manual"],
+    tests = [
+        "asm_interrupt_handler_fpga_cw310_test_otp_" + lc_state
+        for lc_state, _ in get_lc_items(
+            CONST.LCV.TEST_UNLOCKED0,
+            CONST.LCV.DEV,
+            CONST.LCV.RMA,
+        )
     ],
-    tests = ["asm_interrupt_handler_fpga_cw310_test_otp_" + otp_name for otp_name in OTP_CFGS_EXEC_DISABLED],
 )
 
 [

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1643,13 +1643,6 @@ ALL_OTP_CFGS_EXEC_DISABLED = [
     "prod_end",
 ]
 
-# Names of OTP configs shared by tests that require execution to be disabled.
-OTP_CFGS_EXEC_DISABLED = [
-    "test_unlocked0",
-    "dev",
-    "rma",
-]
-
 # Apply an overlay that disables ROM execution on top of the base OTP configs
 # derived from `ALL_OTP_CFGS_EXEC_DISABLED`.
 [
@@ -1770,21 +1763,25 @@ SRAM_JTAG_INJECTION_GDB_SCRIPT = """
 
 [
     opentitan_gdb_fpga_cw310_test(
-        name = "sram_program_fpga_cw310_test_otp_" + otp_name,
+        name = "sram_program_fpga_cw310_test_otp_" + lc_state,
         timeout = "short",
         exit_success_pattern = "sram_program\\.c:\\d+\\] PC: 0x100020e0, SRAM: \\[0x10000000, 0x10020000\\)",
         gdb_script = SRAM_JTAG_INJECTION_GDB_SCRIPT,
         gdb_script_symlinks = {
             "//sw/device/examples/sram_program:sram_program_fpga_cw310.elf": "sram_program.elf",
         },
-        rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
+        rom_bitstream = ":rom_otp_{}_exec_disabled".format(lc_state),
         rom_kind = "Rom",
         tags = [
             "cw310_rom",
             "vivado",
         ],
     )
-    for otp_name in OTP_CFGS_EXEC_DISABLED
+    for lc_state, _ in get_lc_items(
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.DEV,
+        CONST.LCV.RMA,
+    )
 ]
 
 test_suite(
@@ -1792,7 +1789,14 @@ test_suite(
     tags = [
         "manual",
     ],
-    tests = ["sram_program_fpga_cw310_test_otp_" + otp_name for otp_name in OTP_CFGS_EXEC_DISABLED],
+    tests = [
+        "sram_program_fpga_cw310_test_otp_" + lc_state
+        for lc_state, _ in get_lc_items(
+            CONST.LCV.TEST_UNLOCKED0,
+            CONST.LCV.DEV,
+            CONST.LCV.RMA,
+        )
+    ],
 )
 
 [
@@ -1956,7 +1960,7 @@ test_suite(
 
 [
     opentitan_gdb_fpga_cw310_test(
-        name = "shutdown_exception_asm_otp_" + otp_name,
+        name = "shutdown_exception_asm_otp_" + lc_state,
         timeout = "short",
         gdb_expect_output_sequence = [
             ":::: About to reset.",
@@ -1991,20 +1995,31 @@ test_suite(
         gdb_script_symlinks = {
             "//sw/device/silicon_creator/rom:rom_fpga_cw310.elf": "rom.elf",
         },
-        rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
+        rom_bitstream = ":rom_otp_{}_exec_disabled".format(lc_state),
         rom_kind = "Rom",
         tags = [
             "cw310_rom",
             "vivado",
-        ] + maybe_skip_in_ci(structs.to_dict(CONST.LCV)[otp_name.upper()]),
+        ] + maybe_skip_in_ci(lc_state_val),
     )
-    for otp_name in OTP_CFGS_EXEC_DISABLED
+    for lc_state, lc_state_val in get_lc_items(
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.DEV,
+        CONST.LCV.RMA,
+    )
 ]
 
 test_suite(
     name = "rom_e2e_shutdown_exception_asm",
     tags = ["manual"],
-    tests = ["shutdown_exception_asm_otp_" + otp_name for otp_name in OTP_CFGS_EXEC_DISABLED],
+    tests = [
+        "shutdown_exception_asm_otp_" + lc_state
+        for lc_state, _ in get_lc_items(
+            CONST.LCV.TEST_UNLOCKED0,
+            CONST.LCV.DEV,
+            CONST.LCV.RMA,
+        )
+    ],
 )
 
 # Ensure that the watchdog restarts the ROM even when the bite threshold has
@@ -2871,7 +2886,7 @@ test_suite(
 
 [
     opentitan_gdb_fpga_cw310_test(
-        name = "rom_e2e_debug_test_otp_" + otp_name,
+        name = "rom_e2e_debug_test_otp_" + lc_state,
         timeout = "short",
         exit_success_pattern = "OK!GDB-OK(?s:.*)BFV:0142500d",
         gdb_expect_output_sequence = [
@@ -2992,23 +3007,31 @@ test_suite(
         gdb_script_symlinks = {
             "//sw/device/silicon_creator/rom:rom_fpga_cw310.elf": "rom.elf",
         },
-        rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
+        rom_bitstream = ":rom_otp_{}_exec_disabled".format(lc_state),
         rom_kind = "Rom",
         tags = [
             "cw310_rom",
             "exclusive",
             "vivado",
-        ] + maybe_skip_in_ci(structs.to_dict(CONST.LCV)[otp_name.upper()]),
+        ] + maybe_skip_in_ci(lc_state_val),
     )
-    for otp_name in OTP_CFGS_EXEC_DISABLED
+    for lc_state, lc_state_val in get_lc_items(
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.DEV,
+        CONST.LCV.RMA,
+    )
 ]
 
 test_suite(
     name = "rom_e2e_debug_test",
     tags = ["manual"],
     tests = [
-        "rom_e2e_debug_test_otp_" + otp_name
-        for otp_name in OTP_CFGS_EXEC_DISABLED
+        "rom_e2e_debug_test_otp_" + lc_state
+        for lc_state, _ in get_lc_items(
+            CONST.LCV.TEST_UNLOCKED0,
+            CONST.LCV.DEV,
+            CONST.LCV.RMA,
+        )
     ],
 )
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -2011,7 +2011,7 @@ test_suite(
 # been artificially inflated.
 [
     opentitan_gdb_fpga_cw310_test(
-        name = "rom_e2e_asm_watchdog_bark_fpga_cw310_test_otp_" + otp_name,
+        name = "rom_e2e_asm_watchdog_bark_fpga_cw310_test_otp_" + lc_state,
         timeout = "short",
         gdb_script = """
             target extended-remote :3333
@@ -2071,21 +2071,24 @@ test_suite(
         gdb_script_symlinks = {
             "//sw/device/silicon_creator/rom:rom_fpga_cw310.elf": "rom.elf",
         },
-        rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
+        rom_bitstream = ":rom_otp_{}_exec_disabled".format(lc_state),
         rom_kind = "Rom",
         tags = [
             "cw310_rom",
-            "skip_in_ci",
             "vivado",
-        ],
+        ] + maybe_skip_in_ci(lc_state_val),
     )
-    for otp_name in OTP_CFGS_EXEC_DISABLED
+    for lc_state, lc_state_val in get_lc_items(
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.DEV,
+        CONST.LCV.RMA,
+    )
 ]
 
 # Ensure that the watchdog's bite restarts the ROM.
 [
     opentitan_gdb_fpga_cw310_test(
-        name = "rom_e2e_asm_watchdog_bite_fpga_cw310_test_otp_" + otp_name,
+        name = "rom_e2e_asm_watchdog_bite_fpga_cw310_test_otp_" + lc_state,
         timeout = "short",
         gdb_expect_output_sequence = [
             ":::: Wait for interrupt.",
@@ -2136,15 +2139,18 @@ test_suite(
         gdb_script_symlinks = {
             "//sw/device/silicon_creator/rom:rom_fpga_cw310.elf": "rom.elf",
         },
-        rom_bitstream = ":rom_otp_{}_exec_disabled".format(otp_name),
+        rom_bitstream = ":rom_otp_{}_exec_disabled".format(lc_state),
         rom_kind = "Rom",
         tags = [
             "cw310_rom",
-            "skip_in_ci",
             "vivado",
-        ],
+        ] + maybe_skip_in_ci(lc_state_val),
     )
-    for otp_name in OTP_CFGS_EXEC_DISABLED
+    for lc_state, lc_state_val in get_lc_items(
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.DEV,
+        CONST.LCV.RMA,
+    )
 ]
 
 test_suite(
@@ -2153,8 +2159,12 @@ test_suite(
         "manual",
     ],
     tests = [
-        "rom_e2e_asm_watchdog_" + type + "_fpga_cw310_test_otp_" + otp_name
-        for otp_name in OTP_CFGS_EXEC_DISABLED
+        "rom_e2e_asm_watchdog_" + type + "_fpga_cw310_test_otp_" + lc_state
+        for lc_state, lc_state_val in get_lc_items(
+            CONST.LCV.TEST_UNLOCKED0,
+            CONST.LCV.DEV,
+            CONST.LCV.RMA,
+        )
         for type in ("bite", "bark")
     ],
 )

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1635,32 +1635,23 @@ test_suite(
     ],
 )
 
-ALL_OTP_CFGS_EXEC_DISABLED = [
-    "test_unlocked0",
-    "dev",
-    "rma",
-    "prod",
-    "prod_end",
-]
-
-# Apply an overlay that disables ROM execution on top of the base OTP configs
-# derived from `ALL_OTP_CFGS_EXEC_DISABLED`.
+# Apply an overlay that disables ROM execution on top of the base OTP configs.
 [
     otp_image(
-        name = "img_{}_exec_disabled".format(otp_name),
-        src = "//hw/ip/otp_ctrl/data:otp_json_" + otp_name,
+        name = "img_{}_exec_disabled".format(lc_state),
+        src = "//hw/ip/otp_ctrl/data:otp_json_" + lc_state,
         overlays = STD_OTP_OVERLAYS + ["//hw/ip/otp_ctrl/data:otp_json_exec_disabled"],
         visibility = ["//visibility:private"],
     )
-    for otp_name in ALL_OTP_CFGS_EXEC_DISABLED
+    for lc_state, _ in get_lc_items()
 ]
 
 # Splice each execution-disabled OTP image into the ROM bitstream.
 [
     bitstream_splice(
-        name = "rom_otp_{}_exec_disabled".format(otp_name),
+        name = "rom_otp_{}_exec_disabled".format(lc_state),
         src = "//hw/bitstream:rom",
-        data = "img_{}_exec_disabled".format(otp_name),
+        data = "img_{}_exec_disabled".format(lc_state),
         meminfo = "//hw/bitstream:otp_mmi",
         tags = [
             "manual",
@@ -1669,7 +1660,7 @@ ALL_OTP_CFGS_EXEC_DISABLED = [
         update_usr_access = True,
         visibility = ["//visibility:private"],
     )
-    for otp_name in ALL_OTP_CFGS_EXEC_DISABLED
+    for lc_state, _ in get_lc_items()
 ]
 
 SRAM_JTAG_INJECTION_GDB_SCRIPT = """


### PR DESCRIPTION
This PR enables 4 new JTAG-based tests on CI. I estimate that this should only add ~1 minute of additional CI latency.

cc @mundaym