### PR TITLE
[fpv] Add pinmux and rv_plic to sec_cm regression

### DIFF
--- a/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -682,6 +682,7 @@ module pinmux_assert_fpv
   // ------ Check USB connectivity ------
   // TODO: the ones that added ##1 delays have cex, which might related to USB module being
   // black-boxed. Working on solving these cexs.
+  // Note the following assertions only work if the testbench blackboxed u_usbdev_aon_wake module.
   `ASSERT(UsbdevDppullupEnI_A, usbdev_dppullup_en_i <->
           u_usbdev_aon_wake.usb_dppullup_en_i, clk_aon_i, !rst_aon_ni)
 

--- a/hw/ip/pinmux/pinmux.core
+++ b/hw/ip/pinmux/pinmux.core
@@ -42,3 +42,8 @@ targets:
     default_tool: icarus
     parameters:
       - SYNTHESIS=true
+
+  formal:
+    filesets:
+      - files_rtl
+    toplevel: pinmux_tb

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
@@ -210,6 +210,37 @@
              }
 
 
+             // These IPs do not have a block level DV testbench, so use FPV to verify common
+             // one-hot security countermeasure.
+             {
+               name: pinmux_sec_cm
+               dut: pinmux
+               fusesoc_core: lowrisc:ip:pinmux
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/top_earlgrey/ip/pinmux/{sub_flow}/{tool}/sec_cm"
+               task: "FpvSecCm"
+               overrides: [
+                 {
+                    name:  design_level
+                    value: "top"
+                 }
+               ]
+              }
+              {
+               name: rv_plic_sec_cm
+               dut: rv_plic
+               fusesoc_core: lowrisc:opentitan:top_earlgrey_rv_plic_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/top_earlgrey/ip/rv_plic/{sub_flow}/{tool}/sec_cm"
+               task: "FpvSecCm"
+               overrides: [
+                  {
+                    name:  design_level
+                    value: "top"
+                  }
+               ]
+              }
+
              // Other non-standard countermeasure checks.
              //
              // This testbench verifies once LC_CTRL goes to terminal state, there is no way to


### PR DESCRIPTION
This PR adds pinmux and rv_plic to sec_cm regression because they do not have a block level testbench to check one-hot register.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>