### PR TITLE
[dvsim] Add descriptions to timeout

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -391,7 +391,7 @@ class CompileSim(Deploy):
 
         Limit build jobs to 60 minutes if the timeout is not set.
         """
-        return self.build_timeout_mins if self.build_timeout_mins else 60
+        return self.build_timeout_mins
 
 
 class CompileOneShot(Deploy):
@@ -454,7 +454,7 @@ class CompileOneShot(Deploy):
 
         Limit build jobs to 60 minutes if the timeout is not set.
         """
-        return self.build_timeout_mins if self.build_timeout_mins else 60
+        return self.build_timeout_mins
 
 
 class RunTest(Deploy):
@@ -560,7 +560,7 @@ class RunTest(Deploy):
 
         Limit run jobs to 60 minutes if the timeout is not set.
         """
-        return self.run_timeout_mins if self.run_timeout_mins else 60
+        return self.run_timeout_mins
 
     def extract_info_from_log(self, log_text: List):
         """Extracts the time the design was simulated for, from the log."""

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -429,8 +429,10 @@ def parse_args():
 
     buildg.add_argument("--build-timeout-mins",
                         type=int,
+                        default=60,
                         help=('Wall-clock timeout for builds in minutes: if '
-                              'the build takes longer it will be killed.'))
+                              'the build takes longer it will be killed.'
+                              'If 0, the build will not be killed by timeout.'))
 
     disg.add_argument("--gui",
                       action='store_true',
@@ -482,8 +484,10 @@ def parse_args():
 
     rung.add_argument("--run-timeout-mins",
                       type=int,
+                      default=60,
                       help=('Wall-clock timeout for runs in minutes: if '
-                            'the run takes longer it will be killed.'))
+                            'the run takes longer it will be killed.'
+                            'If 0, the run will not be killed by timeout.'))
 
     rung.add_argument("--verbosity",
                       "-v",


### PR DESCRIPTION
Based on the codes[1][], the timeout can be disabled by adding `--build-timeout-mins=0`. Added the description to dvsim argument parser.

[1]: https://cs.opensource.google/opentitan/opentitan/+/53b23c37d29ad00f1d5a22c73e1a7390413ea414:util/dvsim/LocalLauncher.py;l=53
