### PR TITLE
[rdc] Add JTAG TRST scenarios

### DIFF
--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
@@ -17,9 +17,6 @@ set_constant -value 1'b0 u_ast.rglssm_brout
 # Set MuBi4False(4'h9) scanmode
 set_constant -value 4'h9 scanmode
 
-# Strap to FuncSel(2'b00)
-set_constant -value 2'b00 top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q
-
 # Define POK as reset
 create_reset -interval 10 -waveform AON_CLK u_ast.u_rglts_pdm_3p3v.vcaon_pok_h
 

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic.env
@@ -28,3 +28,7 @@ create_reset -interval 10 -high -waveform SPI_DEV_CLK top_earlgrey.u_spi_device.
 
 # SPI_DEVICE CONTROL.mode is stable during the reset analysis
 # set_stable_value top_earlgrey.u_spi_device.u_reg.u_control_mode.q -name SpidControlMode -comment {SW changes the CSR when SPI is idle}
+
+# JTAG Reset Test
+# top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q 'b01 for LC_CTRL , 'b10 for RV_DM
+create_reset -interval 100 top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.jtag_req.trst_n -name TRST_N -waveform JTAG_TCK

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -161,3 +161,25 @@ set_reset_scenario { \
   { POR_N                              { constraint { @t0 1 } } } \
   { top_earlgrey.u_spi_device.rst_ni   { constraint { @t0 1 } } } \
 } -name RstSpidTpmCsb -comment "SPI_DEVICE TPM CSb Assertion"
+
+# JTAG Scenarios
+## RV_DM
+set_reset_scenario { \
+  { top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.jtag_req.trst_n \
+    { reset { @t0 1 } { #10 0 } { #10 1 } } } \
+  { top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q[1] { constraint { @t0 1 } } } \
+  { top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q[0] { constraint { @t0 0 } } } \
+  { POR_N                               { constraint { @t0 1 } } } \
+  { u_ast.u_rglts_pdm_3p3v.vcaon_pok_h  { constraint { @t0 1 } } } \
+  { u_ast.u_rglts_pdm_3p3v.vcmain_pok_h { constraint { @t0 1 } } } \
+} -name JtagRvDm -comment "RV_DM JTAG Reset Scenario"
+## LC_CTRL
+set_reset_scenario { \
+  { top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.jtag_req.trst_n \
+    { reset { @t0 1 } { #10 0 } { #10 1 } } } \
+  { top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q[1] { constraint { @t0 0 } } } \
+  { top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q[0] { constraint { @t0 1 } } } \
+  { POR_N                               { constraint { @t0 1 } } } \
+  { u_ast.u_rglts_pdm_3p3v.vcaon_pok_h  { constraint { @t0 1 } } } \
+  { u_ast.u_rglts_pdm_3p3v.vcmain_pok_h { constraint { @t0 1 } } } \
+} -name JtagLifeCycle -comment "LC_CTRL JTAG Reset Scenario"

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -56,6 +56,7 @@ set_reset_scenario { \
   { top_earlgrey.pwrmgr_aon_low_power                  { constraint { @t0 1 } } } \
   { top_earlgrey.spi_device_passthrough_req.passthrough_en { constraint { @t0 0 } } } \
   { top_earlgrey.u_spi_host0.reg2hw.control.output_en.q    { constraint { @t0 0 } } } \
+  { top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q { constraint { @t0 0 } } } \
 } -name ScnAonPOK
 
 # AST Regulator Resets
@@ -89,6 +90,7 @@ set_reset_scenario { \
   { top_earlgrey.pwrmgr_aon_low_power                  { constraint { @t0 1 } } } \
   { top_earlgrey.spi_device_passthrough_req.passthrough_en { constraint { @t0 0 } } } \
   { top_earlgrey.u_spi_host0.reg2hw.control.output_en.q    { constraint { @t0 0 } } } \
+  { top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.tap_strap_q { constraint { @t0 0 } } } \
 } -name ScnMainPok
 
 #set_reset_scenario { \


### PR DESCRIPTION
This commit adds two reset scenarios:

- RV_DM TRST_N assertion and de-assertion
- LC_CTRL TRST_N assertion and de-assertion

To control, both reset scenarios have constraint to the tap_strap value.