### PR TITLE
[dvsim] Move empty pattern list to common

### DIFF
--- a/hw/cdc/tools/dvsim/common_cdc_cfg.hjson
+++ b/hw/cdc/tools/dvsim/common_cdc_cfg.hjson
@@ -58,9 +58,6 @@
   // Restrict the maximum message count in each bucket
   max_msg_count: 1000
 
-  // TODO(#9079): Need to align with new parser mechanism.
-  build_fail_patterns: []
-
   exports: [
     { CDC_ROOT:     "{cdc_root}" },
     { FOUNDRY_ROOT: "{foundry_root}" },

--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -11,6 +11,12 @@
   scratch_base_path:  "{scratch_root}/{branch}"
   scratch_path:       "{scratch_base_path}/{dut}-{flow}-{tool}"
 
+  // Common data structure
+  build_pass_patterns: []
+  // TODO: Add back FuseSoC fail pattern after
+  // https://github.com/lowRISC/opentitan/issues/7348 is resolved.
+  build_fail_patterns: []
+
   exports: [
     { SCRATCH_PATH: "{scratch_path}" },
     { proj_root: "{proj_root}" }

--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -22,11 +22,6 @@
   // Default file to store build_seed value
   build_seed_file_path: "{build_dir}/build_seed.log"
 
-  // pass and fail patterns
-  build_pass_patterns: []
-  // TODO: Add back FuseSoC fail pattern after
-  // https://github.com/lowRISC/opentitan/issues/7348 is resolved.
-  build_fail_patterns: []
   run_pass_patterns:   ["^TEST PASSED (UVM_)?CHECKS$"]
   run_fail_patterns:   ["^UVM_ERROR\\s[^:].*$",
                         "^UVM_FATAL\\s[^:].*$",

--- a/hw/dv/tools/dvsim/verilator.hjson
+++ b/hw/dv/tools/dvsim/verilator.hjson
@@ -81,7 +81,6 @@
   ]
 
   // pass and fail patterns
-  build_pass_patterns: []
   build_fail_patterns: [// Verilator compile error.
                         "^%Error.*?:",
                         // FuseSoC build error.

--- a/hw/formal/tools/dvsim/common_formal_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_formal_cfg.hjson
@@ -41,7 +41,6 @@
   // Common pass or fail patterns.
   build_fail_patterns: [// FuseSoC build error
                         "^ERROR:.*$"]
-  build_pass_patterns: []
 
   defines: ""
   bbox_cmd: ""

--- a/hw/lint/tools/dvsim/common_lint_cfg.hjson
+++ b/hw/lint/tools/dvsim/common_lint_cfg.hjson
@@ -41,10 +41,6 @@
     {category: "lint", severity: "error",    label: ""}
   ]
 
-  // TODO(#9079): Need to align with new parser mechanism.
-  build_fail_patterns: []
-  build_pass_patterns: []
-
   // These are not needed currently.
   sv_flist_gen_cmd:   ""
   sv_flist_gen_opts:  []

--- a/hw/rdc/tools/dvsim/common_rdc_cfg.hjson
+++ b/hw/rdc/tools/dvsim/common_rdc_cfg.hjson
@@ -58,9 +58,6 @@
   // Restrict the maximum message count in each bucket
   max_msg_count: 1000
 
-  // TODO(#9079): Need to align with new parser mechanism.
-  build_fail_patterns: []
-
   exports: [
     { RDC_ROOT:     "{rdc_root}" },
     { FOUNDRY_ROOT: "{foundry_root}" },

--- a/hw/syn/tools/dvsim/common_syn_cfg.hjson
+++ b/hw/syn/tools/dvsim/common_syn_cfg.hjson
@@ -61,7 +61,6 @@
   // Common pass or fail patterns.
   build_fail_patterns: [// FuseSoC build error
                         "^ERROR:.*$"]
-  build_pass_patterns: []
 
   exports: [
     { SYN_ROOT:          "{syn_root}" },


### PR DESCRIPTION
`build_(pass|fail)_patterns` are mandatory data structure being used in dvsim.Deploy. Not all tool flow uses the data yet. It resulted in having empty list to all cfg hjson.

This commit moves the list to `common_project_cfg.hjson` then make tool flow hjson cleaner.
