### PR TITLE
[SRAM_CTRL] Increase the ECC error tolerance of the scrambling test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -948,7 +948,7 @@
               "chip_sw_hmac_enc_jitter_en",
               "chip_sw_keymgr_key_derivation_jitter_en",
               "chip_sw_kmac_mode_kmac_jitter_en",
-              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en",
+              "chip_sw_sram_ctrl_scrambled_access_jitter_en",
               "chip_sw_edn_entropy_reqs_jitter"]
     }
     {
@@ -982,7 +982,7 @@
               "chip_sw_hmac_enc_jitter_en_reduced_freq",
               "chip_sw_keymgr_key_derivation_jitter_en_reduced_freq",
               "chip_sw_kmac_mode_kmac_jitter_en_reduced_freq",
-              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en_reduced_freq",
+              "chip_sw_sram_ctrl_scrambled_access_jitter_en_reduced_freq",
               "chip_sw_flash_init_reduced_freq",
               "chip_sw_csrng_edn_concurrency_reduced_freq"]
     }
@@ -2585,7 +2585,7 @@
             '''
       stage: V2
       tests: ["chip_sw_sram_ctrl_scrambled_access",
-              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en"]
+              "chip_sw_sram_ctrl_scrambled_access_jitter_en"]
     }
     {
       name: chip_sw_sleep_sram_ret_contents
@@ -3040,7 +3040,7 @@
               "chip_sw_hmac_enc_jitter_en",
               "chip_sw_keymgr_key_derivation_jitter_en",
               "chip_sw_kmac_mode_kmac_jitter_en",
-              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en",
+              "chip_sw_sram_ctrl_scrambled_access_jitter_en",
               "chip_sw_edn_entropy_reqs_jitter"]
     }
     {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1310,7 +1310,7 @@
       run_opts: ["+sw_test_timeout_ns=12_000_000", "+en_scb_tl_err_chk=0"]
     }
     {
-      name: chip_sw_sram_ctrl_main_scrambled_access_jitter_en
+      name: chip_sw_sram_ctrl_scrambled_access_jitter_en
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
       sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
@@ -1678,7 +1678,7 @@
       run_opts: ["+en_jitter=1", "+cal_sys_clk_70mhz=1"]
     }
     {
-      name: chip_sw_sram_ctrl_main_scrambled_access_jitter_en_reduced_freq
+      name: chip_sw_sram_ctrl_scrambled_access_jitter_en_reduced_freq
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
       sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
@@ -1751,7 +1751,7 @@
               "chip_sw_hmac_enc_jitter_en",
               "chip_sw_keymgr_key_derivation_jitter_en",
               "chip_sw_kmac_mode_kmac_jitter_en",
-              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en"]
+              "chip_sw_sram_ctrl_scrambled_access_jitter_en"]
     }
     {
       name: jitter_reduced_freq
@@ -1763,7 +1763,7 @@
               "chip_sw_hmac_enc_jitter_en_reduced_freq",
               "chip_sw_keymgr_key_derivation_jitter_en_reduced_freq",
               "chip_sw_kmac_mode_kmac_jitter_en_reduced_freq",
-              "chip_sw_sram_ctrl_main_scrambled_access_jitter_en_reduced_freq",
+              "chip_sw_sram_ctrl_scrambled_access_jitter_en_reduced_freq",
               "chip_sw_flash_init_reduced_freq",
               "chip_sw_csrng_edn_concurrency_reduced_freq"]
     }
@@ -1801,7 +1801,7 @@
               "chip_sw_plic_sw_irq",
               "chip_sw_aes_enc",
               "chip_sw_aes_enc_jitter_en",
-              "chip_sw_sram_ctrl_main_scrambled_access",
+              "chip_sw_sram_ctrl_scrambled_access",
               // TODO(#16416): uncomment when this is passing nightly.
               // "chip_sw_sram_ctrl_scrambled_access",
               "chip_sw_all_escalation_resets",

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1314,8 +1314,7 @@
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
       sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+mem_sel=main",
-                 "+sw_test_timeout_ns=12_000_000",
+      run_opts: ["+sw_test_timeout_ns=12_000_000",
                  "+en_jitter=1", "+en_scb_tl_err_chk=0"]
     }
     {


### PR DESCRIPTION
The test `sram_ctrl_scrambled_access_test.c` has been used by 3 different tests:
- chip_sw_sram_ctrl_scrambled_access
- chip_sw_sram_ctrl_scrambled_access_jitter_en
- chip_9_jitter_en_reduced_freq

Then the tests of retention SRAM and main SRAM has been merged and now we are testing 32 words rather than only 16 words in the same test. As each test runs with 3 different seeds the probability of false positives in the ECC error checking is:
`365 * 3 * 3 * 0.026 = 85.41` (over 85 times in a year or almost twice a week)

This PR increase the tolerance for false positives from 1 to 3 which will reduce the probability of failures to 0.011%.
This makes any of the tests above to fail `365 * 3 * 3 * 0.000112 = 0.3679` (less than once each two years)

Fix https://github.com/lowRISC/opentitan/issues/16457