### PR TITLE
[opentitantool] SPI port name aliases

### DIFF
--- a/sw/host/opentitanlib/src/app/config/h1dx_devboard_ultradebug.json
+++ b/sw/host/opentitanlib/src/app/config/h1dx_devboard_ultradebug.json
@@ -16,6 +16,12 @@
       "pullup": false
     }
   ],
+  "spi": [
+    {
+      "name": "BOOTSTRAP",
+      "alias_of": "0"
+    }
+  ],
   "uarts": [
     {
       "name": "console",

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
@@ -213,6 +213,16 @@
       "alias_of": "CN7_10"
     }
   ],
+  "spi": [
+    {
+      "name": "BOOTSTRAP",
+      "alias_of": "QSPI"
+    },
+    {
+      "name": "TPM",
+      "alias_of": "SPI2"
+    }
+  ],
   "uarts": [
     {
       "name": "console",

--- a/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
@@ -29,6 +29,12 @@
       "alias_of": "USB_A19"
     }
   ],
+  "spi": [
+    {
+      "name": "BOOTSTRAP",
+      "alias_of": "0"
+    }
+  ],
   "uarts": [
     {
       "name": "console",

--- a/sw/host/opentitanlib/src/app/config/opentitan_ultradebug.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_ultradebug.json
@@ -10,6 +10,12 @@
       "name": "BOOTSTRAP"
     }
   ],
+  "spi": [
+    {
+      "name": "BOOTSTRAP",
+      "alias_of": "0"
+    }
+  ],
   "uarts": [
     {
       "name": "console",

--- a/sw/host/opentitanlib/src/app/config/opentitan_verilator.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_verilator.json
@@ -22,6 +22,12 @@
       { "name": "IOC1", "alias_of": "23" }
       { "name": "IOC2", "alias_of": "24" }
   ],
+  "spi": [
+    {
+      "name": "BOOTSTRAP",
+      "alias_of": "0"
+    }
+  ],
   "uarts": [
     {
       "name": "console",

--- a/sw/host/opentitanlib/src/app/config/structs.rs
+++ b/sw/host/opentitanlib/src/app/config/structs.rs
@@ -94,5 +94,7 @@ pub struct ConfigurationFile {
     pub strappings: Vec<StrappingConfiguration>,
     /// List of UART configurations.
     #[serde(default)]
+    pub spi: Vec<SpiConfiguration>,
+    #[serde(default)]
     pub uarts: Vec<UartConfiguration>,
 }

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -239,6 +239,14 @@ impl TransportWrapper {
             self.strapping_conf_map
                 .insert(strapping_conf.name.to_uppercase(), strapping_pin_map);
         }
+        for spi_conf in file.spi {
+            if let Some(alias_of) = &spi_conf.alias_of {
+                self.spi_map
+                    .insert(spi_conf.name.to_uppercase(), alias_of.clone());
+            }
+            // TODO(#8769): Record bitrate / mode configration for later
+            // use when opening spi port.
+        }
         for uart_conf in file.uarts {
             if let Some(alias_of) = &uart_conf.alias_of {
                 self.uart_map

--- a/sw/host/opentitanlib/src/bootstrap/eeprom.rs
+++ b/sw/host/opentitanlib/src/bootstrap/eeprom.rs
@@ -44,7 +44,7 @@ impl UpdateProtocol for Eeprom {
         payload: &[u8],
         progress: &dyn Fn(u32, u32),
     ) -> Result<()> {
-        let spi = container.spi_params.create(transport)?;
+        let spi = container.spi_params.create(transport, "BOOTSTRAP")?;
         let flash = SpiFlash::from_spi(&*spi)?;
         flash.chip_erase(&*spi)?;
         flash.program_with_progress(&*spi, 0, payload, progress)?;

--- a/sw/host/opentitanlib/src/bootstrap/legacy.rs
+++ b/sw/host/opentitanlib/src/bootstrap/legacy.rs
@@ -229,7 +229,7 @@ impl UpdateProtocol for Legacy {
         payload: &[u8],
         progress: &dyn Fn(u32, u32),
     ) -> Result<()> {
-        let spi = container.spi_params.create(transport)?;
+        let spi = container.spi_params.create(transport, "BOOTSTRAP")?;
 
         let frames = Frame::from_payload(payload);
 

--- a/sw/host/opentitanlib/src/bootstrap/primitive.rs
+++ b/sw/host/opentitanlib/src/bootstrap/primitive.rs
@@ -131,7 +131,7 @@ impl UpdateProtocol for Primitive {
         payload: &[u8],
         progress: &dyn Fn(u32, u32),
     ) -> Result<()> {
-        let spi = container.spi_params.create(transport)?;
+        let spi = container.spi_params.create(transport, "BOOTSTRAP")?;
 
         let frames = Frame::from_payload(payload);
 

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -15,8 +15,8 @@ use crate::util::voltage::Voltage;
 
 #[derive(Clone, Debug, StructOpt, Serialize, Deserialize)]
 pub struct SpiParams {
-    #[structopt(long, help = "SPI instance", default_value = "0")]
-    pub bus: String,
+    #[structopt(long, help = "SPI instance")]
+    pub bus: Option<String>,
 
     #[structopt(long, help = "SPI bus speed")]
     pub speed: Option<u32>,
@@ -29,8 +29,12 @@ pub struct SpiParams {
 }
 
 impl SpiParams {
-    pub fn create(&self, transport: &TransportWrapper) -> Result<Rc<dyn Target>> {
-        let spi = transport.spi(&self.bus)?;
+    pub fn create(
+        &self,
+        transport: &TransportWrapper,
+        default_instance: &str,
+    ) -> Result<Rc<dyn Target>> {
+        let spi = transport.spi(self.bus.as_deref().unwrap_or(default_instance))?;
         if let Some(speed) = self.speed {
             spi.set_max_speed(speed)?;
         }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -160,11 +160,10 @@ impl<T: Flavor> Hyperdebug<T> {
                 }
             }
         }
-        // Eventually, the SPI aliases below should either go into configuration file, or come
-        // from the HyperDebug firmware, declaring what it supports (as is the case with UARTs.)
+        // Eventually, the SPI device names below should come from the HyperDebug firmware,
+        // declaring what it supports (as is the case with UARTs.)
         let spi_names: HashMap<String, u8> = collection! {
             "SPI2".to_string() => 0,
-            "0".to_string() => 0,
         };
         let i2c_names: HashMap<String, u8> = collection! {
             "0".to_string() => 0,

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -66,7 +66,7 @@ impl CommandDispatch for SpiSfdp {
     ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
-        let spi = context.params.create(transport)?;
+        let spi = context.params.create(transport, "BOOTSTRAP")?;
 
         if let Some(length) = self.raw {
             let mut buffer = vec![0u8; length];
@@ -109,7 +109,7 @@ impl CommandDispatch for SpiReadId {
     ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
-        let spi = context.params.create(transport)?;
+        let spi = context.params.create(transport, "BOOTSTRAP")?;
         let jedec_id = SpiFlash::read_jedec_id(&*spi, self.length)?;
         Ok(Some(Box::new(SpiReadIdResponse { jedec_id })))
     }
@@ -158,7 +158,7 @@ impl CommandDispatch for SpiRead {
     ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
-        let spi = context.params.create(transport)?;
+        let spi = context.params.create(transport, "BOOTSTRAP")?;
         let mut flash = SpiFlash::from_spi(&*spi)?;
         flash.set_address_mode_auto(&*spi)?;
 
@@ -208,7 +208,7 @@ impl CommandDispatch for SpiErase {
     ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
-        let spi = context.params.create(transport)?;
+        let spi = context.params.create(transport, "BOOTSTRAP")?;
         let mut flash = SpiFlash::from_spi(&*spi)?;
         flash.set_address_mode_auto(&*spi)?;
 
@@ -250,7 +250,7 @@ impl CommandDispatch for SpiProgram {
     ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
-        let spi = context.params.create(transport)?;
+        let spi = context.params.create(transport, "BOOTSTRAP")?;
         let mut flash = SpiFlash::from_spi(&*spi)?;
         flash.set_address_mode_auto(&*spi)?;
 


### PR DESCRIPTION
We currently have `ott bootstrap` and `ott spi ...` commands which use a SPI port to communicate with a bootlader.  In the future, there will be `ott spi tpm` subcommand to communicate with code running on OpenTitna via SPI using the TPM protocol.  For these different uses, we want to default to using different SPI ports.  (Dauntless uses the same SPI pins for both, but OpenTitan uses the dedicated QSPI lines for bootstrapping, but pinmux'ed lines for the TPM SPI communication.)

In order to support such various setups, this PR introduces SPI port alias_of, the same way as exists for UART ports.  In particular, rather than referring to spi instance "0", all the existing commands are modified to default to a SPI instance called "BOOTSTRAP", the future `ott spi tpm` command will default to a SPI instance called "TPM".

Various json configuration files will declare "BOOTSTRAP" and "TPM" to be aliases of the particular transport instances, for HyperDebug with CW310 for instance "BOOTSTRAP" will map to the new "QSPI" port, and "TPM" will map to the existing "SPI2" port.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>
Change-Id: I86b1873add01f5e935f0b5d584744844f5aad081