### PR TITLE
[dv/cov] Exclude coverage of dv-only code

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -914,6 +914,8 @@ module flash_ctrl_lcmgr
   // assertion
 
 `ifdef INC_ASSERT
+  //VCS coverage off
+  // pragma coverage off
   localparam int MaxRmaDataWidth = MaxRmaProgBurst * BusWidth;
   localparam int ShiftWidth = (MaxRmaProgBurst - 1) * BusWidth;
   logic [MaxRmaDataWidth-1:0] rma_data_q, rma_data;
@@ -922,6 +924,8 @@ module flash_ctrl_lcmgr
       rma_data_q <= rma_data;
     end
   end
+  //VCS coverage on
+  // pragma coverage on
 
   assign rma_data = {rdata_i, rma_data_q[MaxRmaDataWidth-1 -: ShiftWidth]};
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd_buf_dep.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd_buf_dep.sv
@@ -109,6 +109,8 @@ module flash_phy_rd_buf_dep import flash_phy_pkg::*;(
 
   // The total number of dependent buffers cannot never exceed the size of response queue
   `ifdef INC_ASSERT
+  //VCS coverage off
+  // pragma coverage off
   logic [31:0] assert_cnt;
   always_comb begin
     assert_cnt = '0;
@@ -116,6 +118,8 @@ module flash_phy_rd_buf_dep import flash_phy_pkg::*;(
       assert_cnt = assert_cnt + dependency_o[i];
     end
   end
+  //VCS coverage on
+  // pragma coverage on
 
   `ASSERT(DepBufferRspOrder_A, fifo_wr_i |=> assert_cnt <= RspOrderDepth)
   `endif

--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -128,6 +128,8 @@ module prim_count #(
   // Assertions //
   ////////////////
 `ifdef INC_ASSERT
+  //VCS coverage off
+  // pragma coverage off
 
   // We need to disable most assertions in that case using a helper signal.
   // We can't rely on err_o since some error patterns cannot be detected (e.g. all error
@@ -145,6 +147,8 @@ module prim_count #(
                                                   logic signed [Width+1:0] b);
     return (a < b) ? a : b;
   endfunction
+  //VCS coverage on
+  // pragma coverage on
 
   // Cnt next
   `ASSERT(CntNext_A,

--- a/hw/ip/prim/rtl/prim_edn_req.sv
+++ b/hw/ip/prim/rtl/prim_edn_req.sv
@@ -154,6 +154,9 @@ module prim_edn_req
 
   // Check EDN data is valid: Not all zeros, all ones, or not the same as previous data.
 `ifdef INC_ASSERT
+  //VCS coverage off
+  // pragma coverage off
+
   logic [OutWidth-1:0] data_prev, data_curr;
 
   always_ff @(posedge ack_o or negedge rst_ni) begin
@@ -165,6 +168,8 @@ module prim_edn_req
       data_prev <= data_curr;
     end
   end
+  //VCS coverage on
+  // pragma coverage on
 
   `ASSERT(DataOutputValid_A, ack_o |-> (data_o != 0) && (data_o != '1))
   `ASSERT(DataOutputDiffFromPrev_A, data_prev != 0 |-> data_prev != data_o)
@@ -173,6 +178,8 @@ module prim_edn_req
   // EDN Max Latency Checker
 `ifndef SYNTHESIS
   if (MaxLatency != 0) begin: g_maxlatency_assertion
+    //VCS coverage off
+    // pragma coverage off
     localparam int unsigned LatencyW = $clog2(MaxLatency+1);
     logic [LatencyW-1:0] latency_counter;
     logic reset_counter;
@@ -186,6 +193,8 @@ module prim_edn_req
 
     assign reset_counter  = ack_o;
     assign enable_counter = req_i;
+    //VCS coverage on
+    // pragma coverage on
 
     `ASSERT(MaxLatency_A, latency_counter <= MaxLatency)
 

--- a/hw/ip/prim/rtl/prim_max_tree.sv
+++ b/hw/ip/prim/rtl/prim_max_tree.sv
@@ -105,6 +105,9 @@ module prim_max_tree #(
   ////////////////
 
 `ifdef INC_ASSERT
+  //VCS coverage off
+  // pragma coverage off
+
   // Helper functions for assertions below.
   function automatic logic [Width-1:0] max_value (input logic [NumSrc-1:0][Width-1:0] values_i,
                                                   input logic [NumSrc-1:0]            valid_i);
@@ -134,6 +137,8 @@ module prim_max_tree #(
   logic [SrcWidth-1:0] max_idx_exp;
   assign max_value_exp = max_value(values_i, valid_i);
   assign max_idx_exp = max_idx(values_i, valid_i);
+  //VCS coverage on
+  // pragma coverage on
 
   // TODO(10588): Below syntax is not supported in xcelium, track xcelium cases #46591452.
   // `ASSERT(ValidInImpliesValidOut_A, |valid_i <-> max_valid_o)

--- a/hw/ip/prim/rtl/prim_sum_tree.sv
+++ b/hw/ip/prim/rtl/prim_sum_tree.sv
@@ -96,6 +96,9 @@ module prim_sum_tree #(
   ////////////////
 
 `ifdef INC_ASSERT
+  //VCS coverage off
+  // pragma coverage off
+
   // Helper functions for assertions below.
   function automatic logic [Width-1:0] sum_value (input logic [NumSrc-1:0][Width-1:0] values_i,
                                                   input logic [NumSrc-1:0]            valid_i);
@@ -110,6 +113,8 @@ module prim_sum_tree #(
 
   logic [Width-1:0] sum_value_exp;
   assign sum_value_exp = sum_value(values_i, valid_i);
+  //VCS coverage on
+  // pragma coverage on
 
   `ASSERT(ValidInImpliesValidOut_A, |valid_i === sum_valid_o)
   `ASSERT(SumComputation_A, sum_valid_o |-> sum_value_o == sum_value_exp)

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -648,6 +648,8 @@ module pwrmgr
   // EscTimeOutCnt also sets the required clock ratios between escalator and local clock
   // Ie, clk_lc cannot be so slow that the timeout count is reached
   `ifdef INC_ASSERT
+  //VCS coverage off
+  // pragma coverage off
   logic [31:0] cnt;
   always_ff @(posedge clk_i or negedge clk_lc_i or negedge rst_ni) begin
     if (!rst_ni || !clk_lc_i) begin
@@ -656,6 +658,8 @@ module pwrmgr
       cnt <= cnt + 1'b1;
     end
   end
+  //VCS coverage on
+  // pragma coverage on
 
   `ASSERT(ClkRatio_A, cnt < EscTimeOutCnt)
 

--- a/hw/ip/tlul/rtl/tlul_adapter_host.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_host.sv
@@ -154,6 +154,8 @@ module tlul_adapter_host
                                 tl_i.d_user};
 
 `ifdef INC_ASSERT
+  //VCS coverage off
+  // pragma coverage off
   localparam int OutstandingReqCntW =
     (MAX_REQS == 2 ** $clog2(MAX_REQS)) ? $clog2(MAX_REQS) + 1 : $clog2(MAX_REQS);
 
@@ -177,6 +179,8 @@ module tlul_adapter_host
       outstanding_reqs_q <= outstanding_reqs_d;
     end
   end
+  //VCS coverage on
+  // pragma coverage on
 
   `ASSERT(DontExceeedMaxReqs, req_i |-> outstanding_reqs_d <= MAX_REQS)
 `endif


### PR DESCRIPTION
There is a number of places in the RTL where some code is created exclusively to support SVA, and the code is not synthesized. This code needs to be marked to avoid coverage collection so we don't try to increase its coverage.
This PR handles code under `ifdef INC_ASSERT.

Partially addresses #15423

Signed-off-by: Guillermo Maturana <maturana@google.com>