### PR TITLE
[ci] Disable the Verilator weak straps tests in CI

### DIFF
--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -31,5 +31,4 @@ ci/bazelisk.sh test \
     //sw/device/silicon_creator/lib/drivers:alert_functest_sim_verilator \
     //sw/device/silicon_creator/lib/drivers:watchdog_functest_sim_verilator \
     //sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator \
-    //sw/device/silicon_creator/rom:rom_epmp_test_sim_verilator \
-    //sw/device/silicon_creator/rom/e2e/weak_straps/...
+    //sw/device/silicon_creator/rom:rom_epmp_test_sim_verilator


### PR DESCRIPTION
The `sw_strap_value_sim_verilator` test appears to be timing out in CI periodically but passes fine locally. We will disable this test for now in CI.