### PR TITLE
[tl_lc_gate] Add FSM countermeasure labels to instantiating IPs

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -329,6 +329,12 @@
     { name: "FIFO.CTR.REDUN",
       desc: "The FIFO pointers of several FIFOs are implemented with duplicate counters."
     }
+    { name: "MEM_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
+    { name: "PROG_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
   ]
 
   scan: "true",       // Enable `scanmode_i` port

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -340,6 +340,12 @@
     { name: "FIFO.CTR.REDUN",
       desc: "The FIFO pointers of several FIFOs are implemented with duplicate counters."
     }
+    { name: "MEM_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
+    { name: "PROG_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
   ]
 
   scan: "true",       // Enable `scanmode_i` port

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -507,6 +507,7 @@ module flash_ctrl
   // the program path also needs an lc gate to error back when flash is disabled.
   // This is because tlul_adapter_sram does not actually have a way of signaling
   // write errors, only read errors.
+  // SEC_CM: PROG_TL_LC_GATE.FSM.SPARSE
   tlul_lc_gate u_prog_tl_gate (
     .clk_i,
     .rst_ni,
@@ -1289,6 +1290,7 @@ module flash_ctrl
   tlul_pkg::tl_h2d_t gate_tl_h2d;
   tlul_pkg::tl_d2h_t gate_tl_d2h;
 
+  // SEC_CM: MEM_TL_LC_GATE.FSM.SPARSE
   tlul_lc_gate u_tl_gate (
     .clk_i,
     .rst_ni,

--- a/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
@@ -185,5 +185,17 @@
       stage: V2S
       tests: []
     }
+    {
+      name: sec_cm_mem_tl_lc_gate_fsm_sparse
+      desc: "Verify the countermeasure(s) MEM_TL_LC_GATE.FSM.SPARSE."
+      stage: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_prog_tl_lc_gate_fsm_sparse
+      desc: "Verify the countermeasure(s) PROG_TL_LC_GATE.FSM.SPARSE."
+      stage: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -508,6 +508,7 @@ module flash_ctrl
   // the program path also needs an lc gate to error back when flash is disabled.
   // This is because tlul_adapter_sram does not actually have a way of signaling
   // write errors, only read errors.
+  // SEC_CM: PROG_TL_LC_GATE.FSM.SPARSE
   tlul_lc_gate u_prog_tl_gate (
     .clk_i,
     .rst_ni,
@@ -1290,6 +1291,7 @@ module flash_ctrl
   tlul_pkg::tl_h2d_t gate_tl_h2d;
   tlul_pkg::tl_d2h_t gate_tl_d2h;
 
+  // SEC_CM: MEM_TL_LC_GATE.FSM.SPARSE
   tlul_lc_gate u_tl_gate (
     .clk_i,
     .rst_ni,

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -1255,6 +1255,9 @@
     { name: "TEST.BUS.LC_GATED",
       desc: "Prevent access to test signals and the OTP backdoor interface in non-test lifecycle states."
     }
+    { name: "TEST_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
     { name: "DIRECT_ACCESS.CONFIG.REGWEN",
       desc: "The direct access CSRs are REGWEN protected."
     }

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -504,6 +504,9 @@
     { name: "TEST.BUS.LC_GATED",
       desc: "Prevent access to test signals and the OTP backdoor interface in non-test lifecycle states."
     }
+    { name: "TEST_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
     { name: "DIRECT_ACCESS.CONFIG.REGWEN",
       desc: "The direct access CSRs are REGWEN protected."
     }

--- a/hw/ip/otp_ctrl/data/otp_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_sec_cm_testplan.hjson
@@ -264,6 +264,12 @@
       tests: ["otp_ctrl_smoke"]
     }
     {
+      name: sec_cm_test_tl_lc_gate_fsm_sparse
+      desc: "Verify the countermeasure(s) TEST_TL_LC_GATE.FSM.SPARSE."
+      stage: V2S
+      tests: ["otp_ctrl_sec_cm"]
+    }
+    {
       name: sec_cm_direct_access_config_regwen
       desc: "Verify the countermeasure(s) DIRECT_ACCESS.CONFIG.REGWEN."
       stage: V2S

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -739,6 +739,7 @@ module otp_ctrl
 
   // Life cycle qualification of TL-UL test interface.
   // SEC_CM: TEST.BUS.LC_GATED
+  // SEC_CM: TEST_TL_LC_GATE.FSM.SPARSE
   tlul_lc_gate #(
     .NumGatesPerDirection(2)
   ) u_tlul_lc_gate (

--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -119,6 +119,12 @@
             being fed into the TL-UL adapter for the debug ROM.
             '''
     }
+    { name: "SBA_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
+    { name: "MEM_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
     { name: "EXEC.CTRL.MUBI",
       desc: '''
             The instruction fetch enable signal that is modulated with LC_HW_DEBUG_EN

--- a/hw/ip/rv_dm/data/rv_dm_sec_cm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_sec_cm_testplan.hjson
@@ -42,6 +42,18 @@
       tests: []
     }
     {
+      name: sec_cm_sba_tl_lc_gate_fsm_sparse
+      desc: "Verify the countermeasure(s) SBA_TL_LC_GATE.FSM.SPARSE."
+      stage: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_mem_tl_lc_gate_fsm_sparse
+      desc: "Verify the countermeasure(s) MEM_TL_LC_GATE.FSM.SPARSE."
+      stage: V2S
+      tests: []
+    }
+    {
       name: sec_cm_exec_ctrl_mubi
       desc: "Verify the countermeasure(s) EXEC.CTRL.MUBI."
       stage: V2S

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -220,6 +220,7 @@ module rv_dm
   logic                   host_r_other_err;
 
   // SEC_CM: DM_EN.CTRL.LC_GATED
+  // SEC_CM: SBA_TL_LC_GATE.FSM.SPARSE
   tlul_pkg::tl_h2d_t  sba_tl_h_o_int;
   tlul_pkg::tl_d2h_t  sba_tl_h_i_int;
   tlul_lc_gate #(
@@ -352,6 +353,7 @@ module rv_dm
 `endif
 
   // SEC_CM: DM_EN.CTRL.LC_GATED
+  // SEC_CM: MEM_TL_LC_GATE.FSM.SPARSE
   tlul_pkg::tl_h2d_t mem_tl_win_h2d_gated;
   tlul_pkg::tl_d2h_t mem_tl_win_d2h_gated;
   tlul_lc_gate #(

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -150,6 +150,9 @@
     { name: "INSTR.BUS.LC_GATED",
       desc: "Prevent code execution from SRAM in non-test lifecycle states."
     }
+    { name: "RAM_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
     { name: "KEY.GLOBAL_ESC",
       desc: "Scrambling key and nonce are reset to a fixed value upon escalation, and bus transactions going to the memory will be blocked."
     }

--- a/hw/ip/sram_ctrl/data/sram_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_sec_cm_testplan.hjson
@@ -119,6 +119,12 @@
       tests: ["{name}_executable"]
     }
     {
+      name: sec_cm_ram_tl_lc_gate_fsm_sparse
+      desc: "Verify the countermeasure(s) RAM_TL_LC_GATE.FSM.SPARSE."
+      stage: V2S
+      tests: ["{name}_sec_cm"]
+    }
+    {
       name: sec_cm_key_global_esc
       desc: "Verify the countermeasure(s) KEY.GLOBAL_ESC."
       stage: V2S

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -391,6 +391,7 @@ module sram_ctrl
   tlul_pkg::tl_h2d_t ram_tl_in_gated;
   tlul_pkg::tl_d2h_t ram_tl_out_gated;
 
+  // SEC_CM: RAM_TL_LC_GATE.FSM.SPARSE
   tlul_lc_gate #(
     .NumGatesPerDirection(2)
   ) u_tlul_lc_gate (

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -335,6 +335,12 @@
     { name: "FIFO.CTR.REDUN",
       desc: "The FIFO pointers of several FIFOs are implemented with duplicate counters."
     }
+    { name: "MEM_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
+    { name: "PROG_TL_LC_GATE.FSM.SPARSE",
+      desc: "The control FSM inside the TL-UL gating primitive is sparsely encoded."
+    }
   ]
 
   scan: "true",       // Enable `scanmode_i` port

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -514,6 +514,7 @@ module flash_ctrl
   // the program path also needs an lc gate to error back when flash is disabled.
   // This is because tlul_adapter_sram does not actually have a way of signaling
   // write errors, only read errors.
+  // SEC_CM: PROG_TL_LC_GATE.FSM.SPARSE
   tlul_lc_gate u_prog_tl_gate (
     .clk_i,
     .rst_ni,
@@ -1296,6 +1297,7 @@ module flash_ctrl
   tlul_pkg::tl_h2d_t gate_tl_h2d;
   tlul_pkg::tl_d2h_t gate_tl_d2h;
 
+  // SEC_CM: MEM_TL_LC_GATE.FSM.SPARSE
   tlul_lc_gate u_tl_gate (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
This adds SEC_CM labels for the sparse FSM instantiated inside the TL-UL gating module.

Signed-off-by: Michael Schaffner <msf@google.com>