### PR TITLE
[rdc] USBDEV wakeup req

### DIFF
--- a/hw/top_earlgrey/rdc/rdc_waivers.tcl
+++ b/hw/top_earlgrey/rdc/rdc_waivers.tcl
@@ -31,3 +31,11 @@ set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
   -expression {(FromScenario=="RstMgrSwRst") && \
     (ResetFlop=~"*.u_reg_if.outstanding_q")} \
   -comment {RstMgrSwRst scenario: Xbar should not have any outstanding req.}
+
+# USBDEV Wake up to PINMUX
+set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
+  -expression {(ResetFlop=~"*.u_usbdev.u_reg.u_wake_control_cdc.u_src_to_dst_req.dst_level_q") && \
+    (MetaStableFlop=~"*.u_pinmux_aon.u_usbdev_aon_wake.wake_detect_active_q")} \
+  -comment {Suspend request signal is a pulse signal. \
+    It is to initiate the wakeup detector FSM inside pinmux. \
+    When Power is down, the state machine is already configures.}


### PR DESCRIPTION
USBDEV has WAKE_CONTROL CSR to initiate the wake up detector inside usbdev_aon_wake module (inside pinmux). The CSR is write-only. When the main power is off, the USBDEV CSR is being reset. The wakeup module inside the pinmux IP directly uses the signal, which creates the metastability issue.

However, the signal is not active when the power becomes off. The error can be waived.

On the other hand, there is a lurking bug in the module, the metastability may be ignored, but the reset may introduce the discrepancy between the USBDEV and the pinmux as the reset only clears the USBDEV IP.