### PR TITLE
[rom_e2e,dv] increase test timeouts for `boot_policy_valid` `test_unlocked0` tests

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -51,11 +51,11 @@
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=410_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 480
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_good_dev
@@ -131,11 +131,11 @@
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=410_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 480
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_bad_dev
@@ -211,11 +211,11 @@
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=410_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 480
     }
     {
       name: rom_e2e_boot_policy_valid_a_bad_b_good_dev


### PR DESCRIPTION
Tests in the `test_unlocked0` LC state take longer to run.

Signed-off-by: Timothy Trippel <ttrippel@google.com>