### PR TITLE
[test] Randomize the I2C target mask

### DIFF
--- a/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
@@ -57,7 +57,7 @@ static volatile const uint8_t kI2cDeviceAddress0 = 0x55;
 static volatile const uint8_t kI2cDeviceMask0 = 0x7f;
 static volatile const uint8_t kI2cDeviceAddress1 = 0x7f;  // disable match on
                                                           // second address
-static volatile const uint8_t kI2cDeviceMask1 = 0x00;
+static volatile const uint8_t kI2cDeviceMask1 = 0x7f;
 
 /**
  * This symbol is meant to be backdoor loaded by the testbench.


### PR DESCRIPTION
Each I2C target has two IDs consisting of a 7-bit address and a 7-bit mask.
This PR extends chip_sw_i2c_device_tx_rx test by randomizing masks and
addresses, and by randomly selecting one of the two IDs.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>