### PR TITLE
[chip,dv,i2c] en_monitor update for top_earlgrey

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_agent_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_agent_cfg.sv
@@ -23,6 +23,8 @@ class dv_base_agent_cfg extends uvm_object;
   // Indicates that the interface is under reset. The derived monitor detects and maintains it.
   bit in_reset;
 
+  bit en_monitor = 1'b1;
+
   `uvm_object_utils_begin(dv_base_agent_cfg)
     `uvm_field_int (is_active,            UVM_DEFAULT)
     `uvm_field_int (en_cov,               UVM_DEFAULT)

--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class i2c_agent_cfg extends dv_base_agent_cfg;
-
-  bit en_monitor = 1'b1; // enable monitor
-
   // this parameters can be set by test to slow down the agent's responses
   int host_latency_cycles = 0;
   int device_latency_cycles = 0;

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -38,6 +38,7 @@ class i2c_monitor extends dv_base_monitor #(
       bit r_bit = 1'b0;
       i2c_item full_item;
       forever begin
+        wait(cfg.en_monitor);
         if (mon_dut_item.stop ||
             (!mon_dut_item.stop && !mon_dut_item.start && !mon_dut_item.rstart)) begin
           cfg.vif.wait_for_host_start(cfg.timing_cfg);
@@ -242,10 +243,14 @@ class i2c_monitor extends dv_base_monitor #(
   virtual task monitor_ready_to_end();
     forever begin
       @(cfg.vif.scl_i or cfg.vif.sda_i or cfg.vif.scl_o or cfg.vif.sda_o);
-      if (cfg.if_mode == Host) begin
-        // TODO: set end condition if necessary
+      if (cfg.en_monitor) begin
+        if (cfg.if_mode == Host) begin
+          // TODO: set end condition if necessary
+        end else begin
+          ok_to_end = (cfg.vif.scl_i == 1'b1) && (cfg.vif.sda_i == 1'b1);
+        end
       end else begin
-        ok_to_end = (cfg.vif.scl_i == 1'b1) && (cfg.vif.sda_i == 1'b1);
+        ok_to_end = 1;
       end
     end
   endtask : monitor_ready_to_end

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -148,6 +148,8 @@ class chip_env extends cip_base_env #(
 
     foreach (m_i2c_agents[i]) begin
       virtual_sequencer.i2c_sequencer_hs[i] = m_i2c_agents[i].sequencer;
+      // Set default monitor enable to zero for shared io agents.
+      cfg.m_i2c_agent_cfgs[i].en_monitor = 1'b0;
     end
 
     if (cfg.is_active && cfg.m_jtag_riscv_agent_cfg.is_active) begin


### PR DESCRIPTION
This PR has following updates to address #16208 :
- Move en_monitor to dv_base_agent_cfg
- Update default value of en_monitor in chip_env
- Apply en_monitor to i2c_monitor

Signed-off-by: Jaedon Kim <jdonjdon@google.com>