### PR TITLE
[dv/alert_esc_agent] Temp fix to support pwrmgr with multi-reset

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -47,6 +47,8 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   int unsigned handshake_timeout_cycle = 100_000;
   int unsigned ping_timeout_cycle = 32;
 
+  bit under_reset;
+
   `uvm_object_utils_begin(alert_esc_agent_cfg)
     `uvm_field_int(alert_delay_min, UVM_DEFAULT)
     `uvm_field_int(alert_delay_max, UVM_DEFAULT)

--- a/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
@@ -36,10 +36,14 @@ class alert_esc_base_monitor extends dv_base_monitor #(
     forever begin
       @(negedge cfg.vif.rst_n);
       under_reset = 1;
+      // TODO: this is a temp fix to support pwrmgr with multi-resets. Further improvement in
+      // #16374.
+      cfg.under_reset = 1;
       @(posedge cfg.vif.rst_n);
       // reset signals at posedge rst_n to avoid race condition at negedge rst_n
       reset_signals();
       under_reset = 0;
+      cfg.under_reset = 0;
     end
   endtask : reset_thread
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -980,7 +980,8 @@ class cip_base_vseq #(
                 ack_seq.start(p_sequencer.alert_esc_sequencer_h[alert_name]);
               end
               begin
-                wait(!en_auto_alerts_response || cfg.under_reset);
+                // TODO: issue #16374.
+                wait(!en_auto_alerts_response || cfg.m_alert_agent_cfg[alert_name].under_reset);
                 cfg.m_alert_agent_cfg[alert_name].vif.wait_ack_complete();
               end
             join_any


### PR DESCRIPTION
This PR temp fix alert firing issue in pwrmgr where cip_base_vseq and alert_esc_agent have different clk and reset.
The better way to solve this is documented in issue #16374.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>