### PR TITLE
[test-triage] rom_keymgr_functest

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -282,6 +282,7 @@ opentitan_functest(
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing:otp_ctrl_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",


### PR DESCRIPTION
I think this should fix #16060 (tested with dvsim). The failure was due to timeout, because flash_ctr is raising fatal error after the test writes flash secrets.

This fix follows the changes from #15776.