### PR TITLE
[dv/kmac] Fix unmasked regression err

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -1441,7 +1441,12 @@ class kmac_scoreboard extends cip_base_scoreboard #(
           exp_keys = (sideload_en || (in_kmac_app && app_mode == AppKeymgr)) ?
                       get_keymgr_keys : keys;
           for (int i = 0; i < key_word_len; i++) begin
-            unmasked_key.push_back(exp_keys[0][i] ^ exp_keys[1][i]);
+            if (sideload_en || (in_kmac_app && app_mode == AppKeymgr)) begin
+              // Sideload key from keymgr is already masked in keymgr.
+              unmasked_key.push_back(exp_keys[0][i]);
+            end else begin
+              unmasked_key.push_back(exp_keys[0][i] ^ exp_keys[1][i]);
+            end
             `uvm_info(`gfn, $sformatf("unmasked_key[%0d] = 0x%0x", i, unmasked_key[i]), UVM_HIGH)
           end
 


### PR DESCRIPTION
This PR fixes kmac unmasked regression error from PR #14178. The RTL changes the key masking for register input only, but the DV changes impacts the sideload key as well.
So this PR adds a logic to gate key masking if it is sideload key.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>