### PR TITLE
[dv] Add a fcov in sec_cm

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -109,6 +109,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
     if (!cfg.en_cov) begin
       cfg.en_tl_err_cov = 0;
       cfg.en_tl_intg_err_cov = 0;
+      sec_cm_pkg::en_sec_cm_cov = 0;
     end
   endfunction
 

--- a/hw/dv/sv/sec_cm/sec_cm_pkg.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_pkg.sv
@@ -26,6 +26,9 @@ package sec_cm_pkg;
   // store all the sec_cm proxy classes
   sec_cm_base_if_proxy sec_cm_if_proxy_q[$];
 
+  // coverage enable knob
+  bit en_sec_cm_cov = 1;
+
   // Finds and returns a sec_cm interface proxy class instance from the sec_cm_if_proxy_q queue.
   //
   // This function matches the first instance whose `path` matches the input argument `path`.


### PR DESCRIPTION
Add a fcov as prim_onehot_check_if supports injecting different types of faults This also addressed a TODO in prim_onehot_check_if

Signed-off-by: Weicai Yang <weicai@google.com>