### PR TITLE
[dv/lc_ctrl] Fix sec_cm error

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_common_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_common_vseq.sv
@@ -21,7 +21,7 @@ class lc_ctrl_common_vseq extends lc_ctrl_base_vseq;
         `DV_ASSERT_CTRL_REQ("KmacFsmStateRegs_A", enable)
         `DV_ASSERT_CTRL_REQ("SecCmCFILinear_A", enable)
       end
-      SecCmPrimCount, SecCmPrimOnehot: begin
+      SecCmPrimOnehot: begin
         // No need to disable any assertion
       end
       default: `uvm_fatal(`gfn, $sformatf("unexpected sec_cm_type %s", if_proxy.sec_cm_type.name))
@@ -35,34 +35,44 @@ class lc_ctrl_common_vseq extends lc_ctrl_base_vseq;
     // Without error lc_state reflects OTP input
     dec_lc_state_e exp_lc_state_single = dec_lc_state(lc_state_e'(cfg.lc_ctrl_vif.otp_i.state));
 
-    super.check_sec_cm_fi_resp(if_proxy);
+    // In scrap state, the following two prim_flop errors are gated.
+    if (lc_state == LcStScrap &&
+        (!uvm_re_match("*.u_lc_ctrl_fsm.u_state_regs*", if_proxy.path) ||
+         !uvm_re_match("*.u_lc_ctrl_fsm.u_cnt_regs*", if_proxy.path))) begin
+        `uvm_info(`gfn, "Skip checking because the LC entered scrap state", UVM_LOW)
 
-    case (if_proxy.sec_cm_type)
-      SecCmPrimSparseFsmFlop: begin
-        exp_state_error = 1;
-        exp_lc_state_single = DecLcStInvalid;
-      end
+    end else begin
+      super.check_sec_cm_fi_resp(if_proxy);
 
-      default: `uvm_fatal(`gfn, $sformatf("unexpected sec_cm_type %s", if_proxy.sec_cm_type.name))
-    endcase
-    csr_rd_check(.ptr(ral.status.state_error), .compare_value(exp_state_error));
-    csr_rd_check(.ptr(ral.lc_state), .compare_value({6{exp_lc_state_single}}));
+      case (if_proxy.sec_cm_type)
+        SecCmPrimSparseFsmFlop: begin
+          exp_state_error = 1;
+          exp_lc_state_single = DecLcStInvalid;
+        end
+        default: begin
+          `uvm_fatal(`gfn, $sformatf("unexpected sec_cm_type %s", if_proxy.sec_cm_type.name))
+        end
+      endcase
 
-    // Check DUT outputs
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_dft_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_nvm_debug_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_hw_debug_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_cpu_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_creator_seed_sw_rw_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_owner_seed_sw_rw_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_iso_part_sw_rd_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_iso_part_sw_wr_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_seed_hw_rd_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_keymgr_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_escalate_en_o, lc_ctrl_pkg::On)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_check_byp_en_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.clk_byp_req_o, lc_ctrl_pkg::Off)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.flash_rma_req_o, lc_ctrl_pkg::Off)
+      csr_rd_check(.ptr(ral.status.state_error), .compare_value(exp_state_error));
+      csr_rd_check(.ptr(ral.lc_state), .compare_value({6{exp_lc_state_single}}));
+
+      // Check DUT outputs
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_dft_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_nvm_debug_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_hw_debug_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_cpu_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_creator_seed_sw_rw_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_owner_seed_sw_rw_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_iso_part_sw_rd_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_iso_part_sw_wr_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_seed_hw_rd_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_keymgr_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_escalate_en_o, lc_ctrl_pkg::On)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_check_byp_en_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.clk_byp_req_o, lc_ctrl_pkg::Off)
+      `DV_CHECK_EQ(cfg.lc_ctrl_vif.flash_rma_req_o, lc_ctrl_pkg::Off)
+    end
 
   endtask : check_sec_cm_fi_resp
 


### PR DESCRIPTION
This PR fixes regression lc_ctrl_sec_cm error.
When lc_ctrl goes to Scrap state, two of the prim_flop errors are gated.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>