### PR TITLE
[csrng/dv] Fix sampling for recov_alert_sts

### DIFF
--- a/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
@@ -114,7 +114,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
     exp_recov_alert_sts[ral.recov_alert_sts.acmd_flag0_field_alert.get_lsb_pos()] = 1;
     csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
     // Since we already did a backdoor check, sampling with this value is sufficient.
-    cov_vif.cg_recov_alert_sample(.recov_alert(ral.recov_alert_sts.get_mirrored_value()));
+    cov_vif.cg_recov_alert_sample(.recov_alert(exp_recov_alert_sts));
 
     // Clear recov_alert_sts register
     csr_wr(.ptr(ral.recov_alert_sts), .value(32'b0));
@@ -167,7 +167,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
     exp_recov_alert_sts[ral.recov_alert_sts.cs_bus_cmp_alert.get_lsb_pos()] = 1;
     csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
     // Since we already did a backdoor check, sampling with this value is sufficient.
-    cov_vif.cg_recov_alert_sample(.recov_alert(ral.recov_alert_sts.get_mirrored_value()));
+    cov_vif.cg_recov_alert_sample(.recov_alert(exp_recov_alert_sts));
 
     // Clear recov_alert_sts register
     csr_wr(.ptr(ral.recov_alert_sts), .value(32'b0));


### PR DESCRIPTION
Even though the alert test was testing illegal values of `flag0` and when the generated bits are the same as before, this was not reported correctly to the coverage tool. This PR fixes this sampling.

This contributes to issue https://github.com/lowRISC/opentitan/issues/15743