### PR TITLE
[spi_device/dv] Fix regression failures

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -102,9 +102,9 @@ class spi_agent_cfg extends dv_base_agent_cfg;
 
   `uvm_object_new
 
-  virtual task wait_sck_edge(sck_edge_type_e sck_edge_type);
+  virtual task wait_sck_edge(sck_edge_type_e sck_edge_type, bit [CSB_WIDTH-1:0] csb_id);
     bit       wait_posedge;
-    bit [1:0] sck_mode = {vif.sck_polarity, vif.sck_phase};
+    bit [1:0] sck_mode = {sck_polarity[csb_id], sck_phase[csb_id]};
 
     // sck pola   sck_pha   mode
     //        0         0      0: sample at leading  posedge_sck (drive @ prev negedge_sck)
@@ -179,10 +179,11 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   // this task collects one byte data based on num_lanes, which is used in both monitor and driver
   task read_byte(input int num_lanes,
                  input bit is_device_rsp,
+                 input  bit [CSB_WIDTH-1:0] csb_id,
                  output logic [7:0] data);
     int which_bit = 8;
     while (which_bit != 0) begin
-      wait_sck_edge(SamplingEdge);
+      wait_sck_edge(SamplingEdge, csb_id);
       case (num_lanes)
         1: data[--which_bit] = is_device_rsp ? vif.sio[1] : vif.sio[0];
         2: begin

--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -89,7 +89,7 @@ class spi_device_driver extends spi_driver;
                               bits_q.size()), UVM_DEBUG)
     // pop enough bits do drive all needed sio
     while (bits_q.size() > 0) begin
-       if (bits_q.size() > 0) cfg.wait_sck_edge(DrivingEdge);
+       if (bits_q.size() > 0) cfg.wait_sck_edge(DrivingEdge, active_csb);
       for (int i = 0; i < 4; i++) begin
         sio_bits[i] = (i < max_tx_bits) ? bits_q.pop_front() : 1'bz;
       end
@@ -113,7 +113,7 @@ class spi_device_driver extends spi_driver;
       begin : thread_collect_payload
         forever begin
           logic [7:0] byte_data;
-          cfg.read_byte(item.num_lanes, !item.write_command, byte_data);
+          cfg.read_byte(item.num_lanes, !item.write_command, active_csb, byte_data);
           rsp.payload_q.push_back(byte_data);
           if (!item.write_command) rsp.read_size++;
         end
@@ -129,7 +129,7 @@ class spi_device_driver extends spi_driver;
           else spi_mode = Quad;
 
           forever begin
-            cfg.wait_sck_edge(DrivingEdge);
+            cfg.wait_sck_edge(DrivingEdge, active_csb);
             // The first bit in bits_q is the MSB, which is driven on the sio
             // lane with the highest active index.
             for (int i = $high(sio_bits); i >= $low(sio_bits); i--) begin


### PR DESCRIPTION
Fixed a race condition that was introduced in a recent agent update: the vif.sck_phase/polarity was updated in monnitor, but in the meanwhile, host relied on it to drive, which is too late and host ended up using a wrong value.

Used a different approach to get the sck_phase/polarity

Signed-off-by: Weicai Yang <weicai@google.com>