### PR TITLE
[kmac] Add parameter to optionally disable masked SW keys for the masked design

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -51,6 +51,18 @@
       local:   "false"
       expose:  "true"
     }
+    { name:    "SwKeyMasked"
+      type:    "bit"
+      default: "0"
+      desc:    '''
+        Disable(0) or enable(1) software key masking in case masking is disabled (EnMasking == 0).
+        If masking is enabled, this parameter has no effect.
+        Mainly useful for software interface compatibility between the masked and unmasked design.
+        Mostly relevant for SCA measurements.
+        '''
+      local:   "false"
+      expose:  "true"
+    }
     { name:    "SecCmdDelay"
       type:    "int"
       default: "0"

--- a/hw/ip/kmac/doc/_index.md
+++ b/hw/ip/kmac/doc/_index.md
@@ -205,6 +205,16 @@ Incoming message bitstream is not sensitive to the leakage.
 If the `EnMasking` parameter is set and {{<regref "CFG_SHADOWED.msg_mask" >}} is enabled, the message is masked upon loading into the Keccak core using the internal entropy generator.
 The secret key, however, is stored as masked form always.
 
+If the `EnMasking` parameter is not set, the masking is disabled.
+Then, the software has to provide the key in unmasked form by default.
+Any write operations to {{<regref "KEY_SHARE1_0" >}} - {{<regref "KEY_SHARE1_15" >}} are ignored.
+
+If the `EnMasking` parameter is not set and the `SwKeyMasked` parameter is set, software has to provide the key in masked form.
+Internally, the design then unmasks the key by XORing the two key shares together when loading the key into the engine.
+This is useful when software interface compatibility between the masked and unmasked configuration is desirable.
+
+If the `EnMasking` parameter is set, the `SwKeyMasked` parameter has no effect: Software always provides the key in two shares.
+
 ### Keccak State Access
 
 After the Keccak round completes the KMAC/SHA3 operation, the contents of the Keccak state contain the digest value.

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -13,6 +13,9 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
   // Masked KMAC is the default configuration
   bit enable_masking = 1;
 
+  // For the unmasked KMAC, the software key is not masked by default.
+  bit sw_key_masked = 0;
+
   // Disable scb cycle accurate check ("status" and "intr_state" registers).
   bit do_cycle_accurate_check = 1;
 
@@ -50,6 +53,7 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
     keymgr_sideload_agent_cfg = key_sideload_agent_cfg#(keymgr_pkg::hw_key_req_t)::type_id
                                 ::create("keymgr_sideload_agent_cfg");
     void'($value$plusargs("enable_masking=%0d", enable_masking));
+    void'($value$plusargs("sw_key_masked=%0d", sw_key_masked));
     void'($value$plusargs("test_vectors_sha3_variant=%0d", sha3_variant));
     void'($value$plusargs("test_vectors_shake_variant=%0d", shake_variant));
 

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -63,13 +63,18 @@
   build_modes: [
     {
       name: enable_mask_mode
-      build_opts: ["+define+EN_MASKING=1"]
-      run_opts: ["+enable_masking=1"]
+      build_opts: ["+define+EN_MASKING=1", "+define+SW_KEY_MASKED=0"]
+      run_opts: ["+enable_masking=1", "+sw_key_masked=0"]
     }
     {
       name: disable_mask_mode
-      build_opts: ["+define+EN_MASKING=0"]
-      run_opts: ["+enable_masking=0"]
+      build_opts: ["+define+EN_MASKING=0", "+define+SW_KEY_MASKED=0"]
+      run_opts: ["+enable_masking=0", "+sw_key_masked=0"]
+    }
+    {
+      name: disable_mask_mode_with_masked_sw_keys
+      build_opts: ["+define+EN_MASKING=0", "+define+SW_KEY_MASKED=1"]
+      run_opts: ["+enable_masking=0", "+sw_key_masked=1"]
     }
   ]
 

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -48,7 +48,10 @@ module tb;
 
   // dut
 
-  kmac #(.EnMasking(`EN_MASKING)) dut (
+  kmac #(
+    .EnMasking(`EN_MASKING),
+    .SwKeyMasked(`SW_KEY_MASKED)
+  ) dut (
     .clk_i              (clk            ),
     .rst_ni             (rst_n          ),
     .rst_shadowed_ni    (rst_shadowed_n ),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5638,6 +5638,20 @@
           name_top: KmacEnMasking
         }
         {
+          name: SwKeyMasked
+          desc:
+            '''
+            Disable(0) or enable(1) software key masking in case masking is disabled (EnMasking == 0).
+            If masking is enabled, this parameter has no effect.
+            Mainly useful for software interface compatibility between the masked and unmasked design.
+            Mostly relevant for SCA measurements.
+            '''
+          type: bit
+          default: "0"
+          expose: "true"
+          name_top: KmacSwKeyMasked
+        }
+        {
           name: SecCmdDelay
           desc:
             '''

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -984,6 +984,7 @@ module chip_earlgrey_cw310 #(
     .SecAesStartTriggerDelay(40),
     .SecAesAllowForcingMasks(1'b1),
     .KmacEnMasking(0),
+    .KmacSwKeyMasked(1),
     .SecKmacCmdDelay(40),
     .SecKmacIdleAcceptSwMsg(1'b1),
     .KeymgrKmacEnMasking(0),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -67,6 +67,7 @@ module top_earlgrey #(
   // parameters for hmac
   // parameters for kmac
   parameter bit KmacEnMasking = 1,
+  parameter bit KmacSwKeyMasked = 0,
   parameter int SecKmacCmdDelay = 0,
   parameter bit SecKmacIdleAcceptSwMsg = 0,
   // parameters for otbn
@@ -2227,6 +2228,7 @@ module top_earlgrey #(
   kmac #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[46:45]),
     .EnMasking(KmacEnMasking),
+    .SwKeyMasked(KmacSwKeyMasked),
     .SecCmdDelay(SecKmacCmdDelay),
     .SecIdleAcceptSwMsg(SecKmacIdleAcceptSwMsg),
     .RndCnstLfsrSeed(RndCnstKmacLfsrSeed),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1057,6 +1057,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .SecAesStartTriggerDelay(40),
     .SecAesAllowForcingMasks(1'b1),
     .KmacEnMasking(0),
+    .KmacSwKeyMasked(1),
     .SecKmacCmdDelay(40),
     .SecKmacIdleAcceptSwMsg(1'b1),
     .KeymgrKmacEnMasking(0),


### PR DESCRIPTION
This PR contains two commits:
1. The first one adds a parameter to control whether software should provide masked or unmasked keys when masking is disabled. By default, software is expected to provide unmasked keys as in the original implementation.
2. For Earlgrey on the CW310 (where the unmasked KMAC design is instantiated by default due to resource constraints) the parameter is enabled such that software provides the key in two shares. This is useful to have compatible software interfaces between the masked and unmasked design. This compatibility is important for SCA measurements where one usually switches between unmasked and masked designs to verify the setup.

This resolves #16206

Sorry again @eunchan for merging the original PR before getting your approval. This was my fault. It won't happen again.