### PR TITLE
[csrng/dv] Test disabling and re-enabling

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_if.sv
+++ b/hw/dv/sv/csrng_agent/csrng_if.sv
@@ -69,4 +69,15 @@ interface csrng_if (input clk, input rst_n);
     while (!mon_cb.cmd_rsp.csrng_rsp_ack);
   endtask
 
+  task automatic wait_cmd_ack_or_rst_n();
+    // Immediately return if reset is currently not inactive.
+    if (rst_n !== 1'b1) return;
+    // Otherwise wait for cmd_ack or negedge of reset, whichever comes first.
+    fork
+      wait_cmd_ack();
+      do @(clk); while (rst_n === 1'b1); // @(negedge rst_n) does not trigger for some reason
+    join_any
+    disable fork;
+  endtask
+
 endinterface

--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -46,6 +46,7 @@ class csrng_monitor extends dv_base_monitor #(
     forever begin
       @(negedge cfg.vif.rst_n);
       cfg.under_reset = 1;
+      csrng_cmd_fifo.flush();
       // TODO: sample any reset-related covergroups
       @(posedge cfg.vif.rst_n);
       cfg.under_reset = 0;
@@ -82,7 +83,7 @@ class csrng_monitor extends dv_base_monitor #(
               cs_item.genbits_q.push_back(cfg.vif.mon_cb.cmd_rsp.genbits_bus);
             end
           end
-          cfg.vif.wait_cmd_ack();
+          cfg.vif.wait_cmd_ack_or_rst_n();
           `uvm_info(`gfn, $sformatf("Writing analysis_port: %s", cs_item.convert2string()),
                     UVM_HIGH)
           analysis_port.write(cs_item);

--- a/hw/ip/csrng/dv/env/csrng_agents_if.sv
+++ b/hw/ip/csrng/dv/env/csrng_agents_if.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This interface controls the agents connected to CSRNG.
+interface csrng_agents_if;
+
+  logic edn_disable;
+  logic entropy_src_disable;
+
+  function automatic drive_edn_disable(bit val);
+    edn_disable = val;
+  endfunction
+
+  function automatic drive_entropy_src_disable(bit val);
+    entropy_src_disable = val;
+  endfunction
+
+endinterface

--- a/hw/ip/csrng/dv/env/csrng_env.core
+++ b/hw/ip/csrng/dv/env/csrng_env.core
@@ -18,6 +18,7 @@ filesets:
       - lowrisc:dv:aes_model_dpi
     files:
       - csrng_env_pkg.sv
+      - csrng_agents_if.sv
       - csrng_path_if.sv
       - csrng_env_cfg.sv: {is_include_file: true}
       - csrng_env_cov.sv: {is_include_file: true}

--- a/hw/ip/csrng/dv/env/csrng_env.sv
+++ b/hw/ip/csrng/dv/env/csrng_env.sv
@@ -62,6 +62,12 @@ class csrng_env extends cip_base_env #(
         get(this, "", "csrng_path_vif", cfg.csrng_path_vif)) begin
       `uvm_fatal(`gfn, "failed to get csrng_path_vif from uvm_config_db")
     end
+
+    if (!uvm_config_db#(virtual csrng_agents_if)::
+        get(this, "", "csrng_agents_vif", cfg.csrng_agents_vif)) begin
+      `uvm_fatal(`gfn, "failed to get csrng_agents_vif from uvm_config_db")
+    end
+
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -22,6 +22,8 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
 
   virtual csrng_path_if csrng_path_vif; // handle to csrng path interface
 
+  virtual csrng_agents_if csrng_agents_vif;
+
   // Knobs & Weights
   uint otp_en_cs_sw_app_read_pct, otp_en_cs_sw_app_read_inval_pct, lc_hw_debug_en_pct, regwen_pct,
        enable_pct, sw_app_enable_pct, read_int_state_pct, force_state_pct, check_int_state_pct,

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -27,7 +27,14 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   // Knobs & Weights
   uint otp_en_cs_sw_app_read_pct, otp_en_cs_sw_app_read_inval_pct, lc_hw_debug_en_pct, regwen_pct,
        enable_pct, sw_app_enable_pct, read_int_state_pct, force_state_pct, check_int_state_pct,
-       num_cmds_min, num_cmds_max, aes_halt_pct, min_aes_halt_clks, max_aes_halt_clks;
+       num_cmds_min, num_cmds_max, aes_halt_pct, min_aes_halt_clks, max_aes_halt_clks,
+       min_num_disable_enable, max_num_disable_enable,
+       min_enable_clks, max_enable_clks,
+       min_disable_edn_before_csrng_clks, max_disable_edn_before_csrng_clks,
+       min_disable_csrng_before_entropy_src_clks, max_disable_csrng_before_entropy_src_clks,
+       min_disable_clks, max_disable_clks,
+       min_enable_entropy_src_before_csrng_clks, max_enable_entropy_src_before_csrng_clks,
+       min_enable_csrng_before_edn_clks, max_enable_csrng_before_edn_clks;
 
   bit    use_invalid_mubi;
 
@@ -108,6 +115,69 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
       cmd_gen_cnt_err                        := 3, // 3 counters feed into this bit
       [fifo_write_err : fifo_state_err_test] := 1
   };}
+
+  // Number of times CSRNG gets disabled and re-enabled
+  rand uint num_disable_enable;
+  constraint num_disable_enable_c {
+    num_disable_enable >= min_num_disable_enable;
+    num_disable_enable <= max_num_disable_enable;
+  }
+
+  // In tests that disable CSRNG, how many cycles to keep all agents and CSRNG enabled
+  rand uint enable_clks;
+  constraint edn_enable_clks_c {
+    enable_clks >= min_enable_clks;
+    enable_clks <= max_enable_clks;
+  }
+
+  // In tests that disable CSRNG, how many cycles to wait to disable CSRNG after EDN agents have
+  // been disabled
+  rand uint disable_edn_before_csrng_clks;
+  constraint disable_edn_before_csrng_clks_c {
+    disable_edn_before_csrng_clks >= min_disable_edn_before_csrng_clks;
+    disable_edn_before_csrng_clks <= max_disable_edn_before_csrng_clks;
+  }
+
+  // In tests that disable CSRNG, how many cycles to wait to disable entropy_src after CSRNG has
+  // been disabled
+  rand uint disable_csrng_before_entropy_src_clks;
+  constraint disable_csrng_before_entropy_src_clks_c {
+    disable_csrng_before_entropy_src_clks >= min_disable_csrng_before_entropy_src_clks;
+    disable_csrng_before_entropy_src_clks <= max_disable_csrng_before_entropy_src_clks;
+  }
+
+  // In tests that disable CSRNG, how many cycles to keep all agents and CSRNG disabled
+  rand uint disable_clks;
+  constraint disable_clks_c {
+    disable_clks >= min_disable_clks;
+    disable_clks <= max_disable_clks;
+  }
+
+  // In tests that disable CSRNG, how many cycles to enable the entropy_src agent in advance of
+  // CSRNG
+  rand uint enable_entropy_src_before_csrng_clks;
+  constraint enable_entropy_src_before_csrng_clks_c {
+    enable_entropy_src_before_csrng_clks >= min_enable_entropy_src_before_csrng_clks;
+    enable_entropy_src_before_csrng_clks <= max_enable_entropy_src_before_csrng_clks;
+  }
+
+  // In tests that disable CSRNG, how many cycles to enable CSRNG in advance of enabling EDN agents
+  rand uint enable_csrng_before_edn_clks;
+  constraint enable_csrng_before_edn_clks_c {
+    enable_csrng_before_edn_clks >= min_enable_csrng_before_edn_clks;
+    enable_csrng_before_edn_clks <= max_enable_csrng_before_edn_clks;
+  }
+
+  // Re-randomize enable and disable delays.  This is intended to be called between iterations in
+  // tests that disable and re-enable CSRNG (and the agents).
+  function automatic void randomize_disable_enable_clks();
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(enable_clks)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(disable_edn_before_csrng_clks)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(disable_csrng_before_entropy_src_clks)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(disable_clks)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(enable_entropy_src_before_csrng_clks)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(enable_csrng_before_edn_clks)
+  endfunction
 
   // Functions
   function void post_randomize();

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -350,6 +350,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     bit [BLOCK_LEN-1:0]         output_block;
     bit [63:0]                  mod_val;
 
+    `uvm_info(`gfn, $sformatf("Update of app %0d", app), UVM_MEDIUM)
     for (int i = 0; i < (CSRNG_BUS_WIDTH/BLOCK_LEN); i++) begin
       if (CTR_LEN < BLOCK_LEN) begin
         inc = (cfg.v[app][CTR_LEN-1:0] + 1);
@@ -379,6 +380,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
 
     bit [CSRNG_BUS_WIDTH-1:0]   seed_material;
 
+    `uvm_info(`gfn, $sformatf("Instantiate of app %0d", app), UVM_MEDIUM)
     seed_material  = entropy_input ^ additional_input;
     cfg.key[app] = 'h0;
     cfg.v[app]   = 'h0;
@@ -395,6 +397,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
 
     bit [CSRNG_BUS_WIDTH-1:0]   seed_material;
 
+    `uvm_info(`gfn, $sformatf("Reseed of app %0d", app), UVM_MEDIUM)
     seed_material = entropy_input ^ additional_input;
     ctr_drbg_update(app, seed_material);
     cfg.reseed_counter[app] = 1'b1;
@@ -402,6 +405,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   function void ctr_drbg_uninstantiate(uint app);
+    `uvm_info(`gfn, $sformatf("Uninstantiate of app %0d", app), UVM_MEDIUM)
     cfg.key[app] = 'h0;
     cfg.v[app]   = 'h0;
     cfg.reseed_counter[app] = 1'b0;
@@ -418,6 +422,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     bit [BLOCK_LEN-1:0]           output_block;
     bit [63:0]                    mod_val;
 
+    `uvm_info(`gfn, $sformatf("Generate of app %0d", app), UVM_MEDIUM)
     if (additional_input) begin
       ctr_drbg_update(app, additional_input);
     end

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
@@ -88,7 +88,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
         get_rand_mubi4_val(.t_weight(0), .f_weight(0), .other_weight(1)) : MuBi4True;
     cs_item.glen  = 'h0;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(cfg.which_app_err_alert, cs_item);
+    send_cmd_req(cfg.which_app_err_alert, cs_item, .edn_rst_as_ack(0));
 
     // Reseed Command.
     cs_item.acmd  = csrng_pkg::RES;
@@ -97,7 +97,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
         get_rand_mubi4_val(.t_weight(0), .f_weight(0), .other_weight(1)) : MuBi4True;
     cs_item.glen  = 'h1;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(cfg.which_app_err_alert, cs_item);
+    send_cmd_req(cfg.which_app_err_alert, cs_item, .edn_rst_as_ack(0));
 
     if (!flag0_flip_ins_cmd) begin
       // The previous command interpreting flag0 detected an invalid MuBi encoding. We need
@@ -109,7 +109,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
       cs_item.flags = MuBi4True;
       cs_item.glen  = 'h1;
       `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-      send_cmd_req(cfg.which_app_err_alert, cs_item);
+      send_cmd_req(cfg.which_app_err_alert, cs_item, .edn_rst_as_ack(0));
     end
 
     `uvm_info(`gfn, $sformatf("Waiting for alert ack to complete"), UVM_MEDIUM)

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -66,7 +66,7 @@ class csrng_base_vseq extends cip_base_vseq #(
     check_interrupts(.interrupts((1 << CmdReqDone)), .check_set(1'b1));
   endtask
 
-  task send_cmd_req(uint app, csrng_item cs_item, bit await_response=1'b1);
+  task send_cmd_req(uint app, csrng_item cs_item, bit await_response=1'b1, bit edn_rst_as_ack=1'b1);
     bit [csrng_pkg::CSRNG_CMD_WIDTH-1:0]   cmd;
     // Gen cmd_req
     if ((cs_item.acmd != INS) && (cs_item.acmd != RES)) begin
@@ -88,7 +88,8 @@ class csrng_base_vseq extends cip_base_vseq #(
       join_none
       if (await_response) begin
         // Wait for ack
-        cfg.m_edn_agent_cfg[app].vif.wait_cmd_ack();
+        if (edn_rst_as_ack) cfg.m_edn_agent_cfg[app].vif.wait_cmd_ack_or_rst_n();
+        else cfg.m_edn_agent_cfg[app].vif.wait_cmd_ack();
       end
     end
     else begin

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_cmds_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_cmds_vseq.sv
@@ -64,6 +64,24 @@ class csrng_cmds_vseq extends csrng_base_vseq;
     cmds_gen += cs_item_q[app].size();
   endfunction
 
+  function void create_cmds_all_apps();
+    cmds_gen = 0;
+    cmds_sent = 0;
+    // Generate queues of csrng commands
+    for (int i = 0; i < NUM_HW_APPS + 1; i++) begin
+      create_cmds(i);
+    end
+  endfunction
+
+  function void print_cmds_all_apps();
+    for (int i = 0; i < NUM_HW_APPS + 1; i++) begin
+      foreach (cs_item_q[i][j]) begin
+        `uvm_info(`gfn, $sformatf("cs_item_q[%0d][%0d]: %s", i, j,
+            cs_item_q[i][j].convert2string()), UVM_DEBUG)
+      end
+    end
+  endfunction
+
   task body();
     super.body();
 
@@ -78,18 +96,8 @@ class csrng_cmds_vseq extends csrng_base_vseq;
                                               ($sformatf("m_edn_push_seq[%0d]", i));
     end
 
-    // Generate queues of csrng commands
-    for (int i = 0; i < NUM_HW_APPS + 1; i++) begin
-      create_cmds(i);
-    end
-
-    // Print cs_items
-    for (int i = 0; i < NUM_HW_APPS + 1; i++) begin
-      foreach (cs_item_q[i][j]) begin
-        `uvm_info(`gfn, $sformatf("cs_item_q[%0d][%0d]: %s", i, j,
-            cs_item_q[i][j].convert2string()), UVM_DEBUG)
-      end
-    end
+    create_cmds_all_apps();
+    print_cmds_all_apps();
 
     // Start entropy_src agent
     fork

--- a/hw/ip/csrng/dv/tb.sv
+++ b/hw/ip/csrng/dv/tb.sv
@@ -162,4 +162,9 @@ module tb;
           [`CTR_DRBG_UPD.BlkEncAckFifoWidth-1 -: `CTR_DRBG_UPD.BlkLen]) !=
       $past(`BLOCK_ENCRYPT_PATH.cipher_data_out, 2), clk, !rst_n)
 
+  // Assertion controls
+  `DV_ASSERT_CTRL("EntropySrcIf_ReqHighUntilAck_A_CTRL", entropy_src_if.ReqHighUntilAck_A)
+  `DV_ASSERT_CTRL("EntropySrcIf_AckAssertedOnlyWhenReqAsserted_A_CTRL",
+                  entropy_src_if.AckAssertedOnlyWhenReqAsserted_A)
+
 endmodule

--- a/hw/ip/csrng/dv/tests/csrng_cmds_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_cmds_test.sv
@@ -16,6 +16,20 @@ class csrng_cmds_test extends csrng_base_test;
     cfg.min_aes_halt_clks = 400;
     cfg.max_aes_halt_clks = 600;
     cfg.force_state_pct   = 100;
+    cfg.min_num_disable_enable = 0;
+    cfg.max_num_disable_enable = 10;
+    cfg.min_enable_clks = 1;
+    cfg.max_enable_clks = 10000;
+    cfg.min_disable_edn_before_csrng_clks = 10;
+    cfg.max_disable_edn_before_csrng_clks = 200;
+    cfg.min_disable_csrng_before_entropy_src_clks = 10;
+    cfg.max_disable_csrng_before_entropy_src_clks = 200;
+    cfg.min_disable_clks = 20;
+    cfg.max_disable_clks = 200;
+    cfg.min_enable_entropy_src_before_csrng_clks = 10;
+    cfg.max_enable_entropy_src_before_csrng_clks = 200;
+    cfg.min_enable_csrng_before_edn_clks = 10;
+    cfg.max_enable_csrng_before_edn_clks = 200;
 
     for (int i = 0; i < NUM_HW_APPS; i++) begin
       cfg.m_edn_agent_cfg[i].min_genbits_rdy_dly = 0;


### PR DESCRIPTION
Contributes to resolving #16430 by extending the `csrng_cmds` test such that it disables and re-enables CSRNG as well as the agents (for `entropy_src` and EDN). The number of disable-and-re-enable iterations as well as the number of cycles between the disablement or enablement of CSRNG and the agents is randomized.

The extended `csrng_cmds` test passes 50/50 reseeds, conditional to HW fixes that are being developed in PR #16462.  

## TODO
- [x] Depends on #16500; rebase once that has been merged.
- [x] The `entropy_src` agent does not yet get disabled and re-enabled. Fix this (it currently causes failing assertions).