### PR TITLE
[chip-test, keymgr] Extend KMAC sideload test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2403,9 +2403,15 @@
       desc: '''Verify the keymgr sideload interface to KMAC.
 
             - Configure the keymgr and advance to the `OwnerIntKey` state.
-            - Transmit a sideloaded key to the KMAC.
-            - Configure KMAC to use the sideload key to generate digest data.
-            - Verify the digest for correctness.
+            - Request keymgr to generate hw key for KMAC sideload key slot.
+            - Request KMAC operation with sideload key configuration.
+            - Verify the digest for correctness (should match the DV-side result).
+            - Clear keymer's KMAC sideload key slot.
+            - Request KMAC operation with sideload key configuration.
+            - Verify the digest value has changed.
+            - Request keymgr to derive the same key for the KMAC sideload key slot.
+            - Request KMAC operation with sideload key configuration.
+            - Verify the digest for correctness (should match the DV-side result again).
 
             X-ref'ed with chip_kmac_app_keymgr test.
             '''

--- a/sw/device/tests/keymgr_sideload_kmac_test.c
+++ b/sw/device/tests/keymgr_sideload_kmac_test.c
@@ -107,6 +107,20 @@ static void test_kmac_with_sideloaded_key(dif_keymgr_t *keymgr,
 
   // Verify that KMAC output is not equal to the one the from the sideload.
   CHECK_ARRAYS_NE(output, (uint32_t *)sideload_digest_result, kKmacOutputLen);
+
+  // Sideload the same KMAC key again and check if we can compute the same
+  // result as before.
+  keymgr_testutils_generate_versioned_key(keymgr, sideload_params);
+  LOG_INFO("Keymgr regenerated HW output for Kmac at OwnerIntKey State");
+
+  kmac_testutils_kmac(kmac, kKmacMode, &kSoftwareKey, kCustomString,
+                      kCustomStringLen, kKmacMessage, kKmacMessageLen,
+                      kKmacOutputLen, output);
+  LOG_INFO("Re-computed KMAC output for sideloaded key.");
+
+  if (kDeviceType == kDeviceSimDV) {
+    CHECK_ARRAYS_EQ(output, (uint32_t *)sideload_digest_result, kKmacOutputLen);
+  }
 }
 
 bool test_main(void) {


### PR DESCRIPTION
Loading sideload key and computing KMAC again after clearing the sideload key slot, as done in #16614. I also updated the test plan accordingly.