### PR TITLE
[opentitantool] Default SPI speed in conf

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
@@ -216,10 +216,12 @@
   "spi": [
     {
       "name": "BOOTSTRAP",
+      "bits_per_sec": 8000000,
       "alias_of": "QSPI"
     },
     {
       "name": "TPM",
+      "bits_per_sec": 250000,
       "alias_of": "SPI2"
     }
   ],

--- a/sw/host/opentitanlib/src/app/config/structs.rs
+++ b/sw/host/opentitanlib/src/app/config/structs.rs
@@ -72,6 +72,8 @@ pub struct UartConfiguration {
 pub struct SpiConfiguration {
     /// The user-visible name of the SPI controller port.
     pub name: String,
+    /// Data communication rate in bits/second.
+    pub bits_per_sec: Option<u32>,
     /// Name of the SPI controller as defined by the transport.
     pub alias_of: Option<String>,
 }

--- a/sw/host/opentitanlib/src/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/proxy/mod.rs
@@ -44,8 +44,8 @@ impl<'a> SessionHandler<'a> {
         };
         let socket_server = JsonSocketServer::new(TransportCommandHandler::new(transport), socket)?;
         // Configure all GPIO pins to default direction and level, according to
-        // configuration files provided.
-        transport.apply_default_pin_configurations()?;
+        // configuration files provided, and configures SPI port mode/speed, etc.
+        transport.apply_default_configuration()?;
         Ok(Self {
             port,
             socket_server,

--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -55,8 +55,8 @@ pub enum TransportError {
     ProxyConnectError(String, String),
     #[error("Requested capabilities {0:?}, but capabilities {1:?} are supplied")]
     MissingCapabilities(Capability, Capability),
-    #[error("Inconsistent configuration for pin {0}")]
-    InconsistentPinConf(String),
+    #[error("Inconsistent configuration for {0:?} instance {1}")]
+    InconsistentConf(TransportInterfaceType, String),
 }
 impl_serializable_error!(TransportError);
 

--- a/sw/host/opentitantool/src/command/transport.rs
+++ b/sw/host/opentitantool/src/command/transport.rs
@@ -26,8 +26,8 @@ impl CommandDispatch for TransportInit {
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
         // Configure all GPIO pins to default direction and level, according to
-        // configuration files provided.
-        transport.apply_default_pin_configurations()?;
+        // configuration files provided, and configures SPI port mode/speed, etc.
+        transport.apply_default_configuration()?;
         Ok(None)
     }
 }


### PR DESCRIPTION
On top of existing support for aliases for SPI ports, this CL adds the option of specifying a default speed on particular SPI ports in the json configuration.  This allows configuration of defaults appropriate for various transports, while still allowing the user to override by command line flags.