### PR TITLE
[csrng,dv] Add CG to check FIFOs in cmd_stage

### DIFF
--- a/hw/ip/csrng/data/csrng_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_testplan.hjson
@@ -171,5 +171,17 @@
             Covers all possible recoverable alert cases.
             '''
     }
+    {
+      name: csrng_sfifo_cg
+      desc: '''
+            Covers each app's stage FIFO statuses.
+            - cp_hw0_cmd_depth, cp_hw1_cmd_depth, cp_sw_cmd_depth : Covers current number of commands in FIFO
+            - cp_hw0_genbits_depth, cp_hw1_genbits_depth, cp_sw_genbits_depth : Covers current number of genbit responses in FIFO
+            - cmd_depth_cross : Cross for checking each command FIFO status in different apps
+            - genbits_depth_cross : Cross for checking genbits FIFO status in different apps
+            - hw0_cmd_cross, hw1_cmd_cross, sw_cmd_cross : command FIFO status x command valid input x command ready output
+            - hw0_genbits_cross, hw1_genbits_cross, sw_genbits_cross : genbits FIFO status x genbits valid output x genbits ready input
+            '''
+    }
   ]
 }

--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -69,11 +69,7 @@ interface csrng_cov_if (
       illegal_bins more_than_depth = {3};
     }
     cp_hw0_genbits_depth: coverpoint hw0_genbits_depth;
-    hw0_cmd_cross: cross cp_hw0_cmd_depth, hw0_cmd_vld, hw0_cmd_rdy{
-      illegal_bins not_full_and_not_ready = !binsof(cp_hw0_cmd_depth) intersect {2}
-                                              with (!hw0_cmd_rdy);
-      illegal_bins full_and_ready = binsof(cp_hw0_cmd_depth) intersect {2} with (hw0_cmd_rdy);
-    }
+    hw0_cmd_cross: cross cp_hw0_cmd_depth, hw0_cmd_vld, hw0_cmd_rdy;
     hw0_genbits_cross: cross cp_hw0_genbits_depth, hw0_genbits_vld, hw0_genbits_rdy{
       illegal_bins empty_and_valid =
         binsof(cp_hw0_genbits_depth) intersect {0} with (hw0_genbits_vld);
@@ -84,11 +80,7 @@ interface csrng_cov_if (
       illegal_bins more_than_depth = {3};
     }
     cp_hw1_genbits_depth: coverpoint hw1_genbits_depth;
-    hw1_cmd_cross: cross cp_hw1_cmd_depth, hw1_cmd_vld, hw1_cmd_rdy{
-      illegal_bins not_full_and_not_ready = !binsof(cp_hw1_cmd_depth) intersect {2}
-                                              with (!hw1_cmd_rdy);
-      illegal_bins full_and_ready = binsof(cp_hw1_cmd_depth) intersect {2} with (hw1_cmd_rdy);
-    }
+    hw1_cmd_cross: cross cp_hw1_cmd_depth, hw1_cmd_vld, hw1_cmd_rdy;
     hw1_genbits_cross: cross cp_hw1_genbits_depth, hw1_genbits_vld, hw1_genbits_rdy{
       illegal_bins empty_and_valid =
         binsof(cp_hw1_genbits_depth) intersect {0} with (hw1_genbits_vld);
@@ -99,11 +91,7 @@ interface csrng_cov_if (
       illegal_bins more_than_depth = {3};
     }
     cp_sw_genbits_depth: coverpoint sw_genbits_depth;
-    sw_cmd_cross: cross cp_sw_cmd_depth, sw_cmd_vld, sw_cmd_rdy{
-      illegal_bins not_full_and_not_ready = !binsof(cp_sw_cmd_depth) intersect {2}
-                                              with (!sw_cmd_rdy);
-      illegal_bins full_and_ready = binsof(cp_sw_cmd_depth) intersect {2} with (sw_cmd_rdy);
-    }
+    sw_cmd_cross: cross cp_sw_cmd_depth, sw_cmd_vld, sw_cmd_rdy;
     sw_genbits_cross: cross cp_sw_genbits_depth, sw_genbits_vld, sw_genbits_rdy{
       illegal_bins empty_and_valid =
         binsof(cp_sw_genbits_depth) intersect {0} with (sw_genbits_vld);

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_err_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_err_vseq.sv
@@ -56,6 +56,7 @@ class csrng_err_vseq extends csrng_base_vseq;
     $assertoff(0, "tb.dut.u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage.u_state_regs_A");
     $assertoff(0, "tb.dut.u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage.u_state_regs_A");
     cfg.csrng_assert_vif.assert_off();
+    `DV_ASSERT_CTRL_REQ("CmdStageFifoAsserts", 0)
 
     cs_item = csrng_item::type_id::create("cs_item");
 

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
@@ -220,6 +220,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_benblk_arb.ReqStaysHighUntilGranted0_M");
     $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.ReqStaysHighUntilGranted0_M");
     cfg.csrng_assert_vif.assert_off();
+    `DV_ASSERT_CTRL_REQ("CmdStageFifoAsserts", 0)
 
     // Test cs_cmd_req_done interrupt
     // cs_cmd_req_done interrupt is checked in the send_cmd_req()

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_regwen_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_regwen_vseq.sv
@@ -44,6 +44,8 @@ class csrng_regwen_vseq extends csrng_base_vseq;
       `uvm_fatal(`gfn, $sformatf(" Was able to overwrite ERR_CODE_TEST with REGWEN being set to 0"))
     end
 
+    super.body();
+
   endtask : body
 
 endclass : csrng_regwen_vseq

--- a/hw/ip/csrng/dv/tb.sv
+++ b/hw/ip/csrng/dv/tb.sv
@@ -115,4 +115,20 @@ module tb;
     run_test();
   end
 
+  // Assertions
+  for (genvar i = 0; i < NUM_HW_APPS + 1; i++) begin : gen_cmd_stage_asserts
+    `ASSERT(CmdStageFifoNotFullReady,
+      (tb.dut.u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.sfifo_cmd_depth != 2'h2) |->
+      tb.dut.u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.cmd_stage_rdy_o,
+      clk,
+      !rst_n)
+    `ASSERT(CmdStageFifoFullNotReady,
+      (tb.dut.u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.sfifo_cmd_depth == 2'h2) |->
+      !tb.dut.u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.cmd_stage_rdy_o,
+      clk,
+      !rst_n)
+    `DV_ASSERT_CTRL("CmdStageFifoAsserts", CmdStageFifoNotFullReady)
+    `DV_ASSERT_CTRL("CmdStageFifoAsserts", CmdStageFifoFullNotReady)
+  end
+
 endmodule


### PR DESCRIPTION
This commit introduces `csrng_sfifo_cg` which checks FIFOs in csrng_cmd_stage instantiations.

This should help verifying the stall behaviour described in https://github.com/lowRISC/opentitan/issues/15744

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>