### PR TITLE
[dv/xprop] Change reg_top template to enable xprop

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -136,22 +136,15 @@ module flash_ctrl_core_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [432:435]: begin
-        reg_steer = 0;
-      end
-      [436:439]: begin
-        reg_steer = 1;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[432:435]} ? 2'd0 :
+        tl_i.a_address[AW-1:0] inside {[436:439]} ? 2'd1 :
         // Default set to register
-        reg_steer = 2;
-      end
-    endcase
+        2'd2;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 2;
+      reg_steer = 2'd2;
     end
   end
 

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -130,19 +130,14 @@ module hmac_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [2048:4095]: begin
-        reg_steer = 0;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[2048:4095]} ? 1'd0 :
         // Default set to register
-        reg_steer = 1;
-      end
-    endcase
+        1'd1;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 1;
+      reg_steer = 1'd1;
     end
   end
 

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -136,22 +136,15 @@ module kmac_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [1024:1535]: begin
-        reg_steer = 0;
-      end
-      [2048:4095]: begin
-        reg_steer = 1;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[1024:1535]} ? 2'd0 :
+        tl_i.a_address[AW-1:0] inside {[2048:4095]} ? 2'd1 :
         // Default set to register
-        reg_steer = 2;
-      end
-    endcase
+        2'd2;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 2;
+      reg_steer = 2'd2;
     end
   end
 

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -132,22 +132,15 @@ module otbn_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [16384:20479]: begin
-        reg_steer = 0;
-      end
-      [32768:35839]: begin
-        reg_steer = 1;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[16384:20479]} ? 2'd0 :
+        tl_i.a_address[AW-1:0] inside {[32768:35839]} ? 2'd1 :
         // Default set to register
-        reg_steer = 2;
-      end
-    endcase
+        2'd2;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 2;
+      reg_steer = 2'd2;
     end
   end
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -130,19 +130,14 @@ module otp_ctrl_core_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [4096:6143]: begin
-        reg_steer = 0;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[4096:6143]} ? 1'd0 :
         // Default set to register
-        reg_steer = 1;
-      end
-    endcase
+        1'd1;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 1;
+      reg_steer = 1'd1;
     end
   end
 

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -130,19 +130,14 @@ module rv_core_ibex_cfg_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [128:159]: begin
-        reg_steer = 0;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[128:159]} ? 1'd0 :
         // Default set to register
-        reg_steer = 1;
-      end
-    endcase
+        1'd1;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 1;
+      reg_steer = 1'd1;
     end
   end
 

--- a/hw/ip/rv_dm/rtl/rv_dm_mem_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_mem_reg_top.sv
@@ -130,19 +130,14 @@ module rv_dm_mem_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [2048:4095]: begin
-        reg_steer = 0;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[2048:4095]} ? 1'd0 :
         // Default set to register
-        reg_steer = 1;
-      end
-    endcase
+        1'd1;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 1;
+      reg_steer = 1'd1;
     end
   end
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -130,19 +130,14 @@ module spi_device_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [4096:8191]: begin
-        reg_steer = 0;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[4096:8191]} ? 1'd0 :
         // Default set to register
-        reg_steer = 1;
-      end
-    endcase
+        1'd1;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 1;
+      reg_steer = 1'd1;
     end
   end
 

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -132,22 +132,15 @@ module spi_host_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [36:39]: begin
-        reg_steer = 0;
-      end
-      [40:43]: begin
-        reg_steer = 1;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[36:39]} ? 2'd0 :
+        tl_i.a_address[AW-1:0] inside {[40:43]} ? 2'd1 :
         // Default set to register
-        reg_steer = 2;
-      end
-    endcase
+        2'd2;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 2;
+      reg_steer = 2'd2;
     end
   end
 

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -132,19 +132,14 @@ module usbdev_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [2048:4095]: begin
-        reg_steer = 0;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[2048:4095]} ? 1'd0 :
         // Default set to register
-        reg_steer = 1;
-      end
-    endcase
+        1'd1;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 1;
+      reg_steer = 1'd1;
     end
   end
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -136,22 +136,15 @@ module flash_ctrl_core_reg_top (
 
   // Create steering logic
   always_comb begin
-    unique case (tl_i.a_address[AW-1:0]) inside
-      [432:435]: begin
-        reg_steer = 0;
-      end
-      [436:439]: begin
-        reg_steer = 1;
-      end
-      default: begin
+    reg_steer =
+        tl_i.a_address[AW-1:0] inside {[432:435]} ? 2'd0 :
+        tl_i.a_address[AW-1:0] inside {[436:439]} ? 2'd1 :
         // Default set to register
-        reg_steer = 2;
-      end
-    endcase
+        2'd2;
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = 2;
+      reg_steer = 2'd2;
     end
   end
 

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -347,27 +347,23 @@ module ${mod_name} (
 
   // Create steering logic
   always_comb begin
-    unique case (${f'{tl_h2d_expr}.a_address[AW-1:0]'}) inside
+    reg_steer =
   % for i,w in enumerate(rb.windows):
 <%
+      steer_width = steer_msb + 1
       base_addr = w.offset
       limit_addr = w.offset + w.size_in_bytes
       assert (limit_addr-1 >= base_addr)
       addr_test = f"[{base_addr}:{limit_addr-1}]"
 %>\
-      ${addr_test}: begin
-        reg_steer = ${i};
-      end
+        ${f'{tl_h2d_expr}.a_address[AW-1:0]'} inside {${addr_test}} ? ${steer_width}'d${i} :
   % endfor
-      default: begin
         // Default set to register
-        reg_steer = ${num_dsp-1};
-      end
-    endcase
+        ${steer_width}'d${num_dsp-1};
 
     // Override this in case of an integrity error
     if (intg_err) begin
-      reg_steer = ${num_dsp-1};
+      reg_steer = ${steer_width}'d${num_dsp-1};
     end
   end
 % endif


### PR DESCRIPTION
The reg_top sv template creates unique case with "inside" labels SV statements, which the xprop feature doesn't handle.
Create equivalent code that is xprop-friendly.

Addresses some of #16723

Signed-off-by: Guillermo Maturana <maturana@google.com>