### PR TITLE
[lib] Add hardened variants of `status_t` constructs.

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -146,6 +146,30 @@ cc_test(
 )
 
 cc_library(
+    name = "hardened_status",
+    srcs = ["hardened_status.c"],
+    hdrs = ["hardened_status.h"],
+    deps = [
+        ":bitfield",
+        ":hardened",
+        ":macros",
+        ":status",
+    ],
+)
+
+cc_test(
+    name = "hardened_status_unittest",
+    srcs = ["hardened_status_unittest.cc"],
+    defines = [
+        "OT_OFF_TARGET_TEST",
+    ],
+    deps = [
+        ":hardened_status",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "random_order",
     srcs = ["random_order.c"],
     hdrs = ["random_order.h"],

--- a/sw/device/lib/base/hardened_status.c
+++ b/sw/device/lib/base/hardened_status.c
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/hardened_status.h"
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/status.h"
+
+hardened_bool_t hardened_status_ok(status_t s) {
+  if (launder32(s.value) >= 0 && launder32(s.value) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(s.value, kHardenedBoolTrue);
+    return s.value;
+  }
+  return kHardenedBoolFalse;
+}

--- a/sw/device/lib/base/hardened_status.h
+++ b/sw/device/lib/base/hardened_status.h
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_HARDENED_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_HARDENED_STATUS_H_
+
+/**
+ * @file
+ * @brief Hardened handling of status codes.
+ */
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Hardened variant of `OK_STATUS` .
+ *
+ * This passes `kHardenedBoolTrue` as the status code argument, for extra bits
+ * of redundancy in `HARDENED_TRY` and others.
+ */
+#define HARDENED_OK_STATUS OK_STATUS(kHardenedBoolTrue)
+
+/**
+ * Hardened version of the `TRY` macro from `status.h`.
+ *
+ * @param expr_ An expression that evaluates to a `status_t`.
+ * @return The enclosed OK value.
+ */
+#define HARDENED_TRY(expr_)                                            \
+  ({                                                                   \
+    status_t status_ = expr_;                                          \
+    if (!(status_ok(status_) && status_.value == kHardenedBoolTrue)) { \
+      return status_;                                                  \
+    }                                                                  \
+    HARDENED_CHECK_EQ(status_.value, kHardenedBoolTrue);               \
+    status_.value;                                                     \
+  })
+
+/**
+ * Hardened version of `status_ok`.
+ *
+ * Returns `kHardenedBoolTrue` if the status is OK with an argument code of
+ * `kHardenedBoolTrue` (i.e. a result of `HARDENED_OK()`), and
+ * `kHardenedBoolFalse` otherwise.
+ *
+ * @param s The status code.
+ * @return True if the status represents Ok.
+ */
+hardened_bool_t hardened_status_ok(status_t s);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_HARDENED_STATUS_H_

--- a/sw/device/lib/base/hardened_status_unittest.cc
+++ b/sw/device/lib/base/hardened_status_unittest.cc
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/hardened_status.h"
+
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// NOTE: This test does not verify hardening measures; it only checks that the
+// "normal" contract of the functions is upheld.
+
+namespace hardened_status_unittest {
+namespace {
+
+TEST(HardenedStatus, HardenedOkStatusIsOk) {
+  EXPECT_EQ(status_ok(HARDENED_OK_STATUS), true);
+}
+
+TEST(HardenedStatus, HardenedOkStatusIsHardenedOk) {
+  EXPECT_EQ(hardened_status_ok(HARDENED_OK_STATUS), kHardenedBoolTrue);
+}
+
+TEST(HardenedStatus, ErrorIsNotHardenedOk) {
+  EXPECT_EQ(hardened_status_ok(INTERNAL()), kHardenedBoolFalse);
+}
+
+TEST(HardenedStatus, ErrorWithTruthyArgIsNotHardenedOk) {
+  EXPECT_EQ(hardened_status_ok(INTERNAL(kHardenedBoolTrue)),
+            kHardenedBoolFalse);
+}
+
+TEST(HardenedStatus, NormalOkIsNotHardenedOk) {
+  EXPECT_EQ(hardened_status_ok(OK_STATUS()), kHardenedBoolFalse);
+}
+
+}  // namespace
+}  // namespace hardened_status_unittest


### PR DESCRIPTION
In preparation for moving cryptolib to `status_t` error codes (see https://github.com/lowRISC/opentitan/issues/14549), I've created some hardened variants of `OK_STATUS` and `TRY` that use more than one bit to check if an error is OK.

Usage is the same as the `status.h` version except for the following replacements:
- `OK_STATUS()` -> `HARDENED_OK_STATUS` (no arguments possible)
- `TRY` -> `HARDENED_TRY`
- `status_ok(s)` -> `hardened_status_ok(s)`

These are one-way interoperable with the `status.h` error codes; `HARDENED_OK_STATUS` will pass the unhardened `TRY` and `status_ok` checks, but `OK_STATUS()` will not pass `HARDENED_TRY` and `hardened_ok_status`. Non-OK status codes are unaffected and will fail all checks.

The way this works is that `HARDENED_OK_STATUS` is defined as `OK_STATUS(kHardenedBoolTrue)`, and `HARDENED_TRY` and `hardened_status_ok` check that the value is `kHardenedBoolTrue` instead of accepting any positive value.