### PR TITLE
[chip, dv] Fix SVA errors due to X

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -609,13 +609,16 @@ module spi_host
   `ASSERT_KNOWN(CioCsbKnownO_A, cio_csb_o)
   `ASSERT_KNOWN(CioCsbEnKnownO_A, cio_csb_en_o)
   `ASSERT_KNOWN_IF(CioSdKnownO_A, cio_sd_o, !passthrough_i.passthrough_en |
-    (passthrough_i.passthrough_en && passthrough_i.csb_en && !passthrough_i.csb))
+    (passthrough_i.passthrough_en && passthrough_i.csb_en && !passthrough_i.csb),
+    passthrough_i.sck_en & passthrough_i.sck)
   `ASSERT_KNOWN(CioSdEnKnownO_A, cio_sd_en_o)
   `ASSERT_KNOWN(IntrSpiEventKnownO_A, intr_spi_event_o)
   `ASSERT_KNOWN(IntrErrorKnownO_A, intr_error_o)
 
-  `ASSERT_KNOWN_IF(PassthroughKnownO_A, passthrough_o,
-    passthrough_i.passthrough_en && passthrough_i.csb_en && !passthrough_i.csb)
+  // passthrough_o.s is passed through to spi_device, it may contain unknown data,
+  // but the unknown data won't be used based on the SPI protocol.
+  // Hence, instead of checking known data, here does a connectivity check.
+  `ASSERT(PassthroughConn_A, passthrough_o.s === cio_sd_i)
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])


### PR DESCRIPTION
Fixed 2 issues in chip-level sim
1. In foundry sim, we have different delays for combination pathes. Then, we see CSB and CIO take different time to reach spi_host from pads. We used core clk to check CIO is known, which isn't the right clock. Switched to use SPI clock.

2. In foundry sim, due to the pullup delay, when no one drives SPI CIO, the pullup may takes some delay to take effect and assign weak high to CIO, which leads to unknown value. However, this unknown value won't be used by either side. Removed checking `passthrough_o.s` is known, as it's an input passed through to spi device. Changed the SVA to do a connectivity check. Thanks @msfschaffner for helping to look into this.

This will fix the foundry CI failure.

Signed-off-by: Weicai Yang <weicai@google.com>