### PR TITLE
[i2c,dv] Host timeout interrupt test

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -31,6 +31,13 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   uint i2c_host_min_data_rw = 1;
   uint i2c_host_max_data_rw = 10;
 
+  // If 'host_scl_pause' is enabled, 'host_scl_pause_cyc' should be set to non zero value.
+  bit     host_scl_pause_en = 0;
+  bit     host_scl_pause_req = 0;
+  bit     host_scl_pause_ack = 0;
+  bit     host_scl_pause = 0;
+  int     host_scl_pause_cyc = 0;
+
   `uvm_object_utils_begin(i2c_agent_cfg)
     `uvm_field_int(en_monitor,                                UVM_DEFAULT)
     `uvm_field_enum(i2c_target_addr_mode_e, target_addr_mode, UVM_DEFAULT)

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -261,7 +261,7 @@ interface i2c_if(
   endtask: host_start
 
   task automatic host_rstart(ref timing_cfg_t tc);
-    wait(scl_i === 1'b1);
+    @(posedge scl_i && sda_i);
     wait_for_dly(tc.tSetupStart);
     sda_o = 1'b0;
     wait_for_dly(tc.tHoldStart);
@@ -269,11 +269,13 @@ interface i2c_if(
   endtask: host_rstart
 
   task automatic host_data(ref timing_cfg_t tc, input bit bit_i);
+    wait(scl_i === 1'b0);
     sda_o = bit_i;
     wait_for_dly(tc.tClockLow);
     wait_for_dly(tc.tSetupBit);
     wait(scl_i === 1'b1);
     wait_for_dly(tc.tClockPulse);
+    wait(scl_i === 1'b0);
     wait_for_dly(tc.tHoldBit);
     sda_o = 1;
   endtask: host_data
@@ -301,8 +303,7 @@ interface i2c_if(
 
   task automatic wait_scl(int iter = 1, timing_cfg_t tc);
     repeat(iter) begin
-      wait_for_dly(tc.tClockLow + tc.tSetupBit);
-      wait(scl_i === 1'b1);
+      @(posedge scl_i);
       wait_for_dly(tc.tClockPulse + tc.tHoldBit);
     end
   endtask // wait_scl

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -42,6 +42,7 @@ filesets:
       - seq_lib/i2c_target_stress_rd_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_stretch_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_tx_ovf_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_timeout_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -1003,7 +1003,7 @@ class i2c_base_vseq extends cip_base_vseq #(
 
     acq_fifo_empty = 0;
     if (read_one) begin
-    // polling if status.acqempty is zero and skip read fifo
+    // Polling if status.acqempty is zero and skip read fifo
     // if fifo is empty.
       csr_rd(.ptr(ral.status.acqempty), .value(acq_fifo_empty));
       read_data = (acq_fifo_empty)? 0 : 1;

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_timeout_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_timeout_vseq.sv
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//  This sequence set short host_timeout value ('d100).
+//  The timeout event is created by setting  'cfg.m_i2c_agent_cfg.host_scl_pause_req',
+//  after random delay. Once pause is requested from sequence, driver wait for
+//  'active drive period - between transaction start and stop' and
+//  stop when scl is high for a 'host_scl_pause_cyc' clock cycles.
+//  After driver acknowledged pause, sequence wait for HostTimeout interrupt
+//  and clear it.
+
+class i2c_target_timeout_vseq extends i2c_target_smoke_vseq;
+  `uvm_object_utils(i2c_target_timeout_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    super.pre_start();
+    cfg.min_data = 10;
+    cfg.max_data = 20;
+    num_trans = 40;
+    expected_intr[HostTimeout] = 1;
+
+    // Set to lower value than default (0xffff)
+    host_timeout_ctrl = 32'd100;
+    cfg.m_i2c_agent_cfg.host_scl_pause_cyc = 100;
+  endtask
+
+  virtual task body();
+    fork
+      begin
+        super.body();
+      end
+      begin
+        int delay;
+        int round = 0;
+
+        cfg.clk_rst_vif.wait_for_reset(.wait_negedge(0));
+        repeat (10) begin
+          delay = $urandom_range(10, 100);
+          `uvm_info("drv_pause", $sformatf("round %0d begin", ++round), UVM_MEDIUM)
+          #(delay * 1us);
+          `uvm_info("drv_pause", $sformatf("set req: del:%0d", delay), UVM_MEDIUM)
+          cfg.m_i2c_agent_cfg.host_scl_pause_req = 1;
+          `DV_WAIT(cfg.m_i2c_agent_cfg.host_scl_pause_ack,,
+                   cfg.spinwait_timeout_ns, "drv_pause")
+          `uvm_info("drv_pause", "got ack", UVM_MEDIUM)
+          `DV_WAIT(cfg.intr_vif.pins[HostTimeout] === 1,,
+                   cfg.spinwait_timeout_ns, "drv_pause")
+          clear_interrupt(HostTimeout);
+          `uvm_info("drv_pause", $sformatf("round %0d end", round), UVM_MEDIUM)
+        end
+      end
+    join
+  endtask
+endclass

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -25,3 +25,4 @@
 `include "i2c_target_stress_rd_vseq.sv"
 `include "i2c_target_stretch_vseq.sv"
 `include "i2c_target_tx_ovf_vseq.sv"
+`include "i2c_target_timeout_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -152,6 +152,12 @@
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=50_000_000",
                  "+use_intr_handler=1"]
     }
+    {
+      name: i2c_target_timeout
+      uvm_test_seq: i2c_target_timeout_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=50_000_000",
+                 "+use_intr_handler=1"]
+    }
    ]
 
   // List of regressions.
@@ -175,7 +181,7 @@
       tests: ["i2c_target_smoke", "i2c_target_stress_wr",
               "i2c_target_stress_rd", "i2c_target_stretch",
               "i2c_target_intr_smoke", "i2c_target_intr_stress_wr",
-              "i2c_target_tx_ovf"]
+              "i2c_target_timeout"]
     }
   ]
 }


### PR DESCRIPTION
Host timeout is created by pausing scl drive from the i2c driver. Once pause is requested from sequence, driver wait for 'active drive period - between transaction start and stop' and stop when scl is high for a 'host_scl_pause_cyc' clock cycles. After driver acknowledged pause, sequence wait for HostTimeout interrupt set and clear it.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>