### PR TITLE
[i2c,dv] interrupt test part2

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -326,19 +326,17 @@
     {
       name: target_fifo_overflow
       desc: '''
-            Test the overflow interrupt for tx_fifo and acq_fifo overflow.
+            Test the overflow interrupt for tx_fifo overflow.
 
             Stimulus:
               - Configure DUT/Agent to Target/Host mode respectively
-              - Agent keeps sending a number of format byte higher than the size of tx_fifo and
-                acq_fifo
-
+              - Agent keeps sending a number of format byte higher than the size of tx_fifo
             Checking:
               - Ensure excess format bytes are dropped
-              - Ensure tx_overflow and acq_overflow interrupt are asserted
+              - Ensure tx_overflow interrupt are asserted
             '''
       stage: V2
-      tests: [""]
+      tests: ["i2c_target_tx_ovf"]
     }
     {
       name: target_fifo_empty
@@ -354,7 +352,7 @@
                 in tx_fifo otherwise tx_empty interrupt must be de-asserted
             '''
       stage: V2
-      tests: ["i2c_target_stress_rd", "i2c_target_intr_smoke"]
+      tests: ["i2c_target_stress_rd", "i2c_target_intr_smoke", "i2c_target_tx_ovf"]
     }
     {
       name: target_fifo_reset

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -41,6 +41,7 @@ filesets:
       - seq_lib/i2c_target_stress_wr_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_stress_rd_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_stretch_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_tx_ovf_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -43,6 +43,10 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   // Slow tx process
   bit        slow_txq = 1'b0;
 
+  // For tx fifio overflow test.
+  // If this bit is set, tx fifo is fed by 'drooling_write_tx_fifo()' in i2c_base_vseq.sv
+  bit        use_drooling_tx = 1'b0;
+
   `uvm_object_utils_begin(i2c_env_cfg)
     `uvm_field_object(m_i2c_agent_cfg, UVM_DEFAULT)
   `uvm_object_utils_end

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -77,7 +77,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
         forever begin
           target_mode_wr_exp_fifo.get(exp_wr_item);
           str = (exp_wr_item.start) ? "addr" : (exp_wr_item.stop) ? "stop" : "wr";
-          `uvm_info(`gfn, $sformatf("exp_%s_txn%0d\n %s", str,
+          `uvm_info(`gfn, $sformatf("exp_%s_txn %0d\n %s", str,
                                     exp_wr_item.tran_id, exp_wr_item.sprint()), UVM_MEDIUM)
           target_mode_wr_obs_fifo.get(obs_wr_item);
           obs_wr_item.tran_id = obs_wr_id++;

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_tx_ovf_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_tx_ovf_vseq.sv
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// tx_overflow test
+class i2c_target_tx_ovf_vseq extends i2c_target_smoke_vseq;
+  `uvm_object_utils(i2c_target_tx_ovf_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    super.pre_start();
+    cfg.rd_pct = 3;
+    cfg.wr_pct = 1;
+    cfg.min_data = 100;
+    cfg.max_data = 200;
+    expected_intr[TxOverflow] = 1;
+    expected_intr[TxNonEmpty] = 1;
+    cfg.use_drooling_tx = 1;
+    num_trans = 5;
+  endtask
+endclass : i2c_target_tx_ovf_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -24,3 +24,4 @@
 `include "i2c_target_stress_wr_vseq.sv"
 `include "i2c_target_stress_rd_vseq.sv"
 `include "i2c_target_stretch_vseq.sv"
+`include "i2c_target_tx_ovf_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -152,7 +152,13 @@
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=300_000_000",
                  "+use_intr_handler=1", "+slow_acq=1"]
     }
-  ]
+    {
+      name: i2c_target_tx_ovf
+      uvm_test_seq: i2c_target_tx_ovf_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=50_000_000",
+                 "+use_intr_handler=1"]
+    }
+   ]
 
   // List of regressions.
   regressions: [
@@ -164,7 +170,8 @@
       name: target_sanity
       tests: ["i2c_target_smoke", "i2c_target_stress_wr",
               "i2c_target_stress_rd", "i2c_target_stretch",
-              "i2c_target_intr_smoke", "i2c_target_intr_stress_wr"]
+              "i2c_target_intr_smoke", "i2c_target_intr_stress_wr",
+              "i2c_target_tx_ovf"]
     }
   ]
 }


### PR DESCRIPTION
Target mode interrupt test and add drooling tx fifo write. Drooling_tx_fifo_write is called upon receiving read command from acq fifo.
When it is called, it pour data to random level, and possibly triggers tx_overflow and tx_nonempty.
Following interrupts are tested.

- tx_nonempty
- tx_overflow

Signed-off-by: Jaedon Kim <jdonjdon@google.com>