### PR TITLE
[test] Fix rom_e2e_jtag_inject_tests

### DIFF
--- a/sw/device/examples/sram_program/sram_program.c
+++ b/sw/device/examples/sram_program/sram_program.c
@@ -49,7 +49,9 @@ void sram_main() {
   asm("auipc %[pc], 0;" : [pc] "=r"(pc));
   LOG_INFO("PC: %p, SRAM: [%p, %p)", pc, kSramStart, kSramEnd);
   CHECK(pc >= kSramStart && pc < kSramEnd, "PC is outside the main SRAM");
-  test_status_set(kTestStatusPassed);
+  if (kDeviceType == kDeviceSimDV) {
+    test_status_set(kTestStatusPassed);
+  }
 }
 
 // Reference functions that the debugger may wish to call. This prevents the

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -2217,7 +2217,7 @@ SRAM_JTAG_INJECTION_GDB_SCRIPT = """
     opentitan_gdb_fpga_cw310_test(
         name = "sram_program_fpga_cw310_test_otp_" + lc_state,
         timeout = "short",
-        exit_success_pattern = "sram_program\\.c:\\d+\\] PC: 0x100020e0, SRAM: \\[0x10000000, 0x10020000\\)",
+        exit_success_pattern = "sram_program\\.c:\\d+\\] PC: 0x1000[0-2][0-9a-f]{3}, SRAM: \\[0x10000000, 0x10020000\\)",
         gdb_script = SRAM_JTAG_INJECTION_GDB_SCRIPT,
         gdb_script_symlinks = {
             "//sw/device/examples/sram_program:sram_program_fpga_cw310.elf": "sram_program.elf",


### PR DESCRIPTION
This commit fixes `sram_program_fpga_cw310_test_otp_{test_unlocked0, dev, rma}` by calling `test_status_set()` only in DV and relaxing the `exit_success` regexp to match any `PC` value within [0x10000000, 0x10002fff].

Signed-off-by: Alphan Ulusoy <alphan@google.com>