### PR TITLE
[fpv] Support input empty string for expected_failure_hjson

### DIFF
--- a/hw/formal/tools/dvsim/common_formal_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_formal_cfg.hjson
@@ -51,7 +51,7 @@
   exports: [
     { DUT_TOP:        "{dut}" },
     { COV:            "{cov}" },
-    { EXP_FAIL_HJSON: "{exp_fail_hjson}" },
+    { EXP_FAIL_HJSON: "'{exp_fail_hjson}'" },
     { sub_flow:       "{sub_flow}" },
     { FPV_DEFINES:    "{defines}" },
     { BBOX_CMD:       "'{bbox_cmd}'" },

--- a/hw/formal/tools/jaspergold/parse-formal-report.py
+++ b/hw/formal/tools/jaspergold/parse-formal-report.py
@@ -84,7 +84,7 @@ def parse_message(str_buffer):
 
 def get_expected_failures(exp_failure_path):
     '''Get expected fail properties from a hjson file otherwise return None.'''
-    if exp_failure_path is None:
+    if exp_failure_path is None or exp_failure_path == "":
         return {}
     else:
         try:
@@ -227,7 +227,8 @@ def main():
                         default=None,
                         help=('The path of a hjson file that contains expected failing properties.'
                               '''By default is empty, used only if there are properties that are
-                               expected to fail.'''))
+                               expected to fail. If input is an empty string, will treat it as not
+                               passing a file.'''))
 
     args = parser.parse_args()
 


### PR DESCRIPTION
For IPs that do not have expected failure hjson, this PR allows the tool to accept an empty string.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>