### PR TITLE
[dv,i2c] interrupt test part1

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -23,14 +23,6 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   // and allow tb to program a new timing parameter.
   bit     got_stop = 0;
 
-  // In target mode i2c test, sequence finishes when all host transactions are fetched.
-  // However, test has to wait until all read data transferred from DUT to test bench.
-  // If test create a scinario to trigger clock stretch, TB has to wait indefinte time
-  // (because clock stretch froze transmit clock).
-  // This varialbe to indicate all read / write data fetch and trasmitted.
-  // Used only for stretched mode test.
-  bit     use_seq_term = 0;
-
   int     sent_rd_byte = 0;
   int     rcvd_rd_byte = 0;
 

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -245,7 +245,6 @@ class i2c_monitor extends dv_base_monitor #(
       if (cfg.en_monitor) begin
         ok_to_end = 0;
       end
-      wait(cfg.use_seq_term == 0);
       forever begin
         @(cfg.vif.cb);
         if (cfg.vif.scl_i) scl_cnt++;

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -354,7 +354,7 @@
                 in tx_fifo otherwise tx_empty interrupt must be de-asserted
             '''
       stage: V2
-      tests: ["i2c_target_stress_rd"]
+      tests: ["i2c_target_stress_rd", "i2c_target_intr_smoke"]
     }
     {
       name: target_fifo_reset
@@ -380,13 +380,13 @@
             Stimulus:
               - Configure DUT/Agent to Target/Host mode respectively
               - Send enough read and write requests to acq_fifo
-              - Hold reading data from tx_fifo until tx fifo is full
+              - Slow down acq fifo read process to trigger acq_full interrupt
 
             Checking:
               - Check fifo full states by reading status register
             '''
       stage: V2
-      tests: ["i2c_target_stress_wr"]
+      tests: ["i2c_target_stress_wr", "i2c_target_intr_stress_wr"]
     }
     {
       name: target_timeout

--- a/hw/ip/i2c/dv/env/i2c_env.sv
+++ b/hw/ip/i2c/dv/env/i2c_env.sv
@@ -33,9 +33,8 @@ class i2c_env extends cip_base_env #(
     if (cfg.m_i2c_agent_cfg.if_mode == Host) begin
       virtual_sequencer.target_mode_wr_exp_port.connect(
               scoreboard.target_mode_wr_exp_fifo.analysis_export);
-      virtual_sequencer.target_mode_wr_obs_port.connect(
-              scoreboard.target_mode_wr_obs_fifo.analysis_export);
-      m_i2c_agent.monitor.analysis_port.connect(scoreboard.target_mode_rd_obs_fifo.analysis_export);
+      m_i2c_agent.monitor.analysis_port.connect(
+              scoreboard.target_mode_rd_obs_fifo.analysis_export);
       virtual_sequencer.target_mode_rd_exp_port.connect(
               scoreboard.target_mode_rd_exp_fifo.analysis_export);
     end

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -17,6 +17,7 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   tran_type_e trans_type = ReadWrite;
 
   int        spinwait_timeout_ns = 10_000_000; // 10ms
+  int        long_spinwait_timeout_ns = 200_000_000;
   int        sent_acq_cnt;
   int        rcvd_acq_cnt;
 
@@ -30,6 +31,17 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   // dut target mode parameters
   int        min_data = 1;
   int        max_data = 60;
+
+  // Use i2c interrupt handler
+  bit        use_intr_handler = 1'b0;
+  bit        stop_intr_handler = 1'b0;
+  bit        read_all_acq_entries = 1'b0;
+
+  // Slow acq process
+  bit        slow_acq = 1'b0;
+
+  // Slow tx process
+  bit        slow_txq = 1'b0;
 
   `uvm_object_utils_begin(i2c_env_cfg)
     `uvm_field_object(m_i2c_agent_cfg, UVM_DEFAULT)

--- a/hw/ip/i2c/dv/env/i2c_virtual_sequencer.sv
+++ b/hw/ip/i2c/dv/env/i2c_virtual_sequencer.sv
@@ -6,7 +6,6 @@ class i2c_virtual_sequencer extends cip_base_virtual_sequencer #(.CFG_T(i2c_env_
                                                                  .COV_T(i2c_env_cov));
   i2c_sequencer    i2c_sequencer_h;
   uvm_analysis_port #(i2c_item) target_mode_wr_exp_port;
-  uvm_analysis_port #(i2c_item) target_mode_wr_obs_port;
   uvm_analysis_port #(i2c_item) target_mode_rd_exp_port;
 
   `uvm_component_utils(i2c_virtual_sequencer)
@@ -15,7 +14,6 @@ class i2c_virtual_sequencer extends cip_base_virtual_sequencer #(.CFG_T(i2c_env_
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     target_mode_wr_exp_port = new("target_mode_wr_exp_port", this);
-    target_mode_wr_obs_port = new("target_mode_wr_obs_port", this);
     target_mode_rd_exp_port = new("target_mode_rd_exp_port", this);
   endfunction
 endclass : i2c_virtual_sequencer

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_rd_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_rd_vseq.sv
@@ -8,24 +8,11 @@ class i2c_target_stress_rd_vseq extends i2c_target_smoke_vseq;
 
   constraint num_trans_c { num_trans inside {[1 : 5]}; }
 
-  virtual task body();
-    `uvm_info(`gfn, $sformatf("num_trans:%0d", num_trans), UVM_MEDIUM)
-
+  virtual task pre_start();
+    super.pre_start();
     cfg.min_data = 100;
     cfg.max_data = 200;
     cfg.wr_pct = 0;
-    cfg.m_i2c_agent_cfg.use_seq_term = 1;
-
-    // Since read test use tx_empty interrupt,
-    // interrupt read / clear will be handle in the test sequence.
-    do_clear_all_interrupts = 0;
-
-    super.body();
-  endtask // body
-
-  task process_txq();
-    process_slow_txq();
-    cfg.m_i2c_agent_cfg.use_seq_term = 0;
+    cfg.slow_txq = 1;
   endtask
-
 endclass

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_wr_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_wr_vseq.sv
@@ -8,20 +8,11 @@ class i2c_target_stress_wr_vseq extends i2c_target_smoke_vseq;
 
   constraint num_trans_c { num_trans inside {[1 : 5]}; }
 
-  virtual task body();
-    `uvm_info(`gfn, $sformatf("num_trans:%0d", num_trans), UVM_MEDIUM)
-
+  virtual task pre_start();
+    super.pre_start();
     cfg.min_data = 80;
     cfg.max_data = 200;
     cfg.rd_pct = 0;
-    cfg.m_i2c_agent_cfg.use_seq_term = 1;
-
-    super.body();
-  endtask // body
-
-  // slow acq fifo read to create acq_fifo full
-  task process_acq();
-    process_slow_acq();
-    cfg.m_i2c_agent_cfg.use_seq_term = 0;
+    cfg.slow_acq = 1;
   endtask
 endclass

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_stretch_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_stretch_vseq.sv
@@ -6,30 +6,13 @@ class i2c_target_stretch_vseq extends i2c_target_smoke_vseq;
   `uvm_object_utils(i2c_target_stretch_vseq)
   `uvm_object_new
 
-  bit wr_end = 0;
-
   constraint num_trans_c { num_trans inside {[1 : 5]}; }
 
-  virtual task body();
-    `uvm_info(`gfn, $sformatf("num_trans:%0d", num_trans), UVM_MEDIUM)
-
+  virtual task pre_start();
+    super.pre_start();
     cfg.min_data = 100;
     cfg.max_data = 200;
-    cfg.m_i2c_agent_cfg.use_seq_term = 1;
-    do_clear_all_interrupts = 0;
-
-    super.body();
-  endtask // body
-
-  task process_acq();
-    process_slow_acq();
-    wr_end = 1;
+    cfg.slow_acq = 1;
+    cfg.slow_txq = 1;
   endtask
-
-  task process_txq();
-    process_slow_txq();
-    wait (wr_end == 1);
-    cfg.m_i2c_agent_cfg.use_seq_term = 0;
-  endtask
-
 endclass // i2c_target_stretch_vseq

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -133,12 +133,24 @@
     {
       name: i2c_target_stress_rd
       uvm_test_seq: i2c_target_stress_rd_vseq
-      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=10_000_000"]
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=50_000_000"]
     }
     {
       name: i2c_target_stretch
       uvm_test_seq: i2c_target_stretch_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=80_000_000"]
+    }
+    {
+      name: i2c_target_intr_smoke
+      uvm_test_seq: i2c_target_smoke_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
+                 "+use_intr_handler=1"]
+    }
+    {
+      name: i2c_target_intr_stress_wr
+      uvm_test_seq: i2c_target_stress_wr_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=300_000_000",
+                 "+use_intr_handler=1", "+slow_acq=1"]
     }
   ]
 
@@ -151,7 +163,8 @@
     {
       name: target_sanity
       tests: ["i2c_target_smoke", "i2c_target_stress_wr",
-              "i2c_target_stress_rd", "i2c_target_stretch"]
+              "i2c_target_stress_rd", "i2c_target_stretch",
+              "i2c_target_intr_smoke", "i2c_target_intr_stress_wr"]
     }
   ]
 }

--- a/hw/ip/i2c/dv/tests/i2c_base_test.sv
+++ b/hw/ip/i2c/dv/tests/i2c_base_test.sv
@@ -16,12 +16,13 @@ class i2c_base_test extends cip_base_test #(.ENV_T(i2c_env),
 
   virtual function void build_phase(uvm_phase phase);
     if_mode_e mode = Device;
-    max_quit_count  = 50;
     test_timeout_ns = 600_000_000; // 600ms
     super.build_phase(phase);
     `DV_GET_ENUM_PLUSARG(if_mode_e, mode, i2c_agent_mode)
     `uvm_info(`gfn, $sformatf("set i2c agent mode to %s", mode.name), UVM_MEDIUM)
     cfg.m_i2c_agent_cfg.if_mode = mode;
+    void'($value$plusargs("use_intr_handler=%0b", cfg.use_intr_handler));
+    void'($value$plusargs("slow_acq=%0b", cfg.slow_acq));
 
   endfunction : build_phase
 


### PR DESCRIPTION
i2c interrupt handler and the test mode (+use_intr_handler) is added to TB.
 if (acqfull) read acq fifo lvl and read 'n' number of entries (n: fifo lvl)
 if (txempty) write pre created entries to tx fifo
 if (transcomplete) read acq fifo lvl and read 'n' number of entries (n: fifo lvl)

Following target mode interrupts are tested.
- trans_complete
- tx_empty
- acq_full

Signed-off-by: Jaedon Kim <jdonjdon@google.com>