### PR TITLE
[tests] Use a software IRQ instead of NMI for sync

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1714,6 +1714,9 @@
       name: chip_sw_power_sleep_load
       uvm_test_seq: chip_sw_power_sleep_load_vseq
       sw_images: ["//sw/device/tests:chip_power_sleep_load:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      // This is to disable the ping-timeout check in cip_base_scoreboard, see OT issue #16055.
+      run_opts: ["+en_scb_ping_chk=0"]
     }
   ]
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -472,10 +472,6 @@ opentitan_functest(
 opentitan_functest(
     name = "chip_power_sleep_load",
     srcs = ["chip_power_sleep_load.c"],
-    cw310 = cw310_params(
-        # FIXME #16506 test stuck in wfi. Works in DV environment.
-        tags = ["broken"],
-    ),
     deps = [
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:alert_handler",
@@ -484,7 +480,9 @@ opentitan_functest(
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:pwm",
+        "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:alert_handler_testutils",
         "//sw/device/lib/testing:aon_timer_testutils",


### PR DESCRIPTION
For the chip_power_sleep_load test, use a software IRQ instead of an NMI to bring the CPU out of light sleep. The NMI races with WFI, and it cannot be deferred like maskable interrupts.

Fixes #14816 #16506 