### PR TITLE
[prim] Reset assertion improvement

### DIFF
--- a/hw/ip/prim/rtl/prim_sync_reqack.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack.sv
@@ -247,10 +247,10 @@ module prim_sync_reqack #(
 
     // Always reset both domains. Both resets need to be active at the same time.
     `ASSERT(SyncReqAckRstSrc, $fell(rst_src_ni) |->
-        ((src_reset_flag | dst_reset_flag)  == '0),
+        (!src_reset_flag throughout !dst_reset_flag[->1]),
         clk_src_i, 0)
     `ASSERT(SyncReqAckRstDst, $fell(rst_dst_ni) |->
-        ((src_reset_flag | dst_reset_flag) == '0),
+        (!dst_reset_flag throughout !src_reset_flag[->1]),
         clk_dst_i, 0)
 
   `endif


### PR DESCRIPTION
Previous assertion was only allowing resets to happen in a single clock window. This commit makes it more flexible by checking the reset flag not getting high until other reset flag also drops.

Fixes most of the failures in OTBN block level DV failures in nightly regression.