### PR TITLE
[top_earlgrey/dv] Fix quotes in `pre_build_cmds`

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -158,7 +158,7 @@
         "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}",
         // Save build_seed in a file and reuse that file during run phase.
         '''echo {seed} > {build_seed_file_path}; \
-           echo "echo create file {build_seed_file_path}"
+           echo 'echo create file {build_seed_file_path}'
         '''
       ]
       is_sim_mode: 1


### PR DESCRIPTION
Due to the change in 063cd6685, the double quotes of the second command conflict with the quotes around the value passed with the `--command` argument to `flock`.