### PR TITLE
[csrng] Assert that error states imply error output

### DIFF
--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -423,4 +423,6 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   // Make sure that the state machine has a stable error state. This means that after the error
   // state is entered it will not exit it unless a reset signal is received.
   `ASSERT(CsrngCmdStageErrorStStable_A, state_q == Error |=> $stable(state_q))
+  // If in error state, the error output must be high.
+  `ASSERT(CsrngCmdStageErrorOutput_A,   state_q == Error |-> cmd_stage_sm_err_o)
 endmodule

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -597,4 +597,6 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
   // Make sure that the state machine has a stable error state. This means that after the error
   // state is entered it will not exit it unless a reset signal is received.
   `ASSERT(CsrngDrbgGenErrorStStable_A, state_q == ReqError |=> $stable(state_q))
+  // If in error state, the error output must be high.
+  `ASSERT(CsrngDrbgGenErrorOutput_A,   state_q == Error    |-> ctr_drbg_gen_sm_err_o)
 endmodule

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -620,5 +620,8 @@ module csrng_ctr_drbg_upd #(
   `ASSERT(CsrngDrbgUpdBlkEncErrorStStable_A,
           blk_enc_state_q == BEError |=> $stable(blk_enc_state_q))
   `ASSERT(CsrngDrbgUpdOutBlkErrorStStable_A,
-          outblk_state_q == OBError  |=> $stable(outblk_state_q))
+          outblk_state_q  == OBError |=> $stable(outblk_state_q))
+  // If in error state, the error output must be high.
+  `ASSERT(CsrngDrbgUpdBlkEncErrorOutput_A, blk_enc_state_q == BEError |-> ctr_drbg_updbe_sm_err_o)
+  `ASSERT(CsrngDrbgUpdOutBlkErrorOutput_A, outblk_state_q  == OBError |-> ctr_drbg_updob_sm_err_o)
 endmodule

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -182,4 +182,6 @@ module csrng_main_sm import csrng_pkg::*; #(
   // Make sure that the state machine has a stable error state. This means that after the error
   // state is entered it will not exit it unless a reset signal is received.
   `ASSERT(CsrngMainErrorStStable_A, state_q == Error |=> $stable(state_q))
+  // If in error state, the error output must be high.
+  `ASSERT(CsrngMainErrorOutput_A,   state_q == Error |-> main_sm_err_o)
 endmodule


### PR DESCRIPTION
Besides asserts that say that the error state are stable, this PR adds asserts to guarantee the error output wires are set to high when in the error state.