### PR TITLE
[dv/rstmgr] Add stimulus with multiple resets bits set

### DIFF
--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_cnsty_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_cnsty_vseq.sv
@@ -61,11 +61,10 @@ class rstmgr_leaf_rst_cnsty_vseq extends rstmgr_base_vseq;
           set_pos_and_wait();
           set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
           // Send low power entry reset.
-          send_reset(pwrmgr_pkg::LowPwrEntry, '0);
+          send_lowpower_reset();
           expected = 1 << ral.reset_info.low_power_exit.get_lsb_pos();
 
-          check_reset_info(maybe_por_reset | expected,
-                           "expected reset_info to indicate low power");
+          check_reset_info(maybe_por_reset | expected, "expected reset_info to indicate low power");
           check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b1);
 
           csr_wr(.ptr(ral.reset_info), .value('1));
@@ -77,7 +76,7 @@ class rstmgr_leaf_rst_cnsty_vseq extends rstmgr_base_vseq;
           `DV_CHECK_RANDOMIZE_FATAL(this)
           set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
           expected = rstreqs << ral.reset_info.hw_req.get_lsb_pos();
-          send_reset(pwrmgr_pkg::HwReq, rstreqs);
+          send_hw_reset(rstreqs);
           check_reset_info(maybe_por_reset | expected, $sformatf(
                            "expected reset_info to match hw_req 0x%x", expected));
           check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b0);
@@ -89,10 +88,10 @@ class rstmgr_leaf_rst_cnsty_vseq extends rstmgr_base_vseq;
           set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
 
           // Send sw reset.
-          send_sw_reset(MuBi4True);
+          csr_wr(.ptr(ral.reset_req), .value(MuBi4True));
+          send_sw_reset();
           expected = 1 << ral.reset_info.sw_reset.get_lsb_pos();
-          check_reset_info(maybe_por_reset | expected,
-                           "Expected reset_info to indicate sw reset");
+          check_reset_info(maybe_por_reset | expected, "Expected reset_info to indicate sw reset");
           check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 0);
           csr_wr(.ptr(ral.reset_info), .value('1));
         end

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_por_stretcher_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_por_stretcher_vseq.sv
@@ -36,7 +36,7 @@ class rstmgr_por_stretcher_vseq extends rstmgr_base_vseq;
       cfg.aon_clk_rst_vif.wait_clks(glitch_duration_cycles);
       `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel], 1'b0)
     end
-    por_reset_done();
+    por_reset_done(.complete_it(1));
     csr_rd_check(.ptr(ral.reset_info.por), .compare_value(1'b1),
                  .err_msg("Unexpected reset_info.por low"));
   endtask

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sec_cm_scan_intersig_mubi_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sec_cm_scan_intersig_mubi_vseq.sv
@@ -12,7 +12,7 @@ class rstmgr_sec_cm_scan_intersig_mubi_vseq extends rstmgr_smoke_vseq;
 
   task body();
     fork
-      begin
+      begin : isolation_fork
         fork
           super.body();
           add_noise();
@@ -28,23 +28,24 @@ class rstmgr_sec_cm_scan_intersig_mubi_vseq extends rstmgr_smoke_vseq;
     forever begin
       // If scan_rst_ni is active we assume super is doing a scan reset, so keep scanmode_i True.
       if (cfg.rstmgr_vif.scan_rst_ni == 1'b1) begin
-        cfg.rstmgr_vif.scanmode_i = get_rand_mubi4_val(0, 0, 1);
+        cfg.rstmgr_vif.scanmode_i = get_rand_mubi4_val(0, 1, 4);
       end else begin
         cfg.rstmgr_vif.scanmode_i = prim_mubi_pkg::MuBi4True;
       end
-      cfg.io_div4_clk_rst_vif.wait_clks(scan_rst_to_scanmode_cycles);
-      delay = $urandom_range(0, 30);
+      delay = $urandom_range(5, 30);
       fork
         // This waits for a certain number of cycles or for a change in scan_rst_ni,
         //  whichever is sooner, or it could end up skipping a full scan reset.
         begin : isolation_fork
           fork
-            @cfg.rstmgr_vif.scan_rst_ni;
+            @(edge cfg.rstmgr_vif.scan_rst_ni);
             cfg.clk_rst_vif.wait_clks(delay);
           join_any
           disable fork;
         end
       join
+      // Somehow without this VCS will scan_rst_ni transitions to 0.
+      #0;
     end
   endtask : add_noise
 endclass : rstmgr_sec_cm_scan_intersig_mubi_vseq

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -43,11 +43,9 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
     csr_wr(.ptr(ral.reset_info), .value('1));
 
     // Send low power entry reset.
-    send_reset(pwrmgr_pkg::LowPwrEntry, '0);
-    exp_reg = csr_utils_pkg::get_csr_val_with_updated_field(
-              ral.reset_info.low_power_exit, '0, 1);
-    check_reset_info(exp_reg,
-                     "expected reset_info to indicate low power");
+    send_lowpower_reset();
+    exp_reg = csr_utils_pkg::get_csr_val_with_updated_field(ral.reset_info.low_power_exit, '0, 1);
+    check_reset_info(exp_reg, "expected reset_info to indicate low power");
     check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b1);
     wait_between_resets();
 
@@ -58,12 +56,9 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
     `DV_CHECK_RANDOMIZE_FATAL(this)
     set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
 
-    send_reset(pwrmgr_pkg::HwReq, rstreqs);
-    exp_reg = csr_utils_pkg::get_csr_val_with_updated_field(
-              ral.reset_info.hw_req, '0, rstreqs);
-    check_reset_info(exp_reg,
-                     $sformatf("expected reset_info to match 0x%x", exp_reg
-                     ));
+    send_hw_reset(rstreqs);
+    exp_reg = csr_utils_pkg::get_csr_val_with_updated_field(ral.reset_info.hw_req, '0, rstreqs);
+    check_reset_info(exp_reg, $sformatf("expected reset_info to match 0x%x", exp_reg));
     check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b0);
     wait_between_resets();
 
@@ -76,11 +71,10 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
     set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
 
     // Send sw reset.
-    send_sw_reset(MuBi4True);
-    exp_reg = csr_utils_pkg::get_csr_val_with_updated_field(
-              ral.reset_info.sw_reset, '0, 1);
-    check_reset_info(exp_reg,
-                     "Expected reset_info to indicate sw reset");
+    csr_wr(.ptr(ral.reset_req), .value(MuBi4True));
+    send_sw_reset();
+    exp_reg = csr_utils_pkg::get_csr_val_with_updated_field(ral.reset_info.sw_reset, '0, 1);
+    check_reset_info(exp_reg, "Expected reset_info to indicate sw reset");
     check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 0);
     wait_between_resets();
 

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_reset_race_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_reset_race_vseq.sv
@@ -45,12 +45,12 @@ class rstmgr_sw_rst_reset_race_vseq extends rstmgr_base_vseq;
         end
         begin
           cfg.clk_rst_vif.wait_clks(cycles_before_reset);
-          send_reset(.reset_cause(pwrmgr_pkg::HwReq), .rstreqs(rstreqs), .clear_it(0));
+          send_hw_reset(rstreqs, .complete_it(0));
           `uvm_info(`gfn, "Done with send_reset", UVM_MEDIUM)
         end
       join
-      cfg.io_div4_clk_rst_vif.wait_clks(20);
-      release_reset(pwrmgr_pkg::HwReq);
+      #(reset_us * 1us);
+      reset_done();
       clear_sw_rst_ctrl_n();
       expected = rstreqs << ral.reset_info.hw_req.get_lsb_pos();
       check_reset_info(expected, $sformatf("expected reset_info to match 0x%x", expected));


### PR DESCRIPTION
Test the reset_info register captures all transitions in rstreqs_i during a reset event.
Test scenarios with both software and hardware resets during a reset event.

Fixes #11161

Signed-off-by: Guillermo Maturana <maturana@google.com>