### PR TITLE
[rom,e2e] Fix errors in the chip_specific_startup test

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup.c
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup.c
@@ -29,6 +29,13 @@
 
 OTTF_DEFINE_TEST_CONFIG();
 
+enum {
+  kAstInitEnOffset = OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET -
+                     OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET,
+  kJitterEnOffset = OTP_CTRL_PARAM_CREATOR_SW_CFG_JITTER_EN_OFFSET -
+                    OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET,
+};
+
 void epmp_read(rom_epmp_config_t *epmp) {
   // Sadly, CSR reads must use constants for the register name.
   CSR_READ(CSR_REG_MSECCFG, &epmp->mseccfg);
@@ -82,7 +89,7 @@ status_t test_chip_specific_startup(ujson_t *uj) {
       mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
   TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR),
                        &lc));
-  TRY(dif_clkmgr_init(mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR),
+  TRY(dif_clkmgr_init(mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR),
                       &clkmgr));
 
   LOG_INFO("Querying hardware");
@@ -110,12 +117,11 @@ status_t test_chip_specific_startup(ujson_t *uj) {
 
   // We need to know the OTP configs for AST init and jitter in order to
   // correctly determine the pass/fail conditions.
-  TRY(dif_otp_ctrl_read_blocking(
-      &otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
-      OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET,
-      &cs.otp.creator_sw_cfg_ast_init_en, 1));
   TRY(dif_otp_ctrl_read_blocking(&otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
-                                 OTP_CTRL_PARAM_CREATOR_SW_CFG_JITTER_EN_OFFSET,
+                                 kAstInitEnOffset,
+                                 &cs.otp.creator_sw_cfg_ast_init_en, 1));
+  TRY(dif_otp_ctrl_read_blocking(&otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
+                                 kJitterEnOffset,
                                  &cs.otp.creator_sw_cfg_jitter_en, 1));
 
   // Read the entropy config directly from the peripherals.  The DIFs don't

--- a/sw/host/opentitanlib/src/chip/boolean.rs
+++ b/sw/host/opentitanlib/src/chip/boolean.rs
@@ -7,37 +7,37 @@ use crate::with_unknown;
 with_unknown! {
     /// From `//sw/device/lib/base/hardened.h`.
     pub enum HardenedBool: u32 {
-        True= bindgen::hardened::hardened_bool_kHardenedBoolTrue as u32,
-        False= bindgen::hardened::hardened_bool_kHardenedBoolFalse as u32,
+        True = bindgen::hardened::hardened_bool_kHardenedBoolTrue as u32,
+        False = bindgen::hardened::hardened_bool_kHardenedBoolFalse as u32,
     }
 
     /// From `//sw/device/lib/base/hardened.h`.
     pub enum HardenedByteBool: u8 {
-        True= bindgen::hardened::hardened_byte_bool_kHardenedByteBoolTrue as u8,
-        False= bindgen::hardened::hardened_byte_bool_kHardenedByteBoolFalse as u8,
+        True = bindgen::hardened::hardened_byte_bool_kHardenedByteBoolTrue as u8,
+        False = bindgen::hardened::hardened_byte_bool_kHardenedByteBoolFalse as u8,
     }
 
     /// From `//sw/device/lib/base/multibits.h`.
     pub enum MultiBitBool4: u8 {
-        True= bindgen::multibits::multi_bit_bool_kMultiBitBool4True as u8,
-        False= bindgen::multibits::multi_bit_bool_kMultiBitBool4False as u8,
+        True = bindgen::multibits::multi_bit_bool_kMultiBitBool4True as u8,
+        False = bindgen::multibits::multi_bit_bool_kMultiBitBool4False as u8,
     }
 
     /// From `//sw/device/lib/base/multibits.h`.
     pub enum MultiBitBool8: u8 {
-        True= bindgen::multibits::multi_bit_bool_kMultiBitBool8True as u8,
-        False= bindgen::multibits::multi_bit_bool_kMultiBitBool8False as u8,
+        True = bindgen::multibits::multi_bit_bool_kMultiBitBool8True as u8,
+        False = bindgen::multibits::multi_bit_bool_kMultiBitBool8False as u8,
     }
 
     /// From `//sw/device/lib/base/multibits.h`.
     pub enum MultiBitBool12: u16 {
-        True= bindgen::multibits::multi_bit_bool_kMultiBitBool12True as u16,
-        False= bindgen::multibits::multi_bit_bool_kMultiBitBool12False as u16,
+        True = bindgen::multibits::multi_bit_bool_kMultiBitBool12True as u16,
+        False = bindgen::multibits::multi_bit_bool_kMultiBitBool12False as u16,
     }
 
     /// From `//sw/device/lib/base/multibits.h`.
     pub enum MultiBitBool16: u16 {
-        True= bindgen::multibits::multi_bit_bool_kMultiBitBool16True as u16,
-        False= bindgen::multibits::multi_bit_bool_kMultiBitBool16False as u16,
+        True = bindgen::multibits::multi_bit_bool_kMultiBitBool16True as u16,
+        False = bindgen::multibits::multi_bit_bool_kMultiBitBool16False as u16,
     }
 }


### PR DESCRIPTION
1. Initialize clkmgr to the correct base address.
2. Use OTP offsets relative to the start of the partition.

Signed-off-by: Chris Frantz <cfrantz@google.com>