### PR TITLE
[dv/pwrmgr] Add covergroup for rom related inputs

### DIFF
--- a/hw/dv/sv/cip_lib/cip_macros.svh
+++ b/hw/dv/sv/cip_lib/cip_macros.svh
@@ -106,4 +106,21 @@
   `_DV_MUBI_DIST(VAR_, MuBi16True, MuBi16False, T_WEIGHT_, (1 << 16) - 1, F_WEIGHT_, OTHER_WEIGHT_)
 `endif
 
+
+// A macro to simplify the creation of coverpoints for lc_tx_t variables.
+`ifndef DV_LC_TX_T_CP_BINS
+`define DV_LC_TX_T_CP_BINS         \
+    bins on = {lc_ctrl_pkg::On};   \
+    bins off = {lc_ctrl_pkg::Off}; \
+    bins others = default;
+`endif
+
+// A macro to simplify the creation of coverpoints for mubi4_t variables.
+`ifndef DV_MUBI4_CP_BINS
+`define DV_MUBI4_CP_BINS                      \
+    bins true = {prim_mubi_pkg::MuBi4True};   \
+    bins false = {prim_mubi_pkg::MuBi4False}; \
+    bins others = default;
+`endif
+
 `endif  // __CIP_MACROS_SVH__

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
@@ -8,6 +8,8 @@
  * Covergroups may also be wrapped inside helper classes if needed.
  */
 
+`include "cip_macros.svh"
+
 // Wrapper class for wakeup control covergroup.
 class pwrmgr_wakeup_ctrl_cg_wrap;
   // This covers enable, capture, and status of wakeups.
@@ -145,6 +147,25 @@ class pwrmgr_env_cov extends cip_base_env_cov #(
     }
   endgroup
 
+  // This covers the rom inputs that should prevent entering the active state.
+  covergroup rom_active_blockers_cg with function sample (
+      logic [3:0] done, logic [3:0] good, logic [3:0] dft, logic [3:0] debug
+  );
+    done_cp: coverpoint done {
+      `DV_MUBI4_CP_BINS
+    }
+    good_cp: coverpoint good {
+      `DV_MUBI4_CP_BINS
+    }
+    dft_cp: coverpoint dft {
+      `DV_LC_TX_T_CP_BINS
+    }
+    debug_cp: coverpoint debug {
+      `DV_LC_TX_T_CP_BINS
+    }
+    blockers_cross: cross done_cp, good_cp, dft_cp, debug_cp;
+  endgroup
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
     foreach (wakeup_ctrl_cg_wrap[i]) begin
@@ -159,6 +180,7 @@ class pwrmgr_env_cov extends cip_base_env_cov #(
     main_power_reset_cg = new();
     esc_reset_cg = new();
     reset_wakeup_distance_cg = new();
+    rom_active_blockers_cg = new();
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -38,6 +38,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
       wakeup_intr_coverage_collector();
       low_power_coverage_collector();
       reset_coverage_collector();
+      rom_coverage_collector();
     join_none
   endtask
 
@@ -84,7 +85,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     cov.hw_reset_1_cg.sample(cfg.pwrmgr_vif.rstreqs_i[1], cfg.pwrmgr_vif.reset_en[1], sleep);
     cov.rstmgr_sw_reset_cg.sample(cfg.pwrmgr_vif.sw_rst_req_i == prim_mubi_pkg::MuBi4True);
     cov.main_power_reset_cg.sample(
-        cfg.pwrmgr_vif.pwr_rst_req.rstreqs[pwrmgr_reg_pkg::ResetMainPwrIdx],sleep);
+        cfg.pwrmgr_vif.pwr_rst_req.rstreqs[pwrmgr_reg_pkg::ResetMainPwrIdx], sleep);
     cov.esc_reset_cg.sample(cfg.pwrmgr_vif.pwr_rst_req.rstreqs[pwrmgr_reg_pkg::ResetEscIdx], sleep);
     `uvm_info(`gfn, $sformatf(
               {
@@ -115,6 +116,17 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
           end
         end
     join_none
+  endtask
+
+  task rom_coverage_collector();
+    forever
+      @(cfg.pwrmgr_vif.rom_ctrl or cfg.pwrmgr_vif.lc_hw_debug_en or cfg.pwrmgr_vif.lc_dft_en) begin
+        if (cfg.en_cov) begin
+          cov.rom_active_blockers_cg.sample(cfg.pwrmgr_vif.rom_ctrl.done,
+                                            cfg.pwrmgr_vif.rom_ctrl.good, cfg.pwrmgr_vif.lc_dft_en,
+                                            cfg.pwrmgr_vif.lc_hw_debug_en);
+        end
+      end
   endtask
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -210,7 +210,8 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
       cfg.aon_clk_rst_vif.apply_reset();
     join
     // And wait until the responders settle with all okay from the AST.
-    `DV_WAIT(cfg.pwrmgr_vif.pwr_ast_rsp.main_pok &&
+    `DV_WAIT(
+        cfg.pwrmgr_vif.pwr_ast_rsp.main_pok &&
              cfg.pwrmgr_vif.pwr_ast_rsp.core_clk_val &&
              cfg.pwrmgr_vif.pwr_ast_rsp.io_clk_val)
     `uvm_info(`gfn, $sformatf("Out of apply_reset kind='%0s'", kind), UVM_MEDIUM)
@@ -389,8 +390,8 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
           end
         end
       forever
-        @(io_clk_val_sr[cycles_before_io_clk_en + 2]) begin
-          logic new_value = io_clk_val_sr[cycles_before_io_clk_en + 2];
+        @(io_clk_val_sr[cycles_before_io_clk_en+2]) begin
+          logic new_value = io_clk_val_sr[cycles_before_io_clk_en+2];
           cfg.pwrmgr_vif.slow_cb.pwr_ast_rsp.io_clk_val <= new_value;
           drop_slow_objection("io_clk_val");
         end
@@ -787,13 +788,33 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // Drive rom_ctrl at post reset stage
   virtual task init_rom_response();
     if (cfg.pwrmgr_vif.rom_ctrl.done != prim_mubi_pkg::MuBi4True) begin
-      cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+          .t_weight(1), .f_weight(1), .other_weight(1)
+      );
+      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+          .t_weight(0), .f_weight(1), .other_weight(1)
+      );
       `DV_WAIT(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateRomCheckDone)
-      cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+          .t_weight(1), .f_weight(1), .other_weight(1)
+      );
+      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+          .t_weight(0), .f_weight(1), .other_weight(1)
+      );
       cfg.aon_clk_rst_vif.wait_clks(10);
-      cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+          .t_weight(1), .f_weight(1), .other_weight(1)
+      );
+      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+          .t_weight(0), .f_weight(1), .other_weight(1)
+      );
       cfg.aon_clk_rst_vif.wait_clks(5);
-      cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+          .t_weight(1), .f_weight(1), .other_weight(1)
+      );
+      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+          .t_weight(0), .f_weight(1), .other_weight(1)
+      );
       cfg.aon_clk_rst_vif.wait_clks(5);
       cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
       cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
@@ -12,7 +12,7 @@ class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
   constraint wakeups_en_c {wakeups_en == 0;}
 
   function void post_randomize();
-    sw_rst_from_rstmgr = get_rand_mubi4_val(8, 4, 4);
+    sw_rst_from_rstmgr = get_rand_mubi4_val(.t_weight(8), .f_weight(4), .other_weight(4));
     super.post_randomize();
   endfunction
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
@@ -30,16 +30,6 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
     cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
   endtask
 
-  function bit [lc_ctrl_pkg::TxWidth-1:0] get_lc_ctrl();
-    randcase
-      1: get_lc_ctrl = lc_ctrl_pkg::On;
-      1: get_lc_ctrl = lc_ctrl_pkg::Off;
-      2: `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(get_lc_ctrl,
-                                            get_lc_ctrl != lc_ctrl_pkg::On &&
-                                            get_lc_ctrl != lc_ctrl_pkg::Off;)
-    endcase
-  endfunction : get_lc_ctrl
-
   task body();
     num_trans_c.constraint_mode(0);
     num_trans = 50;
@@ -74,11 +64,13 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
       cfg.clk_rst_vif.wait_clks(cycles_from_reset);
       if (super_sequence_done) break;
       `uvm_info(`gfn, "Injection to lc_hw_debug_en", UVM_MEDIUM)
-      cfg.pwrmgr_vif.lc_hw_debug_en = get_lc_ctrl();
+      cfg.pwrmgr_vif.lc_hw_debug_en = get_rand_lc_tx_val(
+          .t_weight(1), .f_weight(1), .other_weight(2)
+      );
       #(micros_to_release * 1us);
       `uvm_info(`gfn, "Injection to lc_dft_en", UVM_MEDIUM)
       if (super_sequence_done) break;
-      cfg.pwrmgr_vif.lc_dft_en = get_lc_ctrl();
+      cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(2));
       #(micros_to_release * 1us);
     end  // repeat (50)
     `uvm_info(`gfn, "ended drv_lc_ctrl", UVM_MEDIUM)

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
@@ -30,7 +30,7 @@ class pwrmgr_reset_invalid_vseq extends pwrmgr_base_vseq;
   constraint wakeups_en_c {wakeups_en == 0;}
 
   function void post_randomize();
-    sw_rst_from_rstmgr = get_rand_mubi4_val(8, 4, 4);
+    sw_rst_from_rstmgr = get_rand_mubi4_val(.t_weight(8), .f_weight(4), .other_weight(4));
     super.post_randomize();
   endfunction
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
@@ -13,7 +13,7 @@ class pwrmgr_reset_vseq extends pwrmgr_base_vseq;
   constraint wakeups_en_c {wakeups_en == 0;}
 
   function void post_randomize();
-    sw_rst_from_rstmgr = get_rand_mubi4_val(8, 4, 4);
+    sw_rst_from_rstmgr = get_rand_mubi4_val(.t_weight(8), .f_weight(4), .other_weight(4));
     super.post_randomize();
   endfunction
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
@@ -104,8 +104,8 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
               enqueue_exp_alert();
             end else expect_fatal_alerts = 0;
             `uvm_info(`gfn, $sformatf(
-                      "Sending power glitch, %0sexpecting an alert",
-                      expect_fatal_alerts ? "" : "not "), UVM_MEDIUM)
+                      "Sending power glitch, expecting %0s alert", expect_fatal_alerts ? "an" : "no"
+                      ), UVM_MEDIUM)
             cfg.pwrmgr_vif.glitch_power_reset();
             enabled_resets = 0;
           end


### PR DESCRIPTION
Create a covergroup to check all rom related inputs that can prevent the pwrmgr to get into the active state.
Create cip macros to ease the creation of bins for lc_tx_t and mubi4_t coverpoints.
Minor changes for readability and replace a custom function by one provided by cip.

Fixes #10241

Signed-off-by: Guillermo Maturana <maturana@google.com>