### PR TITLE
[ci] Add script to check Bazel target names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,11 +159,19 @@ jobs:
   steps:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml
+  # Bazel test suites are a common cause of problematic tags. Check test suites
+  # before checking for other tag issues.
+  - bash:  ci/scripts/check_bazel_test_suites.py
+    displayName: Check Bazel test suites (Experimental)
+    continueOnError: True
   - bash: ci/scripts/check-bazel-tags.sh
-    displayName: Check Bazel Tags
+    displayName: Check Bazel Tags (Experimental)
     continueOnError: True
   - bash: ci/scripts/check-bazel-banned-rules.sh
     displayName: Check for banned rules
+  - bash:  ci/scripts/check_bazel_target_names.py
+    displayName: Check Bazel target names (Experimental)
+    continueOnError: True
   - bash: ci/scripts/check-generated.sh
     displayName: Check Generated
     # Ensure all generated files are clean and up-to-date

--- a/ci/scripts/check-bazel-tags.sh
+++ b/ci/scripts/check-bazel-tags.sh
@@ -23,28 +23,6 @@ check_empty () {
     fi
 }
 
-# Check for test_suites without the manual tag and announce them
-untagged=$(./bazelisk.sh query \
-  "kind(test_suite, //...)
-  except
-  attr(
-      tags,
-      '$(exact_regex "manual")',
-      //...
-  )")
-check_empty "Note:" "${untagged}" \
-"Test_suites above aren't tagged with manual, and probably should be.
-
-Otherwise they will match wildcards like //... and depend on tests so that
-build_tag_filters are unable to filter out test_suites unless they are tagged
-with the same set of tags as their contents, but if their contents have
-different sets of tags, doing so will filter out their contents because of
-how most tags act in test_suites.
-
-There aren't many scenarios in which you need a test_suite to match wildcards
-(because it's tests are also in the workspace) so you should probably tag it
-with manual." || true
-
 # This check ensures OpenTitan software can be built with a wildcard without
 # waiting for Verilator using --build_tag_filters=-verilator
 untagged=$(./bazelisk.sh query \

--- a/ci/scripts/check_bazel_target_names.py
+++ b/ci/scripts/check_bazel_target_names.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Checks for Bazel targets that contain banned characters.
+"""
+
+import sys
+
+from lib.bazel_query import BazelQueryRunner
+
+AZURE_PIPELINES_ERROR = "##vso[task.logissue type=warning]"
+
+if __name__ == '__main__':
+    bazel = BazelQueryRunner()
+
+    results = list(bazel.find_targets_with_banned_chars())
+    if results:
+        print(AZURE_PIPELINES_ERROR +
+              "Some target names have banned characters.")
+    for target, bad_chars in results:
+        print("Target name contains banned characters {}: {}".format(
+            bad_chars, target))
+
+    if results:
+        sys.exit(1)

--- a/ci/scripts/check_bazel_test_suites.py
+++ b/ci/scripts/check_bazel_test_suites.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Checks for test_suite targets that are either empty or not tagged "manual".
+"""
+
+import sys
+
+from lib.bazel_query import BazelQueryRunner
+
+NON_MANUAL_TEST_SUITE_DESCRIPTION = """
+Test suites below aren't tagged with manual, but probably should be.
+
+Without the "manual" tag, these test suites will match wildcards like //... and
+may pull in tests that were otherwise excluded with --build_tag_filters. (This
+will not happen if the test suites have the same tags as their contents.)
+
+There aren't many scenarios in which you need a test_suite to match wildcards
+(because its tests are also in the workspace) so you should probably tag it
+with manual.
+"""
+
+EMPTY_TEST_SUITE_DESCRIPTION = """
+Test suites below contain zero tests. This is probably an accident.
+"""
+
+AZURE_PIPELINES_WARNING = "##vso[task.logissue type=error]"
+AZURE_PIPELINES_ERROR = "##vso[task.logissue type=warning]"
+
+if __name__ == '__main__':
+    bazel = BazelQueryRunner()
+    non_manual_test_suites = list(bazel.find_non_manual_test_suites())
+    empty_test_suites = list(bazel.find_empty_test_suites())
+
+    if non_manual_test_suites:
+        print("-" * 80)
+        print(AZURE_PIPELINES_WARNING + NON_MANUAL_TEST_SUITE_DESCRIPTION)
+        for target in non_manual_test_suites:
+            print("  - " + target)
+
+    if empty_test_suites:
+        print("-" * 80)
+        print(AZURE_PIPELINES_ERROR + EMPTY_TEST_SUITE_DESCRIPTION)
+        for target in empty_test_suites:
+            print("  - " + target)
+
+    if empty_test_suites:
+        sys.exit(1)

--- a/ci/scripts/lib/BUILD
+++ b/ci/scripts/lib/BUILD
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_test")
+
+package(default_visibility = ["//visibility:public"])
+
+py_test(
+    name = "bazel_query_test",
+    srcs = [
+        "bazel_query.py",
+        "bazel_query_test.py",
+    ],
+)

--- a/ci/scripts/lib/bazel_query.py
+++ b/ci/scripts/lib/bazel_query.py
@@ -1,0 +1,117 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import string
+import subprocess
+from typing import Callable, Iterable, List, Set, Tuple
+
+
+class BazelQuery:
+    """A collection of functions useful for constructing Bazel queries."""
+
+    @staticmethod
+    def rule_exact(rule: str, input: str) -> str:
+        """Match targets in `input` defined by `rule`."""
+        return f'kind("^{rule} rule$", {input})'
+
+    @staticmethod
+    def tag_exact(tag: str, input: str) -> str:
+        """Match targets in `input` that are tagged with `tag`."""
+        regex = BazelQuery.regex_for_tag(tag)
+        return f'attr("tags", "{regex}", {input})'
+
+    @staticmethod
+    def regex_for_tag(tag: str) -> str:
+        """Build a regex to find the given tag in a list.
+
+        The query `attr("tags", pattern, input)` would match the given pattern
+        against a serialized list of tags, e.g. `[foo, bar]`. Subtly, if the
+        pattern is "foo", it will also match targets that are tagged "foobar".
+
+        This function constructs a regex that matches only when the list of tags
+        actually contains `tag`, not just a superstring of `tag`, as recommended
+        by the Bazel query docs: https://bazel.build/query/language#attr
+        """
+        return f"[\\[ ]{tag}[,\\]]"
+
+
+class BazelQueryRunner:
+
+    def __init__(self, backend: Callable[[str], List[str]] = None):
+        self._backend = backend
+
+    def find_targets_with_banned_chars(self) -> Iterable[Tuple[str, Set[str]]]:
+        """Find targets in //... with names containing disallowed characters.
+
+        Bazel allows a liberal set of characters in target names [0], which
+        enables type confusion bugs to go unnoticed. For example, a tuple's
+        string representation, complete with parentheses and commas, can
+        accidentally be inserted into a target name via `string.format()`.
+
+        [0]: https://bazel.build/concepts/labels#target-names
+
+        Yields:
+          A tuple for each target that has banned characters in its name. The
+          first element is the Bazel target's name. The second element is the
+          set of characters that must be removed from the target's name.
+
+        """
+        allowed_chars = set(string.ascii_letters + string.digits + '/:_-.')
+        for target in self.query("//..."):
+            if bad_chars := set(target) - allowed_chars:
+                yield (target, bad_chars)
+
+    def find_empty_test_suites(self) -> Iterable[str]:
+        """Find test_suite targets in //... that contain zero tests.
+
+        Finding empty test suites is not as simple as querying for test_suite
+        targets where `tests = []`. In fact, that is a special case of
+        test_suite that causes it to select all tests in the package.
+
+        There are a few ways to wind up with an empty test suite. One way is to
+        provide a nonempty `tests` argument containing only nonexistent labels.
+        Another way is to provide a non-empty list of tests that exist, but to
+        specify `tags` that exclude all the tests.
+
+        Yields:
+          Names of Bazel targets.
+        """
+
+        def print_progress(i, n):
+            if n // 5 == 0 or i % (n // 5) == 0:
+                print(self.find_empty_test_suites.__name__, end="")
+                print(": Running query {}/{}...".format(i + 1, n))
+
+        query_test_suites = BazelQuery.rule_exact("test_suite", "//...")
+        all_test_suites = self.query(query_test_suites)
+
+        for i, test_suite in enumerate(all_test_suites):
+            print_progress(i, len(all_test_suites))
+            tests = self.query("tests({})".format(test_suite))
+            if len(tests) == 0:
+                yield test_suite
+
+    def find_non_manual_test_suites(self) -> Iterable[str]:
+        """Find test_suite targets in //... that are not tagged with 'manual'."""
+        query_pieces = [
+            BazelQuery.rule_exact("test_suite", "//..."),
+            "except",
+            BazelQuery.tag_exact("manual", "//..."),
+        ]
+        query_str = " ".join(query_pieces)
+        return self.query(query_str)
+
+    def query(self, query: str) -> List[str]:
+        """Perform a Bazel query and return the resulting targets."""
+        if self._backend:
+            return self._backend(query)
+
+        bazel = subprocess.run(
+            ["./bazelisk.sh", "query", "--output=label", query],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            encoding='utf-8',
+            check=True)
+        stdout_lines = bazel.stdout.split('\n')
+        return [s for s in stdout_lines if s != ""]

--- a/ci/scripts/lib/bazel_query_test.py
+++ b/ci/scripts/lib/bazel_query_test.py
@@ -1,0 +1,147 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+import unittest
+from unittest.mock import Mock
+
+from bazel_query import BazelQuery, BazelQueryRunner
+
+
+class TestBazelQuery(unittest.TestCase):
+
+    def test_rule_exact(self):
+        query = BazelQuery.rule_exact("foo", "bar")
+        self.assertEqual(query, 'kind("^foo rule$", bar)')
+
+    def test_tag_exact(self):
+        query = BazelQuery.tag_exact("manual", "foo")
+        self.assertEqual(query, 'attr("tags", "[\\[ ]manual[,\\]]", foo)')
+
+    def test_regex_for_tag(self):
+        regex = BazelQuery.regex_for_tag("foo")
+        self.assertEqual(regex, '[\\[ ]foo[,\\]]')
+
+        # Regex doesn't match lists without "foo".
+        self.assertFalse(re.search(regex, "[]"))
+        self.assertFalse(re.search(regex, "[bar]"))
+        self.assertFalse(re.search(regex, "[bar, baz]"))
+
+        # Regex does not match superstrings of "foo".
+        self.assertFalse(re.search(regex, "[foobar]"))
+        self.assertFalse(re.search(regex, "[barfoo]"))
+        self.assertFalse(re.search(regex, "[foofoo]"))
+
+        # Regex matches "foo" in any position.
+        self.assertTrue(re.search(regex, "[bar, foo, baz]"))
+        self.assertTrue(re.search(regex, "[bar, foo]"))
+        self.assertTrue(re.search(regex, "[foo, baz]"))
+        self.assertTrue(re.search(regex, "[foo]"))
+
+
+class TestFindTargetsWithBannedChars(unittest.TestCase):
+
+    def test_no_test_suites(self):
+        backend = Mock()
+        backend.return_value = []
+        bazel = BazelQueryRunner(backend=backend)
+        targets = bazel.find_targets_with_banned_chars()
+        self.assertEqual(list(targets), [])
+
+    def test_one_target_empty_string(self):
+        """Bazel does not allow targets to have empty names.
+
+        This test simply documents how we respond to the impossible scenario.
+        """
+        backend = Mock()
+        backend.return_value = [""]
+        bazel = BazelQueryRunner(backend=backend)
+        targets = bazel.find_targets_with_banned_chars()
+        self.assertEqual(list(targets), [])
+
+    def test_only_good_chars(self):
+        backend = Mock()
+        backend.return_value = ["//foo:bar", "//bar_baz:foo"]
+        bazel = BazelQueryRunner(backend=backend)
+        targets = bazel.find_targets_with_banned_chars()
+        self.assertEqual(list(targets), [])
+
+    def test_only_bad_chars(self):
+        backend = Mock()
+        backend.return_value = ["!@#$", "^&*()", "\x01"]
+        bazel = BazelQueryRunner(backend=backend)
+        targets = bazel.find_targets_with_banned_chars()
+        self.assertCountEqual(list(targets), [
+            ("!@#$", set("!@#$")),
+            ("^&*()", set("^&*()")),
+            ("\x01", set("\x01")),
+        ])
+
+    def test_mixed(self):
+        backend = Mock()
+        backend.return_value = [
+            '!@#$', '\x01', '//foo:bar', '^&*()', '//bar_baz:foo'
+        ]
+        bazel = BazelQueryRunner(backend=backend)
+        targets = bazel.find_targets_with_banned_chars()
+        self.assertCountEqual(list(targets), [
+            ("!@#$", set("!@#$")),
+            ("\x01", set("\x01")),
+            ("^&*()", set("^&*()")),
+        ])
+
+
+class TestFindEmptyTestSuites(unittest.TestCase):
+
+    def test_empty(self):
+        backend = Mock()
+        backend.return_value = []
+        bazel = BazelQueryRunner(backend=backend)
+        targets = bazel.find_empty_test_suites()
+        self.assertEqual(list(targets), [])
+
+    def test_one_empty_suite(self):
+        query_result_sequence = [
+            ["//foo:some_test_suite"],  # List of test suites.
+            [],  # List of tests in the first test suite.
+        ]
+
+        def backend(_query):
+            return query_result_sequence.pop(0)
+
+        bazel = BazelQueryRunner(backend=backend)
+        targets = bazel.find_empty_test_suites()
+        self.assertEqual(list(targets), ["//foo:some_test_suite"])
+        self.assertEqual(query_result_sequence, [])
+
+    def test_second_suite_empty(self):
+        query_result_sequence = [[
+            "//foo:some_test_suite", "//foo:another_test_suite"
+        ], ["//foo:test"], []]
+
+        def backend(_query):
+            return query_result_sequence.pop(0)
+
+        bazel = BazelQueryRunner(backend=backend)
+        targets = bazel.find_empty_test_suites()
+        self.assertEqual(list(targets), ["//foo:another_test_suite"])
+        self.assertEqual(query_result_sequence, [])
+
+
+class TestFindNonManualTestSuites(unittest.TestCase):
+
+    def test_simple(self):
+        backend = Mock()
+        backend.return_value = ["//foo:bar"]
+
+        bazel = BazelQueryRunner(backend=backend)
+        targets = bazel.find_non_manual_test_suites()
+        self.assertEqual(list(targets), ["//foo:bar"])
+        backend.assert_called_once_with(
+            'kind("^test_suite rule$", //...) except attr("tags", "[\\[ ]manual[,\\]]", //...)'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
[ci] Add checks for empty test_suites (and more!)

This commit adds scripts that check for empty test_suite targets and
targets that contain "banned" characters. It also re-homes the check for
test_suite targets that are not tagged "manual".

I'm adding these scripts after making a few mistakes while cleaning up a
BUILD file in PR #16401.

My first mistake was forgetting to unpack a tuple. I wound up inserting
the tuple's string representation, rather than one of the tuple's
elements, into a target name via `string.format()`. Surprisingly, this
is not an analysis-time failure! Bazel has no problem inserting
parentheses and commas into the target name.

If weird characters are in a target name, for some definition of
"weird", it was probably an accident. The new script returns an error
when it finds targets with weird characters.

The second mistake I made was defining a test_suite with a non-empty
`tests` parameter, where none of the labels actually existed. The result
is a test_suite that appears non-empty, but actually contains zero
tests.

I believe an empty test_suite indicates an error. The new script returns
an error if it finds any test_suite targets that contain zero tests.