### PR TITLE
[fpv] Clean up strong property in simulation

### DIFF
--- a/hw/ip/prim/rtl/prim_reg_cdc.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc.sv
@@ -190,6 +190,8 @@ module prim_reg_cdc #(
   `ASSERT_KNOWN(DstReqKnown_A, dst_req, clk_dst_i, !rst_dst_ni)
 
   // If busy goes high, we must eventually see an ack
-  `ASSERT(HungHandShake_A, $rose(src_req) |-> strong(##[0:$] src_ack), clk_src_i, !rst_src_ni)
-
+  `ifdef FPV_ON
+    `ASSERT(HungHandShake_A, $rose(src_req) |-> strong(##[0:$] src_ack), clk_src_i, !rst_src_ni)
+    // TODO: #14913 check if we can add additional sim assertions.
+  `endif
 endmodule // prim_subreg_cdc

--- a/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
@@ -245,10 +245,13 @@ module prim_reg_cdc_arb #(
     assign src_update_o = src_req & (id_q == SelHwReq);
 
     // once hardware makes an update request, we must eventually see an update pulse
-    `ASSERT(ReqTimeout_A, $rose(id_q == SelHwReq) |-> s_eventually(src_update_o),
-            clk_src_i, !rst_src_ni)
+    `ifdef FPV_ON
+      `ASSERT(ReqTimeout_A, $rose(id_q == SelHwReq) |-> s_eventually(src_update_o),
+              clk_src_i, !rst_src_ni)
+      // TODO: #14913 check if we can add additional sim assertions.
+    `endif
 
-    `ifdef INC_ASSERT
+    `ifdef FPV_ON
       //VCS coverage off
       // pragma coverage off
 
@@ -267,6 +270,7 @@ module prim_reg_cdc_arb #(
       // pragma coverage on
 
       // once hardware makes an update request, we must eventually see an update pulse
+      // TODO: #14913 check if we can add additional sim assertions.
       `ASSERT(UpdateTimeout_A, $rose(async_flag) |-> s_eventually(src_update_o),
               clk_src_i, !rst_src_ni)
     `endif

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -984,7 +984,6 @@ opentitan_functest(
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:aon_timer_testutils",
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_alerts.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_alerts.c
@@ -512,8 +512,6 @@ bool test_main(void) {
 
   // Do the cleanup
   cleanup_wakeup_src();
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
 
   return true;
 }

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
@@ -518,8 +518,6 @@ bool test_main(void) {
 
   // Do the cleanup
   cleanup_wakeup_src();
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
 
   return true;
 }

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -237,7 +237,5 @@ bool test_main(void) {
   execute_test(&aon_timer, irq_time,
                /*expected_irq=*/kDifAonTimerIrqWdogTimerBark);
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
+++ b/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
@@ -91,7 +91,5 @@ bool test_main(void) {
     LOG_ERROR("Got unexpected reset_info=0x%x", rst_info);
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/aon_timer_smoketest.c
+++ b/sw/device/tests/aon_timer_smoketest.c
@@ -67,7 +67,5 @@ bool test_main(void) {
   aon_timer_test_wakeup_timer(&aon);
   aon_timer_test_watchdog_timer(&aon);
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon);
   return true;
 }

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -130,8 +130,6 @@ bool test_main(void) {
   } else if (rst_info ==
              (kDifRstmgrResetInfoWatchdog | kDifRstmgrResetInfoLowPowerExit)) {
     LOG_INFO("Booting for the third time due to wdog bite reset during sleep");
-    // Turn off the AON timer hardware completely before exiting.
-    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   }
 

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -248,8 +248,6 @@ bool test_main(void) {
   } else if (rst_info == kDifRstmgrResetInfoEscalation) {
     LOG_INFO("Booting for the second time due to escalation reset");
 
-    // Turn off the AON timer hardware completely before exiting.
-    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   } else {
     LOG_ERROR("Unexpected rst_info=0x%x", rst_info);

--- a/sw/device/tests/ast_clk_outs_test.c
+++ b/sw/device/tests/ast_clk_outs_test.c
@@ -136,7 +136,5 @@ bool test_main(void) {
     return false;
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
   return false;
 }

--- a/sw/device/tests/clkmgr_off_peri_test.c
+++ b/sw/device/tests/clkmgr_off_peri_test.c
@@ -243,8 +243,6 @@ bool test_main(void) {
       LOG_ERROR("This is unreachable since a reset should have been triggered");
       return false;
     } else {
-      // Turn off the AON timer hardware completely before exiting.
-      aon_timer_testutils_shutdown(&aon_timer);
       return true;
     }
   } else {

--- a/sw/device/tests/clkmgr_off_trans_impl.c
+++ b/sw/device/tests/clkmgr_off_trans_impl.c
@@ -186,8 +186,6 @@ bool execute_off_trans_test(dif_clkmgr_hintable_clock_t clock) {
     LOG_INFO("EXC ADDRESS  = 0x%x", cpu_dump[3]);
     */
 
-    // Turn off the AON timer hardware completely before exiting.
-    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   } else {
     dif_rstmgr_reset_info_bitfield_t reset_info;

--- a/sw/device/tests/clkmgr_sleep_frequency_test.c
+++ b/sw/device/tests/clkmgr_sleep_frequency_test.c
@@ -143,7 +143,5 @@ bool test_main(void) {
   CHECK(clkmgr_testutils_check_measurement_counts(&clkmgr));
   CHECK(clkmgr_testutils_check_measurement_enables(&clkmgr, kDifToggleEnabled));
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/flash_ctrl_idle_low_power_test.c
+++ b/sw/device/tests/flash_ctrl_idle_low_power_test.c
@@ -11,7 +11,6 @@
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/irq.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/aon_timer_testutils.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/pwrmgr_testutils.h"
 #include "sw/device/lib/testing/rand_testutils.h"
@@ -166,7 +165,5 @@ bool test_main(void) {
     return false;
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon);
   return true;
 }

--- a/sw/device/tests/pwrmgr_sleep_disabled_test.c
+++ b/sw/device/tests/pwrmgr_sleep_disabled_test.c
@@ -144,8 +144,6 @@ bool test_main(void) {
     // And to be extra safe, check there is no pwrmgr interrupt pending.
     CHECK(!is_pwrmgr_irq_pending());
 
-    // Turn off the AON timer hardware completely before exiting.
-    aon_timer_testutils_shutdown(&aon_timer);
     return true;
 
   } else if (pwrmgr_testutils_is_wakeup_reason(

--- a/sw/device/tests/pwrmgr_smoketest.c
+++ b/sw/device/tests/pwrmgr_smoketest.c
@@ -74,9 +74,6 @@ bool test_main(void) {
     rstmgr_testutils_post_reset(&rstmgr, kDifRstmgrResetInfoLowPowerExit, 0, 0,
                                 0, 0);
 
-    // Turn off the AON timer hardware completely before exiting.
-    aon_timer_testutils_shutdown(&aon_timer);
-
     return true;
   } else {
     dif_pwrmgr_wakeup_reason_t wakeup_reason;

--- a/sw/device/tests/pwrmgr_wdog_reset_reqs_test.c
+++ b/sw/device/tests/pwrmgr_wdog_reset_reqs_test.c
@@ -106,8 +106,6 @@ bool test_main(void) {
   } else if (rst_info == kDifRstmgrResetInfoWatchdog) {
     LOG_INFO("Booting for the second time due to wdog bite reset");
 
-    // Turn off the AON timer hardware completely before exiting.
-    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   }
   LOG_ERROR("Got unexpected reset info 0x%x", rst_info);

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -817,8 +817,6 @@ bool test_main(void) {
   } else if (rst_info == kDifRstmgrResetInfoEscalation && event_idx == 4) {
     collect_alert_dump_and_compare(kRound4);
 
-    // Turn off the AON timer hardware completely before exiting.
-    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   } else {
     LOG_FATAL("unexpected reset info %d", rst_info);

--- a/sw/device/tests/rstmgr_cpu_info_test.c
+++ b/sw/device/tests/rstmgr_cpu_info_test.c
@@ -295,8 +295,6 @@ bool test_main(void) {
                            .mpec_u = (uint32_t)kDoubleFaultFirstAddrUpper,
                        });
 
-      // Turn off the AON timer hardware completely before exiting.
-      aon_timer_testutils_shutdown(&aon_timer);
       return true;
 
     default:

--- a/sw/device/tests/rv_core_ibex_nmi_irq_test.c
+++ b/sw/device/tests/rv_core_ibex_nmi_irq_test.c
@@ -294,7 +294,5 @@ bool test_main(void) {
   // the reset reason is still POR.
   pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0);
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
@@ -152,8 +152,6 @@ bool test_main(void) {
     LOG_INFO("Test round %d", event_idx);
   } else {
     LOG_INFO("Test finish");
-    // Turn off the AON timer hardware completely before exiting.
-    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   }
 

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_reset_reqs_test.c
@@ -510,8 +510,6 @@ bool test_main(void) {
       break;
     case 6:
       LOG_INFO("Last Booting");
-      // Turn off the AON timer hardware completely before exiting.
-      aon_timer_testutils_shutdown(&aon_timer);
       return true;
       break;
     default:

--- a/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_wake_ups.c
+++ b/sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_wake_ups.c
@@ -87,7 +87,5 @@ bool test_main(void) {
     execute_test(wakeup_count + 1, /*deep_sleep=*/true);
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
   return false;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -522,8 +522,6 @@ bool test_main(void) {
       break;
     case 6:
       LOG_INFO("Last Booting");
-      // Turn off the AON timer hardware completely before exiting.
-      aon_timer_testutils_shutdown(&aon_timer);
       return true;
       break;
     default:

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_wake_ups.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_wake_ups.c
@@ -61,8 +61,6 @@ bool test_main(void) {
       LOG_INFO("clean up done source %d", i);
     }
 
-    // Turn off the AON timer hardware completely before exiting.
-    aon_timer_testutils_shutdown(&aon_timer);
     return true;
   }
 

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_reset_reqs_test.c
@@ -602,8 +602,6 @@ bool test_main(void) {
       if (RST_IDX[event_idx] % 2) {
         LOG_INFO("Last Booting");
 
-        // Turn off the AON timer hardware completely before exiting.
-        aon_timer_testutils_shutdown(&aon_timer);
         return true;
       } else {
         LOG_INFO(

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_wake_ups.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_all_wake_ups.c
@@ -114,7 +114,5 @@ bool test_main(void) {
     }
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
   return false;
 }

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
@@ -561,8 +561,6 @@ bool test_main(void) {
       if (RST_IDX[event_idx] % 2) {
         LOG_INFO("Last Booting");
 
-        // Turn off the AON timer hardware completely before exiting.
-        aon_timer_testutils_shutdown(&aon_timer);
         return true;
       } else {
         LOG_INFO(

--- a/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
@@ -194,8 +194,6 @@ bool test_main(void) {
   } else if (rst_info == kDifRstmgrResetInfoWatchdog) {
     LOG_INFO("Booting for the third time due to wdog bite reset");
     LOG_INFO("Last Booting");
-    // Turn off the AON timer hardware completely before exiting.
-    aon_timer_testutils_shutdown(&aon_timer);
     LOG_INFO("Test finish");
     return true;
   }

--- a/sw/device/tests/sleep_pwm_pulses_test.c
+++ b/sw/device/tests/sleep_pwm_pulses_test.c
@@ -205,7 +205,5 @@ bool test_main(void) {
     return false;
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
   return false;
 }

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
@@ -262,7 +262,5 @@ bool test_main(void) {
     LOG_FATAL("Unexepected reset type detected.");
   }
 
-  // Turn off the AON timer hardware completely before exiting.
-  aon_timer_testutils_shutdown(&aon_timer);
   return true;
 }


### PR DESCRIPTION
1). First commit cleans up unnecessary strong assertions.
2). Second commit revert PR #14742.
For issue https://github.com/lowRISC/opentitan/issues/14913

Signed-off-by: Cindy Chen <chencindy@opentitan.org>