### PR TITLE
[bazel] Turn off default debug prints during OTP splicing

### DIFF
--- a/rules/splice.bzl
+++ b/rules/splice.bzl
@@ -104,7 +104,7 @@ bitstream_splice = rule(
         "src": attr.label(allow_single_file = True, doc = "The bitstream to splice"),
         "data": attr.label(allow_single_file = True, doc = "The memory image to splice into the bitstream"),
         "swap_nybbles": attr.bool(default = True, doc = "Swap nybbles while preparing the memory image"),
-        "debug": attr.bool(default = True, doc = "Emit debug info while updating"),
+        "debug": attr.bool(default = False, doc = "Emit debug info while updating"),
         "update_usr_access": attr.bool(default = False, doc = "Update the USR_ACCESS value of the bitstream, breaks hermeticity"),
         "_gen_mem_img": attr.label(
             default = "//hw/ip/rom_ctrl/util:gen_vivado_mem_image",


### PR DESCRIPTION
This PR:
1. Refactors the `bitstream_splice` rule to use the `args` constructor
2. Switches the default debug value for `bitstream_splice` to false. This should remove about 90,000 extra lines of debug output from bitstream splicing when running the full suite of cw310 tests.

Edit: #16278 describes a use case for this generated output, but we will probably looking into capturing that elsewhere rather than dumping it to stdout.