### PR TITLE
[bazel] Allocate CW310s based on extra resources

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,6 +50,9 @@ test:local_test_jobs_per_cpus --local_test_jobs=HOST_CPUS*0.22
 # Empirically 72 cores can support 16 simultaneous tests, but not 17. Setting
 # this will ignore tags like "cpu:5"
 
+# Allow bazel to allocate tests to 1 cw310 board.
+test --local_extra_resources=cw310=1
+
 # We have verilator tests that take more than an hour to complete
 test --test_timeout=60,300,1500,7200
 

--- a/rules/opentitan_gdb_test.bzl
+++ b/rules/opentitan_gdb_test.bzl
@@ -237,7 +237,7 @@ def opentitan_gdb_fpga_cw310_test(
     _opentitan_gdb_fpga_cw310_test(
         tags = tags + [
             "cw310",
-            "exclusive",  # Prevent FPGA tests from running concurrently.
+            "resources:cw310:1",  # Prevent FPGA tests from running concurrently.
             "jtag",
         ],
         opentitantool_cw310_uarts = select({

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -221,7 +221,7 @@ def cw310_params(
     ]
     required_tags = [
         "cw310",
-        "exclusive",
+        "resources:cw310:1",
     ]
     kwargs.update(
         args = default_args + args,

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -3455,7 +3455,6 @@ test_suite(
         rom_kind = "Rom",
         tags = [
             "cw310_rom",
-            "exclusive",
             "vivado",
         ] + maybe_skip_in_ci(lc_state_val),
     )


### PR DESCRIPTION
WIP requires custom bazel binary. Add's the extra resource "cw310" so that 1 test can be dispatched concurrently to other testing.

Signed-off-by: Drew Macrae <drewmacrae@google.com>