### PR TITLE
[dv/alert_handler] Update non-blocking sequence to auto-response seqs

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -23,6 +23,13 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
 
   bit bypass_esc_ready_to_end_check = 0;
 
+  // When this flag is set to 1, and agent in alert host mode, the sequence will automatically
+  // response to alert ping requests.
+  bit start_default_rsp_seq = 1;
+
+  // Control if ping response will timeout or not.
+  bit ping_timeout = 0;
+
   // dut clk frequency, used to generate alert async_clk frequency
   int clk_freq_mhz;
 

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
@@ -68,7 +68,6 @@ package alert_esc_agent_pkg;
   `include "alert_esc_base_monitor.sv"
   `include "alert_monitor.sv"
   `include "esc_monitor.sv"
-  `include "alert_esc_agent.sv"
 
   // Sequences
   `include "seq_lib/alert_receiver_base_seq.sv"
@@ -80,4 +79,5 @@ package alert_esc_agent_pkg;
   `include "seq_lib/esc_receiver_base_seq.sv"
   `include "seq_lib/esc_receiver_esc_rsp_seq.sv"
 
+  `include "alert_esc_agent.sv"
 endpackage

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_ping_rsp_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_ping_rsp_seq.sv
@@ -13,4 +13,40 @@ class alert_sender_ping_rsp_seq extends alert_sender_base_seq;
     s_alert_ping_rsp == 1;
   }
 
+  virtual task body();
+    if (cfg.start_default_rsp_seq) begin
+      default_rsp_thread();
+    end else begin
+      super.body();
+    end
+  endtask
+
+  // Sends random rsps (device data and ack) back to host.
+  virtual task default_rsp_thread();
+    alert_esc_seq_item req_q[$];
+    fork
+      forever begin : get_req
+        p_sequencer.req_analysis_fifo.get(req);
+        req_q.push_back(req);
+      end : get_req
+      forever begin : send_rsp
+        if (cfg.in_reset) begin
+          req_q.delete();
+          wait (!cfg.in_reset);
+        end
+        wait (req_q.size());
+        rsp = req_q.pop_front();
+        start_item(rsp);
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(rsp,
+            s_alert_send     == local::s_alert_send;
+            s_alert_ping_rsp == local::s_alert_ping_rsp;
+            int_err          == 0;
+            ping_timeout     == 0;
+        )
+        finish_item(rsp);
+        get_response(rsp);
+      end : send_rsp
+    join
+  endtask
+
 endclass : alert_sender_ping_rsp_seq

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -342,22 +342,6 @@ class alert_handler_base_vseq extends cip_base_vseq #(
     end
   endtask
 
-  // This task will response to all alert_ping
-  virtual task run_alert_ping_rsp_seq_nonblocking(bit [NUM_ALERTS-1:0] alert_int_err = 0);
-    foreach (cfg.alert_host_cfg[i]) begin
-      automatic int index = i;
-      fork
-        forever begin
-          bit alert_timeout = alert_int_err[index] ? $urandom_range(0, 1) : 0;
-          alert_sender_ping_rsp_seq ping_seq =
-              alert_sender_ping_rsp_seq::type_id::create("ping_seq");
-          `DV_CHECK_RANDOMIZE_WITH_FATAL(ping_seq, int_err == 0; ping_timeout == alert_timeout;)
-          ping_seq.start(p_sequencer.alert_host_seqr_h[index]);
-        end
-      join_none
-    end
-  endtask : run_alert_ping_rsp_seq_nonblocking
-
 endclass : alert_handler_base_vseq
 
 `undef RAND_AND_WR_CLASS_PHASES_CYCLE

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -14,7 +14,6 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
   virtual task body();
     // run alert/esc ping response sequences without error or timeout to prevent triggering local
     // alert failure
-    run_alert_ping_rsp_seq_nonblocking(0);
     run_esc_rsp_seq_nonblocking(0);
     run_common_vseq_wrapper(num_trans);
   endtask : body

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
@@ -53,7 +53,6 @@ class alert_handler_entropy_stress_vseq extends alert_handler_smoke_vseq;
     `uvm_info(`gfn, "Test started", UVM_LOW)
 
     run_esc_rsp_seq_nonblocking();
-    run_alert_ping_rsp_seq_nonblocking();
 
     alert_handler_init(.intr_en('1),                       // Enable all interrupts
                        .alert_en('1),                      // Enable all alerts

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -110,10 +110,8 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
 
   virtual task trigger_non_blocking_seqs();
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(esc_int_err)
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(alert_ping_timeout)
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(esc_ping_timeout)
     run_esc_rsp_seq_nonblocking(esc_int_err, esc_ping_timeout);
-    run_alert_ping_rsp_seq_nonblocking(alert_ping_timeout);
   endtask
 
   virtual task run_smoke_seq();
@@ -126,6 +124,9 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
 
     for (int i = 1; i <= num_trans; i++) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
+
+      // Assign ping timeout value to each alert agent.
+      foreach (cfg.alert_host_cfg[i]) cfg.alert_host_cfg[i].ping_timeout = alert_ping_timeout[i];
 
       `uvm_info(`gfn, $sformatf(
           "start seq %0d/%0d: intr_en=0x%0h, alert=0x%0h, alert_en=0x%0h, loc_alert_en=0x%0h",

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -342,22 +342,6 @@ class alert_handler_base_vseq extends cip_base_vseq #(
     end
   endtask
 
-  // This task will response to all alert_ping
-  virtual task run_alert_ping_rsp_seq_nonblocking(bit [NUM_ALERTS-1:0] alert_int_err = 0);
-    foreach (cfg.alert_host_cfg[i]) begin
-      automatic int index = i;
-      fork
-        forever begin
-          bit alert_timeout = alert_int_err[index] ? $urandom_range(0, 1) : 0;
-          alert_sender_ping_rsp_seq ping_seq =
-              alert_sender_ping_rsp_seq::type_id::create("ping_seq");
-          `DV_CHECK_RANDOMIZE_WITH_FATAL(ping_seq, int_err == 0; ping_timeout == alert_timeout;)
-          ping_seq.start(p_sequencer.alert_host_seqr_h[index]);
-        end
-      join_none
-    end
-  endtask : run_alert_ping_rsp_seq_nonblocking
-
 endclass : alert_handler_base_vseq
 
 `undef RAND_AND_WR_CLASS_PHASES_CYCLE

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -14,7 +14,6 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
   virtual task body();
     // run alert/esc ping response sequences without error or timeout to prevent triggering local
     // alert failure
-    run_alert_ping_rsp_seq_nonblocking(0);
     run_esc_rsp_seq_nonblocking(0);
     run_common_vseq_wrapper(num_trans);
   endtask : body

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
@@ -53,7 +53,6 @@ class alert_handler_entropy_stress_vseq extends alert_handler_smoke_vseq;
     `uvm_info(`gfn, "Test started", UVM_LOW)
 
     run_esc_rsp_seq_nonblocking();
-    run_alert_ping_rsp_seq_nonblocking();
 
     alert_handler_init(.intr_en('1),                       // Enable all interrupts
                        .alert_en('1),                      // Enable all alerts

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -110,10 +110,8 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
 
   virtual task trigger_non_blocking_seqs();
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(esc_int_err)
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(alert_ping_timeout)
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(esc_ping_timeout)
     run_esc_rsp_seq_nonblocking(esc_int_err, esc_ping_timeout);
-    run_alert_ping_rsp_seq_nonblocking(alert_ping_timeout);
   endtask
 
   virtual task run_smoke_seq();
@@ -126,6 +124,9 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
 
     for (int i = 1; i <= num_trans; i++) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
+
+      // Assign ping timeout value to each alert agent.
+      foreach (cfg.alert_host_cfg[i]) cfg.alert_host_cfg[i].ping_timeout = alert_ping_timeout[i];
 
       `uvm_info(`gfn, $sformatf(
           "start seq %0d/%0d: intr_en=0x%0h, alert=0x%0h, alert_en=0x%0h, loc_alert_en=0x%0h",


### PR DESCRIPTION
This PR changes the non-blocking sequence from vseq to auto-responses seqs from agent.
This PR contributes to issue #16374.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>