### PR TITLE
[dv,dvsim] fix DV testbench / dvsim to accomodate ROM E2E tests

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -123,7 +123,8 @@ ifneq (${sw_images},)
 						--output=starlark \
 						--starlark:expr="\"\\n\".join([f.path for f in target.files.to_list()])"); do \
 						cp -f $${artifact} $${run_dir}/$$(basename $${artifact}); \
-						if [[ $$artifact == *.scr.vmem ]]; then \
+						if [[ $$artifact == *.scr.vmem && \
+							-f "$$(echo $${artifact} | cut -d. -f 1).elf" ]]; then \
 							cp -f "$$(echo $${artifact} | cut -d. -f 1).elf" \
 								$${run_dir}/$$(basename "$${artifact%.*.scr.vmem}.elf"); \
 						fi; \

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -46,7 +46,12 @@ class chip_sw_base_vseq extends chip_base_vseq;
     // Initialize the sw logger interface.
     foreach (cfg.sw_images[i]) begin
       if (i inside {SwTypeRom, SwTypeTestSlotA, SwTypeTestSlotB}) begin
-        cfg.sw_logger_vif.add_sw_log_db(cfg.sw_images[i]);
+        if ("no_sw_log_db" inside {cfg.sw_image_flags[i]}) begin
+          `uvm_info(`gfn, $sformatf("Skipping loading SW logging DB for: %0s", cfg.sw_images[i]),
+            UVM_MEDIUM);
+        end else begin
+          cfg.sw_logger_vif.add_sw_log_db(cfg.sw_images[i]);
+        end
       end
     end
     cfg.sw_logger_vif.sw_log_addr = SW_DV_LOG_ADDR;


### PR DESCRIPTION
This PR contains two commits that:

1. Updates the dvsim `sim.mk` file to only copy over an ELF file to the run_dir if one exists. ELF files are loaded in DV to allow backdoor reading/writing SW symbols. But in some cases, we do not need to load an ELF, i.e., if we are testing a corrupted flash image (e.g., the `boot_policy_valid` and `sigverify_always` tests corrupt BIN/VMEM files directly, so there is no ELF to load).

2. Adds a `sw_images` flag to instruct the testbench to skip loading the SW logger database files. The `boot_policy_valid` and `sigverify_always` ROM E2E tests load corrupted images into flash. Such images do not have SW logging database files generated, as they are not generated via the traditional `opentitan_flash_binary` Bazel macros. This adds a flag to allow intentionally skipping loading said files into the testbench.

This unblocks #14634.