### PR TITLE
[chiplevel test] Test GPIOs on hyperdebug

### DIFF
--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -190,6 +190,7 @@ def cw310_params(
         clear_bitstream = False,
         # None
         timeout = "short",
+        interface = "cw310",
         **kwargs):
     """A macro to create CW310 parameters for OpenTitan functional tests.
 
@@ -217,7 +218,7 @@ def cw310_params(
         "--logging={logging}",
     ]
     required_test_cmds = [
-        "--interface=cw310",
+        "--interface={}".format(interface),
     ]
     required_tags = [
         "cw310",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1102,8 +1102,16 @@ opentitan_functest(
 opentitan_functest(
     name = "gpio_pinmux_test",
     srcs = ["gpio_pinmux_test.c"],
+    cw310 = cw310_params(
+        interface = "hyperdebug",
+        tags = ["manual"],
+        test_cmds = [
+            "--bootstrap=\"$(location {flash})\"",
+        ],
+    ),
     targets = [
         "verilator",
+        "cw310_test_rom",
     ],
     test_harness = "//sw/host/tests/chip/gpio",
     verilator = verilator_params(

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
@@ -5,7 +5,7 @@
     {
       "name": "RESET",
       "mode": "OpenDrain",
-      "pull_mode": "PullUp"
+      "pull_mode": "PullUp",
       "alias_of": "CN10_29"
     },
     {

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -24,31 +24,31 @@ mod verilator;
 #[derive(Debug, StructOpt)]
 pub struct BackendOpts {
     #[structopt(long, default_value = "", help = "Name of the debug interface")]
-    interface: String,
+    pub interface: String,
 
     #[structopt(long, parse(try_from_str = u16::from_str),
                 help="USB Vendor ID of the interface")]
-    usb_vid: Option<u16>,
+    pub usb_vid: Option<u16>,
     #[structopt(long, parse(try_from_str = u16::from_str),
                 help="USB Product ID of the interface")]
-    usb_pid: Option<u16>,
+    pub usb_pid: Option<u16>,
     #[structopt(long, help = "USB serial number of the interface")]
-    usb_serial: Option<String>,
+    pub usb_serial: Option<String>,
 
     #[structopt(flatten)]
-    cw310_opts: cw310::Cw310Opts,
+    pub cw310_opts: cw310::Cw310Opts,
 
     #[structopt(flatten)]
-    verilator_opts: verilator::VerilatorOpts,
+    pub verilator_opts: verilator::VerilatorOpts,
 
     #[structopt(flatten)]
-    proxy_opts: proxy::ProxyOpts,
+    pub proxy_opts: proxy::ProxyOpts,
 
     #[structopt(flatten)]
-    ti50emulator_opts: ti50emulator::Ti50EmulatorOpts,
+    pub ti50emulator_opts: ti50emulator::Ti50EmulatorOpts,
 
     #[structopt(long, number_of_values(1), help = "Configuration files")]
-    conf: Vec<PathBuf>,
+    pub conf: Vec<PathBuf>,
 }
 
 #[derive(Error, Debug)]

--- a/sw/host/opentitanlib/src/test_utils/init.rs
+++ b/sw/host/opentitanlib/src/test_utils/init.rs
@@ -128,6 +128,9 @@ impl InitializeTest {
         // Create the transport interface.
         let transport = backend::create(&self.backend_opts)?;
 
+        // Set up the default pin configurations as specified in the transport's config file.
+        transport.apply_default_configuration()?;
+
         // Create the UART first to initialize the desired parameters.
         let _uart = self.bootstrap.options.uart_params.create(&transport)?;
 

--- a/sw/host/tests/chip/gpio/src/main.rs
+++ b/sw/host/tests/chip/gpio/src/main.rs
@@ -38,40 +38,116 @@ struct Config {
 }
 
 lazy_static! {
-static ref VERILATOR: Config = Config {
-    input: collection! {
-        PinmuxPeripheralIn::GpioGpio0 => PinmuxInsel::Iob6,
-        PinmuxPeripheralIn::GpioGpio1 => PinmuxInsel::Iob7,
-        PinmuxPeripheralIn::GpioGpio2 => PinmuxInsel::Iob8,
-        PinmuxPeripheralIn::GpioGpio3 => PinmuxInsel::Iob9,
-        PinmuxPeripheralIn::GpioGpio4 => PinmuxInsel::Iob10,
-        PinmuxPeripheralIn::GpioGpio5 => PinmuxInsel::Iob11,
-        PinmuxPeripheralIn::GpioGpio6 => PinmuxInsel::Iob12,
-        PinmuxPeripheralIn::GpioGpio7 => PinmuxInsel::Ior5,
-        PinmuxPeripheralIn::GpioGpio8 => PinmuxInsel::Ior6,
-        PinmuxPeripheralIn::GpioGpio9 => PinmuxInsel::Ior7,
-        // IOR8-9 aren't MIOs.
-        PinmuxPeripheralIn::GpioGpio10 => PinmuxInsel::Ior10,
-        PinmuxPeripheralIn::GpioGpio11 => PinmuxInsel::Ior11,
-        PinmuxPeripheralIn::GpioGpio12 => PinmuxInsel::Ior12,
-        PinmuxPeripheralIn::GpioGpio13 => PinmuxInsel::Ior13,
+static ref CONFIG: HashMap<&'static str, Config> = collection! {
+    "verilator" => Config {
+        input: collection! {
+            PinmuxPeripheralIn::GpioGpio0 => PinmuxInsel::Iob6,
+            PinmuxPeripheralIn::GpioGpio1 => PinmuxInsel::Iob7,
+            PinmuxPeripheralIn::GpioGpio2 => PinmuxInsel::Iob8,
+            PinmuxPeripheralIn::GpioGpio3 => PinmuxInsel::Iob9,
+            PinmuxPeripheralIn::GpioGpio4 => PinmuxInsel::Iob10,
+            PinmuxPeripheralIn::GpioGpio5 => PinmuxInsel::Iob11,
+            PinmuxPeripheralIn::GpioGpio6 => PinmuxInsel::Iob12,
+            PinmuxPeripheralIn::GpioGpio7 => PinmuxInsel::Ior5,
+            PinmuxPeripheralIn::GpioGpio8 => PinmuxInsel::Ior6,
+            PinmuxPeripheralIn::GpioGpio9 => PinmuxInsel::Ior7,
+            // IOR8-9 aren't MIOs.
+            PinmuxPeripheralIn::GpioGpio10 => PinmuxInsel::Ior10,
+            PinmuxPeripheralIn::GpioGpio11 => PinmuxInsel::Ior11,
+            PinmuxPeripheralIn::GpioGpio12 => PinmuxInsel::Ior12,
+            PinmuxPeripheralIn::GpioGpio13 => PinmuxInsel::Ior13,
+        },
+        output: collection! {
+            PinmuxMioOut::Iob6 => PinmuxOutsel::GpioGpio0,
+            PinmuxMioOut::Iob7 => PinmuxOutsel::GpioGpio1,
+            PinmuxMioOut::Iob8 => PinmuxOutsel::GpioGpio2,
+            PinmuxMioOut::Iob9 => PinmuxOutsel::GpioGpio3,
+            PinmuxMioOut::Iob10 => PinmuxOutsel::GpioGpio4,
+            PinmuxMioOut::Iob11 => PinmuxOutsel::GpioGpio5,
+            PinmuxMioOut::Iob12 => PinmuxOutsel::GpioGpio6,
+            PinmuxMioOut::Ior5 => PinmuxOutsel::GpioGpio7,
+            PinmuxMioOut::Ior6 => PinmuxOutsel::GpioGpio8,
+            PinmuxMioOut::Ior7 => PinmuxOutsel::GpioGpio9,
+            // IOR8-9 aren't MIOs.
+            PinmuxMioOut::Ior10 => PinmuxOutsel::GpioGpio10,
+            PinmuxMioOut::Ior11 => PinmuxOutsel::GpioGpio11,
+            PinmuxMioOut::Ior12 => PinmuxOutsel::GpioGpio12,
+            PinmuxMioOut::Ior13 => PinmuxOutsel::GpioGpio13,
+        },
     },
-    output: collection! {
-        PinmuxMioOut::Iob6 => PinmuxOutsel::GpioGpio0,
-        PinmuxMioOut::Iob7 => PinmuxOutsel::GpioGpio1,
-        PinmuxMioOut::Iob8 => PinmuxOutsel::GpioGpio2,
-        PinmuxMioOut::Iob9 => PinmuxOutsel::GpioGpio3,
-        PinmuxMioOut::Iob10 => PinmuxOutsel::GpioGpio4,
-        PinmuxMioOut::Iob11 => PinmuxOutsel::GpioGpio5,
-        PinmuxMioOut::Iob12 => PinmuxOutsel::GpioGpio6,
-        PinmuxMioOut::Ior5 => PinmuxOutsel::GpioGpio7,
-        PinmuxMioOut::Ior6 => PinmuxOutsel::GpioGpio8,
-        PinmuxMioOut::Ior7 => PinmuxOutsel::GpioGpio9,
-        // IOR8-9 aren't MIOs.
-        PinmuxMioOut::Ior10 => PinmuxOutsel::GpioGpio10,
-        PinmuxMioOut::Ior11 => PinmuxOutsel::GpioGpio11,
-        PinmuxMioOut::Ior12 => PinmuxOutsel::GpioGpio12,
-        PinmuxMioOut::Ior13 => PinmuxOutsel::GpioGpio13,
+    "hyperdebug" => Config {
+        input: collection! {
+            // The commented lines represent multi-fuction pins.  These will
+            // be added back in when the hyperdebug firmware can set these
+            // multifunction pins into GPIO mode.
+
+            //PinmuxPeripheralIn::GpioGpio0 => PinmuxInsel::Ioa0,   // UART4
+            //PinmuxPeripheralIn::GpioGpio1 => PinmuxInsel::Ioa1,   // UART4
+            PinmuxPeripheralIn::GpioGpio2 => PinmuxInsel::Ioa2,
+            PinmuxPeripheralIn::GpioGpio3 => PinmuxInsel::Ioa3,
+            //PinmuxPeripheralIn::GpioGpio4 => PinmuxInsel::Ioa4,   // UART5
+            //PinmuxPeripheralIn::GpioGpio5 => PinmuxInsel::Ioa5,   // UART5
+            PinmuxPeripheralIn::GpioGpio6 => PinmuxInsel::Ioa6,
+            //PinmuxPeripheralIn::GpioGpio7 => PinmuxInsel::Ioa7,   // I2C1
+            //PinmuxPeripheralIn::GpioGpio8 => PinmuxInsel::Ioa8,   // I2C1
+            //PinmuxPeripheralIn::GpioGpio9 => PinmuxInsel::Iob4,   // UART3
+            //PinmuxPeripheralIn::GpioGpio10 => PinmuxInsel::Iob5,  // UART3
+            PinmuxPeripheralIn::GpioGpio11 => PinmuxInsel::Iob6,
+
+            PinmuxPeripheralIn::GpioGpio12 => PinmuxInsel::Ioc0,
+            PinmuxPeripheralIn::GpioGpio13 => PinmuxInsel::Ioc1,
+            PinmuxPeripheralIn::GpioGpio14 => PinmuxInsel::Ioc2,
+
+            PinmuxPeripheralIn::GpioGpio15 => PinmuxInsel::Ioc5,
+            PinmuxPeripheralIn::GpioGpio16 => PinmuxInsel::Ioc6,
+            PinmuxPeripheralIn::GpioGpio17 => PinmuxInsel::Ioc10,
+            PinmuxPeripheralIn::GpioGpio18 => PinmuxInsel::Ioc11,
+            PinmuxPeripheralIn::GpioGpio19 => PinmuxInsel::Ioc12,
+
+            PinmuxPeripheralIn::GpioGpio20 => PinmuxInsel::Ior5,
+            PinmuxPeripheralIn::GpioGpio21 => PinmuxInsel::Ior6,
+            PinmuxPeripheralIn::GpioGpio22 => PinmuxInsel::Ior7,
+            // IOR8-9 aren't MIOs.
+            PinmuxPeripheralIn::GpioGpio25 => PinmuxInsel::Ior10,
+            PinmuxPeripheralIn::GpioGpio26 => PinmuxInsel::Ior11,
+            PinmuxPeripheralIn::GpioGpio27 => PinmuxInsel::Ior12,
+            PinmuxPeripheralIn::GpioGpio28 => PinmuxInsel::Ior13,
+
+        },
+        output: collection! {
+            // The commented lines represent multi-fuction pins.  These will
+            // be added back in when the hyperdebug firmware can set these
+            // multifunction pins into GPIO mode.
+
+            //PinmuxMioOut::Ioa0 => PinmuxOutsel::GpioGpio0,   // UART4
+            //PinmuxMioOut::Ioa1 => PinmuxOutsel::GpioGpio1,   // UART4
+            PinmuxMioOut::Ioa2 => PinmuxOutsel::GpioGpio2,
+            PinmuxMioOut::Ioa3 => PinmuxOutsel::GpioGpio3,
+            //PinmuxMioOut::Ioa4 => PinmuxOutsel::GpioGpio4,   // UART5
+            //PinmuxMioOut::Ioa5 => PinmuxOutsel::GpioGpio5,   // UART5
+            PinmuxMioOut::Ioa6 => PinmuxOutsel::GpioGpio6,
+            //PinmuxMioOut::Ioa7 => PinmuxOutsel::GpioGpio7,   // I2C1
+            //PinmuxMioOut::Ioa8 => PinmuxOutsel::GpioGpio8,   // I2C1
+            //PinmuxMioOut::Iob4 => PinmuxOutsel::GpioGpio9,   // UART3
+            //PinmuxMioOut::Iob5 => PinmuxOutsel::GpioGpio10,  // UART3
+            PinmuxMioOut::Iob6 => PinmuxOutsel::GpioGpio11,
+            PinmuxMioOut::Ioc0 => PinmuxOutsel::GpioGpio12,
+            PinmuxMioOut::Ioc1 => PinmuxOutsel::GpioGpio13,
+            PinmuxMioOut::Ioc2 => PinmuxOutsel::GpioGpio14,
+            PinmuxMioOut::Ioc5 => PinmuxOutsel::GpioGpio15,
+            PinmuxMioOut::Ioc6 => PinmuxOutsel::GpioGpio16,
+            PinmuxMioOut::Ioc10 => PinmuxOutsel::GpioGpio17,
+            PinmuxMioOut::Ioc11 => PinmuxOutsel::GpioGpio18,
+            PinmuxMioOut::Ioc12 => PinmuxOutsel::GpioGpio19,
+            PinmuxMioOut::Ior5 => PinmuxOutsel::GpioGpio20,
+            PinmuxMioOut::Ior6 => PinmuxOutsel::GpioGpio21,
+            PinmuxMioOut::Ior7 => PinmuxOutsel::GpioGpio22,
+            // IOR8-9 aren't MIOs.
+            PinmuxMioOut::Ior10 => PinmuxOutsel::GpioGpio25,
+            PinmuxMioOut::Ior11 => PinmuxOutsel::GpioGpio26,
+            PinmuxMioOut::Ior12 => PinmuxOutsel::GpioGpio27,
+            PinmuxMioOut::Ior13 => PinmuxOutsel::GpioGpio28,
+        },
     },
 };
 }
@@ -148,12 +224,15 @@ fn read_all_verify(
     Ok(())
 }
 
-fn test_gpio_outputs(_opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+fn test_gpio_outputs(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
-    // TODO(cfrantz): Enhance this test to have pinmux configurations for other
-    // platforms, such as cw310+hyperdebug.
-    let config = &VERILATOR;
-    log::info!("Configuring pinmux");
+    log::info!(
+        "Configuring pinmux for {:?}",
+        opts.init.backend_opts.interface
+    );
+    let config = CONFIG
+        .get(opts.init.backend_opts.interface.as_str())
+        .expect("interface");
     PinmuxConfig::configure(&*uart, None, Some(&config.output))?;
 
     log::info!("Configuring debugger GPIOs as inputs");
@@ -175,12 +254,15 @@ fn test_gpio_outputs(_opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     Ok(())
 }
 
-fn test_gpio_inputs(_opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+fn test_gpio_inputs(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
-    // TODO(cfrantz): Enhance this test to have pinmux configurations for other
-    // platforms, such as cw310+hyperdebug.
-    let config = &VERILATOR;
-    log::info!("Configuring pinmux");
+    log::info!(
+        "Configuring pinmux for {:?}",
+        opts.init.backend_opts.interface
+    );
+    let config = CONFIG
+        .get(opts.init.backend_opts.interface.as_str())
+        .expect("interface");
     PinmuxConfig::configure(&*uart, Some(&config.input), None)?;
 
     log::info!("Configuring debugger GPIOs as outputs");


### PR DESCRIPTION
Enhance the gpio test to check gpio connections on the CW310 board connected via hyperdebug.