### PR TITLE
[chip dv] Implement 2 rv_dm tests

### DIFF
--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -185,7 +185,7 @@ package csr_utils_pkg;
                             input bit            en_shadow_wr = 1);
     fork
       begin : isolation_fork
-        string        msg_id = {csr_utils_pkg::msg_id, "::csr_wr"};
+        string msg_id = {csr_utils_pkg::msg_id, "::csr_wr"};
 
         fork
           begin
@@ -326,9 +326,9 @@ package csr_utils_pkg;
                             input  uint           timeout_ns = default_timeout_ns,
                             input  uvm_reg_map    map = null);
     if (backdoor) begin
-        csr_peek(ptr, value, check);
-        status = UVM_IS_OK;
-        return;
+      csr_peek(ptr, value, check);
+      status = UVM_IS_OK;
+      return;
     end
     fork
       begin : isolation_fork
@@ -416,6 +416,7 @@ package csr_utils_pkg;
             uvm_status_e    status;
             uvm_reg_data_t  obs;
             uvm_reg_data_t  exp;
+            uvm_reg_data_t  reset_val;
             string          msg_id = {csr_utils_pkg::msg_id, "::csr_rd_check"};
 
             csr_or_fld = decode_csr_or_field(ptr);
@@ -426,14 +427,17 @@ package csr_utils_pkg;
             // get mirrored value after read to make sure the read reg access is updated
             if (csr_or_fld.field != null) begin
               exp = csr_or_fld.field.get_mirrored_value();
+              reset_val = csr_or_fld.field.get_reset();
             end else begin
               exp = csr_or_fld.csr.get_mirrored_value();
+              reset_val = csr_or_fld.csr.get_reset();
             end
             if (compare && status == UVM_IS_OK && !under_reset) begin
               obs = obs & compare_mask;
               exp = (compare_vs_ral ? exp : compare_value) & compare_mask;
-              `DV_CHECK_EQ(obs, exp, {"Regname: ", ptr.get_full_name(), " ", err_msg},
-                    error, msg_id)
+              `DV_CHECK_EQ(obs, exp, $sformatf("Regname: %0s reset value: 0x%0h %0s",
+                                               ptr.get_full_name(), reset_val, err_msg),
+                           error, msg_id)
             end
           end
         join_none

--- a/hw/dv/sv/sw_test_status/sw_test_status_if.sv
+++ b/hw/dv/sv/sw_test_status/sw_test_status_if.sv
@@ -6,6 +6,8 @@ interface sw_test_status_if #(
   parameter int AddrWidth = 32
 ) (
   input logic clk_i,
+  input logic rst_ni,               // Under reset.
+  input logic fetch_en,             // Fetch enabled.
   input logic wr_valid,             // Qualified write access.
   input logic [AddrWidth-1:0] addr, // Incoming addr.
   input logic [15:0] data           // Incoming data.
@@ -42,7 +44,15 @@ interface sw_test_status_if #(
   endfunction
 
   always @(posedge clk_i) begin
-    if (data_valid) begin
+    if (!rst_ni) begin
+      sw_test_status_prev = sw_test_status;
+      sw_test_status = SwTestStatusUnderReset;
+    end
+    else if (sw_test_status == SwTestStatusUnderReset && fetch_en) begin
+      sw_test_status_prev = sw_test_status;
+      sw_test_status = SwTestStatusBooted;
+    end
+    else if (data_valid) begin
       sw_test_status_prev = sw_test_status;
       sw_test_status = sw_test_status_e'(data);
 

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -629,7 +629,7 @@
               reset phase of the test.
             '''
       stage: V2
-      tests: []
+      tests: ["chip_sw_rv_dm_ndm_reset_req_when_cpu_halted"]
     }
     {
       name: chip_rv_dm_access_after_wakeup

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -651,7 +651,7 @@
             - An activation would be required, and the tap strap would also be sampled again.
             '''
       stage: V3
-      tests: []
+      tests: ["chip_sw_rv_dm_access_after_escalation_reset"]
     }
     {
       name: chip_sw_rv_dm_jtag_tap_sel

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -611,15 +611,22 @@
       stage: V2
       tests: ["chip_rv_dm_ndm_reset_req"]
     }
-    // TODO, this could be a block-level test. Put it here since we don't have block-level testplan.
     {
-      name: chip_rv_dm_ndm_reset_req_when_ibex_halted
-      desc: '''Verify non-debug reset request initiated from RV_DM when ibex is in halted state.
+      name: chip_sw_rv_dm_ndm_reset_req_when_cpu_halted
+      desc: '''Verify non-debug reset request initiated from RV_DM when the CPU  is in halted state.
 
-            - Configure ibex in halted state (dmstatus.anyhalted/dmstatus.allhalted is asserted).
-            - Configure RV_DM to send NDM reset request.
-            - Check that halted state is clear (dmstatus.anyhalted/dmstatus.allhalted should be
-              de-asserted).
+            - Initialize the DUT in a HW-debug enabled life cycle state.
+            - Activate the RISCV debug module.
+            - Run some SW test on the CPU.
+            - Initiate a CPU halt request via JTAG.
+            - Wait for the CPU to be in halted state via JTAG by polling dmstatus.anyhalted.
+            - Deassert the CPU haltreq and verify that we are still in halted state.
+            - (Optional) Using the abstract command, read the dcsr register to verify the cause
+              reflects the debug halt request.
+            - Issue an NDM reset request. All non-debug parts of the chip should reset. Read the
+              dmstatus.anyhalted / dvstatus.allhalted and verify that they are cleared.
+            - De-assert the NDM reset request and wait for the CPU to reboot and finish the post-NDM
+              reset phase of the test.
             '''
       stage: V2
       tests: []
@@ -635,6 +642,16 @@
             '''
       stage: V2
       tests: ["chip_sw_rv_dm_access_after_wakeup"]
+    }
+    {
+      name: chip_sw_rv_dm_access_after_hw_reset
+      desc: '''Verify RV_DM works after a watchdog or escalated reset.
+
+            - Access some RV_DM CSRs both before and after resets.
+            - An activation would be required, and the tap strap would also be sampled again.
+            '''
+      stage: V3
+      tests: []
     }
     {
       name: chip_sw_rv_dm_jtag_tap_sel
@@ -664,16 +681,6 @@
             '''
       stage: V2
       tests: ["chip_rv_dm_lc_disabled"]
-    }
-    {
-      name: chip_rv_dm_access_after_hw_reset
-      desc: '''Verify RV_DM works after a watchdog or escalated reset.
-
-            - Access some RV_DM CSRs both before and after resets.
-            - An activation would be required, and the tap strap would also be sampled again.
-            '''
-      stage: V3
-      tests: []
     }
 
     // RV_TIMER (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1479,6 +1479,13 @@
       run_opts: ["+en_scb_tl_err_chk=0", "+use_jtag_dmi=1"]
     }
     {
+      name: chip_sw_rv_dm_ndm_reset_req_when_cpu_halted
+      uvm_test_seq: "chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq"
+      sw_images: ["//sw/device/tests/sim_dv:rv_dm_ndm_reset_req_when_cpu_halted:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_jtag_dmi=1"]
+    }
+    {
       name: chip_tap_straps_dev
       uvm_test_seq: chip_tap_straps_vseq
       en_run_modes: ["strap_tests_mode"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1012,7 +1012,7 @@
       // Disable scoreboard to avoid incorrect alert prediction from the alert_monitor. Due to the
       // cross-domain alert senders and receivers, the monitor from the chip level did not support
       // processing alerts accurately from both ends.
-      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=5000000", "+bypass_alert_ready_to_end_check=1"]
+      run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
     }
     {
       name: chip_sw_alert_handler_ping_timeout
@@ -1482,6 +1482,13 @@
       name: chip_sw_rv_dm_ndm_reset_req_when_cpu_halted
       uvm_test_seq: "chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq"
       sw_images: ["//sw/device/tests/sim_dv:rv_dm_ndm_reset_req_when_cpu_halted:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_jtag_dmi=1"]
+    }
+    {
+      name: chip_sw_rv_dm_access_after_escalation_reset
+      uvm_test_seq: "chip_sw_rv_dm_access_after_escalation_reset_vseq"
+      sw_images: ["//sw/device/tests/sim_dv:alert_handler_escalation_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_jtag_dmi=1"]
     }

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -105,6 +105,7 @@ filesets:
       - seq_lib/chip_sw_rstmgr_alert_info_vseq.sv: {is_include_file: true}
       - seq_lib/chip_rv_dm_ndm_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rv_dm_access_after_escalation_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_rv_dm_lc_disabled_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_entropy_src_fuse_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -104,6 +104,7 @@ filesets:
       - seq_lib/chip_sw_repeat_reset_wkup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rstmgr_alert_info_vseq.sv: {is_include_file: true}
       - seq_lib/chip_rv_dm_ndm_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv: {is_include_file: true}
       - seq_lib/chip_rv_dm_lc_disabled_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_entropy_src_fuse_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -247,8 +247,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
     // We leave the DM 'activated' for CSR tests to reduce noise. We exclude this from further
     // writes to avoid side-effects.
-    csr_excl.add_excl(jtag_dmi_ral.dmcontrol.dmactive.get_full_name(),
-        CsrExclWrite, CsrNonInitTests);
+    csr_excl.add_excl(jtag_dmi_ral.dmcontrol.get_full_name(), CsrExclWrite, CsrNonInitTests);
 
     // This field is tied off to 0 due to no hart array mask being implemented.
     // TODO: Change these to access policy.
@@ -307,7 +306,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
         CsrExclWriteCheck, CsrNonInitTests);
 
     // Abstractcs cmderr bits are updated by RTL.
-    csr_excl.add_excl(jtag_dmi_ral.abstractcs.cmderr.get_full_name(),
+    csr_excl.add_excl(jtag_dmi_ral.abstractcs.get_full_name(),
         CsrExclWriteCheck, CsrNonInitTests);
 
     // Not all bits of abstractauto are set - and its also impacted by writes to other CSRs.

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -437,7 +437,6 @@ interface chip_if;
   jtag_if flash_ctrl_jtag_if();
 
   // TODO: Revisit this logic.
-  wire lc_ready = `LC_CTRL_HIER.u_reg.u_status_ready.qs;
   wire lc_hw_debug_en = (`LC_CTRL_HIER.lc_hw_debug_en_o == lc_ctrl_pkg::On);
   assign flash_ctrl_jtag_enabled = enable_flash_ctrl_jtag && lc_hw_debug_en;
   assign mios[top_earlgrey_pkg::MioPadIob0] = flash_ctrl_jtag_enabled ?
@@ -619,6 +618,8 @@ interface chip_if;
   wire io_div4_clk = `CLKMGR_HIER.clocks_o.clk_io_div4_powerup;
   wire io_div4_rst_n = `RSTMGR_HIER.resets_o.rst_por_io_div4_n[0];
   clk_rst_if io_div4_clk_rst_if(.clk(io_div4_clk), .rst_n(io_div4_rst_n));
+
+  wire lc_ready = `LC_CTRL_HIER.u_reg.u_status_ready.qs;
 
   wire pwrmgr_low_power = `PWRMGR_HIER.low_power_o;
 

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -320,6 +320,9 @@ interface chip_if;
   //
   // The pinmux version of lc_dft_en is used below because it goes through synchronizers.
   wire pinmux_lc_dft_en = (`PINMUX_HIER.u_pinmux_strap_sampling.lc_dft_en[0] == lc_ctrl_pkg::On);
+  wire pinmux_lc_hw_debug_en = `PINMUX_HIER.u_pinmux_strap_sampling.pinmux_hw_debug_en_o ==
+                               lc_ctrl_pkg::On;
+
   wire pwrmgr_fast_pwr_state_strap_en = `PINMUX_HIER.u_pinmux_strap_sampling.strap_en_q;
   initial begin
     fork
@@ -622,6 +625,7 @@ interface chip_if;
   wire lc_ready = `LC_CTRL_HIER.u_reg.u_status_ready.qs;
 
   wire pwrmgr_low_power = `PWRMGR_HIER.low_power_o;
+  wire pwrmgr_cpu_fetch_en = `PWRMGR_HIER.fetch_en_o == lc_ctrl_pkg::On;
 
   wire rom_ctrl_done = `PWRMGR_HIER.rom_ctrl_i.done == prim_mubi_pkg::MuBi4True;
   wire rom_ctrl_good = `PWRMGR_HIER.rom_ctrl_i.good == prim_mubi_pkg::MuBi4True;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -59,6 +59,7 @@ class chip_base_vseq #(
     // the CPU starts executing right away which can cause breakages.
     cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.do_trst_n();
     super.apply_reset(kind);
+    if (jtag_dmi_ral != null) jtag_dmi_ral.reset(kind);
   endtask
 
   virtual task apply_resets_concurrently(int reset_duration_ps = 0);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -12,6 +12,8 @@ class chip_base_vseq #(
 );
   `uvm_object_utils(chip_base_vseq)
 
+  jtag_dmi_reg_block jtag_dmi_ral;
+
   // knobs to enable pre_start routines
 
   // knobs to enable post_start routines
@@ -22,6 +24,11 @@ class chip_base_vseq #(
   byte uart_tx_data_q[$];
 
   `uvm_object_new
+
+  virtual function void set_handles();
+    super.set_handles();
+    jtag_dmi_ral = cfg.jtag_dmi_ral;
+  endfunction // set_handles
 
   virtual function void set_sva_check_rstreqs(bit enable);
     `uvm_info(`gfn, $sformatf("Remote setting check_rstreqs_en=%b", enable), UVM_MEDIUM)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_base_vseq.sv
@@ -13,12 +13,6 @@ class chip_jtag_base_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_jtag_base_vseq)
 
   `uvm_object_new
-  jtag_dmi_reg_block jtag_dmi_ral;
-
-  virtual function void set_handles();
-    super.set_handles();
-    jtag_dmi_ral = cfg.jtag_dmi_ral;
-  endfunction // set_handles
 
   virtual task pre_start();
     cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -104,7 +104,6 @@ class chip_sw_base_vseq extends chip_base_vseq;
       cfg.mem_bkdr_util_h[FlashBank1Data].load_mem_from_file(
           {cfg.sw_images[SwTypeTestSlotB], ".64.scr.vmem"});
     end
-    cfg.sw_test_status_vif.sw_test_status = SwTestStatusBooted;
 
     config_jitter();
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_dm_access_after_escalation_reset_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_dm_access_after_escalation_reset_vseq.sv
@@ -1,0 +1,79 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Verifies that the debug resources are accessible before and after a HW reset event due to
+// alert escalation.
+//
+// This test reuses the same SW test as chip_sw_alert_handler_escalation test. The SV portion of the
+// SW test does different things. For this test, the SV side verifies the accessibility the JTAG DMI
+// space via JTAG before, during and after escalation reset reboot.
+class chip_sw_rv_dm_access_after_escalation_reset_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_rv_dm_access_after_escalation_reset_vseq)
+  `uvm_object_new
+
+  bit pause_jtag_dmi_ral_csr_rw_seq;
+  bit jtag_dmi_ral_csr_rw_seq_busy;
+
+  virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
+    super.pre_start();
+    max_outstanding_accesses = 1;
+  endtask
+
+  virtual task body();
+    super.body();
+
+    `uvm_info(`gfn, "Waiting for HW debug to be enabled", UVM_MEDIUM)
+    `DV_WAIT(cfg.chip_vif.pinmux_lc_hw_debug_en)
+    cfg.chip_vif.aon_clk_por_rst_if.wait_clks(10);
+
+    `uvm_info(`gfn, "Activating the debug module", UVM_MEDIUM)
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(1), .blocking(1), .predict(1));
+    fork run_jtag_dmi_ral_csr_rw_seq(); join_none
+
+    // These checkpoints ensure SW is progressing through the escalation stages.
+    `DV_WAIT(string'(cfg.sw_logger_vif.printed_log) == "Keymgr entered Init State")
+    `DV_WAIT(string'(cfg.sw_logger_vif.printed_log) == "You are experiencing an NMI")
+    pause_jtag_dmi_ral_csr_rw_seq = 1;
+
+    `uvm_info(`gfn, "Waiting for escalation reset to complete", UVM_MEDIUM)
+    `DV_WAIT(!cfg.chip_vif.pinmux_lc_hw_debug_en)
+    // The JTAG CSR access sequence must have stopped by now, or else we will have issues.
+    `DV_CHECK_FATAL(!jtag_dmi_ral_csr_rw_seq_busy)
+
+    fork
+      // The escalation reset will reset the debug module. The JTAG agent needs to also be reset.
+      cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.do_trst_n(2);
+      `DV_WAIT(cfg.chip_vif.pinmux_lc_hw_debug_en)
+    join
+
+    cfg.chip_vif.aon_clk_por_rst_if.wait_clks(10);
+    `uvm_info(`gfn, "Activating the debug module again after escalation reset", UVM_MEDIUM)
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(1), .blocking(1), .predict(1));
+    pause_jtag_dmi_ral_csr_rw_seq = 0;
+
+    `DV_WAIT(string'(cfg.sw_logger_vif.printed_log) == "Reset due to alert escalation")
+    pause_jtag_dmi_ral_csr_rw_seq = 1;
+    `DV_WAIT(!jtag_dmi_ral_csr_rw_seq_busy)
+  endtask
+
+  // Run the CSR RW sequence on jtag_dmi_ral.
+  //
+  // A forever running thread which continuously accesses the JTAG DMI space, with exclusions
+  // factored in. Execution can be paused temporarily with pause_jtag_dmi_ral_csr_rw_seq signal.
+  virtual task run_jtag_dmi_ral_csr_rw_seq();
+    csr_rw_seq m_csr_seq = csr_rw_seq::type_id::create("m_csr_seq");
+    csr_excl_item csr_excl = csr_utils_pkg::get_excl_item(jtag_dmi_ral);
+    m_csr_seq.models = {jtag_dmi_ral};
+    if (csr_excl != null) csr_excl.print_exclusions();
+    forever begin
+      if (pause_jtag_dmi_ral_csr_rw_seq) wait (!pause_jtag_dmi_ral_csr_rw_seq);
+      `uvm_info(`gfn, "Running JTAG DMI RAL CSR rw seq", UVM_MEDIUM)
+      jtag_dmi_ral_csr_rw_seq_busy = 1;
+      m_csr_seq.start(null);
+      jtag_dmi_ral_csr_rw_seq_busy = 0;
+    end
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv
@@ -1,0 +1,100 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Verifies that an NDM reset request after the CPU has been halted resets the original haltreq.
+class chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    bit rebooted;
+    uvm_reg_data_t rw_data;
+    super.body();
+
+    `DV_WAIT(string'(cfg.sw_logger_vif.printed_log) == "Ready for CPU halt request",
+             "Timed out waiting for the CPU to be ready for a halt request.")
+    cfg.chip_vif.cpu_clk_rst_if.wait_clks($urandom_range(200, 1000));
+
+    `uvm_info(`gfn, "Activating the debug module", UVM_MEDIUM)
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(1), .blocking(1), .predict(1));
+    cfg.chip_vif.cpu_clk_rst_if.wait_clks($urandom_range(200, 1000));
+
+    csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(rw_data), .blocking(1));
+    `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.anyrunning, rw_data), 1)
+    `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.allrunning, rw_data), 1)
+
+    `uvm_info(`gfn, "Asserting CPU haltreq", UVM_MEDIUM)
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.haltreq), .value(1), .blocking(1), .predict(1));
+
+    `uvm_info(`gfn, "Waiting for CPU halted", UVM_MEDIUM)
+    `DV_SPINWAIT(
+      do begin
+        csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(rw_data), .blocking(1));
+      end while (dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.anyhalted, rw_data) == 0);
+    )
+    `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.anyhalted, rw_data), 1)
+    `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.allhalted, rw_data), 1)
+    `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.anyrunning, rw_data), 0)
+    `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.allrunning, rw_data), 0)
+    cfg.chip_vif.cpu_clk_rst_if.wait_clks($urandom_range(200, 1000));
+
+    `uvm_info(`gfn, "De-asserting CPU haltreq since CPU is halted", UVM_MEDIUM)
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.haltreq), .value(0), .blocking(1), .predict(1));
+    cfg.chip_vif.cpu_clk_rst_if.wait_clks($urandom_range(1000, 10000));
+    csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(rw_data), .blocking(1));
+    `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.allhalted, rw_data), 1)
+
+    // TODO: Execute abstract command to read DCSR and verify the cause field.
+
+    `uvm_info(`gfn, "Issuing an NDM reset request", UVM_MEDIUM)
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(1), .blocking(1), .predict(1));
+
+    fork
+      begin
+        cfg.chip_vif.aon_clk_por_rst_if.wait_clks($urandom_range(5, 20));
+        `uvm_info(`gfn, "Clearing the NDM reset request", UVM_MEDIUM)
+        // If we do not clear the ndm reset req, it will result in reboot loop.
+        csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(0), .blocking(1), .predict(1));
+      end
+      begin
+        `uvm_info(`gfn, "Verifying the CPU halted state is cleared", UVM_MEDIUM)
+        `DV_SPINWAIT(
+          do begin
+            csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(rw_data), .blocking(1));
+          end while (dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.anyhalted, rw_data) == 1);
+        )
+        `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.anyhalted, rw_data), 0)
+        `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.allhalted, rw_data), 0)
+        `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.anyrunning, rw_data), 1)
+        `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.allrunning, rw_data), 1)
+
+        `uvm_info(`gfn, "Continuing to read dmstatus CSR through NDM reset", UVM_LOW)
+        // This proves that the debugger can access the debug resources while the NDM reset is
+        // ongoing, and there are no lockups elsewhere.
+        while (!rebooted) begin
+          csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(rw_data), .blocking(1));
+          `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.anyhalted, rw_data), 0)
+          `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.allhalted, rw_data), 0)
+          `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.anyrunning, rw_data), 1)
+          `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(jtag_dmi_ral.dmstatus.allrunning, rw_data), 1)
+        end
+      end
+      begin
+        `uvm_info(`gfn, "Waiting for NDM reset to complete", UVM_MEDIUM)
+        `DV_WAIT(!cfg.chip_vif.lc_ready)
+        `DV_WAIT(cfg.chip_vif.lc_ready)
+        cfg.chip_vif.aon_clk_por_rst_if.wait_clks(1);
+        rebooted = 1;
+      end
+    join
+
+    // Let the CPU SW run its course (second reset phase after NDM reset).
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -60,6 +60,7 @@
 `include "chip_sw_rstmgr_alert_info_vseq.sv"
 `include "chip_rv_dm_ndm_reset_vseq.sv"
 `include "chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv"
+`include "chip_sw_rv_dm_access_after_escalation_reset_vseq.sv"
 `include "chip_rv_dm_lc_disabled_vseq.sv"
 `include "chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv"
 `include "chip_sw_alert_handler_lpg_clkoff_vseq.sv"

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -59,6 +59,7 @@
 `include "chip_sw_repeat_reset_wkup_vseq.sv"
 `include "chip_sw_rstmgr_alert_info_vseq.sv"
 `include "chip_rv_dm_ndm_reset_vseq.sv"
+`include "chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv"
 `include "chip_rv_dm_lc_disabled_vseq.sv"
 `include "chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv"
 `include "chip_sw_alert_handler_lpg_clkoff_vseq.sv"

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -172,8 +172,9 @@ module tb;
 
   // Bind the SW test status interface directly to the sim SRAM interface.
   bind `SIM_SRAM_IF sw_test_status_if u_sw_test_status_if (
-    .addr (tl_h2d.a_address),
-    .data (tl_h2d.a_data[15:0]),
+    .addr     (tl_h2d.a_address),
+    .data     (tl_h2d.a_data[15:0]),
+    .fetch_en (dut.chip_if.pwrmgr_cpu_fetch_en),
     .*
   );
 

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -911,6 +911,21 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "rv_dm_ndm_reset_req_when_cpu_halted",
+    srcs = ["rv_dm_ndm_reset_req_when_cpu_halted.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "sram_ctrl_execution_main_test",
     srcs = ["sram_ctrl_execution_main_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/alert_handler_escalation.c
+++ b/sw/device/tests/sim_dv/alert_handler_escalation.c
@@ -150,14 +150,16 @@ bool test_main(void) {
 
     // Stop execution here and just wait for something to happen
     wait_for_interrupt();
-    CHECK(false, "Should have reset before this line");
+    LOG_ERROR("Should have reset before this line");
+    return false;
 
   } else if (rst_info & kDifRstmgrResetInfoEscalation) {
+    // DO NOT REMOVE, DV sync message
     LOG_INFO("Reset due to alert escalation");
     return true;
 
   } else {
-    LOG_FATAL("unexpected reset info %d", rst_info);
+    LOG_ERROR("Unexpected reset info %d", rst_info);
   }
 
   return false;

--- a/sw/device/tests/sim_dv/rv_dm_ndm_reset_req_when_cpu_halted.c
+++ b/sw/device/tests/sim_dv/rv_dm_ndm_reset_req_when_cpu_halted.c
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_rstmgr_t rstmgr;
+
+OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
+                        .can_clobber_uart = false, );
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  if (rstmgr_testutils_is_reset_info(&rstmgr, kDifRstmgrResetInfoPor)) {
+    rstmgr_testutils_reason_clear();
+
+    // Sync log used by the SV sequence. Do not modify.
+    LOG_INFO("Ready for CPU halt request");
+
+    // Wait for 1ms. The host test sequence will issue a halt request, followed
+    // by an NDM reset request.
+    busy_spin_micros(10000);
+
+    LOG_ERROR("Timed out waiting for an NDM reset request.");
+    return false;
+
+  } else if (rstmgr_testutils_is_reset_info(&rstmgr, kDifRstmgrResetInfoNdm)) {
+    LOG_INFO("Rebooted after NDM reset request.");
+    rstmgr_testutils_reason_clear();
+    return true;
+
+  } else {
+    dif_rstmgr_reset_info_bitfield_t reset_info;
+    reset_info = rstmgr_testutils_reason_get();
+    LOG_ERROR("Unexpected reset_info: %d", reset_info);
+    return false;
+  }
+
+  return false;
+}


### PR DESCRIPTION
In this PR, two of the pending RV_DM tests are implemented. 

- `chip_rv_dm_access_after_hw_reset`, tracked in #15796.
- `chip_rv_dm_ndm_reset_req_when_ibex_halted` tracked in #14149 

There are other related commits to other parts of the codebase to support the test development. 