### PR TITLE
[ci] Limit SW Build and Test step to 4 parallel jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -192,7 +192,7 @@ jobs:
 - job: sw_build
   displayName: Earl Grey SW Build & Test
   # Build and test Software for Earl Grey toplevel design
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public
@@ -229,6 +229,7 @@ jobs:
       --define DISABLE_VERILATOR_BUILD=true \
       --build_tag_filters=-vivado \
       --test_tag_filters=-broken,-cw310,-verilator,-dv \
+      --jobs=4 \
       -- //... \
       -//quality/... \
       -//third_party/riscv-compliance/... \


### PR DESCRIPTION
After moving the sw_build job to the ci-public machines, it seems like the jobs are sometimes even slower. This could potentially be due to Bazel parallelizing too much (i.e. running 20+ actions when there are only 4 available cores). This PR limits the number of jobs to 4 and increases the timeout to reduce CI failures.

Signed-off-by: Miles Dai <milesdai@google.com>