### PR TITLE
[csrng, dv] Tune fatal_err distribution for csrng_intr test

### DIFF
--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -96,9 +96,16 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
                           0 :/ (100 - aes_halt_pct) };}
 
   // Behind the aes_cipher_sm_err error code, there are which_aes_cm.num() countermeasures each of
-  // which can be stimulated by forcing the Sp2VWidth independent logic rails. We bias the
-  // distribution towards aes_cipher_sm_err to get away with a reasonable number of seeds.
+  // which can be stimulated by forcing the Sp2VWidth independent logic rails. We bias error
+  // distributions towards aes_cipher_sm_err to get away with a reasonable number of seeds.
   int num_bins_aes_cipher_sm_err = which_aes_cm.num() * Sp2VWidth;
+  constraint which_fatal_err_c { which_fatal_err dist {
+      [sfifo_cmd_error : sfifo_blkenc_error]     := 3, // 3 error types per sfifo
+      [cmd_stage_sm_error : drbg_updob_sm_error] := 1, // 1 error type per FSM
+      aes_cipher_sm_error                        := num_bins_aes_cipher_sm_err,
+      cmd_gen_cnt_error                          := 3, // 3 counters feed into this bit
+      [fifo_write_error : fifo_state_error]      := 1
+  };}
   constraint which_err_code_c { which_err_code dist {
       [sfifo_cmd_err : sfifo_blkenc_err]     := 3, // 3 error types per sfifo
       [cmd_stage_sm_err : drbg_updob_sm_err] := 1, // 1 error type per FSM


### PR DESCRIPTION
Similar to commit 935b9fab9f20eada99d0b9b7269856de1da18281 which tuned the err_code distribution for the csrng_err test, this commit tunes the distribution of fatal_err used in the csrng_intr test.