### PR TITLE
[dv/lc_ctrl] Support clk_byp_check 

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -143,6 +143,7 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0] status_val;
     uvm_reg_data_t val;
     csr_wr(ral.claim_transition_if, CLAIM_TRANS_VAL);
+    if ($urandom_range(0, 1)) csr_wr(ral.transition_ctrl, $urandom_range(0, 1));
     csr_wr(ral.transition_target, {DecLcStateNumRep{next_lc_state[DecLcStateWidth-1:0]}});
     foreach (ral.transition_token[i]) begin
       csr_wr(ral.transition_token[i], token_val[TL_DW-1:0]);

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -90,6 +90,9 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
         sw_transition_req(next_lc_state, token_val);
         cfg.set_test_phase(LcCtrlTransitionComplete);
       end else begin
+        // Test items that do not need a LC transition
+        csr_wr(ral.claim_transition_if, CLAIM_TRANS_VAL);
+        csr_wr(ral.transition_ctrl, $urandom_range(0, 1));
         cfg.set_test_phase(LcCtrlBadNextState);
         // wait at least two clks for scb to finish checking lc outputs
         cfg.clk_rst_vif.wait_clks($urandom_range(2, 10));


### PR DESCRIPTION
According to issue #16529, this PR drives ext_clock_en csr before lc transition.
This PR also drives this register without an actual lc transition.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>