### PR TITLE
[chip, dv] Fix X detected in chip_csr_hw_reset

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -827,7 +827,8 @@
                       // time, which results in wkup_cause register to mismatch, OR, result in
                       // assertion error due to a pin programmed for wakeup detection is undriven
                       // (Xs on d_data). Hence, we just turn off the wake up detection logic.
-                      tags: ["excl:CsrNonInitTests:CsrExclWrite"]
+                      // Also exclude write for csr_hw_reset, otherwise, X may be detected and propagating.
+                      tags: ["excl:CsrAllTests:CsrExclWrite"]
                     }
                   ]
                 }

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -913,8 +913,8 @@
                       // wakeup gets enabled and signaled due to a pin being low for a programmed
                       // time, which results in wkup_cause register to mismatch, OR, result in
                       // assertion error due to a pin programmed for wakeup detection is undriven
-                      // (Xs on d_data). Hence, we just turn off the wake up detection logic.
-                      tags: ["excl:CsrNonInitTests:CsrExclWrite"]
+                      // Also exclude write for csr_hw_reset, otherwise, X may be detected and propagating.
+                      tags: ["excl:CsrAllTests:CsrExclWrite"]
                     }
                   ]
                 }

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -24,6 +24,10 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
   virtual task body();
     string csr_test_type;
     void'($value$plusargs("+csr_%0s", csr_test_type));
+    // sio are driven X when csb is inactive, but these pins can be configured as wakeup cause,
+    // assign a known value to avoid X propagation in case that `PINMUX.WKUP_CAUSE` is programmed.
+    cfg.chip_vif.spi_host_if.sio_out = $urandom;
+
     // These types of CSR tests are quite long; run them only once.
     if (csr_test_type inside {"bit_bash", "aliasing"}) num_trans = 1;
     run_common_vseq_wrapper(num_trans);

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -909,8 +909,8 @@
                       // wakeup gets enabled and signaled due to a pin being low for a programmed
                       // time, which results in wkup_cause register to mismatch, OR, result in
                       // assertion error due to a pin programmed for wakeup detection is undriven
-                      // (Xs on d_data). Hence, we just turn off the wake up detection logic.
-                      tags: ["excl:CsrNonInitTests:CsrExclWrite"]
+                      // Also exclude write for csr_hw_reset, otherwise, X may be detected and propagating.
+                      tags: ["excl:CsrAllTests:CsrExclWrite"]
                     }
                   ]
                 }


### PR DESCRIPTION
Some of chip pins are driven X, when we enable them for wakeup via writing WKUP_DETECTOR_EN, the X will be propagated to everywhere.

Fixed #15969

Signed-off-by: Weicai Yang <weicai@google.com>