### PR TITLE
[i2c,dv] remove nonempty check from overflow test

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -352,7 +352,7 @@
                 in tx_fifo otherwise tx_empty interrupt must be de-asserted
             '''
       stage: V2
-      tests: ["i2c_target_stress_rd", "i2c_target_intr_smoke", "i2c_target_tx_ovf"]
+      tests: ["i2c_target_stress_rd", "i2c_target_intr_smoke"]
     }
     {
       name: target_fifo_reset

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -872,8 +872,9 @@ class i2c_base_vseq extends cip_base_vseq #(
           end
         end
       end // else: !if(cfg.intr_vif.pins[TransComplete])
-      if (cfg.use_drooling_tx & read_cmd_q.size > 0) begin
-        bit dum = read_cmd_q.pop_front();
+      if (cfg.use_drooling_tx & (read_cmd_q.size > 0 || read_on_going == 1)) begin
+        bit dum;
+        if (read_cmd_q.size > 0) dum = read_cmd_q.pop_front();
         drooling_write_tx_fifo();
       end
     end
@@ -969,7 +970,7 @@ class i2c_base_vseq extends cip_base_vseq #(
           end
         end
       end else begin // if (data == 0)
-        csr_wr(.ptr(ral.intr_state.tx_overflow), .value(1'b1));
+        clear_interrupt(TxOverflow);
       end // else: !if(data == 0)
     end // repeat (lvl)
   endtask


### PR DESCRIPTION
Remove nonempty fifo interrupt and stertch_ctrl csr access to sync with the latest rtl update #16647 

Signed-off-by: Jaedon Kim <jdonjdon@google.com>