### PR TITLE
[opentitantool] Add TPM subcommand

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -77,6 +77,8 @@ rust_library(
         "src/test_utils/mod.rs",
         "src/test_utils/rpc.rs",
         "src/test_utils/status.rs",
+        "src/tpm/driver.rs",
+        "src/tpm/mod.rs",
         "src/transport/common/mod.rs",
         "src/transport/common/uart.rs",
         "src/transport/cw310/gpio.rs",

--- a/sw/host/opentitanlib/src/lib.rs
+++ b/sw/host/opentitanlib/src/lib.rs
@@ -15,6 +15,7 @@ pub mod otp;
 pub mod proxy;
 pub mod spiflash;
 pub mod test_utils;
+pub mod tpm;
 pub mod transport;
 pub mod uart;
 pub mod util;

--- a/sw/host/opentitanlib/src/tpm/driver.rs
+++ b/sw/host/opentitanlib/src/tpm/driver.rs
@@ -1,0 +1,173 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, bail, Result};
+use serde::{Deserialize, Serialize};
+use std::rc::Rc;
+use structopt::clap::arg_enum;
+use thiserror::Error;
+
+use crate::io::i2c;
+use crate::io::spi;
+
+arg_enum! {
+    /// Tpm registers, can be specified in command line arguments.
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+    pub enum Register {
+        ACCESS,
+        INT_ENABLE,
+        INT_VECTOR,
+        INT_STATUS,
+        INTF_CAPABILITY,
+        STS,
+        DATA_FIFO,
+        INTERFACE_ID,
+        XDATA_FIFO,
+        DID_VID,
+        RID,
+    }
+}
+
+impl Register {
+    /// Size of given TPM register in bytes, `None` means variable size.
+    pub fn size(&self) -> Option<usize> {
+        Some(match *self {
+            Self::ACCESS => 1,
+            Self::INT_ENABLE => 4,
+            Self::INT_VECTOR => 4,
+            Self::INT_STATUS => 4,
+            Self::INTF_CAPABILITY => 4,
+            Self::STS => 4,
+            Self::DATA_FIFO => return None,
+            Self::INTERFACE_ID => 4,
+            Self::XDATA_FIFO => return None,
+            Self::DID_VID => 4,
+            Self::RID => 4,
+        })
+    }
+}
+
+/// Errors relating to TPM communication.
+#[derive(Error, Debug)]
+pub enum TpmError {
+    #[error("TPM timeout")]
+    Timeout,
+}
+
+/// Low level interface for accessing TPM.  Separate implementations exist for SPI and I2C.
+pub trait Driver {
+    /// Read from the given TPM register, number of bytes to read given by length of data slice.
+    fn read_register(&self, register: Register, data: &mut [u8]) -> Result<()>;
+    /// Write to the given TPM register.
+    fn write_register(&self, register: Register, data: &[u8]) -> Result<()>;
+}
+
+/// Implementation of the low level interface via standard SPI protocol.
+pub struct SpiDriver {
+    spi: Rc<dyn spi::Target>,
+}
+
+impl SpiDriver {
+    pub fn new(spi: Rc<dyn spi::Target>) -> Self {
+        Self { spi }
+    }
+
+    /// Numerical TPM register address as used in SPI protocol.
+    pub fn addr(register: Register) -> u16 {
+        match register {
+            Register::ACCESS => 0x0000,
+            Register::INT_ENABLE => 0x0008,
+            Register::INT_VECTOR => 0x000C,
+            Register::INT_STATUS => 0x0010,
+            Register::INTF_CAPABILITY => 0x0014,
+            Register::STS => 0x0018,
+            Register::DATA_FIFO => 0x0024,
+            Register::INTERFACE_ID => 0x0030,
+            Register::XDATA_FIFO => 0x0080,
+            Register::DID_VID => 0x0F00,
+            Register::RID => 0x0F04,
+        }
+    }
+}
+
+const SPI_TPM_READ: u32 = 0xC0000000;
+const SPI_TPM_DATA_LEN_POS: u8 = 23;
+const SPI_TPM_ADDRESS_OFFSET: u32 = 0x00D40000;
+
+impl Driver for SpiDriver {
+    fn read_register(&self, register: Register, data: &mut [u8]) -> Result<()> {
+        let _cs_asserted = Rc::clone(&self.spi).assert_cs()?; // Deasserts when going out of scope.
+        let mut buffer = vec![0u8; 4];
+        let req: u32 = SPI_TPM_READ
+            | ((data.len() as u32 - 1) << SPI_TPM_DATA_LEN_POS)
+            | SPI_TPM_ADDRESS_OFFSET
+            | (Self::addr(register) as u32);
+        self.spi
+            .run_transaction(&mut [spi::Transfer::Both(&req.to_be_bytes(), &mut buffer)])?;
+        if buffer[3] & 1 == 0 {
+            let mut retries = 10;
+            while {
+                self.spi
+                    .run_transaction(&mut [spi::Transfer::Read(&mut buffer[0..1])])?;
+                buffer[0] & 1 == 0
+            } {
+                retries -= 1;
+                if retries == 0 {
+                    bail!(TpmError::Timeout)
+                }
+            }
+        }
+        self.spi.run_transaction(&mut [spi::Transfer::Read(data)])?;
+        Ok(())
+    }
+
+    fn write_register(&self, _register: Register, _data: &[u8]) -> Result<()> {
+        bail!(anyhow!("Unimplemented"))
+    }
+}
+
+/// Implementation of the low level interface via Google I2C protocol.
+pub struct I2cDriver {
+    i2c: Rc<dyn i2c::Bus>,
+    addr: u8,
+}
+
+impl I2cDriver {
+    pub fn new(i2c: Rc<dyn i2c::Bus>, addr: u8) -> Self {
+        Self { i2c, addr }
+    }
+
+    /// Numerical TPM register address as used in Google I2C protocol.
+    pub fn addr(reg: Register) -> Option<u8> {
+        match reg {
+            Register::ACCESS => Some(0x00),
+            Register::STS => Some(0x01),
+            Register::DATA_FIFO => Some(0x05),
+            Register::DID_VID => Some(0x06),
+            _ => None,
+        }
+    }
+}
+
+impl Driver for I2cDriver {
+    fn read_register(&self, register: Register, data: &mut [u8]) -> Result<()> {
+        self.i2c.run_transaction(
+            self.addr,
+            &mut [
+                i2c::Transfer::Write(&[Self::addr(register).unwrap()]),
+                i2c::Transfer::Read(data),
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn write_register(&self, register: Register, data: &[u8]) -> Result<()> {
+        let mut buffer = vec![Self::addr(register).unwrap()];
+        buffer.extend_from_slice(data);
+        self.i2c
+            .run_transaction(self.addr, &mut [i2c::Transfer::Write(&buffer)])?;
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/tpm/mod.rs
+++ b/sw/host/opentitanlib/src/tpm/mod.rs
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+mod driver;
+
+pub use driver::{Driver, I2cDriver, Register, SpiDriver};

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -26,6 +26,7 @@ rust_binary(
         "src/command/rsa.rs",
         "src/command/set_pll.rs",
         "src/command/spi.rs",
+        "src/command/tpm.rs",
         "src/command/transport.rs",
         "src/command/update_usr_access.rs",
         "src/command/version.rs",

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -17,6 +17,7 @@ pub mod reset_sam3x;
 pub mod rsa;
 pub mod set_pll;
 pub mod spi;
+pub mod tpm;
 pub mod transport;
 pub mod update_usr_access;
 pub mod version;

--- a/sw/host/opentitantool/src/command/tpm.rs
+++ b/sw/host/opentitantool/src/command/tpm.rs
@@ -1,0 +1,129 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use serde_annotate::Annotate;
+use std::any::Any;
+use structopt::StructOpt;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::tpm;
+
+/// Read the value of a given TPM register.
+#[derive(Debug, StructOpt)]
+pub struct TpmReadRegister {
+    #[structopt(
+        name = "REGISTER",
+        case_insensitive = true,
+        help = "The TPM register to inspect"
+    )]
+    register: tpm::Register,
+
+    #[structopt(long, help = "Number of bytes to read.")]
+    length: Option<usize>,
+}
+
+#[derive(Annotate, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct TpmReadRegisterResponse {
+    hexdata: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uint32: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uint8: Option<u8>,
+}
+
+impl CommandDispatch for TpmReadRegister {
+    fn run(
+        &self,
+        context: &dyn Any,
+        _transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        let tpm = context.downcast_ref::<Box<dyn tpm::Driver>>().unwrap();
+        let length = self
+            .length
+            .or(self.register.size())
+            .ok_or(anyhow!("Must specify --length"))?;
+        let mut buffer = vec![0u8; length];
+        tpm.read_register(self.register, &mut buffer)?;
+        Ok(Some(Box::new(TpmReadRegisterResponse {
+            hexdata: Option::Some(hex::encode(&buffer)),
+            uint32: if buffer.len() == 4 {
+                Some(u32::from_le_bytes([
+                    buffer[0], buffer[1], buffer[2], buffer[3],
+                ]))
+            } else {
+                Option::None
+            },
+            uint8: if buffer.len() == 1 {
+                Some(buffer[0])
+            } else {
+                Option::None
+            },
+        })))
+    }
+}
+
+/// Write to a given TPM register.
+#[derive(Debug, StructOpt)]
+pub struct TpmWriteRegister {
+    #[structopt(
+        name = "REGISTER",
+        case_insensitive = true,
+        help = "The TPM register to modify"
+    )]
+    register: tpm::Register,
+
+    #[structopt(
+        short = "d",
+        long,
+        conflicts_with_all=&["uint32", "uint8"],
+        help = "Data to write, specify only one kind.",
+    )]
+    hexdata: Option<String>,
+    #[structopt(
+        short = "w",
+        long,
+        conflicts_with_all=&["hexdata", "uint8"],
+        help = "Data to write, specify only one kind.",
+    )]
+    uint32: Option<u32>,
+    #[structopt(
+        short = "b",
+        long,
+        conflicts_with_all=&["hexdata", "uint32"],
+        help = "Data to write, specify only one kind.",
+    )]
+    uint8: Option<u8>,
+}
+
+#[derive(Annotate, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct TpmWriteRegisterResponse {}
+
+impl CommandDispatch for TpmWriteRegister {
+    fn run(
+        &self,
+        context: &dyn Any,
+        _transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        let tpm = context.downcast_ref::<Box<dyn tpm::Driver>>().unwrap();
+        if let Some(hexdata) = &self.hexdata {
+            tpm.write_register(self.register, &hex::decode(hexdata)?)?;
+        } else if let Some(uint32) = self.uint32 {
+            tpm.write_register(self.register, &u32::to_le_bytes(uint32))?;
+        } else if let Some(uint8) = self.uint8 {
+            tpm.write_register(self.register, &[uint8])?;
+        }
+        Ok(Some(Box::new(TpmWriteRegisterResponse {})))
+    }
+}
+
+/// Commands for interacting with a TPM.  These appear as subcommands of both `opentitantool i2c
+/// tpm` and `opentitantool spi tpm`.
+#[derive(Debug, StructOpt, CommandDispatch)]
+pub enum TpmSubCommand {
+    ReadRegister(TpmReadRegister),
+    WriteRegister(TpmWriteRegister),
+}


### PR DESCRIPTION
Add drivers for the lowest level of the TPM protocol: reading and writing "TPM registers".  Later, higher level functionality can be added to use the TPM status and fifo registers to send TPM commands, and retrieve the output of their execution.

Sample commands:
```
opentitantool i2c --addr 80 tpm read-register DID_VID
opentitantool spi tpm read-register DID_VID
```