### PR TITLE
[bitstreams] Add manifest schema and example for the cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -397,7 +397,7 @@ jobs:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml
   - bash: |
-      ci/scripts/get-bitstream-strategy.sh "@bitstreams//:bitstream_test_rom" ':!/sw/' ':!/*testplan.hjson' ':!/site/' ':!/doc/' ':!/COMMITTERS' ':!/CLA' ':!/*.md' ':!/hw/**/dv/*'
+      ci/scripts/get-bitstream-strategy.sh "@bitstreams//:chip_earlgrey_cw310_bitstream" ':!/sw/' ':!/*testplan.hjson' ':!/site/' ':!/doc/' ':!/COMMITTERS' ':!/CLA' ':!/*.md' ':!/hw/**/dv/*'
     displayName: Configure bitstream strategy
   - bash: |
       set -ex
@@ -534,7 +534,6 @@ jobs:
         parentDir: "$BIN_DIR/hw/top_earlgrey"
         includeFiles:
           - "lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig"
-          - "lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice"
           - "rom.mmi"
           - "otp.mmi"
           - "chip_earlgrey_cw310_hyperdebug/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.bit"

--- a/ci/scripts/prepare-cached-bitstream.sh
+++ b/ci/scripts/prepare-cached-bitstream.sh
@@ -12,10 +12,9 @@ set -ex
 readonly TOPLEVEL=top_earlgrey
 readonly TOPLEVEL_BIN_DIR="${BIN_DIR}/hw/${TOPLEVEL}"
 readonly TARGETS=(
-  @bitstreams//:bitstream_test_rom
-  @bitstreams//:bitstream_rom
-  @bitstreams//:rom_mmi
-  @bitstreams//:otp_mmi
+  @bitstreams//:chip_earlgrey_cw310_bitstream
+  @bitstreams//:chip_earlgrey_cw310_rom_mmi
+  @bitstreams//:chip_earlgrey_cw310_otp_mmi
 )
 readonly BAZEL_OPTS=(
   "--define"

--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -83,7 +83,7 @@ filegroup(
     srcs = select({
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:rom_mmi"],
-        "//conditions:default": ["@bitstreams//:rom_mmi"],
+        "//conditions:default": ["@bitstreams//:chip_earlgrey_cw310_rom_mmi"],
     }),
     tags = ["manual"],
 )
@@ -94,7 +94,7 @@ filegroup(
     srcs = select({
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:otp_mmi"],
-        "//conditions:default": ["@bitstreams//:otp_mmi"],
+        "//conditions:default": ["@bitstreams//:chip_earlgrey_cw310_otp_mmi"],
     }),
     tags = ["manual"],
 )
@@ -118,7 +118,7 @@ filegroup(
 bitstream_splice(
     name = "gcp_spliced_test_rom",
     testonly = True,
-    src = "@bitstreams//:bitstream_test_rom",
+    src = "@bitstreams//:chip_earlgrey_cw310_bitstream",
     data = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem",
     meminfo = ":rom_mmi",
     tags = ["manual"],
@@ -130,7 +130,7 @@ bitstream_splice(
 bitstream_splice(
     name = "gcp_spliced_rom",
     testonly = True,
-    src = "@bitstreams//:bitstream_test_rom",
+    src = "@bitstreams//:chip_earlgrey_cw310_bitstream",
     data = "//sw/device/silicon_creator/rom:rom_with_fake_keys_fpga_cw310_scr_vmem",
     meminfo = ":rom_mmi",
     tags = ["manual"],

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -4,6 +4,7 @@
 
 # Keep sorted.
 hjson==3.1.0
+jsonschema==4.17.3; python_version >= "3.7"
 libcst==0.4.1
 mako==1.1.6
 pluralizer==1.2.0

--- a/rules/bitstreams.bzl
+++ b/rules/bitstreams.bzl
@@ -2,6 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 load("@python3//:defs.bzl", "interpreter")
+load("@ot_python_deps//:requirements.bzl", "all_requirements")
+
+def _make_pythonpath(rctx):
+    # Create a PYTHONPATH with all the pip deps from requirements.txt
+    directories = [
+        rctx.path(Label(pip_req + ":BUILD.bazel")).dirname
+        for pip_req in all_requirements
+    ]
+    pythonpath = ":".join([str(directory) for directory in directories])
+    return pythonpath
 
 def _bitstreams_repo_impl(rctx):
     # First, check if an existing pre-built bitstream cache repo exists, and if
@@ -19,6 +29,9 @@ def _bitstreams_repo_impl(rctx):
             "--cache={}".format(cache_path),
             "--refresh-time={}".format(rctx.attr.refresh_time),
         ],
+        environment = {
+            "PYTHONPATH": _make_pythonpath(rctx),
+        },
         quiet = False,
     )
     if result.return_code != 0:

--- a/rules/scripts/BUILD
+++ b/rules/scripts/BUILD
@@ -25,6 +25,9 @@ py_library(
     srcs = [
         "bitstreams_workspace.py",
     ],
+    deps = [
+        requirement("jsonschema"),
+    ],
 )
 
 py_test(

--- a/rules/scripts/bitstreams_manifest.example.json
+++ b/rules/scripts/bitstreams_manifest.example.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": 1,
+  "buildId": "abcdefg",
+  "outputFiles": {
+    "lowrisc_systems_chip_earlgrey_cw310_0.1.bit": {
+      "buildTarget": "//hw/bitstream/vivado:fpga_cw310",
+      "outputInfo": {
+        "@type": "bitstreamInfo",
+        "design": "chip_earlgrey_cw310"
+      }
+    },
+    "otp.mmi": {
+      "buildTarget": "//hw/bitstream/vivado:fpga_cw310",
+      "outputInfo": {
+        "@type": "memoryMapInfo",
+        "design": "chip_earlgrey_cw310",
+        "memoryId": "otp"
+      }
+    },
+    "rom.mmi": {
+      "buildTarget": "//hw/bitstream/vivado:fpga_cw310",
+      "outputInfo": {
+        "@type": "memoryMapInfo",
+        "design": "chip_earlgrey_cw310",
+        "memoryId": "rom"
+      }
+    },
+    "chip_earlgrey_cw310_hyperdebug/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.bit": {
+      "buildTarget": "//hw/bitstream/vivado:fpga_cw310_hyperdebug",
+      "outputInfo": {
+        "@type": "bitstreamInfo",
+        "design": "chip_earlgrey_cw310_hyperdebug"
+      }
+    },
+    "chip_earlgrey_cw310_hyperdebug/otp.mmi": {
+      "buildTarget": "//hw/bitstream/vivado:fpga_cw310_hyperdebug",
+      "outputInfo": {
+        "@type": "memoryMapInfo",
+        "design": "chip_earlgrey_cw310_hyperdebug",
+        "memoryId": "otp"
+      }
+    },
+    "chip_earlgrey_cw310_hyperdebug/rom.mmi": {
+      "buildTarget": "//hw/bitstream/vivado:fpga_cw310_hyperdebug",
+      "outputInfo": {
+        "@type": "memoryMapInfo",
+        "design": "chip_earlgrey_cw310_hyperdebug",
+        "memoryId": "rom"
+      }
+    }
+  }
+}

--- a/rules/scripts/bitstreams_manifest.schema.json
+++ b/rules/scripts/bitstreams_manifest.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/rules/scripts/bitstreams_manifest.schema.json",
+  "title": "Bitstreams Cache Manifest v1",
+  "description":
+      "A manifest of bitstreams in a cache entry, informing what is there and how to reproduce",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "description": "Version number of this manifest's schema",
+      "type": "number",
+      "minimum": 1,
+      "maximum": 1
+    },
+    "buildId": {
+      "description": "Build ID associated with this entry (typically a git hash)",
+      "type": "string"
+    },
+    "outputFiles": {
+      "description": "Map of output file paths to their metadata objects",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/outputFile" }
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "buildId",
+    "outputFiles"
+  ],
+  "$defs": {
+    "bitstreamInfo": {
+      "description": "Bitstream build output",
+      "type": "object",
+      "properties": {
+        "@type": {
+          "description": "Tag for type of this object",
+          "type": "string",
+          "const": "bitstreamInfo"
+        },
+        "design": {
+          "description": "Design name / top for the bitstream",
+          "type": "string"
+        }
+      },
+      "required": [
+        "@type",
+        "design"
+      ]
+    },
+    "memoryMapInfo": {
+      "description": "Build output that maps memories to cells in a hardware implementation",
+      "type": "object",
+      "properties": {
+        "@type": {
+          "description": "Tag for type of this object",
+          "type": "string",
+          "const": "memoryMapInfo"
+        },
+        "design": {
+          "description": "Design name / top for the bitstream",
+          "type": "string"
+        },
+        "memoryId": {
+          "description": "Name or key identifying the associated memory",
+          "type": "string"
+        }
+      },
+      "required": [
+        "@type",
+        "design",
+        "memoryId"
+      ]
+    },
+    "outputFile": {
+      "description": "Information about a build output file",
+      "type": "object",
+      "properties": {
+        "buildTarget": {
+          "description": "Build target that generated the output",
+          "type": "string"
+        },
+        "outputInfo": {
+          "oneOf": [
+            { "$ref": "#/$defs/bitstreamInfo" },
+            { "$ref": "#/$defs/memoryMapInfo" }
+          ]
+        }
+      },
+      "required": [
+        "outputInfo"
+      ]
+    }
+  }
+}

--- a/rules/scripts/bitstreams_workspace_test.py
+++ b/rules/scripts/bitstreams_workspace_test.py
@@ -42,12 +42,32 @@ class TestBitstreamCache(unittest.TestCase):
 
         self.assertEqual(
             dict(cached_files), {
-                'orig': set([os.path.join('cache', 'abcd', BITSTREAM_ORIG)]),
-                'splice': set(
-                    [os.path.join('cache', 'abcd', BITSTREAM_SPLICE)]),
-                'mmi': {
-                    os.path.join('cache', 'abcd', 'rom.mmi'),
-                    os.path.join('cache', 'abcd', 'otp.mmi'),
+                "schemaVersion": 1,
+                "buildId": "abcd",
+                "outputFiles": {
+                    BITSTREAM_ORIG: {
+                        "buildTarget": "//hw/bitstream/vivado:fpga_cw310",
+                        "outputInfo": {
+                            "@type": "bitstreamInfo",
+                            "design": "chip_earlgrey_cw310"
+                        }
+                    },
+                    "rom.mmi": {
+                        "buildTarget": "//hw/bitstream/vivado:fpga_cw310",
+                        "outputInfo": {
+                            "@type": "memoryMapInfo",
+                            "design": "chip_earlgrey_cw310",
+                            "memoryId": "rom",
+                        }
+                    },
+                    "otp.mmi": {
+                        "buildTarget": "//hw/bitstream/vivado:fpga_cw310",
+                        "outputInfo": {
+                            "@type": "memoryMapInfo",
+                            "design": "chip_earlgrey_cw310",
+                            "memoryId": "otp",
+                        }
+                    },
                 },
             })
 
@@ -87,22 +107,17 @@ package(default_visibility = ["//visibility:public"])
 exports_files(glob(["cache/**"]))
 
 filegroup(
-    name = "bitstream_test_rom",
+    name = "chip_earlgrey_cw310_bitstream",
     srcs = ["cache/abcd/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig"],
 )
 
 filegroup(
-    name = "bitstream_rom",
-    srcs = ["cache/abcd/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice"],
-)
-
-filegroup(
-    name = "otp_mmi",
+    name = "chip_earlgrey_cw310_otp_mmi",
     srcs = ["cache/abcd/otp.mmi"],
 )
 
 filegroup(
-    name = "rom_mmi",
+    name = "chip_earlgrey_cw310_rom_mmi",
     srcs = ["cache/abcd/rom.mmi"],
 )
 ''')

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -166,7 +166,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   readonly LATEST_BISTREAM_HASH_FILE="${SYSTEM_BITSTREAM_CACHE}/latest.txt"
   # The revision named in latest.txt is not necessarily on disk. Induce the
   # cache backend to fetch the latest bitstreams.
-  BITSTREAM=latest ${BAZELISK} build @bitstreams//:bitstream_test_rom
+  BITSTREAM=latest ${BAZELISK} fetch @bitstreams//...
   cp "${LATEST_BISTREAM_HASH_FILE}" \
     "${BAZEL_AIRGAPPED_DIR}/${BAZEL_BITSTREAMS_CACHE}/"
   LATEST_BISTREAM_HASH=$(cat "${LATEST_BISTREAM_HASH_FILE}")


### PR DESCRIPTION
This commit is a proposal for an MVP for the manifest's descriptors, and it assumes no spliced bitstreams will be in the cache. This merely encodes the current data we handle in the bazel rules generator, plus some information about reproducing the build.

If there is a desire to continue having spliced bitstreams in the cache, we can add more tagged data: With this round, I attempted to make only a minimal effort to handle multiple tops.

One file is a JSON schema that can validate objects, and the other is an example output. See the schema for information about each property.