### PR TITLE
[lint] Fix various Verilator lint width errors in different IPs

### DIFF
--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -398,7 +398,7 @@ module edn_core import edn_pkg::*;
   assign hw2reg.recov_alert_sts.edn_enable_field_alert.de = edn_enable_pfa;
   assign hw2reg.recov_alert_sts.edn_enable_field_alert.d  = edn_enable_pfa;
 
-  for (genvar i = FatalErr; i < LastEdnEntry; i = i+1) begin : gen_mubi_en_copies
+  for (genvar i = int'(FatalErr); i < LastEdnEntry; i = i+1) begin : gen_mubi_en_copies
     assign edn_enable_fo[i] = mubi4_test_true_strict(mubi_edn_enable_fanout[i]);
   end : gen_mubi_en_copies
 

--- a/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
@@ -187,7 +187,7 @@ module keymgr_sideload_key_ctrl import keymgr_pkg::*;(
   );
 
   logic [LastIdx-1:0] valid_tracking_q;
-  for (genvar i = AesIdx; i < LastIdx; i++) begin : gen_tracking_valid
+  for (genvar i = int'(AesIdx); i < LastIdx; i++) begin : gen_tracking_valid
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
         valid_tracking_q[i] <= '0;

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -145,8 +145,12 @@ module rv_dm
   // Life Cycle Gating //
   ///////////////////////
 
-  // debug enable gating
-  typedef enum logic [3:0] {
+  // Debug enable gating.
+  localparam int LcEnDebugReqVal = 4 - 1;
+  localparam int LcEnResetReqVal = LcEnDebugReqVal + NrHarts;
+  // +1 to get number of bits and another +1 because LcEnLastPos is one more than LcEnResetReq.
+  localparam int RvDmLcEnSize    = $clog2(LcEnResetReqVal + 2);
+  typedef enum logic [RvDmLcEnSize-1:0] {
     LcEnFetch,
     LcEnRom,
     LcEnSba,
@@ -155,9 +159,12 @@ module rv_dm
     LcEnDebugReq,
     // The above literal accommodates NrHarts number of debug requests - so we number the next
     // literal accordingly.
-    LcEnResetReq = 4 + NrHarts - 1,
+    LcEnResetReq = RvDmLcEnSize'(LcEnResetReqVal),
+    // LcEnLastPos must immediately follow LcEnResetReq to calculate RvDmLcEnSize.
     LcEnLastPos
   } rv_dm_lc_en_e;
+  // These must be equal so that the difference between LcEnResetReq and LcEnDebugReq is NrHarts.
+  `ASSERT(RvDmLcEnDebugVal_A, int'(LcEnDebugReq) == LcEnDebugReqVal)
 
   // debug enable gating
   typedef enum logic [3:0] {


### PR DESCRIPTION
I think these changes are relatively uncontroversial, so it touches 5 IPs, but I can split this up into separate PRs as well.