### PR TITLE
[dv] Update spi_agent for polarity and phase

### DIFF
--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -43,6 +43,9 @@ class spi_device_driver extends spi_driver;
       seq_item_port.get_next_item(req);
       `DV_CHECK_EQ(cfg.vif.disconnected, 0)
 
+      if (cfg.csb_sel_in_cfg) active_csb = cfg.csid;
+      else                    active_csb = req.csb_sel;
+
       $cast(rsp, req.clone());
       rsp.set_id_info(req);
       // The response should read the payload actually consumed, not start with

--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -57,8 +57,6 @@ class spi_host_driver extends spi_driver;
   endtask : gen_sck
 
   task switch_polarity_and_phase();
-    cfg.vif.sck_polarity = cfg.sck_polarity[active_csb];
-    cfg.vif.sck_phase = cfg.sck_phase[active_csb];
     if (cfg.vif.sck != cfg.sck_polarity[active_csb]) begin
       cfg.vif.sck <= cfg.sck_polarity[active_csb];
       #TIME_SCK_STABLE_TO_CSB_NS;
@@ -261,7 +259,6 @@ class spi_host_driver extends spi_driver;
       #($urandom_range(1, 100) * 1ns);
       cfg.vif.sck <= ~cfg.vif.sck;
     end
-    cfg.vif.sck <= cfg.sck_polarity[0];
   endtask
 
   task drive_csb_no_sck_item();

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -44,6 +44,9 @@ class spi_monitor extends dv_base_monitor#(
     wait (&cfg.vif.csb === 0);
     active_csb = cfg.vif.get_active_csb();
 
+    cfg.vif.sck_polarity = cfg.sck_polarity[active_csb];
+    cfg.vif.sck_phase = cfg.sck_phase[active_csb];
+
     host_item   = spi_item::type_id::create("host_item", this);
     device_item = spi_item::type_id::create("device_item", this);
     fork

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -78,18 +78,8 @@ class spi_device_base_vseq extends cip_base_vseq #(
     core_spi_freq_ratio inside {[1:8]};
     spi_freq_faster -> core_spi_freq_ratio <= 4;
   }
-  // re-active sequence
-  spi_device_seq m_spi_device_seq;
 
   `uvm_object_new
-
-  virtual task start_reactive_seq();
-    // start device seq's
-    fork
-        m_spi_device_seq = spi_device_seq::type_id::create("m_spi_device_seq");
-        m_spi_device_seq.start(p_sequencer.spi_sequencer_d);
-    join
-  endtask // start_reactive_seq
 
   virtual task apply_reset(string kind = "HARD");
     super.apply_reset(kind);

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -321,7 +321,8 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     end else begin
       // flash mode only supports these 2 values.
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(sck_polarity_phase,
-          sck_polarity_phase inside {0, 'b11};)
+          // TODO (#16339), add back 'b11 once this issue is fixed
+          sck_polarity_phase inside {0};)
     end
     cfg.spi_host_agent_cfg.sck_polarity[0] = sck_polarity_phase[0];
     cfg.spi_host_agent_cfg.sck_phase[0] = sck_polarity_phase[1];

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -314,8 +314,6 @@ class spi_host_base_vseq extends cip_base_vseq #(
     cfg.m_spi_agent_cfg.csid              = spi_host_ctrl_reg.csid;
     cfg.m_spi_agent_cfg.spi_mode          = spi_host_command_reg.mode;
     cfg.m_spi_agent_cfg.decode_commands   = 1'b1;
-    cfg.m_spi_agent_cfg.vif.sck_polarity  = spi_config_regs.cpol[0];
-    cfg.m_spi_agent_cfg.vif.sck_phase     = spi_config_regs.cpha[0];
     print_spi_host_regs();
   endfunction : update_spi_agent_regs
 

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_stress_all_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_stress_all_vseq.sv
@@ -7,13 +7,13 @@ class spi_host_stress_all_vseq extends spi_host_tx_rx_vseq;
   `uvm_object_utils(spi_host_stress_all_vseq)
   `uvm_object_new
 
-  task pre_randomize();
+  function void pre_randomize();
     super.pre_randomize();
     cfg.seq_cfg.host_spi_min_trans = 2;
     cfg.seq_cfg.host_spi_max_trans = 3;
     cfg.seq_cfg.host_spi_min_runs = 2;
     cfg.seq_cfg.host_spi_max_runs = 5;
-  endtask
+  endfunction
 
 
   virtual task body();


### PR DESCRIPTION
Set vif.sck_polarity/sck_phase in spi_monitor instead of in host_driver
Also found sck_polarity/sck_phase weren't set correctly for device_driver, fixing this
uncovered a design issue.
