### PR TITLE
[dv/top-level] Exclude coverage for nodes tied to constants

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -69,7 +69,7 @@
     // IPs. See `hw/dv/tools/dvsim/common_sim_cfg.hjson` for the default value.
     {
       name: default_vcs_cov_cfg_file
-      value: "-cm_hier {top_dv_path}/cov/chip_cover.cfg+{top_dv_path}/autogen/xbar_tgl_excl.cfg+{top_dv_path}/autogen/rstmgr_tgl_excl.cfg -cm_fsmcfg {top_dv_path}/cov/chip_fsm.cfg"
+      value: "-cm_hier {top_dv_path}/cov/chip_cover.cfg+{top_dv_path}/autogen/xbar_tgl_excl.cfg+{top_dv_path}/autogen/rstmgr_tgl_excl.cfg+{top_dv_path}/cov/clkmgr_tgl_excl.cfg+{top_dv_path}/cov/pwrmgr_tgl_excl.cfg -cm_fsmcfg {top_dv_path}/cov/chip_fsm.cfg"
     }
     // Used by 'cover_reg_top' only builds - we only cover the *_reg_top of
     // the non-pre-verified modules at the chip level. See

--- a/hw/top_earlgrey/dv/cov/clkmgr_tgl_excl.cfg
+++ b/hw/top_earlgrey/dv/cov/clkmgr_tgl_excl.cfg
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+//======================================================================
+// This file contains outputs of clkmgr tied to constants.
+//======================================================================
+-node tb.dut*.u_clkmgr_aon.cg_en_o.aon_powerup
+-node tb.dut*.u_clkmgr_aon.cg_en_o.usb_powerup
+-node tb.dut*.u_clkmgr_aon.cg_en_o.main_powerup
+-node tb.dut*.u_clkmgr_aon.cg_en_o.io_powerup
+-node tb.dut*.u_clkmgr_aon.cg_en_o.io_div2_powerup
+-node tb.dut*.u_clkmgr_aon.cg_en_o.io_div4_powerup
+-node tb.dut*.u_clkmgr_aon.cg_en_o.aon_peri
+-node tb.dut*.u_clkmgr_aon.cg_en_o.aon_timers
+-node tb.dut*.u_clkmgr_aon.cg_en_o.aon_secure

--- a/hw/top_earlgrey/dv/cov/pwrmgr_tgl_excl.cfg
+++ b/hw/top_earlgrey/dv/cov/pwrmgr_tgl_excl.cfg
@@ -1,0 +1,8 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+//======================================================================
+// This file contains outputs of pwrmgr tied to constants.
+//======================================================================
+-node tb.dut*.u_pwrmgr_aon.pwr_ast_o.slow_clk_en


### PR DESCRIPTION
Exclude toggle coverage for clkmgr and pwrmgr outputs tied to constants.

Signed-off-by: Guillermo Maturana <maturana@google.com>