### PR TITLE
[dv/scoreboard] Create function to reset the alert state

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -21,13 +21,18 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   mem_model#() exp_mem[string];
 
+  // Holds the information related to expected alerts.
+  typedef struct packed {
+    bit expected;
+    bit is_fatal;
+    int max_delay;
+  } expected_alert_t;
+
   // alert checking related parameters
   bit do_alert_check = 1;
   bit check_alert_sig_int_err = 1;
   bit under_alert_handshake[string];
-  bit exp_alert[string];
-  bit is_fatal_alert[string];
-  int alert_chk_max_delay[string];
+  expected_alert_t expected_alert[string];
   int alert_count[string];
 
   // intg check
@@ -207,10 +212,10 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   // Called at the start of each alert handshake. The default implementation depends on the
   // do_alert_check flag. If that is set, it checks that an alert is expected (by checking
-  // exp_alert[alert_name]).
+  // expected_alert[alert_name].expected).
   virtual function void on_alert(string alert_name, alert_esc_seq_item item);
     if (do_alert_check) begin
-      `DV_CHECK_EQ(exp_alert[alert_name], 1,
+      `DV_CHECK_EQ(expected_alert[alert_name].expected, 1,
                    $sformatf("alert %0s triggered unexpectedly", alert_name))
     end
   endfunction
@@ -240,23 +245,23 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     return alert_count[alert_name];
   endfunction
 
-  // this task is implemented to check if expected alert is triggered within certain clock cycles
-  // if alert is fatal alert, it will expect alert handshakes until reset
-  // if alert is not fatal alert, it will set exp_alert back to 0 once finish alert_checking
+  // This task checks if expected alert is triggered within certain clock cycles.
+  // If alert is fatal it will expect alert handshakes until reset, otherwise it will clear
+  // expected_alert's expected flag when check is finished.
   virtual task check_alerts();
     foreach (cfg.list_of_alerts[i]) begin
       automatic string alert_name = cfg.list_of_alerts[i];
       fork
         forever begin
-          wait(exp_alert[alert_name] == 1 && cfg.under_reset == 0);
-          if (is_fatal_alert[alert_name]) begin
+          wait(expected_alert[alert_name].expected == 1 && cfg.under_reset == 0);
+          if (expected_alert[alert_name].is_fatal) begin
             while (cfg.under_reset == 0) begin
               check_alert_triggered(alert_name);
               wait(under_alert_handshake[alert_name] == 0 || cfg.under_reset == 1);
             end
           end else begin
             check_alert_triggered(alert_name);
-            exp_alert[alert_name] = 0;
+            expected_alert[alert_name].expected = 0;
           end
         end
       join_none
@@ -265,13 +270,13 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   virtual task check_alert_triggered(string alert_name);
     // Add 1 extra negedge edge clock to make sure no race condition.
-    repeat(alert_esc_agent_pkg::ALERT_B2B_DELAY + 1 + alert_chk_max_delay[alert_name]) begin
+    repeat(alert_esc_agent_pkg::ALERT_B2B_DELAY + 1 + expected_alert[alert_name].max_delay) begin
       cfg.clk_rst_vif.wait_n_clks(1);
       if (under_alert_handshake[alert_name] || cfg.under_reset) return;
     end
     if (!cfg.en_scb) return;
     `uvm_error(`gfn, $sformatf("alert %0s did not trigger max_delay:%0d",
-                               alert_name, alert_chk_max_delay[alert_name]))
+                               alert_name, expected_alert[alert_name].max_delay))
   endtask
 
   // This function is used for individual IPs to set when they expect certain alert to trigger
@@ -291,18 +296,16 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
         // delay a negedge clk to avoid race condition between this function and
         // `under_alert_handshake` variable
         cfg.clk_rst_vif.wait_n_clks(1);
-        if (under_alert_handshake[alert_name] || exp_alert[alert_name]) begin
+        if (under_alert_handshake[alert_name] || expected_alert[alert_name].expected) begin
           `uvm_info(`gfn, $sformatf(
                     "Current %0s status: under_alert_handshake=%0b, exp_alert=%0b, request ignored",
                     alert_name,
                     under_alert_handshake[alert_name],
-                    exp_alert[alert_name]
+                    expected_alert[alert_name].expected
                     ), UVM_MEDIUM)
         end else begin
           `uvm_info(`gfn, $sformatf("alert %0s is expected to trigger", alert_name), UVM_HIGH)
-          is_fatal_alert[alert_name] = is_fatal;
-          exp_alert[alert_name] = 1;
-          alert_chk_max_delay[alert_name] = max_delay;
+          expected_alert[alert_name] = '{1, is_fatal, max_delay};
         end
       end
     join_none
@@ -581,18 +584,20 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     return 1;
   endfunction
 
+  protected virtual function void reset_alert_state();
+    foreach (cfg.list_of_alerts[i]) begin
+      alert_fifos[cfg.list_of_alerts[i]].flush();
+      expected_alert[cfg.list_of_alerts[i]] = '0;
+      under_alert_handshake[cfg.list_of_alerts[i]] = 0;
+    end
+  endfunction
+
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
     foreach (tl_a_chan_fifos[i]) tl_a_chan_fifos[i].flush();
     foreach (tl_d_chan_fifos[i]) tl_d_chan_fifos[i].flush();
     foreach (edn_fifos[i]) edn_fifos[i].flush();
-    foreach(cfg.list_of_alerts[i]) begin
-      alert_fifos[cfg.list_of_alerts[i]].flush();
-      exp_alert[cfg.list_of_alerts[i]]             = 0;
-      under_alert_handshake[cfg.list_of_alerts[i]] = 0;
-      is_fatal_alert[cfg.list_of_alerts[i]]        = 0;
-      alert_chk_max_delay[cfg.list_of_alerts[i]]   = 0;
-    end
+    reset_alert_state();
     cfg.tl_mem_access_gated = 0;
   endfunction
 

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -860,11 +860,14 @@ class flash_ctrl_scoreboard #(
     hs_state = item.alert_handshake_sta;
 
     `uvm_info(`gfn, $sformatf("alert %0s detected, alert_status is %s exp:%0d contd:%0d",
-                              alert_name, item.alert_handshake_sta, exp_alert[alert_name],
-                              exp_alert_contd[alert_name]), UVM_MEDIUM)
+                              alert_name,
+                              item.alert_handshake_sta,
+                              expected_alert[alert_name].expected,
+                              exp_alert_contd[alert_name]
+                              ), UVM_MEDIUM)
     if (item.alert_handshake_sta == AlertReceived) begin
       under_alert_handshake[alert_name] = 1;
-      if (exp_alert_ff[alert_name].size > 0) exp_alert[alert_name] = 1;
+      if (exp_alert_ff[alert_name].size > 0) expected_alert[alert_name].expected = 1;
       on_alert(alert_name, item);
       alert_count[alert_name]++;
     end else begin
@@ -872,10 +875,10 @@ class flash_ctrl_scoreboard #(
         `uvm_error(`gfn, $sformatf("alert %0s is not received!", alert_name))
       end
       pop_out = exp_alert_ff[alert_name].pop_front();
-      if (exp_alert_ff[alert_name].size() == 0) exp_alert[alert_name] = 0;
+      if (exp_alert_ff[alert_name].size() == 0) expected_alert[alert_name].expected = 0;
       under_alert_handshake[alert_name] = 0;
       if (exp_alert_contd[alert_name] > 0) begin
-        exp_alert[alert_name] = 1;
+        expected_alert[alert_name].expected = 1;
         exp_alert_contd[alert_name]--;
       end
     end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_access_after_disable_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_access_after_disable_vseq.sv
@@ -41,8 +41,8 @@ class flash_ctrl_access_after_disable_vseq extends flash_ctrl_otf_base_vseq;
     tl_addr[OTFBankId] = $urandom_range(0, 1);
 
     cfg.scb_h.exp_tl_rsp_intg_err = 1;
-    cfg.scb_h.exp_alert["fatal_std_err"] = 1;
-    cfg.scb_h.alert_chk_max_delay["fatal_std_err"] = 2000;
+    cfg.scb_h.expected_alert["fatal_std_err"].expected = 1;
+    cfg.scb_h.expected_alert["fatal_std_err"].max_delay = 2000;
     cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
 
     // fatal_err.phy_storage_err

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -1333,7 +1333,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   function void set_otf_exp_alert(string str);
     cfg.scb_h.exp_alert_ff[str].push_back(1);
-    cfg.scb_h.alert_chk_max_delay[str] = 2000;
+    cfg.scb_h.expected_alert[str].max_delay = 2000;
     `uvm_info("set_otf_exp_alert",
               $sformatf("exp_alert_ff[%s] size: %0d",
                         str, cfg.scb_h.exp_alert_ff[str].size()), UVM_MEDIUM)

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_prog_rma_wipe_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_prog_rma_wipe_err_vseq.sv
@@ -24,8 +24,8 @@ class flash_ctrl_hw_prog_rma_wipe_err_vseq extends flash_ctrl_err_base_vseq;
     `uvm_info(`gfn, $sformatf("event_idx :%0d", event_idx), UVM_MEDIUM)
      `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rma_state == StRmaWordSel);,
                   , state_wait_timeout_ns)
-    cfg.scb_h.exp_alert["fatal_err"] = 1;
-    cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+    cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+    cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
     add_glitch(event_idx);
@@ -41,8 +41,8 @@ class flash_ctrl_hw_prog_rma_wipe_err_vseq extends flash_ctrl_err_base_vseq;
       0, 1: begin
         // This will trigger std_fault_status.prog_intg_err
         // but it will be captured in the other test.
-        cfg.scb_h.exp_alert["fatal_std_err"] = 1;
-        cfg.scb_h.alert_chk_max_delay["fatal_std_err"] = 2000;
+        cfg.scb_h.expected_alert["fatal_std_err"].expected = 1;
+        cfg.scb_h.expected_alert["fatal_std_err"].max_delay = 2000;
         cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
         $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
         flip_2bits(path);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_read_seed_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_read_seed_err_vseq.sv
@@ -25,8 +25,8 @@ class flash_ctrl_hw_read_seed_err_vseq extends flash_ctrl_err_base_vseq;
     `uvm_info(`gfn, $sformatf("event_idx :%0d", event_idx), UVM_MEDIUM)
     `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.hw_rvalid == 1);,
                  , wait_timeout_ns)
-    cfg.scb_h.exp_alert["fatal_err"] = 1;
-    cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+    cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+    cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
     add_glitch(event_idx);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -154,15 +154,15 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     wait_flash_op_done(.clear_op_status(0), .timeout_ns(cfg.seq_cfg.prog_timeout_ns));
 
     expect_alert          = 1;
-    cfg.scb_h.exp_alert["recov_err"] = 1;
-    cfg.scb_h.alert_chk_max_delay["recov_err"] = 1000;
+    cfg.scb_h.expected_alert["recov_err"].expected = 1;
+    cfg.scb_h.expected_alert["recov_err"].max_delay = 1000;
     flash_op_inv.op       = FlashOpInvalid;
     flash_ctrl_start_op(flash_op_inv);
     wait_flash_op_done();
 
     ral.err_code.op_err.predict(expect_alert);
     check_exp_alert_status(expect_alert, "op_err", flash_op_inv, flash_op_data);
-    cfg.scb_h.exp_alert["recov_err"] = 0;
+    cfg.scb_h.expected_alert["recov_err"].expected = 0;
 
     flash_op_rd.op = FlashOpRead;
     flash_op_data = {};
@@ -175,12 +175,12 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
 
     flash_op_inv.op = FlashOpInvalid;
-    cfg.scb_h.exp_alert["recov_err"] = 1;
+    cfg.scb_h.expected_alert["recov_err"].expected = 1;
     flash_ctrl_start_op(flash_op_inv);
     wait_flash_op_done();
     ral.err_code.op_err.predict(expect_alert);
     check_exp_alert_status(expect_alert, "op_err", flash_op_inv, flash_op_data);
-    cfg.scb_h.exp_alert["recov_err"] = 0;
+    cfg.scb_h.expected_alert["recov_err"].expected = 0;
 
     flash_op_rd.op = FlashOpRead;
     flash_op_data = {};

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
@@ -21,8 +21,8 @@ class flash_ctrl_lcmgr_intg_vseq extends flash_ctrl_err_base_vseq;
 
       `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.hw_rvalid == 1);,
                    , wait_timeout_ns)
-      cfg.scb_h.exp_alert["fatal_std_err"] = 1;
-      cfg.scb_h.alert_chk_max_delay["fatal_std_err"] = 2000;
+      cfg.scb_h.expected_alert["fatal_std_err"].expected = 1;
+      cfg.scb_h.expected_alert["fatal_std_err"].max_delay = 2000;
       cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
 
       $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -179,10 +179,10 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
       end
       illegal_trans = 0;
 
-      // This 'wait' will be terminated by alert_chk_max_delay from scoreboard
+      // This 'wait' will be terminated by expected_alert's max_delay from scoreboard
       `uvm_info("seq", $sformatf("wait for recov_err alert  exp:%0d   obs:%0d max_delay:%0d",
                                  exp_alert_cnt, cfg.scb_h.alert_count["recov_err"],
-                                 cfg.scb_h.alert_chk_max_delay["recov_err"]), UVM_MEDIUM)
+                                 cfg.scb_h.expected_alert["recov_err"].max_delay), UVM_MEDIUM)
 
       `DV_SPINWAIT(wait(cfg.scb_h.alert_count["recov_err"] == exp_alert_cnt);,
                    $sformatf({"wait timeout for alert_count == exp_alertcnt after do_mp_reg() ",
@@ -190,7 +190,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
                              cfg.scb_h.alert_count["recov_err"], exp_alert_cnt),
                    cfg.alert_max_delay_in_ns)
 
-      cfg.scb_h.exp_alert["recov_err"] = 0;
+      cfg.scb_h.expected_alert["recov_err"].expected = 0;
     end
 
     // Send info region access and bank erase
@@ -227,7 +227,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
                    "wait timeout for hs_state == AlertAckComplete",
                    cfg.alert_max_delay_in_ns)
 
-      cfg.scb_h.exp_alert["recov_err"] = 0;
+      cfg.scb_h.expected_alert["recov_err"].expected = 0;
      end
   endtask : body
 
@@ -342,21 +342,22 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
 
     if(illegal_trans) begin
       if (flash_op.op != FlashOpErase) begin
-        cfg.scb_h.exp_alert["recov_err"] = 1;
+        cfg.scb_h.expected_alert["recov_err"].expected = 1;
         cfg.scb_h.exp_alert_contd["recov_err"] = 31;
         exp_alert_cnt += 32;
       end else begin
-        cfg.scb_h.exp_alert["recov_err"] = 1;
+        cfg.scb_h.expected_alert["recov_err"].expected = 1;
         exp_alert_cnt +=1;
       end
-      cfg.scb_h.alert_chk_max_delay["recov_err"] = 2000; // cycles
+      cfg.scb_h.expected_alert["recov_err"].max_delay = 2000; // cycles
     end
     `uvm_info("do_info_bank", $sformatf("flash_op: %p", flash_op), UVM_MEDIUM)
     `uvm_info("do_info_bank", $sformatf("INFO_TBL[%0d][%0d][%0d] = %p", flash_op.addr[19],
                                          info_sel, info_page_addr, my_info), UVM_MEDIUM)
     `uvm_info("do_info_bank", $sformatf("trans:%0d  illegal_trans:%0d exp_alert:%0d op:%s",
                                         ++trans_cnt, illegal_trans,
-                                        cfg.scb_h.exp_alert["recov_err"], flash_op.op.name),
+                                        cfg.scb_h.expected_alert["recov_err"].expected,
+                                        flash_op.op.name),
                                         UVM_MEDIUM)
 
     if (flash_op.op == FlashOpProgram) begin

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -617,12 +617,12 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
                                           {flash_op.addr[31:3], 3'h0}), UVM_MEDIUM)
         global_derr_is_set = 1;
         if (cfg.scb_h.do_alert_check == 1) begin
-          cfg.scb_h.exp_alert["fatal_err"] = 1;
-          cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+          cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+          cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
           cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
-          cfg.scb_h.exp_alert["recov_err"] = 1;
-          cfg.scb_h.alert_chk_max_delay["recov_err"] = 2000;
+          cfg.scb_h.expected_alert["recov_err"].expected = 1;
+          cfg.scb_h.expected_alert["recov_err"].max_delay = 2000;
           cfg.scb_h.exp_alert_contd["recov_err"] = 10000;
         end
       end
@@ -797,8 +797,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
 
       if (cfg.ecc_mode > FlashSerrTestMode) begin
         if (derr & cfg.scb_h.do_alert_check) begin
-          cfg.scb_h.exp_alert["fatal_err"] = 1;
-          cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+          cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+          cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
           cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
         end
       end
@@ -988,12 +988,12 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         exp_item.derr = 1;
 
         if (cfg.scb_h.do_alert_check == 1) begin
-          cfg.scb_h.exp_alert["fatal_err"] = 1;
-          cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+          cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+          cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
           cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
-          cfg.scb_h.exp_alert["recov_err"] = 1;
-          cfg.scb_h.alert_chk_max_delay["recov_err"] = 2000;
+          cfg.scb_h.expected_alert["recov_err"].expected = 1;
+          cfg.scb_h.expected_alert["recov_err"].max_delay = 2000;
           cfg.scb_h.exp_alert_contd["recov_err"] = 10000;
         end
       end
@@ -1115,8 +1115,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         derr = 1;
          cfg.scb_h.ecc_error_addr[{tl_addr[31:3],3'h0}] = 1;
         if (derr & cfg.scb_h.do_alert_check) begin
-          cfg.scb_h.exp_alert["fatal_err"] = 1;
-          cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+          cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+          cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
           cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
         end
       end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
@@ -14,8 +14,8 @@ class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_
     string path1 = "tb.dut.u_eflash.gen_flash_cores[0].u_core.ctrl_rsp_vld";
     string path2 = "tb.dut.u_eflash.gen_flash_cores[0].u_core.host_req_done_o";
 
-    cfg.scb_h.exp_alert["fatal_err"] = 1;
-    cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+    cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+    cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
     repeat (2) begin

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -10,8 +10,8 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
     int delay;
     string path = {"tb.dut.u_eflash.gen_flash_cores[0].",
                    "u_core.u_host_arb.gen_input_bufs[1].u_req_buf.out_o[1:0]"};
-    cfg.scb_h.exp_alert["fatal_err"] = 1;
-    cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+    cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+    cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
     // unit 100 ns;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_host_grant_err_vseq.sv
@@ -12,8 +12,8 @@ class flash_ctrl_phy_host_grant_err_vseq extends flash_ctrl_err_base_vseq;
     int delay;
     string path = "tb.dut.u_eflash.gen_flash_cores[0].u_core.muxed_part";
 
-    cfg.scb_h.exp_alert["fatal_err"] = 1;
-    cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+    cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+    cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
      // unit 100 ns;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
@@ -33,8 +33,8 @@ class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_legacy_base_vseq;
       `uvm_info(`gfn, $sformatf("Assert read path err idx1:%0d idx2:%0d", idx1, idx2), UVM_LOW)
       `DV_CHECK(uvm_hdl_force(path1, 1'b0))
       `DV_CHECK(uvm_hdl_force(path2, 1'b0))
-      cfg.scb_h.exp_alert["fatal_err"] = 1;
-      cfg.scb_h.alert_chk_max_delay["fatal_err"] = 2000;
+      cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+      cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
       cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
       cfg.scb_h.exp_tl_rsp_intg_err = 1;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
@@ -42,8 +42,8 @@ class flash_ctrl_wr_path_intg_vseq extends flash_ctrl_rw_vseq;
             end
             randcase
               cfg.otf_wr_pct: begin
-                cfg.scb_h.exp_alert["fatal_std_err"] = 1;
-                cfg.scb_h.alert_chk_max_delay["fatal_std_err"] = 2000;
+                cfg.scb_h.expected_alert["fatal_std_err"].expected = 1;
+                cfg.scb_h.expected_alert["fatal_std_err"].max_delay = 2000;
                 cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
 
                 // prog_err and mp_err

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -91,13 +91,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
           if (cfg.pwrmgr_vif.fetch_en == lc_ctrl_pkg::On) begin
             // End of d0 reset request.
             `uvm_info(`gfn, "pwrmgr end reset in reset_cip_helper", UVM_MEDIUM)
-            foreach (cfg.list_of_alerts[i]) begin
-              alert_fifos[cfg.list_of_alerts[i]].flush();
-              exp_alert[cfg.list_of_alerts[i]] = 0;
-              under_alert_handshake[cfg.list_of_alerts[i]] = 0;
-              is_fatal_alert[cfg.list_of_alerts[i]] = 0;
-              alert_chk_max_delay[cfg.list_of_alerts[i]] = 0;
-            end
+            reset_alert_state();
           end
         end
     join


### PR DESCRIPTION
The pwrmgr scoreboard needs to reset the cip scoreboard's alert state. Create a function in the cip scoreboard to explicitly do that rather than replicating the code in pwrmgr.
Merge some arrays dealing with expected alerts into an array of structs.

This is a follow-up to #16713

Signed-off-by: Guillermo Maturana <maturana@google.com>