### PR TITLE
[test] Do an SRAM read check upon local escalation

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -392,7 +392,7 @@
       sw_images: ["//sw/device/tests/sim_dv:all_escalation_resets_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
-      reseed: 60
+      reseed: 100
     }
     {
       name: chip_sw_data_integrity_escalation


### PR DESCRIPTION
This adds a check to the all_escalation_resets_test that makes sure that the retention SRAM cannot be accessed anymore after it has escalated locally.

This restructures the escalation phases similarly to #16107 in order to allow regular ISRs to execute before triggering an NMI. In addition, the alert class used in this test is chosen at random.

Addresses the remaining part of #15970.

Signed-off-by: Michael Schaffner <msf@google.com>