### PR TITLE
[chip dv] rom_e2e_jtag_debug|inject_test bringup in DV

### DIFF
--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -210,6 +210,80 @@ package dv_utils_pkg;
     join_none
   endtask : poll_for_stop
 
+  // Extracts the address and size of a const symbol in a SW test (supplied as an ELF file).
+  //
+  // Used by a testbench to modify the given symbol in an executable (elf) generated for an embedded
+  // CPU within the DUT. This function only returns the extracted address and size of the symbol
+  // using the readelf utility. Readelf comes with binutils, a package typically available on linux
+  // machines. If not available, the assumption is, it can be relatively easily installed.
+  // The actual job of writing the new value into the symbol is handled externally (often via a
+  // backdoor mechanism to write the memory).
+  // Return 1 on success and 0 on failure.
+  function automatic bit sw_symbol_get_addr_size(input string elf_file,
+                                                 input string symbol,
+                                                 input bit does_not_exist_ok,
+                                                 output longint unsigned addr,
+                                                 output longint unsigned size);
+
+    string msg_id = "sw_symbol_get_addr_size";
+    string escaped_symbol = "";
+
+    `DV_CHECK_STRNE_FATAL(elf_file, "", "Input arg \"elf_file\" cannot be an empty string", msg_id)
+    `DV_CHECK_STRNE_FATAL(symbol,   "", "Input arg \"symbol\" cannot be an empty string", msg_id)
+
+    // If the symbol has special characters, such as '$', escape it for the cmd below, but don't
+    // escape it when creating the file.
+    foreach (symbol[i]) begin
+      if (symbol[i] == "$") begin
+        escaped_symbol = {escaped_symbol, "\\", symbol[i]};
+      end else begin
+        escaped_symbol = {escaped_symbol, symbol[i]};
+      end
+    end
+
+    begin
+      int ret;
+      string line;
+      int out_file_d = 0;
+      string out_file = $sformatf("%0s.dat", symbol);
+      string cmd = $sformatf(
+          // use `--wide` to avoid truncating the output, in case of long symbol name
+          // `\s%0s$` ensures we are looking for an exact match, with no pre- or postfixes.
+          "/usr/bin/readelf -s --wide %0s | grep \"\\s%0s$\" | awk \'{print $2\" \"$3}\' > %0s",
+          elf_file, escaped_symbol, out_file);
+
+      // TODO #3838: shell pipes are bad 'mkay?
+      ret = $system(cmd);
+      `DV_CHECK_EQ_FATAL(ret, 0, $sformatf("Command \"%0s\" failed with exit code %0d", cmd, ret),
+                         msg_id)
+
+      out_file_d = $fopen(out_file, "r");
+      `DV_CHECK_FATAL(out_file_d, $sformatf("Failed to open \"%0s\"", out_file), msg_id)
+
+      ret = $fgets(line, out_file_d);
+
+      // If the symbol did not exist in the elf (empty file), and we are ok with that, then return.
+      if (!ret && does_not_exist_ok) return 0;
+
+      `DV_CHECK_FATAL(ret, $sformatf("Failed to read line from \"%0s\"", out_file), msg_id)
+
+      // The first line should have the addr in hex followed by its size as integer.
+      ret = $sscanf(line, "%h %d", addr, size);
+      `DV_CHECK_EQ_FATAL(ret, 2, $sformatf("Failed to extract {addr size} from line \"%0s\"", line),
+                         msg_id)
+
+      // Attempt to read the next line should be met with EOF.
+      void'($fgets(line, out_file_d));
+      ret = $feof(out_file_d);
+      `DV_CHECK_FATAL(ret, $sformatf("EOF expected to be reached for \"%0s\"", out_file), msg_id)
+      $fclose(out_file_d);
+
+      ret = $system($sformatf("rm -rf %0s", out_file));
+      `DV_CHECK_EQ_FATAL(ret, 0, $sformatf("Failed to delete \"%0s\"", out_file), msg_id)
+      return 1;
+    end
+  endfunction
+
   // sources
 `ifdef UVM
   `include "dv_report_catcher.sv"

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -227,17 +227,19 @@ package dv_utils_pkg;
 
     string msg_id = "sw_symbol_get_addr_size";
     string escaped_symbol = "";
+    string symbol_for_filename = "";
 
     `DV_CHECK_STRNE_FATAL(elf_file, "", "Input arg \"elf_file\" cannot be an empty string", msg_id)
     `DV_CHECK_STRNE_FATAL(symbol,   "", "Input arg \"symbol\" cannot be an empty string", msg_id)
 
-    // If the symbol has special characters, such as '$', escape it for the cmd below, but don't
-    // escape it when creating the file.
+    // If the symbol has special characters, such as '$', escape it for the cmd below, but when
+    // creating the file, omit the special characters entirely.
     foreach (symbol[i]) begin
       if (symbol[i] == "$") begin
         escaped_symbol = {escaped_symbol, "\\", symbol[i]};
       end else begin
         escaped_symbol = {escaped_symbol, symbol[i]};
+        symbol_for_filename = {symbol_for_filename, symbol[i]};
       end
     end
 
@@ -245,7 +247,7 @@ package dv_utils_pkg;
       int ret;
       string line;
       int out_file_d = 0;
-      string out_file = $sformatf("%0s.dat", symbol);
+      string out_file = $sformatf("%0s.dat", symbol_for_filename);
       string cmd = $sformatf(
           // use `--wide` to avoid truncating the output, in case of long symbol name
           // `\s%0s$` ensures we are looking for an exact match, with no pre- or postfixes.

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -54,6 +54,10 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
   // drive trans received from sequencer
   virtual task get_and_drive_host_mode();
     forever begin
+      if (!cfg.vif.trst_n) begin
+        `DV_WAIT(cfg.vif.trst_n)
+        cfg.vif.wait_tck(1);
+      end
       seq_item_port.get_next_item(req);
       $cast(rsp, req.clone());
       rsp.set_id_info(req);

--- a/hw/dv/sv/jtag_agent/jtag_if.sv
+++ b/hw/dv/sv/jtag_agent/jtag_if.sv
@@ -56,8 +56,6 @@ interface jtag_if #(time JtagDefaultTckPeriodNs = 20ns) ();
     trst_n <= 1'b0;
     wait_tck(cycles);
     trst_n <= 1'b1;
-    // Give time for subsequent events to get away from the reset edge
-    wait_tck(1);
   endtask
 
   // Generate the tck, with UartDefaultClkPeriodNs period as default

--- a/hw/dv/sv/jtag_dmi_agent/jtag_rv_debugger.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_rv_debugger.sv
@@ -17,17 +17,30 @@ class jtag_rv_debugger extends uvm_object;
   // A pre-created handle to the JTAG DMI reg block with a frontdoor accessor attached.
   protected jtag_dmi_reg_block ral;
 
+  // The elf file executed by the CPU.
+  protected string elf_file;
+
   // Enable prediction on writes.
   bit predict_dmi_writes = 1;
 
   // Number of harts in the system. TODO: add support for multi-hart system.
   int num_harts = 1;
 
+  // Number of breakpoints (triggers) supported.
+  int num_triggers;
+
   // Indicates whether aarpostincrement is supported.
   bit aarpostincrement_supported;
 
   // An sba_access_reg_frontdoor instance to provide access to system CSRs via SBA using JTAG.
   sba_access_reg_frontdoor m_sba_access_reg_frontdoor;
+
+  // Internal status signals to optimize debugger performance.
+  // TODO: Use these bits effectively.
+  protected bit dmactive_is_set;
+  protected bit cpu_is_halted;
+  protected bit step_entered;
+  protected logic [BUS_AW-1:0] symbol_table[string];
 
   function new (string name = "");
     super.new(name);
@@ -56,16 +69,35 @@ class jtag_rv_debugger extends uvm_object;
     return ral;
   endfunction
 
+  // Sets the elf file name.
+  virtual function void set_elf_file(string elf_file);
+    this.elf_file = elf_file;
+    symbol_table.delete();
+  endfunction
+
+  // Returns the elf file name.
+  virtual function string get_elf_file();
+    return elf_file;
+  endfunction
+
   // Asserts TRST_N for a few cycles.
   virtual task do_trst_n(int cycles = $urandom_range(5, 20));
     `uvm_info(`gfn, "Asserting TRST_N", UVM_MEDIUM)
     cfg.vif.do_trst_n(cycles);
+    dmactive_is_set = 0;
+    cpu_is_halted = 0;
+    step_entered = 0;
   endtask
 
   // Enables the debug module.
   virtual task set_dmactive(bit value);
     `uvm_info(`gfn, $sformatf("Setting dmactive = %0b", value), UVM_MEDIUM)
     csr_wr(.ptr(ral.dmcontrol.dmactive), .value(value), .blocking(1), .predict(predict_dmi_writes));
+    dmactive_is_set = value;
+    if (!value) begin
+      cpu_is_halted = 0;
+      step_entered = 0;
+    end
   endtask
 
   // Issues a CPU halt request.
@@ -77,7 +109,7 @@ class jtag_rv_debugger extends uvm_object;
   // Waits for the CPU to be in halted state.
   virtual task wait_cpu_halted(int hart = 0);
     uvm_reg_data_t data;
-    `uvm_info(`gfn, "Waiting for CPU halted", UVM_MEDIUM)
+    `uvm_info(`gfn, "Waiting for CPU to halt", UVM_MEDIUM)
     `DV_SPINWAIT(
       do begin
         csr_rd(.ptr(ral.dmstatus), .value(data), .blocking(1));
@@ -86,7 +118,7 @@ class jtag_rv_debugger extends uvm_object;
     if (num_harts == 1) begin
       `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(ral.dmstatus.allhalted, data), 1)
     end
-    `uvm_info(`gfn, "Done waiting for CPU halted", UVM_MEDIUM)
+    `uvm_info(`gfn, "CPU has halted", UVM_MEDIUM)
   endtask
 
   // Issues an NDM reset request.
@@ -100,6 +132,23 @@ class jtag_rv_debugger extends uvm_object;
     `uvm_info(`gfn, $sformatf("Setting resumereq = %0b", value), UVM_MEDIUM)
     csr_wr(.ptr(ral.dmcontrol.resumereq), .value(value), .blocking(1),
            .predict(predict_dmi_writes));
+  endtask
+
+  // Waits for the CPU to be in resumed state.
+  virtual task wait_cpu_resumed(int hart = 0);
+    uvm_reg_data_t data;
+    `uvm_info(`gfn, "Waiting for CPU to resume", UVM_MEDIUM)
+    `DV_SPINWAIT(
+      do begin
+        csr_rd(.ptr(ral.dmstatus), .value(data), .blocking(1));
+      end while (dv_base_reg_pkg::get_field_val(ral.dmstatus.anyhalted, data) == 1);
+    )
+    `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(ral.dmstatus.anyrunning, data), 1)
+    if (num_harts == 1) begin
+      `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(ral.dmstatus.allhalted, data), 0)
+      `DV_CHECK_EQ(dv_base_reg_pkg::get_field_val(ral.dmstatus.allrunning, data), 1)
+    end
+    `uvm_info(`gfn, "CPU has resumed", UVM_MEDIUM)
   endtask
 
   // Checks if we are ready for executing abstract commands.
@@ -138,6 +187,7 @@ class jtag_rv_debugger extends uvm_object;
     if (status != AbstractCmdErrNone && cmderr_clear) begin
       csr_wr(.ptr(ral.abstractcs.cmderr), .value(1), .blocking(1), .predict(predict_dmi_writes));
     end
+    `uvm_info(`gfn, "Abstract command completed", UVM_MEDIUM)
   endtask
 
   // Disables the abstract cmd by setting the control field to 0.
@@ -165,19 +215,18 @@ class jtag_rv_debugger extends uvm_object;
   // regno: The starting CPU register number.
   // value_q: A queue of returned reads.
   // size: The Number of successive reads. The regno is incremented this many times.
-  // postexec: Have the CPU execute the progbuf immediately after the command.
-  // progbuf_q: A new set of arbitrary commands.
+  // postexec: Have the CPU execute the progbuf immediately after the command. The progbuf is
+  // assumed to have been loaded already.
   // TODO: add support for sub-word transfer size.
+  // TODO: Add support for reg read via program buffer.
   virtual task abstract_cmd_reg_read(input abstract_cmd_regno_t regno,
                                      output logic [BUS_DW-1:0] value_q[$],
                                      output abstract_cmd_err_e status,
                                      input int size = 1,
-                                     input bit postexec = 0,
-                                     input logic [BUS_DW-1:0] progbuf_q[$] = {});
+                                     input bit postexec = 0);
     uvm_reg_data_t rw_data = '0;
     abstract_cmd_reg_access_t cmd = '0;
 
-    if (postexec) write_progbuf(progbuf_q);
     if (aarpostincrement_supported && size > 1) begin
       write_abstract_cmd_auto(.autoexecdata(1));
       cmd.aarpostincrement = 1;
@@ -210,6 +259,8 @@ class jtag_rv_debugger extends uvm_object;
       // Before the last read, reset the autoexecdata bit.
       if (aarpostincrement_supported && size > 1 && i == size - 1) write_abstract_cmd_auto();
       csr_rd(.ptr(ral.abstractdata[0]), .value(value_q[i]), .blocking(1));
+      `uvm_info(`gfn, $sformatf("Read CPU register 0x%0h: 0x%0h", regno + i, value_q[i]),
+                UVM_MEDIUM)
     end
   endtask
 
@@ -218,17 +269,16 @@ class jtag_rv_debugger extends uvm_object;
   // regno: The starting CPU register number.
   // value_q: A queue of data written. regno is incremented for each value.
   // size: The Number of successive reads.
-  // postexec: Have the CPU execute the progbuf immediately after the command.
-  // progbuf_q: A new set of arbitrary commands.
+  // postexec: Have the CPU execute the progbuf immediately after the command. The progbuf is
+  // assumed to have been loaded already.
+  // TODO: Add support for reg read via program buffer.
   virtual task abstract_cmd_reg_write(input abstract_cmd_regno_t regno,
                                       input logic [BUS_DW-1:0] value_q[$],
                                       output abstract_cmd_err_e status,
-                                      input bit postexec = 0,
-                                      input logic [BUS_DW-1:0] progbuf_q[$] = {});
+                                      input bit postexec = 0);
     uvm_reg_data_t rw_data = '0;
     abstract_cmd_reg_access_t cmd = '0;
 
-    if (postexec) write_progbuf(progbuf_q);
     csr_wr(.ptr(ral.abstractdata[0]), .value(value_q[0]), .blocking(1),
            .predict(predict_dmi_writes));
 
@@ -243,6 +293,8 @@ class jtag_rv_debugger extends uvm_object;
     rw_data = csr_utils_pkg::get_csr_val_with_updated_field(ral.command.control, rw_data,
                                                             cmd);
     csr_wr(.ptr(ral.command), .value(rw_data), .blocking(1), .predict(predict_dmi_writes));
+    `uvm_info(`gfn, $sformatf("Wrote 0x%0h to CPU register 0x%0h", value_q[0], cmd.regno),
+              UVM_MEDIUM)
 
     if (aarpostincrement_supported && (value_q.size() > 1)) begin
       write_abstract_cmd_auto(.autoexecdata(1));
@@ -261,29 +313,188 @@ class jtag_rv_debugger extends uvm_object;
                                                                 cmd);
         csr_wr(.ptr(ral.command), .value(rw_data), .blocking(1), .predict(predict_dmi_writes));
       end
+      `uvm_info(`gfn, $sformatf("Wrote 0x%0h to CPU register 0x%0h", value_q[i], regno + i),
+                UVM_MEDIUM)
     end
     abstract_cmd_busy_wait(.status(status), .cmderr_clear(1));
     // After the last write, reset the autoexecdata bit.
     if (aarpostincrement_supported && (value_q.size() > 1)) write_abstract_cmd_auto();
   endtask
 
-  // Reads (a) memory location(s) via an abstract command.
+  // Reads (a) system memory location(s) via an abstract command.
+  //
+  // The system memory address space can be accessed either via `AbstractCmdMemAccess` abstract
+  // command type, or indirectly using the CPU using the program buffer. The former is not currently
+  // supported.
+  // addr: The starting system address.
+  // value_q: The read data returned to the caller.
+  // status: The status of the op returned to the caller.
+  // size: The size of the read access in terms of full bus words.
+  // route: The route taken to access the system memory.
   virtual task abstract_cmd_mem_read(input logic [BUS_AW-1:0] addr,
                                      output logic [BUS_DW-1:0] value_q[$],
                                      output abstract_cmd_err_e status,
                                      input int size = 1,
-                                     input bit postexec = 0,
-                                     input logic [BUS_DW-1:0] progbuf_q[$] = {});
-    `uvm_fatal(`gfn, "Not implemented")
+                                     input mem_access_route_e route = MemAccessViaProgbuf);
+    `DV_CHECK(size)
+    case (route)
+      MemAccessViaAbstractCmd: begin
+        `uvm_fatal(`gfn, "Accessing the system memory using AbstractCmdMemAccess is not supproted")
+      end
+      MemAccessViaProgbuf: begin
+        logic [BUS_DW-1:0] progbuf_q[$];
+        logic [BUS_DW-1:0] rwdata[$];
+        logic [BUS_DW-1:0] s0, s1;
+
+        if (size == 1) progbuf_q = '{LwS0S0, Ebreak};
+        else progbuf_q = '{LwS1S0, AddiS0S04, Ebreak};
+
+        abstract_cmd_reg_read(.regno(RvCoreCsrGprS0), .value_q(rwdata), .status(status));
+        if (status != AbstractCmdErrNone) return;
+        s0 = rwdata[0];
+        if (size > 1) begin
+          abstract_cmd_reg_read(.regno(RvCoreCsrGprS1), .value_q(rwdata), .status(status));
+          if (status != AbstractCmdErrNone) return;
+          s1 = rwdata[0];
+        end
+        `uvm_info(`gfn, $sformatf("Saved CPU registers S0 = 0x%0h and S1 = 0x%0h",  s0, s1),
+                  UVM_HIGH)
+
+        value_q.delete();
+        write_progbuf(progbuf_q);
+        abstract_cmd_reg_write(.regno(RvCoreCsrGprS0), .value_q({addr}), .status(status),
+                               .postexec(1));
+        if (status != AbstractCmdErrNone) return;
+        abstract_cmd_busy_wait(.status(status), .cmderr_clear(1));
+        if (status != AbstractCmdErrNone) return;
+        if (size == 1) begin
+          abstract_cmd_reg_read(.regno(RvCoreCsrGprS0), .value_q(value_q), .status(status));
+          if (status != AbstractCmdErrNone) return;
+        end else begin
+          abstract_cmd_reg_read(.regno(RvCoreCsrGprS1), .value_q(rwdata), .status(status),
+                                .postexec(1));
+          if (status != AbstractCmdErrNone) return;
+          value_q[0] = rwdata[0];
+          `uvm_info(`gfn, $sformatf("Read from system memory: [0x%0h] = 0x%0h", addr,
+                                    value_q[0]), UVM_MEDIUM)
+          write_abstract_cmd_auto(.autoexecdata(1));
+          for (int i = 1; i < size; i++) begin
+            abstract_cmd_busy_wait(.status(status), .cmderr_clear(1));
+            if (status != AbstractCmdErrNone) return;
+            // Before the last read, reset the autoexecdata bit.
+            if (i == size - 1) write_abstract_cmd_auto();
+            csr_rd(.ptr(ral.abstractdata[0]), .value(value_q[i]), .blocking(1));
+            `uvm_info(`gfn, $sformatf("Read from system memory: [0x%0h] = 0x%0h", addr + i * 4,
+                                      value_q[i]), UVM_MEDIUM)
+          end
+        end
+
+        abstract_cmd_reg_write(.regno(RvCoreCsrGprS0), .value_q({s0}), .status(status));
+        if (status != AbstractCmdErrNone) return;
+        if (size > 1) begin
+          abstract_cmd_reg_write(.regno(RvCoreCsrGprS1), .value_q({s1}), .status(status));
+          if (status != AbstractCmdErrNone) return;
+        end
+        `uvm_info(`gfn, $sformatf("Restored CPU registers S0 = 0x%0h and S1 = 0x%0h",  s0, s1),
+                  UVM_HIGH)
+      end
+      MemAccessViaSba: begin
+        `uvm_fatal(`gfn, "Please invoke sba_read instead")
+      end
+      default: begin
+        `uvm_fatal(`gfn, $sformatf("The mem access route %s is invalid or unsupported",
+                                   route.name()))
+      end
+    endcase
   endtask
 
-  // Writes (a) memory location(s) via an abstract command.
+  // Writes (a) system memory location(s) via an abstract command.
+  //
+  // The system memory address space can be accessed either via `AbstractCmdMemAccess` abstract
+  // command type, or indirectly using the CPU using the program buffer. The former is not currently
+  // supported.
+  // addr: The starting system address.
+  // value_q: The data set to be written.
+  // status: The status of the op returned to the caller.
+  // route: The route taken to access the system memory.
   virtual task abstract_cmd_mem_write(input logic [BUS_AW-1:0] addr,
                                       input logic [BUS_DW-1:0] value_q[$],
                                       output abstract_cmd_err_e status,
-                                      input bit postexec = 0,
-                                      input logic [BUS_DW-1:0] progbuf_q[$] = {});
-    `uvm_fatal(`gfn, "Not implemented")
+                                      input mem_access_route_e route = MemAccessViaProgbuf);
+    `DV_CHECK(value_q.size())
+    case (route)
+      MemAccessViaAbstractCmd: begin
+        `uvm_fatal(`gfn, "Accessing the system memory using AbstractCndMemAccess is not supproted")
+      end
+      MemAccessViaProgbuf: begin
+        logic [BUS_DW-1:0] progbuf_q[$];
+        logic [BUS_DW-1:0] rwdata[$];
+        logic [BUS_DW-1:0] s0, s1;
+
+        if (value_q.size() == 1) progbuf_q = '{SwS1S0, Ebreak};
+        else progbuf_q = '{SwS1S0, AddiS0S04, Ebreak};
+
+        abstract_cmd_reg_read(.regno(RvCoreCsrGprS0), .value_q(rwdata), .status(status));
+        if (status != AbstractCmdErrNone) return;
+        s0 = rwdata[0];
+        abstract_cmd_reg_read(.regno(RvCoreCsrGprS1), .value_q(rwdata), .status(status));
+        if (status != AbstractCmdErrNone) return;
+        s1 = rwdata[0];
+        `uvm_info(`gfn, $sformatf("Saved CPU registers S0 = 0x%0h and S1 = 0x%0h",  s0, s1),
+                  UVM_HIGH)
+
+        write_progbuf(progbuf_q);
+        abstract_cmd_reg_write(.regno(RvCoreCsrGprS0), .value_q({addr}), .status(status));
+        if (status != AbstractCmdErrNone) return;
+        abstract_cmd_reg_write(.regno(RvCoreCsrGprS1), .value_q({value_q[0]}), .status(status),
+                               .postexec(1));
+        if (status != AbstractCmdErrNone) return;
+        `uvm_info(`gfn, $sformatf("Wrote to system memory: [0x%0h] = 0x%0h", addr, value_q[0]),
+                  UVM_MEDIUM)
+        if (value_q.size() > 1) begin
+          write_abstract_cmd_auto(.autoexecdata(1));
+          for (int i = 1; i < value_q.size(); i++) begin
+            csr_wr(.ptr(ral.abstractdata[0]), .value(value_q[i]), .blocking(1),
+                   .predict(predict_dmi_writes));
+            abstract_cmd_busy_wait(.status(status), .cmderr_clear(1));
+            if (status != AbstractCmdErrNone) return;
+            `uvm_info(`gfn, $sformatf("Wrote to system memory: [0x%0h] = 0x%0h", addr + i * 4,
+                                      value_q[i]), UVM_MEDIUM)
+          end
+          write_abstract_cmd_auto();
+        end
+
+        abstract_cmd_reg_write(.regno(RvCoreCsrGprS0), .value_q({s0}), .status(status));
+        if (status != AbstractCmdErrNone) return;
+        abstract_cmd_reg_write(.regno(RvCoreCsrGprS1), .value_q({s1}), .status(status));
+        if (status != AbstractCmdErrNone) return;
+        `uvm_info(`gfn, $sformatf("Restored CPU registers S0 = 0x%0h and S1 = 0x%0h",  s0, s1),
+                  UVM_HIGH)
+      end
+      MemAccessViaSba: begin
+        `uvm_fatal(`gfn, "Please invoke sba_write instead")
+      end
+      default: begin
+        `uvm_fatal(`gfn, $sformatf("The mem access route %s is invalid or unsupported",
+                                   route.name()))
+      end
+    endcase
+  endtask
+
+  // Have the CPU execute arbitrary instructions in the program buffer.
+  virtual task abstract_cmd_exec_progbuf(input logic [BUS_DW-1:0] progbuf_q[$],
+                                         output abstract_cmd_err_e status);
+    uvm_reg_data_t rw_data = '0;
+    abstract_cmd_reg_access_t cmd = '0;
+    write_progbuf(progbuf_q);
+    cmd.postexec = 1;
+    cmd.transfer = 0;
+    rw_data = csr_utils_pkg::get_csr_val_with_updated_field(ral.command.cmdtype, rw_data,
+                                                            AbstractCmdRegAccess);
+    rw_data = csr_utils_pkg::get_csr_val_with_updated_field(ral.command.control, rw_data,
+                                                            cmd);
+    csr_wr(.ptr(ral.command), .value(rw_data), .blocking(1), .predict(predict_dmi_writes));
+    abstract_cmd_busy_wait(.status(status), .cmderr_clear(1));
   endtask
 
   // Issue a quick access command.
@@ -300,28 +511,6 @@ class jtag_rv_debugger extends uvm_object;
     // progbuf and then, resumed.
   endtask
 
-  // Have the CPU execute arbitrary instructions in the program buffer.
-  virtual task abstract_cmd_exec_progbuf(input logic [BUS_DW-1:0] progbuf_q[$],
-                                         output abstract_cmd_err_e status);
-    uvm_reg_data_t rw_data = '0;
-    abstract_cmd_reg_access_t cmd = '0;
-
-    write_progbuf(progbuf_q);
-    cmd.postexec = 1;
-    cmd.transfer = 0;
-    rw_data = csr_utils_pkg::get_csr_val_with_updated_field(ral.command.cmdtype, rw_data,
-                                                            AbstractCmdRegAccess);
-    rw_data = csr_utils_pkg::get_csr_val_with_updated_field(ral.command.control, rw_data,
-                                                            cmd);
-    csr_wr(.ptr(ral.command), .value(rw_data), .blocking(1), .predict(predict_dmi_writes));
-    abstract_cmd_busy_wait(.status(status), .cmderr_clear(1));
-  endtask
-
- // Issue a quick access command.
-  virtual task abstract_cmd_custom(/* abstract_cmd_item req*/);
-    `uvm_fatal(`gfn, "Not implemented")
-  endtask
-
   // Write arbitrary commands into progbuf.
   virtual task write_progbuf(logic [BUS_DW-1:0] progbuf_q[$]);
     `DV_CHECK_LE_FATAL(progbuf_q.size(), ral.abstractcs.progbufsize.get())
@@ -329,16 +518,454 @@ class jtag_rv_debugger extends uvm_object;
       csr_wr(.ptr(ral.progbuf[i]), .value(progbuf_q[i]), .blocking(1),
              .predict(predict_dmi_writes));
     end
+    `uvm_info(`gfn, $sformatf("Wrote progbuf: %p", progbuf_q), UVM_MEDIUM)
   endtask
 
-  // Insert a breakpoint.
-  virtual task insert_breakpoint();
+  // Returns the saved PC via DPC register.
+  virtual task read_pc(output logic [BUS_DW-1:0] pc);
+    abstract_cmd_err_e status;
+    logic [BUS_DW-1:0] cmd_data[$];
+    abstract_cmd_reg_read(.regno(RvCoreCsrDpc), .value_q(cmd_data), .status(status));
+    `DV_CHECK_EQ(status, AbstractCmdErrNone)
+    `uvm_info(`gfn, $sformatf("DPC = 0x%0h", cmd_data[0]), UVM_LOW)
+    pc = cmd_data[0];
+  endtask
+
+  // Set PC to a new value with address or the symbol
+  virtual task write_pc(logic [BUS_AW-1:0] addr = 'x, string symbol = "");
+    abstract_cmd_err_e status;
+    logic [BUS_DW-1:0] cmd_data[$];
+
+    addr_or_symbol_set(addr, symbol);
+    abstract_cmd_reg_write(.regno(RvCoreCsrDpc), .value_q({addr}), .status(status));
+    `DV_CHECK_EQ(status, AbstractCmdErrNone)
+    `uvm_info(`gfn, $sformatf("Wrote new DPC = 0x%0h", addr), UVM_LOW)
+  endtask
+
+  // Returns the DCSR value.
+  virtual task read_dcsr(output rv_core_csr_dcsr_t dcsr);
+    abstract_cmd_err_e status;
+    logic [BUS_DW-1:0] cmd_data[$];
+    abstract_cmd_reg_read(.regno(RvCoreCsrDcsr), .value_q(cmd_data), .status(status));
+    `DV_CHECK_EQ(status, AbstractCmdErrNone)
+    dcsr = rv_core_csr_dcsr_t'(cmd_data[0]);
+    `uvm_info(`gfn, $sformatf("DCSR = %p", dcsr), UVM_MEDIUM)
+  endtask
+
+  // Set the DCSR value.
+  virtual task write_dcsr(rv_core_csr_dcsr_t dcsr);
+    abstract_cmd_err_e status;
+    abstract_cmd_reg_write(.regno(RvCoreCsrDcsr), .value_q({BUS_DW'(dcsr)}), .status(status));
+    `DV_CHECK_EQ(status, AbstractCmdErrNone)
+    step_entered = dcsr.step;
+  endtask
+
+  // Internal helper function which returns the address of a symbol from the elf file.
+  protected virtual function logic [BUS_AW-1:0] get_symbol_address(string symbol);
+    longint unsigned addr, size;
+    // Return address if we already looked it up before.
+    if (symbol_table.exists(symbol)) return symbol_table[symbol];
+    `DV_CHECK(dv_utils_pkg::sw_symbol_get_addr_size(.elf_file(elf_file), .symbol(symbol),
+                  .does_not_exist_ok(0), .addr(addr), .size(size)))
+    return BUS_AW'(addr);
+  endfunction
+
+  // Internal helper function enforces either address or the symbol to be set.
+  //
+  // It throws an error if both, symbol and addr are set to known values. It also throws an error if
+  // neither of them are set. If the symbol is set, then the address is updated to the symbol's
+  // physical address.
+  //
+  // addr: The address. If set to 'x, it is updated to the symbol's physical address and returned.
+  // symbol: The symbolic address.
+  protected virtual function void addr_or_symbol_set(inout logic [BUS_AW-1:0] addr,
+                                                     input string symbol);
+    if (addr === 'x && symbol == "") begin
+      `uvm_fatal(`gfn, "Either addr or symbol expected to be set. Neither are set.")
+    end else if (addr !== 'x && symbol != "") begin
+      `uvm_fatal(`gfn, "Either addr or symbol expected to be set. Both are set.")
+    end
+    if (symbol != "") addr = get_symbol_address(symbol);
+  endfunction
+
+  // Checks if the halted CPU's PC is at the given address or symbol.
+  //
+  // exp_addr: Expected address.
+  // exp_symbol: Expected symbolic address.
+  // error_if_eq: 0: throw error on mismatch, 1: throw error on match.
+  // NOTE: Either exp_addr or exp_symbol must be set (pseudo-function overloading).
+  virtual task check_pc(logic [BUS_AW-1:0] exp_addr = 'x,
+                        string exp_symbol = "",
+                        bit error_if_eq = 0);
+    logic [BUS_DW-1:0] pc;
+    addr_or_symbol_set(exp_addr, exp_symbol);
+    read_pc(pc);
+    if (error_if_eq)  `DV_CHECK_NE(pc, exp_addr)
+    else              `DV_CHECK_EQ(pc, exp_addr)
+  endtask
+
+  // Checks if the reason for entering the debug mode matches the expected cause.
+  //
+  // exp_debug_cause: The expected debug cause.
+  virtual task check_debug_cause(rv_core_csr_dcsr_cause_e exp_debug_cause);
+    rv_core_csr_dcsr_t dcsr;
+    read_dcsr(dcsr);
+    `DV_CHECK_EQ(dcsr.cause, exp_debug_cause)
+  endtask
+
+  // Check if trigger select is valid.
+  virtual task is_valid_tselect_index(input int index, output bit valid);
+    abstract_cmd_err_e status;
+    logic [BUS_DW-1:0] cmd_data[$];
+    abstract_cmd_reg_write(.regno(RvCoreCsrTSelect), .value_q({index}), .status(status));
+    `DV_CHECK_EQ(status, AbstractCmdErrNone)
+    abstract_cmd_reg_read(.regno(RvCoreCsrTSelect), .value_q(cmd_data), .status(status));
+    `DV_CHECK_EQ(status, AbstractCmdErrNone)
+    valid = (index == cmd_data[0]);
+  endtask
+
+  // List breakpoints.
+  //
+  // TODO: Only match type breakpoints on address supported.
+  // For each breakpoint, list the following information:
+  // Breakpoint on addr|data 0x%0d before|after load|store|execute op.
+  // breakpoints: The list of breakpoints returned to the caller.
+  // delete_breakpoints: Optionally, enable deleting all breakpoints to allow further execution.
+  virtual task info_breakpoints(output breakpoint_t breakpoints[$],
+                                input bit delete_breakpoints = 0);
+    abstract_cmd_err_e status;
+    logic [BUS_DW-1:0] cmd_data[$];
+
+    breakpoints.delete();
+    for (int i = 0; i >= 0; i++) begin  // Infinite loop.
+      bit valid;
+      is_valid_tselect_index(i, valid);
+      if (valid) begin
+        rv_core_csr_trigger_mcontrol_t mcontrol;
+        abstract_cmd_reg_read(.regno(RvCoreCsrTData1), .value_q(cmd_data), .status(status));
+        `DV_CHECK_EQ(status, AbstractCmdErrNone)
+        mcontrol = rv_core_csr_trigger_mcontrol_t'(cmd_data[0]);
+        if (!(mcontrol.trigger_type == RvTriggerTypeMatch &&
+              (mcontrol.load || mcontrol.store || mcontrol.execute))) continue;
+        // This slot has as a valid breakpoint.
+        abstract_cmd_reg_read(.regno(RvCoreCsrTData2), .value_q(cmd_data), .status(status));
+        `DV_CHECK_EQ(status, AbstractCmdErrNone)
+        breakpoints.push_back(
+            '{trigger_type: RvTriggerTypeMatch,
+              index       : i,
+              tdata1      : BUS_DW'(mcontrol),
+              tdata2      : cmd_data[0]});
+        if (delete_breakpoints) clear_tdata1(0);
+      end else break;
+    end
+    print_breakpoints(breakpoints);
+  endtask
+
+  // Prints breakpoints in human-friendly way.
+  virtual function void print_breakpoints(ref breakpoint_t breakpoints[$]);
+    string format = {"\n\t%0d: %0s type breakpoint on %0s 0x%0h %0s 3'b%0b(execute|store|load) ",
+                     "op, with action %0s"};
+    string msg = "";
+
+    foreach (breakpoints[i]) begin
+      rv_core_csr_trigger_mcontrol_t mcontrol = rv_core_csr_trigger_mcontrol_t'(
+          breakpoints[i].tdata1);
+      msg = {msg, $sformatf(format,
+                            breakpoints[i].index,
+                            breakpoints[i].trigger_type.name(),
+                            mcontrol.select ? "data" : "addr",
+                            breakpoints[i].tdata2,
+                            mcontrol.timing ? "after" : "before",
+                            {mcontrol.execute, mcontrol.store, mcontrol.load},
+                            mcontrol.action.name())};
+    end
+    if (msg != "") `uvm_info(`gfn, msg, UVM_LOW)
+    else           `uvm_info(`gfn, "No breakpoints added yet", UVM_LOW)
+  endfunction
+
+  // Insert a breakpoint at the given address or symbol.
+  //
+  // addr: The PC address.
+  // symbol: Symbolic address.
+  // TODO: Only trigger on exact address match before execution supported.
+  virtual task add_breakpoint(logic [BUS_AW-1:0] addr = 'x, string symbol = "");
+    abstract_cmd_err_e status;
+    logic [BUS_DW-1:0] cmd_data[$];
+
+    addr_or_symbol_set(addr, symbol);
+    `uvm_info(`gfn, $sformatf("Adding breakpoint on 0x%0h(%0s)", addr, symbol), UVM_LOW)
+    for (int i = 0; i >= 0; i++) begin  // Infinite loop.
+      bit valid;
+      is_valid_tselect_index(i, valid);
+      if (valid) begin
+        rv_core_csr_trigger_mcontrol_t mcontrol;
+        abstract_cmd_reg_read(.regno(RvCoreCsrTData1), .value_q(cmd_data), .status(status));
+        `DV_CHECK_EQ(status, AbstractCmdErrNone)
+        mcontrol = rv_core_csr_trigger_mcontrol_t'(cmd_data[0]);
+        if (mcontrol.trigger_type == RvTriggerTypeMatch &&
+            (mcontrol.load || mcontrol.store || mcontrol.execute)) continue;
+        // This slot is available for a new breakpoint.
+        mcontrol.trigger_type = RvTriggerTypeMatch;
+        mcontrol.dmode = 1;
+        mcontrol.select = 0;
+        mcontrol.timing = 0;
+        mcontrol.action = RvTriggerActionEnterDebugMode;
+        mcontrol.match = 0;
+        mcontrol.u = 1;
+        mcontrol.execute = 1;
+        mcontrol.store = 0;
+        mcontrol.load = 0;
+        abstract_cmd_reg_write(.regno(RvCoreCsrTData1), .value_q({BUS_DW'(mcontrol)}),
+                               .status(status));
+        `DV_CHECK_EQ(status, AbstractCmdErrNone)
+        abstract_cmd_reg_write(.regno(RvCoreCsrTData2), .value_q({addr}), .status(status));
+        `DV_CHECK_EQ(status, AbstractCmdErrNone)
+        return;
+      end else break;
+    end
+    `uvm_error(`gfn, "No free breakpoint slots available")
+  endtask
+
+  // Restores previously deleted breakpoints.
+  virtual task restore_breakpoints(breakpoint_t breakpoints[$]);
+    `DV_CHECK(breakpoints.size())
+    foreach (breakpoints[i]) begin
+      abstract_cmd_err_e status;
+      abstract_cmd_reg_write(.regno(RvCoreCsrTSelect), .value_q({breakpoints[i].index}),
+                             .status(status));
+      `DV_CHECK_EQ(status, AbstractCmdErrNone)
+      abstract_cmd_reg_write(.regno(RvCoreCsrTData1), .value_q({breakpoints[i].tdata1}),
+                             .status(status));
+      `DV_CHECK_EQ(status, AbstractCmdErrNone)
+      abstract_cmd_reg_write(.regno(RvCoreCsrTData2), .value_q({breakpoints[i].tdata2}),
+                             .status(status));
+      `DV_CHECK_EQ(status, AbstractCmdErrNone)
+    end
+  endtask
+
+  // Clear trigger data1 register and optionally, tdata2 as well.
+  //
+  // clear_tdata2: Knob to clear tdata2 as well.
+  // Note: It is upto the the caller to ensure the right trigger is selected first. Also, we are
+  // leaving tdata2 in a stale state.
+  protected virtual task clear_tdata1(bit clear_tdata2);
+    abstract_cmd_err_e status;
+    abstract_cmd_reg_write(.regno(RvCoreCsrTData1), .value_q({0}), .status(status));
+    `DV_CHECK_EQ(status, AbstractCmdErrNone)
+    if (clear_tdata2) begin
+      abstract_cmd_reg_write(.regno(RvCoreCsrTData2), .value_q({0}), .status(status));
+      `DV_CHECK_EQ(status, AbstractCmdErrNone)
+    end
+  endtask
+
+  // Delete an existing breakpoint by index, or on the given address or symbol.
+  //
+  // index: The selected trigger index.
+  // addr: The PC address.
+  // symbol: Symbolic PC address.
+  // clear_tdata2: Knob to clear tdata2 as well.
+  // Note: Only either set index, addr or symbol.
+  virtual task delete_breakpoint(logic [BUS_AW-1:0] addr = 'x,
+                                 string symbol = "",
+                                 int index = -1,
+                                 bit clear_tdata2 = 0);
+    abstract_cmd_err_e status;
+    logic [BUS_DW-1:0] cmd_data[$];
+
+    if (index != -1) begin
+      bit valid;
+      if (addr !== 'x || symbol != "") `uvm_fatal(`gfn, "Only set either index, or addr or symbol")
+      is_valid_tselect_index(index, valid);
+
+      if (valid) begin
+        `uvm_info(`gfn, $sformatf("Deleting breakpoint at index %0d", index), UVM_LOW)
+        clear_tdata1(clear_tdata2);
+      end else begin
+        `uvm_error(`gfn, $sformatf("Index %0d appears to be out of bounds", index))
+      end
+      return;
+    end
+
+    addr_or_symbol_set(addr, symbol);
+    for (int i = 0; i >= 0; i++) begin  // Infinite loop.
+      bit valid;
+      is_valid_tselect_index(i, valid);
+      if (valid) begin
+        rv_core_csr_trigger_mcontrol_t mcontrol;
+        abstract_cmd_reg_read(.regno(RvCoreCsrTData1), .value_q(cmd_data), .status(status));
+        `DV_CHECK_EQ(status, AbstractCmdErrNone)
+        mcontrol = rv_core_csr_trigger_mcontrol_t'(cmd_data[0]);
+        if (!(mcontrol.trigger_type == RvTriggerTypeMatch &&
+              (mcontrol.load || mcontrol.store || mcontrol.execute))) continue;
+        // This slot has as a valid breakpoint. Check if address matches.
+        abstract_cmd_reg_read(.regno(RvCoreCsrTData2), .value_q(cmd_data), .status(status));
+        `DV_CHECK_EQ(status, AbstractCmdErrNone)
+        if (addr == cmd_data[0]) begin
+          `uvm_info(`gfn, $sformatf("Deleting breakpoint on 0x%0h(%0s)", addr, symbol), UVM_LOW)
+          clear_tdata1(clear_tdata2);
+          return;
+        end
+      end else break;
+    end
+    `uvm_error(`gfn, $sformatf("No breakpoint found associated with addr 0x%0h (%s)", addr,
+                               symbol))
   endtask
 
   // Single step.
+  //
+  // Read-modify-writes the DCSR register with the step field set to 1. The `step_entered` local
+  // status bit is checked for improved performance.
   virtual task step(int num = 1);
-    // Write step bit in dcsr.
-    // Assert resumereq.
+    if (!step_entered) begin
+      rv_core_csr_dcsr_t dcsr;
+      read_dcsr(dcsr);
+      dcsr.step = 1;
+      write_dcsr(dcsr);
+    end
+    `uvm_info(`gfn, "Single stepping", UVM_LOW)
+    set_resumereq(1);
+    wait_cpu_halted();
+  endtask
+
+  // Resume execution after entering a halted state.
+  //
+  // Equivalent of `continue` gdb command (`continue` is a reserved keyword in SystemVerilog, so we
+  // pick the name `continue_execution()` instead).
+  // If there is a breakpoint on the DPC register, then this task deletes all breakpoints,
+  // single-steps, restores all breakpoints and then resumes.
+  // do_wait_cpu_resumed: Optionally, poll the dmstatus register to wait for the CPU to have
+  //                      resumed (default off).
+  virtual task continue_execution(bit do_wait_cpu_resumed = 0);
+    logic [BUS_DW-1:0] pc;
+    breakpoint_t breakpoints[$];
+    rv_core_csr_dcsr_t dcsr;
+
+    read_pc(pc);
+    info_breakpoints(.breakpoints(breakpoints));
+    foreach (breakpoints[i]) begin
+      if (breakpoints[i].tdata2 == pc) begin
+        delete_breakpoint(.addr(pc));
+        step();
+        restore_breakpoints(.breakpoints({breakpoints[i]}));
+        break;
+      end
+    end
+
+    read_dcsr(dcsr);
+    dcsr.step = 0;
+    write_dcsr(dcsr);
+    `uvm_info(`gfn, "Continuing execution", UVM_LOW)
+    set_resumereq(1);
+
+    // NOTE: It may take a short while for the CPU to resume. If there are other upcoming
+    // breakpoints, the CPU may execute and immediately halt again, by the time `wait_cpu_resumed()`
+    // reads the dmstatus register to ascertain the CPU has indeed resumed. That will result in a
+    // timeout error. So, it is left to the caller to synchronize these events. The step below is
+    // hence conditioned on an optional argument which is set to 0 by default.
+    if (do_wait_cpu_resumed) wait_cpu_resumed();
+  endtask
+
+  // Execute calls as one instruction.
+  virtual task next();
+    `uvm_fatal(`gfn, "Not implemented")
+  endtask
+
+  // Finish executing the current function.
+  //
+  // It is assumed that the CPU is in a halted state at this point, and has just begun executing an
+  // arbitrary function. It reads the CPU's RA register and adds a breakpoint on it before
+  // continuing the execution.
+  //
+  // Note that this task adds a new breakpoint on the return address. After the CPU resumes, it
+  // waits for a few TCK cycles to let the CPU exit the debug mode. Then, it waits for the CPU to
+  // halt again. When it halts, the newly added breakpoint is deleted.
+  // return_address: Use an externally provided return address. If set to X, it reads the return
+  //                 address from the RA register.
+  // noreturn_function: Indicate that the function does not return. If set to 1, a breakpoint on RA
+  //                    is not added, and the task exits immediately after having the CPU continue
+  //                    executing the function.
+  virtual task finish(logic [BUS_AW-1:0] return_address = 'x, bit noreturn_function = 0);
+    if (return_address === 'x) begin
+      abstract_cmd_err_e status;
+      logic [BUS_DW-1:0] cmd_data[$];
+      abstract_cmd_reg_read(.regno(RvCoreCsrGprRa), .value_q(cmd_data), .status(status));
+      `DV_CHECK_EQ(status, AbstractCmdErrNone)
+      return_address = BUS_AW'(cmd_data[0]);
+    end
+    `uvm_info(`gfn, $sformatf("Adding a breakpoint on the return address: 0x%0h",
+                              return_address), UVM_MEDIUM)
+
+    if (!noreturn_function) add_breakpoint(.addr(return_address));
+    continue_execution();
+    if (!noreturn_function) begin
+      // It is better to wait for a few TCKs than call wait_cpu_resumed(), since the latter takes a
+      // long time, within which the CPU could have re-entered the halted state.
+      cfg.vif.wait_tck(20);
+      wait_cpu_halted();
+      check_pc(.exp_addr(return_address));
+      delete_breakpoint(.addr(return_address));
+    end
+  endtask
+
+  // Have the CPU execute a function with the specified arguments.
+  //
+  // addr: The function address.
+  // symbol: The function's symbol.
+  // args: The function args.
+  // noreturn_function: Indicate that the CPU does not return from this function.
+  virtual task call(logic [BUS_AW-1:0] addr = 'x,
+                    string symbol = "",
+                    logic [BUS_DW-1:0] args[$] = {},
+                    bit noreturn_function = 0);
+    byte status;
+    abstract_cmd_err_e abs_status;
+    logic [BUS_DW-1:0] cmd_data[$];
+    logic [BUS_DW-1:0] gprs[abstract_cmd_regno_t], new_sp;
+
+    `uvm_info(`gfn, "Saving all necessary GPRS", UVM_MEDIUM)
+    `DV_CHECK(args.size() <= 8)
+    abstract_cmd_reg_read(.regno(RvCoreCsrGprRa), .value_q(cmd_data), .status(abs_status));
+    `DV_CHECK_EQ(abs_status, AbstractCmdErrNone)
+    gprs[RvCoreCsrGprRa] = cmd_data[0];
+    abstract_cmd_reg_read(.regno(RvCoreCsrGprSp), .value_q(cmd_data), .status(abs_status));
+    `DV_CHECK_EQ(abs_status, AbstractCmdErrNone)
+    gprs[RvCoreCsrGprSp] = cmd_data[0];
+    // Setup a new stack 32 bytes from the current stack pointer, and align it to 32 bytes.
+    new_sp = (cmd_data[0] - 32) & ~('h1f);
+    abstract_cmd_reg_read(.regno(RvCoreCsrGprGp), .value_q(cmd_data), .status(abs_status));
+    `DV_CHECK_EQ(abs_status, AbstractCmdErrNone)
+    gprs[RvCoreCsrGprGp] = cmd_data[0];
+    for (int i = 0; i < cmd_data.size(); i++) begin
+      abstract_cmd_reg_read(.regno(RvCoreCsrGprA0 + i), .value_q(cmd_data), .status(abs_status));
+      `DV_CHECK_EQ(abs_status, AbstractCmdErrNone)
+      gprs[RvCoreCsrGprA0 + i] = cmd_data[0];
+    end
+    read_pc(gprs[RvCoreCsrDpc]);
+
+    `uvm_info(`gfn, $sformatf("Setting new SP and RA: 0x%0h", new_sp), UVM_MEDIUM)
+    abstract_cmd_reg_write(.regno(RvCoreCsrGprRa), .value_q({new_sp}), .status(abs_status));
+    `DV_CHECK_EQ(abs_status, AbstractCmdErrNone)
+    abstract_cmd_reg_write(.regno(RvCoreCsrGprSp), .value_q({new_sp}), .status(abs_status));
+    `DV_CHECK_EQ(abs_status, AbstractCmdErrNone)
+    `uvm_info(`gfn, "Writing the opcode 'ebreak' at the SP address", UVM_MEDIUM)
+    mem_write(.addr(new_sp), .value_q({Ebreak}), .status(status));
+    `DV_CHECK_EQ(status, 0)
+    `uvm_info(`gfn, $sformatf("Writing function arguments [%p] to A registers", args), UVM_MEDIUM)
+    foreach (args[i]) begin
+      abstract_cmd_reg_write(.regno(RvCoreCsrGprA0 + i), .value_q({args[i]}), .status(abs_status));
+      `DV_CHECK_EQ(abs_status, AbstractCmdErrNone)
+    end
+
+    write_pc(addr, symbol);
+    finish(.return_address(new_sp), .noreturn_function(noreturn_function));
+
+    if (!noreturn_function) begin
+      foreach (gprs[i]) begin
+        abstract_cmd_reg_write(.regno(i), .value_q({gprs[i]}), .status(abs_status));
+        `DV_CHECK_EQ(abs_status, AbstractCmdErrNone)
+      end
+      `uvm_info(`gfn, "Restored all necessary GPRS", UVM_MEDIUM)
+    end
   endtask
 
   // Initiates a single SBA access through JTAG (-> DTM -> DMI -> SBA).
@@ -525,7 +1152,7 @@ class jtag_rv_debugger extends uvm_object;
 
   // Simplified version of sba_access(), for 32-bit reads.
   virtual task sba_read(input logic [BUS_AW-1:0] addr,
-                        output logic [BUS_DW-1:0] value[$],
+                        output logic [BUS_DW-1:0] value_q[$],
                         output sba_access_err_e status,
                         input int size = 1);
     sba_access_item sba_item = sba_access_item::type_id::create("sba_item");
@@ -537,7 +1164,7 @@ class jtag_rv_debugger extends uvm_object;
     sba_item.readondata = size > 1;
     sba_access(sba_item);
     `DV_CHECK_EQ(sba_item.rdata.size(), size)
-    value = sba_item.rdata;
+    value_q = sba_item.rdata;
     status = sba_item.is_err;
     `DV_CHECK(!sba_item.is_busy_err)
     `DV_CHECK(!sba_item.timed_out)
@@ -545,18 +1172,96 @@ class jtag_rv_debugger extends uvm_object;
 
   // Simplified version of sba_access(), for 32-bit writes.
   virtual task sba_write(input logic [BUS_AW-1:0] addr,
-                         input logic [BUS_DW-1:0] value[$],
+                         input logic [BUS_DW-1:0] value_q[$],
                          output sba_access_err_e status);
     sba_access_item sba_item = sba_access_item::type_id::create("sba_item");
     sba_item.bus_op = BusOpWrite;
     sba_item.addr = addr;
-    sba_item.wdata = value;
+    sba_item.wdata = value_q;
     sba_item.size = SbaAccessSize32b;
-    sba_item.autoincrement = value.size() > 1 ? value.size() : 0;
+    sba_item.autoincrement = value_q.size() > 1 ? value_q.size() : 0;
     sba_access(sba_item);
     status = sba_item.is_err;
     `DV_CHECK(!sba_item.is_busy_err)
     `DV_CHECK(!sba_item.timed_out)
   endtask
+
+  // Wrapper task for reading the system memory either via SBA or via program buffer.
+  //
+  // addr: The starting system address.
+  // value_q: The read data returned to the caller.
+  // status: The status of the op returned to the caller.
+  // size: The size of the read access in terms of full bus words.
+  // route: The route taken to access the system memory.
+  virtual task mem_read(input logic [BUS_AW-1:0] addr,
+                        output logic [BUS_DW-1:0] value_q[$],
+                        output byte status,
+                        input mem_access_route_e route = randomize_mem_access_route(),
+                        input int size = 1);
+    case (route)
+      MemAccessViaAbstractCmd, MemAccessViaProgbuf: begin
+        abstract_cmd_err_e abs_status;
+        abstract_cmd_mem_read(.addr(addr), .value_q(value_q), .status(abs_status), .size(size),
+                              .route(route));
+        status = byte'(abs_status);
+      end
+      MemAccessViaSba: begin
+        sba_access_err_e sba_status;
+        sba_read(.addr(addr), .value_q(value_q), .status(sba_status), .size(size));
+        status = byte'(sba_status);
+      end
+      default: `uvm_fatal(`gfn, $sformatf("Invalid route: 0x%0h", route))
+    endcase
+  endtask
+
+  // Wrapper task for writing to the system memory either via SBA or via program buffer.
+  //
+  // addr: The starting address of the system memory.
+  // value_q: The read data returned to the caller.
+  // status: The status of the op returned to the caller.
+  // size: The size of the read access in terms of full bus words.
+  // route: The route taken to access the system memory.
+  virtual task mem_write(input logic [BUS_AW-1:0] addr,
+                         input logic [BUS_DW-1:0] value_q[$],
+                         output byte status,
+                         input mem_access_route_e route = randomize_mem_access_route());
+    case (route)
+      MemAccessViaAbstractCmd, MemAccessViaProgbuf: begin
+        abstract_cmd_err_e abs_status;
+        abstract_cmd_mem_write(.addr(addr), .value_q(value_q), .status(abs_status), .route(route));
+        status = byte'(abs_status);
+      end
+      MemAccessViaSba: begin
+        sba_access_err_e sba_status;
+        sba_write(.addr(addr), .value_q(value_q), .status(sba_status));
+        status = byte'(sba_status);
+      end
+      default: `uvm_fatal(`gfn, $sformatf("Invalid route: 0x%0h", route))
+    endcase
+  endtask
+
+  // Load a memory location in the device with a custom image.
+  //
+  // Reads a VMEM file and writes the contents to the memory.
+  // vmem_file: Path to vmem file. Must be BUS_DW word sized.
+  // addr: The starting address of the system memory.
+  // route: The route taken to access the system memory.
+  virtual task load_image(string vmem_file,
+                          logic [BUS_AW-1:0] addr,
+                          input mem_access_route_e route = randomize_mem_access_route());
+    logic [BUS_DW-1:0] vmem_data[$];
+    byte status;
+    dv_utils_pkg::read_vmem(vmem_file, vmem_data);
+    `DV_CHECK_FATAL(vmem_data.size(), "vmem_data is empty!")
+    mem_write(.addr(addr), .value_q(vmem_data), .status(status), .route(route));
+    `DV_CHECK_EQ(status, 0)
+  endtask
+
+  virtual function mem_access_route_e randomize_mem_access_route();
+    mem_access_route_e route;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(route,
+                                       route inside {MemAccessViaProgbuf, MemAccessViaSba};)
+    return route;
+  endfunction
 
 endclass

--- a/hw/dv/sv/jtag_dmi_agent/jtag_rv_debugger_pkg.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_rv_debugger_pkg.sv
@@ -81,6 +81,144 @@ package jtag_rv_debugger_pkg;
     SbaErrOther = 7
   } sba_access_err_e;
 
+  // The standard RISCV registers.
+  //
+  // Only some are captured here. More can be added if the need arises.
+  // See: https://riscv.org/wp-content/uploads/2019/03/riscv-debug-release.pdf (section 4.8) for
+  // more details.
+  typedef enum abstract_cmd_regno_t {
+    // Debug CSRs.
+    RvCoreCsrDcsr = 'h7b0,
+    RvCoreCsrDpc = 'h7b1,
+    RvCoreCsrDScratch0 = 'h7b2,
+    RvCoreCsrDScratch1 = 'h7b3,
+
+    // Trigger CSRs.
+    RvCoreCsrTSelect = 'h7a0,
+    RvCoreCsrTData1 = 'h7a1,
+    RvCoreCsrTData2 = 'h7a2,
+    RvCoreCsrTData3 = 'h7a3,
+    RvCoreCsrTInfo = 'h7a4,
+    RvCoreCsrMContext = 'h7a8,
+    RvCoreCsrSContext = 'h7aa,
+
+    // GPRs ABI Name (these map to x0-x31) (based on RV ISA).
+    RvCoreCsrGprZero = 'h1000,
+    RvCoreCsrGprRa,
+    RvCoreCsrGprSp,
+    RvCoreCsrGprGp,
+    RvCoreCsrGprTp,
+    RvCoreCsrGprT[0:2],
+    RvCoreCsrGprS[0:1],
+    RvCoreCsrGprA[0:7],
+    RvCoreCsrGprS[2:11],
+    RvCoreCsrGprT[3:6]
+  } rv_core_csr_e;
+
+  // CPU privilege levels
+  typedef enum logic [1:0] {
+    RvPrivilegeLevelM = 2'b11,
+    RvPrivilegeLevelS = 2'b01,
+    RvPrivilegeLevelU = 2'b00
+  } rv_privilege_level_e;
+
+  // Debug mode causes.
+  typedef enum logic [2:0] {
+    RvDebugCauseNone = 0,
+    RvDebugCauseEbreak = 1,
+    RvDebugCauseTrigger = 2,
+    RvDebugCauseHaltReq = 3,
+    RvDebugCauseStep = 4,
+    RvDebugCauseResetHaltReq = 5
+  } rv_core_csr_dcsr_cause_e;
+
+  // Ways to access the system memory.
+  typedef enum logic [1:0] {
+    MemAccessViaAbstractCmd,  // Unsupported.
+    MemAccessViaProgbuf,
+    MemAccessViaSba
+  } mem_access_route_e;
+
+  // Typical commands used in debugger activities.
+  typedef enum logic [31:0] {
+    Illegal = 'h0,
+    Fence = 'hf,
+    Nop = 'h13,
+    AddiS0S04 = 'h440413, // addr s0, s0, 4
+    SwS1S0 = 'h942023,  // swr s1 0(s0)
+    LwS0S0 = 'h42403,  // lw s0, 0(s0)
+    LwS1S0 = 'h42483,  // lw s1, 0(s0)
+    FenceI = 'h100f,
+    Ebreak = 'h100073,
+    Wfi = 'h10500073
+  } rv_opcode_e;
+
+  // DCSR fields.
+  //
+  // See: https://riscv.org/wp-content/uploads/2019/03/riscv-debug-release.pdf (section 4.8.1) for
+  // more details.
+  typedef struct packed {
+    logic [3:0]               xdebugver;
+    logic [11:0]              zero2;
+    logic                     ebreakm;
+    logic                     zero1;
+    logic                     ebreaks;
+    logic                     ebreaku;
+    logic                     stepie;
+    logic                     stopcount;
+    logic                     stoptime;
+    rv_core_csr_dcsr_cause_e  cause;
+    logic                     zero0;
+    logic                     mprven;
+    logic                     nmip;
+    logic                     step;
+    rv_privilege_level_e      prv;
+  } rv_core_csr_dcsr_t;
+
+  // Types of triggers.
+  typedef enum logic [3:0] {
+    RvTriggerTypeNone = 0,
+    RvTriggerTypeLegacy = 1,
+    RvTriggerTypeMatch = 2,
+    RvTriggerTypeICount = 3,
+    RvTriggerTypeException = 4
+  } rv_core_csr_trigger_type_e;
+
+  typedef enum logic [3:0] {
+    RvTriggerActionRaiseBreakpointException = 0,
+    RvTriggerActionEnterDebugMode = 1,
+    RvTriggerActionReserved[2:15]
+  } rv_core_csr_trigger_action_e;
+
+  // Address / data match trigger control CSR.
+  typedef struct packed {
+    rv_core_csr_trigger_type_e    trigger_type;  // 31:28
+    logic                         dmode;
+    logic [5:0]                   maskmax;
+    logic                         hit;  // 20
+    logic                         select;
+    logic                         timing;
+    logic [1:0]                   sizelo;
+    rv_core_csr_trigger_action_e  action;
+    logic                         chain;  // 12
+    logic [3:0]                   match;
+    logic                         m;
+    logic                         zero;
+    logic                         s;
+    logic                         u;
+    logic                         execute;
+    logic                         store;
+    logic                         load;
+  } rv_core_csr_trigger_mcontrol_t;
+
+  // A generic breakpoint datastructure.
+  typedef struct packed {
+    rv_core_csr_trigger_type_e  trigger_type;
+    int unsigned                index;
+    logic [BUS_DW-1:0]          tdata1;
+    logic [BUS_DW-1:0]          tdata2;
+  } breakpoint_t;
+
   // Sources.
   `include "sba_access_item.sv"
   `include "sba_access_monitor.sv"

--- a/hw/dv/sv/str_utils/str_utils_pkg.sv
+++ b/hw/dv/sv/str_utils/str_utils_pkg.sv
@@ -18,6 +18,16 @@ package str_utils_pkg;
     return 0;
   endfunction : str_has_substr
 
+  // Returns 1 when string 's' starts with substring 'sub'.
+  function automatic bit str_starts_with(string s, string sub);
+    return s.substr(0, sub.len() - 1) == sub;
+  endfunction
+
+  // Returns 1 when string 's' ends with substring 'sub'.
+  function automatic bit str_ends_with(string s, string sub);
+    return s.substr(s.len() - sub.len(), s.len() - 1) == sub;
+  endfunction
+
   // Returns the index of first occurrence of string 'sub' within string 's''s given index range.
   // Returns -1 otherwise.
   function automatic int str_find(string s, string sub, int range_lo = 0, int range_hi = -1);
@@ -128,6 +138,31 @@ package str_utils_pkg;
     end
     return str;
   endfunction : str_join
+
+  // Cuts sections (such as comments) from string s starting and ending with provided substrings.
+  //
+  // start_delim: substring representing the start of section to be removed (e.g. "//", "/*").
+  // end_delim: substring representing the end of the section to be removed (e.g. "\n", "*/").
+  // remove_start_delim: include the start_delim substring in the removal.
+  // remove_end_delim: include the end_delim substring in the removal.
+  function automatic string str_remove_sections(string s,
+                                                string start_delim,
+                                                string end_delim,
+                                                bit remove_start_delim = 1,
+                                                bit remove_end_delim = 1);
+      int start_idx, end_idx;
+      start_idx = str_utils_pkg::str_find(s, start_delim);
+      while (start_idx != -1) begin
+        int rm_start_idx, rm_end_idx;
+        rm_start_idx = remove_start_delim ? start_idx : start_idx + start_delim.len() - 1;
+        end_idx = str_utils_pkg::str_find(s, end_delim, .range_lo(start_idx + start_delim.len()));
+        if (end_idx == -1) break;
+        rm_end_idx = remove_end_delim ? end_idx + end_delim.len() - 1 : end_idx - 1;
+        s = str_utils_pkg::str_replace(s, s.substr(rm_start_idx, rm_end_idx), "");
+        start_idx = str_utils_pkg::str_find(s, start_delim, .range_lo(end_idx + end_delim.len()));
+      end
+      return s;
+  endfunction
 
   // Converts a string to an array of bytes.
   function automatic void str_to_bytes(string s, output byte bytes[]);

--- a/hw/dv/sv/uart_agent/uart_agent_cfg.sv
+++ b/hw/dv/sv/uart_agent/uart_agent_cfg.sv
@@ -23,7 +23,6 @@ class uart_agent_cfg extends dv_base_agent_cfg;
   // Logger settings.
   bit en_logger           = 1'b0; // enable logger on tx
   bit use_rx_for_logger   = 1'b0; // use rx instead of tx
-  string logger_id        = "uart_logger";
   bit write_logs_to_file  = 1'b1;
 
   // reset is controlled at upper seq-level as no reset pin on uart interface

--- a/hw/dv/sv/uart_agent/uart_logger.sv
+++ b/hw/dv/sv/uart_agent/uart_logger.sv
@@ -8,17 +8,21 @@ class uart_logger extends uvm_component;
   int logs_output_fd = 0;
 
   uart_agent_cfg cfg;
-  uvm_tlm_analysis_fifo #(uart_item) log_item_fifo;
+  uvm_tlm_analysis_fifo #(uart_item)  log_item_fifo;
+  uvm_analysis_port #(string)         log_analysis_port;
 
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
     log_item_fifo = new("log_item_fifo", this);
+    log_analysis_port = new("log_analysis_port", this);
   endfunction
 
   virtual task run_phase(uvm_phase phase);
+    string fname = {`gfn, ".log"};
     if (cfg.write_logs_to_file) begin
-      logs_output_fd = $fopen({cfg.logger_id, ".log"}, "w");
+      logs_output_fd = $fopen(fname, "w");
+      `DV_CHECK_FATAL(!logs_output_fd, $sformatf("Failed to open %s for writing", fname))
     end
     capture_logs();
   endtask
@@ -39,10 +43,11 @@ class uart_logger extends uvm_component;
       forever begin
         log_item_fifo.get(item);
         char = string'(item.data);
-        `uvm_info(cfg.logger_id, $sformatf("received char: %0s", char), UVM_DEBUG)
+        `uvm_info(`gfn, $sformatf("received char: %0s", char), UVM_DEBUG)
         // Continue concatenating chars into the log string untl lf or cr is encountered.
         if (item.data inside {lf, cr}) begin
           print_log(log);
+          log_analysis_port.write(log);
           log = "";
         end
         else begin
@@ -69,19 +74,20 @@ class uart_logger extends uvm_component;
     if (log == "") return;
     case (1)
       (!uvm_re_match(info, log)): begin
-        `uvm_info(cfg.logger_id, log.substr(info.len() - 1, log.len() - 1), UVM_LOW)
+        `uvm_info(`gfn, log.substr(info.len() - 1, log.len() - 1), UVM_LOW)
       end
       (!uvm_re_match(warn, log)): begin
-        `uvm_warning(cfg.logger_id, log.substr(warn.len() - 1, log.len() - 1))
+        // verilog_lint: waive forbidden-macro
+        `uvm_warning(`gfn, log.substr(warn.len() - 1, log.len() - 1))
       end
       (!uvm_re_match(error, log)): begin
-        `uvm_error(cfg.logger_id, log.substr(error.len() - 1, log.len() - 1))
+        `uvm_error(`gfn, log.substr(error.len() - 1, log.len() - 1))
       end
       (!uvm_re_match(fatal, log)): begin
-        `uvm_fatal(cfg.logger_id, log.substr(fatal.len() - 1, log.len() - 1))
+        `uvm_fatal(`gfn, log.substr(fatal.len() - 1, log.len() - 1))
       end
       default: begin
-        `uvm_info(cfg.logger_id, log, UVM_LOW)
+        `uvm_info(`gfn, log, UVM_LOW)
       end
     endcase
     if (logs_output_fd) begin

--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -127,7 +127,7 @@ ifneq (${sw_images},)
 						if [[ $$artifact == *.bin && \
 							-f "$$(echo $${artifact} | cut -d. -f 1).elf" ]]; then \
 							cp -f "$$(echo $${artifact} | cut -d. -f 1).elf" \
-								$${run_dir}/$$(basename "$${artifact%.bin}.elf"); \
+								$${run_dir}/$$(basename -s .bin $${artifact}).elf; \
 						fi; \
 					done; \
 				fi; \

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -588,6 +588,93 @@
       run_timeout_mins: 180
     }
     {
+      name: rom_e2e_jtag_debug_test_unlocked0
+      uvm_test_seq: chip_sw_rom_e2e_jtag_debug_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:img_test_unlocked0_exec_disabled:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+en_uart_logger=1",
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_jtag_debug_dev
+      uvm_test_seq: chip_sw_rom_e2e_jtag_debug_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+en_uart_logger=1",
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_jtag_debug_rma
+      uvm_test_seq: chip_sw_rom_e2e_jtag_debug_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:img_rma_exec_disabled:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+en_uart_logger=1",
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_jtag_inject_test_unlocked0
+      uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:img_test_unlocked0_exec_disabled:4",
+        "//sw/device/examples/sram_program:sram_program:5",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+en_uart_logger=1",
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_jtag_inject_dev
+      uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
+        "//sw/device/examples/sram_program:sram_program:5",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+en_uart_logger=1",
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_jtag_inject_rma
+      uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:img_rma_exec_disabled:4",
+        "//sw/device/examples/sram_program:sram_program:5",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+en_uart_logger=1",
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      reseed: 1
+      run_timeout_mins: 120
+    }
+    {
       name: rom_e2e_static_critical
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:1:signed"]
@@ -877,6 +964,22 @@
         "rom_e2e_sigverify_mod_exp_prod_end_sw",
         "rom_e2e_sigverify_mod_exp_rma_otbn",
         "rom_e2e_sigverify_mod_exp_rma_sw",
+      ]
+    }
+    {
+      name: rom_e2e_jtag_debug
+      tests: [
+        "rom_e2e_jtag_debug_test_unlocked0",
+        "rom_e2e_jtag_debug_dev",
+        "rom_e2e_jtag_debug_rma",
+      ]
+    }
+    {
+      name: rom_e2e_jtag_inject
+      tests: [
+        "rom_e2e_jtag_inject_test_unlocked0",
+        "rom_e2e_jtag_inject_dev",
+        "rom_e2e_jtag_inject_rma",
       ]
     }
   ]

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -595,7 +595,7 @@
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+en_uart_logger=1",
+        "+use_jtag_dmi=1",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
@@ -609,7 +609,7 @@
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+en_uart_logger=1",
+        "+use_jtag_dmi=1",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
@@ -623,7 +623,7 @@
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+en_uart_logger=1",
+        "+use_jtag_dmi=1",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
@@ -633,16 +633,16 @@
       name: rom_e2e_jtag_inject_test_unlocked0
       uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:img_test_unlocked0_exec_disabled:4",
+        "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
         "//sw/device/examples/sram_program:sram_program:5",
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+en_uart_logger=1",
+        "+use_jtag_dmi=1",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 200
     }
     {
       name: rom_e2e_jtag_inject_dev
@@ -653,26 +653,26 @@
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+en_uart_logger=1",
+        "+use_jtag_dmi=1",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 200
     }
     {
       name: rom_e2e_jtag_inject_rma
       uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:img_rma_exec_disabled:4",
+        "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
         "//sw/device/examples/sram_program:sram_program:5",
       ]
       en_run_modes: ["sw_test_mode_rom"]
       run_opts: [
-        "+en_uart_logger=1",
+        "+use_jtag_dmi=1",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 200
     }
     {
       name: rom_e2e_static_critical

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -35,7 +35,6 @@ filesets:
       - lowrisc:dv:lc_ctrl_dv_utils
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
       - "fileset_partner ? (partner:systems:ast_pkg)"
-      - pulp-platform:riscv-dbg:0.1
     files:
       - chip_common_pkg.sv
       - chip_if.sv

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -133,6 +133,8 @@ filesets:
       - seq_lib/chip_sw_rom_e2e_shutdown_output_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_asm_init_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rom_e2e_jtag_debug_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rom_e2e_jtag_inject_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_power_idle_load_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_power_sleep_load_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_ast_clk_rst_inputs_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -224,6 +224,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     debugger.set_cfg(m_jtag_agent_cfg);
     debugger.set_ral(jtag_dmi_ral);
     debugger.num_harts = rv_dm_reg_pkg::NrHarts;
+    debugger.num_triggers = 4;  // TODO: wire this from `top_earlgrey_pkg`.
 
     // This TL agent is used in stub_cpu mode and connected with ibex data port.
     // It can have up to 3 outstanding items, because req/rsp fifo can each hold 1 and
@@ -417,7 +418,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
         end else if (i == SwTypeOtp) begin
           otp_images[OtpTypeCustom] = $sformatf("%0s.24.vmem", sw_images[i]);
         end else if (i == SwTypeDebug) begin
-          sw_images[i] = $sformatf("%0s.32.vmem", sw_images[i]);
+          sw_images[i] = $sformatf("%0s_%0s", sw_images[i], sw_build_device);
         end
       end
     end

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -155,68 +155,6 @@ package chip_env_pkg;
     SpiFlashEx4B         = 8'hE9
   } spi_flash_cmd_e;
 
-  // Extracts the address and size of a const symbol in a SW test (supplied as an ELF file).
-  //
-  // Used by a testbench to modify the given symbol in an executable (elf) generated for an embedded
-  // CPU within the DUT. This function only returns the extracted address and size of the symbol
-  // using the readelf utility. Readelf comes with binutils, a package typically available on user
-  // / corp machines. If not available, the assumption is, it can be relatively easily installed.
-  // The actual job of writing the new value into the symbol is handled externally (often via a
-  // backdoor mechanism to write the memory).
-  // Return 1 on success and 0 on failure.
-  function automatic bit sw_symbol_get_addr_size(input string elf_file,
-                                                 input string symbol,
-                                                 input bit does_not_exist_ok,
-                                                 output longint unsigned addr,
-                                                 output longint unsigned size);
-
-    string msg_id = "sw_symbol_get_addr_size";
-    `DV_CHECK_STRNE_FATAL(elf_file, "", "Input arg \"elf_file\" cannot be an empty string", msg_id)
-    `DV_CHECK_STRNE_FATAL(symbol,   "", "Input arg \"symbol\" cannot be an empty string", msg_id)
-
-    begin
-      int ret;
-      string line;
-      int out_file_d = 0;
-      string out_file = $sformatf("%0s.dat", symbol);
-      string cmd = $sformatf(
-          // use `--wide` to avoid truncating the output, in case of long symbol name
-          // `\s%0s$` ensures we are looking for an exact match, with no pre- or postfixes.
-          "/usr/bin/readelf -s --wide %0s | grep \"\\s%0s$\" | awk \'{print $2\" \"$3}\' > %0s",
-          elf_file, symbol, out_file);
-
-      // TODO #3838: shell pipes are bad 'mkay?
-      ret = $system(cmd);
-      `DV_CHECK_EQ_FATAL(ret, 0, $sformatf("Command \"%0s\" failed with exit code %0d", cmd, ret),
-                         msg_id)
-
-      out_file_d = $fopen(out_file, "r");
-      `DV_CHECK_FATAL(out_file_d, $sformatf("Failed to open \"%0s\"", out_file), msg_id)
-
-      ret = $fgets(line, out_file_d);
-
-      // If the symbol did not exist in the elf (empty file), and we are ok with that, then return.
-      if (!ret && does_not_exist_ok) return 0;
-
-      `DV_CHECK_FATAL(ret, $sformatf("Failed to read line from \"%0s\"", out_file), msg_id)
-
-      // The first line should have the addr in hex followed by its size as integer.
-      ret = $sscanf(line, "%h %d", addr, size);
-      `DV_CHECK_EQ_FATAL(ret, 2, $sformatf("Failed to extract {addr size} from line \"%0s\"", line),
-                         msg_id)
-
-      // Attempt to read the next line should be met with EOF.
-      void'($fgets(line, out_file_d));
-      ret = $feof(out_file_d);
-      `DV_CHECK_FATAL(ret, $sformatf("EOF expected to be reached for \"%0s\"", out_file), msg_id)
-      $fclose(out_file_d);
-
-      ret = $system($sformatf("rm -rf %0s", out_file));
-      `DV_CHECK_EQ_FATAL(ret, 0, $sformatf("Failed to delete \"%0s\"", out_file), msg_id)
-      return 1;
-    end
-  endfunction
-
   // package sources
   `include "chip_env_cfg.sv"
   `include "chip_env_cov.sv"

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -631,7 +631,7 @@ interface chip_if;
 
   wire pwrmgr_low_power = `PWRMGR_HIER.low_power_o;
   wire pwrmgr_cpu_fetch_en = `PWRMGR_HIER.fetch_en_o == lc_ctrl_pkg::On;
-  wire permgr_fast_pwr_state_active = `PWRMGR_HIER.u_fsm.state_q
+  wire pwrmgr_fast_pwr_state_active = `PWRMGR_HIER.u_fsm.state_q
       == pwrmgr_pkg::FastPwrStateActive;
 
   wire rom_ctrl_done = `PWRMGR_HIER.rom_ctrl_i.done == prim_mubi_pkg::MuBi4True;
@@ -692,7 +692,7 @@ interface chip_if;
   typedef struct packed {
     logic [31:0][31:0] gprs;
     // Debug CSRs.
-    dm::dcsr_t   dcsr;
+    jtag_rv_debugger_pkg::rv_core_csr_dcsr_t dcsr;
     logic [31:0] dpc;
     logic [31:0] dscratch0;
     logic [31:0] dscratch1;
@@ -705,8 +705,8 @@ interface chip_if;
   for (genvar i = 0; i < 32; i++) begin : gen_probed_cpu_csrs_conn
     assign probed_cpu_csrs.gprs[i] = `CPU_CORE_HIER.gen_regfile_ff.register_file_i.rf_reg[i][31:0];
   end
-  assign probed_cpu_csrs.dcsr =
-      dm::dcsr_t'(`CPU_CORE_HIER.u_ibex_core.cs_registers_i.u_dcsr_csr.rd_data_o);
+  assign probed_cpu_csrs.dcsr = jtag_rv_debugger_pkg::rv_core_csr_dcsr_t'(
+      `CPU_CORE_HIER.u_ibex_core.cs_registers_i.u_dcsr_csr.rd_data_o);
   assign probed_cpu_csrs.dpc =
       `CPU_CORE_HIER.u_ibex_core.cs_registers_i.u_depc_csr.rd_data_o;
   assign probed_cpu_csrs.dscratch0 =

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -631,6 +631,8 @@ interface chip_if;
 
   wire pwrmgr_low_power = `PWRMGR_HIER.low_power_o;
   wire pwrmgr_cpu_fetch_en = `PWRMGR_HIER.fetch_en_o == lc_ctrl_pkg::On;
+  wire permgr_fast_pwr_state_active = `PWRMGR_HIER.u_fsm.state_q
+      == pwrmgr_pkg::FastPwrStateActive;
 
   wire rom_ctrl_done = `PWRMGR_HIER.rom_ctrl_i.done == prim_mubi_pkg::MuBi4True;
   wire rom_ctrl_good = `PWRMGR_HIER.rom_ctrl_i.good == prim_mubi_pkg::MuBi4True;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -538,7 +538,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     // Find the symbol in the sw elf file.
     image = $sformatf("%0s.elf", cfg.sw_images[sw_type]);
-    ret = sw_symbol_get_addr_size(image, symbol, does_not_exist_ok, addr, size);
+    ret = dv_utils_pkg::sw_symbol_get_addr_size(image, symbol, does_not_exist_ok, addr, size);
     if (!ret) begin
       string msg = $sformatf("Failed to find symbol %0s in %0s", symbol, image);
       if (does_not_exist_ok) begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -45,7 +45,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     // Initialize the sw logger interface.
     foreach (cfg.sw_images[i]) begin
-      if (i inside {SwTypeRom, SwTypeTestSlotA, SwTypeTestSlotB}) begin
+      if (i inside {SwTypeRom, SwTypeDebug, SwTypeTestSlotA, SwTypeTestSlotB}) begin
         cfg.sw_logger_vif.add_sw_log_db(cfg.sw_images[i]);
       end
     end

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
@@ -22,9 +22,12 @@ class chip_sw_gpio_smoke_vseq extends chip_sw_base_vseq;
   function void pre_randomize();
     int addr;
     // Find how many bytes the SW allocate for SW_SYM_GPIO_VALS, then convert to word size.
-    void'(sw_symbol_get_addr_size(.elf_file({p_sequencer.cfg.sw_images[SwTypeTestSlotA], ".elf"}),
-                                  .symbol(SW_SYM_GPIO_VALS), .does_not_exist_ok(0), .addr(addr),
-                                  .size(num_gpio_vals)));
+    void'(dv_utils_pkg::sw_symbol_get_addr_size(
+              .elf_file({p_sequencer.cfg.sw_images[SwTypeTestSlotA], ".elf"}),
+              .symbol(SW_SYM_GPIO_VALS),
+              .does_not_exist_ok(0),
+              .addr(addr),
+              .size(num_gpio_vals)));
     num_gpio_vals /= 4;
   endfunction
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_jtag_debug_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_jtag_debug_vseq.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_rom_e2e_jtag_debug_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_rom_e2e_jtag_debug_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    lc_ctrl_state_pkg::lc_state_e lc_state = cfg.mem_bkdr_util_h[Otp].otp_read_lc_partition_state();
+    super.body();
+    // Wait for complete power up.
+    `DV_WAIT(cfg.chip_vif.permgr_fast_pwr_state_active)
+
+    // Enable UART0 to fetch console messages.
+    `uvm_info(`gfn, "Configuring and connecting UART0", UVM_LOW)
+    cfg.m_uart_agent_cfgs[0].set_parity(1'b0, 1'b0);
+    cfg.m_uart_agent_cfgs[0].set_baud_rate(cfg.uart_baud_rate);
+    cfg.m_uart_agent_cfgs[0].en_tx_monitor = 1;
+    cfg.chip_vif.enable_uart(0, 1);
+
+    cfg.sw_test_status_vif.can_pass_only_in_test = 0;
+    #5ms;
+    override_test_status_and_finish(0);
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_jtag_debug_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_jtag_debug_vseq.sv
@@ -12,21 +12,253 @@ class chip_sw_rom_e2e_jtag_debug_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual task body();
-    lc_ctrl_state_pkg::lc_state_e lc_state = cfg.mem_bkdr_util_h[Otp].otp_read_lc_partition_state();
+    string elf_file = {cfg.sw_images[SwTypeRom], ".elf"};
+    string uart_msg_via_mem_access = "OK!";
+    string uart_msg_via_call = "GDB-OK!";
+    string uart_msg_received;
+    breakpoint_t breakpoints[$];
+    byte status;
+
     super.body();
-    // Wait for complete power up.
-    `DV_WAIT(cfg.chip_vif.permgr_fast_pwr_state_active)
-
-    // Enable UART0 to fetch console messages.
-    `uvm_info(`gfn, "Configuring and connecting UART0", UVM_LOW)
-    cfg.m_uart_agent_cfgs[0].set_parity(1'b0, 1'b0);
-    cfg.m_uart_agent_cfgs[0].set_baud_rate(cfg.uart_baud_rate);
-    cfg.m_uart_agent_cfgs[0].en_tx_monitor = 1;
-    cfg.chip_vif.enable_uart(0, 1);
-
     cfg.sw_test_status_vif.can_pass_only_in_test = 0;
-    #5ms;
-    override_test_status_and_finish(0);
+
+    // The steps in this test closely follow the gdb steps, which is embedded directly into the
+    // `opentitan_gdb_fpga_cw310_test` target `rom_e2e_debug_test_otp__<lc_state>` in the bazel
+    // BUILD file located at sw/device/silicon_creator/rom/e2e/BUILD.
+
+    // Halt the CPU before the first instruction is executed. The chip just came out of POR - so
+    // there is no need to issue an NDM reset again. Just wait for lc_ready signal and immediately
+    // issue a halt req.
+    cfg.debugger.set_elf_file(elf_file);
+    `DV_WAIT(cfg.chip_vif.pinmux_lc_hw_debug_en)
+    cfg.chip_vif.aon_clk_por_rst_if.wait_clks(1);
+    cfg.debugger.set_dmactive(1);
+    cfg.debugger.set_haltreq(1);
+    cfg.debugger.wait_cpu_halted();
+    cfg.debugger.set_haltreq(0);
+
+    // Verify that we are in ROM's reset vector.
+    begin
+      bit result;
+      longint unsigned addr, size;
+      result = dv_utils_pkg::sw_symbol_get_addr_size(.elf_file(elf_file),
+          .symbol("_rom_interrupt_vector_asm"), .does_not_exist_ok(0), .addr(addr), .size(size));
+      `DV_CHECK(result)
+      addr += 32 * 4;  // 33rd entry in the reset vector.
+      `uvm_info(`gfn, $sformatf("CPU reset vector: 0x%0h", addr), UVM_LOW)
+      cfg.debugger.check_pc(.exp_addr(addr));
+    end
+
+    // Single step and verify we are in `_rom_start_boot` (this is where the reset vector jumps to).
+    cfg.debugger.step();
+    cfg.debugger.check_pc(.exp_symbol("_rom_start_boot"));
+    cfg.debugger.check_debug_cause(jtag_rv_debugger_pkg::RvDebugCauseStep);
+
+    cfg.debugger.info_breakpoints(breakpoints);
+    `DV_CHECK(breakpoints.size() == 0)
+
+    `uvm_info(`gfn, "Run until we check whether ROM execution is enabled", UVM_LOW)
+    cfg.debugger.add_breakpoint(.symbol("kRomStartBootMaybeHalt"));
+    cfg.debugger.continue_execution();
+    cfg.chip_vif.cpu_clk_rst_if.wait_clks(200);
+    cfg.debugger.wait_cpu_halted();
+    cfg.debugger.check_pc(.exp_symbol("kRomStartBootMaybeHalt"));
+    cfg.debugger.check_debug_cause(jtag_rv_debugger_pkg::RvDebugCauseTrigger);
+
+    `uvm_info(`gfn, "Set all but one available breakpoints", UVM_LOW)
+    cfg.debugger.add_breakpoint(.symbol("rom_main"));
+    cfg.debugger.add_breakpoint(.symbol("uart_init"));
+    cfg.debugger.info_breakpoints(breakpoints);
+    `DV_CHECK(breakpoints.size() == 3)
+
+    `uvm_info(`gfn, "Pretend execution is enabled", UVM_LOW)
+    cfg.debugger.write_pc(.symbol("kRomStartBootExecEn"));
+
+    `uvm_info(`gfn, "Continue until watchdog config", UVM_LOW)
+    cfg.debugger.add_breakpoint(.symbol("kRomStartWatchdogEnabled"));
+    cfg.debugger.info_breakpoints(breakpoints);
+    `DV_CHECK(breakpoints.size() == 4)
+    cfg.debugger.continue_execution();
+    cfg.chip_vif.cpu_clk_rst_if.wait_clks(200);
+    cfg.debugger.wait_cpu_halted();
+    cfg.debugger.check_pc(.exp_symbol("kRomStartWatchdogEnabled"));
+    cfg.debugger.check_debug_cause(jtag_rv_debugger_pkg::RvDebugCauseTrigger);
+
+    `uvm_info(`gfn, "Disable watchdog config", UVM_LOW)
+    cfg.debugger.mem_write(.addr(ral.aon_timer_aon.wdog_ctrl.get_address()),
+                           .value_q({0}),
+                           .status(status));
+    `DV_CHECK_EQ(status, 0)
+    cfg.debugger.delete_breakpoint(.index(3));
+    cfg.debugger.info_breakpoints(breakpoints);
+    `DV_CHECK(breakpoints.size() == 3)
+
+    `uvm_info(`gfn, "Continue until rom_main", UVM_LOW)
+    cfg.debugger.continue_execution();
+    cfg.chip_vif.cpu_clk_rst_if.wait_clks(200);
+    cfg.debugger.wait_cpu_halted();
+    cfg.debugger.check_pc(.exp_symbol("rom_main"));
+    cfg.debugger.check_debug_cause(jtag_rv_debugger_pkg::RvDebugCauseTrigger);
+
+    `uvm_info(`gfn, "Continue until uart_init", UVM_LOW)
+    cfg.debugger.continue_execution();
+    cfg.chip_vif.cpu_clk_rst_if.wait_clks(200);
+    cfg.debugger.wait_cpu_halted();
+    cfg.debugger.check_pc(.exp_symbol("uart_init"));
+    cfg.debugger.check_debug_cause(jtag_rv_debugger_pkg::RvDebugCauseTrigger);
+    cfg.debugger.finish();
+    configure_uart_agent(.uart_idx(ROM_CONSOLE_UART), .enable(1));
+    fork get_uart_tx_items(ROM_CONSOLE_UART); join_none
+
+    `uvm_info(`gfn, "Read and write GPRs and selected CPU CSRs", UVM_LOW)
+    test_cpu_gprs_csrs_access();
+
+    `uvm_info(`gfn, "Read and write memory (both SRAM and device)", UVM_LOW)
+    test_chip_mem_access();
+
+    `uvm_info(`gfn, "Manually write bytes to UART0", UVM_LOW)
+    foreach (uart_msg_via_mem_access[i]) begin
+      cfg.debugger.mem_write(.addr(ral.uart0.wdata.get_address()),
+                             .value_q({BUS_DW'(uart_msg_via_mem_access[i])}),
+                             .status(status));
+      `DV_CHECK_EQ(status, 0)
+    end
+
+    `uvm_info(`gfn, "Execute code from GDB with `call` command", UVM_LOW)
+    foreach (uart_msg_via_call[i]) begin
+      cfg.debugger.call(.symbol("uart_putchar"), .args({BUS_DW'(uart_msg_via_call[i])}));
+    end
+
+    `uvm_info(`gfn, "Verify UART messages received over the TX port", UVM_LOW)
+    configure_uart_agent(.uart_idx(ROM_CONSOLE_UART), .enable(0));
+    `DV_WAIT(uart_tx_data_q.size() == (uart_msg_via_mem_access.len() + uart_msg_via_call.len()))
+    uart_msg_received = {>>{uart_tx_data_q}};
+    `DV_CHECK_STREQ(uart_msg_received, {uart_msg_via_mem_access, uart_msg_via_call})
+
+    `uvm_info(`gfn, "Have the CPU write pass pattern", UVM_LOW)
+    cfg.debugger.mem_write(.addr(SW_DV_TEST_STATUS_ADDR),
+                           .value_q({sw_test_status_pkg::SwTestStatusPassed}),
+                           .status(status));
+    `DV_CHECK_EQ(status, 0)
+
+    `uvm_info(`gfn, "Silence the CPU by jumping to boot halted loop", UVM_LOW)
+    cfg.debugger.write_pc(.symbol("kRomStartBootHalted"));
+    cfg.debugger.continue_execution();
+  endtask
+
+  // Write-read check CPU GPRs and CSRs.
+  //
+  // Save and restore original values at the end, since it may corrupt the flow of execution.
+  task test_cpu_gprs_csrs_access();
+    logic [BUS_DW-1:0] orig_data[jtag_rv_debugger_pkg::abstract_cmd_regno_t];
+    logic [BUS_DW-1:0] new_data[jtag_rv_debugger_pkg::abstract_cmd_regno_t];
+    jtag_rv_debugger_pkg::abstract_cmd_err_e status;
+    jtag_rv_debugger_pkg::abstract_cmd_regno_t csrs[$] = '{
+      // Hand-picked CSRs that are RW.
+      jtag_rv_debugger_pkg::RvCoreCsrDScratch0,
+      jtag_rv_debugger_pkg::RvCoreCsrDScratch1,
+      ibex_pkg::CSR_MSCRATCH,
+      ibex_pkg::CSR_MCYCLEH,
+      ibex_pkg::CSR_MINSTRETH
+    };
+
+    // Add the X1-X31 GPRs starting at RA. Skip S0 and A0 since it is actively used by the CPU.
+    for (jtag_rv_debugger_pkg::abstract_cmd_regno_t gpr = jtag_rv_debugger_pkg::RvCoreCsrGprRa;
+         gpr <= jtag_rv_debugger_pkg::RvCoreCsrGprT6;
+         gpr++) begin
+      if (gpr inside {jtag_rv_debugger_pkg::RvCoreCsrGprS0,
+                      jtag_rv_debugger_pkg::RvCoreCsrGprA0}) continue;
+      csrs.push_back(gpr);
+    end
+    `uvm_info(`gfn, $sformatf("Testing CPU registers:\n%p", csrs), UVM_MEDIUM)
+
+    // Read original CSR values.
+    csrs.shuffle();
+    foreach (csrs[i]) begin
+      logic [BUS_DW-1:0] value_q[$];
+      cfg.debugger.abstract_cmd_reg_read(.regno(csrs[i]), .value_q(value_q), .status(status));
+      `DV_CHECK_EQ(status, jtag_rv_debugger_pkg::AbstractCmdErrNone)
+      orig_data[csrs[i]] = value_q[0];
+    end
+
+    // Write new random values.
+    csrs.shuffle();
+    foreach (csrs[i]) begin
+      logic [BUS_DW-1:0] data;
+      `DV_CHECK_STD_RANDOMIZE_FATAL(data)
+      cfg.debugger.abstract_cmd_reg_write(.regno(csrs[i]), .value_q({data}), .status(status));
+      `DV_CHECK_EQ(status, jtag_rv_debugger_pkg::AbstractCmdErrNone)
+      new_data[csrs[i]] = data;
+    end
+
+    // Read CSRs and verify new values.
+    csrs.shuffle();
+    foreach (csrs[i]) begin
+      logic [BUS_DW-1:0] value_q[$];
+      cfg.debugger.abstract_cmd_reg_read(.regno(csrs[i]), .value_q(value_q), .status(status));
+      `DV_CHECK_EQ(status, jtag_rv_debugger_pkg::AbstractCmdErrNone)
+      `DV_CHECK_EQ(value_q[0], new_data[csrs[i]], $sformatf("for CSR 0x%0h", csrs[i]))
+    end
+
+    // Restore original values.
+    csrs.shuffle();
+    foreach (csrs[i]) begin
+      cfg.debugger.abstract_cmd_reg_write(.regno(csrs[i]), .value_q({orig_data[csrs[i]]}),
+                                          .status(status));
+      `DV_CHECK_EQ(status, jtag_rv_debugger_pkg::AbstractCmdErrNone)
+    end
+
+    // Read CSRs and verify restored values.
+    csrs.shuffle();
+    foreach (csrs[i]) begin
+      logic [BUS_DW-1:0] value_q[$];
+      cfg.debugger.abstract_cmd_reg_read(.regno(csrs[i]), .value_q(value_q), .status(status));
+      `DV_CHECK_EQ(status, jtag_rv_debugger_pkg::AbstractCmdErrNone)
+      `DV_CHECK_EQ(value_q[0], orig_data[csrs[i]], $sformatf("for CSR 0x%0h", csrs[i]))
+    end
+  endtask
+
+  // Write-read check the SRAM main and ret memories.
+  //
+  // Since we have taken full control of the CPU execution using the debugger, it is not necessary
+  // to save and restore the SRAM addresses we write to as a part of this task.
+  task test_chip_mem_access();
+    byte status;
+    logic [BUS_DW-1:0] test_addrs[$];
+    logic [BUS_DW-1:0] test_data[$];
+    addr_range_t sram_main = '{
+        start_addr: top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR,
+        end_addr: top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR +
+                  top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES - 1
+
+    };
+    addr_range_t sram_ret = '{
+        start_addr: top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR,
+        end_addr: top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR +
+                  top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES - 1
+
+    };
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(test_addrs,
+        test_addrs.size() inside {[5:20]};
+        foreach (test_addrs[i]) {
+          test_addrs[i] inside {[sram_main.start_addr:sram_main.end_addr]} ||
+          test_addrs[i] inside {[sram_ret.start_addr:sram_ret.end_addr]};
+          test_addrs[i][1:0] == '0;
+        }
+    )
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(test_data, test_data.size() == test_addrs.size();)
+    foreach (test_addrs[i]) begin
+      logic [BUS_DW-1:0] value_q[$];
+      cfg.debugger.mem_write(.addr(test_addrs[i]), .value_q({test_data[i]}), .status(status));
+      `DV_CHECK_EQ(status, 0)
+    end
+    foreach (test_addrs[i]) begin
+      logic [BUS_DW-1:0] value_q[$];
+      cfg.debugger.mem_read(.addr(test_addrs[i]), .value_q(value_q), .status(status));
+      `DV_CHECK_EQ(status, 0)
+      `DV_CHECK_EQ(value_q[0], test_data[i], $sformatf("for addr 0x%0h", test_addrs[i]))
+    end
   endtask
 
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_jtag_inject_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_jtag_inject_vseq.sv
@@ -12,21 +12,116 @@ class chip_sw_rom_e2e_jtag_inject_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual task body();
-    lc_ctrl_state_pkg::lc_state_e lc_state = cfg.mem_bkdr_util_h[Otp].otp_read_lc_partition_state();
-    super.body();
-    // Wait for complete power up.
-    `DV_WAIT(cfg.chip_vif.permgr_fast_pwr_state_active)
+    string elf_file = {cfg.sw_images[SwTypeDebug], ".elf"};
+    logic [BUS_DW-1:0] value_q[$];
+    jtag_rv_debugger_pkg::abstract_cmd_err_e abs_status;
+    byte status;
+    logic [BUS_AW-1:0] sram_program_sp, sram_program_gp, sram_program_start;
 
-    // Enable UART0 to fetch console messages.
-    `uvm_info(`gfn, "Configuring and connecting UART0", UVM_LOW)
-    cfg.m_uart_agent_cfgs[0].set_parity(1'b0, 1'b0);
-    cfg.m_uart_agent_cfgs[0].set_baud_rate(cfg.uart_baud_rate);
-    cfg.m_uart_agent_cfgs[0].en_tx_monitor = 1;
-    cfg.chip_vif.enable_uart(0, 1);
+    super.body();
 
     cfg.sw_test_status_vif.can_pass_only_in_test = 0;
-    #5ms;
-    override_test_status_and_finish(0);
+
+    // The steps in this test closely follow the gdb steps, which is embedded directly into the
+    // bazel BUILD file located at sw/device/silicon_creator/rom/e2e/BUILD as the variable
+    // `SRAM_JTAG_INJECTION_GDB_SCRIPT`. It is passed as argument to the
+    // `opentitan_gdb_fpga_cw310_test` target `sram_program_fpga_cw310_test_otp_<lc_state>`.
+
+    // Let the chip power up and allow the ROM to execute upto an arbitrary point.
+    `DV_WAIT(cfg.chip_vif.pwrmgr_fast_pwr_state_active)
+    begin
+      uint32_t cpu_cycles;
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cpu_cycles,
+          cpu_cycles dist {
+            0             :/ 3,
+            [1:1000]      :/ 3,
+            [1000:10000]  :/ 2,
+            [10000:20000] :/ 2
+          };
+      )
+      cfg.chip_vif.cpu_clk_rst_if.wait_clks(cpu_cycles);
+    end
+
+    // Halt the CPU.
+    cfg.debugger.set_elf_file(elf_file);
+    cfg.debugger.set_dmactive(1);
+    cfg.debugger.set_haltreq(1);
+    cfg.debugger.wait_cpu_halted();
+    cfg.debugger.set_haltreq(0);
+
+    `uvm_info(`gfn, "Disable the watchdog timer", UVM_LOW)
+    cfg.debugger.mem_read(.addr(ral.aon_timer_aon.wdog_ctrl.get_address()),
+                          .value_q(value_q),
+                          .status(status));
+    `DV_CHECK_EQ(status, 0)
+    void'(ral.aon_timer_aon.wdog_ctrl.predict(.value(value_q[0]), .kind(UVM_PREDICT_DIRECT)));
+    if (`gmv(ral.aon_timer_aon.wdog_ctrl.enable)) begin
+      `uvm_info(`gfn, "WDOG is enabled. Disabling it", UVM_LOW)
+      cfg.debugger.mem_write(.addr(ral.aon_timer_aon.wdog_ctrl.get_address()),
+                             .value_q({0}),
+                             .status(status));
+      `DV_CHECK_EQ(status, 0)
+      `uvm_info(`gfn, "Reset the WDOG count", UVM_LOW)
+      cfg.debugger.mem_write(.addr(ral.aon_timer_aon.wdog_count.get_address()),
+                             .value_q({0}),
+                             .status(status));
+      `DV_CHECK_EQ(status, 0)
+      `uvm_info(`gfn, "Clear the interrupt (if any) by writing to INTR_STATE", UVM_LOW)
+      cfg.debugger.mem_write(.addr(ral.aon_timer_aon.intr_state.get_address()),
+                             .value_q({0}),
+                             .status(status));
+      `DV_CHECK_EQ(status, 0)
+    end else begin
+      `uvm_info(`gfn, "WDOG is not enabled.", UVM_LOW)
+    end
+
+    // See additional notes on the PMP configuration in the GDB script referenced above.
+    `uvm_info(`gfn, "Configure the PMP unit", UVM_LOW)
+    // "Write "L NAPOT X W R" to pmp{0,1,2,3}cfg in pmpcfg0. Crucially, this value is no less
+    // permissive than whatever the current value is."
+    cfg.debugger.abstract_cmd_reg_write(.regno(dm::CSR_PMPCFG0), .value_q({'h9f9f9f9f}),
+                                        .status(abs_status));
+    `DV_CHECK_EQ(abs_status, jtag_rv_debugger_pkg::AbstractCmdErrNone)
+    cfg.debugger.abstract_cmd_reg_write(.regno(dm::CSR_PMPADDR0), .value_q({'hffffffff}),
+                                        .status(abs_status));
+    `DV_CHECK_EQ(abs_status, jtag_rv_debugger_pkg::AbstractCmdErrNone)
+
+    begin
+      longint unsigned addr, size;
+      bit result;
+      result = dv_utils_pkg::sw_symbol_get_addr_size(.elf_file(elf_file),
+          .symbol("_stack_end"), .does_not_exist_ok(0), .addr(addr), .size(size));
+      `DV_CHECK(result)
+      sram_program_sp = BUS_AW'(addr);
+      result = dv_utils_pkg::sw_symbol_get_addr_size(.elf_file(elf_file),
+          .symbol("__global_pointer$"), .does_not_exist_ok(0), .addr(addr), .size(size));
+      `DV_CHECK(result)
+      sram_program_gp = BUS_AW'(addr);
+      result = dv_utils_pkg::sw_symbol_get_addr_size(.elf_file(elf_file),
+          .symbol("sram_main"), .does_not_exist_ok(0), .addr(addr), .size(size));
+      `DV_CHECK(result)
+      sram_program_start = BUS_AW'(addr);
+    end
+
+    `uvm_info(`gfn, "Load the SRAM program onto the device", UVM_LOW)
+    cfg.debugger.load_image(.vmem_file({cfg.sw_images[SwTypeDebug], ".32.vmem"}),
+                            .addr(sram_program_start));
+
+    `uvm_info(`gfn, "Update registers before calling functions", UVM_LOW)
+    cfg.debugger.abstract_cmd_reg_write(.regno(jtag_rv_debugger_pkg::RvCoreCsrGprSp),
+                                        .value_q({sram_program_sp}),
+                                        .status(abs_status));
+    `DV_CHECK_EQ(abs_status, jtag_rv_debugger_pkg::AbstractCmdErrNone)
+    cfg.debugger.abstract_cmd_reg_write(.regno(jtag_rv_debugger_pkg::RvCoreCsrGprGp),
+                                        .value_q({sram_program_gp}),
+                                        .status(abs_status));
+    `DV_CHECK_EQ(abs_status, jtag_rv_debugger_pkg::AbstractCmdErrNone)
+
+    `uvm_info(`gfn, "Invalidate the icache", UVM_LOW)
+    cfg.debugger.call(.symbol("icache_invalidate"));
+
+    `uvm_info(`gfn, "Call sram_main (it writes the PASS pattern to the DV monitor)", UVM_LOW)
+    cfg.debugger.call(.symbol("sram_main"), .noreturn_function(1));
   endtask
 
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_jtag_inject_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_jtag_inject_vseq.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_rom_e2e_jtag_inject_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_rom_e2e_jtag_inject_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    lc_ctrl_state_pkg::lc_state_e lc_state = cfg.mem_bkdr_util_h[Otp].otp_read_lc_partition_state();
+    super.body();
+    // Wait for complete power up.
+    `DV_WAIT(cfg.chip_vif.permgr_fast_pwr_state_active)
+
+    // Enable UART0 to fetch console messages.
+    `uvm_info(`gfn, "Configuring and connecting UART0", UVM_LOW)
+    cfg.m_uart_agent_cfgs[0].set_parity(1'b0, 1'b0);
+    cfg.m_uart_agent_cfgs[0].set_baud_rate(cfg.uart_baud_rate);
+    cfg.m_uart_agent_cfgs[0].en_tx_monitor = 1;
+    cfg.chip_vif.enable_uart(0, 1);
+
+    cfg.sw_test_status_vif.can_pass_only_in_test = 0;
+    #5ms;
+    override_test_status_and_finish(0);
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_smoke_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_smoke_vseq.sv
@@ -22,13 +22,7 @@ class chip_sw_uart_smoke_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-
-    `uvm_info(`gfn, $sformatf("Configuring and connecting UART%0d", uart_idx), UVM_LOW)
-    cfg.m_uart_agent_cfgs[uart_idx].set_parity(1'b0, 1'b0);
-    cfg.m_uart_agent_cfgs[uart_idx].set_baud_rate(cfg.uart_baud_rate);
-    cfg.m_uart_agent_cfgs[uart_idx].en_tx_monitor = 1;
-    cfg.m_uart_agent_cfgs[uart_idx].en_rx_monitor = 1;
-    cfg.chip_vif.enable_uart(uart_idx, 1);
+    configure_uart_agent(.uart_idx(uart_idx), .enable(1), .enable_rx_monitor(1));
   endtask
 
   virtual task post_start();
@@ -38,6 +32,7 @@ class chip_sw_uart_smoke_vseq extends chip_sw_base_vseq;
     cfg.m_uart_agent_cfgs[uart_idx].en_rx_monitor = 0;
     // TODO: The SW test needs to release the pinmux to UART connection before we can disconnect the
     // UART interface from the chip IOs. Not doing so will result in X-prop.
+    // configure_uart_agent(.uart_idx(uart_idx), .enable(0));
     // cfg.chip_vif.enable_uart(uart_idx, 0);
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -89,6 +89,8 @@
 `include "chip_sw_rom_e2e_shutdown_output_vseq.sv"
 `include "chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv"
 `include "chip_sw_rom_e2e_asm_init_vseq.sv"
+`include "chip_sw_rom_e2e_jtag_debug_vseq.sv"
+`include "chip_sw_rom_e2e_jtag_inject_vseq.sv"
 `include "chip_sw_power_idle_load_vseq.sv"
 `include "chip_sw_power_sleep_load_vseq.sv"
 `include "chip_sw_ast_clk_rst_inputs_vseq.sv"

--- a/sw/device/examples/sram_program/BUILD
+++ b/sw/device/examples/sram_program/BUILD
@@ -29,9 +29,11 @@ opentitan_ram_binary(
     deps = [
         ":sram_program_linker_script",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:status",
     ],
 )

--- a/sw/device/examples/sram_program/sram_program.c
+++ b/sw/device/examples/sram_program/sram_program.c
@@ -4,12 +4,14 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/status.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -23,28 +25,31 @@ enum {
 };
 
 void sram_main() {
-  // Configure the pinmux.
-  CHECK_DIF_OK(dif_pinmux_init(
-      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
-  pinmux_testutils_init(&pinmux);
+  if (kDeviceType != kDeviceSimDV) {
+    // Configure the pinmux.
+    CHECK_DIF_OK(dif_pinmux_init(
+        mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+    pinmux_testutils_init(&pinmux);
 
-  // Initialize UART.
-  CHECK_DIF_OK(dif_uart_init(
-      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK_DIF_OK(
-      dif_uart_configure(&uart0, (dif_uart_config_t){
-                                     .baudrate = kUartBaudrate,
-                                     .clk_freq_hz = kClockFreqPeripheralHz,
-                                     .parity_enable = kDifToggleDisabled,
-                                     .parity = kDifUartParityEven,
-                                 }));
-  base_uart_stdout(&uart0);
+    // Initialize UART.
+    CHECK_DIF_OK(dif_uart_init(
+        mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
+    CHECK_DIF_OK(
+        dif_uart_configure(&uart0, (dif_uart_config_t){
+                                       .baudrate = kUartBaudrate,
+                                       .clk_freq_hz = kClockFreqPeripheralHz,
+                                       .parity_enable = kDifToggleDisabled,
+                                       .parity = kDifUartParityEven,
+                                   }));
+    base_uart_stdout(&uart0);
+  }
 
   // Read the program counter and check that we are executing from SRAM.
   uint32_t pc = 0;
   asm("auipc %[pc], 0;" : [pc] "=r"(pc));
   LOG_INFO("PC: %p, SRAM: [%p, %p)", pc, kSramStart, kSramEnd);
   CHECK(pc >= kSramStart && pc < kSramEnd, "PC is outside the main SRAM");
+  test_status_set(kTestStatusPassed);
 }
 
 // Reference functions that the debugger may wish to call. This prevents the

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -849,7 +849,8 @@
             `CREATOR_SW_CFG_ROM_EXEC_EN` should be set to `0`.
 
             - Verify that ROM can be debugged in TEST, DEV, and RMA life cycle states.
-              - Test debugging with commands to GDB connected via OpenOCD and JTAG
+              - Test debugging with commands to GDB connected via OpenOCD and JTAG (or the
+                SystemVerilog based JTAG debugger model in case of DV simulations).
               - Read back GDB responses to check they match expected behaviour
               - Connect a debugger and verify that ROM halts very early in `rom_start.S`.
               - Trial the following activities within GDB, ensuring the correct

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -151,6 +151,7 @@ LABEL_FOR_TEST(kRomStartBootMaybeHalt)
             OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET)
   lw   t0, OTP_CTRL_PARAM_CREATOR_SW_CFG_ROM_EXEC_EN_OFFSET(a0)
   bnez t0, .L_exec_en
+LABEL_FOR_TEST(kRomStartBootHalted)
 .L_halt_loop:
   wfi
   j .L_halt_loop


### PR DESCRIPTION
The first commit introduces the ROM E2E jtag debug and inject tests (addition of shell SV sequence, addition of tests in the hjson, andother related minor updates). 

THe subsequent PRs are helper commits in various sections of the codebase to support the development of these tests. 

The last commit fully implements the tests in the SV sequence, and fully models the GDB / OpenOCD paths in an SV debugger model. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>