### PR TITLE
[lint,prim_generic] Turn off unused Verilator lint in clock buf

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_clock_buf.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_clock_buf.sv
@@ -5,8 +5,12 @@
 `include "prim_assert.sv"
 
 module prim_generic_clock_buf #(
+  // Turning off these verilator lints because keeping these parameters makes it consistent with
+  // the IP in hw/ip/prim_xilinx/rtl/ .
+  /* verilator lint_off UNUSED */
   parameter bit NoFpgaBuf = 1'b0, // serves no function in generic
   parameter bit RegionSel = 1'b0  // serves no function in generic
+  /* verilator lint_on UNUSED */
 ) (
   input clk_i,
   output logic clk_o


### PR DESCRIPTION
The reason we want to keep these parameters is that when we don't use the generic primitive these parameters are used, so it is useful to keep those in sync.