### PR TITLE
[top, dv] Clean up spi en_monitor

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -431,9 +431,6 @@ class chip_sw_base_vseq extends chip_base_vseq;
       .backdoor(1),
       .spinwait_delay_ns(5000));
 
-    // Enable monitor to check the SPI interface.
-    cfg.m_spi_host_agent_cfg.en_monitor = 1;
-
     read_sw_frames(sw_image, sw_byte_q);
 
     `uvm_create_on(m_spi_host_seq, p_sequencer.spi_host_sequencer_h)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_host_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_host_tx_rx_vseq.sv
@@ -44,10 +44,8 @@ class chip_sw_spi_host_tx_rx_vseq extends chip_sw_base_vseq;
     // enable spi agent
     cfg.chip_vif.enable_spi_device(spi_host_idx, 1);
 
-    // enable spi agent interface to begin
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "spi host configuration complete",
              "Timedout waiting for spi host c configuration.")
-    cfg.m_spi_device_agent_cfgs[spi_host_idx].en_monitor = 1'b1;
 
     // create and start the spi_device sequence
     m_device_seq = spi_device_seq::type_id::create("m_device_seq");

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
@@ -145,8 +145,6 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
 
     super.body();
 
-    // Enable the monitor for the agent connected to spi_host0.
-    cfg.m_spi_device_agent_cfgs[0].en_monitor = 1'b1;
     cfg.m_spi_device_agent_cfgs[0].byte_order = '0;
 
     // Set CSB inactive times to reasonable values. sys_clk is at 24 MHz, and

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -33,15 +33,6 @@ class chip_base_test extends cip_base_test #(
       cfg.clk_freq_mhz = cfg.chip_clock_source;
     end
 
-    // the spi device agents will trigger on any change in csb
-    // and begin looking for transactions.  While this is okay at
-    // block level, it creates problems for top level because
-    // the transition does not necessarily mean anything from
-    // the DUT is driving Csb
-    for (int i = 0; i < chip_common_pkg::NUM_SPI_HOSTS; i++) begin
-      cfg.m_spi_device_agent_cfgs[i].en_monitor = 1'b0;
-    end
-
     // Knob to set the UART baud rate (set to 2M by default).
     void'($value$plusargs("uart_baud_rate=%0d", cfg.uart_baud_rate));
 


### PR DESCRIPTION
Remove [all](https://cs.opensource.google/search?q=spi.*en_monitor&sq=&ss=opentitan%2Fopentitan:hw%2Ftop_earlgrey%2Fdv%2F) the `spi.*en_monitor` in chip-level.

No need to disable the SPI monitor as CSB is assigned to 1 (inactive), when SPI enable is off.

```
  assign spi_device0_if.csb = __enable_spi_device[0] ?
      {'1, dios[top_earlgrey_pkg::DioPadSpiHostCsL]} : '1;
```
Signed-off-by: Weicai Yang <weicai@google.com>