### PR TITLE
[test-top] added ADC Controller to chip_sw_power_sleep_load

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -471,6 +471,7 @@ opentitan_functest(
     srcs = ["chip_power_sleep_load.c"],
     deps = [
         "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:adc_ctrl",
         "//sw/device/lib/dif:alert_handler",
         "//sw/device/lib/dif:aon_timer",
         "//sw/device/lib/dif:gpio",


### PR DESCRIPTION
Added code to activate ADC Controller in low power mode, as required in the test plan.