### PR TITLE
[opentitantool] Consolidate GPIO declarations before applying

### DIFF
--- a/sw/host/opentitanlib/src/app/config/mod.rs
+++ b/sw/host/opentitanlib/src/app/config/mod.rs
@@ -10,7 +10,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
-use crate::app::TransportWrapper;
+use crate::app::TransportWrapperBuilder;
 use crate::collection;
 
 mod structs;
@@ -32,7 +32,7 @@ fn read_into_string<'a>(path: &Path, s: &'a mut String) -> Result<&'a str> {
     Ok(s.as_str())
 }
 
-pub fn process_config_file(env: &mut TransportWrapper, conf_file: &Path) -> Result<()> {
+pub fn process_config_file(env: &mut TransportWrapperBuilder, conf_file: &Path) -> Result<()> {
     log::debug!("Reading config file {:?}", conf_file);
     let mut string = String::new();
     let conf_data = if conf_file.starts_with("/__builtin__/") {

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -8,7 +8,7 @@ use structopt::StructOpt;
 use thiserror::Error;
 
 use crate::app::config::process_config_file;
-use crate::app::TransportWrapper;
+use crate::app::{TransportWrapper, TransportWrapperBuilder};
 use crate::transport::hyperdebug::c2d2::C2d2Flavor;
 use crate::transport::hyperdebug::StandardFlavor;
 use crate::transport::{EmptyTransport, Transport};
@@ -89,7 +89,7 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
         ),
         _ => return Err(Error::UnknownInterface(interface.to_string()).into()),
     };
-    let mut env = TransportWrapper::new(backend);
+    let mut env = TransportWrapperBuilder::new(backend);
 
     if args.conf.is_empty() {
         if let Some(conf_file) = default_conf {
@@ -99,7 +99,7 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
     for conf_file in &args.conf {
         process_config_file(&mut env, conf_file.as_ref())?
     }
-    Ok(env)
+    env.build()
 }
 
 pub fn create_empty_transport() -> Result<Box<dyn Transport>> {

--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -55,6 +55,8 @@ pub enum TransportError {
     ProxyConnectError(String, String),
     #[error("Requested capabilities {0:?}, but capabilities {1:?} are supplied")]
     MissingCapabilities(Capability, Capability),
+    #[error("Inconsistent configuration for pin {0}")]
+    InconsistentPinConf(String),
 }
 impl_serializable_error!(TransportError);
 


### PR DESCRIPTION
Sometimes a pin may appear under several levels of aliases in multiple configuration files, and one file may specify e.g. OpenDrain mode without specifying a level, while anoter file specifies a default "high" level, without mentioning the mode.  If such two declarations used different names for the same pin, the existing code could end up applying the level before the mode, which HyperDebug may object to.  (As it rejects setting level on pins in input mode.)

This change makes it such that before applying any pin configuration, all pin configurations ultimately referring to the same pin will be "consolidated", such that mode, level and weak pull will all be applied atomically.  This both prevents glitches on the signals, and prevents the aforementioned HyperDebug issue.

Some other undesirable behavior is fixed along the way, such as previously if two gpio entries in the same file mentioned the same pin name, but with different configuration, the latter would silently override the former.  Doing the same now will cause an error (unless the configurations are "compatible").

Signed-off-by: Jes B. Klinke <jbk@chromium.org>
Change-Id: I896033cf9d3c13dff0157164c4a7bf62a38657c5