### PR TITLE
[rom_e2e] test `asm_init` in multiple LC states

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -415,39 +415,66 @@ opentitan_functest(
     test_harness = "//sw/host/tests/rom/e2e_bootstrap_disabled",
 )
 
-opentitan_functest(
-    name = "e2e_chip_specific_startup",
-    srcs = ["chip_specific_startup.c"],
-    args = [],
-    cw310 = cw310_params(
-        test_cmds = [
-            "--rom-kind=rom",
-            "--bitstream=\"$(location //hw/bitstream:rom)\"",
-            "--bootstrap=\"$(location {flash})\"",
-            "--otp-unprogrammed",
+[
+    bitstream_splice(
+        name = "bitstream_chip_specific_startup_{}".format(lc_state.lower()),
+        src = "//hw/bitstream:rom",
+        data = ":otp_img_e2e_bootstrap_entry_{}".format(lc_state.lower()),
+        meminfo = "//hw/bitstream:otp_mmi",
+        tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
+        update_usr_access = True,
+    )
+    for lc_state, lc_state_val in get_lc_items()
+]
+
+[
+    opentitan_functest(
+        name = "e2e_chip_specific_startup_{}".format(lc_state.lower()),
+        srcs = ["chip_specific_startup.c"],
+        args = [],
+        cw310 = cw310_params(
+            bitstream = ":bitstream_chip_specific_startup_{}".format(lc_state.lower()),
+            otp = ":otp_img_e2e_bootstrap_entry_{}".format(lc_state.lower()),
+            tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
+            test_cmds = [
+                "--rom-kind=rom",
+                "--bitstream=\"$(location //sw/device/silicon_creator/rom/e2e:bitstream_chip_specific_startup_{})\"".format(lc_state.lower()),
+                "--bootstrap=\"$(location {flash})\"",
+                "--otp-unprogrammed",
+            ],
+        ),
+        signed = True,
+        targets = ["cw310_rom"],
+        test_harness = "//sw/host/tests/rom/e2e_chip_specific_startup",
+        deps = [
+            "//hw/ip/csrng/data:csrng_regs",
+            "//hw/ip/edn/data:edn_regs",
+            "//hw/ip/entropy_src/data:entropy_src_regs",
+            "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+            "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/base:mmio",
+            "//sw/device/lib/dif:clkmgr",
+            "//sw/device/lib/dif:lc_ctrl",
+            "//sw/device/lib/dif:otp_ctrl",
+            "//sw/device/lib/dif:sram_ctrl",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing/json:chip_specific_startup",
+            "//sw/device/lib/testing/json:command",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/lib/testing/test_framework:ujson_ottf",
+            "//sw/device/lib/ujson",
         ],
-    ),
-    signed = True,
-    targets = ["cw310_rom"],
-    test_harness = "//sw/host/tests/rom/e2e_chip_specific_startup",
-    deps = [
-        "//hw/ip/csrng/data:csrng_regs",
-        "//hw/ip/edn/data:edn_regs",
-        "//hw/ip/entropy_src/data:entropy_src_regs",
-        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
-        "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:mmio",
-        "//sw/device/lib/dif:clkmgr",
-        "//sw/device/lib/dif:lc_ctrl",
-        "//sw/device/lib/dif:otp_ctrl",
-        "//sw/device/lib/dif:sram_ctrl",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing/json:chip_specific_startup",
-        "//sw/device/lib/testing/json:command",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/lib/testing/test_framework:ujson_ottf",
-        "//sw/device/lib/ujson",
+    )
+    for lc_state, lc_state_val in get_lc_items()
+]
+
+test_suite(
+    name = "e2e_chip_specific_startup",
+    tags = ["manual"],
+    tests = [
+        "e2e_chip_specific_startup_{}".format(lc_state)
+        for lc_state, _ in get_lc_items()
     ],
 )
 


### PR DESCRIPTION
This prior `rom_e2e_ast_init` test (named `e2e_chip_specific_startup` in the BUILD file) only ran in the default LC state (RMA). This runs the test in all LC states required by the test plan description.

Signed-off-by: Timothy Trippel <ttrippel@google.com>