### PR TITLE
[csrng, dv] Add verification for AES_CIPHER.FSM.REDUN countermeasure

### DIFF
--- a/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
@@ -111,8 +111,6 @@
       tests: ["csrng_sec_cm", "csrng_intr", "csrng_err"]
     }
     {
-      // TODO: Currently, only the alert connection and triggering are verified through FPV.
-      // There is no dedicated bit in the ERR_CODE register.
       // All counter errors are collected in ERR_CODE.CMD_GEN_CNT_ERR.
       name: sec_cm_drbg_upd_ctr_redun
       desc: '''
@@ -125,8 +123,6 @@
       tests: ["csrng_sec_cm", "csrng_intr", "csrng_err"]
     }
     {
-      // TODO: Currently, only the alert connection and triggering are verified through FPV.
-      // There is no dedicated bit in the ERR_CODE register.
       // All counter errors are collected in ERR_CODE.CMD_GEN_CNT_ERR.
       name: sec_cm_drbg_gen_ctr_redun
       desc: '''

--- a/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
@@ -193,14 +193,11 @@
       tests: ["csrng_sec_cm", "csrng_intr", "csrng_err"]
     }
     {
-      // TODO: This is currently untested.
-      // The csrng_intr and csrng_err tests need to be extended to force one of the redundant three FSM copies inside the AES cipher core into a different, valid state.
-      // The DUT must signal a fatal alert, report a cs_fatal_err interrupt, set the corresponding bit in the ERR_CODE register.
-      // For inspiration, refer to the aes_fi and aes_cipher_fi tests.
+      // This is already fully verified as part of AES V2S.
       name: sec_cm_aes_cipher_fsm_redun
       desc: '''
             Verify the countermeasure(s) AES_CIPHER.FSM.REDUN.
-            It is ensured that upon randomly forcing the state, inputs or outputs of any of the independent, redundant logic rails of the AES cipher core FSM to both valid and invalid encodings, 1) this signals a fatal alert, 2) this is reported with a cs_fatal_err interrupt in the INTR_STATE register and 3) the corresponding bit in the ERR_CODE register is set.
+            It is ensured that upon forcing the state of any of the independent, redundant logic rails of the AES cipher core FSM to a different valid encoding, 1) this signals a fatal alert, 2) this is reported with a cs_fatal_err interrupt in the INTR_STATE register and 3) the corresponding bit in the ERR_CODE register is set.
             '''
       stage: V2S
       tests: ["csrng_intr", "csrng_err"]

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -41,6 +41,10 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   rand which_fifo_err_e which_fifo_err;
   rand invalid_mubi_e   which_invalid_mubi;
   rand which_cnt_e      which_cnt;
+  rand which_aes_cm_e   which_aes_cm;
+  // TODO extrend this constraint as we add additional tests and remove it once all AES CMs are
+  // tested.
+  constraint which_aes_cm_c { which_aes_cm inside {fsm_sparse, fsm_redun};}
 
   bit                                    compliance[NUM_HW_APPS + 1], status[NUM_HW_APPS + 1];
   bit [csrng_env_pkg::KEY_LEN-1:0]       key[NUM_HW_APPS + 1];

--- a/hw/ip/csrng/dv/env/csrng_env_pkg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_pkg.sv
@@ -207,6 +207,13 @@ package csrng_env_pkg;
     drbg_gen_cnt_sel = 2
   } which_cnt_e;
 
+  typedef enum int {
+    fsm_sparse  = 0,
+    fsm_redun   = 1,
+    ctrl_sparse = 2,
+    ctr_redun   = 3
+  } which_aes_cm_e;
+
   // functions
 
   // package sources

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
@@ -91,6 +91,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
   task test_cs_fatal_err();
     string        path, path1, path2;
     bit           value1, value2;
+    bit [7:0]     value3;
     string        fifo_name, fld_name;
     int           first_index, last_index;
     string        fifo_base_path;
@@ -147,13 +148,32 @@ class csrng_intr_vseq extends csrng_base_vseq;
         force_path_err(path, 8'b0, ral.intr_state.cs_fatal_err, 1'b1);
       end
       aes_cipher_sm_error: begin
-        if (aes_pkg::SP2V_LOGIC_HIGH[cfg.which_sp2v] == 1'b1) begin
-          path = cfg.csrng_path_vif.aes_cipher_fsm_err_path(cfg.which_sp2v, "p");
-          force_path_err(path, 8'b0, ral.intr_state.cs_fatal_err, 1'b1);
-        end else begin
-          path = cfg.csrng_path_vif.aes_cipher_fsm_err_path(cfg.which_sp2v, "n");
-          force_path_err(path, 8'b0, ral.intr_state.cs_fatal_err, 1'b1);
-        end
+        case (cfg.which_aes_cm) inside
+          fsm_sparse, fsm_redun: begin
+            if (cfg.which_aes_cm == fsm_sparse) begin
+              // Force an invalid state encoding.
+              value3 = 8'b0;
+            end else begin
+              // Force a valid state encoding. We take a state in which the FSM is just for one
+              // clock cycle to ensure it's detected no matter what the DUT is actually doing,
+              // i.e., whether it is idle or stalled.
+              value3 = {2'b00, {aes_pkg::CIPHER_CTRL_CLEAR_S}};
+            end
+            if (aes_pkg::SP2V_LOGIC_HIGH[cfg.which_sp2v] == 1'b1) begin
+              path = cfg.csrng_path_vif.aes_cipher_fsm_err_path(cfg.which_sp2v, "p");
+              force_path_err(path, value3, ral.intr_state.cs_fatal_err, 1'b1);
+            end else begin
+              path = cfg.csrng_path_vif.aes_cipher_fsm_err_path(cfg.which_sp2v, "n");
+              force_path_err(path, value3, ral.intr_state.cs_fatal_err, 1'b1);
+            end
+          end
+          ctrl_sparse: begin
+            // TODO glitch an important control signal.
+          end
+          ctr_redun: begin
+            // TODO glitch the round counter.
+          end
+        endcase
       end
       cmd_gen_cnt_error: begin
         path = cfg.csrng_path_vif.cmd_gen_cnt_err_path(cfg.NHwApps);


### PR DESCRIPTION
This adds basic verification for the AES_CIPHER.FSM.REDUN countermeasure inside CSRNG.

This is related to [#16238](https://github.com/lowRISC/opentitan/issues/16238).