### PR TITLE
[test] Fix testplan for rom_e2e_default_otp_bootup test

### DIFF
--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -29,9 +29,9 @@
                 - LIFE_CYCLE count value set to 1
             - Ensure that the ROM can boot.
             '''
-      tags: ["rom", "verilator", "dv", "fpga", "silicon"]
+      tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
-      tests: ["rom_e2e_default_otp_smoke"]
+      tests: []
     }
 
     {


### PR DESCRIPTION
Fix a bad entry in `rom_e2e_testplan.hjson` for the `rom_e2e_default_otp_bootup` test.

Addresses the comments [here](https://github.com/lowRISC/opentitan/pull/16621/files#r1041486858).

Signed-off-by: Miles Dai <milesdai@google.com>