### PR TITLE
[dv, alert_handler] Disable some constraints for escalate sequences

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_esc_alert_accum_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_esc_alert_accum_vseq.sv
@@ -26,4 +26,9 @@ class alert_handler_esc_alert_accum_vseq extends alert_handler_smoke_vseq;
     foreach (accum_thresh[i]) {accum_thresh[i] inside {[0:100]};}
   }
 
+  function void pre_randomize();
+    this.enable_one_alert_c.constraint_mode(0);
+    this.enable_classa_only_c.constraint_mode(0);
+  endfunction
+
 endclass : alert_handler_esc_alert_accum_vseq

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_esc_intr_timeout_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_esc_intr_timeout_vseq.sv
@@ -14,4 +14,9 @@ class alert_handler_esc_intr_timeout_vseq extends alert_handler_smoke_vseq;
     do_esc_intr_timeout == 1;
   }
 
+  function void pre_randomize();
+    this.enable_one_alert_c.constraint_mode(0);
+    this.enable_classa_only_c.constraint_mode(0);
+  endfunction
+
 endclass : alert_handler_esc_intr_timeout_vseq

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_esc_alert_accum_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_esc_alert_accum_vseq.sv
@@ -26,4 +26,9 @@ class alert_handler_esc_alert_accum_vseq extends alert_handler_smoke_vseq;
     foreach (accum_thresh[i]) {accum_thresh[i] inside {[0:100]};}
   }
 
+  function void pre_randomize();
+    this.enable_one_alert_c.constraint_mode(0);
+    this.enable_classa_only_c.constraint_mode(0);
+  endfunction
+
 endclass : alert_handler_esc_alert_accum_vseq

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_esc_intr_timeout_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_esc_intr_timeout_vseq.sv
@@ -14,4 +14,9 @@ class alert_handler_esc_intr_timeout_vseq extends alert_handler_smoke_vseq;
     do_esc_intr_timeout == 1;
   }
 
+  function void pre_randomize();
+    this.enable_one_alert_c.constraint_mode(0);
+    this.enable_classa_only_c.constraint_mode(0);
+  endfunction
+
 endclass : alert_handler_esc_intr_timeout_vseq


### PR DESCRIPTION
Without disabling these constraints the escalate sequences rarely trigger an escalation.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>