### PR TITLE
Revert "[dv] Updated build seed writing command" 

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -159,7 +159,7 @@
         "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}",
         // Save build_seed in a file and reuse that file during run phase.
         '''echo {seed} > {build_seed_file_path}; \
-           echo 'echo create file {build_seed_file_path}'
+           echo "echo create file {build_seed_file_path}"
         '''
       ]
       is_sim_mode: 1

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -158,7 +158,8 @@
         // Generate OTP memory map and scrambling constants keys.
         "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}",
         // Save build_seed in a file and reuse that file during run phase.
-        '''echo {seed} > {build_seed_file_path};
+        '''echo {seed} > {build_seed_file_path}; \
+           echo 'echo create file {build_seed_file_path}'
         '''
       ]
       is_sim_mode: 1

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -157,8 +157,10 @@
         "cd {proj_root} && ./util/design/gen-lc-state-enc.py --seed {seed}",
         // Generate OTP memory map and scrambling constants keys.
         "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}",
-        // Save build_seed in a file and reuse that file during run phase.
-        '''echo {seed} > {build_seed_file_path}; \
+        // Use eval_cmd to save build_seed in a file and reuse that file during run phase.
+        // Create the build directory first because eval_cmd runs before actual build phase command
+        // execution.
+        '''{eval_cmd} mkdir -p {build_dir}; echo {seed} > {build_seed_file_path}; \
            echo "echo create file {build_seed_file_path}"
         '''
       ]


### PR DESCRIPTION
This change causes issues with regressions, likely because we forgot to keep the `{eval_cmd}` in the string.
Let's revert the entire change for now - we will clean this up anyways when moving the OTP image generation to bazel.