### PR TITLE
[opentitantool] HyperDebug refactoring, and control SPI speed

### DIFF
--- a/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
@@ -52,19 +52,19 @@ impl C2d2ResetPin {
 impl GpioPin for C2d2ResetPin {
     /// Reads the value of the the reset pin.
     fn read(&self) -> Result<bool> {
-        let mut result: Result<bool> =
-            Err(TransportError::CommunicationError("No output from gpioget".to_string()).into());
-        self.inner
-            .execute_command("gpioget SPIVREF_RSVD_H1VREF_H1_RST_ODL", |line| {
-                result = Ok(line.trim_start().starts_with('1'))
+        let line = self
+            .inner
+            .cmd_one_line_output("gpioget SPIVREF_RSVD_H1VREF_H1_RST_ODL")
+            .map_err(|_| {
+                TransportError::CommunicationError("No output from gpioget".to_string())
             })?;
-        result
+        Ok(line.trim_start().starts_with('1'))
     }
 
     /// Sets the value of the GPIO reset pin by means of the special h1_reset command.
     fn write(&self, value: bool) -> Result<()> {
         self.inner
-            .execute_command(&format!("h1_reset {}", if value { 0 } else { 1 }), |_| {})?;
+            .cmd_no_output(&format!("h1_reset {}", if value { 0 } else { 1 }))?;
         Ok(())
     }
 

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -367,11 +367,17 @@ impl Target for HyperdebugSpiTarget {
     }
 
     fn get_max_speed(&self) -> Result<u32> {
-        todo!();
+        let mut buf = String::new();
+        let captures = self.inner.cmd_one_line_output_match(
+            &format!("spiget {}", &self.target_idx),
+            &super::SPI_REGEX,
+            &mut buf,
+        )?;
+        Ok(captures.get(3).unwrap().as_str().parse().unwrap())
     }
-    fn set_max_speed(&self, _frequency: u32) -> Result<()> {
-        log::info!("Setting of SPI speed not implemented for HyperDebug, ignoring\n",);
-        Ok(())
+    fn set_max_speed(&self, frequency: u32) -> Result<()> {
+        self.inner
+            .cmd_no_output(&format!("spisetspeed {} {}", &self.target_idx, frequency))
     }
 
     fn get_max_transfer_count(&self) -> Result<usize> {


### PR DESCRIPTION
Introduce convenience functions for doing textual request/response with HyperDebug hardware.  Then use these methods to get and set SPI speed (supported on recent HyperDebug firmware).