### PR TITLE
[dv] add slot for debug SRAM image

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -403,6 +403,8 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
           end
         end else if (i == SwTypeOtp) begin
           otp_images[OtpTypeCustom] = $sformatf("%0s.24.vmem", sw_images[i]);
+        end else if (i == SwTypeDebug) begin
+          sw_images[i] = $sformatf("%0s.32.vmem", sw_images[i]);
         end
       end
     end

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -91,7 +91,8 @@ package chip_env_pkg;
     SwTypeTestSlotA = 1, // Ibex SW - test SW in (flash) slot A.
     SwTypeTestSlotB = 2, // Ibex SW - test SW in (flash) slot B.
     SwTypeOtbn      = 3, // Otbn SW
-    SwTypeOtp       = 4  // Customized OTP image
+    SwTypeOtp       = 4, // Customized OTP image
+    SwTypeDebug     = 5  // Debug SW - injected into SRAM.
   } sw_type_e;
 
   // Our dvsim.py configuration always generates five base OTP images (in various lifecycle states)


### PR DESCRIPTION
This facilitates running JTAG inject / debug ROM E2E tests in DV.

Signed-off-by: Timothy Trippel <ttrippel@google.com>