### PR TITLE
[dv/alert_handler] Fix entropy_stress test timeout error

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -21,6 +21,8 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   // For IP level test, please set `exp_fatal_alert` in post_start() instead.
   bit bypass_alert_ready_to_end_check = 0;
 
+  bit bypass_esc_ready_to_end_check = 0;
+
   // dut clk frequency, used to generate alert async_clk frequency
   int clk_freq_mhz;
 

--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -228,9 +228,11 @@ class esc_monitor extends alert_esc_base_monitor;
 
   // end phase when no escalation signal is triggered
   virtual task monitor_ready_to_end();
-    forever @(cfg.vif.monitor_cb.esc_rx.resp_p || cfg.vif.monitor_cb.esc_tx.esc_p) begin
-      ok_to_end = !cfg.vif.monitor_cb.esc_rx.resp_p && cfg.vif.monitor_cb.esc_rx.resp_n &&
-                  !get_esc();
+    if (!cfg.bypass_esc_ready_to_end_check) begin
+      forever @(cfg.vif.monitor_cb.esc_rx.resp_p || cfg.vif.monitor_cb.esc_tx.esc_p) begin
+        ok_to_end = !cfg.vif.monitor_cb.esc_rx.resp_p && cfg.vif.monitor_cb.esc_rx.resp_n &&
+                    !get_esc();
+      end
     end
   endtask
 

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
@@ -35,6 +35,12 @@ class alert_handler_entropy_stress_vseq extends alert_handler_smoke_vseq;
     foreach (cfg.alert_host_cfg[i]) begin
       cfg.alert_host_cfg[i].alert_delay_max = 0;
       cfg.alert_host_cfg[i].ping_delay_max = 0;
+
+      // Bypass alert and escalation ready_to_end check.
+      // In this test, we force the alert/esc ping requests to have very short wait cycles.
+      // So alert or escalation ports might always have incoming traffic and will never end.
+      cfg.alert_host_cfg[i].bypass_alert_ready_to_end_check = 1;
+      cfg.alert_host_cfg[i].bypass_esc_ready_to_end_check = 1;
     end
     super.pre_start();
   endtask

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
@@ -35,6 +35,12 @@ class alert_handler_entropy_stress_vseq extends alert_handler_smoke_vseq;
     foreach (cfg.alert_host_cfg[i]) begin
       cfg.alert_host_cfg[i].alert_delay_max = 0;
       cfg.alert_host_cfg[i].ping_delay_max = 0;
+
+      // Bypass alert and escalation ready_to_end check.
+      // In this test, we force the alert/esc ping requests to have very short wait cycles.
+      // So alert or escalation ports might always have incoming traffic and will never end.
+      cfg.alert_host_cfg[i].bypass_alert_ready_to_end_check = 1;
+      cfg.alert_host_cfg[i].bypass_esc_ready_to_end_check = 1;
     end
     super.pre_start();
   endtask


### PR DESCRIPTION
Entropy_stress test timeout because ping request comes too frequently and cannot exit the ok_to_end condition.
So to let this test pass, I bypass the monitor checking because it is expected for the alert/esc pings to come very frequently.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>