### PR TITLE
[fpv] Support expected failure properties

### DIFF
--- a/hw/formal/tools/dvsim/common_formal_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_formal_cfg.hjson
@@ -36,7 +36,8 @@
   report_opts: ["--logpath={build_log}",
                 "--reppath={build_dir}/results.hjson",
                 "--cov={cov}",
-                "--dut={dut}"]
+                "--dut={dut}",
+                "--exp-fail-path={exp_fail_hjson}"]
 
   // Common pass or fail patterns.
   build_fail_patterns: [// FuseSoC build error
@@ -44,14 +45,16 @@
 
   defines: ""
   bbox_cmd: ""
+  exp_fail_hjson: ""
 
   // Vars that need to exported to the env
   exports: [
-    { DUT_TOP:     "{dut}" },
-    { COV:         "{cov}" },
-    { sub_flow:    "{sub_flow}"},
-    { FPV_DEFINES: "{defines}"},
-    { BBOX_CMD:    "'{bbox_cmd}'"},
+    { DUT_TOP:        "{dut}" },
+    { COV:            "{cov}" },
+    { EXP_FAIL_HJSON: "{exp_fail_hjson}" },
+    { sub_flow:       "{sub_flow}" },
+    { FPV_DEFINES:    "{defines}" },
+    { BBOX_CMD:       "'{bbox_cmd}'" },
   ]
 
   overrides: [

--- a/hw/ip_templates/rv_plic/fpv/rv_plic_expected_failure.hjson
+++ b/hw/ip_templates/rv_plic/fpv/rv_plic_expected_failure.hjson
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+{
+  unreachable:
+  [
+    rv_plic_tb.dut.FpvSecCmRegWeOnehotCheck_A:precondition1
+    rv_plic_tb.dut.u_reg.u_prim_reg_we_check.u_prim_onehot_check.Onehot0Check_A:precondition1
+    rv_plic_tb.dut.u_reg.u_prim_reg_we_check.u_prim_onehot_check.gen_enable_check.gen_not_strict.EnableCheck_A:precondition1
+  ]
+}

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
@@ -53,6 +53,7 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/rv_plic/{sub_flow}/{tool}"
                cov: true
+               exp_fail_hjson: "{proj_root}/hw/top_earlgrey/ip_autogen/rv_plic/fpv/rv_plic_expected_failure.hjson"
                overrides: [
                  {
                    name:  design_level

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/rv_plic_expected_failure.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/rv_plic_expected_failure.hjson
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+{
+  unreachable:
+  [
+    rv_plic_tb.dut.FpvSecCmRegWeOnehotCheck_A:precondition1
+    rv_plic_tb.dut.u_reg.u_prim_reg_we_check.u_prim_onehot_check.Onehot0Check_A:precondition1
+    rv_plic_tb.dut.u_reg.u_prim_reg_we_check.u_prim_onehot_check.gen_enable_check.gen_not_strict.EnableCheck_A:precondition1
+  ]
+}


### PR DESCRIPTION
This PR supports parsing results with expected failures. Some of the formal properties are expected to failure in normal formal testbenchs.
For example: most of the security countermeasures are not supposed to be proven under normal formal conditions. They are only reachable via forcing the env.

So this PR adds support to results parsing. It allows user to input a expected_failure hjson file. And these failing properties won't be calculated towards total failing tests.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>