### PR TITLE
[cryptolib, kmac] Connect SHA-3 to cryptolib's hash API

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -39,12 +39,16 @@ opentitan_functest(
 cc_library(
     name = "kmac",
     srcs = ["kmac.c"],
-    hdrs = ["kmac.h"],
+    hdrs = [
+        "kmac.h",
+        "//sw/device/lib/crypto/include:datatypes.h",
+    ],
     deps = [
         "//hw/ip/kmac/data:kmac_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
     ],
 )
@@ -69,6 +73,7 @@ opentitan_functest(
         ":kmac_test_vectors",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
+        "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -442,8 +442,17 @@ kmac_error_t kmac_init(kmac_operation_t operation,
     return err;
   }
 
+  // We need to preserve some bits of CFG register, such as:
+  // entropy_mode, entropy_ready etc. On the other hand, some bits
+  // need to be reset for each invocation.
   uint32_t cfg_reg =
       abs_mmio_read32(kKmacBaseAddr + KMAC_CFG_SHADOWED_REG_OFFSET);
+
+  // Make sure kmac_en and sideload bits of CFG are reset at each invocation
+  // These bits should be set to 1 only if needed by the rest of the code
+  // in this function.
+  cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_KMAC_EN_BIT, 0);
+  cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_SIDELOAD_BIT, 0);
 
   switch (operation) {
     case kKmacOperationSHA3:

--- a/sw/device/lib/crypto/drivers/kmac_test.c
+++ b/sw/device/lib/crypto/drivers/kmac_test.c
@@ -6,6 +6,8 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/kmac_test_vectors.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/hash.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -27,13 +29,27 @@ bool test_main(void) {
 
   size_t i = 0;
   for (; i < nist_kmac_nr_of_vectors; i++) {
-    LOG_INFO("test #%d", i);
+    LOG_INFO("Testing internal KMAC driver API #%d", i);
     current_test_vector = nist_kmac_vectors[i];
 
-    err = kmac_init(
-        current_test_vector->operation, current_test_vector->security_str,
-        current_test_vector->func_name, current_test_vector->func_name_len,
-        current_test_vector->custom_str, current_test_vector->custom_str_len);
+    crypto_const_uint8_buf_t input_buf;
+    input_buf.data = current_test_vector->input_str;
+    input_buf.len = current_test_vector->input_str_len;
+
+    crypto_const_uint8_buf_t func_name;
+    func_name.data = current_test_vector->func_name;
+    func_name.len = current_test_vector->func_name_len;
+
+    crypto_const_uint8_buf_t cust_str;
+    cust_str.data = current_test_vector->custom_str;
+    cust_str.len = current_test_vector->custom_str_len;
+
+    crypto_uint8_buf_t digest_buf;
+    digest_buf.data = digest;
+    digest_buf.len = current_test_vector->digest_len;
+
+    err = kmac_init(current_test_vector->operation,
+                    current_test_vector->security_str);
     CHECK(err == kKmacOk);
 
     if (current_test_vector->operation == kKmacOperationKMAC) {
@@ -44,21 +60,58 @@ bool test_main(void) {
 
     if (current_test_vector->operation == kKmacOperationKMAC ||
         current_test_vector->operation == kKmacOperationCSHAKE) {
-      err = kmac_write_prefix_block(
-          current_test_vector->operation, current_test_vector->func_name,
-          current_test_vector->func_name_len, current_test_vector->custom_str,
-          current_test_vector->custom_str_len);
+      err = kmac_write_prefix_block(current_test_vector->operation, func_name,
+                                    cust_str);
       CHECK(err == kKmacOk);
     }
 
-    err = kmac_process_msg_blocks(current_test_vector->operation,
-                                  current_test_vector->input_str,
-                                  current_test_vector->input_str_len, digest,
-                                  current_test_vector->digest_len);
+    err = kmac_process_msg_blocks(current_test_vector->operation, input_buf,
+                                  &digest_buf);
 
     CHECK(err == kKmacOk);
-    CHECK_ARRAYS_EQ(current_test_vector->digest, digest,
+    CHECK_ARRAYS_EQ(current_test_vector->digest, digest_buf.data,
                     current_test_vector->digest_len);
+  }
+
+  // Below we repeat some of the test above, but through higher-level
+  // cryptolib API. The gist is to test if glueing is done correctly.
+  for (i = 0; i < nist_kmac_nr_of_vectors; i++) {
+    current_test_vector = nist_kmac_vectors[i];
+
+    crypto_const_uint8_buf_t input_buf;
+    input_buf.data = current_test_vector->input_str;
+    input_buf.len = current_test_vector->input_str_len;
+
+    crypto_uint8_buf_t digest_buf;
+    digest_buf.data = digest;
+    digest_buf.len = current_test_vector->digest_len;
+
+    if (current_test_vector->operation == kKmacOperationSHA3) {
+      LOG_INFO("Testing cryptolib API (glueing) #%d", i);
+      hash_mode_t hash_mode;
+      switch (current_test_vector->security_str) {
+        case kKmacSecurityStrength224:
+          hash_mode = kHashModeSha3_224;
+          break;
+        case kKmacSecurityStrength256:
+          hash_mode = kHashModeSha3_256;
+          break;
+        case kKmacSecurityStrength384:
+          hash_mode = kHashModeSha3_384;
+          break;
+        case kKmacSecurityStrength512:
+          hash_mode = kHashModeSha3_512;
+          break;
+        default:
+          return false;
+      }
+
+      crypto_status_t err_status =
+          otcrypto_hash(input_buf, hash_mode, &digest_buf);
+      CHECK(err_status == kCryptoStatusOK);
+      CHECK_ARRAYS_EQ(current_test_vector->digest, digest_buf.data,
+                      current_test_vector->digest_len);
+    }
   }
 
   return true;

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -15,3 +15,17 @@ cc_library(
         "//sw/device/lib/base:hardened",
     ],
 )
+
+cc_library(
+    name = "hash",
+    srcs = ["hash.c"],
+    hdrs = [
+        "//sw/device/lib/crypto/drivers:kmac.h",
+        "//sw/device/lib/crypto/include:datatypes.h",
+        "//sw/device/lib/crypto/include:hash.h",
+    ],
+    deps = [
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/crypto/drivers:kmac",
+    ],
+)

--- a/sw/device/lib/crypto/include/hash.h
+++ b/sw/device/lib/crypto/include/hash.h
@@ -5,6 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_HASH_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_HASH_H_
 
+#include "sw/device/lib/crypto/include/datatypes.h"
+
 /**
  * @file
  * @brief Hash functions for the OpenTitan cryptography library.


### PR DESCRIPTION
Filler code between the cryptolib API and KMAC driver. This only connects SHA-3 to higher-level API. SHAKE/cSHAKE/KMAC will come in follow-up PRs.

Some of the things on the testing side is a bit messy. I didn't want to remove the test code (in `kmac_test`) that directly works with the KMAC driver, because it allows easier debugging.