### PR TITLE
[bazel] Add new-repository case to http_archive_or_local

### DIFF
--- a/rules/repo.bzl
+++ b/rules/repo.bzl
@@ -4,12 +4,17 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def http_archive_or_local(**kwargs):
-    local = kwargs.pop("local", None)
-    if local:
+def http_archive_or_local(local = None, build_file = None, **kwargs):
+    if not local:
+        http_archive(build_file = build_file, **kwargs)
+    elif build_file:
+        native.new_local_repository(
+            name = kwargs.get("name"),
+            path = local,
+            build_file = build_file,
+        )
+    else:
         native.local_repository(
             name = kwargs.get("name"),
             path = local,
         )
-    else:
-        http_archive(**kwargs)

--- a/third_party/openocd/repos.bzl
+++ b/third_party/openocd/repos.bzl
@@ -5,11 +5,12 @@
 load("//rules:repo.bzl", "http_archive_or_local")
 
 def openocd_repos(local = None):
+    OPENOCD_VERSION = "0.12.0-rc1"
     http_archive_or_local(
         name = "openocd",
         local = local,
-        url = "https://sourceforge.net/projects/openocd/files/openocd/0.12.0-rc1/openocd-0.12.0-rc1.tar.gz",
-        strip_prefix = "openocd-0.12.0-rc1",
-        build_file = Label("//third_party/openocd:BUILD.openocd.bazel"),
+        url = "https://sourceforge.net/projects/openocd/files/openocd/{version}/openocd-{version}.tar.gz".format(version = OPENOCD_VERSION),
+        strip_prefix = "openocd-" + OPENOCD_VERSION,
+        build_file = "//third_party/openocd:BUILD.openocd.bazel",
         sha256 = "cdd3654a6c2fd046fe766de5ed897d75467138be9b9c271229bbd7409eb902a5",
     )


### PR DESCRIPTION
I tried building OpenOCD from a local repo and discovered that `http_archive_or_local` assumes the local repo has a a WORKSPACE file.

This PR changes the behavior of `openocd_repos` depending on the `local` parameter. When `local` is not None, it uses `new_local_repository`, which lets us provide a BUILD file.

Alternatively, I could change the behavior of `http_archive_or_local` when `build_file` is passed in. I haven't checked if there are any other call sites that might benefit from this abstraction.