### PR TITLE
[dv,top-level] Tighten chip_sw_pwrmgr_random_sleep_power_glitch_reset

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -870,7 +870,9 @@
       uvm_test_seq: chip_sw_random_power_glitch_vseq
       sw_images: ["//sw/device/tests/sim_dv:pwrmgr_random_sleep_power_glitch_reset_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+bypass_alert_ready_to_end_check=1"]
+      run_opts: ["+bypass_alert_ready_to_end_check=1",
+                 "+sw_test_timeout_ns=24_000_000"]
+      run_timeout_mins: 120
     }
     {
       name: chip_sw_pwrmgr_sleep_disabled

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_power_glitch_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_power_glitch_vseq.sv
@@ -27,7 +27,7 @@ class chip_sw_random_power_glitch_vseq extends chip_sw_base_vseq;
 
   constraint cycles_after_trigger_c {cycles_after_trigger inside {[300 : 320]};}
   constraint cycles_tll_reset_c {cycles_till_reset inside {[0 : 200]};}
-  constraint reset_delay_c {reset_delay inside {[0 : 10]};}
+  constraint reset_delay_c {reset_delay inside {[0 : 4]};}
 
   rand bit[7:0] assa[NumRound-1];
   constraint assa_c {


### PR DESCRIPTION
Reduce the delay for main glitch reset so it doesn't end up occurring past the concurrent normal or deep sleep resets, or the test setup cannot handle the situation and ends up without a way to wake up the device.

Signed-off-by: Guillermo Maturana <maturana@google.com>