### PR TITLE
[rdc] Add quiescent DMI req/rsp constraints

### DIFF
--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_scenario.tcl
@@ -172,7 +172,16 @@ set_reset_scenario { \
   { POR_N                               { constraint { @t0 1 } } } \
   { u_ast.u_rglts_pdm_3p3v.vcaon_pok_h  { constraint { @t0 1 } } } \
   { u_ast.u_rglts_pdm_3p3v.vcmain_pok_h { constraint { @t0 1 } } } \
-} -name JtagRvDm -comment "RV_DM JTAG Reset Scenario"
+  { top_earlgrey.u_rv_dm.dmi_req_valid  { constraint { @t0 0 } } } \
+  { top_earlgrey.u_rv_dm.dmi_rsp_valid  { constraint { @t0 0 } } } \
+} -name JtagRvDm \
+  -comment { \
+    RV_DM JTAG Reset Scenario \
+    \
+    Assumption: \
+      - POR_N is not asserting if JTAG is enabled \
+      - No pending transaction if JTAG TRST_N is asserted \
+  }
 ## LC_CTRL
 set_reset_scenario { \
   { top_earlgrey.u_pinmux_aon.u_pinmux_strap_sampling.jtag_req.trst_n \
@@ -182,4 +191,6 @@ set_reset_scenario { \
   { POR_N                               { constraint { @t0 1 } } } \
   { u_ast.u_rglts_pdm_3p3v.vcaon_pok_h  { constraint { @t0 1 } } } \
   { u_ast.u_rglts_pdm_3p3v.vcmain_pok_h { constraint { @t0 1 } } } \
+  { top_earlgrey.u_lc_ctrl.dmi_req_valid  { constraint { @t0 0 } } } \
+  { top_earlgrey.u_lc_ctrl.dmi_resp_valid { constraint { @t0 0 } } } \
 } -name JtagLifeCycle -comment "LC_CTRL JTAG Reset Scenario"


### PR DESCRIPTION
Current prim_fifo_async has one bit pointers inside if Depth is 1.

If JTAG TRST is asserted when the pointer is 1, then there's chance the metastability issue occurs on the core clock side.

One way to resolve this is to make the async FIFO synchronous reset. It is not as of now (async assert / sync de-assert for JTAG TRST) in dmi_cdc.

Either we can waive the scenario as asserting TRST_N during the JTAG debugging is rare in my opinion, or making synchronous reset in dmi_cdc would be solutions.
