### PR TITLE
Use version of CRT with jump guards hardening

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,6 +15,10 @@ build --strip='never'
 # our codebase generates a lot of warnings by setting the -Wpedantic flag
 build --features=-all_warnings
 
+# Enable toolchain hardening features.
+# `guards` adds `unimp` guard instructions after unconditional jumps.
+build --features=guards
+
 # Enable toolchain resolution with cc
 build --incompatible_enable_cc_toolchain_resolution
 

--- a/third_party/crt/repos.bzl
+++ b/third_party/crt/repos.bzl
@@ -15,7 +15,7 @@ def crt_repos(local = None):
         maybe(
             http_archive,
             name = "crt",
-            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.3.4.tar.gz",
-            sha256 = "01a66778d1a0d5bbfb4ba30e72bd6876d0c20766d0b1921ab36ca3350cb48c60",
-            strip_prefix = "crt-0.3.4",
+            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.3.10.tar.gz",
+            sha256 = "3514e15cd7ae7d3243864fdce6ea483cbbeb1b45c4c09a2a70f75376e9ea3934",
+            strip_prefix = "crt-0.3.10",
         )


### PR DESCRIPTION
WIP. I think we should do a versioned release in the CRT repo first. Let's just see if CI detects any test failures that my local testing didn't catch.