### PR TITLE
[rom_e2e,dv] add `sigverify_mod_exp_*` tests to DV

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -603,6 +603,34 @@
       run_timeout_mins: 120
     }
     {
+      name: rom_e2e_sigverify_mod_exp_test_unlocked0_otbn
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_test_unlocked0_otbn:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=200_000_000"
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 480
+    }
+    {
+      name: rom_e2e_sigverify_mod_exp_test_unlocked0_sw
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_test_unlocked0_sw:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=200_000_000"
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 480
+    }
+    {
       name: rom_e2e_sigverify_mod_exp_dev_otbn
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
@@ -797,6 +825,8 @@
     {
       name: rom_e2e_sigverify_mod_exp
       tests: [
+        "rom_e2e_sigverify_mod_exp_test_unlocked0_otbn",
+        "rom_e2e_sigverify_mod_exp_test_unlocked0_sw",
         "rom_e2e_sigverify_mod_exp_dev_otbn",
         "rom_e2e_sigverify_mod_exp_dev_sw",
         "rom_e2e_sigverify_mod_exp_prod_otbn",

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -602,6 +602,20 @@
       run_opts: ["+sw_test_timeout_ns=20000000"]
       run_timeout_mins: 120
     }
+    {
+      name: rom_e2e_sigverify_mod_exp_rma_sw
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_rma_sw:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=20_000_000"
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 120
+    }
 
     // Signed chip-level tests to be run with ROM, instead of test ROM.
     {
@@ -680,6 +694,12 @@
         "rom_e2e_asm_init_prod",
         "rom_e2e_asm_init_prod_end",
         "rom_e2e_asm_init_rma",
+      ]
+    }
+    {
+      name: rom_e2e_sigverify_mod_exp
+      tests: [
+        "rom_e2e_sigverify_mod_exp_rma_sw",
       ]
     }
   ]

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -603,6 +603,20 @@
       run_timeout_mins: 120
     }
     {
+      name: rom_e2e_sigverify_mod_exp_rma_otbn
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_rma_otbn:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=20_000_000"
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 120
+    }
+    {
       name: rom_e2e_sigverify_mod_exp_rma_sw
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
@@ -699,6 +713,7 @@
     {
       name: rom_e2e_sigverify_mod_exp
       tests: [
+        "rom_e2e_sigverify_mod_exp_rma_otbn",
         "rom_e2e_sigverify_mod_exp_rma_sw",
       ]
     }

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -603,6 +603,34 @@
       run_timeout_mins: 120
     }
     {
+      name: rom_e2e_sigverify_mod_exp_prod_end_otbn
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_end_otbn:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=20_000_000"
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_mod_exp_prod_end_sw
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_end_sw:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=20_000_000"
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 120
+    }
+    {
       name: rom_e2e_sigverify_mod_exp_rma_otbn
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
@@ -713,6 +741,8 @@
     {
       name: rom_e2e_sigverify_mod_exp
       tests: [
+        "rom_e2e_sigverify_mod_exp_prod_end_otbn",
+        "rom_e2e_sigverify_mod_exp_prod_end_sw",
         "rom_e2e_sigverify_mod_exp_rma_otbn",
         "rom_e2e_sigverify_mod_exp_rma_sw",
       ]

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -603,6 +603,34 @@
       run_timeout_mins: 120
     }
     {
+      name: rom_e2e_sigverify_mod_exp_dev_otbn
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_dev_otbn:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=20_000_000"
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_mod_exp_dev_sw
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_dev_sw:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=20_000_000"
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 120
+    }
+    {
       name: rom_e2e_sigverify_mod_exp_prod_otbn
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
@@ -769,6 +797,8 @@
     {
       name: rom_e2e_sigverify_mod_exp
       tests: [
+        "rom_e2e_sigverify_mod_exp_dev_otbn",
+        "rom_e2e_sigverify_mod_exp_dev_sw",
         "rom_e2e_sigverify_mod_exp_prod_otbn",
         "rom_e2e_sigverify_mod_exp_prod_sw",
         "rom_e2e_sigverify_mod_exp_prod_end_otbn",

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -603,6 +603,34 @@
       run_timeout_mins: 120
     }
     {
+      name: rom_e2e_sigverify_mod_exp_prod_otbn
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_otbn:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=20_000_000"
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 120
+    }
+    {
+      name: rom_e2e_sigverify_mod_exp_prod_sw
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_sw:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=20_000_000"
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 120
+    }
+    {
       name: rom_e2e_sigverify_mod_exp_prod_end_otbn
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
@@ -741,6 +769,8 @@
     {
       name: rom_e2e_sigverify_mod_exp
       tests: [
+        "rom_e2e_sigverify_mod_exp_prod_otbn",
+        "rom_e2e_sigverify_mod_exp_prod_sw",
         "rom_e2e_sigverify_mod_exp_prod_end_otbn",
         "rom_e2e_sigverify_mod_exp_prod_end_sw",
         "rom_e2e_sigverify_mod_exp_rma_otbn",

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -778,6 +778,7 @@
       tags: ["rom", "dv", "fpga", "silicon"]
       stage: V2
       tests: [
+        "rom_e2e_sigverify_mod_exp_rma_otbn",
         "rom_e2e_sigverify_mod_exp_rma_sw",
       ]
     }

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -778,6 +778,8 @@
       tags: ["rom", "dv", "fpga", "silicon"]
       stage: V2
       tests: [
+        "rom_e2e_sigverify_mod_exp_prod_otbn",
+        "rom_e2e_sigverify_mod_exp_prod_sw",
         "rom_e2e_sigverify_mod_exp_prod_end_otbn",
         "rom_e2e_sigverify_mod_exp_prod_end_sw",
         "rom_e2e_sigverify_mod_exp_rma_otbn",

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -778,6 +778,8 @@
       tags: ["rom", "dv", "fpga", "silicon"]
       stage: V2
       tests: [
+        "rom_e2e_sigverify_mod_exp_dev_otbn",
+        "rom_e2e_sigverify_mod_exp_dev_sw",
         "rom_e2e_sigverify_mod_exp_prod_otbn",
         "rom_e2e_sigverify_mod_exp_prod_sw",
         "rom_e2e_sigverify_mod_exp_prod_end_otbn",

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -778,6 +778,8 @@
       tags: ["rom", "dv", "fpga", "silicon"]
       stage: V2
       tests: [
+        "rom_e2e_sigverify_mod_exp_test_unlocked0_otbn",
+        "rom_e2e_sigverify_mod_exp_test_unlocked0_sw",
         "rom_e2e_sigverify_mod_exp_dev_otbn",
         "rom_e2e_sigverify_mod_exp_dev_sw",
         "rom_e2e_sigverify_mod_exp_prod_otbn",

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -775,9 +775,11 @@
             | `kHardenedBoolFalse`               | Success |
             | `0`                                | Failure |
             '''
-      tags: ["rom", "no_dv", "fpga", "silicon"]
+      tags: ["rom", "dv", "fpga", "silicon"]
       stage: V2
-      tests: []
+      tests: [
+        "rom_e2e_sigverify_mod_exp_rma_sw",
+      ]
     }
 
     {

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -778,6 +778,8 @@
       tags: ["rom", "dv", "fpga", "silicon"]
       stage: V2
       tests: [
+        "rom_e2e_sigverify_mod_exp_prod_end_otbn",
+        "rom_e2e_sigverify_mod_exp_prod_end_sw",
         "rom_e2e_sigverify_mod_exp_rma_otbn",
         "rom_e2e_sigverify_mod_exp_rma_sw",
       ]

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1299,7 +1299,10 @@ SIGVERIFY_MOD_EXP_CASES = [
 opentitan_flash_binary(
     name = "empty_test_sigverify_mod_exp",
     srcs = ["empty_test.c"],
-    devices = ["fpga_cw310"],
+    devices = [
+        "fpga_cw310",
+        "sim_dv",
+    ],
     local_defines = [
         shell.quote("EMPTY_TEST_MSG=\"use_sw_rsa_verify=0x%08x\", otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_USE_SW_RSA_VERIFY_OFFSET)"),
     ],


### PR DESCRIPTION
This adds the ROM E2E `sigverify_mod_exp_*` tests to DV so we can get some runtime statistics on SW vs OTBN signature verification times in DV.