### PR TITLE
[keymgr/dv] Add cov_if for lc_keymgr_en

### DIFF
--- a/hw/ip/keymgr/dv/cov/keymgr_cov_bind.sv
+++ b/hw/ip/keymgr/dv/cov/keymgr_cov_bind.sv
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binds functional coverage interaface to the top level keymgr module.
+module keymgr_cov_bind;
+
+  bind keymgr cip_lc_tx_cov_if u_lc_escalate_en_cov_if (
+    .rst_ni (rst_ni),
+    .val    (lc_keymgr_en_i)
+  );
+endmodule

--- a/hw/ip/keymgr/dv/keymgr_sim.core
+++ b/hw/ip/keymgr/dv/keymgr_sim.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:dv:keymgr_sva
     files:
       - tb.sv
+      - cov/keymgr_cov_bind.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -38,7 +38,7 @@
                 ]
 
   // Add additional tops for simulation.
-  sim_tops: ["keymgr_bind", "sec_cm_prim_count_bind",
+  sim_tops: ["keymgr_bind", "keymgr_cov_bind", "sec_cm_prim_count_bind",
              "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.


### PR DESCRIPTION
It's a lc_tx_t port, need to bind an interface to collect coverage

Signed-off-by: Weicai Yang <weicai@google.com>