### PR TITLE
[bazel] Mark chip_power_sleep_load_sim_verilator as broken

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -472,6 +472,9 @@ opentitan_functest(
 opentitan_functest(
     name = "chip_power_sleep_load",
     srcs = ["chip_power_sleep_load.c"],
+    verilator = verilator_params(
+        tags = ["broken"],  # FIXME #16374 test doesn't make progress after enabling PWM
+    ),
     deps = [
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:alert_handler",


### PR DESCRIPTION
Signed-off-by: Drew Macrae <drewmacrae@google.com>