### PR TITLE
[adc_ctrl, doc] Update ADC_INTR_CTL register polarity according to th…

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -304,7 +304,7 @@
       fields: [
         { bits: "8:0",
           name: "EN",
-          desc: "0: interrupt source is enabled; 1: interrupt source not enabled",
+          desc: "0: interrupt source is not enabled; 1: interrupt source is enabled",
         }
       ]
     }


### PR DESCRIPTION
…e design

Signed-off-by: Sharon Topaz <sharon.topaz@nuvoton.com>

@msfschaffner Following our conversion and debug  yesterday, adc_intr_ctrl polarity was updated to match the RTL.
The new polarity: 0: interrupt is disabled, 1:interrupt is enabled. 

Also I see that the ADC_CTRL documentation includes some registers (like intr_test register) that don't appear in the adc_ctrl.hjson file.
See https://docs.opentitan.org/hw/ip/adc_ctrl/doc/index.html#Reg_intr_test and https://github.com/lowRISC/opentitan/blob/master/hw/ip/adc_ctrl/data/adc_ctrl.hjson.