### PR TITLE
[chip dv] Fix compile warnings in RTL and DV

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -70,7 +70,7 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
     // During pause period, let drive_scl control scl
     `DV_WAIT(scl_pause == 1'b0,, scl_spinwait_timeout_ns, "drive_host_item")
     `uvm_info(`gfn, $sformatf("drv: %s", req.drv_type.name), UVM_MEDIUM)
-    unique case (req.drv_type)
+    case (req.drv_type)
       HostStart: begin
         cfg.vif.host_start(cfg.timing_cfg);
         cfg.host_scl_start = 1;
@@ -110,7 +110,7 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
     bit [7:0] rd_data_cnt = 8'd0;
     bit [7:0] rdata;
 
-    unique case (req.drv_type)
+    case (req.drv_type)
       DevAck: begin
         cfg.timing_cfg.tStretchHostClock = gen_num_stretch_host_clks(cfg.timing_cfg);
          `uvm_info(`gfn, $sformatf("sending an ack"), UVM_MEDIUM)

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -28,6 +28,8 @@
                "+warn=noUII-L",
                // Disable unnecessary LCA warning.
                "+warn=noLCA_FEATURES_ENABLED",
+               // Disable warnings about bind directive not being applied.
+               "+warn=noBNA",
                // Below option required for $error/$fatal system calls
                "-assert svaext",
                // Force unique and priority to evaluate compliance checking only on the stable

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -598,5 +598,6 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
   // state is entered it will not exit it unless a reset signal is received.
   `ASSERT(CsrngDrbgGenErrorStStable_A, state_q == ReqError |=> $stable(state_q))
   // If in error state, the error output must be high.
-  `ASSERT(CsrngDrbgGenErrorOutput_A,   state_q == Error    |-> ctr_drbg_gen_sm_err_o)
+  `ASSERT(CsrngDrbgGenErrorOutput_A,
+          !(state_q inside {ReqIdle, ReqSend, ESHalt}) |-> ctr_drbg_gen_sm_err_o)
 endmodule

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1223,12 +1223,12 @@ module otbn
       !rst_ni || u_otbn_core.urnd_reseed_err || u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
     // After execution, it's expected to see a change resulting with a nonzero register value
     `ASSERT(SecWipeChangedBaseRegs_A,
-      $rose(busy_secure_wipe) |-> (##[0:$]
+      $rose(busy_secure_wipe) |-> ((##[0:$]
         u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.g_rf_flops[i].rf_reg_q !=
           EccZeroWord &&
         $changed(
-          u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.g_rf_flops[i].rf_reg_q)
-        within $rose(busy_secure_wipe) ##[0:$] $fell(busy_secure_wipe)),
+          u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.g_rf_flops[i].rf_reg_q))
+        within ($rose(busy_secure_wipe) ##[0:$] $fell(busy_secure_wipe))),
       clk_i,
       !rst_ni || u_otbn_core.urnd_reseed_err || u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
   end
@@ -1252,12 +1252,12 @@ module otbn
 
     // After execution, it's expected to see a change resulting with a nonzero register value
     `ASSERT(SecWipeChangedWideRegs_A,
-            $rose(busy_secure_wipe) |-> (##[0:$]
+            $rose(busy_secure_wipe) |-> ((##[0:$]
               u_otbn_core.u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.rf[i] !=
                 EccWideZeroWord &&
               $changed(
-                u_otbn_core.u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.rf[i])
-              within $rose(busy_secure_wipe) ##[0:$] $fell(busy_secure_wipe)),
+                u_otbn_core.u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.rf[i]))
+              within ($rose(busy_secure_wipe) ##[0:$] $fell(busy_secure_wipe))),
           clk_i, !rst_ni || u_otbn_core.urnd_reseed_err ||
             u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
   end

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -41,7 +41,6 @@ package chip_env_pkg;
   import sw_test_status_pkg::*;
   import tl_agent_pkg::*;
   import uart_agent_pkg::*;
-  import spi_agent_pkg::*;
   import xbar_env_pkg::*;
   import top_earlgrey_pkg::*;
   import top_earlgrey_rnd_cnst_pkg::*;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
@@ -2,15 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 class chip_sw_lc_ctrl_scrap_vseq extends chip_sw_base_vseq;
-  import lc_ctrl_state_pkg::dec_lc_state_e;
-  import lc_ctrl_state_pkg::lc_state_e;
-  import lc_ctrl_dv_utils_pkg::encode_lc_state;
-
   `uvm_object_utils(chip_sw_lc_ctrl_scrap_vseq)
-
   `uvm_object_new
 
-  rand dec_lc_state_e src_state;
+  rand lc_ctrl_state_pkg::dec_lc_state_e src_state;
   rand bit perform_transition_via_sw;
 
   constraint valid_src_state_c {
@@ -61,7 +56,8 @@ class chip_sw_lc_ctrl_scrap_vseq extends chip_sw_base_vseq;
 
   virtual function void backdoor_override_otp();
     // Override the LC partition to TestLocked1 state.
-    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(encode_lc_state(src_state));
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(
+        lc_ctrl_dv_utils_pkg::encode_lc_state(src_state));
   endfunction : backdoor_override_otp
 
   virtual task dut_init(string reset_kind = "HARD");

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_mio_dio_val_vseq.sv
@@ -35,7 +35,7 @@ class chip_sw_sleep_pin_mio_dio_val_vseq extends chip_sw_base_vseq;
     localparam string StartEvent = "BEGIN Chosen Retention Types";
     localparam string EndEvent = "END Chosen Retention Types";
 
-    `DV_WAIT(cfg.sw_logger_vif.printed_log == StartEvent)
+    `DV_WAIT(string'(cfg.sw_logger_vif.printed_log) == StartEvent)
     forever begin
       string printed_log;
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
-  import dv_utils_pkg::*;
   `uvm_object_utils(chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq)
   `uvm_object_new
 
@@ -65,7 +64,7 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
     sw_symbol_backdoor_overwrite("kTestPhase", test_phase);
   endfunction
 
-  virtual function check_wakeup_pin();
+  virtual function void check_wakeup_pin();
     logic wakeup_result;
     // Read PAD_Z3WAKEUP_PATH <-> IOB7
     wakeup_result = cfg.chip_vif.pinmux_wkup_if.sample_pin(0);

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -154,7 +154,7 @@ module tb;
   wire sel_sim_sram = !dut.chip_if.stub_cpu & en_sim_sram;
 
   sim_sram u_sim_sram (
-    .clk_i    (sel_sim_sram ? `CPU_HIER.clk_i : 0),
+    .clk_i    (sel_sim_sram ? `CPU_HIER.clk_i : 1'b0),
     .rst_ni   (`CPU_HIER.rst_ni),
     .tl_in_i  (tlul_pkg::tl_h2d_t'(`CPU_HIER.u_tlul_req_buf.out_o)),
     .tl_in_o  (),


### PR DESCRIPTION
Theis commit fixes various compilation warnings thrown by VCS in RTL and DV code. See comments inline that describe the warnings thrown. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>