### PR TITLE
[flash_ctrl,chip] fix chip_sw_flash_crash_alert failure

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -641,6 +641,8 @@ interface chip_if;
   wire sram_main_init_done = `SRAM_CTRL_MAIN_HIER.u_reg_regs.status_init_done_qs;
   wire sram_ret_init_done = `SRAM_CTRL_RET_HIER.u_reg_regs.status_init_done_qs;
 
+  wire flash_core1_host_req = `FLASH_CTRL_HIER.u_eflash.gen_flash_cores[1].u_core.host_req_i;
+
   // alert_esc_if alert_if[NUM_ALERTS](.clk  (`ALERT_HANDLER_HIER.clk_i),
   //                                   .rst_n(`ALERT_HANDLER_HIER.rst_ni));
   // for (genvar i = 0; i < NUM_ALERTS; i++) begin : gen_alert_rx_conn

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv
@@ -9,8 +9,6 @@ class chip_sw_flash_host_gnt_err_inj_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_flash_host_gnt_err_inj_vseq)
   `uvm_object_new
 
-  localparam string FLASH_BANK1_HOST_GNT_PATH =
-       "tb.dut.top_earlgrey.u_flash_ctrl.u_eflash.gen_flash_cores[1].u_core.host_req_i";
   localparam string FLASH_BANK1_HOST_GNT_ERR_PATH =
        "tb.dut.top_earlgrey.u_flash_ctrl.u_eflash.gen_flash_cores[1].u_core.muxed_part";
 
@@ -18,8 +16,8 @@ class chip_sw_flash_host_gnt_err_inj_vseq extends chip_sw_base_vseq;
     int polling_timeout_ns = 300_000;
     super.body();
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
-    `DV_SPINWAIT(polling_host_gnt();,
-                 "polling_host_gnt is timed out",
+    `DV_SPINWAIT(wait(cfg.chip_vif.flash_core1_host_req == 1);,
+                 "wait for core1_host_req is timed out",
                  polling_timeout_ns)
     `uvm_info(`gfn, "polling is done", UVM_MEDIUM)
     `DV_CHECK(uvm_hdl_force(FLASH_BANK1_HOST_GNT_ERR_PATH, 1))
@@ -29,11 +27,4 @@ class chip_sw_flash_host_gnt_err_inj_vseq extends chip_sw_base_vseq;
     `DV_CHECK(uvm_hdl_release(FLASH_BANK1_HOST_GNT_ERR_PATH))
   endtask // body
 
-  task polling_host_gnt();
-    bit val = 0;
-    while (!val) begin
-      `DV_CHECK(uvm_hdl_read(FLASH_BANK1_HOST_GNT_PATH, val));
-      cfg.clk_rst_vif.wait_clks(1);
-    end
-  endtask // polling_host_gnt
 endclass // chip_sw_flash_host_gnt_err_inj_vseq


### PR DESCRIPTION
Address issue #16645 
This test failed due to uvm_hdl_read take more than 1 cycle and fail to capture 1 cycle pulse.
Replace uvm_hdl_read with wait statement.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>