### PR TITLE
[bazel] Mark //hw/bitstream:test_rom as testonly

### DIFF
--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -55,6 +55,7 @@ config_setting(
 
 filegroup(
     name = "test_rom",
+    testonly = True,
     srcs = select({
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_test_rom"],


### PR DESCRIPTION
This PR adds the `testonly` attribute that was missed in #16221.

Before:
```
$ bazel build --define bitstream=gcp_splice //hw/bitstream:test_rom //hw/bitstream:rom //hw/bitstream:rom_otp_dev //hw/bitstream:rom_mmi //hw/bitstream:otp_mmi
INFO: Invocation ID: 05fb39d6-4108-4944-ba29-3a1fa5645868
ERROR: /workspace/worktrees/opentitan/cached-flow-fix/hw/bitstream/BUILD:56:10: in filegroup rule //hw/bitstream:test_rom: non-test target '//hw/bitstream:test_rom' depends on testonly target '//hw/bitstream:gcp_spliced_test_rom' and doesn't have testonly attribute set
ERROR: /workspace/worktrees/opentitan/cached-flow-fix/hw/bitstream/BUILD:56:10: Analysis of target '//hw/bitstream:test_rom' failed
ERROR: Analysis of target '//hw/bitstream:test_rom' failed; build aborted: 
INFO: Elapsed time: 0.330s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (1 packages loaded, 10 targets configured)
```

After:
```
$ bazel build --define bitstream=gcp_splice //hw/bitstream:test_rom //hw/bitstream:rom //hw/bitstream:rom_otp_dev //hw/bitstream:rom_mmi //hw/bitstream:otp_mmi
INFO: Invocation ID: 30aa320c-d5eb-4191-b39c-f8e3349c38fa
INFO: Analyzed 5 targets (1 packages loaded, 11 targets configured).
INFO: Found 5 targets...
INFO: Elapsed time: 0.486s, Critical Path: 0.11s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```

The reason for missing this in CI seems to be the fact that CI either fully builds the bitstream or uses the cached one. Created #16547.

Signed-off-by: Alphan Ulusoy <alphan@google.com>