### PR TITLE
[ci, test] Speculative fixes for flaky FPGA failures

### DIFF
--- a/rules/opentitan_gdb_test.bzl
+++ b/rules/opentitan_gdb_test.bzl
@@ -149,7 +149,16 @@ def _opentitan_gdb_fpga_cw310_test_impl(ctx):
     if ctx.attr.opentitantool_cw310_uarts != "":
         test_script += " " + ctx.attr.opentitantool_cw310_uarts
 
-    gdb_script_content = "target extended-remote :3333\n" + ctx.attr.gdb_script
+    gdb_script_prefix = """
+        target extended-remote :3333
+
+        echo :::: Flip dmcontrol.ndmreset off, on, and off again.\\n
+        monitor riscv dmi_write 0x10 0x80000001
+        monitor riscv dmi_write 0x10 0x80000003
+        monitor riscv dmi_write 0x10 0x80000001
+    """
+
+    gdb_script_content = gdb_script_prefix + ctx.attr.gdb_script
     ctx.actions.write(output = gdb_script_file, content = gdb_script_content)
     ctx.actions.write(output = ctx.outputs.executable, content = test_script)
 

--- a/rules/opentitan_gdb_test.bzl
+++ b/rules/opentitan_gdb_test.bzl
@@ -149,7 +149,8 @@ def _opentitan_gdb_fpga_cw310_test_impl(ctx):
     if ctx.attr.opentitantool_cw310_uarts != "":
         test_script += " " + ctx.attr.opentitantool_cw310_uarts
 
-    ctx.actions.write(output = gdb_script_file, content = ctx.attr.gdb_script)
+    gdb_script_content = "target extended-remote :3333\n" + ctx.attr.gdb_script
+    ctx.actions.write(output = gdb_script_file, content = gdb_script_content)
     ctx.actions.write(output = ctx.outputs.executable, content = test_script)
 
     # Construct a dict that we can pass to `ctx.runfiles()`, mapping symlink

--- a/rules/scripts/gdb_test_coordinator.py
+++ b/rules/scripts/gdb_test_coordinator.py
@@ -174,6 +174,11 @@ def main(rom_kind: str = typer.Option(...),
         ]),
         "-f",
         openocd_earlgrey_config,
+        "-c",
+        "; ".join([
+            "init",
+            "reset halt",
+        ])
     ]
     gdb_command = [
         # For debugging, it may be useful to use `--init-command`, which causes

--- a/rules/scripts/gdb_test_coordinator.py
+++ b/rules/scripts/gdb_test_coordinator.py
@@ -177,7 +177,7 @@ def main(rom_kind: str = typer.Option(...),
         "-c",
         "; ".join([
             "init",
-            "reset halt",
+            "reset init",
         ])
     ]
     gdb_command = [

--- a/rules/scripts/gdb_test_coordinator.py
+++ b/rules/scripts/gdb_test_coordinator.py
@@ -177,6 +177,7 @@ def main(rom_kind: str = typer.Option(...),
         "-c",
         "; ".join([
             "init",
+            "adapter deassert srst",
             "reset init",
         ])
     ]

--- a/rules/scripts/gdb_test_coordinator.py
+++ b/rules/scripts/gdb_test_coordinator.py
@@ -178,7 +178,7 @@ def main(rom_kind: str = typer.Option(...),
         "; ".join([
             "init",
             "adapter deassert srst",
-            "reset init",
+            "reset halt",
         ])
     ]
     gdb_command = [

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1680,12 +1680,6 @@ OTP_CFGS_EXEC_DISABLED = [
 ]
 
 SRAM_JTAG_INJECTION_GDB_SCRIPT = """
-        target extended-remote :3333
-
-        echo :::: Send OpenOCD the 'reset halt' command.\\n
-        monitor reset halt
-
-
         # Mitigate flakiness from the watchdog timer. Prior to connecting
         # OpenOCD and GDB, the device is executing normally. The ROM has
         # probably already started up and configured the watchdog timer. This is
@@ -1852,11 +1846,6 @@ test_suite(
         timeout = "short",
         expect_debug_disallowed = otp_name in ("prod", "prod_end"),
         gdb_script = """
-            target extended-remote :3333
-
-            echo :::: Send OpenOCD the 'reset halt' command.\\n
-            monitor reset halt
-
             echo :::: Load ROM symbols into GDB.\\n
             file rom.elf
 
@@ -1890,11 +1879,6 @@ test_suite(
         name = "asm_interrupt_handler_fpga_cw310_test_otp_" + otp_name,
         timeout = "short",
         gdb_script = """
-            target extended-remote :3333
-
-            echo :::: Send OpenOCD the 'reset halt' command.\\n
-            monitor reset halt
-
             echo :::: Load ROM symbols into GDB.\\n
             file rom.elf
 
@@ -1945,11 +1929,6 @@ test_suite(
             "unable to resume hart 0",
         ],
         gdb_script = """
-            target extended-remote :3333
-
-            echo :::: Send OpenOCD the 'reset halt' command.\\n
-            monitor reset halt
-
             echo :::: Load ROM symbols into GDB.\\n
             file rom.elf
 
@@ -1999,11 +1978,6 @@ REDACT = structs.to_dict(CONST.SHUTDOWN.REDACT)
         name = "rom_e2e_asm_watchdog_bark_fpga_cw310_test_otp_" + otp_name,
         timeout = "short",
         gdb_script = """
-            target extended-remote :3333
-
-            echo :::: Send OpenOCD the 'reset halt' command.\\n
-            monitor reset halt
-
             echo :::: Load ROM symbols into GDB.\\n
             file rom.elf
 
@@ -2077,11 +2051,6 @@ REDACT = structs.to_dict(CONST.SHUTDOWN.REDACT)
             "Hart 0 unexpectedly reset!",
         ],
         gdb_script = """
-            target extended-remote :3333
-
-            echo :::: Send OpenOCD the 'reset halt' command.\\n
-            monitor reset halt
-
             echo :::: Load ROM symbols into GDB.\\n
             file rom.elf
 
@@ -2857,11 +2826,6 @@ test_suite(
                     quit 1
                 end
             end
-
-            target extended-remote :3333
-
-            echo :::: Send OpenOCD the 'reset halt' command.\\n
-            monitor reset halt
 
             echo :::: Load ROM symbols into GDB.\\n
             file rom.elf


### PR DESCRIPTION
We observed two kinds of flaky FPGA failures that seemed to coincide with the addition of two new FPGA boards.

* JTAG tests fail with `[OPENOCD] Error: riscv.tap: IR capture error; saw 0x1f not 0x01`. [Example](https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=102260&view=logs&j=421a2038-410f-5c10-767f-4482292362ca&t=fe805732-5e37-5249-8636-c69eaa5ddf8e&l=9219).
* CW310 functests (and probably JTAG tests, too) fail with `[2022-11-15T06:40:27Z INFO  opentitantool] Command result: SFDP header contains incorrect signature: 0xffffffff`. [Example](https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=102379&view=logs&j=f83f7932-3bfb-5c11-a975-dd0ec4661e3b&s=b15d9194-8f26-5328-b47f-5968c76b37e7&t=61409ac2-879f-5842-13d9-79a0f9ad6ec8&l=13618).

I haven't been able to reproduce these failures on my local machine despite running JTAG tests upwards of 100 times, so I guess it's time for speculative fixes.