### PR TITLE
[rom_e2e,dv] add `sigverify_always` test to DV

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -212,6 +212,91 @@
       run_timeout_mins: 120
     }
     {
+      name: rom_e2e_sigverify_always_a_nothing_b_bad_test_unlocked0
+      // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_test_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_nothing_b_bad_dev
+      // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_dev_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_nothing_b_bad_prod
+      // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_nothing_b_bad_prod_end
+      // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_nothing_b_bad_rma
+      // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
       name: rom_e2e_static_critical
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:1:signed"]
@@ -269,6 +354,11 @@
         "rom_e2e_sigverify_always_a_bad_b_nothing_prod",
         "rom_e2e_sigverify_always_a_bad_b_nothing_prod_end",
         "rom_e2e_sigverify_always_a_bad_b_nothing_rma",
+        "rom_e2e_sigverify_always_a_nothing_b_bad_test_unlocked0",
+        "rom_e2e_sigverify_always_a_nothing_b_bad_dev",
+        "rom_e2e_sigverify_always_a_nothing_b_bad_prod",
+        "rom_e2e_sigverify_always_a_nothing_b_bad_prod_end",
+        "rom_e2e_sigverify_always_a_nothing_b_bad_rma",
       ]
     }
   ]

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -42,6 +42,91 @@
       ]
     }
     {
+      name: rom_e2e_sigverify_always_a_bad_b_bad_test_unlocked0
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_test_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_test_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_bad_b_bad_dev
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_dev_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_dev_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_bad_b_bad_prod
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_bad_b_bad_prod_end
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_bad_b_bad_rma
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
       name: rom_e2e_static_critical
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:1:signed"]
@@ -85,6 +170,16 @@
     {
       name: signed
       tests: ["chip_sw_uart_smoketest_signed"]
+    }
+    {
+      name: rom_e2e_sigverify_always
+      tests: [
+        "rom_e2e_sigverify_always_a_bad_b_bad_test_unlocked0",
+        "rom_e2e_sigverify_always_a_bad_b_bad_dev",
+        "rom_e2e_sigverify_always_a_bad_b_bad_prod",
+        "rom_e2e_sigverify_always_a_bad_b_bad_prod_end",
+        "rom_e2e_sigverify_always_a_bad_b_bad_rma",
+      ]
     }
   ]
 }

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -127,6 +127,91 @@
       run_timeout_mins: 120
     }
     {
+      name: rom_e2e_sigverify_always_a_bad_b_nothing_test_unlocked0
+      // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_test_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_bad_b_nothing_dev
+      // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_dev_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_bad_b_nothing_prod
+      // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_bad_b_nothing_prod_end
+      // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_always_a_bad_b_nothing_rma
+      // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
+      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=50_000_000",
+        "+use_otp_image=OtpTypeCustom",
+        "+bypass_alert_ready_to_end_check=1",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
       name: rom_e2e_static_critical
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:1:signed"]
@@ -158,7 +243,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/silicon_creator/lib/drivers:keymgr_functest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=10000000"]
+      run_opts: ["+sw_test_timeout_ns=10_000_000"]
     }
   ]
 
@@ -179,6 +264,11 @@
         "rom_e2e_sigverify_always_a_bad_b_bad_prod",
         "rom_e2e_sigverify_always_a_bad_b_bad_prod_end",
         "rom_e2e_sigverify_always_a_bad_b_bad_rma",
+        "rom_e2e_sigverify_always_a_bad_b_nothing_test_unlocked0",
+        "rom_e2e_sigverify_always_a_bad_b_nothing_dev",
+        "rom_e2e_sigverify_always_a_bad_b_nothing_prod",
+        "rom_e2e_sigverify_always_a_bad_b_nothing_prod_end",
+        "rom_e2e_sigverify_always_a_bad_b_nothing_rma",
       ]
     }
   ]

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -51,12 +51,12 @@
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=410_000_000",
         "+use_otp_image=OtpTypeCustom",
         "+bypass_alert_ready_to_end_check=1",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 480
     }
     {
       name: rom_e2e_sigverify_always_a_bad_b_bad_dev
@@ -136,12 +136,12 @@
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=410_000_000",
         "+use_otp_image=OtpTypeCustom",
         "+bypass_alert_ready_to_end_check=1",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 480
     }
     {
       name: rom_e2e_sigverify_always_a_bad_b_nothing_dev
@@ -221,12 +221,12 @@
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=410_000_000",
         "+use_otp_image=OtpTypeCustom",
         "+bypass_alert_ready_to_end_check=1",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 480
     }
     {
       name: rom_e2e_sigverify_always_a_nothing_b_bad_dev

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -118,6 +118,7 @@ filesets:
       - seq_lib/chip_padctrl_attributes_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_shutdown_output_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_shutdown_exception_c_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - alerts_if.sv
       - ast_ext_clk_if.sv

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_shutdown_output_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_shutdown_output_vseq.sv
@@ -58,7 +58,8 @@ class chip_sw_rom_e2e_shutdown_output_vseq extends chip_sw_base_vseq;
     cfg.chip_vif.enable_uart(UART0_IDX, 1);
 
     // Wait until we receive the expected boot fault message length of bytes over UART0.
-    `DV_WAIT(uart_tx_data_q.size() == exp_msg.len())
+    `DV_WAIT(uart_tx_data_q.size() == exp_msg.len(),
+      "Timeout waiting for UART FIFO to fill.", 40_000_000)
     `uvm_info(`gfn, "Checking the UART TX data matches expected boot fault msg ...", UVM_LOW)
     foreach (uart_tx_data_q[i]) begin
       `DV_CHECK_EQ(uart_tx_data_q[i], exp_msg[i],

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_shutdown_output_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_shutdown_output_vseq.sv
@@ -59,7 +59,7 @@ class chip_sw_rom_e2e_shutdown_output_vseq extends chip_sw_base_vseq;
 
     // Wait until we receive the expected boot fault message length of bytes over UART0.
     `DV_WAIT(uart_tx_data_q.size() == exp_msg.len(),
-      "Timeout waiting for UART FIFO to fill.", 40_000_000)
+      "Timeout waiting for UART FIFO to fill.", 200_000_000)
     `uvm_info(`gfn, "Checking the UART TX data matches expected boot fault msg ...", UVM_LOW)
     foreach (uart_tx_data_q[i]) begin
       `DV_CHECK_EQ(uart_tx_data_q[i], exp_msg[i],

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq extends
+  chip_sw_rom_e2e_shutdown_output_vseq;
+  `uvm_object_utils(chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq)
+  `uvm_object_new
+
+  lc_ctrl_state_pkg::lc_state_e lc_state;
+
+  // Matches BFV.SIGVERIFY.BAD_ENCODED_MSG in `rules/const.bzl`.
+  string bfv = "01535603";
+
+  // This matches the expected values in `sw/device/silicon_creator/rom/e2e/BUILD`. Note,
+  // SystemVerilog does not support "\r" carriage return in a string literal, so we use the hex code
+  // of "\x0d" instead. Also note, this cannot be a localparam as it turns out, our SV compiler
+  // does not seem to have any knowledge of `lc_state_e` enum at the time when it is processing
+  // localparams.
+  string exp_boot_fault_msgs[lc_ctrl_state_pkg::lc_state_e] = '{
+      lc_ctrl_state_pkg::LcStTestUnlocked0: $sformatf("BFV:%0s\x0d\nLCV:02108421\x0d\n", bfv),
+      lc_ctrl_state_pkg::LcStDev:           $sformatf("BFV:%0s\x0d\nLCV:21084210\x0d\n", bfv),
+      lc_ctrl_state_pkg::LcStProd:          $sformatf("BFV:%0s\x0d\nLCV:2318c631\x0d\n", bfv),
+      lc_ctrl_state_pkg::LcStProdEnd:       $sformatf("BFV:%0s\x0d\nLCV:25294a52\x0d\n", bfv),
+      lc_ctrl_state_pkg::LcStRma:           $sformatf("BFV:%0s\x0d\nLCV:2739ce73\x0d\n", bfv)};
+
+  virtual task check_rom_console_messages();
+    // Wait for SRAM initialization to be done before hooking up the UART agent to prevent
+    // X's propagating as a result of multiple drivers on pins IOC3 and IOC4 (due to DFT strap
+    // sampling in TestUnlocked* and RMA lifecycel states).
+    `DV_WAIT(sram_init_done_event.triggered)
+    lc_state = cfg.mem_bkdr_util_h[Otp].otp_read_lc_partition_state();
+    check_uart_output_msg(exp_boot_fault_msgs[lc_state]);
+  endtask
+
+endclass : chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -79,3 +79,4 @@
 `include "chip_padctrl_attributes_vseq.sv"
 `include "chip_sw_rom_e2e_shutdown_output_vseq.sv"
 `include "chip_sw_rom_e2e_shutdown_exception_c_vseq.sv"
+`include "chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv"

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -662,6 +662,11 @@
         "rom_e2e_sigverify_always_a_bad_b_nothing_prod",
         "rom_e2e_sigverify_always_a_bad_b_nothing_prod_end",
         "rom_e2e_sigverify_always_a_bad_b_nothing_rma",
+        "rom_e2e_sigverify_always_a_nothing_b_bad_test_unlocked0",
+        "rom_e2e_sigverify_always_a_nothing_b_bad_dev",
+        "rom_e2e_sigverify_always_a_nothing_b_bad_prod",
+        "rom_e2e_sigverify_always_a_nothing_b_bad_prod_end",
+        "rom_e2e_sigverify_always_a_nothing_b_bad_rma",
       ]
     }
 

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -651,7 +651,13 @@
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V2
-      tests: []
+      tests: [
+        "rom_e2e_sigverify_always_a_bad_b_bad_test_unlocked0",
+        "rom_e2e_sigverify_always_a_bad_b_bad_dev",
+        "rom_e2e_sigverify_always_a_bad_b_bad_prod",
+        "rom_e2e_sigverify_always_a_bad_b_bad_prod_end",
+        "rom_e2e_sigverify_always_a_bad_b_bad_rma",
+      ]
     }
 
     {

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -657,6 +657,11 @@
         "rom_e2e_sigverify_always_a_bad_b_bad_prod",
         "rom_e2e_sigverify_always_a_bad_b_bad_prod_end",
         "rom_e2e_sigverify_always_a_bad_b_bad_rma",
+        "rom_e2e_sigverify_always_a_bad_b_nothing_test_unlocked0",
+        "rom_e2e_sigverify_always_a_bad_b_nothing_dev",
+        "rom_e2e_sigverify_always_a_bad_b_nothing_prod",
+        "rom_e2e_sigverify_always_a_bad_b_nothing_prod_end",
+        "rom_e2e_sigverify_always_a_bad_b_nothing_rma",
       ]
     }
 


### PR DESCRIPTION
This PR adds the  ROM E2E `sigverify_always` test to DV. To reduce test runtime, this test is split into several individual tests that test different slot image and LC state configurations, since in each LC state, ROM may attempt to do two signature verifications (in the worst case, when both slots contain a corrupted image) before boot faulting.

This partially addresses #14634.