### PR TITLE
[dv/lc_ctrl] Fix lc_ctrl regression failure

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -85,7 +85,7 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
         end
 
         if (cfg.escalate_injected) begin
-          exp_lc_o = EXP_LC_OUTPUTS[int'(EscalateSt)];
+          exp_lc_o = EXP_LC_OUTPUTS[int'(DecLcStEscalate)];
         end
 
         fork


### PR DESCRIPTION
There are lc_ctrl regression failure regarding comparing with X output. The issue is the index of EscalationSt should use the decoded version.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>