### PR TITLE
[i2c] Allow tx_fifo to self clear upon transaction complete

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -301,6 +301,15 @@
           name: "TXRST"
           desc: "TX FIFO reset. Write 1 to the register resets it. Read returns 0"
         }
+        { bits: "9"
+          swaccess: "rw"
+          name: "TX_AUTO_CLEAR"
+          desc: '''
+            Automatically clear TX FIFO on re-start or stop.
+            This ensures that if the previous segment or transaction finishes with leftover data,
+            it is not sent out during a subsequent segment (potentially to a different address) by accident.
+          '''
+        }
       ]
     }
     { name: "FIFO_STATUS"

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -228,7 +228,14 @@ module  i2c_core #(
   assign i2c_fifo_rxilvl  = reg2hw.fifo_ctrl.rxilvl.q;
   assign i2c_fifo_fmtilvl = reg2hw.fifo_ctrl.fmtilvl.q;
 
-  assign i2c_fifo_txrst   = reg2hw.fifo_ctrl.txrst.q & reg2hw.fifo_ctrl.txrst.qe;
+  // Tx fifo reset is either manually triggered, or whenever a transaction completes.
+  // The latter prevents the hardware from potentially sending out stale data without
+  // software intervention.
+  assign i2c_fifo_txrst   = (reg2hw.fifo_ctrl.txrst.q & reg2hw.fifo_ctrl.txrst.qe) |
+                            (reg2hw.fifo_ctrl.tx_auto_clear.q & event_trans_complete);
+  logic unused_qe;
+  assign unused_qe = reg2hw.fifo_ctrl.tx_auto_clear.qe;
+
   assign i2c_fifo_acqrst  = reg2hw.fifo_ctrl.acqrst.q & reg2hw.fifo_ctrl.acqrst.qe;
 
   always_ff @ (posedge clk_i or negedge rst_ni) begin : watermark_transition

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -260,6 +260,10 @@ package i2c_reg_pkg;
       logic        q;
       logic        qe;
     } txrst;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } tx_auto_clear;
   } i2c_reg2hw_fifo_ctrl_reg_t;
 
   typedef struct packed {
@@ -528,14 +532,14 @@ package i2c_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [391:376]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [375:360]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [359:328]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [327:326]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [325:323]
-    i2c_reg2hw_rdata_reg_t rdata; // [322:314]
-    i2c_reg2hw_fdata_reg_t fdata; // [313:295]
-    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [294:280]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [393:378]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [377:362]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [361:330]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [329:328]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [327:325]
+    i2c_reg2hw_rdata_reg_t rdata; // [324:316]
+    i2c_reg2hw_fdata_reg_t fdata; // [315:297]
+    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [296:280]
     i2c_reg2hw_ovrd_reg_t ovrd; // [279:277]
     i2c_reg2hw_timing0_reg_t timing0; // [276:245]
     i2c_reg2hw_timing1_reg_t timing1; // [244:213]


### PR DESCRIPTION
Currently, if tx fifo data is not completely drained during a target read, a nonempty interrupt is fired to alert software.

However, if before software handling is available another read is started, it is possible we will send out stale data (imagine for example the reads are targetting different registers).

In order to get around this, allow the tx fifo to self clear upon completition, this will cause the target to stretch and give software ample time to complete.

Signed-off-by: Timothy Chen <timothytim@google.com>