### PR TITLE
[i2c,dv] ack stop test

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -38,6 +38,10 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   bit     host_scl_pause = 0;
   int     host_scl_pause_cyc = 0;
 
+  // ack followed by stop test mode
+  bit     allow_ack_stop = 0;
+  bit     ack_stop_det = 0;
+
   `uvm_object_utils_begin(i2c_agent_cfg)
     `uvm_field_int(en_monitor,                                UVM_DEFAULT)
     `uvm_field_enum(i2c_target_addr_mode_e, target_addr_mode, UVM_DEFAULT)

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -43,6 +43,7 @@ filesets:
       - seq_lib/i2c_target_stretch_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_tx_ovf_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_timeout_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_ack_stop_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -45,6 +45,10 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   // If this bit is set, tx fifo is fed by 'drooling_write_tx_fifo()' in i2c_base_vseq.sv
   bit        use_drooling_tx = 1'b0;
 
+  //  ack stop test
+  int        sent_ack_stop = 0;
+  int        rcvd_ack_stop = 0;
+
   `uvm_object_utils_begin(i2c_env_cfg)
     `uvm_field_object(m_i2c_agent_cfg, UVM_DEFAULT)
   `uvm_object_utils_end

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -469,6 +469,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     `DV_CHECK_EQ(obs.tran_id, exp.tran_id)
     `DV_CHECK_EQ(obs.num_data, exp.num_data)
     `DV_CHECK_EQ(obs.data_q.size(), exp.data_q.size())
+
     foreach (exp.data_q[i]) begin
       `DV_CHECK_EQ(obs.data_q[i], exp.data_q[i])
     end

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_ack_stop_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_ack_stop_vseq.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class i2c_target_ack_stop_vseq extends i2c_target_smoke_vseq;
+  `uvm_object_utils(i2c_target_ack_stop_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    super.pre_start();
+    expected_intr[UnexpStop] = 1;
+    cfg.m_i2c_agent_cfg.allow_ack_stop = 1;
+  endtask
+
+  virtual task body();
+    fork begin
+      fork
+        super.body();
+        begin
+          cfg.clk_rst_vif.wait_for_reset(.wait_negedge(0));
+          wait(cfg.sent_ack_stop > 0);
+
+          forever begin
+            wait(cfg.m_i2c_agent_cfg.ack_stop_det);
+            `uvm_info("ack_stop_seq", $sformatf("assa ack_stop rcvd %0d", cfg.rcvd_ack_stop),
+                      UVM_MEDIUM)
+            clear_interrupt(UnexpStop);
+            cfg.m_i2c_agent_cfg.ack_stop_det = 0;
+            cfg.rcvd_ack_stop++;
+          end
+        end
+      join_any
+      disable fork;
+    end join
+  endtask
+endclass

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -105,7 +105,12 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
           end
           `DV_WAIT(cfg.sent_acq_cnt == cfg.rcvd_acq_cnt,, cfg.spinwait_timeout_ns, id)
           csr_spinwait(.ptr(ral.status.acqempty), .exp_data(1'b1));
+
+          if (cfg.m_i2c_agent_cfg.allow_ack_stop) send_ack_stop();
+          // add drain time before stop interrupt handler
+          cfg.clk_rst_vif.wait_clks(1000);
           cfg.stop_intr_handler = 1;
+          `uvm_info("stop_intr_handler", "called stop_intr_handler", UVM_MEDIUM)
         end
       end
     join

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -26,3 +26,4 @@
 `include "i2c_target_stretch_vseq.sv"
 `include "i2c_target_tx_ovf_vseq.sv"
 `include "i2c_target_timeout_vseq.sv"
+`include "i2c_target_ack_stop_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -158,7 +158,13 @@
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=50_000_000",
                  "+use_intr_handler=1"]
     }
-   ]
+    {
+      name: i2c_target_ack_stop
+      uvm_test_seq: i2c_target_ack_stop_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=50_000_000",
+                 "+use_intr_handler=1"]
+    }
+  ]
 
   // List of regressions.
   regressions: [


### PR DESCRIPTION
This PR add unexpected stop test.
Test creates ack followed by stop or restart for read data.
No data loss is expected and 'UnexpStop' interrupt is check and clear only when ack / stop condition
is met.


Signed-off-by: Jaedon Kim <jdonjdon@google.com>
