### PR TITLE
[entropy_src/doc] Document that only supported bypass window size is 384

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -339,6 +339,10 @@
                    is active after reset for the first and only test run, or when this mode is
                    programmed by firmware.
                    The default value is (384 bits * 1 clock/4 bits);
+
+                   Note that currently only a window size of 384 is supported and tested (this
+                   corresponds to the register default value 0x60). Do not use any other values,
+                   unless you know what you are doing.
                 '''
           resval: "0x0060"
         }

--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -115,7 +115,10 @@ dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
   // Configure health test window.
   // Conditioning bypass is hardcoded to disabled (see above). If we want to
   // expose the ES_TYPE field in the future, we need to also configure the
-  // health test window size for bypass mode.
+  // health test window size for bypass mode. Note however that the only
+  // supported bypass window size is the default value of 0x60 at the moment,
+  // hence even if the ES_TYPE field is exposed in the future, we should not
+  // change the bypass window size as this may break.
   uint32_t health_test_window_sizes =
       bitfield_field32_write(ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_RESVAL,
                              ENTROPY_SRC_HEALTH_TEST_WINDOWS_FIPS_WINDOW_FIELD,


### PR DESCRIPTION
Fixes #16146.

Signed-off-by: Michael Schaffner <msf@google.com>