### PR TITLE
[lint,tlul] Resolve width error raised by Verilator lint

### DIFF
--- a/hw/ip/tlul/rtl/tlul_sram_byte.sv
+++ b/hw/ip/tlul/rtl/tlul_sram_byte.sv
@@ -209,7 +209,7 @@ module tlul_sram_byte import tlul_pkg::*; #(
       combined_user.data_intg = data_intg;
     end
 
-    localparam logic [top_pkg::TL_SZW-1:0] AccessSize = $clog2(top_pkg::TL_DBW);
+    localparam int unsigned AccessSize = $clog2(top_pkg::TL_DBW);
     always_comb begin
       // Pass-through by default
       tl_sram_o = tl_i;
@@ -228,7 +228,7 @@ module tlul_sram_byte import tlul_pkg::*; #(
         tl_sram_o.a_opcode  = PutFullData;
         // Since we are performing a read-modify-write operation,
         // we always access the entire word.
-        tl_sram_o.a_size    = AccessSize;
+        tl_sram_o.a_size    = top_pkg::TL_SZW'(AccessSize);
         tl_sram_o.a_mask    = '{default: '1};
         // override with held / combined data.
         // need to use word aligned addresses here.
@@ -246,7 +246,7 @@ module tlul_sram_byte import tlul_pkg::*; #(
         if (!error_i || stall_host) begin
           // Since we are performing a read-modify-write operation,
           // we always access the entire word.
-          tl_sram_o.a_size    = AccessSize;
+          tl_sram_o.a_size    = top_pkg::TL_SZW'(AccessSize);
           tl_sram_o.a_mask    = '{default: '1};
           // use incoming valid as long as we are not stalling the host
           tl_sram_o.a_valid   = tl_i.a_valid & ~stall_host;
@@ -254,6 +254,9 @@ module tlul_sram_byte import tlul_pkg::*; #(
         end
       end
     end
+
+    // This assert is necessary for the casting of AccessSize.
+    `ASSERT(TlulSramByteTlSize_A, top_pkg::TL_SZW >= $clog2(AccessSize + 1))
 
     logic unused_held_data;
     assign unused_held_data = ^{held_data.a_address[AccessSize-1:0],


### PR DESCRIPTION
From a previous PR, the conversation went as follows:
https://github.com/lowRISC/opentitan/pull/16824#discussion_r1048849199
https://github.com/lowRISC/opentitan/pull/16824#discussion_r1049518890

Essentially this PR solves the following Verilator lint error:
```
%Warning-WIDTH: ../src/lowrisc_tlul_adapter_sram_0.1/rtl/tlul_sram_byte.sv:212:44: Operator VAR 'AccessSize' expects 2 bits on the Initial value, but Initial value's CLOG2 generates 32 bits.
```