### PR TITLE
[fpv/sec_cm] Add stopat for sram tb

### DIFF
--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
@@ -206,6 +206,7 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/sram_ctrl/{sub_flow}/{tool}"
                task: "FpvSecCm"
+               stopats: ["*u_state_regs.state_o"]
              }
 
 


### PR DESCRIPTION
SRAM_CTRL has a prim_flop but did not add a stopat to create the fault injection.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>