### PR TITLE
[fpv] Add pimux expected failure Hjson

### DIFF
--- a/hw/ip/pinmux/fpv/pinmux_expected_failure.hjson
+++ b/hw/ip/pinmux/fpv/pinmux_expected_failure.hjson
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+{
+  unreachable:
+  [
+    pinmux_tb.dut.FpvSecCmRegWeOnehotCheck_A:precondition1
+    pinmux_tb.dut.u_reg.u_prim_reg_we_check.u_prim_onehot_check.Onehot0Check_A:precondition1
+    pinmux_tb.dut.u_reg.u_prim_reg_we_check.u_prim_onehot_check.gen_enable_check.gen_not_strict.EnableCheck_A:precondition1
+  ]
+}

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
@@ -26,6 +26,7 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/pinmux/{sub_flow}/{tool}"
                defines: "FPV_ALERT_NO_SIGINT_ERR"
+               exp_fail_hjson: "{proj_root}/hw/ip/pinmux/fpv/pinmux_expected_failure.hjson"
                cov: true
              }
 
@@ -38,6 +39,7 @@
                rel_path: "hw/top_earlgrey/ip/pinmux/{sub_flow}/{tool}"
                defines: "FPV_ALERT_NO_SIGINT_ERR"
                cov: true
+               exp_fail_hjson: "{proj_root}/hw/top_earlgrey/ip/pinmux/fpv/pinmux_expected_failure.hjson"
                overrides: [
                  {
                    name:  design_level

--- a/hw/top_earlgrey/ip/pinmux/fpv/pinmux_expected_failure.hjson
+++ b/hw/top_earlgrey/ip/pinmux/fpv/pinmux_expected_failure.hjson
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+{
+  unreachable:
+  [
+    pinmux_tb.dut_asic.FpvSecCmRegWeOnehotCheck_A:precondition1
+    pinmux_tb.dut_asic.u_reg.u_prim_reg_we_check.u_prim_onehot_check.Onehot0Check_A:precondition1
+    pinmux_tb.dut_asic.u_reg.u_prim_reg_we_check.u_prim_onehot_check.gen_enable_check.gen_not_strict.EnableCheck_A:precondition1
+  ]
+}


### PR DESCRIPTION
This PR adds two expected failure hjson for block and top-level pinmux.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>