### PR TITLE
[i2c,dv] various minor regression fix

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -39,7 +39,7 @@ class i2c_monitor extends dv_base_monitor #(
     if (cfg.if_mode == Host) begin
       bit r_bit = 1'b0;
       i2c_item full_item;
-      fork begin
+      fork
         forever begin
           wait(cfg.en_monitor);
           if (mon_dut_item.stop ||
@@ -83,7 +83,7 @@ class i2c_monitor extends dv_base_monitor #(
           mon_dut_item.clear_data();
         end // forever begin
         ack_stop_mon();
-      end join_none
+      join_none
     end else begin
       forever begin
         fork
@@ -279,7 +279,6 @@ class i2c_monitor extends dv_base_monitor #(
     mon_dut_item.nack   = 1'b0;
     mon_rstart = 0;
     target_read_phase = 1;
-
     // Previous data collecting thread replied on nack / stop
     // For ack / stop test, this thread need to be forked with
     // separate ack_stop_monitor

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -579,7 +579,7 @@ class i2c_base_vseq extends cip_base_vseq #(
       if (myq[i].rstart) begin
         if (cfg.m_i2c_agent_cfg.allow_ack_stop) begin
           if (read) begin
-            `uvm_info("seq", $sformatf("xeos: %s", (read_ack_nack_q[rd_idx++]) ?
+            `uvm_info("seq", $sformatf("eos: %s", (read_ack_nack_q[rd_idx++]) ?
                                        "NACK" : "ACK"), UVM_MEDIUM)
           end
         end

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_error_intr_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_error_intr_vseq.sv
@@ -28,6 +28,7 @@ class i2c_host_error_intr_vseq extends i2c_rx_tx_vseq;
 
   virtual task body();
     `uvm_info(`gfn, "\n--> start of i2c_host_error_intr_vseq", UVM_DEBUG)
+    $assertoff(0, "tb.dut.i2c_core.u_i2c_fsm.SclInputGlitch_A");
     initialization(.mode(Host));
     for (int i = 1; i <= num_runs; i++) begin
       `uvm_info(`gfn, $sformatf("\n  run simulation %0d/%0d", i, num_runs), UVM_DEBUG)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_stress_all_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_stress_all_vseq.sv
@@ -32,7 +32,7 @@ class i2c_host_stress_all_vseq extends i2c_rx_tx_vseq;
     // otherwise it is excluded for stress_all_with_rand_reset test
     if (common_seq_type != "stress_all_with_rand_reset") begin
       uint size = seq_names.size();
-      seq_names.push_back("i2c_error_intr_vseq");
+      seq_names.push_back("i2c_host_error_intr_vseq");
     end
   endtask : pre_start
 

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -31,7 +31,6 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
   // Add additional tops for simulation.


### PR DESCRIPTION
- i2c_host_error_intr : disable 'SclInputGlitch_A' for error test
- i2c_host_stress_all : fix typo in the sequence name
- i2c_target_unexp_stop : fix typo in i2c_monitor to activate ack_stop_mon
- remove invalid i2c_stress_* (this is replaced by dedicaate i2c_host/target_*' 

Signed-off-by: Jaedon Kim <jdonjdon@google.com>