### PR TITLE
[csrng/dv] Add asserts to guarantee error states are stable

### DIFF
--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -420,4 +420,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
 
   assign cmd_stage_ack_sts_o = cmd_ack_sts_q;
 
+  // Make sure that the state machine has a stable error state. This means that after the error
+  // state is entered it will not exit it unless a reset signal is received.
+  `ASSERT(CsrngCmdStageErrorStStable_A, state_q == Error |=> $stable(state_q))
 endmodule

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -586,5 +586,7 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
          (ctr_drbg_gen_ccmd_o == UPD) ||
          (ctr_drbg_gen_ccmd_o == UNI));
 
-
+  // Make sure that the state machine has a stable error state. This means that after the error
+  // state is entered it will not exit it unless a reset signal is received.
+  `ASSERT(CsrngDrbgGenErrorStStable_A, state_q == ReqError |=> $stable(state_q))
 endmodule

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -603,5 +603,10 @@ module csrng_ctr_drbg_upd #(
           (sfifo_final_pop && !sfifo_final_not_empty),
           (sfifo_final_full && !sfifo_final_not_empty)};
 
-
+  // Make sure that the two state machines have a stable error state. This means that after the
+  // error state is entered it will not exit it unless a reset signal is received.
+  `ASSERT(CsrngDrbgUpdBlkEncErrorStStable_A,
+          blk_enc_state_q == BEError |=> $stable(blk_enc_state_q))
+  `ASSERT(CsrngDrbgUpdOutBlkErrorStStable_A,
+          outblk_state_q == OBError  |=> $stable(outblk_state_q))
 endmodule

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -179,4 +179,7 @@ module csrng_main_sm import csrng_pkg::*; #(
     end
   end
 
+  // Make sure that the state machine has a stable error state. This means that after the error
+  // state is entered it will not exit it unless a reset signal is received.
+  `ASSERT(CsrngMainErrorStStable_A, state_q == Error |=> $stable(state_q))
 endmodule


### PR DESCRIPTION
These assertions are inspired by the assertion in EDN to guarantee that error states are stable: https://github.com/lowRISC/opentitan/blob/b010469eddd1540aaefbeb679f1f3bcba9557464/hw/ip/edn/rtl/edn_main_sm.sv#L204

Thanks to @ctopal who explained how these asserts should work.