### PR TITLE
[rdc] Turn off SPI_HOST when reset

### DIFF
--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -54,6 +54,8 @@ set_reset_scenario { \
   { top_earlgrey.clkmgr_aon_clocks.clk_io_peri         { constraint { @t0 0 } } } \
   { top_earlgrey.clkmgr_aon_clocks.clk_usb_peri        { constraint { @t0 0 } } } \
   { top_earlgrey.pwrmgr_aon_low_power                  { constraint { @t0 1 } } } \
+  { top_earlgrey.spi_device_passthrough_req.passthrough_en { constraint { @t0 0 } } } \
+  { top_earlgrey.u_spi_host0.reg2hw.control.output_en.q    { constraint { @t0 0 } } } \
 } -name ScnAonPOK
 
 # AST Regulator Resets
@@ -85,6 +87,8 @@ set_reset_scenario { \
   { top_earlgrey.clkmgr_aon_clocks.clk_io_peri         { constraint { @t0 0 } } } \
   { top_earlgrey.clkmgr_aon_clocks.clk_usb_peri        { constraint { @t0 0 } } } \
   { top_earlgrey.pwrmgr_aon_low_power                  { constraint { @t0 1 } } } \
+  { top_earlgrey.spi_device_passthrough_req.passthrough_en { constraint { @t0 0 } } } \
+  { top_earlgrey.u_spi_host0.reg2hw.control.output_en.q    { constraint { @t0 0 } } } \
 } -name ScnMainPok
 
 #set_reset_scenario { \
@@ -115,6 +119,8 @@ set_reset_scenario { \
   { u_ast.u_rglts_pdm_3p3v.vcmain_pok_h { constraint { @t0 1 } } } \
   { u_ast.u_rglts_pdm_3p3v.vcaon_pok_h  { constraint { @t0 1 } } } \
   { top_earlgrey.u_spi_device.cio_sck_i { constraint { @t0 0 } } } \
+  { top_earlgrey.spi_device_passthrough_req.passthrough_en { constraint { @t0 0 } } } \
+  { top_earlgrey.u_spi_host0.reg2hw.control.output_en.q    { constraint { @t0 0 } } } \
 } -name RstMgrSwRst -comment "RSTMGR SW Controlled Resets"
 
 # SPI_DEVICE FIFO Reset (Sync)


### PR DESCRIPTION
For SW_RST_REQ, AonPok, and MainPok scenarios, the device is assumed to be in idle state. One common error shows up in the report is from SPI_HOST CONTROL.output_en to SPI_HOST PADs.

This commit adds constraints to turn off Passthrough and the SPI_HOST Output when resetting the IP.
