### PR TITLE
[chip, dv] Update sysrst_ctrl CSR exclusion to fix a csr test failure

### DIFF
--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -825,6 +825,9 @@
       hwaccess: "hwo",
       resval: "0",
       async: "clk_aon_i",
+      tags: [ // the value of these regs is determined by the value on the pins
+              // or other CSRs, hence it cannot be predicted.
+              "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits:   "0",
           name:   "pwrb_H2L",


### PR DESCRIPTION
In chip-level, even if we keep all sysrst_ctrl pin all 0s, randomly writing CSRs may still trigger `key_intr_status`.

In block-level, we didn't see this issue, as core clk is really fast compared to the aon_clk, and this intr depends on aon_clk. In chip-level, the CSR tests take ver long, so that we can occasionally see this failure.

Fixed #16482
Signed-off-by: Weicai Yang <weicai@google.com>