### PR TITLE
[dv] ensure RAM ELF file gets copied to the rundir

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -124,10 +124,10 @@ ifneq (${sw_images},)
 						--output=starlark \
 						--starlark:expr="\"\\n\".join([f.path for f in target.files.to_list()])"); do \
 						cp -f $${artifact} $${run_dir}/$$(basename $${artifact}); \
-						if [[ $$artifact == *.scr.vmem && \
+						if [[ $$artifact == *.bin && \
 							-f "$$(echo $${artifact} | cut -d. -f 1).elf" ]]; then \
 							cp -f "$$(echo $${artifact} | cut -d. -f 1).elf" \
-								$${run_dir}/$$(basename "$${artifact%.*.scr.vmem}.elf"); \
+								$${run_dir}/$$(basename "$${artifact%.bin}.elf"); \
 						fi; \
 					done; \
 				fi; \


### PR DESCRIPTION
The opentitan_ram_binary Bazel macro generates a VMEM file that was not getting copied to the dvsim rundir. This should fix this and enable runing the `rom_e2e_{debug,jtag_inject}` tests in DV.

Signed-off-by: Timothy Trippel <ttrippel@google.com>