### PR TITLE
[csrng/rtl] Fix state clearing on disable

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -72,7 +72,7 @@ module csrng_core import csrng_pkg::*; #(
   localparam int MaxClen = 12;
   localparam int ADataDepthWidth = SeedLen/AppCmdWidth;
   localparam unsigned ADataDepthClog = $clog2(ADataDepthWidth)+1;
-  localparam int CsEnableCopies = 51;
+  localparam int CsEnableCopies = 53;
   localparam int LcHwDebugCopies = 1;
   localparam int Flag0Copies = 3;
 
@@ -1244,11 +1244,13 @@ module csrng_core import csrng_pkg::*; #(
 
   // Capture entropy from entropy_src
   assign entropy_src_seed_d =
+         ~cs_enable_fo[51] ? '0 :
          cmd_req_dly_q ? '0 :                  // reset after every cmd
          (cmd_entropy_avail && flag0_fo[1]) ? '0 : // special case where zero is used
          cmd_entropy_avail ? (entropy_src_hw_if_i.es_bits ^ seed_diversification) :
          entropy_src_seed_q;
   assign entropy_src_fips_d =
+         ~cs_enable_fo[52] ? '0 :
          cmd_req_dly_q ? '0 :                  // reset after every cmd
          (cmd_entropy_avail && flag0_fo[2]) ? '0 : // special case where zero is used
          cmd_entropy_avail ? entropy_src_hw_if_i.es_fips :

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
@@ -219,7 +219,7 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
 
   assign prep_gen_adata_null = (cmdreq_ccmd == GEN) && (cmdreq_adata == '0);
 
-  assign gen_adata_null_d = prep_gen_adata_null;
+  assign gen_adata_null_d = ~ctr_drbg_cmd_enable_i ? '0 : prep_gen_adata_null;
 
   // send to the update block
   assign cmd_upd_req_o = sfifo_cmdreq_not_empty && !prep_gen_adata_null;


### PR DESCRIPTION
This PR fixes the state clearing on disable of the DRBG modules as well as of the `entropy_src_seed_q` and `entropy_src_fips_q` FFs in `csrng_core`. Please check the commit messages for a full description of both changes and why they are required.

With this PR applied, the disable & re-enable test of PR #16461 consistently passes; without it, that test fails. The pass rates of the other tests are not affected, as confirmed by a full regression run.