### PR TITLE
[aes] Improve FI detection when OR-combining multi-rail signals

### DIFF
--- a/hw/ip/aes/pre_syn/syn_yosys.sh
+++ b/hw/ip/aes/pre_syn/syn_yosys.sh
@@ -151,7 +151,7 @@ for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
     # Remove the StateEnumT parameter from prim_sparse_fsm_flop instances. Yosys doesn't seem to
     # support this.
     sed -i '/\.StateEnumT(logic \[.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i '/\.StateEnumT_StateWidth(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i '/\.StateEnumT_aes_pkg.*(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
 done
 
 #-------------------------------------------------------------------------

--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -323,7 +323,9 @@ module aes_cipher_control import aes_pkg::*;
       key_dec_sel_o   = key_dec_sel_e'({key_dec_sel_o}     | {mr_key_dec_sel[i]});
       key_words_sel_o = key_words_sel_e'({key_words_sel_o} | {mr_key_words_sel[i]});
       round_key_sel_o = round_key_sel_e'({round_key_sel_o} | {mr_round_key_sel[i]});
+    end
 
+    for (int i = 0; i < Sp2VWidth; i++) begin
       if (state_sel_o     != mr_state_sel[i]     ||
           add_rk_sel_o    != mr_add_rk_sel[i]    ||
           key_full_sel_o  != mr_key_full_sel[i]  ||
@@ -345,7 +347,9 @@ module aes_cipher_control import aes_pkg::*;
     rnd_ctr_err = 1'b0;
     for (int i = 0; i < Sp2VWidth; i++) begin
       rnd_ctr |= mr_rnd_ctr[i];
+    end
 
+    for (int i = 0; i < Sp2VWidth; i++) begin
       if (rnd_ctr != mr_rnd_ctr[i]) begin
         rnd_ctr_err = 1'b1;
       end

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -487,7 +487,9 @@ module aes_control
       add_state_out_sel_o = add_so_sel_e'({add_state_out_sel_o} | {mr_add_state_out_sel[i]});
       key_init_sel_o      = key_init_sel_e'({key_init_sel_o}    | {mr_key_init_sel[i]});
       iv_sel_o            = iv_sel_e'({iv_sel_o}                | {mr_iv_sel[i]});
+    end
 
+    for (int i = 0; i < Sp2VWidth; i++) begin
       if (data_in_prev_sel_o  != mr_data_in_prev_sel[i]  ||
           state_in_sel_o      != mr_state_in_sel[i]      ||
           add_state_in_sel_o  != mr_add_state_in_sel[i]  ||

--- a/hw/ip/aes/rtl/aes_ctr.sv
+++ b/hw/ip/aes/rtl/aes_ctr.sv
@@ -159,7 +159,9 @@ module aes_ctr import aes_pkg::*;
     for (int i = 0; i < Sp2VWidth; i++) begin
       ctr_slice_idx |= mr_ctr_slice_idx[i];
       ctr_o_slice   |= mr_ctr_o_slice[i];
+    end
 
+    for (int i = 0; i < Sp2VWidth; i++) begin
       if (ctr_slice_idx != mr_ctr_slice_idx[i] ||
           ctr_o_slice   != mr_ctr_o_slice[i]) begin
         mr_err = 1'b1;


### PR DESCRIPTION
This is needed for #16427.

Previously, OR-combination and error detection for multi-bit, multi-rail signals was done in a single for loop inside an always_comb block. In every loop iteration, the current combined signal was only compared to the current signal added to the combination. This is not ideal from a fault detection perspective.

For example, when faulting the last rail of the round counter to 1 when the counter is actually 0 wouldn't be detected immediately. For the first and second loop iteration, the OR-combined value was still 0. For the last rail, the OR-combined value would be 1 which is equal to the faulted counter. In practice this didn't really matter because a faulted round counter itself isn't problematic. But the faulted round counter changes the control flow of one rail which is always detected, e.g., by a register write enable signal taking on an invalid encoding as the different rails driving that get out of sync.

This minimal RTL change performs the comparison in a separate loop to effectively compare all rails with the total OR-combined value. In the example above, the final OR-combined counter value is compared against both un-faulted rails and the fault is immediately detected.

The associated area impact of this change is neglibile. With Yosys + nangate45, AES is now 110.17 kGE vs. 109.86 kGE (+0.28%). But it improves FI detection and most importantly simplifies DV as faults in the round counter are detected immediately and independent whether the AES cipher core is busy or idle.