### PR TITLE
[ci,dv] run more tests in private CI with Xcelium

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1817,8 +1817,7 @@
               "chip_sw_aes_enc",
               "chip_sw_aes_enc_jitter_en",
               "chip_sw_sram_ctrl_scrambled_access",
-              // TODO(#16416): uncomment when this is passing nightly.
-              // "chip_sw_sram_ctrl_scrambled_access",
+              "chip_sw_sram_ctrl_scrambled_access",
               "chip_sw_all_escalation_resets",
               "chip_rv_dm_ndm_reset_req",
               "chip_sw_entropy_src_ast_rng_req",


### PR DESCRIPTION
This runs more tests in private CI that were previously commented out as they were failing the night regression runs.

Signed-off-by: Timothy Trippel <ttrippel@google.com>