### PR TITLE
[kmac] Fix usage of sideload key if masking is disabled

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -1441,12 +1441,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
           exp_keys = (sideload_en || (in_kmac_app && app_mode == AppKeymgr)) ?
                       get_keymgr_keys : keys;
           for (int i = 0; i < key_word_len; i++) begin
-            if (sideload_en || (in_kmac_app && app_mode == AppKeymgr)) begin
-              // Sideload key from keymgr is already masked in keymgr.
-              unmasked_key.push_back(exp_keys[0][i]);
-            end else begin
-              unmasked_key.push_back(exp_keys[0][i] ^ exp_keys[1][i]);
-            end
+            unmasked_key.push_back(exp_keys[0][i] ^ exp_keys[1][i]);
             `uvm_info(`gfn, $sformatf("unmasked_key[%0d] = 0x%0x", i, unmasked_key[i]), UVM_HIGH)
           end
 

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -742,7 +742,7 @@ module kmac_app
   end else begin : g_unmasked_key
     always_comb begin
       keymgr_key[0] = '0;
-      for (int i = 0; i < Share; i++) begin
+      for (int i = 0; i < keymgr_pkg::Shares; i++) begin
         keymgr_key[0][KeyMgrKeyW-1:0] ^= keymgr_key_i.key[i];
       end
     end


### PR DESCRIPTION
Previously, only Share 0 for the sideload key (always provided in masked form) was used despite the KMAC documentation stating: "KeyMgr provides the sideloaded key in two-share masked form regardless of the compile-time parameter EnMasking. If EnMasking is not defined, the KMAC merges the shared key to the unmasked form before uses the key."

This commit fixes the RTL to XOR the two shares for the unmasked design and align the RTL with the documentation. The masked design is not affected.

This is related to lowRISC/OpenTitan#16550 and reverts commit ded4e7a4200a81ec18f9636f10b5542f1490af23 .

Signed-off-by: Pirmin Vogel <vogelpi@lowrisc.org>