### PR TITLE
[util, top] Add ANALOGSIM macros for chip_earlgrey_asic

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -132,6 +132,7 @@ top-hjson = $(PRJ_DIR)/hw/$*/data/$*.hjson
 top: $(tops_gen) $(tops_reg)
 $(tops_gen): %_gen:
 	${PRJ_DIR}/util/topgen.py -t $(top-hjson) -o ${PRJ_DIR}/hw/$*/ ${toolflags}
+	${PRJ_DIR}/util/analogsim_asic.py
 
 $(tops_reg): %_reg:
 	mkdir -p ${REG_OUTPUT_DV_DIR}/$*

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv.orig
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv.orig
@@ -16,8 +16,8 @@ module chip_earlgrey_asic #(
   inout POR_N, // Manual Pad
   inout USB_P, // Manual Pad
   inout USB_N, // Manual Pad
-  `INOUT_AI CC1, // Manual Pad
-  `INOUT_AI CC2, // Manual Pad
+  inout CC1, // Manual Pad
+  inout CC2, // Manual Pad
   inout FLASH_TEST_VOLT, // Manual Pad
   inout FLASH_TEST_MODE0, // Manual Pad
   inout FLASH_TEST_MODE1, // Manual Pad
@@ -41,8 +41,8 @@ module chip_earlgrey_asic #(
   // Muxed Pads
   inout IOA0, // MIO Pad 0
   inout IOA1, // MIO Pad 1
-  `INOUT_AO IOA2, // MIO Pad 2
-  `INOUT_AO IOA3, // MIO Pad 3
+  inout IOA2, // MIO Pad 2
+  inout IOA3, // MIO Pad 3
   inout IOA4, // MIO Pad 4
   inout IOA5, // MIO Pad 5
   inout IOA6, // MIO Pad 6
@@ -500,8 +500,8 @@ module chip_earlgrey_asic #(
       FLASH_TEST_MODE1,
       FLASH_TEST_MODE0,
       FLASH_TEST_VOLT,
-      `CC2_A,
-      `CC1_A,
+      CC2,
+      CC1,
       USB_N,
       USB_P,
       POR_N
@@ -551,8 +551,8 @@ module chip_earlgrey_asic #(
       IOA6,
       IOA5,
       IOA4,
-      `IOA3_A,
-      `IOA2_A,
+      IOA3,
+      IOA2,
       IOA1,
       IOA0
     }),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -977,4 +977,21 @@ package top_earlgrey_pkg;
   // TODO: Enumeration for PLIC Interrupt source peripheral.
   // TODO: Enumeration for PLIC Interrupt Ids.
 
+  // MACROs for AST analog simulation support
+  `ifdef ANALOGSIM
+    `define INOUT_AI input ast_pkg::awire_t
+    `define INOUT_AO output ast_pkg::awire_t
+    `define CC1_A '0
+    `define CC2_A '0
+    `define IOA2_A '0
+    `define IOA3_A '0
+  `else
+    `define INOUT_AI inout
+    `define INOUT_AO inout
+    `define CC1_A CC1
+    `define CC2_A CC2
+    `define IOA2_A IOA2
+    `define IOA3_A IOA3
+  `endif
+
 endpackage

--- a/util/analogsim_asic.py
+++ b/util/analogsim_asic.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+#  1. Changes 'chip_earlgrey_asic' interface port lines:
+#     inout CC1, // Manual Pad
+#     inout CC2, // Manual Pad
+#  ...
+#     inout IOA2, // MIO Pad 2
+#     inout IOA3, // MIO Pad 3
+#
+#  To:
+#     `INOUT_AI CC1, // Manual Pad
+#     `INOUT_AI CC2, // Manual Pad
+#  ...
+#     `INOUT_AO IOA2, // MIO Pad 2
+#     `INOUT_AO IOA3, // MIO Pad 3
+#
+#  2. Changes 'u_padring' instance ports lines:
+#        CC2,
+#        CC1,
+#  ...
+#        IOA3,
+#        IOA2,
+#
+#  To:
+#        `CC2_A,
+#        `CC1_A,
+#  ...
+#        `IOA3_A,
+#        `IOA2_A,
+
+import re
+import shutil
+
+input_file = "top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv"
+# Keep the original file for reference
+shutil.copy(input_file, "".join([input_file, ".orig"]))
+
+with open(input_file, "r") as rfile:
+    s = rfile.read()
+
+s = re.sub(r'(^\s+)inout CC1,', r'\1`INOUT_AI CC1,', s, flags=re.M)
+s = re.sub(r'(^\s+)inout CC2,', r'\1`INOUT_AI CC2,', s, flags=re.M)
+s = re.sub(r'(^\s+)inout IOA2,', r'\1`INOUT_AO IOA2,', s, flags=re.M)
+s = re.sub(r'(^\s+)inout IOA3,', r'\1`INOUT_AO IOA3,', s, flags=re.M)
+s = re.sub(r'(^\s+)CC2,', r'\1`CC2_A,', s, flags=re.M)
+s = re.sub(r'(^\s+)CC1,', r'\1`CC1_A,', s, flags=re.M)
+s = re.sub(r'(^\s+)IOA3,', r'\1`IOA3_A,', s, flags=re.M)
+s = re.sub(r'(^\s+)IOA2,', r'\1`IOA2_A,', s, flags=re.M)
+
+with open(input_file, "w") as wfile:
+    wfile.write(s)

--- a/util/topgen/templates/toplevel_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_pkg.sv.tpl
@@ -142,4 +142,21 @@ package top_${top["name"]}_pkg;
   // TODO: Enumeration for PLIC Interrupt source peripheral.
   // TODO: Enumeration for PLIC Interrupt Ids.
 
+  // MACROs for AST analog simulation support
+  `ifdef ANALOGSIM
+    `define INOUT_AI input ast_pkg::awire_t
+    `define INOUT_AO output ast_pkg::awire_t
+    `define CC1_A '0
+    `define CC2_A '0
+    `define IOA2_A '0
+    `define IOA3_A '0
+  `else
+    `define INOUT_AI inout
+    `define INOUT_AO inout
+    `define CC1_A CC1
+    `define CC2_A CC2
+    `define IOA2_A IOA2
+    `define IOA3_A IOA3
+  `endif
+
 endpackage


### PR DESCRIPTION
Adding ANALOGSIM macros in `top_earlgrey_pkg.sv` and using them at `chip_earlgrey_asic.sv`.
See issue: [top] ANALOGSIM macro-base solution #15050.

One of the key points for this Analog simulation mode is to check the protocol between the AST_ADC and the ADC_CTRL block without using forces in a full-chip 
DV to verify that protocol is OK.

PLEASE NOTE: The changes are only for DV full-chip ASIC tests support much like all 'plusargs' that was added to the AST.

@arnonsha @sha-ron @ariel9678 @meisnere 
Signed-off-by: Jacob Levy <jacob.levy@nuvoton.com>