### PR TITLE
[dv/kmac] update key XOR sharing

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -1441,8 +1441,10 @@ class kmac_scoreboard extends cip_base_scoreboard #(
           exp_keys = (sideload_en || (in_kmac_app && app_mode == AppKeymgr)) ?
                       get_keymgr_keys : keys;
           for (int i = 0; i < key_word_len; i++) begin
-            if (sideload_en || (in_kmac_app && app_mode == AppKeymgr)) begin
-              // Sideload key from keymgr is already masked in keymgr.
+            if (!cfg.enable_masking &&
+                (sideload_en || (in_kmac_app && app_mode == AppKeymgr))) begin
+              // If enable_masking is set to 0, sideload key from keymgr is already masked in
+              // keymgr.
               unmasked_key.push_back(exp_keys[0][i]);
             end else begin
               unmasked_key.push_back(exp_keys[0][i] ^ exp_keys[1][i]);


### PR DESCRIPTION
The previous PR #16528 did not align with RTL completely. RTL still XOR the sideload key if enable_masking = 1. 
Issue #16206 will further enhance RTL.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>