### PR TITLE
[dv/chip] alert_handler_lpg_clkoff test alert_ping_req check

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1050,7 +1050,11 @@
       uvm_test_seq: chip_sw_alert_handler_lpg_clkoff_vseq
       sw_images: ["//sw/device/tests:alert_handler_lpg_clkoff_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000"]
+      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000",
+                 // TODO: when ping timer wait time is forced to a small value, alert might be sent
+                 // for ping response, we cannot easily identify this in interface. Need to enhance
+                 // the alert_esc_agent. Issue #16374.
+                 "+bypass_alert_ready_to_end_check=1"]
       run_timeout_mins: 240
     }
     {

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -870,6 +870,10 @@ interface chip_if;
   `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_alert_handler_ping_timer_wait_cyc_mask_i,
       `ALERT_HANDLER_HIER.u_ping_timer.wait_cyc_mask_i)
 
+  // Signal probe function for alert_ping_req in alert_handler.
+  `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_alert_handler_ping_reqs,
+      `ALERT_HANDLER_HIER.alert_ping_req)
+
   // Signal probe function for keymgr key state.
   `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_keymgr_key_state,
       `KEYMGR_HIER.u_ctrl.key_state_q)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_lpg_clkoff_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_lpg_clkoff_vseq.sv
@@ -2,18 +2,66 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_sw_alert_handler_lpg_clkoff_vseq extends chip_sw_base_vseq;
+class chip_sw_alert_handler_lpg_clkoff_vseq extends
+      chip_sw_alert_handler_shorten_ping_wait_cycle_vseq;
   `uvm_object_utils(chip_sw_alert_handler_lpg_clkoff_vseq)
 
   `uvm_object_new
 
-  virtual task pre_start();
-    // The wait-time between two ping requests is a 16-bit value, coming from an LFSR.
-    // In DV, we force the wait-time to known fixed value so that the alert handler's ping mechanism
-    // is able to hit all blocks within a reasonable amount of simulated / wall clock time. We pick
-    // 7 which is the minimum-allowed value.
-    void'(cfg.chip_vif.signal_probe_alert_handler_ping_timer_wait_cyc_mask_i(SignalProbeForce, 7));
-    super.pre_start();
+  typedef alert_id_e alert_ids_t[];
+
+  // The list of IPs tested in this test. This enumeration must match the array in
+  // sw/device/tests/alert_handler_lpg_clkoff_test.c::kPeripherals[].
+  alert_ids_t IpAlertsUnderTest[string] = '{
+      "AES":       '{TopEarlgreyAlertIdAesRecovCtrlUpdateErr, TopEarlgreyAlertIdAesFatalFault},
+      "HMAC":      '{TopEarlgreyAlertIdHmacFatalFault},
+      "KMAC":      '{TopEarlgreyAlertIdKmacRecovOperationErr, TopEarlgreyAlertIdKmacFatalFaultErr},
+      "OTBN":      '{TopEarlgreyAlertIdOtbnFatal, TopEarlgreyAlertIdOtbnRecov},
+      "SPI_HOST0": '{TopEarlgreyAlertIdSpiHost0FatalFault},
+      "SPI_HOST1": '{TopEarlgreyAlertIdSpiHost1FatalFault},
+      "USB":       '{TopEarlgreyAlertIdUsbdevFatalFault}
+   };
+
+  virtual function void write_test_done_to_sw(int idx);
+    sw_symbol_backdoor_overwrite("kTestIp", {<<8{idx}});
+  endfunction
+
+  virtual task body();
+    int i = 0;
+    super.body();
+    foreach (IpAlertsUnderTest[ip_name]) begin
+
+      // Wait for design to turn off the IP clock.
+      `uvm_info(`gfn, $sformatf("Waiting for alert ping %0s", ip_name), UVM_LOW)
+      `DV_WAIT(cfg.sw_logger_vif.printed_log == $sformatf("Turn off %0s clock", ip_name))
+
+      fork begin : isolation_fork
+        alert_ids_t list_of_alerts = IpAlertsUnderTest[ip_name];
+        foreach (list_of_alerts[j]) begin
+          automatic alert_id_e alert_idx = list_of_alerts[j];
+          fork
+            begin
+              bit [alert_pkg::NAlerts-1:0] alert_reqs;
+              // Wait for alert_handler to send the ping request(s) to prim_alert_receiver.
+              // If the alert_reqs were not set in certain timeout limit, the SW wait function
+              // will timeout.
+              while (alert_reqs[alert_idx] == 0) begin
+                @(negedge cfg.chip_vif.alerts_if.clk);
+                alert_reqs = cfg.chip_vif.signal_probe_alert_handler_ping_reqs(SignalProbeSample);
+                @(posedge cfg.chip_vif.alerts_if.clk);
+              end
+              `uvm_info(`gfn, $sformatf("Alert ping %0s triggered", alert_idx.name), UVM_LOW)
+            end
+          join_none
+        end
+        wait fork;
+        `uvm_info(`gfn, $sformatf("All alerts pings triggered in %0s", ip_name), UVM_LOW)
+
+        // Write ip index + 1 because the default value for `kTestIp` is 0.
+        i++;
+        write_test_done_to_sw(i);
+      end join
+    end
   endtask
 
 endclass

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -303,4 +303,22 @@ void flash_ctrl_testutils_backdoor_init(dif_flash_ctrl_state_t *flash_state);
 void flash_ctrl_testutils_backdoor_wait_update(
     dif_flash_ctrl_state_t *flash_state, uintptr_t addr, size_t timeout);
 
+/**
+ * This is a backdoor API to be used with dvsim testbench.
+ * This function is very similar to `flash_ctrl_testutils_backdoor_wait_update`.
+ * But this function keeps reading the address until it equals to the expected
+ * input data.
+ * Before using this function `flash_ctrl_testutils_backdoor_init` should be
+ * called.
+ *
+ * @param flash_state A flash_ctrl handle.
+ * @param addr The address to a `const uint32_t` variable where the testbench
+ * will write to.
+ * @param exp_data The expected read data for the addr.
+ * @param timeout Timeout.
+ */
+void flash_ctrl_testutils_backdoor_wait_eq(dif_flash_ctrl_state_t *flash_state,
+                                           uintptr_t addr, uint32_t exp_data,
+                                           size_t timeout);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_FLASH_CTRL_TESTUTILS_H_

--- a/sw/device/tests/alert_handler_lpg_clkoff_test.c
+++ b/sw/device/tests/alert_handler_lpg_clkoff_test.c
@@ -59,6 +59,8 @@ static dif_flash_ctrl_state_t flash_ctrl;
 
 static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
 
+static volatile const uint32_t kTestIp = 0;
+
 static plic_isr_ctx_t plic_ctx = {
     .rv_plic = &plic,
     .hart_id = kPlicTarget,
@@ -375,13 +377,16 @@ void set_peripheral_clock(const test_t *peripheral,
           "intended_clk_state = %d, received_clk_state = %d", new_clk_state,
           clk_state);
   }
+  if (new_clk_state == kDifToggleDisabled) {
+    LOG_INFO("Turn off %s clock", peripheral->name);
+  }
 };
 
 /**
  * A utility function to wait enough until the alert handler pings a peripheral
  * alert
  */
-void wait_enough_for_alert_ping() {
+void wait_enough_for_alert_ping(uint32_t peri_idx) {
   // wait enough
   if (kDeviceType == kDeviceFpgaCw310) {
     // NUM_ALERTS*2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
@@ -390,7 +395,8 @@ void wait_enough_for_alert_ping() {
   } else if (kDeviceType == kDeviceSimDV) {
     // NUM_ALERTS*2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
     // (2**6)*2*4*(2**3)*(40ns) = 160us
-    busy_spin_micros(160);
+    flash_ctrl_testutils_backdoor_wait_eq(&flash_ctrl, (uintptr_t)&kTestIp,
+                                          peri_idx + 1, 640);
   } else {
     // Verilator
     // NUM_ALERTS*2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
@@ -439,6 +445,8 @@ bool test_main(void) {
   size_t test_phase;
   size_t test_step_cnt;
   size_t peri_idx;
+
+  flash_ctrl_testutils_backdoor_init(&flash_ctrl);
 
   // Need a NVM counter to keep the test-step info
   // between resets on the FPGA.
@@ -495,7 +503,7 @@ bool test_main(void) {
           /*ping_timeout*/ 2);
 
       // wait enough until the alert handler pings the peripheral
-      wait_enough_for_alert_ping();
+      wait_enough_for_alert_ping(peri_idx);
 
       // Check the ping_timeout alert status
       CHECK_DIF_OK(dif_alert_handler_local_alert_is_cause(
@@ -554,7 +562,7 @@ bool test_main(void) {
     set_peripheral_clock(&kPeripherals[peri_idx], kDifToggleDisabled);
 
     // wait enough until the alert handler pings the peripheral
-    wait_enough_for_alert_ping();
+    wait_enough_for_alert_ping(peri_idx);
 
     // Check the alert status
     CHECK_DIF_OK(dif_alert_handler_local_alert_is_cause(


### PR DESCRIPTION
This PR enhances the current alert_handler_lpg_clkoff test with the following DV check:

When the IP's clock is off, this PR will use chip_if to probe and wait until alert_handler sends out the alert_ping_req for that IP. This wait check will ensure alert_handler will still send out alert_ping_req to the prim_alert_receiver, but should not trigger a ping timeout error because the LPG is off.

This PR Implements #16336 

Signed-off-by: Cindy Chen <chencindy@opentitan.org>