### PR TITLE
[csrng,dv] Coverage hole fixes for sw_cmd_sts CSR

### DIFF
--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -61,6 +61,8 @@ class csrng_base_vseq extends cip_base_vseq #(
   endtask
 
   task wait_cmd_req_done();
+    // Sample while SW app is not ready
+    cov_vif.cg_err_code_sample(.err_code(32'b0));
     csr_spinwait_or_edn_rst_n(.ptr(ral.intr_state.cs_cmd_req_done), .exp_data(1'b1));
     if (edn_under_reset()) return;
     csr_rd_check(.ptr(ral.sw_cmd_sts.cmd_sts), .compare_value(1'b0));


### PR DESCRIPTION
We need to sample while waiting for the request being done to catch not ready state in the register. Also, implemented a new function to force sts output of SW app to see that part of the register field can also be set...

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>