### PR TITLE
[pwrmgr] Identify power glitch reset issues

### DIFF
--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -312,8 +312,11 @@ module pwrmgr
   // to silence the reset, this gives us one potential back-up path through alert_handler.
   // Allow capture of main_pd fault status whenever the system is live.
   assign hw2reg.fault_status.main_pd_glitch.de  = pwr_clk_o.main_ip_clk_en;
-  assign hw2reg.fault_status.main_pd_glitch.d   = peri_reqs_masked.rstreqs[ResetMainPwrIdx];
+  assign hw2reg.fault_status.main_pd_glitch.d   = peri_reqs_masked.rstreqs[ResetMainPwrIdx] |
+                                                  reg2hw.fault_status.main_pd_glitch.q;
 
+  `ASSERT(GlitchStatusPersist_A, $rose(reg2hw.fault_status.main_pd_glitch.q) |->
+          reg2hw.fault_status.main_pd_glitch.q until !rst_lc_ni)
 
   ////////////////////////////
   ///  alerts

--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -459,7 +459,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
 
       FastPwrStateResetWait: begin
         rst_lc_req_d = {PowerDomains{1'b1}};
-        clr_slow_req_o = 1'b1;
+        clr_slow_req_o = reset_reqs_i[ResetMainPwrIdx];
         // The main power reset request is checked here specifically because it is
         // the only reset request in the system that operates on the POR domain.
         // This has to be the case since it would otherwise not be able to monitor


### PR DESCRIPTION
Two issues were identified

1. The fault status would self clear without reset
2. the fault status and reset request could get out of sync

This commit fixes the issue above by only clearing the reset request if one is actually observed.

Signed-off-by: Timothy Chen <timothytim@google.com>