### PR TITLE
[chip/scrap] implemented SW side for chip_lc_scrap

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
@@ -11,15 +11,44 @@ class chip_sw_lc_ctrl_scrap_vseq extends chip_sw_base_vseq;
   `uvm_object_new
 
   rand dec_lc_state_e src_state;
+  rand bit perform_transition_via_sw;
+
   constraint valid_src_state_c {
     !(src_state inside {DecLcStScrap, DecLcStInvalid, DecLcStPostTrans, DecLcStEscalate});
+    solve src_state before perform_transition_via_sw;
   }
+
+  // don't try to perform transition via SW for the following states
+  constraint transition_via_sw_c {
+    src_state inside {DecLcStRaw,
+                      DecLcStTestLocked0,
+                      DecLcStTestLocked1,
+                      DecLcStTestLocked2,
+                      DecLcStTestLocked3,
+                      DecLcStTestLocked4,
+                      DecLcStTestLocked5,
+                      DecLcStTestLocked6} ->
+    perform_transition_via_sw == 0;
+  }
+
+  function void pre_randomize();
+    super.pre_randomize();
+
+    // disable source state randomization if it's set by the command line
+    // and set the source state value
+    if ($test$plusargs("src_dec_state")) begin
+      this.valid_src_state_c.constraint_mode(0);
+      this.src_state.rand_mode(0);
+
+      // source state is randomized by default,
+      // but if a plusarg is supplied, assign the given value
+      `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, src_state, src_dec_state)
+      `uvm_info(`gfn, $sformatf("Source state is %0s", src_state.name), UVM_MEDIUM)
+    end
+  endfunction : pre_randomize
 
   function void post_randomize();
     super.post_randomize();
-    // source state is randomized, but if a plusarg is supplied, assign the given value
-    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, src_state, src_dec_state)
-    `uvm_info(`gfn, $sformatf("Source state is %0s", src_state.name), UVM_MEDIUM)
 
     // a guard to check we didn't screw up
     `DV_CHECK_FATAL(src_state != DecLcStScrap)
@@ -40,23 +69,56 @@ class chip_sw_lc_ctrl_scrap_vseq extends chip_sw_base_vseq;
     backdoor_override_otp();
   endtask : dut_init
 
-  virtual task body();
-    bit [BUS_DW-1:0] state;
-    super.body();
+  protected task sync_with_sw();
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusBooted)
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+  endtask : sync_with_sw
 
-    // Wait for LC_CTRL post initialization
-    wait_lc_ready(.allow_err(1));
+  protected task perform_transition_to_scrap();
+    // perform transition through JTAG if we're not using SW transition
+    // or if SW transition isn't allowed (RAW/TEST_LOCKED*)
+    if (!perform_transition_via_sw) begin : jtag_transition
+      // acquire the LC controller access to registers
+      wait_lc_ready(.allow_err(1));
 
-    // perform a LC state transition to SCRAP
-    jtag_lc_state_transition(src_state, DecLcStScrap);
+      // perform a LC state transition
+      jtag_lc_state_transition(src_state, DecLcStScrap);
+    end : jtag_transition
+
+    // else, we're performing the transition though SW
+    else begin : sw_transition
+      // sync with SW, and let perform the transition
+      sync_with_sw();
+    end : sw_transition
+
+    // wait for transition to end
+    wait_lc_transition_successful();
 
     // LC state transition requires a chip reset.
     `uvm_info(`gfn, $sformatf("Applying reset after lc transition from %s state", src_state.name),
               UVM_MEDIUM)
     apply_reset();
+  endtask : perform_transition_to_scrap
 
+  task cpu_init();
+    super.cpu_init();
+
+    // tell SW whether the transition is done by JTAG or SW
+    sw_symbol_backdoor_overwrite("kPerformTransitionBySW", {perform_transition_via_sw});
+  endtask : cpu_init
+
+  virtual task body();
+    bit [BUS_DW-1:0] state;
+    super.body();
+
+    // perform the transition to SCRAP state
+    perform_transition_to_scrap();
+
+    // acquire again access to LC controller
+    // this now can only be done by JTAG, as we're in SCRAP state
     wait_lc_initialized(.allow_err(1));
 
+    // read the LC state from the LC controller and
     // check LC state is indeed in SCRAP
     jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.lc_state.get_offset(),
                                         p_sequencer.jtag_sequencer_h, state);
@@ -64,9 +126,11 @@ class chip_sw_lc_ctrl_scrap_vseq extends chip_sw_base_vseq;
   endtask : body
 
   task post_start();
-    // once in SCRAP mode, the CPU can't execute any SW code, so
-    // we don't expect the SW to be done
-    // so we shutdown the device, and then override the test exit from here
+    // post-transition reset is performed via SV
+    // however, as it's the last step of the test
+    // and SW can't execute (SCRAP state),
+    // we'll need to override the SW test status
+    // from there
     override_test_status_and_finish(.passed(1));
 
     super.post_start();

--- a/sw/device/tests/sim_dv/chip_sw_lc_ctrl_scrap_test.c
+++ b/sw/device/tests/sim_dv/chip_sw_lc_ctrl_scrap_test.c
@@ -16,95 +16,58 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-#define LC_TOKEN_SIZE 16
-
 static dif_lc_ctrl_t lc;
 
-/**
- * Track number of iterations of this C test.
- *
- * From the software / compiler's perspective, this is a constant (hence the
- * `const` qualifier). However, the external DV testbench finds this symbol's
- * address and modifies it via backdoor, to track how many transactions have
- * been sent. Hence, we add the `volatile` keyword to prevent the compiler from
- * optimizing it out.
- * The `const` is needed to put it in the .rodata section, otherwise it gets
- * placed in .data section in the main SRAM. We cannot backdoor write anything
- * in SRAM at the start of the test because the CRT init code wipes it to 0s.
- */
-static volatile const uint8_t kTestIterationCount = 0x0;
-
-// LC exit token value for LC state transition.
-static volatile const uint8_t kLcExitToken[LC_TOKEN_SIZE] = {
-    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
-};
+// Symbol that tells if the transition should be done via SW (overriden by
+// Host).
+static volatile const uint8_t kPerformTransitionBySW = 0;
 
 /**
- * Tests the state transition request handshake between LC_CTRL and OTP_CTRL.
+ * Tests the state transition request handshake between LC_CTRL and OTP_CTRL for
+ * transition into `Scrap` state.
  *
  * 1). OTP pre-load image with lc_count = `8`.
- * 2). Backdoor write OTP's LC partition to `TestLocked1` state, and backdoor
- * write OTP's `test_exit` token and `test_unlock` token to match the rand
- * patterns.
- * 3). `TestLocked1` state disabled CPU, so external testbench will drive JTAG
- * interface to transit to `TestUnlocked2` state and increment the LC_CNT.
- * 4). When LC_CTRL is ready, check LC_CNT and LC_STATE register.
- * 5). Program LC state transition request to advance to `Dev` state.
- * 6). Issue hard reset.
- * 7). Wait for LC_CTRL is ready, then check if LC_STATE advanced to `Dev`
- * state, and lc_count advanced to `9`.
- * 8). Issue hard reset and override OTP's LC partition, and reset LC state to
- * `TestLocked1` state.
- * 9). Repeat the steps above in a few iterations.
+ * 2). Program LC state transition request to advance to `Scrap` state,
+ * if doing the transition through SW.
+ * 3). Return control to Host side.
+ * 4). Host will wait for LC_CTRL to enter PostTransition state, then issue a
+ * hard reset 5). Host will check the LC state is `Scrap`
  *
  * In summary, this sequence walks through the following LC states:
- * "TestLocked1" -> "TestUnlocked2" -> "Dev"
+ * "Any Source State (!Scrap) -> Scrap".
  */
 
 bool execute_lc_ctrl_scrap_test(bool use_ext_clk) {
-  LOG_INFO("Start LC_CTRL scrap test");
+  if (kPerformTransitionBySW) {
+    LOG_INFO("Start LC_CTRL scrap test");
 
-  mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
-  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
+    mmio_region_t lc_reg =
+        mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
+    CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
 
-  LOG_INFO("Read and check LC state.");
-  dif_lc_ctrl_state_t curr_state;
-  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc, &curr_state));
-
-  // The OTP preload image hardcodes the initial LC state transition count to 8.
-  // With each iteration of test, there are two LC_CTRL state transitions.
-  // And the first LC_CTRL state transition is done via external JTAG interface.
-  // `kTestIterationCount` starts with 1 in SystemVerilog.
-  const uint8_t kLcStateTransitionCount = 8 + 1 + (kTestIterationCount - 1) * 2;
-
-  if (curr_state == kDifLcCtrlStateTestUnlocked2) {
-    // LC TestUnlocked2 is the intial test state for this sequence.
-    // The sequence will check if lc_count matches the preload value.
-    lc_ctrl_testutils_check_transition_count(&lc, kLcStateTransitionCount);
-
-    // Request lc_state transfer to Dev state.
-    dif_lc_ctrl_token_t token;
-    for (int i = 0; i < LC_TOKEN_SIZE; i++) {
-      token.data[i] = kLcExitToken[i];
-    }
+    // Acquire the mutex and perform a transition to SCRAP
     CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));
     CHECK_DIF_OK(
-        dif_lc_ctrl_configure(&lc, kDifLcCtrlStateDev, use_ext_clk, &token),
+        dif_lc_ctrl_configure(&lc, kDifLcCtrlStateScrap, use_ext_clk, NULL),
         "LC transition configuration failed!");
     CHECK_DIF_OK(dif_lc_ctrl_transition(&lc), "LC transition failed!");
 
     LOG_INFO("Waiting for LC transtition done and reboot.");
-    wait_for_interrupt();
 
+    // Release the access mutex to LC conroller's registers before
+    // finishing the SW.
+    CHECK_DIF_OK(dif_lc_ctrl_mutex_release(&lc));
+
+    // At this point a reset should be issued for the new LC state to take
+    // effect. However, as we are transitioning into SCRAP, the core won't be
+    // able to execute any SW code, so this sequence will never return true.
+    // Instead, the reset task will be handled by Host code.
+    wait_for_interrupt();
+    CHECK(false, "Should have reset before this line.");
   } else {
-    // LC Dev is the requested state from previous lc_state transition request.
-    // Once the sequence checks current state and count via CSRs, the test can
-    // exit successfully.
-    CHECK(curr_state == kDifLcCtrlStateDev, "State transition failed!");
-    lc_ctrl_testutils_check_transition_count(&lc, kLcStateTransitionCount + 1);
-    return true;
+    LOG_INFO("LC transition is performed by JTAG. Skipping SW...");
   }
+
   return true;
 }
 


### PR DESCRIPTION
Signed-off-by: Dror Kabely <dror.kabely@opentitan.org>

Implementation of SW side for #16428 

Additional changes:

1. Transition to `SCRAP` is randomized between {JTAG, SW} for relevant source states {Dev, Prod, ProdEnd, Rma, TestUnlocked*}
    For all other states, transition is performed exclusively by JTAG.