### PR TITLE
[rdc] Power OK and USBDEV Waivers

### DIFF
--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -53,6 +53,7 @@ set_reset_scenario { \
   { top_earlgrey.clkmgr_aon_clocks.clk_io_div2_peri    { constraint { @t0 0 } } } \
   { top_earlgrey.clkmgr_aon_clocks.clk_io_peri         { constraint { @t0 0 } } } \
   { top_earlgrey.clkmgr_aon_clocks.clk_usb_peri        { constraint { @t0 0 } } } \
+  { top_earlgrey.pwrmgr_aon_low_power                  { constraint { @t0 1 } } } \
 } -name ScnAonPOK
 
 # AST Regulator Resets
@@ -83,6 +84,7 @@ set_reset_scenario { \
   { top_earlgrey.clkmgr_aon_clocks.clk_io_div2_peri    { constraint { @t0 0 } } } \
   { top_earlgrey.clkmgr_aon_clocks.clk_io_peri         { constraint { @t0 0 } } } \
   { top_earlgrey.clkmgr_aon_clocks.clk_usb_peri        { constraint { @t0 0 } } } \
+  { top_earlgrey.pwrmgr_aon_low_power                  { constraint { @t0 1 } } } \
 } -name ScnMainPok
 
 #set_reset_scenario { \

--- a/hw/top_earlgrey/rdc/rdc_waivers.tcl
+++ b/hw/top_earlgrey/rdc/rdc_waivers.tcl
@@ -48,3 +48,13 @@ set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
     (ClockDomains=="USB_CLK::USB_CLK")} \
   -comment {SW Reset is sync assert and sync de-assert. \
     So, when signal crossing the domain, it has no metastability issue.}
+
+# USBDEV, CSR to PAD
+set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
+  -expression {(ResetFlop=~"*.u_usbdev.u_reg.u_phy_pins_drive_d*_o.q*") && \
+    (MetaStableFlop=~"USB_*")} \
+  -comment {For AonPok, MainPok drop cases, the module floats the PAD \
+  intentionally. If the PADs should drive values, the values are \
+  pre-configured before entering to the low power modes. \
+  For SW_RST_REQ cases, SW should correctly configure the pull-ups, \
+  pull-downs prior to resetting the USBDEV IP.}


### PR DESCRIPTION
When AonPok or MainPok drops (intentionally), the power manager already
moved to the Low Power state. This commit adds that conditon to the
reset scenarios.

----

For AonPok, MainPok drop cases, the module floats the PAD intentionally. If the PADs should drive values, the values are pre-configured before entering to the low power modes.

For SW_RST_REQ cases, SW should correctly configure the pull-ups, pull-downs prior to resetting the USBDEV IP.