### PR TITLE
[dv, sram_ctrl] Fix `sram_ctrl_scrambled_access` sporadic failure

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
@@ -229,6 +229,8 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
     join_none
 
     sync_with_sw();
+    ret_sram_offset = int'(cfg.sw_logger_vif.printed_arg[0]);
+    main_sram_offset = int'(cfg.sw_logger_vif.printed_arg[1]);
 
     `uvm_info(`gfn, $sformatf("Testing ret sram addr: %x", ret_sram_offset), UVM_LOW);
     fork


### PR DESCRIPTION
 Depending on the seed the retention sram crator region was chosen then during the reset the test_rom was overwriting the test data. This PR fixes the retention SRAM address at the owner range during the main SRAM test phase.

Fixes https://github.com/lowRISC/opentitan/issues/16479