### PR TITLE
[dv] continue sim even if SW logs database files are missing

### DIFF
--- a/hw/dv/sv/sw_logger_if/sw_logger_if.sv
+++ b/hw/dv/sv/sw_logger_if/sw_logger_if.sv
@@ -154,7 +154,8 @@ interface sw_logger_if #(
       int fd;
       fd = $fopen(sw_log_db_files[sw], "r");
       if (!fd) begin
-        `dv_fatal($sformatf("Failed to open sw log db file %s.", sw_log_db_files[sw]))
+        `dv_info($sformatf("Failed to open sw log db file %s.", sw_log_db_files[sw]))
+        return 1'b0;
       end
 
       while (!$feof(fd)) begin

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -45,8 +45,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_test_unlocked0
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_test_key_0:no_sw_log_db",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_test_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_test_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -62,8 +62,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_dev
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_dev_key_0:no_sw_log_db",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_dev_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_dev_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_dev_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -79,8 +79,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_prod
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -96,8 +96,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_prod_end
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -113,8 +113,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_rma
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -131,7 +131,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_test_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_test_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -148,7 +148,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_dev_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_dev_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -165,7 +165,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -182,7 +182,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -199,7 +199,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -216,7 +216,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_test_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_test_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -233,7 +233,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_dev_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_dev_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -250,7 +250,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -267,7 +267,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -284,7 +284,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0:no_sw_log_db",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -46,12 +46,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     // Initialize the sw logger interface.
     foreach (cfg.sw_images[i]) begin
       if (i inside {SwTypeRom, SwTypeTestSlotA, SwTypeTestSlotB}) begin
-        if ("no_sw_log_db" inside {cfg.sw_image_flags[i]}) begin
-          `uvm_info(`gfn, $sformatf("Skipping loading SW logging DB for: %0s", cfg.sw_images[i]),
-            UVM_MEDIUM);
-        end else begin
-          cfg.sw_logger_vif.add_sw_log_db(cfg.sw_images[i]);
-        end
+        cfg.sw_logger_vif.add_sw_log_db(cfg.sw_images[i]);
       end
     end
     cfg.sw_logger_vif.sw_log_addr = SW_DV_LOG_ADDR;


### PR DESCRIPTION
Some ROM E2E tests load corrupted software images that have no SW logging database files. This simplifies the testbench to not crash if these files are not present. Additionally, this removes the need to add the "no_sw_logs_db" flag to such images in the dvsim config file.

This addresses review feedback in #16335.

Signed-off-by: Timothy Trippel <ttrippel@google.com>