### PR TITLE
[i2c,dv] host mode regression fix

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -10,6 +10,7 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;
 
   timing_cfg_t    timing_cfg;
+  bit host_stretch_test_mode = 0;
 
   virtual i2c_if  vif;
 

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -141,7 +141,8 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
     // intr_stretch_timeout_o interrupt would be generated uniformly
     // To test this feature more regressive, there might need a dedicated vseq (V2)
     // in which TIMEOUT_CTRL.EN is always set.
-    return $urandom_range(tc.tClockPulse, tc.tClockPulse + 2*tc.tTimeOut);
+    if (cfg.host_stretch_test_mode) return tc.tClockPulse;
+    else return $urandom_range(tc.tClockPulse, tc.tClockPulse + 2*tc.tTimeOut);
   endfunction : gen_num_stretch_host_clks
 
   virtual task process_reset();

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -211,7 +211,7 @@
 
             '''
       stage: V2
-      tests: ["i2c_host_timeout"]
+      tests: ["i2c_host_stretch_timeout"]
     }
     {
       name: host_rx_oversample

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -31,7 +31,6 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
   // Add additional tops for simulation.
@@ -89,11 +88,6 @@
       name: i2c_host_fifo_reset_rx
       uvm_test_seq: i2c_host_fifo_reset_rx_vseq
       run_opts: ["+test_timeout_ns=10_000_000"]
-    }
-
-    {
-      name: i2c_host_timeout
-      uvm_test_seq: i2c_host_timeout_vseq
     }
 
     {


### PR DESCRIPTION
- clean up unmapped tests
- update host_rx_oversample constraint
- update host_stretch_timeout test s.t.
  - trigger stretch_timeout interrupt at every ack from tb target agent. 

Signed-off-by: Jaedon Kim <jdonjdon@google.com>