### PR TITLE
[doc] Fix apt command text wrapping in Getting Started guide

### DIFF
--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -255,7 +255,9 @@ def generate_pkg_reqs():
         cmd_lines = textwrap.wrap(cmd,
                                   width=78,
                                   replace_whitespace=True,
-                                  subsequent_indent='    ')
+                                  subsequent_indent='    ',
+                                  break_long_words=False,
+                                  break_on_hyphens=False)
         # Newlines need to be escaped
         cmd = " \\\n".join(cmd_lines)
 


### PR DESCRIPTION
* The apt command invocation in the Getting Started Guide is currently
  broken, since build_docs wraps package names at the hyphen boundary
  (e.g., "lsb-release" is wrapped as "lsb- \")
* This commit modifies the build_docs script to disable wrapping of
   long and hyphenated words

Signed-off-by: Arun Thomas <arunthomas@google.com>
