### PR TITLE
[test] Updates to chip_sw_flash_rma_unlocked test 

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -30,6 +30,7 @@ filesets:
       - lowrisc:dv:pattgen_agent
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:pwrmgr_pkg
+      - lowrisc:dv:lc_ctrl_dv_utils
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
       - "fileset_partner ? (partner:systems:ast_pkg)"
       - pulp-platform:riscv-dbg:0.1

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -30,6 +30,7 @@ package chip_env_pkg;
   import rv_dm_reg_pkg::NumAlerts;
   import kmac_pkg::*;
   import lc_ctrl_state_pkg::*;
+  import lc_ctrl_dv_utils_pkg::*;
   import mem_bkdr_util_pkg::*;
   import otp_ctrl_pkg::*;
   import spi_agent_pkg::*;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_rma_unlocked_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_rma_unlocked_vseq.sv
@@ -19,13 +19,24 @@ class chip_sw_flash_rma_unlocked_vseq extends chip_sw_base_vseq;
     TestPhaseCheckWipe = 2
   } test_phases_e;
 
+  localparam string CHIP_GEN_PATH = "tb.dut.top_earlgrey.LcCtrlChipGen";
+  localparam string CHIP_REV_PATH = "tb.dut.top_earlgrey.LcCtrlChipRev";
+
   localparam string LC_CTRL_TRANS_SUCCESS_PATH =
     "tb.dut.top_earlgrey.u_lc_ctrl.u_lc_ctrl_fsm.trans_success_o";
 
-  rand bit [7:0] rma_unlock_token[TokenWidthByte];
+  bit [15:0] chip_gen = 16'h 0000;
+  bit [15:0] chip_rev = 16'h 0000;
 
+  bit [TokenWidthByte*8-1:0] rma_unlock_token_vector;
+  rand bit [7:0] rma_unlock_token[TokenWidthByte];
   rand bit [7:0] creator_root_key0[KeyWidthByte];
   rand bit [7:0] creator_root_key1[KeyWidthByte];
+
+  rand bit [lc_ctrl_reg_pkg::NumDeviceIdWords*BUS_DW-1:0] device_id;
+  rand bit [lc_ctrl_reg_pkg::NumManufStateWords*BUS_DW-1:0] manuf_state;
+
+  lc_ctrl_state_pkg::dec_lc_state_e src_lc_state;
 
   virtual function bit [KeyWidthBit-1:0] get_otp_key(bit [7:0] key_in[KeyWidthByte]);
     bit [kmac_pkg::AppDigestW-1:0] digest_bits;
@@ -38,71 +49,123 @@ class chip_sw_flash_rma_unlocked_vseq extends chip_sw_base_vseq;
     return (digest_bits[KeyWidthBit-1:0]);
   endfunction
 
-  // When the RMA transition has been completed the CPU will be disabled
-  // and therefore it cannot be detected in SW. Detect this transition here
-  // to allow the CPU to be reset.
-  virtual task wait_for_transition();
-    int retval;
-    int transition_success = 0;
-    time rma_timeout_ns = 120_000_000; // 120ms
-    retval = uvm_hdl_check_path(LC_CTRL_TRANS_SUCCESS_PATH);
-    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
-                       "Hierarchical path %0s appears to be invalid.", LC_CTRL_TRANS_SUCCESS_PATH))
-   `DV_SPINWAIT(while (transition_success == 0) begin
-                  retval = uvm_hdl_read(LC_CTRL_TRANS_SUCCESS_PATH, transition_success);
-                  `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", LC_CTRL_TRANS_SUCCESS_PATH))
-                  cfg.clk_rst_vif.wait_clks(1);
-                end,
-                "timeout while wait for flash rma complete",
-                rma_timeout_ns)
-  endtask
-
   virtual function void write_test_phase(test_phases_e phase);
     bit [7:0] test_phase[1];
     test_phase[0] = phase;
-    sw_symbol_backdoor_overwrite("kTestPhase", test_phase);
+    sw_symbol_backdoor_overwrite("kTestPhase", test_phase, SwTypeRom);
   endfunction
 
   virtual task dut_init(string reset_kind = "HARD");
+    int retval;
     super.dut_init(reset_kind);
-    // Override the LC partition to Dev state.
-    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStDev);
+
+    // Flip a coin and either select Dev or Prod to start and override the state in OTP.
+    if ($urandom_range(0, 1)) src_lc_state = DecLcStDev;
+    else                      src_lc_state = DecLcStProd;
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(encode_lc_state(src_lc_state));
+
+    // Override Device ID and Manufacturing state with random values.
+    cfg.mem_bkdr_util_h[Otp].otp_write_hw_cfg_partition(
+      .device_id(device_id),
+      .manuf_state(manuf_state),
+      // Use same default config as in otp_ctrl_img_hw_cfg.hjson
+      .en_sram_ifetch(prim_mubi_pkg::MuBi8False),
+      .en_csrng_sw_app_read(prim_mubi_pkg::MuBi8True),
+      .en_entropy_src_fw_read(prim_mubi_pkg::MuBi8True),
+      .en_entropy_src_fw_over(prim_mubi_pkg::MuBi8True));
+
+    // Read current chip revision and generation parameter values.
+    retval = uvm_hdl_read(CHIP_GEN_PATH, chip_gen);
+    `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", CHIP_GEN_PATH))
+    retval = uvm_hdl_read(CHIP_REV_PATH, chip_rev);
+    `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", CHIP_REV_PATH))
+  endtask
+
+  virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
+    super.pre_start();
   endtask
 
   virtual task cpu_init();
+    bit [7:0] state[1] = {8'(src_lc_state)};
     super.cpu_init();
-    sw_symbol_backdoor_overwrite("kLcRmaUnlockToken", rma_unlock_token, SwTypeRom);
+    // Let SW know which lc state we picked.
+    sw_symbol_backdoor_overwrite("kSrcLcState", state, SwTypeRom);
   endtask
 
-  virtual task body();
-    // First Boot.
-    super.body();
-    write_test_phase(TestPhaseWriteData);
+  virtual task check_lc_state(dec_lc_state_e exp_state);
+    bit [BUS_DW-1:0] state;
+    // acquire access for JTAG to LC CTRL
+    wait_lc_initialized(.allow_err(1));
+    // check LC state is correct
+    jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.lc_state.get_offset(),
+                                        p_sequencer.jtag_sequencer_h, state);
+    `DV_CHECK_EQ(state, {DecLcStateNumRep{exp_state}})
+  endtask
 
-    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
-    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
-    write_test_phase(TestPhaseEnterRMA);
-    apply_reset();
+  // Reads info registers in the LC controller via JTAG and checks whether they are correct.
+  virtual task check_lc_info_regs();
+    bit [BUS_DW-1:0] word;
+    // acquire access for JTAG to LC CTRL
+    wait_lc_initialized(.allow_err(1));
 
-    // Second Boot.
+    // Check Revision
+    jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.hw_rev.get_offset(),
+                                        p_sequencer.jtag_sequencer_h, word);
+    `DV_CHECK_EQ(word, {chip_gen, chip_rev})
+
+    // Check Device ID
+    for (int k = 0; k < lc_ctrl_reg_pkg::NumDeviceIdWords; k++) begin
+      jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.device_id[k].get_offset(),
+                                          p_sequencer.jtag_sequencer_h, word);
+      `DV_CHECK_EQ(word, device_id[k*BUS_DW +: BUS_DW])
+    end
+
+    // Check Manuf State
+    for (int k = 0; k < lc_ctrl_reg_pkg::NumManufStateWords; k++) begin
+      jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.manuf_state[k].get_offset(),
+                                          p_sequencer.jtag_sequencer_h, word);
+      `DV_CHECK_EQ(word, manuf_state[k*BUS_DW +: BUS_DW])
+    end
+  endtask
+
+  virtual task provision_secret2_partition();
     // Override the rma unlock token to match SW test's input token.
     cfg.mem_bkdr_util_h[Otp].otp_write_secret2_partition(
         .rma_unlock_token(dec_otp_token_from_lc_csrs(rma_unlock_token)),
         .creator_root_key0(get_otp_key(creator_root_key0)),
         .creator_root_key1(get_otp_key(creator_root_key1)));
+    // Convert to right format for jtag_lc_state_transition function below.
+    rma_unlock_token_vector = {<< byte {rma_unlock_token}};
+  endtask
 
+  virtual task body();
+    super.body();
+    write_test_phase(TestPhaseWriteData);
+
+    // First Boot.
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
+    check_lc_state(src_lc_state);
+    check_lc_info_regs();
+    provision_secret2_partition();
+    write_test_phase(TestPhaseEnterRMA);
+    apply_reset();
 
-    wait_for_transition();
+    // Second Boot.
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
+    check_lc_state(src_lc_state);
+    check_lc_info_regs();
+    // This function waits until the transition has successfully ended.
+    jtag_lc_state_transition(src_lc_state, DecLcStRma, rma_unlock_token_vector);
     write_test_phase(TestPhaseCheckWipe);
-
-    cfg.clk_rst_vif.wait_clks(1000);
     apply_reset();
 
     // Third Boot.
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
-
+    check_lc_state(DecLcStRma);
+    check_lc_info_regs();
   endtask
 
 endclass


### PR DESCRIPTION
As discussed in https://github.com/lowRISC/opentitan/issues/15911, this adds more readout checks through the LC JTAG. It also makes the RMA transition request more realistic by initiating it via the LC TAP, and by leveraging the status CSR in to determine whether the transition is done or not instead of using a hierarchical signal probe into the DUT).