### PR TITLE
[i2c,dv] host mode regression fix

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -149,7 +149,11 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
     // intr_stretch_timeout_o interrupt would be generated uniformly
     // To test this feature more regressive, there might need a dedicated vseq (V2)
     // in which TIMEOUT_CTRL.EN is always set.
-    if (cfg.host_stretch_test_mode) return tc.tClockPulse;
+
+    // If Stretch value is greater than 2*tTimeOut, it will create 2 interrupt events.
+    // Which can cause faluse error in 'host_stretch_testmode'.
+    // So, this value should be associated with tTimeout in host stretch testmode
+    if (cfg.host_stretch_test_mode) return (tc.tTimeOut + 1);
     else return $urandom_range(tc.tClockPulse, tc.tClockPulse + 2*tc.tTimeOut);
   endfunction : gen_num_stretch_host_clks
 

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -202,6 +202,9 @@ class i2c_monitor extends dv_base_monitor #(
 
     mon_dut_item.stop   = 1'b0;
     mon_dut_item.rstart = 1'b0;
+    `uvm_info(`gfn, $sformatf("host_write_thread begin: tran_id:%0d num_data%0d",
+                              mon_dut_item.tran_id, mon_dut_item.num_data), UVM_HIGH)
+
     while (!mon_dut_item.stop && !mon_dut_item.rstart) begin
       fork
         begin : iso_fork_write
@@ -218,7 +221,8 @@ class i2c_monitor extends dv_base_monitor #(
               `uvm_info(`gfn, $sformatf("Monitor collected data %0x", mon_data), UVM_HIGH)
               mon_dut_item.num_data++;
               mon_dut_item.data_q.push_back(mon_data);
-
+              `uvm_info(`gfn, $sformatf("host_write_thread data %2x num_data:%0d",
+                                        mon_data, mon_dut_item.num_data), UVM_HIGH)
               // send device ack to host write
               mon_dut_item.wdata = mon_data;
               mon_dut_item.drv_type = DevAck;
@@ -240,6 +244,8 @@ class i2c_monitor extends dv_base_monitor #(
         end : iso_fork_write
       join
     end
+    `uvm_info(`gfn, $sformatf("host_write_thread end: tran_id:%0d num_data:%0d",
+                              mon_dut_item.tran_id, mon_dut_item.num_data), UVM_HIGH)
   endtask : write_thread
 
   // update of_to_end to prevent sim finished when there is any activity on the bus

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -91,7 +91,7 @@
               - Ensure transactions are transmitted/received correctly
               - Ensure reset is handled correctly
             '''
-      stage: V2
+      stage: V3
       tests: ["i2c_host_stress_all_with_rand_reset"]
     }
     {
@@ -401,7 +401,7 @@
 
             '''
       stage: V2
-      tests: [""]
+      tests: ["i2c_target_timeout"]
     }
     {
       name: target_clock_stretch

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -71,6 +71,26 @@ package i2c_env_pkg;
     return item;
   endfunction // acq2item
 
+  // Print write data with 16 byte aligned.
+  function automatic void print_host_wr_data(bit [7:0] data[$]);
+    int idx = 1;
+    string str;
+    foreach (data[i]) begin
+      if (i % 16 == 0) begin
+        str = $sformatf("wrdata: %4d:", i  / 16);
+      end
+      str = {str, $sformatf(" %2x", data[i])};
+      if ((i+1) % 16 == 0) begin
+        `uvm_info("print_host_wr_data", str, UVM_MEDIUM)
+        str = "";
+      end
+    end
+    if (str != "") begin
+      `uvm_info("print_host_wr_data", str, UVM_MEDIUM)
+    end
+    `uvm_info("print_host_wr_data", $sformatf("wrdata: size: %0d", data.size()), UVM_MEDIUM)
+  endfunction
+
   // package sources
   `include "i2c_seq_cfg.sv"
   `include "i2c_env_cfg.sv"

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_rx_oversample_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_rx_oversample_vseq.sv
@@ -33,8 +33,10 @@ class i2c_host_rx_oversample_vseq extends i2c_rx_tx_vseq;
     } else {
       tsu_sta inside {[cfg.seq_cfg.i2c_min_timing : cfg.seq_cfg.i2c_max_timing]};
       // force derived timing parameters to be positive (correct DUT config)
-      tlow    inside {[(t_r + tsu_dat + thd_dat + 1) :
-                       (t_r + tsu_dat + thd_dat + 1) + cfg.seq_cfg.i2c_time_range]};
+      // This should be tied to 'get_timing_values' in i2c_base_vseq.sv
+      // To avoid tClockLow 'min tlow should be greater than 5
+      tlow    inside {[(t_r + tsu_dat + thd_dat + 2) :
+                       (t_r + tsu_dat + thd_dat + 2) + cfg.seq_cfg.i2c_time_range]};
       t_buf   inside {[(tsu_sta - t_r + 1) :
                        (tsu_sta - t_r + 1) + cfg.seq_cfg.i2c_time_range]};
       t_sda_unstable     inside {[0 : t_r + thigh + t_f - 1]};
@@ -45,6 +47,7 @@ class i2c_host_rx_oversample_vseq extends i2c_rx_tx_vseq;
 
   virtual task body();
     initialization(.mode(Host));
+    print_time_property();
     for(int i = 0; i < num_runs; i++) begin
       bit do_interrupt = 1'b1;
       `uvm_info(`gfn, "\n--> start of sequence", UVM_DEBUG)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_stretch_timeout_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_stretch_timeout_vseq.sv
@@ -2,7 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// basic stretch_timeout test vseq
+// This sequence use 'host_stretch_test_mode' in i2c_driver.
+// Under host_stretch_test_mode, i2c_driver stretch scl at 'target ack' cycle.
+// stretch cycle is determined to be greater than 't_timeout' vlaue.
+// At the end of stretch event, 'process_stretch_timeout_intr' check
+// StretchTimeout interrupt.
+// In each transaction, for write cycle, host will get # of write byte + 1 (command) ack.
+// For read cycle host will get 1 ack.
+// cnt_wr/rd_stretch will evaluate following the above.
 class i2c_host_stretch_timeout_vseq extends i2c_rx_tx_vseq;
   `uvm_object_utils(i2c_host_stretch_timeout_vseq)
   `uvm_object_new
@@ -50,7 +57,6 @@ class i2c_host_stretch_timeout_vseq extends i2c_rx_tx_vseq;
             // adding 1 is for the target's ACK to the response address byte sent by host
             `DV_CHECK_EQ(cnt_wr_stretch, (num_wr_bytes + 1))
           end
-
           check_rd_stretch = 1'b1;
           host_send_trans(.max_trans(1), .trans_type(ReadOnly));
           check_rd_stretch = 1'b0;

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
@@ -192,6 +192,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
     if (num_wr_bytes == 256) begin
       `uvm_info(`gfn, "\n  write transaction length is 256 byte", UVM_DEBUG)
     end
+    print_host_wr_data(wr_data);
 
     for (int i = 1; i <= num_wr_bytes; i++) begin
       // randomize until at least one of format bits is non-zero to ensure
@@ -214,7 +215,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
       if (i == num_wr_bytes) begin
         `uvm_info(`gfn, $sformatf("\n  transaction WRITE ended %0s", (fmt_item.stop) ?
             "with STOP, next transaction should begin with START" :
-            "without STOP, next transaction should begin with RSTART"), UVM_DEBUG)
+            "without STOP, next transaction should begin with RSTART"), UVM_MEDIUM)
       end
       program_format_flag(fmt_item, "program_write_data_to_target", 1);
     end

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -31,6 +31,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
   // Add additional tops for simulation.
@@ -59,7 +60,7 @@
     {
       name: i2c_host_rx_oversample
       uvm_test_seq: i2c_host_rx_oversample_vseq
-      run_opts: ["+test_timeout_ns=10_000_000"]
+      run_opts: ["+test_timeout_ns=15_000_000"]
     }
 
     {


### PR DESCRIPTION
Move rand reset test to v3
Following host test failures are fixed

1. host_rx_oversample:
   . Update t_low constraint to prevent zero value
   . Increase test run time
2. host_stretch_timeout:
   . Update stretch timeout constraint to be less then tClockpulse
  . Add more test description in seq file.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>