### PR TITLE
[dv] adjust milestone labels for ROM E2E and coremark tests

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -3254,7 +3254,7 @@
     {
       name: chip_sw_coremark
       desc: '''Run the coremark benchmark on the full chip.'''
-      stage: V2
+      stage: V3
       tests: ["chip_sw_coremark"]
     }
     {

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -822,8 +822,8 @@
                 - Executing code from GDB (using the call command)
               - Verify that ROM fails to boot with `BFV:0142500d`.
             '''
-      tags: ["rom", "no_dv", "fpga", "silicon"]
-      stage: V2
+      tags: ["rom", "dv", "verilator", "fpga", "silicon"]
+      stage: V3
       tests: []
     }
 
@@ -858,7 +858,7 @@
             for detils.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
-      stage: V2
+      stage: V3
       tests: []
     }
 


### PR DESCRIPTION
This updates the milestone labels in the DV dashboard for the following tests (based on our offline discussions this week):

- rom_e2e_jtag_inject
- rom_e2e_debug
- chip_sw_coremark

Signed-off-by: Timothy Trippel <ttrippel@google.com>