### PR TITLE
[dv/alert_handler] Increase run timeout value

### DIFF
--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -120,7 +120,9 @@
     }
 
     {
-      name: alert_handler_stress_all_with_rand_reset
+      name: alert_handler_shadow_reg_errors_with_csr_rw
+      run_opts: ["+test_timeout_ns=500_000_000"]
+      run_timeout_mins: 120
     }
   ]
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -120,7 +120,9 @@
     }
 
     {
-      name: alert_handler_stress_all_with_rand_reset
+      name: alert_handler_shadow_reg_errors_with_csr_rw
+      run_opts: ["+test_timeout_ns=500_000_000"]
+      run_timeout_mins: 120
     }
   ]
 


### PR DESCRIPTION
Alert_handler has lots of shadowed registers, so
`shadowed_reg_error_with_csr_rw` might exceeds run time limit.

This PR increases the runtime so it can finish.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>