### PR TITLE
[otbn/pre_syn] Add experimental Yosys synthesis flow

### DIFF
--- a/hw/ip/otbn/pre_syn/.gitignore
+++ b/hw/ip/otbn/pre_syn/.gitignore
@@ -1,0 +1,2 @@
+syn_out
+syn_setup.sh

--- a/hw/ip/otbn/pre_syn/README.md
+++ b/hw/ip/otbn/pre_syn/README.md
@@ -1,0 +1,1 @@
+../../../../hw/vendor/lowrisc_ibex/syn/README.md

--- a/hw/ip/otbn/pre_syn/otbn.nangate.sdc
+++ b/hw/ip/otbn/pre_syn/otbn.nangate.sdc
@@ -1,0 +1,1 @@
+../../../../hw/vendor/lowrisc_ibex/syn/ibex_top.nangate.sdc

--- a/hw/ip/otbn/pre_syn/otbn_abc.nangate.sdc
+++ b/hw/ip/otbn/pre_syn/otbn_abc.nangate.sdc
@@ -1,0 +1,1 @@
+../../../../hw/vendor/lowrisc_ibex/syn/ibex_top_abc.nangate.sdc

--- a/hw/ip/otbn/pre_syn/otbn_lr_synth_conf.tcl
+++ b/hw/ip/otbn/pre_syn/otbn_lr_synth_conf.tcl
@@ -1,0 +1,38 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# List of inputs and outputs.  Number is timing constraint expressed as a % of
+# clock cycle, e.g.
+#
+# {instr_req_o 70.0}
+#
+# as an output means the instr_req_o output must be stable by 70% of total clock
+# cycle
+#
+# {instr_gnt_i 30.0}
+#
+# as an input means the instr_gnt_i input will be stable by 30% of the total
+# clock cycle
+
+# These IO constraints are an educated guess, they effectively assume there's a
+# bit of external logic on the inputs and outputs but not much before they reach
+# a flop.
+set lr_synth_outputs [list {*_o 70.0}]
+set lr_synth_inputs [list {*_i 30.0}]
+
+# Clock and reset IO names (at top-level)
+set lr_synth_clk_input clk_i
+set lr_synth_rst_input rst_ni
+
+# Clock period in ps, this gives a 125 MHz clock. Using the nangate45 library
+# the AES module can happily meet this on all paths with the
+# lr_synth_abc_clk_uprate setting below. With a lower uprate timing may not be
+# met.
+set lr_synth_clk_period 8000.0
+
+# Amount to subtract from clk period to give the clock period passed to ABC in
+# the synth flow. ABC maps the design to the standard cell library and
+# optimises paths for timing, better results are obtained by giving it a faster
+# clock period so it optimises more.
+set lr_synth_abc_clk_uprate 4000.0

--- a/hw/ip/otbn/pre_syn/python
+++ b/hw/ip/otbn/pre_syn/python
@@ -1,0 +1,1 @@
+../../../../hw/vendor/lowrisc_ibex/syn/python

--- a/hw/ip/otbn/pre_syn/syn_setup.example.sh
+++ b/hw/ip/otbn/pre_syn/syn_setup.example.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Setup IP name and top module.
+# When changing the top module, some parameters might not exist and
+# tcl/yosys_run_synth.tcl might need to be adjusted accordingly.
+# Known working top modules are: otbn_core, otbn
+export LR_SYNTH_IP_NAME=otbn
+export LR_SYNTH_TOP_MODULE=otbn_core
+
+# Setup module parameters.
+export LR_SYNTH_IMEM_SIZE_BYTE=4096
+export LR_SYNTH_DMEM_SIZE_BYTE=4096
+
+# Setup cell library path.
+# Change the line below to set the path to an appropriate .lib file
+#export LR_SYNTH_CELL_LIBRARY_PATH=/path/to/NangateOpenCellLibrary_typical.lib
+export LR_SYNTH_CELL_LIBRARY_NAME=nangate
+if [ -z "$LR_SYNTH_CELL_LIBRARY_PATH" ]; then
+    echo >&2 "You forgot to set LR_SYNTH_CELL_LIBRARY_PATH!";
+    exit 1;
+fi
+if [ ! -f "$LR_SYNTH_CELL_LIBRARY_PATH" ]; then
+    echo >&2 "Cannot find cell library $LR_SYNTH_CELL_LIBRARY_PATH";
+    echo >&2 "Check your LR_SYNTH_CELL_LIBRARY_PATH variable!";
+    exit 1;
+fi
+if [ -z "$LR_SYNTH_CELL_LIBRARY_NAME" ]; then
+    echo >&2 "You forgot to set LR_SYNTH_CELL_LIBRARY_NAME!";
+    exit 1;
+fi
+
+# Control synthesis flow.
+export LR_SYNTH_TIMING_RUN=0
+export LR_SYNTH_FLATTEN=1
+
+# For timing runs, hierarchy flattening is needed.
+if [[ $LR_SYNTH_TIMING_RUN == 1 ]] && [[ $LR_SYNTH_FLATTEN == 0 ]]; then
+    echo >&2 "LR_SYNTH_TIMING_RUN requires LR_SYNTH_FLATTEN!";
+    exit 1;
+fi
+
+# Output directory
+if [ $# -eq 1 ]; then
+    export LR_SYNTH_OUT_DIR=$1
+elif [ $# -eq 0 ]; then
+    export LR_SYNTH_OUT_DIR_PREFIX="syn_out/${LR_SYNTH_TOP_MODULE}"
+    LR_SYNTH_OUT_DIR=$(date +"${LR_SYNTH_OUT_DIR_PREFIX}_%Y_%m_%d_%H_%M_%S")
+    export LR_SYNTH_OUT_DIR
+else
+    echo "Usage $0 [synth_out_dir]"
+    exit 1
+fi

--- a/hw/ip/otbn/pre_syn/syn_yosys.sh
+++ b/hw/ip/otbn/pre_syn/syn_yosys.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script drives the experimental Yosys synthesis flow. More details can be found in README.md
+
+set -e
+set -o pipefail
+
+error () {
+    echo >&2 "$@"
+    exit 1
+}
+
+teelog () {
+    tee "$LR_SYNTH_OUT_DIR/log/$1.log"
+}
+
+if [ ! -f syn_setup.sh ]; then
+    error "No syn_setup.sh file: see README.md for instructions"
+fi
+
+#-------------------------------------------------------------------------
+# setup flow variables
+#-------------------------------------------------------------------------
+source syn_setup.sh
+
+#-------------------------------------------------------------------------
+# prepare output folders
+#-------------------------------------------------------------------------
+mkdir -p "$LR_SYNTH_OUT_DIR/generated"
+mkdir -p "$LR_SYNTH_OUT_DIR/log"
+mkdir -p "$LR_SYNTH_OUT_DIR/reports/timing"
+
+rm -f syn_out/latest
+ln -s "${LR_SYNTH_OUT_DIR#syn_out/}" syn_out/latest
+
+#-------------------------------------------------------------------------
+# use sv2v to convert all SystemVerilog files to Verilog
+#-------------------------------------------------------------------------
+export LR_SYNTH_SRC_DIR="../../$LR_SYNTH_IP_NAME"
+
+# Get OpenTitan dependency sources.
+OT_DEP_SOURCES=(
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_adapter_reg.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_err.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_cmd_intg_chk.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_rsp_intg_gen.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_data_integ_dec.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_data_integ_enc.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_secded_inv_64_57_dec.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_secded_inv_64_57_enc.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_secded_inv_39_32_dec.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_secded_inv_39_32_enc.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_sparse_fsm_flop.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_subreg.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_subreg_ext.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_subreg_shadow.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_subreg_arb.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_alert_sender.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_diff_decode.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_lc_sync.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_sync_reqack_data.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_sync_reqack.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_packer_fifo.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_lfsr.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_flop_2sync.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_cdc_rand_delay.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_reg_we_check.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_onehot_check.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_mubi4_sender.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_fifo_sync_cnt.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_generic/rtl/prim_generic_flop.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xilinx_flop.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xilinx_flop_en.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xilinx_buf.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xilinx_xor2.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xilinx_and2.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_adapter_sram.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_sram_byte.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_socket_1n.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_err_resp.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_fifo_sync.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_intr_hw.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_edn_req.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_fifo_sync.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_arbiter_fixed.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_packer.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_count.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_double_lfsr.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_onehot_mux.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_onehot_enc.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_blanker.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_crc32.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_xoshiro256pp.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_ram_1p_scr.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_ram_1p_adv.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_generic/rtl/prim_generic_ram_1p.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_subst_perm.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_prince.sv
+)
+
+# Get OpenTitan dependency packages.
+OT_DEP_PACKAGES=(
+    "$LR_SYNTH_SRC_DIR"/../../top_earlgrey/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../edn/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../entropy_src/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../lc_ctrl/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../keymgr/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../otp_ctrl/rtl/*_pkg.sv
+)
+
+# Convert OpenTitan dependency sources.
+for file in "${OT_DEP_SOURCES[@]}"; do
+    module=`basename -s .sv $file`
+
+    # Skip packages
+    if echo "$module" | grep -q '_pkg$'; then
+        continue
+    fi
+
+    sv2v \
+        --define=SYNTHESIS --define=SYNTHESIS_MEMORY_BLACK_BOXING --define=YOSYS \
+        "${OT_DEP_PACKAGES[@]}" \
+        -I"$LR_SYNTH_SRC_DIR"/../prim/rtl \
+        $file \
+        > $LR_SYNTH_OUT_DIR/generated/${module}.v
+
+    # Make sure auto-generated primitives are resolved to generic or Xilinx-specific primitives
+    # where available.
+    sed -i 's/prim_flop/prim_xilinx_flop/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_buf/prim_xilinx_buf/g'                $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_and2/prim_xilinx_and2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_ram_1p/prim_generic_ram_1p/g'         $LR_SYNTH_OUT_DIR/generated/${module}.v
+
+    # Remove calls to $value$plusargs(). Yosys doesn't seem to support this.
+    sed -i '/$value$plusargs(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+done
+
+# Rename the prim_sparse_fsm_flop module. For some reason, sv2v decides to append a suffix.
+sed -i 's/module prim_sparse_fsm_flop_.*/module prim_sparse_fsm_flop \(/g' \
+    $LR_SYNTH_OUT_DIR/generated/prim_sparse_fsm_flop.v
+
+# Get and convert core sources.
+for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
+    module=`basename -s .sv $file`
+
+    # Skip packages
+    if echo "$module" | grep -q '_pkg$'; then
+        continue
+    fi
+
+    sv2v \
+        --define=SYNTHESIS \
+        "${OT_DEP_PACKAGES[@]}" \
+        "$LR_SYNTH_SRC_DIR"/rtl/*_pkg.sv \
+        -I"$LR_SYNTH_SRC_DIR"/../prim/rtl \
+        $file \
+        > $LR_SYNTH_OUT_DIR/generated/${module}.v
+
+    # Make sure auto-generated primitives are resolved to generic or Xilinx-specific primitives
+    # where available.
+    sed -i 's/prim_flop/prim_xilinx_flop/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_buf/prim_xilinx_buf/g'                $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_and2/prim_xilinx_and2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_ram_1p/prim_generic_ram_1p/g'         $LR_SYNTH_OUT_DIR/generated/${module}.v
+
+    # Rename prim_sparse_fsm_flop instances. For some reason, sv2v decides to append a suffix.
+    sed -i 's/prim_sparse_fsm_flop_.*/prim_sparse_fsm_flop \#(/g' \
+        $LR_SYNTH_OUT_DIR/generated/${module}.v
+
+    # Remove the StateEnumT parameter from prim_sparse_fsm_flop instances. Yosys doesn't seem to
+    # support this.
+    sed -i '/\.StateEnumT(logic \[.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i '/\.StateEnumT_otbn_pkg.*Width.*(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+done
+
+#-------------------------------------------------------------------------
+# run Yosys synthesis
+#-------------------------------------------------------------------------
+yosys -c ./tcl/yosys_run_synth.tcl |& teelog syn || {
+    error "Failed to synthesize RTL with Yosys"
+}
+
+#-------------------------------------------------------------------------
+# run static timing analysis
+#-------------------------------------------------------------------------
+if [[ $LR_SYNTH_TIMING_RUN == 1 ]] ; then
+    sta ./tcl/sta_run_reports.tcl |& teelog sta || {
+        error "Failed to run static timing analysis"
+    }
+
+    ./translate_timing_rpts.sh
+fi
+
+#-------------------------------------------------------------------------
+# report kGE number
+#-------------------------------------------------------------------------
+python/get_kge.py $LR_SYNTH_CELL_LIBRARY_PATH $LR_SYNTH_OUT_DIR/reports/area.rpt

--- a/hw/ip/otbn/pre_syn/tcl/flow_utils.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/flow_utils.tcl
@@ -1,0 +1,1 @@
+../../../../../hw/vendor/lowrisc_ibex/syn/tcl/flow_utils.tcl

--- a/hw/ip/otbn/pre_syn/tcl/lr_synth_flow_var_setup.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/lr_synth_flow_var_setup.tcl
@@ -1,0 +1,48 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+puts "=================== Flow Vars ==================="
+
+# Every variable "variable_name" can be overwritten by defining a corresponding environment variable "LR_SYNTH_VARIABLE_NAME".
+# function (see flow_utils.tcl) - variable name - default value
+
+set_flow_var cell_library_path "cmos_cells.lib" "Path to cell library"
+set_flow_var ip_name "otbn" "IP name"
+set_flow_var top_module "otbn_core" "top module"
+set_flow_var out_dir "syn_out" "Output directory for synthesis"
+set_flow_var pre_map_out "./${lr_synth_out_dir}/generated/${lr_synth_top_module}.pre_map.v" "Pre-mapping netlist out"
+set_flow_var alma_out "./${lr_synth_out_dir}/generated/${lr_synth_top_module}.alma.v" "Alma netlist out for pre-silicon SCA verification"
+set_flow_var netlist_out "./${lr_synth_out_dir}/generated/${lr_synth_top_module}_netlist.v" "netlist out"
+set_flow_var config_file "${lr_synth_ip_name}_lr_synth_conf.tcl" "Synth config file"
+set_flow_var rpt_out "./${lr_synth_out_dir}/reports" "Report output directory"
+set_flow_bool_var flatten 1 "flatten"
+set_flow_bool_var timing_run 0 "timing run"
+set_flow_var imem_size_byte 4096 "IMEM size in bytes"
+set_flow_var dmem_size_byte 4096 "DMEM size in bytes"
+
+source $lr_synth_config_file
+
+if { $lr_synth_timing_run } {
+  set_flow_var cell_library_name "nangate" "Name of cell library"
+  set_flow_var sdc_file_in "${lr_synth_ip_name}.${lr_synth_cell_library_name}.sdc" "Input SDC file"
+  set_flow_var abc_sdc_file_in "${lr_synth_ip_name}_abc.${lr_synth_cell_library_name}.sdc" "Input SDC file for ABC"
+
+  set sdc_file_out_default [string range $lr_synth_sdc_file_in 0 [expr [string last ".sdc" $lr_synth_sdc_file_in] - 1]]
+  set sdc_file_out_default "./${lr_synth_out_dir}/generated/$sdc_file_out_default.out.sdc"
+  set_flow_var sdc_file_out $sdc_file_out_default "Output SDC file"
+
+  set sta_netlist_out_default [string range $lr_synth_netlist_out 0 [expr [string last ".v" $lr_synth_netlist_out] - 1]]
+  set sta_netlist_out_default "$sta_netlist_out_default.sta.v"
+  set_flow_var sta_netlist_out $sta_netlist_out_default "STA netlist out"
+  set_flow_var sta_paths_per_group 1000 "STA paths reported per group"
+  set_flow_var sta_overall_paths 1000 "STA paths reported in overall report"
+  puts "clock period: $lr_synth_clk_period ps"
+
+  if { $lr_synth_abc_clk_uprate > $lr_synth_clk_period } {
+    puts "WARNING: abc_clk_uprate must be less than clk_period otherwise ABC will be given a negative clk period"
+  }
+
+}
+
+puts "================================================="

--- a/hw/ip/otbn/pre_syn/tcl/sta_common.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/sta_common.tcl
@@ -1,0 +1,1 @@
+../../../../../hw/vendor/lowrisc_ibex/syn/tcl/sta_common.tcl

--- a/hw/ip/otbn/pre_syn/tcl/sta_open_design.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/sta_open_design.tcl
@@ -1,0 +1,1 @@
+../../../../../hw/vendor/lowrisc_ibex/syn/tcl/sta_open_design.tcl

--- a/hw/ip/otbn/pre_syn/tcl/sta_run_reports.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/sta_run_reports.tcl
@@ -1,0 +1,1 @@
+../../../../../hw/vendor/lowrisc_ibex/syn/tcl/sta_run_reports.tcl

--- a/hw/ip/otbn/pre_syn/tcl/sta_utils.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/sta_utils.tcl
@@ -1,0 +1,1 @@
+../../../../../hw/vendor/lowrisc_ibex/syn/tcl/sta_utils.tcl

--- a/hw/ip/otbn/pre_syn/tcl/yosys_common.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/yosys_common.tcl
@@ -1,0 +1,1 @@
+../../../../../hw/vendor/lowrisc_ibex/syn/tcl/yosys_common.tcl

--- a/hw/ip/otbn/pre_syn/tcl/yosys_post_synth.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/yosys_post_synth.tcl
@@ -1,0 +1,1 @@
+../../../../../hw/vendor/lowrisc_ibex/syn/tcl/yosys_post_synth.tcl

--- a/hw/ip/otbn/pre_syn/tcl/yosys_pre_map.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/yosys_pre_map.tcl
@@ -1,0 +1,1 @@
+../../../../../hw/vendor/lowrisc_ibex/syn/tcl/yosys_pre_map.tcl

--- a/hw/ip/otbn/pre_syn/tcl/yosys_run_synth.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/yosys_run_synth.tcl
@@ -1,0 +1,81 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+source ./tcl/yosys_common.tcl
+
+if { $lr_synth_flatten } {
+  set flatten_opt "-flatten"
+} else {
+  set flatten_opt ""
+}
+
+if { $lr_synth_timing_run } {
+  write_sdc_out $lr_synth_sdc_file_in $lr_synth_sdc_file_out
+}
+
+yosys "read_verilog -sv $lr_synth_out_dir/generated/*.v"
+
+# Set top-module parameters.
+if { $lr_synth_top_module == "otbn_core" } {
+  yosys "chparam -set ImemSizeByte $lr_synth_imem_size_byte $lr_synth_top_module"
+  yosys "chparam -set DmemSizeByte $lr_synth_dmem_size_byte $lr_synth_top_module"
+}
+
+# Remap Xilinx Vivado "dont_touch" attributes to Yosys "keep" attributes.
+yosys "attrmap -tocase keep -imap dont_touch=\"yes\" keep=1 -imap dont_touch=\"no\" keep=0 -remove keep=0"
+
+# Place keep_hierarchy contraints on relevant modules to prevent aggressive synthesis optimzations
+# across the boundaries of these modules.
+yosys "hierarchy -check -top $lr_synth_top_module"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_xilinx*"
+
+# Synthesize.
+yosys "synth -nofsm $flatten_opt -top $lr_synth_top_module"
+yosys "opt -purge"
+
+yosys "write_verilog $lr_synth_pre_map_out"
+
+# Remove keep_hierarchy constraints before writing out the netlist for Alma as it doesn't like
+# these constraints.
+yosys "setattr -mod -set keep_hierarchy 0 *prim_xilinx*"
+
+yosys "write_verilog $lr_synth_alma_out"
+
+# Re-add keep_hierarchy constraints for further synthesis steps.
+yosys "setattr -mod -set keep_hierarchy 1 *prim_xilinx*"
+
+yosys "dfflibmap -liberty $lr_synth_cell_library_path"
+yosys "opt"
+
+set yosys_abc_clk_period [expr $lr_synth_clk_period - $lr_synth_abc_clk_uprate]
+
+if { $lr_synth_timing_run } {
+  yosys "abc -liberty $lr_synth_cell_library_path -constr $lr_synth_abc_sdc_file_in -D $yosys_abc_clk_period"
+} else {
+  yosys "abc -liberty $lr_synth_cell_library_path"
+}
+
+# Remove keep_hierarchy constraints before the final flattening step. We're done optimizing.
+yosys "setattr -mod -set keep_hierarchy 0 *prim_xilinx*"
+
+# Final flattening.
+if { $lr_synth_flatten } {
+  yosys "flatten"
+}
+
+yosys "clean"
+yosys "write_verilog $lr_synth_netlist_out"
+
+if { $lr_synth_timing_run } {
+  # Produce netlist that OpenSTA can use
+  yosys "setundef -zero"
+  yosys "splitnets"
+  yosys "clean"
+  yosys "write_verilog -noattr -noexpr -nohex -nodec $lr_synth_sta_netlist_out"
+}
+
+yosys "check"
+yosys "log ======== Yosys Stat Report ========"
+yosys "tee -o $lr_synth_out_dir/reports/area.rpt stat -liberty $lr_synth_cell_library_path"
+yosys "log ====== End Yosys Stat Report ======"

--- a/hw/ip/otbn/pre_syn/translate_timing_rpts.sh
+++ b/hw/ip/otbn/pre_syn/translate_timing_rpts.sh
@@ -1,0 +1,1 @@
+../../aes/pre_syn/translate_timing_rpts.sh


### PR DESCRIPTION
This PR adds an experimental Yosys synthesis flow for OTBN similar to what we have for AES and KMAC. The main purpose of this flow is to enable formal masking verification using tools like Alma.

Ideally, we would provide a shared Yosys synthesis flow for modules that need it but this is left for future work for after the ES.
