### PR TITLE
[chip-test, kmac] Extend KMAC sideload

### DIFF
--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -551,9 +551,10 @@
           name: "VAL",
           resval: "0"
           desc: '''
-            Depending on the value programmed, a different side load key slot is cleared.
-            If the value programmed is not one of the enumerated values below, ALL side
-            load key slots are continuously cleared.
+            Depending on the value programmed, a different sideload key slot is cleared.
+            If the value programmed is not one of the enumerated values below, ALL sideload
+            key slots are continuously cleared. In order to stop continuous clearing, SW should
+            toggle the clear bit again (i.e. disable continuous clearing).
           ''',
           enum: [
             { value: "0",

--- a/hw/ip/keymgr/doc/_index.md
+++ b/hw/ip/keymgr/doc/_index.md
@@ -192,7 +192,7 @@ The generate output command is composed of 2 options
 *  Generate output key for software, referred to as `generate-output-sw`
 *  Generate output key for hardware, referred to as `generate-output-hw`
 
-The hardware option is meant specifically for symmetric side load use cases.
+The hardware option is meant specifically for symmetric sideload use cases.
 When this option is issued, the output of the KMAC invocation is not stored in software visible registers, but instead in hardware registers that directly output to symmetric primitives such as AES, KMAC and OTBN.
 
 ## KMAC Operations
@@ -419,7 +419,7 @@ See diagram below for an example transfer:
 }
 {{< /wavejson >}}
 
-### Side Load Keys
+### Sideload Keys
 
 There are three sideload keys.
 One for AES, one for KMAC and one for OTBN.
@@ -435,6 +435,9 @@ Note, there may not be a valid key in the sideload register if it has been clear
 The sideload key can be overwritten with another generate command, or cleared with entropy through {{< regref SIDELOAD_CLEAR >}}.
 
 The clearing can be done one slot at a time, or all at once.
+Once a clearing bit is enabled for a particular key slot, its value is continuously re-randomized every clock cycle.
+Therefore, SW is responsible for toggling this bit back to disabled state, which makes the last random value remain stable on the sideload slot.
+Otherwise, the sideload key slot is continuously randomized which prevents sideloading an actual key to the target HWIP.
 
 The following diagram illustrates an example when there is no valid key in the KMAC sideload registers and an operation is called.
 During the duration of the operation, the key is valid and shows the internal key state.

--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -12,6 +12,21 @@
 #include "sw/device/lib/dif/autogen/dif_keymgr_autogen.h"
 
 /**
+ * Make sure dif_keymgr_sideload_clr_t enum is in sync with autogenarated
+ * values.
+ */
+OT_ASSERT_ENUM_VALUE(kDifKeyMgrSideLoadClearNone,
+                     KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_NONE);
+OT_ASSERT_ENUM_VALUE(kDifKeyMgrSideLoadClearAes,
+                     KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_AES);
+OT_ASSERT_ENUM_VALUE(kDifKeyMgrSideLoadClearKmac,
+                     KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_KMAC);
+OT_ASSERT_ENUM_VALUE(kDifKeyMgrSideLoadClearOtbn,
+                     KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_OTBN);
+OT_ASSERT_ENUM_VALUE(kDifKeyMgrSideLoadClearAll,
+                     KEYMGR_SIDELOAD_CLEAR_VAL_MASK);
+
+/**
  * Address spaces of SEALING_SW_BINDING_N, SALT_N, SW_SHARE0_OUTPUT_N, and
  * SW_SHARE1_OUTPUT_N registers must be contiguous to be able to use
  * `mmio_region_memcpy_to/from_mmio32()`.

--- a/sw/device/lib/dif/dif_keymgr.h
+++ b/sw/device/lib/dif/dif_keymgr.h
@@ -48,12 +48,14 @@ extern "C" {
  * Enumeration for side load slot clearing.
  */
 typedef enum dif_keymgr_sideload_clr {
-  kDifKeyMgrSideLoadClearNone,
-  kDifKeyMgrSideLoadClearAes,
-  kDifKeyMgrSideLoadClearHmac,
-  kDifKeyMgrSideLoadClearKmac,
-  kDifKeyMgrSideLoadClearOtbn,
-  kDifKeyMgrSideLoadClearAll,
+  kDifKeyMgrSideLoadClearNone = 0,
+  kDifKeyMgrSideLoadClearAes = 1,
+  kDifKeyMgrSideLoadClearKmac = 2,
+  kDifKeyMgrSideLoadClearOtbn = 3,
+  // Using different value than those enumerated above should clear all slots,
+  // so we can use the mask value of this field to denote ALL case. This was
+  // we can statically assert this value on the .c side of this DIF.
+  kDifKeyMgrSideLoadClearAll = 7,
 } dif_keymgr_sideload_clr_t;
 
 /**


### PR DESCRIPTION
2nd item on the list of #16443: clear sideloaded KMAC key and perform a final inequality check.

I opened it as a draft because it violates the following assertion.

https://github.com/lowRISC/opentitan/blob/943ada2193860db2db90439ae581bc9405336478/hw/ip/kmac/rtl/kmac_core.sv#L464-L467