### PR TITLE
[opentitantool] Allow switching pins in and out of alternate mode

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/weak_straps/gpio.bzl
+++ b/sw/device/silicon_creator/rom/e2e/weak_straps/gpio.bzl
@@ -27,15 +27,19 @@ def strap_combination(strap):
         val = (strap >> (2 * i)) & 3
         if val == 0:
             settings["b{}_mode".format(i)] = "PushPull"
+            settings["b{}_pull".format(i)] = "None"
             settings["b{}_value".format(i)] = "false"
         elif val == 1:
-            settings["b{}_mode".format(i)] = "WeakPushPull"
-            settings["b{}_value".format(i)] = "false"
+            settings["b{}_mode".format(i)] = "Input"
+            settings["b{}_pull".format(i)] = "PullDown"
+            settings["b{}_value".format(i)] = "false"  # Don't care
         elif val == 2:
-            settings["b{}_mode".format(i)] = "WeakPushPull"
-            settings["b{}_value".format(i)] = "true"
+            settings["b{}_mode".format(i)] = "Input"
+            settings["b{}_pull".format(i)] = "PullUp"
+            settings["b{}_value".format(i)] = "true"  # Don't care
         elif val == 3:
             settings["b{}_mode".format(i)] = "PushPull"
+            settings["b{}_pull".format(i)] = "None"
             settings["b{}_value".format(i)] = "true"
     return settings
 
@@ -57,12 +61,12 @@ def strap_combination_test(name, rom, value, evaluator = None, tags = [], extra_
         verilator = verilator_params(
             rom = rom,
             test_cmds = extra_verilator_args + [
-                "--exec=\"gpio set-mode IOC0 {b0_mode}\"".format(**settings),
-                "--exec=\"gpio set-mode IOC1 {b1_mode}\"".format(**settings),
-                "--exec=\"gpio set-mode IOC2 {b2_mode}\"".format(**settings),
-                "--exec=\"gpio write IOC0 {b0_value}\"".format(**settings),
-                "--exec=\"gpio write IOC1 {b1_value}\"".format(**settings),
-                "--exec=\"gpio write IOC2 {b2_value}\"".format(**settings),
+                "--exec=\"gpio set IOC0 --mode={b0_mode} --value={b0_value} --pull={b0_pull}\""
+                    .format(**settings),
+                "--exec=\"gpio set IOC1 --mode={b1_mode} --value={b1_value} --pull={b1_pull}\""
+                    .format(**settings),
+                "--exec=\"gpio set IOC2 --mode={b2_mode} --value={b2_value} --pull={b2_pull}\""
+                    .format(**settings),
                 "--exec=\"{}\"".format(evaluator),
                 "no-op",
             ],

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -138,16 +138,7 @@ impl TransportWrapper {
     /// Apply given configuration to a single pins.
     fn apply_pin_configuration(&self, name: &str, conf: &PinConfiguration) -> Result<()> {
         let pin = self.gpio_pin(name)?;
-        if let Some(pin_mode) = conf.mode {
-            pin.set_mode(pin_mode)?;
-        }
-        if let Some(pull_mode) = conf.pull_mode {
-            pin.set_pull_mode(pull_mode)?;
-        }
-        if let Some(level) = conf.level {
-            pin.write(level)?;
-        }
-        Ok(())
+        pin.set(conf.mode, conf.level, conf.pull_mode)
     }
 
     /// Apply given configuration to a all the given pins.

--- a/sw/host/opentitanlib/src/io/gpio.rs
+++ b/sw/host/opentitanlib/src/io/gpio.rs
@@ -71,4 +71,25 @@ pub trait GpioPin {
 
     /// Sets the weak pull resistors of the GPIO pin.
     fn set_pull_mode(&self, mode: PullMode) -> Result<()>;
+
+    /// Simultaneously sets mode, value, and weak pull, some transports may guarantee atomicity.
+    fn set(
+        &self,
+        mode: Option<PinMode>,
+        value: Option<bool>,
+        pull: Option<PullMode>,
+    ) -> Result<()> {
+        // Transports must override this function for truly atomic behavior.  Default
+        // implementation below applies each setting separately.
+        if let Some(mode) = mode {
+            self.set_mode(mode)?;
+        }
+        if let Some(pull) = pull {
+            self.set_pull_mode(pull)?;
+        }
+        if let Some(value) = value {
+            self.write(value)?;
+        }
+        Ok(())
+    }
 }

--- a/sw/host/opentitanlib/src/io/gpio.rs
+++ b/sw/host/opentitanlib/src/io/gpio.rs
@@ -43,7 +43,6 @@ arg_enum! {
     pub enum PinMode {
         Input,
         PushPull,
-        WeakPushPull,
         OpenDrain,
     }
 }

--- a/sw/host/opentitanlib/src/io/gpio.rs
+++ b/sw/host/opentitanlib/src/io/gpio.rs
@@ -44,6 +44,7 @@ arg_enum! {
         Input,
         PushPull,
         OpenDrain,
+        Alternate, // Pin used for UART/SPI/I2C or something else
     }
 }
 

--- a/sw/host/opentitanlib/src/transport/cw310/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/gpio.rs
@@ -42,6 +42,7 @@ impl GpioPin for CW310GpioPin {
             PinMode::Input => usb.pin_set_output(&self.pinname, false)?,
             PinMode::PushPull => usb.pin_set_output(&self.pinname, true)?,
             PinMode::OpenDrain => return Err(GpioError::UnsupportedPinMode(mode).into()),
+            PinMode::Alternate => return Err(GpioError::UnsupportedPinMode(mode).into()),
         }
         Ok(())
     }

--- a/sw/host/opentitanlib/src/transport/cw310/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/gpio.rs
@@ -42,7 +42,6 @@ impl GpioPin for CW310GpioPin {
             PinMode::Input => usb.pin_set_output(&self.pinname, false)?,
             PinMode::PushPull => usb.pin_set_output(&self.pinname, true)?,
             PinMode::OpenDrain => return Err(GpioError::UnsupportedPinMode(mode).into()),
-            PinMode::WeakPushPull => return Err(GpioError::UnsupportedPinMode(mode).into()),
         }
         Ok(())
     }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -53,6 +53,7 @@ impl GpioPin for HyperdebugGpioPin {
                     PinMode::Input => "input",
                     PinMode::OpenDrain => "opendrain",
                     PinMode::PushPull => "pushpull",
+                    PinMode::Alternate => "alternate",
                 }
             ),
             |_| {},

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use std::rc::Rc;
 
-use crate::io::gpio::{GpioError, GpioPin, PinMode, PullMode};
+use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::transport::hyperdebug::Inner;
 use crate::transport::TransportError;
 
@@ -53,7 +53,6 @@ impl GpioPin for HyperdebugGpioPin {
                     PinMode::Input => "input",
                     PinMode::OpenDrain => "opendrain",
                     PinMode::PushPull => "pushpull",
-                    PinMode::WeakPushPull => return Err(GpioError::UnsupportedPinMode(mode).into()),
                 }
             ),
             |_| {},

--- a/sw/host/opentitanlib/src/transport/ti50emulator/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/gpio.rs
@@ -134,8 +134,6 @@ impl From<GpioConfiguration> for Logic {
         match (state.pin_mode, state.pull_mode, state.value) {
             (Some(PinMode::PushPull), _, false) => Logic::StrongZero,
             (Some(PinMode::PushPull), _, true) => Logic::StrongOne,
-            (Some(PinMode::WeakPushPull), _, false) => Logic::WeakZero,
-            (Some(PinMode::WeakPushPull), _, true) => Logic::WeakOne,
             (Some(PinMode::OpenDrain), _, false) => Logic::StrongZero,
             (Some(PinMode::OpenDrain), PullMode::PullUp, true) => Logic::WeakOne,
             (Some(PinMode::OpenDrain), PullMode::PullDown, true) => Logic::WeakZero,

--- a/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
@@ -91,7 +91,6 @@ impl GpioPin for UltradebugGpioPin {
         let direction = match mode {
             PinMode::Input => false,
             PinMode::PushPull => true,
-            PinMode::WeakPushPull => return Err(GpioError::UnsupportedPinMode(mode).into()),
             PinMode::OpenDrain => return Err(GpioError::UnsupportedPinMode(mode).into()),
         };
         self.device

--- a/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
@@ -92,6 +92,7 @@ impl GpioPin for UltradebugGpioPin {
             PinMode::Input => false,
             PinMode::PushPull => true,
             PinMode::OpenDrain => return Err(GpioError::UnsupportedPinMode(mode).into()),
+            PinMode::Alternate => return Err(GpioError::UnsupportedPinMode(mode).into()),
         };
         self.device
             .borrow_mut()


### PR DESCRIPTION
Some pins of HyperDebug default to being used for UART/SPI/I2C/etc. and
were not previously usable as GPIO.  This change allows opentitantool to
set their mode to "Input", "Output", or "PushPull", while retaining the
ability to set them back to their "Alternate" mode.