### PR TITLE
[i2c] Remove passthrough option on fifos

### DIFF
--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -286,7 +286,7 @@ module  i2c_core #(
 
   prim_fifo_sync #(
     .Width   (13),
-    .Pass    (1'b1),
+    .Pass    (1'b0),
     .Depth   (FifoDepth)
   ) u_i2c_fmtfifo (
     .clk_i,
@@ -332,7 +332,7 @@ module  i2c_core #(
 
   prim_fifo_sync #(
     .Width(8),
-    .Pass(1'b1),
+    .Pass(1'b0),
     .Depth(FifoDepth)
   ) u_i2c_txfifo (
     .clk_i,

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -173,7 +173,7 @@ module i2c_fsm #(
   end
 
   logic unused_fifo_outputs;
-  assign unused_fifo_outputs = |{tx_fifo_depth_i, tx_fifo_wvalid_i};
+  assign unused_fifo_outputs = |{tx_fifo_depth_i, tx_fifo_wvalid_i, fmt_fifo_wvalid_i};
 
   always_ff @ (posedge clk_i or negedge rst_ni) begin : clk_counter
     if (!rst_ni) begin
@@ -1061,7 +1061,7 @@ module i2c_fsm #(
           state_d = ClockStop;
           load_tcount = 1'b1;
           tcount_sel = tClockStop;
-        end else if (fmt_fifo_depth_i == 7'd1 && !fmt_fifo_wvalid_i) begin
+        end else if (fmt_fifo_depth_i == 7'h1) begin
           state_d = Idle;
           load_tcount = 1'b1;
           tcount_sel = tNoDelay;


### PR DESCRIPTION
- there's no good reason to need passthrough fifos for i2c,
  the interface overall is not fast enough where 1 core clock
  cycle would make a significant difference.

- remove the passthrough option to simplify some of the "1 entry"
  and wvalid checking.


