### PR TITLE
[dv_macros] Kill live assertions when disabling in `DV_ASSERT_CTRL`

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -438,6 +438,7 @@
       end else begin \
         `uvm_info(ID_, $sformatf("Disabling assertions: %0s", `DV_STRINGIFY(HIER_)), UVM_LOW) \
         $assertoff(LEVELS_, HIER_); \
+        $assertkill(LEVELS_, HIER_); \
       end \
     end \
   end


### PR DESCRIPTION
`DV_ASSERT_CTRL` currently disables assertions but does not kill assertion instances that are already live, i.e., for which the preconditions have been met but the sequence has not terminated yet. Thus, when assertions are later re-enabled, assertions that survived between disabling and re-enabling can still fail.

This commit extends `DV_ASSERT_CTRL` to kill assertions when disabling them.