### PR TITLE
[dv/edn] Fix compile warning

### DIFF
--- a/hw/ip/edn/dv/env/edn_if.sv
+++ b/hw/ip/edn/dv/env/edn_if.sv
@@ -6,10 +6,7 @@
 // It deals with the force paths in EDN interrupt and error tests,
 // and helps pass the disable signal to the csrng agent.
 
-interface edn_if
-(
-  input edn_i
-);
+interface edn_if(input clk, input rst_n);
 
   import uvm_pkg::*;
 

--- a/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
@@ -38,7 +38,7 @@ class edn_disable_auto_req_mode_vseq extends edn_base_vseq;
                 auto_req_sts[rand_st_idx].name), UVM_HIGH)
       `DV_SPINWAIT(
           while (state_val != auto_req_sts[rand_st_idx]) begin
-            uvm_hdl_read(main_sm_d_path, state_val);
+            `DV_CHECK(uvm_hdl_read(main_sm_d_path, state_val))
             cfg.clk_rst_vif.wait_n_clks(1);
           end)
     end

--- a/hw/ip/edn/dv/env/seq_lib/edn_disable_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_disable_vseq.sv
@@ -44,7 +44,7 @@ class edn_disable_vseq extends edn_base_vseq;
                     boot_sts[rand_st_idx].name), UVM_HIGH)
           `DV_SPINWAIT(
               while (state_val != boot_sts[rand_st_idx]) begin
-                uvm_hdl_read(main_sm_d_path, state_val);
+                `DV_CHECK(uvm_hdl_read(main_sm_d_path, state_val))
                 cfg.clk_rst_vif.wait_clks(1);
               end)
          end

--- a/hw/ip/edn/dv/sva/edn_assert_if.sv
+++ b/hw/ip/edn/dv/sva/edn_assert_if.sv
@@ -20,10 +20,7 @@
 `define PATH7 \
     tb.dut.u_edn_core.gen_ep_blk[0].u_edn_ack_sm_ep
 
-interface edn_assert_if
-(
-  input edn_i
-);
+interface edn_assert_if(input clk, input rst_n);
 
   task automatic assert_off ();
     $assertoff(0, `PATH1.CntErrBackward_A);

--- a/hw/ip/edn/dv/tb.sv
+++ b/hw/ip/edn/dv/tb.sv
@@ -31,8 +31,8 @@ module tb;
   csrng_if csrng_if(.clk(clk), .rst_n(edn_disable_o === 1 ? ~edn_disable_o : rst_n));
   push_pull_if#(.HostDataWidth(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH))
        endpoint_if[MAX_NUM_ENDPOINTS](.clk(clk), .rst_n(rst_n));
-  edn_if edn_if (.edn_i(edn_i));
-  edn_assert_if edn_assert_if (.edn_i(edn_i));
+  edn_if edn_if(.clk(clk), .rst_n(rst_n));
+  edn_assert_if edn_assert_if(.clk(clk), .rst_n(rst_n));
 
   `DV_ALERT_IF_CONNECT
   assign edn_disable_o = edn_if.edn_disable_o;


### PR DESCRIPTION
This PR fixes VCS compile warning:
1). uvm_hdl_read check results.
2). Fix interface with undriven ports.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>