### PR TITLE
[ast] Update OS ADC model to check channels connectivity

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/adc_ana.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/adc_ana.sv
@@ -16,20 +16,30 @@ module adc_ana (
 `ifndef SYNTHESIS
 // Behavioral Model
 ////////////////////////////////////////
-ast_pkg::awire_t vref;
-ast_pkg::awire_t adc_vi0, adc_vi1;
+real vref = 2.3;
+real adc_vi0_hook = 1.0;
+real adc_vi1_hook = 1.0;
+real adc_vi0, adc_vi1;
 
-assign vref = 2.3;
+`ifdef ANALOGSIM
 assign adc_vi0 = adc_a0_ai;
 assign adc_vi1 = adc_a1_ai;
+`else
+assign adc_vi0 = adc_a0_ai ? adc_vi0_hook : 0.0;
+assign adc_vi1 = adc_a1_ai ? adc_vi1_hook : 0.0;
+`endif
 assign adc_d_ch0_o = $rtoi((adc_vi0/vref) * $itor(10'h3ff));
 assign adc_d_ch1_o = $rtoi((adc_vi1/vref) * $itor(10'h3ff));
 `else  // of SYNTHESIS
 // FPGA/VERILATOR
 ////////////////////////////////////////
+logic [10-1:0] adc_d_vi0_hook, adc_d_vi1_hook;
 
-assign adc_d_ch0_o = {9'h018, adc_a0_ai};  // 0.111V
-assign adc_d_ch1_o = {9'h10f, adc_a1_ai};  // 1.222V
+assign adc_d_vi0_hook = 10'h155;
+assign adc_d_vi1_hook = 10'h2AA;
+
+assign adc_d_ch0_o = adc_a0_ai ? adc_d_vi0_hook : 10'h000;
+assign adc_d_ch1_o = adc_a1_ai ? adc_d_vi1_hook : 10'h000;
 `endif
 
 endmodule : adc_ana


### PR DESCRIPTION
Update the ADC analog model to support connectivity check and conversion model.

* When CC1/CC2 are 1'b0 (0.0v), ADC Data is 10'h000 after conversion.
* When CC1/CC2 are  1'b1 (1.0v), ADC Data is 10'h1bc after conversion.

When hooks are uses (CC1/CC2 are  1'b1), the 'real' values written to the hook
get converted into digital value.

The ADC input hooks are:
```
     u_ast/u_adc/u_adc_ana/adc_vi[0,1]_hook   
     Value 0.0-2.3 can be assigned
```
Using the hooks eliminates the need for forcing the ADC output data. 

For example, driving channel-0/1 analog inputs:
```
assign CC1 = 1'b1;
assign u_ast/u_adc/u_adc_ana/adc_vi0_hook = 1.22;

assign CC2 = 1'b1;
assign u_ast/u_adc/u_adc_ana/adc_vi1_hook = 0.55;
```
When `adc_chnsel_i` goes  0->1 the 1.22 will be converted to 10 bit data with valid pulse.

This will enable checking also the logic of the ADC conrol (debunce & interrupt).

@sha-ron @ariel9678 @arnonsha 
Signed-off-by: Jacob Levy <jacob.levy@nuvoton.com>