### PR TITLE
[flash_ctrl] Add initialized

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -1722,6 +1722,10 @@
           { bits: "4",    name: "init_wip",   desc: "Flash controller undergoing init, inclusive of phy init"
             tags: [ // Bit changes immediately after start from reset value to 1b1 due to initialization
             "excl:CsrAllTests:CsrExclAll"]
+          }
+          { bits: "5",    name: "initialized",desc: "Flash controller initialized"
+            tags: [ // Bit changes immediately after start from reset value to 1b1 due to initialization
+            "excl:CsrAllTests:CsrExclAll"]
           },
         ]
       },

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -1197,6 +1197,10 @@
           { bits: "4",    name: "init_wip",   desc: "Flash controller undergoing init, inclusive of phy init"
             tags: [ // Bit changes immediately after start from reset value to 1b1 due to initialization
             "excl:CsrAllTests:CsrExclAll"]
+          }
+          { bits: "5",    name: "initialized",desc: "Flash controller initialized"
+            tags: [ // Bit changes immediately after start from reset value to 1b1 due to initialization
+            "excl:CsrAllTests:CsrExclAll"]
           },
         ]
       },

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -261,6 +261,7 @@ module flash_ctrl
   flash_prog_e op_prog_type;
 
   logic ctrl_init_busy;
+  logic ctrl_initialized;
   logic fifo_clr;
 
   // sw read fifo interface
@@ -488,6 +489,7 @@ module flash_ctrl
 
     // init ongoing
     .init_busy_o(ctrl_init_busy),
+    .initialized_o(ctrl_initialized),
 
     .debug_state_o(hw2reg.debug_state.d)
   );
@@ -848,6 +850,8 @@ module flash_ctrl
   assign hw2reg.status.prog_empty.de = sw_sel;
   assign hw2reg.status.init_wip.d    = flash_phy_busy | ctrl_init_busy;
   assign hw2reg.status.init_wip.de   = 1'b1;
+  assign hw2reg.status.initialized.d  = ctrl_initialized & ~flash_phy_busy;
+  assign hw2reg.status.initialized.de = 1'b1;
   assign hw2reg.control.start.d      = 1'b0;
   assign hw2reg.control.start.de     = sw_ctrl_done;
   // if software operation selected, based on transaction start

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -262,6 +262,7 @@ module flash_ctrl
   flash_prog_e op_prog_type;
 
   logic ctrl_init_busy;
+  logic ctrl_initialized;
   logic fifo_clr;
 
   // sw read fifo interface
@@ -489,6 +490,7 @@ module flash_ctrl
 
     // init ongoing
     .init_busy_o(ctrl_init_busy),
+    .initialized_o(ctrl_initialized),
 
     .debug_state_o(hw2reg.debug_state.d)
   );
@@ -849,6 +851,8 @@ module flash_ctrl
   assign hw2reg.status.prog_empty.de = sw_sel;
   assign hw2reg.status.init_wip.d    = flash_phy_busy | ctrl_init_busy;
   assign hw2reg.status.init_wip.de   = 1'b1;
+  assign hw2reg.status.initialized.d  = ctrl_initialized & ~flash_phy_busy;
+  assign hw2reg.status.initialized.de = 1'b1;
   assign hw2reg.control.start.d      = 1'b0;
   assign hw2reg.control.start.de     = sw_ctrl_done;
   // if software operation selected, based on transaction start

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -951,6 +951,7 @@ module flash_ctrl_core_reg_top (
   logic status_prog_full_qs;
   logic status_prog_empty_qs;
   logic status_init_wip_qs;
+  logic status_initialized_qs;
   logic debug_state_re;
   logic [10:0] debug_state_qs;
   logic err_code_we;
@@ -10177,6 +10178,32 @@ module flash_ctrl_core_reg_top (
     .qs     (status_init_wip_qs)
   );
 
+  //   F[initialized]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_status_initialized (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.status.initialized.de),
+    .d      (hw2reg.status.initialized.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (status_initialized_qs)
+  );
+
 
   // R[debug_state]: V(True)
   prim_subreg_ext #(
@@ -13135,6 +13162,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[2] = status_prog_full_qs;
         reg_rdata_next[3] = status_prog_empty_qs;
         reg_rdata_next[4] = status_init_wip_qs;
+        reg_rdata_next[5] = status_initialized_qs;
       end
 
       addr_hit[93]: begin

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -87,6 +87,7 @@ module flash_ctrl_lcmgr
 
   // init ongoing
   output logic init_busy_o,
+  output logic initialized_o,
 
   // debug state output
   output logic [10:0] debug_state_o
@@ -894,6 +895,9 @@ module flash_ctrl_lcmgr
   assign addr_o = seed_phase ? {addr, {BusByteWidth{1'b0}}} :
                                {rma_addr, {BusByteWidth{1'b0}}};
   assign init_busy_o = seed_phase;
+
+  // Initialization is considered done when read buffer is enabled.
+  assign initialized_o = rd_buf_en_o;
   assign req_o = seed_phase | rma_phase;
   assign rready_o = 1'b1;
   assign seeds_o = seeds_q;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -556,6 +556,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } init_wip;
+    struct packed {
+      logic        d;
+      logic        de;
+    } initialized;
   } flash_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -760,12 +764,12 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [196:185]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [184:184]
-    flash_ctrl_hw2reg_control_reg_t control; // [183:182]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [181:180]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [179:176]
-    flash_ctrl_hw2reg_status_reg_t status; // [175:166]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [198:187]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [186:186]
+    flash_ctrl_hw2reg_control_reg_t control; // [185:184]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [183:182]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [181:178]
+    flash_ctrl_hw2reg_status_reg_t status; // [177:166]
     flash_ctrl_hw2reg_debug_state_reg_t debug_state; // [165:155]
     flash_ctrl_hw2reg_err_code_reg_t err_code; // [154:139]
     flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [138:121]

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -1728,6 +1728,10 @@
           { bits: "4",    name: "init_wip",   desc: "Flash controller undergoing init, inclusive of phy init"
             tags: [ // Bit changes immediately after start from reset value to 1b1 due to initialization
             "excl:CsrAllTests:CsrExclAll"]
+          }
+          { bits: "5",    name: "initialized",desc: "Flash controller initialized"
+            tags: [ // Bit changes immediately after start from reset value to 1b1 due to initialization
+            "excl:CsrAllTests:CsrExclAll"]
           },
         ]
       },

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -293,5 +293,17 @@
       stage: V2S
       tests: ["flash_ctrl_sec_cm"]
     }
+    {
+      name: sec_cm_mem_tl_lc_gate_fsm_sparse
+      desc: "Verify the countermeasure(s) MEM_TL_LC_GATE.FSM.SPARSE."
+      stage: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_prog_tl_lc_gate_fsm_sparse
+      desc: "Verify the countermeasure(s) PROG_TL_LC_GATE.FSM.SPARSE."
+      stage: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -268,6 +268,7 @@ module flash_ctrl
   flash_prog_e op_prog_type;
 
   logic ctrl_init_busy;
+  logic ctrl_initialized;
   logic fifo_clr;
 
   // sw read fifo interface
@@ -495,6 +496,7 @@ module flash_ctrl
 
     // init ongoing
     .init_busy_o(ctrl_init_busy),
+    .initialized_o(ctrl_initialized),
 
     .debug_state_o(hw2reg.debug_state.d)
   );
@@ -855,6 +857,8 @@ module flash_ctrl
   assign hw2reg.status.prog_empty.de = sw_sel;
   assign hw2reg.status.init_wip.d    = flash_phy_busy | ctrl_init_busy;
   assign hw2reg.status.init_wip.de   = 1'b1;
+  assign hw2reg.status.initialized.d  = ctrl_initialized & ~flash_phy_busy;
+  assign hw2reg.status.initialized.de = 1'b1;
   assign hw2reg.control.start.d      = 1'b0;
   assign hw2reg.control.start.de     = sw_ctrl_done;
   // if software operation selected, based on transaction start

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -951,6 +951,7 @@ module flash_ctrl_core_reg_top (
   logic status_prog_full_qs;
   logic status_prog_empty_qs;
   logic status_init_wip_qs;
+  logic status_initialized_qs;
   logic debug_state_re;
   logic [10:0] debug_state_qs;
   logic err_code_we;
@@ -10177,6 +10178,32 @@ module flash_ctrl_core_reg_top (
     .qs     (status_init_wip_qs)
   );
 
+  //   F[initialized]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_status_initialized (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.status.initialized.de),
+    .d      (hw2reg.status.initialized.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (status_initialized_qs)
+  );
+
 
   // R[debug_state]: V(True)
   prim_subreg_ext #(
@@ -13135,6 +13162,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[2] = status_prog_full_qs;
         reg_rdata_next[3] = status_prog_empty_qs;
         reg_rdata_next[4] = status_init_wip_qs;
+        reg_rdata_next[5] = status_initialized_qs;
       end
 
       addr_hit[93]: begin

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -556,6 +556,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } init_wip;
+    struct packed {
+      logic        d;
+      logic        de;
+    } initialized;
   } flash_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -760,12 +764,12 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [196:185]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [184:184]
-    flash_ctrl_hw2reg_control_reg_t control; // [183:182]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [181:180]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [179:176]
-    flash_ctrl_hw2reg_status_reg_t status; // [175:166]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [198:187]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [186:186]
+    flash_ctrl_hw2reg_control_reg_t control; // [185:184]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [183:182]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [181:178]
+    flash_ctrl_hw2reg_status_reg_t status; // [177:166]
     flash_ctrl_hw2reg_debug_state_reg_t debug_state; // [165:155]
     flash_ctrl_hw2reg_err_code_reg_t err_code; // [154:139]
     flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [138:121]


### PR DESCRIPTION
- Address part of https://github.com/lowRISC/opentitan/issues/15783
- Make sure there is both a status indication and a busy indication.
  This disambiguates not-busy-initialized from not initialized at all.