### PR TITLE
[rdc] TAP Strap / HW Debug En waivers

### DIFF
--- a/hw/top_earlgrey/rdc/rdc_waivers.tcl
+++ b/hw/top_earlgrey/rdc/rdc_waivers.tcl
@@ -137,3 +137,11 @@ set_rule_status -rule {E_RST_METASTABILITY} -status {Waived} \
     (MetaStableFlop=~"SPI_HOST_CLK")} \
   -comment {If SPI_HOST receives a reset, CS_L will be de-asserted. \
     Any transactions will be cancelled.}
+
+# W_ASYNC_RST_FLOPS
+set_rule_status -rule W_ASYNC_RST_FLOPS -status Waived \
+  -expression {(DrivingSignal=~"*strap_sampling.tap_strap_q*")} \
+  -comment {STRAP can be changed. \
+    However, whenever the tap sample is changed, TRST_N holds the \
+    reset state. So, all TAPs remain in the reset state. \
+    Async reset glitch won't affect the design.  }

--- a/hw/top_earlgrey/rdc/rdc_waivers.tcl
+++ b/hw/top_earlgrey/rdc/rdc_waivers.tcl
@@ -145,3 +145,7 @@ set_rule_status -rule W_ASYNC_RST_FLOPS -status Waived \
     However, whenever the tap sample is changed, TRST_N holds the \
     reset state. So, all TAPs remain in the reset state. \
     Async reset glitch won't affect the design.  }
+set_rule_status -rule W_ASYNC_RST_FLOPS -status Waived \
+  -expression {(DrivingSignal=~"*.u_rv_dm.u_pm_en_sync.*")} \
+  -comment {LifeCycle HW Debug Enable signal is static and determined \
+    at boot time.}


### PR DESCRIPTION
- tap strap value won't change until next reset.
- HW_DEBUG_EN is static until the life cycle moves, when the life cycle moves to the next state, it affects at the next reset cycle.

this PR contains #16721 . Please review the last two commits.