### PR TITLE
[dv,top-level,escalation] Add two more escalation tests

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -330,7 +330,7 @@ module flash_ctrl
   // flash disable declaration
   mubi4_t [FlashDisableLast-1:0] flash_disable;
 
-  // flash control arbitration between softawre / harware interfaces
+  // flash control arbitration between software and hardware interfaces
   flash_ctrl_arb u_ctrl_arb (
     .clk_i,
     .rst_ni,

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -331,7 +331,7 @@ module flash_ctrl
   // flash disable declaration
   mubi4_t [FlashDisableLast-1:0] flash_disable;
 
-  // flash control arbitration between softawre / harware interfaces
+  // flash control arbitration between software and hardware interfaces
   flash_ctrl_arb u_ctrl_arb (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -28,6 +28,7 @@
              "pwrmgr_bind",
              "rstmgr_bind",
              "sec_cm_prim_onehot_check_bind",
+             "sec_cm_prim_sparse_fsm_flop_bind",
              "top_earlgrey_error_injection_ifs_bind",
              "top_earlgrey_bind",
              "xbar_main_bind",

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -337,7 +337,7 @@ module flash_ctrl
   // flash disable declaration
   mubi4_t [FlashDisableLast-1:0] flash_disable;
 
-  // flash control arbitration between softawre / harware interfaces
+  // flash control arbitration between software and hardware interfaces
   flash_ctrl_arb u_ctrl_arb (
     .clk_i,
     .rst_ni,

--- a/sw/device/lib/testing/alert_handler_testutils.c
+++ b/sw/device/lib/testing/alert_handler_testutils.c
@@ -69,19 +69,19 @@ void alert_info_to_string(const alert_info_t *info) {
            info->class_accum_cnt[0], info->class_accum_cnt[1],
            info->class_accum_cnt[2], info->class_accum_cnt[3]);
   LOG_INFO("loc_alert_cause=0x%x", info->loc_alert_cause);
-  char cause_bits[81];
-  cause_bits[80] = '\0';
-  int string_index = 0;
+  int set_count = 0;
+  LOG_INFO("alert_cause bits set:");
+  // Typically very few bits are set, so it is more clear to only show the
+  // on bits.
   for (int i = 0; i < ALERT_HANDLER_PARAM_N_ALERTS; ++i) {
-    cause_bits[string_index] = info->alert_cause[i] ? '1' : '0';
-    ++string_index;
-    if (i % 8 == 0) {
-      cause_bits[string_index] = '_';
-      ++string_index;
+    if (info->alert_cause[i]) {
+      LOG_INFO("alert_cause[%d] = 1", i);
+      ++set_count;
     }
   }
-  cause_bits[string_index] = '\0';
-  LOG_INFO("alert_cause=%s (in increasing order left to right)", cause_bits);
+  if (set_count == 0) {
+    LOG_INFO("No bits set");
+  }
 }
 
 void alert_handler_testutils_configure_all(


### PR DESCRIPTION
Add tests for TopEarlgreyAlertIdRvPlicFatalFault and TopEarlgreyAlertIdLcCtrlFatalStateError fatal errors.

Addresses two cases from #15649

Signed-off-by: Guillermo Maturana <maturana@google.com>