### PR TITLE
Revert "[csrng] Temporarily hack-in disable handling"

### DIFF
--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -401,12 +401,6 @@ module csrng_cmd_stage import csrng_pkg::*; #(
         cmd_stage_sm_err_o = 1'b1;
       end
     endcase // unique case (state_q)
-
-    // if disable, cycle back to Idle
-    if (!cs_enable_i && state_q != Idle) begin
-      state_d = Idle;
-    end
-
   end
 
   //---------------------------------------------------------


### PR DESCRIPTION
The reverted commit was originally introduced as part of lowRISC/OpenTitan#14410 to work around a temporary issue until lowRISC/OpenTitan#14534 got merged. It seems we forgot to remove that temporary workaround before merging the PR.

The workaround is critical because it weakens a security countermeasure inside CSRNG: errors injected into the command stage FSMs are no longer fatal. By disabling and re-enabling the module these FSMs can be made to leave the "terminal" error state.

For this reason, we need to remove this workaround. This reverts commit f4df12fa7e2bc1f4249ae21e94e258ad00aa9756.