### PR TITLE
[doc/fpv] Explain splited top_earlgrey FPV targets

### DIFF
--- a/doc/getting_started/setup_formal.md
+++ b/doc/getting_started/setup_formal.md
@@ -13,11 +13,18 @@ Please refer to the [OpenTitan Assertions]({{< relref "hw/formal/doc" >}}) for i
 
 ## Formal property verification (FPV)
 
-It is recommended to use the [fpvgen]({{< relref "util/fpvgen/doc" >}}) tool to automatically create an FPV testbench template.
-To run the FPV tests in `dvsim`, please add the target in `hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson`, then run with command:
+The formal property verification is used to prove assertions in the target.
+There are three sets of FPV jobs in OpenTitan. They are all under the directory `hw/top_earlgrey/formal`.
+* `top_earlgrey_fpv_ip_cfgs.hjson`: List of IP targets.
+* `top_earlgrey_fpv_prim_cfgs.hjson`: List of prim targets (such as counters, fifos, etc) that are usually imported by an IP.
+* `top_earlgrey_fpv_sec_cm_cfgs.hjson`: List of IPs that contains standard security countermeasure assertions. This FPV environment only proves these security countermeasure assertions. Detailed description of this FPV use case is documented in [Running FPV on security blocks for common countermeasure primitives]({{< relref "hw/formal/doc#running-fpv-on-security-blocks-for-common-countermeasure-primitives" >}}).
+
+To automatically create a FPV testbench, it is recommended to use the [fpvgen]({{< relref "util/fpvgen/doc" >}}) tool to create a template.
+To run the FPV tests in `dvsim`, please add the target to the corresponding `top_earlgrey_fpv_{category}_cfgs.hjson` file , then run with command:
 ```console
-util/dvsim/dvsim.py hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson --select-cfgs {target_name}
+util/dvsim/dvsim.py hw/top_earlgrey/formal/top_earlgrey_fpv_{category}_cfgs.hjson --select-cfgs {target_name}
 ```
+
 It is recommended to add the FPV target to [lint]({{< relref "hw/lint/doc" >}}) script `hw/top_earlgrey/lint/top_earlgrey_fpv_lint_cfgs.hjson` to quickly find typos.
 
 ## Formal connectivity verification
@@ -28,3 +35,5 @@ User can trigger top_earlgrey's connectivity test using `dvsim`:
 ```
 util/dvsim/dvsim.py hw/top_earlgrey/formal/chip_conn_cfgs.hjson
 ```
+
+The connectivity testplan is documented under `hw/top_earlgrey/data/chip_conn_testplan.hjson`.


### PR DESCRIPTION
This PR explains three FPV batch targets in the top_earlgrey.
We used to put all FPV targets into one batch script, but for better
tracking and display purpose, we split it into three different targets.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>