### PR TITLE
[spi_host/dv] add SPIEN test

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -58,6 +58,8 @@ package spi_agent_pkg;
     SpiModeTpm
   } spi_func_mode_e;
 
+  // Command-Set implemented by the agent in device_mode.
+  // The first byte in a transaction should be one of these commands.
   typedef enum bit [7:0] {
     ReadStd      = 8'b11001100,
     WriteStd     = 8'b11111100,
@@ -77,6 +79,12 @@ package spi_agent_pkg;
     // Fixed 4b addr
     SpiFlashAddr4b
   } spi_flash_addr_mode_e;
+
+  typedef enum bit [1:0] {
+    SpiIdle,
+    SpiCmd,
+    SpiData
+  } spi_fsm_e;
 
   // forward declare classes to allow typedefs below
   typedef class spi_item;

--- a/hw/ip/spi_host/data/spi_host_testplan.hjson
+++ b/hw/ip/spi_host/data/spi_host_testplan.hjson
@@ -202,6 +202,27 @@
       tests: ["spi_host_stress_all"]
     }
     {
+        name: spien
+        desc: '''
+          Check that with mid-transaction writes to CONTROL.SPIEN, the block behaves according
+          to the documentation.
+          - Writing a zero to this register temporarily suspends any previously
+            submitted transactions.
+          - If the block is re-enabled by writing a one to CONTROL.SPIEN, any previously
+            executing commands will continue from wherever they left off.
+
+          Stimulus:
+            - Issue a transaction
+            - De-assert CONTROL.SPIEN after the command byte is receieved
+            - Re-assert after a randomized delay
+          Checking:
+            - Ensure transactions are transmitted/received correctly, even with a large
+              temporary suspension in the middle.
+          '''
+        stage: V2
+        tests: ["spi_host_spien"]
+    }
+    {
       name: stall
       desc: '''
             Stimulus:

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -135,16 +135,18 @@ class spi_host_base_vseq extends cip_base_vseq #(
   function void transaction_init();
     transaction = new();
 
-    transaction.read_weight    = cfg.seq_cfg.read_pct;
-    transaction.write_weight   = cfg.seq_cfg.write_pct;
-    transaction.std_en         = cfg.seq_cfg.std_en;
-    transaction.dual_en        = cfg.seq_cfg.dual_en;
-    transaction.quad_en        = cfg.seq_cfg.quad_en;
-    transaction.rx_only_weight = cfg.seq_cfg.rx_only_weight;
-    transaction.tx_only_weight = cfg.seq_cfg.tx_only_weight;
-    transaction.spi_len_min    = cfg.seq_cfg.host_spi_min_len;
-    transaction.spi_len_max    = cfg.seq_cfg.host_spi_max_len;
-    transaction.num_cmd_bytes  = cfg.num_cmd_bytes;
+    transaction.read_weight     = cfg.seq_cfg.read_pct;
+    transaction.write_weight    = cfg.seq_cfg.write_pct;
+    transaction.std_en          = cfg.seq_cfg.std_en;
+    transaction.dual_en         = cfg.seq_cfg.dual_en;
+    transaction.quad_en         = cfg.seq_cfg.quad_en;
+    transaction.rx_only_weight  = cfg.seq_cfg.rx_only_weight;
+    transaction.tx_only_weight  = cfg.seq_cfg.tx_only_weight;
+    transaction.spi_len_min     = cfg.seq_cfg.host_spi_min_len;
+    transaction.spi_len_max     = cfg.seq_cfg.host_spi_max_len;
+    transaction.spi_num_seg_min = cfg.seq_cfg.host_spi_min_num_seg;
+    transaction.spi_num_seg_max = cfg.seq_cfg.host_spi_max_num_seg;
+    transaction.num_cmd_bytes   = cfg.num_cmd_bytes;
   endfunction
 
 

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_spien_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_spien_vseq.sv
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test starts a transaction, then deasserts the CONTROL.SPIEN bit
+// mid-transaction.
+
+class spi_host_spien_vseq extends spi_host_tx_rx_vseq;
+  `uvm_object_utils(spi_host_spien_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    super.pre_start();
+    // Ensure the command is long enough for us to stop in the middle of it.
+    cfg.seq_cfg.host_spi_min_len = 4;
+    cfg.seq_cfg.host_spi_max_len = 6;
+    cfg.seq_cfg.host_spi_min_num_seg = 4;
+    cfg.seq_cfg.host_spi_max_num_seg = 8;
+  endtask // pre_start
+
+  virtual task body();
+    spi_host_status_t status;
+
+    fork start_reactive_seq(); join_none
+    wait_ready_for_command();
+
+    fork
+      begin
+        read_rx_fifo();
+        // Read RXFIFO until STATUS.ACTIVE == 0
+      end
+      begin
+        start_spi_host_trans(.num_transactions(3), .wait_ready(1));
+        // Wait until the DUT has finished processing commands, and
+        // the RXFIFO is empty (has been fully processed by the scoreboard).
+        csr_spinwait(.ptr(ral.status.active), .exp_data(1'b0), .timeout_ns(50_000_000));
+        csr_spinwait(.ptr(ral.status.rxqd), .exp_data(8'h0));
+        cfg.clk_rst_vif.wait_clks(100);
+        // This thread should be the last to end.
+      end
+      do begin
+        cfg.clk_rst_vif.wait_clks($urandom_range(0, 20000)); // clk_i cycles
+
+        // Deassert CONTROL.SPIEN for a random length of time
+        csr_wr(.ptr(ral.control.spien), .value(1'b0));
+        cfg.clk_rst_vif.wait_clks($urandom_range(0, 20000));
+        csr_wr(.ptr(ral.control.spien), .value(1'b1));
+
+        // Break when STATUS.ACTIVE == 0
+        csr_rd(.ptr(ral.status), .value(status), .backdoor(1));
+      end while (status.active == 1);
+    join
+
+  endtask : body
+
+endclass : spi_host_spien_vseq

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_vseq_list.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_vseq_list.sv
@@ -16,3 +16,4 @@
 `include "spi_host_stress_all_vseq.sv"
 `include "spi_host_passthrough_mode_vseq.sv"
 `include "spi_host_common_vseq.sv"
+`include "spi_host_spien_vseq.sv"

--- a/hw/ip/spi_host/dv/env/spi_host_env.core
+++ b/hw/ip/spi_host/dv/env/spi_host_env.core
@@ -37,6 +37,7 @@ filesets:
       - seq_lib/spi_host_idlecsbactive_vseq.sv: {is_include_file: true}
       - seq_lib/spi_host_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/spi_host_passthrough_mode_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_host_spien_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -259,7 +259,7 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
           if (cfg.en_cov) begin
             cov.control_cg.sample(spi_ctrl_reg,spien,output_en,sw_rst);
           end
-          if (sw_rst || spien) begin
+          if (sw_rst) begin
             write_segment_q.delete();
             rx_data_q.delete();
             in_tx_seg_cnt = 0;

--- a/hw/ip/spi_host/dv/env/spi_host_seq_cfg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_seq_cfg.sv
@@ -26,6 +26,8 @@ class spi_host_seq_cfg extends uvm_object;
   uint host_spi_max_dly               = 5;
   uint host_spi_max_rxwm              = SPI_HOST_RX_DEPTH;
   uint host_spi_max_txwm              = SPI_HOST_TX_DEPTH;
+  uint host_spi_min_num_seg           = 1;
+  uint host_spi_max_num_seg           = 4;
 
   uint host_spi_min_num_wr_bytes      = 1;
   uint host_spi_max_num_wr_bytes      = SPI_HOST_TX_DEPTH;

--- a/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson
+++ b/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson
@@ -119,6 +119,10 @@
       uvm_test_seq: spi_host_stress_all_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
     }
+    {
+      name: spi_host_spien
+      uvm_test_seq: spi_host_spien_vseq
+    }
     // TODO: add more tests here
   ]
 


### PR DESCRIPTION
Implement test as described in #13582 / #15076 / #5158

Building on the initial work started by @visbaz.

~~I've implemented the test slightly differently, by looking at the state of the agent we can reliably wait until the middle of a transaction to set SPIEN=0.~~
This test waits for the start of the first transaction, then toggles SPIEN off/on a number of times with randomized delays each time. 

With this stimulus, the only meaningful change to the scoreboard was to not clear-out the queues/state when writing to the CONTROL.SPIEN, I did not add any further queue flushes. ~~This may be required in the future if the future plans (proposed in the above linked issues) to cross the SPIEN de-assertion with FSM states is pursued, as I suspect if the stimulus was mid-byte we would again see problems. This test should be a useful starting point for that further work.~~

I found that the `cmd_rsp_seq` did not seem to be transitioning between states as expected, and was not resetting properly upon the end of a transaction (posedge CSB). I started making some changes which turned into a small refactor of that code, with less code-duplication and is easier to understand now IMO. Changes in the second commit.
I ran a small local spi_host regression with these changes and saw no regress.

Closes #15076 

