### PR TITLE
[conn] Add vendor_test connectivity check

### DIFF
--- a/hw/top_earlgrey/data/chip_conn_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_conn_testplan.hjson
@@ -216,6 +216,18 @@
       tags: ["conn"]
     }
 
+    //////////////////////////////
+    // otp_lc_vendor_test.csv   //
+    //////////////////////////////
+    {
+      name: vendor_test_connections
+      desc: '''Verify the connectivity of vendor_test IOs between otp_ctrl and lc_ctrl.'''
+      stage: V2
+      tests: ["lc_otp_vendor_test_ctrl", "lc_otp_vendor_test_status"]
+      tags: ["conn"]
+    }
+
+
     //////////////////////////
     // clkmgr_cg_en.csv     //
     //////////////////////////

--- a/hw/top_earlgrey/formal/chip_conn_cfg.hjson
+++ b/hw/top_earlgrey/formal/chip_conn_cfg.hjson
@@ -11,7 +11,8 @@
 
   bbox_cmd: "[list aon_osc io_osc sys_osc usb_osc]"
   conn_csvs_dir: "{proj_root}/hw/top_earlgrey/formal/conn_csvs"
-  conn_csvs: ["{conn_csvs_dir}/aon_timer_rst.csv",
+  conn_csvs: ["{conn_csvs_dir}/analog_sigs.csv",
+              "{conn_csvs_dir}/aon_timer_rst.csv",
               "{conn_csvs_dir}/ast_infra.csv",
               "{conn_csvs_dir}/ast_entropy_src_cfg.csv",
               "{conn_csvs_dir}/ast_mem_cfg.csv",
@@ -29,9 +30,9 @@
               "{conn_csvs_dir}/clkmgr_secure.csv",
               "{conn_csvs_dir}/clkmgr_timers.csv",
               "{conn_csvs_dir}/clkmgr_trans.csv",
-              "{conn_csvs_dir}/analog_sigs.csv",
               "{conn_csvs_dir}/jtag.csv",
               "{conn_csvs_dir}/lc_ctrl_broadcast.csv",
+              "{conn_csvs_dir}/otp_lc_vendor_test.csv",
               "{conn_csvs_dir}/pwrmgr_rstmgr.csv",
               "{conn_csvs_dir}/rstmgr_resets_o.csv",
               "{conn_csvs_dir}/rstmgr_rst_en.csv",

--- a/hw/top_earlgrey/formal/conn_csvs/otp_lc_vendor_test.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/otp_lc_vendor_test.csv
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run these checks with:
+#  ./util/dvsim/dvsim.py hw/top_earlgrey/formal/chip_conn_cfg.hjson
+
+,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
+
+# Verify the vendor_test connectivities.
+CONNECTION, LC_OTP_VENDOR_TEST_CTRL,   top_earlgrey.u_lc_ctrl,  lc_otp_vendor_test_o, top_earlgrey.u_otp_ctrl, lc_otp_vendor_test_i
+CONNECTION, LC_OTP_VENDOR_TEST_STATUS, top_earlgrey.u_otp_ctrl, lc_otp_vendor_test_o, top_earlgrey.u_lc_ctrl,  lc_otp_vendor_test_i


### PR DESCRIPTION
This PR adds a connectivity check for vendor_test ports between otp_ctrl and lc_ctrl.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>