### PR TITLE
[bazel] Remove broken tag from passing tests

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -44,10 +44,6 @@ opentitan_functest(
 opentitan_functest(
     name = "aes_entropy_test",
     srcs = ["aes_entropy_test.c"],
-    cw310 = cw310_params(
-        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-        tags = ["broken"],
-    ),
     deps = [
         "//hw/ip/aes:model",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -64,10 +60,11 @@ opentitan_functest(
 opentitan_functest(
     name = "aes_idle_test",
     srcs = ["aes_idle_test.c"],
-    cw310 = cw310_params(
-        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-        tags = ["broken"],
-    ),
+    targets = [
+        "dv",
+        "verilator",
+        "cw310_test_rom",
+    ],
     deps = [
         "//hw/ip/aes:model",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -632,10 +629,6 @@ opentitan_functest(
 opentitan_functest(
     name = "clkmgr_reset_frequency_test",
     srcs = ["clkmgr_reset_frequency_test.c"],
-    cw310 = cw310_params(
-        # FIXME #13611
-        tags = ["broken"],
-    ),
     verilator = verilator_params(
         # FIXME #13611
         tags = ["broken"],
@@ -658,10 +651,6 @@ opentitan_functest(
 opentitan_functest(
     name = "clkmgr_sleep_frequency_test",
     srcs = ["clkmgr_sleep_frequency_test.c"],
-    cw310 = cw310_params(
-        # FIXME #13611
-        tags = ["broken"],
-    ),
     verilator = verilator_params(
         # FIXME #13611
         tags = ["broken"],
@@ -1551,10 +1540,11 @@ opentitan_functest(
 opentitan_functest(
     name = "rstmgr_cpu_info_test",
     srcs = ["rstmgr_cpu_info_test.c"],
-    cw310 = cw310_params(
-        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-        tags = ["broken"],
-    ),
+    targets = [
+        "cw310_test_rom",
+        "dv",
+        "verilator",
+    ],
     verilator = verilator_params(
         timeout = "long",
         tags = ["broken"],

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -11,15 +11,8 @@ package(default_visibility = ["//visibility:public"])
 opentitan_functest(
     name = "aes_gcm_functest",
     srcs = ["aes_gcm_functest.c"],
-    cw310 = cw310_params(
-        timeout = "long",
-        tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/15788
-        # [test-triage] test not constant time with icache enabled
-    ),
     verilator = verilator_params(
         timeout = "long",
-        tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/15788
-        # [test-triage] test not constant time with icache enabled
     ),
     deps = [
         ":aes_gcm_testutils",
@@ -53,9 +46,13 @@ opentitan_functest(
     srcs = ["aes_gcm_timing_test.c"],
     cw310 = cw310_params(
         timeout = "long",
+        tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/15788
+        # [test-triage] test not constant time with icache enabled
     ),
     verilator = verilator_params(
         timeout = "long",
+        tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/15788
+        # [test-triage] test not constant time with icache enabled
     ),
     deps = [
         ":aes_gcm_testutils",


### PR DESCRIPTION
At least two of these tags were added by me to the wrong tests.

These were all found by running `bazel test //... --test_tag_filters=broken` but in some cases fixing the tag will cause CI to check the tests and make sure they stay fixed.

Signed-off-by: Drew Macrae <drewmacrae@google.com>