### PR TITLE
[dv/xprop] Change code to be more xprop-friendly

### DIFF
--- a/hw/dv/tools/vcs/xprop.cfg
+++ b/hw/dv/tools/vcs/xprop.cfg
@@ -6,3 +6,4 @@ merge = xmerge;
 
 // Turn on xprop for dut only
 instance { tb.dut } { xpropOn };
+module { prim_cdc_rand_delay } { xpropOff };

--- a/hw/ip/flash_ctrl/rtl/flash_phy_prog.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_prog.sv
@@ -358,23 +358,23 @@ module flash_phy_prog import flash_phy_pkg::*; (
   // Assertions
   /////////////////////////////////
 
-`ifndef SYNTHESIS
+`ifdef INC_ASSERT
   logic txn_done;
-  logic [15:0] done_cnt;
+  logic [15:0] done_cnt_d, done_cnt_q;
 
   assign txn_done = req_i && ack_o && last_i;
+  assign done_cnt_d = txn_done ? '0 : (done ? done_cnt_q + 16'h1 : done_cnt_q);
+
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (rst_ni) begin
-      done_cnt <= '0;
-    end else if (txn_done) begin
-      done_cnt <= '0;
-    end else if (done) begin
-      done_cnt <= done_cnt + 1'b1;
+    if (!rst_ni) begin
+      done_cnt_q <= '0;
+    end else begin
+      done_cnt_q <= done_cnt_d;
     end
   end
 
   // We can only observe one done per transaction.
-  `ASSERT(OneDonePerTxn_A,  txn_done |-> done_cnt == '0)
+  `ASSERT(OneDonePerTxn_A,  txn_done |-> done_cnt_d == '0)
 
 `endif
 

--- a/hw/ip/prim/rtl/prim_sync_reqack.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack.sv
@@ -330,9 +330,13 @@ module prim_sync_reqack #(
   `ifdef INC_ASSERT
     //VCS coverage off
     // pragma coverage off
+
+    logic effective_rst_n;
+    assign effective_rst_n = rst_src_ni && rst_dst_ni;
+
     logic chk_flag;
-    always_ff @(posedge clk_src_i or negedge rst_src_ni or negedge rst_dst_ni) begin
-      if (!rst_src_ni || !rst_dst_ni) begin
+    always_ff @(posedge clk_src_i or negedge effective_rst_n) begin
+      if (!effective_rst_n) begin
         chk_flag <= '0;
       end else if (src_req_i && !chk_flag) begin
         chk_flag <= 1'b1;

--- a/hw/ip/prim/rtl/prim_sync_reqack_data.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack_data.sv
@@ -100,21 +100,26 @@ module prim_sync_reqack_data #(
 `ifdef INC_ASSERT
     //VCS coverage off
     // pragma coverage off
-    logic chk_flag;
-    always_ff @(posedge clk_src_i or negedge rst_src_ni or negedge rst_dst_ni) begin
-      if (!rst_src_ni || !rst_dst_ni) begin
-        chk_flag <= '0;
-      end else if (src_req_i && !chk_flag) begin
-        chk_flag <= 1'b1;
+    logic effective_rst_n;
+    assign effective_rst_n = rst_src_ni && rst_dst_ni;
+
+    logic chk_flag_d, chk_flag_q;
+    assign chk_flag_d = src_req_i && !chk_flag_q ? 1'b1 : chk_flag_q;
+
+    always_ff @(posedge clk_src_i or negedge effective_rst_n) begin
+      if (!effective_rst_n) begin
+        chk_flag_q <= '0;
+      end else begin
+        chk_flag_q <= chk_flag_d;
       end
     end
     //VCS coverage on
     // pragma coverage on
 
     // SRC domain cannot change data while waiting for ACK.
-    `ASSERT(SyncReqAckDataHoldSrc2Dst, !$stable(data_i) && chk_flag |->
+    `ASSERT(SyncReqAckDataHoldSrc2Dst, !$stable(data_i) && chk_flag_q |->
         (!src_req_i || (src_req_i && src_ack_o)),
-        clk_src_i, !rst_src_ni || !rst_dst_ni || !chk_flag)
+        clk_src_i, !rst_src_ni || !rst_dst_ni || !chk_flag_q)
 
     // Register stage cannot be used.
     `ASSERT_INIT(SyncReqAckDataReg, DataSrc2Dst && !DataReg)
@@ -144,24 +149,29 @@ module prim_sync_reqack_data #(
 `ifdef INC_ASSERT
     //VCS coverage off
     // pragma coverage off
-    logic chk_flag;
-    always_ff @(posedge clk_src_i or negedge rst_src_ni or negedge rst_dst_ni) begin
-      if (!rst_src_ni || !rst_dst_ni) begin
-        chk_flag <= '0;
-      end else if (src_req_i && !chk_flag) begin
-        chk_flag <= 1'b1;
+    logic effective_rst_n;
+    assign effective_rst_n = rst_src_ni && rst_dst_ni;
+
+    logic chk_flag_d, chk_flag_q;
+    assign chk_flag_d = src_req_i && !chk_flag_q ? 1'b1 : chk_flag_q;
+
+    always_ff @(posedge clk_src_i or negedge effective_rst_n) begin
+      if (!effective_rst_n) begin
+        chk_flag_q <= '0;
+      end else begin
+        chk_flag_q <= chk_flag_d;
       end
     end
     //VCS coverage on
     // pragma coverage on
 
     `ASSERT(SyncReqAckDataHoldDst2SrcA,
-            chk_flag && src_req_i && src_ack_o |->
+            chk_flag_q && src_req_i && src_ack_o |->
             $past(data_o, 2) == data_o && $past(data_o) == data_o,
-            clk_src_i, !rst_src_ni || !rst_dst_ni || !chk_flag)
+            clk_src_i, !rst_src_ni || !rst_dst_ni || !chk_flag_q)
     `ASSERT(SyncReqAckDataHoldDst2SrcB,
-            chk_flag && $past(src_req_i && src_ack_o) |-> $past(data_o) == data_o,
-            clk_src_i, !rst_src_ni || !rst_dst_ni || !chk_flag)
+            chk_flag_q && $past(src_req_i && src_ack_o) |-> $past(data_o) == data_o,
+            clk_src_i, !rst_src_ni || !rst_dst_ni || !chk_flag_q)
 `endif
   end
 

--- a/hw/ip/prim/rtl/prim_util_get_scramble_params.svh
+++ b/hw/ip/prim/rtl/prim_util_get_scramble_params.svh
@@ -6,31 +6,21 @@
   export "DPI-C" function simutil_get_scramble_key;
 
   function int simutil_get_scramble_key(output bit [127:0] val);
-    if (!key_valid_i) begin
-      return 0;
-    end
-
-    if (DataKeyWidth != 128) begin
-      return 0;
-    end
-
-    val = key_i;
-    return 1;
+    int valid;
+    valid = key_valid_i && DataKeyWidth == 128 ? 1 : 0;
+    if (valid == 1) val = key_i;
+    return valid;
   endfunction
 
   export "DPI-C" function simutil_get_scramble_nonce;
 
   function int simutil_get_scramble_nonce(output bit [319:0] nonce);
-    if (!key_valid_i) begin
-      return 0;
+    int valid;
+    valid = key_valid_i && NonceWidth <= 320 ? 1 : 0;
+    if (valid == 1) begin
+       nonce = '0;
+       nonce[NonceWidth-1:0] = nonce_i;
     end
-
-    if (NonceWidth > 320) begin
-      return 0;
-    end
-
-    nonce = '0;
-    nonce[NonceWidth-1:0] = nonce_i;
-    return 1;
+    return valid;
   endfunction
 `endif

--- a/hw/ip/prim/rtl/prim_util_memload.svh
+++ b/hw/ip/prim/rtl/prim_util_memload.svh
@@ -34,37 +34,23 @@
   export "DPI-C" function simutil_set_mem;
 
   function int simutil_set_mem(input int index, input bit [311:0] val);
-
-    // Function will only work for memories <= 312 bits
-    if (Width > 312) begin
-      return 0;
-    end
-
-    if (index >= Depth) begin
-      return 0;
-    end
-
-    mem[index] = val[Width-1:0];
-    return 1;
+    int valid;
+    valid = Width > 312 || index >= Depth ? 0 : 1;
+    if (valid == 1) mem[index] = val[Width-1:0];
+    return valid;
   endfunction
 
   // Function for getting a specific element in |mem|
   export "DPI-C" function simutil_get_mem;
 
   function int simutil_get_mem(input int index, output bit [311:0] val);
-
-    // Function will only work for memories <= 312 bits
-    if (Width > 312) begin
-      return 0;
+    int valid;
+    valid = Width > 312 || index >= Depth ? 0 : 1;
+    if (valid == 1) begin
+      val = 0;
+      val[Width-1:0] = mem[index];
     end
-
-    if (index >= Depth) begin
-      return 0;
-    end
-
-    val = 0;
-    val[Width-1:0] = mem[index];
-    return 1;
+    return valid;
   endfunction
 `endif
 

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
@@ -72,7 +72,7 @@ module pwrmgr_bind;
     .slow_esc_rst_req(slow_peri_reqs.rstreqs[3]),
     .slow_mp_rst_req(slow_peri_reqs.rstreqs[2]),
     .slow_fsm_invalid,
-    .fast_state(u_fsm.state_q),
+    .fast_fsm_invalid(u_fsm.u_state_regs.unused_err_o),
     .rom_intg_chk_dis(u_fsm.rom_intg_chk_dis),
     .rom_intg_chk_ok(prim_mubi_pkg::mubi4_and_hi(u_fsm.rom_intg_chk_done, u_fsm.rom_intg_chk_good)),
     .lc_dft_en_i,

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -650,9 +650,12 @@ module pwrmgr
   `ifdef INC_ASSERT
   //VCS coverage off
   // pragma coverage off
+  logic effective_rst_n;
+  assign effective_rst_n = clk_lc_i && rst_ni;
+
   logic [31:0] cnt;
-  always_ff @(posedge clk_i or negedge clk_lc_i or negedge rst_ni) begin
-    if (!rst_ni || !clk_lc_i) begin
+  always_ff @(posedge clk_i or negedge effective_rst_n) begin
+    if (!effective_rst_n) begin
       cnt <= '0;
     end else begin
       cnt <= cnt + 1'b1;


### PR DESCRIPTION
Xprop improves the SV semantics when conditions contain 'X values. Change RTL or DV code to enable more xprop instrumentation.

Addresses some of #16723

Signed-off-by: Guillermo Maturana <maturana@google.com>