### PR TITLE
[chip, dv] Fix a i2c failure

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -249,7 +249,7 @@
             Verify all instances of I2C in the chip.
             '''
       stage: V2
-      tests: ["chip_sw_i2c_host_tx_rx"]
+      tests: ["chip_sw_i2c_host_tx_rx", "chip_sw_i2c_host_tx_rx_idx1", "chip_sw_i2c_host_tx_rx_idx2"]
     }
     {
       name: chip_sw_i2c_device_tx_rx

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -36,7 +36,7 @@ void i2c_testutils_wr(dif_i2c_t *i2c, uint8_t addr, uint8_t byte_count,
 
   // TODO: The current function does not support write payloads
   // larger than the fifo depth.
-  CHECK(byte_count < I2C_PARAM_FIFO_DEPTH);
+  CHECK(byte_count <= I2C_PARAM_FIFO_DEPTH);
 
   // TODO: #15377 The I2C DIF says: "Callers should prefer
   // `dif_i2c_write_byte()` instead, since that function provides clearer


### PR DESCRIPTION
Fixed a condition - there is a small change we may get `byte_count == I2C_PARAM_FIFO_DEPTH`
Also fixed unmapped tests

Signed-off-by: Weicai Yang <weicai@google.com>