### PR TITLE
[prim-cdc-rand-delay] Fix bug due to dv macro

### DIFF
--- a/hw/ip/prim/rtl/prim_cdc_rand_delay.sv
+++ b/hw/ip/prim/rtl/prim_cdc_rand_delay.sv
@@ -37,7 +37,7 @@ module prim_cdc_rand_delay #(
       if (DataWidth <= 32) begin
         data = $urandom();
       end else begin
-        `DV_CHECK_STD_RANDOMIZE_FATAL(data, "Randomization of data failed", $sformatf("%m"))
+        if (!std::randomize(data)) $fatal("%t: [%m] Failed to randomize data", $time);
       end
       return data;
     endfunction


### PR DESCRIPTION
The use of dv macros requires including dv_macros.svh, which we are avoiding in RTL (and related) components.

This change replaces the `DV_CHECK_*` invovation with its expanded version.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>