### PR TITLE
[sysrst_ctrl] Fix sysrst_ctrl_in_irq test

### DIFF
--- a/sw/device/lib/dif/dif_sysrst_ctrl.c
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.c
@@ -80,8 +80,7 @@ dif_result_t dif_sysrst_ctrl_key_combo_detect_configure(
 dif_result_t dif_sysrst_ctrl_input_change_detect_configure(
     const dif_sysrst_ctrl_t *sysrst_ctrl,
     dif_sysrst_ctrl_input_change_config_t config) {
-  if (sysrst_ctrl == NULL || config.input_changes & (1U << 7) ||
-      config.input_changes > kDifSysrstCtrlInputAll) {
+  if (sysrst_ctrl == NULL || config.input_changes > kDifSysrstCtrlInputAll) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/dif_sysrst_ctrl.h
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.h
@@ -170,35 +170,35 @@ typedef enum dif_sysrst_ctrl_input_change {
   /**
    * Power button input signal low-to-high.
    */
-  kDifSysrstCtrlInputPowerButtonL2H = 1U << 8,
+  kDifSysrstCtrlInputPowerButtonL2H = 1U << 7,
   /**
    * Key 0 input signal low-to-high.
    */
-  kDifSysrstCtrlInputKey0L2H = 1U << 9,
+  kDifSysrstCtrlInputKey0L2H = 1U << 8,
   /**
    * Key 1 input signal low-to-high.
    */
-  kDifSysrstCtrlInputKey1L2H = 1U << 10,
+  kDifSysrstCtrlInputKey1L2H = 1U << 9,
   /**
    * Key 2 input signal low-to-high.
    */
-  kDifSysrstCtrlInputKey2L2H = 1U << 11,
+  kDifSysrstCtrlInputKey2L2H = 1U << 10,
   /**
    * AC power present input signal low-to-high.
    */
-  kDifSysrstCtrlInputAcPowerPresetL2H = 1U << 12,
+  kDifSysrstCtrlInputAcPowerPresetL2H = 1U << 11,
   /**
    * Embedded controller reset input signal low-to-high.
    */
-  kDifSysrstCtrlInputEcResetL2H = 1U << 13,
+  kDifSysrstCtrlInputEcResetL2H = 1U << 12,
   /**
    * Flash write protect input signal low-to-high.
    */
-  kDifSysrstCtrlInputFlashWriteProtectL2H = 1U << 14,
+  kDifSysrstCtrlInputFlashWriteProtectL2H = 1U << 13,
   /**
    * All input signal transitions.
    */
-  kDifSysrstCtrlInputAll = ((1U << 15) - 1) & ~(1U << 7),
+  kDifSysrstCtrlInputAll = ((1U << 14) - 1),
 } dif_sysrst_ctrl_input_change_t;
 
 /**

--- a/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
@@ -104,10 +104,7 @@ TEST_F(InputChangeDetectConfigTest, NullArgs) {
 
 TEST_F(InputChangeDetectConfigTest, BadArgs) {
   // Bad input signal changes.
-  config_.input_changes = static_cast<dif_sysrst_ctrl_input_change_t>(1U << 7);
-  EXPECT_DIF_BADARG(
-      dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl_, config_));
-  config_.input_changes = static_cast<dif_sysrst_ctrl_input_change_t>(1U << 15);
+  config_.input_changes = static_cast<dif_sysrst_ctrl_input_change_t>(1U << 14);
   EXPECT_DIF_BADARG(
       dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl_, config_));
 }

--- a/sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test.c
@@ -75,14 +75,8 @@ void sysrst_ctrl_input_change_detect(
   IBEX_SPIN_FOR(phase++ == kCurrentTestPhase, kCurrentTestPhaseTimeoutUsec);
 
   // Configure for input change.
-  dif_sysrst_ctrl_input_change_t input_change;
-  if (expected_key_intr_src >= kDifSysrstCtrlKeyIntrStatusInputPowerButtonL2H) {
-    input_change = (dif_sysrst_ctrl_input_change_t)expected_key_intr_src << 1;
-  } else {
-    input_change = (dif_sysrst_ctrl_input_change_t)expected_key_intr_src;
-  }
   dif_sysrst_ctrl_input_change_config_t config = {
-      .input_changes = input_change,
+      .input_changes = (dif_sysrst_ctrl_input_change_t)expected_key_intr_src,
       .debounce_time_threshold = 1,  // 5us
   };
   CHECK_DIF_OK(


### PR DESCRIPTION
The changes in PR #16584 broke sysrst_ctrl_in_irq test. Update sysrst_ctrl_input indexes to fix that.

Fixes #16633.

Signed-off-by: Abdullah Varici <abdullah.varici@lowrisc.org>