### PR TITLE
[rv_dm, dv] Fix compile error

### DIFF
--- a/hw/ip/rv_dm/dv/cov/cover_reg_top.cfg
+++ b/hw/ip/rv_dm/dv/cov/cover_reg_top.cfg
@@ -7,10 +7,10 @@
 
 // Non-RTL assertion only blocks.
 -moduletree rv_dm_regs_csr_assert_fpv
+
 begin assert
   +moduletree rv_dm_regs_csr_assert_fpv
 end
--module prim_onehot_check    // FPV verified
 
 // The JTAG DTM is functionally verified, even in CSR tests.
 begin line+cond+fsm+branch+assert
@@ -19,4 +19,6 @@ begin line+cond+fsm+branch+assert
   +moduletree rv_dm_mem_reg_top
   +moduletree tlul_adapter_host
   +moduletree tlul_adapter_sram
+  // Verified in FPV
+  -moduletree prim_onehot_check
 end


### PR DESCRIPTION
The nightly reports a compile error due to a bug
in the coverage configuration for this block.
This commit fixes that.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>