### PR TITLE
[i2c,dv] tx fifo reset test

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -362,14 +362,13 @@
             Stimulus:
               - Configure DUT/Agent to Target/Host mode respectively
               - Run read write mixed traffic.
-              - For acq fifo, assert reset any period between stop
-                and the next start.
+              - Assert reset any period between stop and the next start.
 
             Checking:
               - Ensure the remaining entries are not show up after each fifio is reset,
             '''
       stage: V2
-      tests: ["i2c_target_fifo_reset_acq"]
+      tests: ["i2c_target_fifo_reset_acq", "i2c_target_fifo_reset_tx"]
     }
     {
       name: target_fifo_full

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -46,6 +46,7 @@ filesets:
       - seq_lib/i2c_target_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_ack_stop_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_fifo_reset_acq_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_fifo_reset_tx_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -1143,6 +1143,8 @@ class i2c_base_vseq extends cip_base_vseq #(
     clear_interrupt(CmdComplete, 0);
   endtask // proc_intr_cmdcomplete
 
+  // This task is called when tb interrupt handler receives
+  // txstretch interrupt.
   virtual task proc_intr_txstretch();
     bit acq_fifo_empty;
     if (!cfg.use_drooling_tx) begin

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_tx_vseq.sv
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence asserts 'fifo_ctrl.txrst' at the end of transaction.
+// Upon receiving txrst, dut and tb wil flush tx_fifo and expect
+// to receive a new tx data. acq process shouldn't be affected by setting txrst.
+class i2c_target_fifo_reset_tx_vseq extends i2c_target_runtime_base_vseq;
+  `uvm_object_utils(i2c_target_fifo_reset_tx_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    super.pre_start();
+
+    cfg.scb_h.read_rnd_data = 1;
+    cfg.rd_pct = 3;
+    seq_runtime = 10000;
+  endtask
+
+  task test_event();
+    #50us;
+    repeat (5) begin
+      wait(cfg.m_i2c_agent_cfg.got_stop);
+      // stop writing tx fifo and sequence
+      pause_seq = 1;
+
+      // flush acq
+      ral.fifo_ctrl.txrst.set(1'b1);
+      csr_update(ral.fifo_ctrl);
+
+      // clean up sb
+      cfg.scb_h.target_mode_rd_obs_fifo.flush();
+      cfg.scb_h.mirrored_txdata = '{};
+
+     #10us;
+      pause_seq = 0;
+
+      // random delay before the next round
+      #($urandom_range(1, 5) * 10us);
+    end
+  endtask // test_event
+
+  task proc_intr_cmdcomplete();
+    // read acq fifo in 'body' task
+    clear_interrupt(CmdComplete, 0);
+  endtask // proc_itnr_cmd_complete
+
+  task process_acq();
+    bit fifo_empty, pop_all;
+    int delay;
+
+    while (!cfg.stop_intr_handler) begin
+      delay = $urandom_range(0, 10);
+      cfg.clk_rst_vif.wait_clks(delay * acq_rd_cyc);
+      // pop one all entries by 25% of chance.
+      pop_all = ($urandom_range(0,3) > 0);
+      read_acq_fifo(~pop_all, fifo_empty);
+    end
+  endtask // process_acq
+endclass // i2c_target_fifo_reset_tx_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_runtime_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_runtime_base_vseq.sv
@@ -45,7 +45,7 @@ class i2c_target_runtime_base_vseq extends i2c_target_smoke_vseq;
             // To avoid race between 'pause_seq set' and
             // 'cfg.m_i2c_agent_cfg.got_stop = 1'
             cfg.clk_rst_vif.wait_clks(1);
-            `DV_WAIT(pause_seq == 0, "pause_acq_read==0 wait timeout occurred!",
+            `DV_WAIT(pause_seq == 0, "pause_seq == 0 wait timeout occurred!",
                      cfg.spinwait_timeout_ns, "target_runtime_base_vseq")
           end
           process_target_interrupts();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -29,3 +29,4 @@
 `include "i2c_target_timeout_vseq.sv"
 `include "i2c_target_ack_stop_vseq.sv"
 `include "i2c_target_fifo_reset_acq_vseq.sv"
+`include "i2c_target_fifo_reset_tx_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -171,6 +171,12 @@
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
     }
+    {
+      name: i2c_target_fifo_reset_tx
+      uvm_test_seq: i2c_target_fifo_reset_tx_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
+                 "+use_intr_handler=1"]
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR implement tx fifo reset test for i2c target mode.
In the test, tx fifo reset is asserted only when the bus is idle
otherwise host can be received unexpected data and cause spurious test failure.
acq fifo process should not be affected by this event.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>