### PR TITLE
[chiplevel test] Add a basic GPIO test

### DIFF
--- a/hw/dv/dpi/gpiodpi/gpiodpi.c
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.c
@@ -213,8 +213,9 @@ uint32_t gpiodpi_host_to_device_tick(void *ctx_void, svBitVecVal *gpio_oe,
   assert(ctx);
 
   if (ctx->counter % TICKS_PER_SYSCALL == 0) {
-    char gpio_str[32 + 2];
-    ssize_t read_len = read(ctx->host_to_dev_fifo, gpio_str, 32 + 1);
+    char gpio_str[256];
+    ssize_t read_len =
+        read(ctx->host_to_dev_fifo, gpio_str, sizeof(gpio_str) - 1);
     if (read_len > 0) {
       gpio_str[read_len] = '\0';
 
@@ -222,8 +223,6 @@ uint32_t gpiodpi_host_to_device_tick(void *ctx_void, svBitVecVal *gpio_oe,
       char *gpio_text = gpio_str;
       for (; *gpio_text != '\0'; ++gpio_text) {
         switch (*gpio_text) {
-          case '\n':
-          case '\r':
           case '\0':
             goto parse_loop_end;
           case 'w':

--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -134,6 +134,7 @@ RUST_TARGETS = [
     "//sw/host/opentitanlib:opentitanlib_test",
     "//sw/host/opentitansession:opentitansession",
     "//sw/host/opentitantool:opentitantool",
+    "//sw/host/tests/chip/gpio:gpio",
     "//sw/host/tests/rom/e2e_bootstrap_disabled:e2e_bootstrap_disabled",
     "//sw/host/tests/rom/e2e_bootstrap_entry:e2e_bootstrap_entry",
     "//sw/host/tests/rom/e2e_chip_specific_startup:e2e_chip_specific_startup",

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -215,6 +215,7 @@ cc_library(
         ":check",
         ":coverage",
         ":freertos_port",
+        ":ottf_flow_control",
         ":ottf_start",
         ":ottf_test_config",
         ":status",
@@ -258,7 +259,6 @@ dual_cc_library(
         device = [
             ":check",
             ":ottf_start",
-            ":ottf_main",
             "//sw/device/lib/base:mmio",
             "//sw/device/lib/dif:rv_plic",
             "//sw/device/lib/runtime:ibex",

--- a/sw/device/lib/testing/test_framework/ottf_flow_control.c
+++ b/sw/device/lib/testing/test_framework/ottf_flow_control.c
@@ -15,9 +15,12 @@
 #include "sw/device/lib/runtime/irq.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_isrs.h"
-#include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// We declare this `extern` here to avoid a circular dependency with
+// `ottf_main.h`.
+extern dif_uart_t *ottf_console(void);
 
 #define FLOW_CONTROL_LOW_WATERMARK 4
 #define FLOW_CONTROL_HIGH_WATERMARK 8

--- a/sw/device/lib/testing/test_framework/ottf_flow_control_functest.c
+++ b/sw/device/lib/testing/test_framework/ottf_flow_control_functest.c
@@ -15,7 +15,7 @@
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"
 
-OTTF_DEFINE_TEST_CONFIG();
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
 status_t ottf_flow_control_test(ujson_t *uj) {
   // Adjust the delay in the wait loop so that the host test harness
@@ -52,8 +52,6 @@ status_t ottf_flow_control_test(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  // Enable UART flow control.
-  ottf_flow_control_enable();
   ujson_t uj = ujson_ottf_console();
   status_t status = ottf_flow_control_test(&uj);
   return status_ok(status);

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -22,6 +22,7 @@
 #include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/coverage.h"
+#include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 
@@ -123,6 +124,9 @@ void _ottf_main(void) {
   // Initialize the UART to enable logging for non-DV simulation platforms.
   if (kDeviceType != kDeviceSimDV) {
     init_uart();
+    if (kOttfTestConfig.enable_uart_flow_control) {
+      ottf_flow_control_enable();
+    }
     LOG_INFO("Running %s", kOttfTestConfig.file);
   }
 

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -33,6 +33,14 @@ typedef struct ottf_test_config {
   bool enable_concurrency;
 
   /**
+   * Indicates that this test will utilize the UART to receive commands from
+   * a test harness and that the UART should enable software flow control.
+   * Note that requesting flow control will unmask the external interrupt and
+   * enable interrupt handling before `test_main` begins.
+   */
+  bool enable_uart_flow_control;
+
+  /**
    * Indicates that `test_main()` does something non-trivial to the UART
    * device. Setting this to true will make `test_main()` guard against this
    * by resetting the UART device before printing debug information.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1075,6 +1075,28 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "gpio_pinmux_test",
+    srcs = ["gpio_pinmux_test.c"],
+    targets = [
+        "verilator",
+    ],
+    test_harness = "//sw/host/tests/chip/gpio",
+    verilator = verilator_params(
+        timeout = "eternal",
+        test_cmds = [],
+    ),
+    deps = [
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/testing/json:command",
+        "//sw/device/lib/testing/json:gpio",
+        "//sw/device/lib/testing/json:pinmux_config",
+        "//sw/device/lib/testing/test_framework:ottf_flow_control",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "hmac_enc_test",
     srcs = ["hmac_enc_test.c"],
     deps = [

--- a/sw/device/tests/gpio_pinmux_test.c
+++ b/sw/device/tests/gpio_pinmux_test.c
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/json/gpio.h"
+#include "sw/device/lib/testing/json/pinmux_config.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+static dif_gpio_t gpio;
+static dif_pinmux_t pinmux;
+
+status_t command_processor(ujson_t *uj) {
+  while (true) {
+    test_command_t command;
+    TRY(ujson_deserialize_test_command_t(uj, &command));
+    switch (command) {
+      case kTestCommandGpioSet:
+        RESP_ERR(uj, gpio_set(uj, &gpio));
+        break;
+      case kTestCommandGpioGet:
+        RESP_ERR(uj, gpio_get(uj, &gpio));
+        break;
+      case kTestCommandPinmuxConfig:
+        RESP_ERR(uj, pinmux_config(uj, &pinmux));
+        break;
+      default:
+        LOG_ERROR("Unrecognized command: %d", command);
+        RESP_ERR(uj, INVALID_ARGUMENT());
+    }
+  }
+  // We should never reach here.
+  return INTERNAL();
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(
+      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
+  ujson_t uj = ujson_ottf_console();
+
+  status_t s = command_processor(&uj);
+  LOG_INFO("status = %r", s);
+  return status_ok(s);
+}

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -13,6 +13,18 @@ ujson_rust(
     defines = ["opentitanlib=crate"],
 )
 
+ujson_rust(
+    name = "gpio",
+    srcs = ["//sw/device/lib/testing/json:gpio"],
+    defines = ["opentitanlib=crate"],
+)
+
+ujson_rust(
+    name = "pinmux_config",
+    srcs = ["//sw/device/lib/testing/json:pinmux_config"],
+    defines = ["opentitanlib=crate"],
+)
+
 filegroup(
     name = "config",
     srcs = glob(["src/app/config/*.json"]),
@@ -72,6 +84,7 @@ rust_library(
         "src/test_utils/bootstrap.rs",
         "src/test_utils/e2e_command.rs",
         "src/test_utils/epmp.rs",
+        "src/test_utils/gpio.rs",
         "src/test_utils/init.rs",
         "src/test_utils/load_bitstream.rs",
         "src/test_utils/mod.rs",
@@ -131,11 +144,14 @@ rust_library(
         "//sw/device:is_english_breakfast": [],
         "//conditions:default": [
             "src/chip/earlgrey.rs",
+            "src/test_utils/pinmux_config.rs",
         ],
     }),
     compile_data = [
         ":config",
+        ":gpio",
         ":e2e_command",
+        ":pinmux_config",
     ],
     crate_features = select({
         "//sw/device:is_english_breakfast": ["english_breakfast"],
@@ -146,6 +162,8 @@ rust_library(
     ],
     rustc_env = {
         "e2e_command": "$(location :e2e_command)",
+        "gpio": "$(location :gpio)",
+        "pinmux_config": "$(location :pinmux_config)",
     },
     deps = [
         "//sw/host/opentitanlib/bindgen",
@@ -195,6 +213,8 @@ rust_test(
     name = "opentitanlib_test",
     compile_data = [
         ":e2e_command",
+        ":gpio",
+        ":pinmux_config",
         "src/bootstrap/simple.bin",
         "src/spiflash/SFDP_MX66L1G.bin",
     ],
@@ -212,5 +232,7 @@ rust_test(
     ],
     rustc_env = {
         "e2e_command": "$(location :e2e_command)",
+        "gpio": "$(location :gpio)",
+        "pinmux_config": "$(location :pinmux_config)",
     },
 )

--- a/sw/host/opentitanlib/src/chip/earlgrey.rs
+++ b/sw/host/opentitanlib/src/chip/earlgrey.rs
@@ -5,7 +5,7 @@
 use crate::with_unknown;
 
 with_unknown! {
-    pub enum PinmuxPeripheralIn: u32 {
+    pub enum PinmuxPeripheralIn: u32 [default = Self::End] {
         GpioGpio0 = bindgen::earlgrey::top_earlgrey_pinmux_peripheral_in_kTopEarlgreyPinmuxPeripheralInGpioGpio0,
         GpioGpio1 = bindgen::earlgrey::top_earlgrey_pinmux_peripheral_in_kTopEarlgreyPinmuxPeripheralInGpioGpio1,
         GpioGpio2 = bindgen::earlgrey::top_earlgrey_pinmux_peripheral_in_kTopEarlgreyPinmuxPeripheralInGpioGpio2,
@@ -66,7 +66,7 @@ with_unknown! {
         End = bindgen::earlgrey::top_earlgrey_pinmux_peripheral_in_kTopEarlgreyPinmuxPeripheralInLast + 1,
     }
 
-    pub enum PinmuxInsel: u32 {
+    pub enum PinmuxInsel: u32 [default = Self::End] {
         ConstantZero = bindgen::earlgrey::top_earlgrey_pinmux_insel_kTopEarlgreyPinmuxInselConstantZero,
         ConstantOne = bindgen::earlgrey::top_earlgrey_pinmux_insel_kTopEarlgreyPinmuxInselConstantOne,
         Ioa0 = bindgen::earlgrey::top_earlgrey_pinmux_insel_kTopEarlgreyPinmuxInselIoa0,
@@ -119,7 +119,7 @@ with_unknown! {
         End = bindgen::earlgrey::top_earlgrey_pinmux_insel_kTopEarlgreyPinmuxInselLast + 1,
     }
 
-    pub enum PinmuxMioOut: u32 {
+    pub enum PinmuxMioOut: u32 [default = Self::End] {
         Ioa0 = bindgen::earlgrey::top_earlgrey_pinmux_mio_out_kTopEarlgreyPinmuxMioOutIoa0,
         Ioa1 = bindgen::earlgrey::top_earlgrey_pinmux_mio_out_kTopEarlgreyPinmuxMioOutIoa1,
         Ioa2 = bindgen::earlgrey::top_earlgrey_pinmux_mio_out_kTopEarlgreyPinmuxMioOutIoa2,
@@ -170,7 +170,7 @@ with_unknown! {
         End = bindgen::earlgrey::top_earlgrey_pinmux_mio_out_kTopEarlgreyPinmuxMioOutLast + 1,
     }
 
-    pub enum PinmuxOutsel: u32 {
+    pub enum PinmuxOutsel: u32 [default = Self::End] {
         ConstantZero = bindgen::earlgrey::top_earlgrey_pinmux_outsel_kTopEarlgreyPinmuxOutselConstantZero,
         ConstantOne = bindgen::earlgrey::top_earlgrey_pinmux_outsel_kTopEarlgreyPinmuxOutselConstantOne,
         ConstantHighZ = bindgen::earlgrey::top_earlgrey_pinmux_outsel_kTopEarlgreyPinmuxOutselConstantHighZ,
@@ -252,7 +252,7 @@ with_unknown! {
         End = bindgen::earlgrey::top_earlgrey_pinmux_outsel_kTopEarlgreyPinmuxOutselLast + 1,
     }
 
-    pub enum DirectPads: u32 {
+    pub enum DirectPads: u32 [default = Self::End] {
         UsbdevUsbDp = bindgen::earlgrey::top_earlgrey_direct_pads_kTopEarlgreyDirectPadsUsbdevUsbDp,
         UsbdevUsbDn = bindgen::earlgrey::top_earlgrey_direct_pads_kTopEarlgreyDirectPadsUsbdevUsbDn,
         SpiHost0Sd0 = bindgen::earlgrey::top_earlgrey_direct_pads_kTopEarlgreyDirectPadsSpiHost0Sd0,
@@ -272,7 +272,7 @@ with_unknown! {
         End = bindgen::earlgrey::top_earlgrey_direct_pads_kTopEarlgreyDirectPadsLast + 1,
     }
 
-    pub enum MuxedPads: u32 {
+    pub enum MuxedPads: u32 [default = Self::End] {
         Ioa0 = bindgen::earlgrey::top_earlgrey_muxed_pads_kTopEarlgreyMuxedPadsIoa0,
         Ioa1 = bindgen::earlgrey::top_earlgrey_muxed_pads_kTopEarlgreyMuxedPadsIoa1,
         Ioa2 = bindgen::earlgrey::top_earlgrey_muxed_pads_kTopEarlgreyMuxedPadsIoa2,
@@ -322,4 +322,15 @@ with_unknown! {
         Ior13 = bindgen::earlgrey::top_earlgrey_muxed_pads_kTopEarlgreyMuxedPadsIor13,
         End = bindgen::earlgrey::top_earlgrey_muxed_pads_kTopEarlgreyMuxedPadsLast + 1,
     }
+}
+
+#[allow(non_camel_case_types)]
+pub mod ujson_alias {
+    use super::*;
+    // Create aliases for the C names of these types so that the ujson
+    // created structs can access these structures by their C names.
+    pub type pinmux_peripheral_in_t = PinmuxPeripheralIn;
+    pub type pinmux_insel_t = PinmuxInsel;
+    pub type pinmux_mio_out_t = PinmuxMioOut;
+    pub type pinmux_outsel_t = PinmuxOutsel;
 }

--- a/sw/host/opentitanlib/src/test_utils/gpio.rs
+++ b/sw/host/opentitanlib/src/test_utils/gpio.rs
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::time::Duration;
+
+use crate::io::uart::Uart;
+use crate::test_utils::e2e_command::TestCommand;
+use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::status::Status;
+
+// Bring in the auto-generated sources.
+include!(env!("gpio"));
+
+impl GpioSet {
+    fn execute(&self, uart: &dyn Uart) -> Result<()> {
+        TestCommand::GpioSet.send(uart)?;
+        self.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+
+    pub fn write(uart: &dyn Uart, pin: u32, state: bool) -> Result<()> {
+        let payload = GpioSet {
+            action: GpioAction::Write,
+            pin_mask: pin,
+            state: state.into(),
+        };
+        payload.execute(uart)
+    }
+    pub fn set_enabled(uart: &dyn Uart, pin: u32, state: bool) -> Result<()> {
+        let payload = GpioSet {
+            action: GpioAction::SetEnabled,
+            pin_mask: pin,
+            state: state.into(),
+        };
+        payload.execute(uart)
+    }
+
+    pub fn write_all(uart: &dyn Uart, state: u32) -> Result<()> {
+        let payload = GpioSet {
+            action: GpioAction::WriteAll,
+            pin_mask: 0,
+            state,
+        };
+        payload.execute(uart)
+    }
+    pub fn set_enabled_all(uart: &dyn Uart, state: u32) -> Result<()> {
+        let payload = GpioSet {
+            action: GpioAction::SetEnabledAll,
+            pin_mask: 0,
+            state,
+        };
+        payload.execute(uart)
+    }
+
+    pub fn write_masked(uart: &dyn Uart, mask: u32, state: u32) -> Result<()> {
+        let payload = GpioSet {
+            action: GpioAction::WriteMasked,
+            pin_mask: mask,
+            state,
+        };
+        payload.execute(uart)
+    }
+    pub fn set_enabled_masked(uart: &dyn Uart, mask: u32, state: u32) -> Result<()> {
+        let payload = GpioSet {
+            action: GpioAction::SetEnabledMasked,
+            pin_mask: mask,
+            state,
+        };
+        payload.execute(uart)
+    }
+    pub fn set_input_noise_filter(uart: &dyn Uart, mask: u32, state: u32) -> Result<()> {
+        let payload = GpioSet {
+            action: GpioAction::SetInputNoiseFilter,
+            pin_mask: mask,
+            state,
+        };
+        payload.execute(uart)
+    }
+}
+
+impl GpioGet {
+    pub fn read_all(uart: &dyn Uart) -> Result<u32> {
+        TestCommand::GpioGet.send(uart)?;
+        let data = GpioGet::recv(uart, Duration::from_secs(300), false)?;
+        Ok(data.state)
+    }
+}

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -5,8 +5,14 @@
 pub mod bootstrap;
 pub mod e2e_command;
 pub mod epmp;
+pub mod gpio;
 pub mod init;
 pub mod load_bitstream;
+// The "english breakfast" variant of the chip doesn't have the same
+// set of IO and pinmux constants as the "earlgrey" chip.
+#[cfg(not(feature = "english_breakfast"))]
+pub mod pinmux_config;
+
 pub mod rpc;
 pub mod status;
 

--- a/sw/host/opentitanlib/src/test_utils/pinmux_config.rs
+++ b/sw/host/opentitanlib/src/test_utils/pinmux_config.rs
@@ -1,0 +1,80 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::chip::earlgrey::{PinmuxInsel, PinmuxMioOut, PinmuxOutsel, PinmuxPeripheralIn};
+use crate::io::uart::Uart;
+use crate::test_utils::e2e_command::TestCommand;
+use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::status::Status;
+
+// Bring in the auto-generated sources.
+use crate::chip::earlgrey::ujson_alias::*;
+include!(env!("pinmux_config"));
+
+impl Default for PinmuxConfig {
+    fn default() -> Self {
+        Self {
+            input: PinmuxInputSelection {
+                peripheral: Default::default(),
+                selector: Default::default(),
+            },
+            output: PinmuxOutputSelection {
+                mio: Default::default(),
+                selector: Default::default(),
+            },
+        }
+    }
+}
+
+impl PinmuxConfig {
+    pub fn configure(
+        uart: &dyn Uart,
+        inputs: Option<&HashMap<PinmuxPeripheralIn, PinmuxInsel>>,
+        outputs: Option<&HashMap<PinmuxMioOut, PinmuxOutsel>>,
+    ) -> Result<()> {
+        // The PinmuxConfig struct can carry a limited number of input
+        // and output configurations.  We'll take the whole config and
+        // chunk it into as many PinmuxConfig commands as necessary.
+
+        let len = std::cmp::max(
+            inputs.map(|h| h.len()).unwrap_or(0),
+            outputs.map(|h| h.len()).unwrap_or(0),
+        );
+
+        let df_ik = PinmuxPeripheralIn::default();
+        let df_iv = PinmuxInsel::default();
+        let df_ok = PinmuxMioOut::default();
+        let df_ov = PinmuxOutsel::default();
+
+        let mut inputs = inputs.map(|h| h.iter());
+        let mut outputs = outputs.map(|h| h.iter());
+        let mut i = 0;
+        while i < len {
+            let mut config = Self::default();
+            for j in 0..config.input.peripheral.len() {
+                let (ik, iv) = inputs
+                    .as_mut()
+                    .and_then(|i| i.next())
+                    .unwrap_or((&df_ik, &df_iv));
+                let (ok, ov) = outputs
+                    .as_mut()
+                    .and_then(|i| i.next())
+                    .unwrap_or((&df_ok, &df_ov));
+                config.input.peripheral[j] = *ik;
+                config.input.selector[j] = *iv;
+                config.output.mio[j] = *ok;
+                config.output.selector[j] = *ov;
+                i += 1;
+            }
+            TestCommand::PinmuxConfig.send(uart)?;
+            config.send(uart)?;
+            Status::recv(uart, Duration::from_secs(300), false)?;
+        }
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/test_utils/rpc.rs
+++ b/sw/host/opentitanlib/src/test_utils/rpc.rs
@@ -19,6 +19,7 @@ pub trait UartSend {
 impl<T: Serialize> UartSend for T {
     fn send(&self, uart: &dyn Uart) -> Result<()> {
         let s = serde_json::to_string(self)?;
+        log::info!("Sending: {}", s);
         uart.write(s.as_bytes())?;
         Ok(())
     }

--- a/sw/host/tests/chip/gpio/BUILD
+++ b/sw/host/tests/chip/gpio/BUILD
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "gpio",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:humantime",
+        "//third_party/rust/crates:lazy_static",
+        "//third_party/rust/crates:log",
+        "//third_party/rust/crates:serde_json",
+        "//third_party/rust/crates:structopt",
+    ],
+)

--- a/sw/host/tests/chip/gpio/src/main.rs
+++ b/sw/host/tests/chip/gpio/src/main.rs
@@ -1,0 +1,218 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use std::time::Duration;
+use structopt::StructOpt;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::gpio::PinMode;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::gpio::{GpioGet, GpioSet};
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::pinmux_config::PinmuxConfig;
+use opentitanlib::uart::console::UartConsole;
+use opentitanlib::{collection, execute_test};
+
+use opentitanlib::chip::earlgrey::{PinmuxInsel, PinmuxMioOut, PinmuxOutsel, PinmuxPeripheralIn};
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+
+    #[structopt(
+        long, parse(try_from_str=humantime::parse_duration),
+        default_value = "600s",
+        help = "Console receive timeout",
+    )]
+    timeout: Duration,
+}
+
+struct Config {
+    input: HashMap<PinmuxPeripheralIn, PinmuxInsel>,
+    output: HashMap<PinmuxMioOut, PinmuxOutsel>,
+}
+
+lazy_static! {
+static ref VERILATOR: Config = Config {
+    input: collection! {
+        PinmuxPeripheralIn::GpioGpio0 => PinmuxInsel::Iob6,
+        PinmuxPeripheralIn::GpioGpio1 => PinmuxInsel::Iob7,
+        PinmuxPeripheralIn::GpioGpio2 => PinmuxInsel::Iob8,
+        PinmuxPeripheralIn::GpioGpio3 => PinmuxInsel::Iob9,
+        PinmuxPeripheralIn::GpioGpio4 => PinmuxInsel::Iob10,
+        PinmuxPeripheralIn::GpioGpio5 => PinmuxInsel::Iob11,
+        PinmuxPeripheralIn::GpioGpio6 => PinmuxInsel::Iob12,
+        PinmuxPeripheralIn::GpioGpio7 => PinmuxInsel::Ior5,
+        PinmuxPeripheralIn::GpioGpio8 => PinmuxInsel::Ior6,
+        PinmuxPeripheralIn::GpioGpio9 => PinmuxInsel::Ior7,
+        // IOR8-9 aren't MIOs.
+        PinmuxPeripheralIn::GpioGpio10 => PinmuxInsel::Ior10,
+        PinmuxPeripheralIn::GpioGpio11 => PinmuxInsel::Ior11,
+        PinmuxPeripheralIn::GpioGpio12 => PinmuxInsel::Ior12,
+        PinmuxPeripheralIn::GpioGpio13 => PinmuxInsel::Ior13,
+    },
+    output: collection! {
+        PinmuxMioOut::Iob6 => PinmuxOutsel::GpioGpio0,
+        PinmuxMioOut::Iob7 => PinmuxOutsel::GpioGpio1,
+        PinmuxMioOut::Iob8 => PinmuxOutsel::GpioGpio2,
+        PinmuxMioOut::Iob9 => PinmuxOutsel::GpioGpio3,
+        PinmuxMioOut::Iob10 => PinmuxOutsel::GpioGpio4,
+        PinmuxMioOut::Iob11 => PinmuxOutsel::GpioGpio5,
+        PinmuxMioOut::Iob12 => PinmuxOutsel::GpioGpio6,
+        PinmuxMioOut::Ior5 => PinmuxOutsel::GpioGpio7,
+        PinmuxMioOut::Ior6 => PinmuxOutsel::GpioGpio8,
+        PinmuxMioOut::Ior7 => PinmuxOutsel::GpioGpio9,
+        // IOR8-9 aren't MIOs.
+        PinmuxMioOut::Ior10 => PinmuxOutsel::GpioGpio10,
+        PinmuxMioOut::Ior11 => PinmuxOutsel::GpioGpio11,
+        PinmuxMioOut::Ior12 => PinmuxOutsel::GpioGpio12,
+        PinmuxMioOut::Ior13 => PinmuxOutsel::GpioGpio13,
+    },
+};
+}
+
+fn write_all_verify(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    value: u32,
+    config: &HashMap<PinmuxMioOut, PinmuxOutsel>,
+) -> Result<()> {
+    let mask = config.values().fold(0, |acc, v| {
+        let i = u32::from(*v) - u32::from(PinmuxOutsel::GpioGpio0);
+        acc | 1u32 << i
+    });
+    let masked_value = value & mask;
+    log::info!(
+        "write & verify pattern: {:08x} & {:08x} -> {:08x}",
+        value,
+        mask,
+        masked_value
+    );
+    if masked_value == 0 {
+        log::info!(
+            "skipping: {:08x} has no bits in common with the pinmux configuration",
+            value
+        );
+    } else {
+        GpioSet::write_all(uart, masked_value)?;
+        let mut result = 0u32;
+        for (k, v) in config.iter() {
+            let n = u32::from(transport.gpio_pin(&k.to_string())?.read()?);
+            let i = u32::from(*v) - u32::from(PinmuxOutsel::GpioGpio0);
+            result |= n << i;
+        }
+        log::info!("result = {:08x}", result);
+        assert_eq!(masked_value, result);
+    }
+    Ok(())
+}
+
+fn read_all_verify(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    value: u32,
+    config: &HashMap<PinmuxPeripheralIn, PinmuxInsel>,
+) -> Result<()> {
+    let mask = config.keys().fold(0, |acc, k| {
+        let i = u32::from(*k) - u32::from(PinmuxPeripheralIn::GpioGpio0);
+        acc | 1u32 << i
+    });
+    let masked_value = value & mask;
+    log::info!(
+        "read & verify pattern: {:08x} & {:08x} -> {:08x}",
+        value,
+        mask,
+        masked_value
+    );
+    if masked_value == 0 {
+        log::info!(
+            "skipping: {:08x} has no bits in common with the pinmux configuration",
+            value
+        );
+    } else {
+        for (k, v) in config.iter() {
+            let i = u32::from(*k) - u32::from(PinmuxPeripheralIn::GpioGpio0);
+            transport
+                .gpio_pin(&v.to_string())?
+                .write((masked_value >> i) & 1 != 0)?;
+        }
+        let result = GpioGet::read_all(uart)? & mask;
+        log::info!("result = {:08x}", result);
+        assert_eq!(masked_value, result);
+    }
+    Ok(())
+}
+
+fn test_gpio_outputs(_opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    // TODO(cfrantz): Enhance this test to have pinmux configurations for other
+    // platforms, such as cw310+hyperdebug.
+    let config = &VERILATOR;
+    log::info!("Configuring pinmux");
+    PinmuxConfig::configure(&*uart, None, Some(&config.output))?;
+
+    log::info!("Configuring debugger GPIOs as inputs");
+    // The outputs (with respect to pinmux config) correspond to the input pins on the debug board.
+    for pin in config.output.keys() {
+        transport
+            .gpio_pin(&pin.to_string())?
+            .set_mode(PinMode::Input)?;
+    }
+
+    log::info!("Enabling outputs on the DUT");
+    GpioSet::set_enabled_all(&*uart, 0xFFFFFFFF)?;
+    write_all_verify(transport, &*uart, 0x5555_5555, &config.output)?;
+    write_all_verify(transport, &*uart, 0xAAAA_AAAA, &config.output)?;
+
+    for i in 0..32 {
+        write_all_verify(transport, &*uart, 1 << i, &config.output)?;
+    }
+    Ok(())
+}
+
+fn test_gpio_inputs(_opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    // TODO(cfrantz): Enhance this test to have pinmux configurations for other
+    // platforms, such as cw310+hyperdebug.
+    let config = &VERILATOR;
+    log::info!("Configuring pinmux");
+    PinmuxConfig::configure(&*uart, Some(&config.input), None)?;
+
+    log::info!("Configuring debugger GPIOs as outputs");
+    // The inputs (with respect to pinmux config) correspond to the output pins on the debug board.
+    for pin in config.input.values() {
+        transport
+            .gpio_pin(&pin.to_string())?
+            .set_mode(PinMode::PushPull)?;
+    }
+
+    log::info!("Disabling outputs on the DUT");
+    GpioSet::set_enabled_all(&*uart, 0x0)?;
+
+    read_all_verify(transport, &*uart, 0x5555_5555, &config.input)?;
+    read_all_verify(transport, &*uart, 0xAAAA_AAAA, &config.input)?;
+
+    for i in 0..32 {
+        read_all_verify(transport, &*uart, 1 << i, &config.input)?;
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    execute_test!(test_gpio_outputs, &opts, &transport);
+    execute_test!(test_gpio_inputs, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This test programs a pinmux configuration and then tests all GPIO inputs
and outputs.

1. Add flow control as an OTTF test configuration.
2. Increase the size of the gpio pipe read buffer to prevent splitting a gpio request across two reads.
3. Enhance `with_unknown!` to implement `Default`.
4. Add a basic GPIO test.

Meta:  Where should this test go?  I've located the C code at `sw/device/tests` and the rust-based test harness at `sw/host/tests/chip/...`.

As-is, this test runs only on verilator.  I plan to send follow-up PRs which add support for the CW310 board.

Signed-off-by: Chris Frantz <cfrantz@google.com>