### PR TITLE
[bazel] Clean up ROM e2e targets

### DIFF
--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -99,12 +99,19 @@ def get_lc_items(*want_lc_values):
         fail("get_lc_items would produce list with incorrect length")
     return out
 
-def lc_hw_to_sw(hw_lc_state):
-    """Converts any TEST_* LC states to TEST"""
-    if hw_lc_state.startswith("TEST_"):
-        return "TEST"
-    else:
-        return hw_lc_state
+def lcv_hw_to_sw(hw_lc_state_val):
+    """Return the software LCV corresponding to the given hardware LCV."""
+    lcv_map = {
+        CONST.LCV.DEV: CONST.LCV_SW.DEV,
+        CONST.LCV.PROD: CONST.LCV_SW.PROD,
+        CONST.LCV.PROD_END: CONST.LCV_SW.PROD_END,
+        CONST.LCV.RMA: CONST.LCV_SW.RMA,
+        CONST.LCV.TEST_UNLOCKED0: CONST.LCV_SW.TEST,
+    }
+    sw_lcv = lcv_map.get(hw_lc_state_val)
+    if sw_lcv == None:
+        fail("Could not find software LCV for hardware LCV: 0x{}".format(hex(hw_lc_state_val)))
+    return sw_lcv
 
 _HEX_MAP = "0123456789abcdef"
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -591,22 +591,22 @@ opentitan_functest(
 )
 
 [otp_image(
-    name = "otp_img_shutdown_output_{}".format(lc_state.lower()),
-    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+    name = "otp_img_shutdown_output_{}".format(lc_state),
+    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
     overlays = STD_OTP_OVERLAYS,
-) for lc_state in structs.to_dict(CONST.LCV)]
+) for lc_state, _ in get_lc_items()]
 
 # Splice OTP images into bitstreams
 [
     bitstream_splice(
-        name = "bitstream_shutdown_output_{}".format(lc_state.lower()),
+        name = "bitstream_shutdown_output_{}".format(lc_state),
         src = "//hw/bitstream:rom",
-        data = ":otp_img_shutdown_output_{}".format(lc_state.lower()),
+        data = ":otp_img_shutdown_output_{}".format(lc_state),
         meminfo = "//hw/bitstream:otp_mmi",
         tags = ["vivado"],
         update_usr_access = True,
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, _ in get_lc_items()
 ]
 
 manifest({
@@ -616,19 +616,19 @@ manifest({
 })
 
 [opentitan_functest(
-    name = "shutdown_output_{}".format(lc_state.lower()),
+    name = "shutdown_output_{}".format(lc_state),
     cw310 = cw310_params(
-        bitstream = ":bitstream_shutdown_output_{}".format(lc_state.lower()),
+        bitstream = ":bitstream_shutdown_output_{}".format(lc_state),
         exit_failure = MSG_PASS,
         exit_success = MSG_TEMPLATE_BFV_LCV.format(
             hex(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
             hex(lc_state_val),
         ),
-        otp = ":otp_img_shutdown_output_{}".format(lc_state.lower()),
+        otp = ":otp_img_shutdown_output_{}".format(lc_state),
         tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
     ),
     dv = dv_params(
-        otp = ":otp_img_shutdown_output_{}".format(lc_state.lower()),
+        otp = ":otp_img_shutdown_output_{}".format(lc_state),
         rom = "//sw/device/silicon_creator/rom",
     ),
     manifest = ":manifest_bad_identifier",
@@ -638,12 +638,12 @@ manifest({
         "cw310_rom",
         "dv",
     ],
-) for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()]
+) for lc_state, lc_state_val in get_lc_items()]
 
 test_suite(
     name = "shutdown_output",
     tags = ["manual"],
-    tests = ["shutdown_output_{}".format(lc_state.lower()) for lc_state in structs.to_dict(CONST.LCV)],
+    tests = ["shutdown_output_{}".format(lc_state) for lc_state, _ in get_lc_items()],
 )
 
 SEC_VERS = [
@@ -799,53 +799,61 @@ otp_json(
 )
 
 [otp_image(
-    name = "otp_img_boot_policy_rollback_{}".format(lc_state.lower()),
-    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+    name = "otp_img_boot_policy_rollback_{}".format(lc_state),
+    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
     overlays = STD_OTP_OVERLAYS + [":otp_json_boot_policy_rollback"],
     visibility = ["//visibility:private"],
-) for lc_state in structs.to_dict(CONST.LCV)]
+) for lc_state, _ in get_lc_items()]
 
 [bitstream_splice(
     name = "bitstream_boot_policy_rollback_{}".format(
-        lc_state.lower(),
+        lc_state,
     ),
     src = "//hw/bitstream:rom",
     data = ":otp_img_boot_policy_rollback_{}".format(
-        lc_state.lower(),
+        lc_state,
     ),
     meminfo = "//hw/bitstream:otp_mmi",
     tags = ["vivado"],
     update_usr_access = True,
     visibility = ["//visibility:private"],
-) for lc_state in structs.to_dict(CONST.LCV)]
+) for lc_state, _ in get_lc_items()]
 
-[opentitan_functest(
-    name = "boot_policy_rollback_{}_a_{}_b_{}".format(
-        lc_state.lower(),
-        t["a"],
-        t["b"],
-    ),
-    cw310 = cw310_params(
-        bitstream = "bitstream_boot_policy_rollback_{}".format(lc_state.lower()),
-        exit_success = t["exit_success"],
-        tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
-    ),
-    key = "multislot",
-    ot_flash_binary = ":sec_ver_{}_{}_image".format(
-        t["a"],
-        t["b"],
-    ),
-    targets = ["cw310_rom"],
-) for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items() for t in BOOT_POLICY_ROLLBACK_CASES]
+[
+    opentitan_functest(
+        name = "boot_policy_rollback_{}_a_{}_b_{}".format(
+            lc_state,
+            t["a"],
+            t["b"],
+        ),
+        cw310 = cw310_params(
+            bitstream = "bitstream_boot_policy_rollback_{}".format(lc_state),
+            exit_success = t["exit_success"],
+            tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
+        ),
+        key = "multislot",
+        ot_flash_binary = ":sec_ver_{}_{}_image".format(
+            t["a"],
+            t["b"],
+        ),
+        targets = ["cw310_rom"],
+    )
+    for lc_state, lc_state_val in get_lc_items()
+    for t in BOOT_POLICY_ROLLBACK_CASES
+]
 
 test_suite(
     name = "rom_e2e_boot_policy_rollback",
     tags = ["manual"],
-    tests = ["boot_policy_rollback_{}_a_{}_b_{}".format(
-        lc_state.lower(),
-        t["a"],
-        t["b"],
-    ) for lc_state in structs.to_dict(CONST.LCV) for t in BOOT_POLICY_ROLLBACK_CASES],
+    tests = [
+        "boot_policy_rollback_{}_a_{}_b_{}".format(
+            lc_state,
+            t["a"],
+            t["b"],
+        )
+        for lc_state, _ in get_lc_items()
+        for t in BOOT_POLICY_ROLLBACK_CASES
+    ],
 )
 
 # Watchdog configuration test cases.
@@ -991,33 +999,30 @@ test_suite(
 # life cycle state.
 
 # Alert handler configuration is not checked in the TEST LC state.
-ALERT_LC_STATES = {
-    k: structs.to_dict(CONST.LCV)[k]
-    for k in [
-        "PROD",
-        "PROD_END",
-        "DEV",
-        "RMA",
-    ]
-}
+ALERT_LC_STATES = get_lc_items(
+    CONST.LCV.PROD,
+    CONST.LCV.PROD_END,
+    CONST.LCV.DEV,
+    CONST.LCV.RMA,
+)
 
 [otp_image(
-    name = "otp_img_alert_{}".format(lc_state.lower()),
-    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+    name = "otp_img_alert_{}".format(lc_state),
+    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
     overlays = STD_OTP_OVERLAYS,
-) for lc_state in ALERT_LC_STATES]
+) for lc_state, _ in ALERT_LC_STATES]
 
 [bitstream_splice(
-    name = "bitstream_alert_{}".format(lc_state.lower()),
+    name = "bitstream_alert_{}".format(lc_state),
     src = "//hw/bitstream:rom",
-    data = ":otp_img_alert_{}".format(lc_state.lower()),
+    data = ":otp_img_alert_{}".format(lc_state),
     meminfo = "//hw/bitstream:otp_mmi",
     tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
     update_usr_access = True,
-) for lc_state, lc_state_val in ALERT_LC_STATES.items()]
+) for lc_state, lc_state_val in ALERT_LC_STATES]
 
 [opentitan_flash_binary(
-    name = "rom_e2e_alert_config_test_{}".format(lc_state.lower()),
+    name = "rom_e2e_alert_config_test_{}".format(lc_state),
     srcs = ["rom_e2e_alert_config_test.c"],
     devices = [
         "fpga_cw310",
@@ -1033,33 +1038,33 @@ ALERT_LC_STATES = {
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/drivers:otp",
     ],
-) for lc_state in ALERT_LC_STATES]
+) for lc_state, _ in ALERT_LC_STATES]
 
 [
     opentitan_functest(
         name = "alert_{}".format(
-            lc_state.lower(),
+            lc_state,
         ),
         cw310 = cw310_params(
-            bitstream = ":bitstream_alert_{}".format(lc_state.lower()),
+            bitstream = ":bitstream_alert_{}".format(lc_state),
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         key = "fake_prod_key_0",
-        ot_flash_binary = ":rom_e2e_alert_config_test_{}".format(lc_state.lower()),
+        ot_flash_binary = ":rom_e2e_alert_config_test_{}".format(lc_state),
         signed = True,
         targets = [
             "cw310_rom",
         ],
     )
-    for lc_state, lc_state_val in ALERT_LC_STATES.items()
+    for lc_state, lc_state_val in ALERT_LC_STATES
 ]
 
 test_suite(
     name = "rom_e2e_alert_config",
     tags = ["manual"],
     tests = [
-        "alert_{}".format(lc_state.lower())
-        for lc_state in ALERT_LC_STATES
+        "alert_{}".format(lc_state)
+        for lc_state, _ in ALERT_LC_STATES
     ],
 )
 
@@ -1127,25 +1132,25 @@ otp_alert_digest(
 )
 
 [otp_image(
-    name = "otp_img_shutdown_alert_{}".format(lc_state.lower()),
-    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+    name = "otp_img_shutdown_alert_{}".format(lc_state),
+    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
     overlays = STD_OTP_OVERLAYS + [
         ":shutdown_alert_owner_sw_cfg",
         ":shutdown_alert_digest_cfg",
     ],
-) for lc_state in ALERT_LC_STATES]
+) for lc_state, _ in ALERT_LC_STATES]
 
 [bitstream_splice(
-    name = "bitstream_shutdown_alert_{}".format(lc_state.lower()),
+    name = "bitstream_shutdown_alert_{}".format(lc_state),
     src = "//hw/bitstream:rom",
-    data = ":otp_img_shutdown_alert_{}".format(lc_state.lower()),
+    data = ":otp_img_shutdown_alert_{}".format(lc_state),
     meminfo = "//hw/bitstream:otp_mmi",
     tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
     update_usr_access = True,
-) for lc_state, lc_state_val in ALERT_LC_STATES.items()]
+) for lc_state, lc_state_val in ALERT_LC_STATES]
 
 [opentitan_flash_binary(
-    name = "rom_e2e_shutdown_alert_config_test_{}".format(lc_state.lower()),
+    name = "rom_e2e_shutdown_alert_config_test_{}".format(lc_state),
     srcs = ["rom_e2e_shutdown_alert_config_test.c"],
     devices = [
         "fpga_cw310",
@@ -1158,33 +1163,31 @@ otp_alert_digest(
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
         "//sw/device/silicon_creator/lib/drivers:rstmgr",
     ],
-) for lc_state in ALERT_LC_STATES]
+) for lc_state, _ in ALERT_LC_STATES]
 
 [
     opentitan_functest(
-        name = "shutdown_alert_{}".format(
-            lc_state.lower(),
-        ),
+        name = "shutdown_alert_{}".format(lc_state),
         cw310 = cw310_params(
-            bitstream = ":bitstream_shutdown_alert_{}".format(lc_state.lower()),
+            bitstream = ":bitstream_shutdown_alert_{}".format(lc_state),
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         key = "fake_prod_key_0",
-        ot_flash_binary = ":rom_e2e_shutdown_alert_config_test_{}".format(lc_state.lower()),
+        ot_flash_binary = ":rom_e2e_shutdown_alert_config_test_{}".format(lc_state),
         signed = True,
         targets = [
             "cw310_rom",
         ],
     )
-    for lc_state, lc_state_val in ALERT_LC_STATES.items()
+    for lc_state, lc_state_val in ALERT_LC_STATES
 ]
 
 test_suite(
     name = "rom_e2e_shutdown_alert_config",
     tags = ["manual"],
     tests = [
-        "shutdown_alert_{}".format(lc_state.lower())
-        for lc_state in ALERT_LC_STATES
+        "shutdown_alert_{}".format(lc_state)
+        for lc_state, _ in ALERT_LC_STATES
     ],
 )
 
@@ -1192,19 +1195,19 @@ SIGVERIFY_MOD_EXP_CASES = [
     {
         "name": "sw",
         "use_sw_rsa_verify": CONST.TRUE,
-        "exit_success": {lc_state.lower(): "use_sw_rsa_verify=0x00000739" for lc_state in structs.to_dict(CONST.LCV)},
+        "exit_success": {lc_state: "use_sw_rsa_verify=0x00000739" for lc_state, _ in get_lc_items()},
     },
     {
         "name": "otbn",
         "use_sw_rsa_verify": CONST.FALSE,
-        "exit_success": {lc_state.lower(): "use_sw_rsa_verify=0x000001d4" for lc_state in structs.to_dict(CONST.LCV)},
+        "exit_success": {lc_state: "use_sw_rsa_verify=0x000001d4" for lc_state, _ in get_lc_items()},
     },
     {
         "name": "invalid",
         "use_sw_rsa_verify": 0,
         "exit_success": {
-            lc_state.lower(): MSG_TEMPLATE_BFV.format(hex(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)) if lc_state_val != CONST.LCV.TEST_UNLOCKED0 else "use_sw_rsa_verify=0x00000000"
-            for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+            lc_state: MSG_TEMPLATE_BFV.format(hex(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)) if lc_state_val != CONST.LCV.TEST_UNLOCKED0 else "use_sw_rsa_verify=0x00000000"
+            for lc_state, lc_state_val in get_lc_items()
         },
     },
 ]
@@ -1242,26 +1245,26 @@ opentitan_flash_binary(
 [
     otp_image(
         name = "otp_img_sigverify_mod_exp_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             t["name"],
         ),
-        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS + [":otp_json_sigverify_mod_exp_{}".format(t["name"])],
         visibility = ["//visibility:private"],
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, _ in get_lc_items()
     for t in SIGVERIFY_MOD_EXP_CASES
 ]
 
 [
     bitstream_splice(
         name = "bitstream_sigverify_mod_exp_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             t["name"],
         ),
         src = "//hw/bitstream:rom",
         data = ":otp_img_sigverify_mod_exp_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             t["name"],
         ),
         meminfo = "//hw/bitstream:otp_mmi",
@@ -1269,38 +1272,42 @@ opentitan_flash_binary(
         update_usr_access = True,
         visibility = ["//visibility:private"],
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, _ in get_lc_items()
     for t in SIGVERIFY_MOD_EXP_CASES
 ]
 
 [
     opentitan_functest(
         name = "sigverify_mod_exp_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             t["name"],
         ),
         cw310 = cw310_params(
             bitstream = ":bitstream_sigverify_mod_exp_{}_{}".format(
-                lc_state.lower(),
+                lc_state,
                 t["name"],
             ),
-            exit_success = t["exit_success"][lc_state.lower()],
+            exit_success = t["exit_success"][lc_state],
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         ot_flash_binary = ":empty_test_sigverify_mod_exp",
         targets = ["cw310_rom"],
     )
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
     for t in SIGVERIFY_MOD_EXP_CASES
 ]
 
 test_suite(
     name = "rom_e2e_sigverify_mod_exp",
     tags = ["manual"],
-    tests = ["sigverify_mod_exp_{}_{}".format(
-        lc_state.lower(),
-        t["name"],
-    ) for lc_state in structs.to_dict(CONST.LCV) for t in SIGVERIFY_MOD_EXP_CASES],
+    tests = [
+        "sigverify_mod_exp_{}_{}".format(
+            lc_state,
+            t["name"],
+        )
+        for lc_state, _ in get_lc_items()
+        for t in SIGVERIFY_MOD_EXP_CASES
+    ],
 )
 
 BOOT_POLICY_BAD_MANIFEST_CASES = [
@@ -1491,14 +1498,14 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
 [
     otp_image(
         name = "otp_img_boot_policy_bad_manifest_{}_sec_ver_{}".format(
-            lc_state.lower(),
+            lc_state,
             sec_ver,
         ),
-        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS + [":otp_json_sec_ver_{}".format(sec_ver)],
         visibility = ["//visibility:private"],
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, _ in get_lc_items()
     for sec_ver in [
         0,
         1,
@@ -1508,12 +1515,12 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
 [
     bitstream_splice(
         name = "bitstream_boot_policy_bad_manifest_{}_sec_ver_{}".format(
-            lc_state.lower(),
+            lc_state,
             sec_ver,
         ),
         src = "//hw/bitstream:rom",
         data = ":otp_img_boot_policy_bad_manifest_{}_sec_ver_{}".format(
-            lc_state.lower(),
+            lc_state,
             sec_ver,
         ),
         meminfo = "//hw/bitstream:otp_mmi",
@@ -1521,7 +1528,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
         update_usr_access = True,
         visibility = ["//visibility:private"],
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, _ in get_lc_items()
     for sec_ver in [
         0,
         1,
@@ -1531,13 +1538,13 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
 [
     opentitan_functest(
         name = "boot_policy_bad_manifest_{}_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             t["name"],
             slot,
         ),
         cw310 = cw310_params(
             bitstream = "bitstream_boot_policy_bad_manifest_{}_sec_ver_{}".format(
-                lc_state.lower(),
+                lc_state,
                 t.get("sec_ver", 0),
             ),
             exit_success = t["exit_success"],
@@ -1560,7 +1567,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             ],
         ),
     )
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
     for t in BOOT_POLICY_BAD_MANIFEST_CASES
     for slot in SLOTS
 ]
@@ -1570,11 +1577,11 @@ test_suite(
     tags = ["manual"],
     tests = [
         "boot_policy_bad_manifest_{}_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             t["name"],
             slot,
         )
-        for lc_state in structs.to_dict(CONST.LCV)
+        for lc_state, _ in get_lc_items()
         for t in BOOT_POLICY_BAD_MANIFEST_CASES
         for slot in SLOTS
     ],
@@ -1819,12 +1826,12 @@ BOOT_POLICY_VALID_CASES = [
 [
     opentitan_functest(
         name = "boot_policy_valid_{}_a_{}_b_{}".format(
-            lc_state.lower(),
+            lc_state,
             a["desc"],
             b["desc"],
         ),
         cw310 = cw310_params(
-            bitstream = "bitstream_boot_policy_valid_{}".format(lc_state.lower()),
+            bitstream = "bitstream_boot_policy_valid_{}".format(lc_state),
             exit_failure = MSG_PASS if a["desc"] == b["desc"] and a["desc"] == "bad" else DEFAULT_TEST_FAILURE_MSG,
             exit_success = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG)) if a["desc"] == b["desc"] and a["desc"] == "bad" else MSG_PASS,
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
@@ -1836,7 +1843,7 @@ BOOT_POLICY_VALID_CASES = [
         ),
         targets = ["cw310_rom"],
     )
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
     for a in BOOT_POLICY_VALID_CASES
     for b in BOOT_POLICY_VALID_CASES
 ]
@@ -1846,11 +1853,11 @@ test_suite(
     tags = ["manual"],
     tests = [
         "boot_policy_valid_{}_a_{}_b_{}".format(
-            lc_state.lower(),
+            lc_state,
             a["desc"],
             b["desc"],
         )
-        for lc_state in structs.to_dict(CONST.LCV)
+        for lc_state, _ in get_lc_items()
         for a in BOOT_POLICY_VALID_CASES
         for b in BOOT_POLICY_VALID_CASES
     ],
@@ -1998,9 +2005,7 @@ SRAM_JTAG_INJECTION_GDB_SCRIPT = """
 
 test_suite(
     name = "rom_e2e_jtag_inject_tests",
-    tags = [
-        "manual",
-    ],
+    tags = ["manual"],
     tests = [
         "sram_program_fpga_cw310_test_otp_" + lc_state
         for lc_state, _ in get_lc_items(
@@ -2013,10 +2018,10 @@ test_suite(
 
 [
     opentitan_functest(
-        name = "epmp_init_otp_" + lc_state.lower(),
+        name = "epmp_init_otp_" + lc_state,
         srcs = ["epmp_init_test.c"],
         cw310 = cw310_params(
-            bitstream = "//hw/bitstream:rom_otp_" + lc_state.lower(),
+            bitstream = "//hw/bitstream:rom_otp_" + lc_state,
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         key = LC_KEY_TYPES[lc_state_val][0],
@@ -2033,7 +2038,7 @@ test_suite(
         ],
         verilator = verilator_params(
             timeout = "eternal",
-            otp = "//hw/ip/otp_ctrl/data:img_" + lc_state.lower(),
+            otp = "//hw/ip/otp_ctrl/data:img_" + lc_state,
             rom = "//sw/device/silicon_creator/rom:rom",
         ),
         deps = [
@@ -2048,18 +2053,13 @@ test_suite(
             "//sw/device/silicon_creator/lib:epmp_defs",
         ],
     )
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
 ]
 
 test_suite(
     name = "rom_e2e_epmp_init",
-    tags = [
-        "manual",
-    ],
-    tests = [
-        "epmp_init_otp_" + lc_state.lower()
-        for lc_state in structs.to_dict(CONST.LCV).keys()
-    ],
+    tags = ["manual"],
+    tests = ["epmp_init_otp_" + lc_state for lc_state, _ in get_lc_items()],
 )
 
 [
@@ -2382,9 +2382,7 @@ test_suite(
 
 test_suite(
     name = "rom_e2e_asm_watchdog",
-    tags = [
-        "manual",
-    ],
+    tags = ["manual"],
     tests = [
         "rom_e2e_asm_watchdog_" + type + "_fpga_cw310_test_otp_" + lc_state
         for lc_state, lc_state_val in get_lc_items(
@@ -2421,26 +2419,26 @@ REDACT.update({"INVALID": 0x0})
 [
     otp_image(
         name = "img_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             redact.lower(),
         ),
-        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS + [":otp_json_{}_overlay".format(redact.lower())],
         visibility = ["//visibility:private"],
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, _ in get_lc_items()
     for redact in REDACT
 ]
 
 [
     bitstream_splice(
         name = "bitstream_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             redact.lower(),
         ),
         src = "//hw/bitstream:rom",
         data = ":img_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             redact.lower(),
         ),
         meminfo = "//hw/bitstream:otp_mmi",
@@ -2448,20 +2446,20 @@ REDACT.update({"INVALID": 0x0})
         update_usr_access = True,
         visibility = ["//visibility:private"],
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, _ in get_lc_items()
     for redact in REDACT
 ]
 
 [
     opentitan_functest(
         name = "e2e_shutdown_redact_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             redact.lower(),
         ),
         srcs = ["empty_test.c"],
         cw310 = cw310_params(
             bitstream = "bitstream_{}_{}".format(
-                lc_state.lower(),
+                lc_state,
                 redact.lower(),
             ),
             exit_failure = MSG_PASS,
@@ -2481,17 +2479,21 @@ REDACT.update({"INVALID": 0x0})
             "//sw/device/silicon_creator/lib/drivers:otp",
         ],
     )
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
     for redact, redact_val in REDACT.items()
 ]
 
 test_suite(
     name = "rom_e2e_shutdown_redact",
     tags = ["manual"],
-    tests = ["e2e_shutdown_redact_{}_{}".format(
-        lc_state.lower(),
-        redact.lower(),
-    ) for lc_state in structs.to_dict(CONST.LCV) for redact in REDACT],
+    tests = [
+        "e2e_shutdown_redact_{}_{}".format(
+            lc_state,
+            redact.lower(),
+        )
+        for lc_state, _ in get_lc_items()
+        for redact in REDACT
+    ],
 )
 
 [
@@ -2581,22 +2583,22 @@ test_suite(
 ]
 
 [otp_image(
-    name = "otp_img_sigverify_always_{}".format(lc_state.lower()),
-    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+    name = "otp_img_sigverify_always_{}".format(lc_state),
+    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
     overlays = STD_OTP_OVERLAYS,
-) for lc_state in structs.to_dict(CONST.LCV)]
+) for lc_state, _ in get_lc_items()]
 
 # Splice OTP images into bitstreams
 [
     bitstream_splice(
-        name = "bitstream_sigverify_always_{}".format(lc_state.lower()),
+        name = "bitstream_sigverify_always_{}".format(lc_state),
         src = "//hw/bitstream:rom",
-        data = ":otp_img_sigverify_always_{}".format(lc_state.lower()),
+        data = ":otp_img_sigverify_always_{}".format(lc_state),
         meminfo = "//hw/bitstream:otp_mmi",
         tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         update_usr_access = True,
     )
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
 ]
 
 SIGVERIFY_BAD_CASES = [
@@ -2633,29 +2635,29 @@ SIGVERIFY_LCS_2_VALID_KEY = {
 [
     opentitan_functest(
         name = "sigverify_always_{}_a_{}_b_{}".format(
-            lc_state.lower(),
+            lc_state,
             case["a"],
             case["b"],
         ),
         cw310 = cw310_params(
-            bitstream = ":bitstream_sigverify_always_{}".format(lc_state.lower()),
+            bitstream = ":bitstream_sigverify_always_{}".format(lc_state),
             exit_failure = MSG_PASS,
             exit_success = MSG_TEMPLATE_BFV_LCV.format(
                 case["expected_bfv"],
                 hex(lc_state_val),
             ),
-            otp = ":otp_img_sigverify_always_{}".format(lc_state.lower()),
+            otp = ":otp_img_sigverify_always_{}".format(lc_state),
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         dv = dv_params(
-            otp = ":otp_img_sigverify_always_{}".format(lc_state.lower()),
+            otp = ":otp_img_sigverify_always_{}".format(lc_state),
             rom = "//sw/device/silicon_creator/rom",
         ),
         key = "multislot",
         ot_flash_binary = ":sigverify_always_img_a_{}_b_{}_{}".format(
             case["a"],
             case["b"],
-            SIGVERIFY_LCS_2_VALID_KEY[lc_state.lower()],
+            SIGVERIFY_LCS_2_VALID_KEY[lc_state],
         ),
         targets = [
             "dv",
@@ -2663,7 +2665,7 @@ SIGVERIFY_LCS_2_VALID_KEY = {
         ],
     )
     for case in SIGVERIFY_BAD_CASES
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
 ]
 
 test_suite(
@@ -2671,39 +2673,39 @@ test_suite(
     tags = ["manual"],
     tests = [
         "sigverify_always_{}_a_{}_b_{}".format(
-            lc_state.lower(),
+            lc_state,
             case["a"],
             case["b"],
         )
         for case in SIGVERIFY_BAD_CASES
-        for lc_state in structs.to_dict(CONST.LCV)
+        for lc_state, _ in get_lc_items()
     ],
 )
 
 [
     otp_image(
-        name = "otp_img_sigverify_key_type_{}".format(lc_state.lower()),
-        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+        name = "otp_img_sigverify_key_type_{}".format(lc_state),
+        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS,
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, _ in get_lc_items()
 ]
 
 [
     bitstream_splice(
         name = "bitstream_sigverify_key_type_{}".format(
-            lc_state.lower(),
+            lc_state,
         ),
         src = "//hw/bitstream:rom",
         data = ":otp_img_sigverify_key_type_{}".format(
-            lc_state.lower(),
+            lc_state,
         ),
         meminfo = "//hw/bitstream:otp_mmi",
         tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         update_usr_access = True,
         visibility = ["//visibility:private"],
     )
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
 ]
 
 SIGVERIFY_KEY_TYPE_KEYS = [
@@ -2715,11 +2717,11 @@ SIGVERIFY_KEY_TYPE_KEYS = [
 [
     opentitan_functest(
         name = "sigverify_key_type_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             key,
         ),
         cw310 = cw310_params(
-            bitstream = ":bitstream_sigverify_key_type_{}".format(lc_state.lower()),
+            bitstream = ":bitstream_sigverify_key_type_{}".format(lc_state),
             exit_failure = MSG_PASS if key not in LC_KEY_TYPES[lc_state_val] else MSG_TEMPLATE_BFV_LCV.format(
                 hex(CONST.BFV.SIGVERIFY.BAD_KEY),
                 hex(lc_state_val),
@@ -2736,7 +2738,7 @@ SIGVERIFY_KEY_TYPE_KEYS = [
             "cw310_rom",
         ],
     )
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
     for key in SIGVERIFY_KEY_TYPE_KEYS
 ]
 
@@ -2745,10 +2747,10 @@ test_suite(
     tags = ["manual"],
     tests = [
         "sigverify_key_type_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             key,
         )
-        for lc_state in structs.to_dict(CONST.LCV)
+        for lc_state, _ in get_lc_items()
         for key in SIGVERIFY_KEY_TYPE_KEYS
     ],
 )
@@ -2767,38 +2769,38 @@ otp_json(
 
 [
     otp_image(
-        name = "otp_img_sigverify_key_validity_{}".format(lc_state.lower()),
-        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+        name = "otp_img_sigverify_key_validity_{}".format(lc_state),
+        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS + [":otp_json_sigverify_key_validity"],
     )
-    for lc_state in structs.to_dict(CONST.LCV)
+    for lc_state, _ in get_lc_items()
 ]
 
 [
     bitstream_splice(
         name = "bitstream_sigverify_key_validity_{}".format(
-            lc_state.lower(),
+            lc_state,
         ),
         src = "//hw/bitstream:rom",
         data = ":otp_img_sigverify_key_validity_{}".format(
-            lc_state.lower(),
+            lc_state,
         ),
         meminfo = "//hw/bitstream:otp_mmi",
         tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         update_usr_access = True,
         visibility = ["//visibility:private"],
     )
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
 ]
 
 [
     opentitan_functest(
         name = "sigverify_key_validity_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             key,
         ),
         cw310 = cw310_params(
-            bitstream = ":bitstream_sigverify_key_validity_{}".format(lc_state.lower()),
+            bitstream = ":bitstream_sigverify_key_validity_{}".format(lc_state),
             exit_failure = MSG_PASS if lc_state_val != CONST.LCV.TEST_UNLOCKED0 else MSG_TEMPLATE_BFV_LCV.format(
                 hex(CONST.BFV.SIGVERIFY.BAD_KEY),
                 hex(lc_state_val),
@@ -2815,7 +2817,7 @@ otp_json(
             "cw310_rom",
         ],
     )
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
     for key in LC_KEY_TYPES[lc_state_val]
 ]
 
@@ -2824,10 +2826,10 @@ test_suite(
     tags = ["manual"],
     tests = [
         "sigverify_key_validity_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             key,
         )
-        for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+        for lc_state, lc_state_val in get_lc_items()
         for key in LC_KEY_TYPES[lc_state_val]
     ],
 )
@@ -2871,21 +2873,21 @@ otp_json(
 )
 
 [otp_image(
-    name = "otp_img_sigverify_usage_constraints_{}".format(lc_state.lower()),
-    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state.lower()),
+    name = "otp_img_sigverify_usage_constraints_{}".format(lc_state),
+    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
     overlays = STD_OTP_OVERLAYS + [":otp_json_set_usage_constraint_params_overlay"],
     visibility = ["//visibility:private"],
-) for lc_state, _ in structs.to_dict(CONST.LCV).items()]
+) for lc_state, _ in get_lc_items()]
 
 [bitstream_splice(
-    name = "bitstream_sigverify_usage_constraints_{}".format(lc_state.lower()),
+    name = "bitstream_sigverify_usage_constraints_{}".format(lc_state),
     src = "//hw/bitstream:rom",
-    data = ":otp_img_sigverify_usage_constraints_{}".format(lc_state.lower()),
+    data = ":otp_img_sigverify_usage_constraints_{}".format(lc_state),
     meminfo = "//hw/bitstream:otp_mmi",
     tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
     update_usr_access = True,
     visibility = ["//visibility:private"],
-) for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()]
+) for lc_state, lc_state_val in get_lc_items()]
 
 _SIGVERIFY_FAIL_MSG = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG))
 
@@ -2961,7 +2963,7 @@ device_id_test_cases = [
 lc_state_test_cases = [
     {
         "name": "lc_state_{}_{}".format(
-            lc_state.lower(),
+            lc_state,
             "match" if match_case else "no_match",
         ),
         # Note: the manifest value for a given life-cycle state is determined
@@ -3008,7 +3010,7 @@ all_constr_test_cases = [
     {
         "name": "all_constraints_mf_lc_{}_bs_lc_{}".format(
             mf_lc_state.lower(),
-            bs_lc_state.lower(),
+            bs_lc_state,
         ),
         "manifest": {
             "selector_bits": "0x7ff",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -11,7 +11,7 @@ load(
     "opentitan_functest",
     "verilator_params",
 )
-load("//rules:const.bzl", "CONST", "error_redact", "get_lc_items", "hex", "lc_hw_to_sw")
+load("//rules:const.bzl", "CONST", "error_redact", "get_lc_items", "hex", "lcv_hw_to_sw")
 load(
     "//rules:opentitan.bzl",
     "bin_to_vmem",
@@ -2971,17 +2971,14 @@ lc_state_test_cases = [
         # performing the lookup.
         "manifest": {
             "selector_bits": "0x400",
-            "life_cycle_state": hex(getattr(
-                CONST.LCV_SW,
-                lc_hw_to_sw(lc_state),
-            )) if match_case else "0",
+            "life_cycle_state": hex(lcv_hw_to_sw(lc_state_val)) if match_case else "0",
         },
-        "bitstream": ":bitstream_sigverify_usage_constraints_{}".format(lc_state.lower()),
+        "bitstream": ":bitstream_sigverify_usage_constraints_{}".format(lc_state),
         "exit_success": DEFAULT_TEST_SUCCESS_MSG if match_case else _SIGVERIFY_FAIL_MSG,
         "exit_failure": _SIGVERIFY_FAIL_MSG if match_case else DEFAULT_TEST_SUCCESS_MSG,
         "lc_state_val": lc_state_val,
     }
-    for lc_state, lc_state_val in structs.to_dict(CONST.LCV).items()
+    for lc_state, lc_state_val in get_lc_items()
     for match_case in (True, False)
 ]
 
@@ -3020,13 +3017,13 @@ all_constr_test_cases = [
             "manuf_state_creator": _test_manuf_states["creator"],
             "manuf_state_owner": _test_manuf_states["owner"],
         },
-        "bitstream": ":bitstream_sigverify_usage_constraints_{}".format(bs_lc_state.lower()),
-        "exit_success": DEFAULT_TEST_SUCCESS_MSG if mf_lc_state == lc_hw_to_sw(bs_lc_state) else _SIGVERIFY_FAIL_MSG,
-        "exit_failure": _SIGVERIFY_FAIL_MSG if mf_lc_state == lc_hw_to_sw(bs_lc_state) else DEFAULT_TEST_SUCCESS_MSG,
+        "bitstream": ":bitstream_sigverify_usage_constraints_{}".format(bs_lc_state),
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG if mf_lc_val == lcv_hw_to_sw(bs_lc_val) else _SIGVERIFY_FAIL_MSG,
+        "exit_failure": _SIGVERIFY_FAIL_MSG if mf_lc_val == lcv_hw_to_sw(bs_lc_val) else DEFAULT_TEST_SUCCESS_MSG,
         "lc_state_val": bs_lc_val,
     }
     for mf_lc_state, mf_lc_val in structs.to_dict(CONST.LCV_SW).items()
-    for bs_lc_state, bs_lc_val in structs.to_dict(CONST.LCV).items()
+    for bs_lc_state, bs_lc_val in get_lc_items()
 ]
 
 # Usage constraints that are not selected by the selector_bits must be set to


### PR DESCRIPTION
This PR eliminates two unnecessary bitstream splices and makes use of `get_lc_items()` to simplify iterating over lifecycle values.