### PR TITLE
[rdc] USBDEV waiver for SW RST REQ scn

### DIFF
--- a/hw/top_earlgrey/rdc/rdc_waivers.tcl
+++ b/hw/top_earlgrey/rdc/rdc_waivers.tcl
@@ -39,3 +39,12 @@ set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
   -comment {Suspend request signal is a pulse signal. \
     It is to initiate the wakeup detector FSM inside pinmux. \
     When Power is down, the state machine is already configures.}
+
+# USBDEV SW RST REQ: All reset are in phase (sync assert, sync de-assert)
+set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
+  -expression {(FromScenario=="RstMgrSwRst") && \
+    (ResetFlop=~"*.u_usbdev.gen_no_stubbed_*") && \
+    (MetaStableFlop=~"*.u_xbar_main.u_ast_41.*.fifo_*ptr*") && \
+    (ClockDomains=="USB_CLK::USB_CLK")} \
+  -comment {SW Reset is sync assert and sync de-asser. \
+    So, when signal crossing the domain, it has no metastability issue.}


### PR DESCRIPTION

In SW reset request scenario, the reset signal is asserted and
de-asserted synchronized to the clock. In this case, any metastability
issue won't occur if the source signal and the end signal are in the
same clock domain.

This commit waives the errors.