### PR TITLE
[dv] Use build seed to regenerate LC encoding for each build

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -98,6 +98,7 @@ ifneq (${sw_images},)
 			bazel_opts="${sw_build_opts} --define DISABLE_VERILATOR_BUILD=true"; \
 			bazel_opts+=" --//hw/ip/otp_ctrl/data:img_seed=${seed}"; \
 			if [[ "${build_seed}" != "None" ]]; then \
+				bazel_opts+=" --//hw/ip/otp_ctrl/data:lc_seed=${build_seed}"; \
 				bazel_opts+=" --//hw/ip/otp_ctrl/data:otp_seed=${build_seed}"; \
 			fi; \
 			if [[ -z $${BAZEL_PYTHON_WHEELS_REPO} ]]; then \

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -20,6 +20,11 @@ int_flag(
 )
 
 int_flag(
+    name = "lc_seed",
+    build_setting_default = 0,
+)
+
+int_flag(
     name = "otp_seed",
     build_setting_default = 0,
 )

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -153,6 +153,9 @@
         // '''cd {proj_root} && ./util/topgen.py -t {ral_spec} \
         //        -o hw/top_earlgrey --rnd_cnst_seed {seed}
         // ''',
+        // Generate LC encoding
+        "cd {proj_root} && ./util/design/gen-lc-state-enc.py --seed {seed}",
+        // Generate OTP memory map and scrambling constants keys.
         "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}",
         // Use eval_cmd to save build_seed in a file and reuse that file during run phase.
         // Create the build directory first because eval_cmd runs before actual build phase command
@@ -209,7 +212,7 @@
                             '''{eval_cmd} file=`echo {build_seed_file_path}`; \
                                if [ -f $file ]; then \
                                  while read line; do \
-                                   echo "--otp-seed $line"; \
+                                   echo "--otp-seed $line --lc-seed $line"; \
                                  done < $file; \
                                fi ''']
   // Add run modes.

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -156,10 +156,8 @@
         "cd {proj_root} && ./util/design/gen-lc-state-enc.py --seed {seed}",
         // Generate OTP memory map and scrambling constants keys.
         "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}",
-        // Use eval_cmd to save build_seed in a file and reuse that file during run phase.
-        // Create the build directory first because eval_cmd runs before actual build phase command
-        // execution.
-        '''{eval_cmd} mkdir -p {build_dir}; echo {seed} > {build_seed_file_path}; \
+        // Save build_seed in a file and reuse that file during run phase.
+        '''echo {seed} > {build_seed_file_path}; \
            echo "echo create file {build_seed_file_path}"
         '''
       ]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -148,11 +148,10 @@
     {
       name: build_seed
       pre_build_cmds: [
-        // TODO: find where in run phase we are using this pkg. It fails during ibex TLUL integrity
-        // check.
-        // '''cd {proj_root} && ./util/topgen.py -t {ral_spec} \
-        //        -o hw/top_earlgrey --rnd_cnst_seed {seed}
-        // ''',
+        // Generate RndCnsts
+        '''cd {proj_root} && ./util/topgen.py -t {ral_spec} \
+               -o hw/top_earlgrey --rnd_cnst_seed {seed}
+        ''',
         // Generate LC encoding
         "cd {proj_root} && ./util/design/gen-lc-state-enc.py --seed {seed}",
         // Generate OTP memory map and scrambling constants keys.

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -157,6 +157,8 @@ def _otp_image(ctx):
     args.add("--mmap-def", ctx.file.mmap_def)
     if ctx.attr.img_seed:
         args.add("--img-seed", ctx.attr.img_seed[BuildSettingInfo].value)
+    if ctx.attr.lc_seed:
+        args.add("--lc-seed", ctx.attr.lc_seed[BuildSettingInfo].value)
     if ctx.attr.otp_seed:
         args.add("--otp-seed", ctx.attr.otp_seed[BuildSettingInfo].value)
     args.add("--img-cfg", ctx.file.src)
@@ -198,6 +200,10 @@ otp_image = rule(
         "img_seed": attr.label(
             default = "//hw/ip/otp_ctrl/data:img_seed",
             doc = "Configuration override seed used to randomize field values in an OTP image.",
+        ),
+        "lc_seed": attr.label(
+            default = "//hw/ip/otp_ctrl/data:lc_seed",
+            doc = "Configuration override seed used to randomize LC netlist constants.",
         ),
         "otp_seed": attr.label(
             default = "//hw/ip/otp_ctrl/data:otp_seed",


### PR DESCRIPTION
This re-enables `RndCnst` randomization with the build seed, and also adds support for life cycle state randomization.

Fixes #12127

CC @vrozic @vogelpi @jadephilipoom these three generation steps need to be updated so that they can use the new entropy buffer file mechanism.

Signed-off-by: Michael Schaffner <msf@google.com>