### PR TITLE
[fpv] Fix typo

### DIFF
--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
@@ -26,7 +26,7 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/pinmux/{sub_flow}/{tool}"
                defines: "FPV_ALERT_NO_SIGINT_ERR"
-  i            cov: true
+               cov: true
              }
 
              // Use chip_eargrey_asic parameters to verify pinmux.
@@ -37,7 +37,7 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip/pinmux/{sub_flow}/{tool}"
                defines: "FPV_ALERT_NO_SIGINT_ERR"
-  i            cov: true
+               cov: true
                overrides: [
                  {
                    name:  design_level
@@ -52,7 +52,7 @@
                fusesoc_core: lowrisc:opentitan:top_earlgrey_rv_plic_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/rv_plic/{sub_flow}/{tool}"
-  i            cov: true
+               cov: true
                overrides: [
                  {
                    name:  design_level


### PR DESCRIPTION
Accidentally added a 'i' variable. This PR just removes this variable.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>