### PR TITLE
[ci] increase airgapped build check timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,6 +140,7 @@ jobs:
 
 - job: airgapped_bazel_build
   displayName: Test an airgapped Bazel build
+  timeoutInMinutes: 90
   dependsOn: checkout
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:


### PR DESCRIPTION
The airgapped build check seems to occasionally timeout in CI as we are building more artifacts in `sw/device/silicon_creator/` now. This increases the timeout from 60 min to 90 min.

Signed-off-by: Timothy Trippel <ttrippel@google.com>