### PR TITLE
[coverage] Add unit test coverage measurement support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,9 +26,22 @@ build --workspace_status_command=util/get_workspace_status.sh
 # --config=riscv32
 build:riscv32 --platforms=@crt//platforms/riscv32:opentitan
 
-# Generate coverage in lcov format, which can be post-processed by lcov
-# into html-formatted reports.
-coverage --combined_report=lcov --instrument_test_targets --experimental_cc_coverage
+# Configuration for clang's source-based coverage instrumentation. Enable with
+# `--config=coverage_clang`. Bazel seems to support this only partially, thus we have to
+# perform some additional processing. See
+# https://github.com/bazelbuild/bazel/commit/21b5eb627d78c09d47c4de957e9e6b56a9ae6fad
+# and `util/coverage/coverage_off_target.py`.
+build:coverage_clang --repo_env=CC=clang
+build:coverage_clang --repo_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
+build:coverage_clang --java_runtime_version=remotejdk_11
+build:coverage_clang --collect_code_coverage
+build:coverage_clang --copt='-O0'
+build:coverage_clang --cxxopt='-O0'
+coverage:coverage_clang --repo_env=GCOV=/usr/bin/llvm-profdata
+coverage:coverage_clang --repo_env=BAZEL_LLVM_COV=/usr/bin/llvm-cov
+# Docs state that bazel will fail to create coverage information if tests have been
+# cached previously. See https://bazel.build/configure/coverage?hl=en#remote-execution
+coverage:coverage_clang --nocache_test_results
 
 # Verilator is built for 4 cores and can time out if bazel is running more
 # than 1 test per four cores.

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -23,10 +23,10 @@ dual_cc_library(
     name = "mod_exp_ibex",
     srcs = dual_inputs(
         device = ["mod_exp_ibex.c"],
-        host = ["mod_exp_ibex_mock.cc"],
+        host = ["mock_mod_exp_ibex.cc"],
     ),
     hdrs = dual_inputs(
-        host = ["mod_exp_ibex_mock.h"],
+        host = ["mock_mod_exp_ibex.h"],
         shared = ["mod_exp_ibex.h"],
     ),
     deps = dual_inputs(
@@ -93,10 +93,10 @@ dual_cc_library(
     name = "mod_exp_otbn",
     srcs = dual_inputs(
         device = ["mod_exp_otbn.c"],
-        host = ["mod_exp_otbn_mock.cc"],
+        host = ["mock_mod_exp_otbn.cc"],
     ),
     hdrs = dual_inputs(
-        host = ["mod_exp_otbn_mock.h"],
+        host = ["mock_mod_exp_otbn.h"],
         shared = ["mod_exp_otbn.h"],
     ),
     target_compatible_with = dual_inputs(
@@ -223,7 +223,7 @@ cc_library(
 )
 
 cc_library(
-    name = "sigverify_without_mod_exp_ibex_mock",
+    name = "sigverify_without_mock_mod_exp_ibex",
     visibility = ["//sw/device/silicon_creator/rom:__pkg__"],
     deps = [
         dual_cc_device_library_of(":mod_exp_ibex"),

--- a/sw/device/silicon_creator/lib/sigverify/mock_mod_exp_ibex.cc
+++ b/sw/device/silicon_creator/lib/sigverify/mock_mod_exp_ibex.cc
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/silicon_creator/lib/sigverify/mod_exp_ibex_mock.h"
+#include "sw/device/silicon_creator/lib/sigverify/mock_mod_exp_ibex.h"
 
 namespace rom_test {
 extern "C" {

--- a/sw/device/silicon_creator/lib/sigverify/mock_mod_exp_ibex.h
+++ b/sw/device/silicon_creator/lib/sigverify/mock_mod_exp_ibex.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOD_EXP_IBEX_MOCK_H_
-#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOD_EXP_IBEX_MOCK_H_
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOCK_MOD_EXP_IBEX_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOCK_MOD_EXP_IBEX_H_
 
 #include "sw/device/lib/base/global_mock.h"
 #include "sw/device/silicon_creator/lib/sigverify/mod_exp_ibex.h"
@@ -29,4 +29,4 @@ using MockSigverifyModExpIbex =
     testing::StrictMock<internal::MockSigverifyModExpIbex>;
 }  // namespace rom_test
 
-#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOD_EXP_IBEX_MOCK_H_
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOCK_MOD_EXP_IBEX_H_

--- a/sw/device/silicon_creator/lib/sigverify/mock_mod_exp_otbn.cc
+++ b/sw/device/silicon_creator/lib/sigverify/mock_mod_exp_otbn.cc
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/silicon_creator/lib/sigverify/mod_exp_otbn_mock.h"
+#include "sw/device/silicon_creator/lib/sigverify/mock_mod_exp_otbn.h"
 
 namespace rom_test {
 extern "C" {

--- a/sw/device/silicon_creator/lib/sigverify/mock_mod_exp_otbn.h
+++ b/sw/device/silicon_creator/lib/sigverify/mock_mod_exp_otbn.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOD_EXP_OTBN_MOCK_H_
-#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOD_EXP_OTBN_MOCK_H_
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOCK_MOD_EXP_OTBN_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOCK_MOD_EXP_OTBN_H_
 
 #include "sw/device/lib/base/global_mock.h"
 #include "sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.h"
@@ -29,4 +29,4 @@ using MockSigverifyModExpOtbn =
     testing::StrictMock<internal::MockSigverifyModExpOtbn>;
 }  // namespace rom_test
 
-#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOD_EXP_OTBN_MOCK_H_
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_MOCK_MOD_EXP_OTBN_H_

--- a/sw/device/silicon_creator/lib/sigverify/sigverify_unittest.cc
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify_unittest.cc
@@ -13,8 +13,8 @@
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
-#include "sw/device/silicon_creator/lib/sigverify/mod_exp_ibex_mock.h"
-#include "sw/device/silicon_creator/lib/sigverify/mod_exp_otbn_mock.h"
+#include "sw/device/silicon_creator/lib/sigverify/mock_mod_exp_ibex.h"
+#include "sw/device/silicon_creator/lib/sigverify/mock_mod_exp_otbn.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "flash_ctrl_regs.h"

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -286,7 +286,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/drivers:rnd",
         "//sw/device/silicon_creator/lib/sigverify:rsa_key",
-        "//sw/device/silicon_creator/lib/sigverify:sigverify_without_mod_exp_ibex_mock",
+        "//sw/device/silicon_creator/lib/sigverify:sigverify_without_mock_mod_exp_ibex",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/keys/fake/sigverify_rsa_keys_fake_unittest.cc
+++ b/sw/device/silicon_creator/rom/keys/fake/sigverify_rsa_keys_fake_unittest.cc
@@ -14,7 +14,7 @@
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_rnd.h"
 #include "sw/device/silicon_creator/lib/error.h"
-#include "sw/device/silicon_creator/lib/sigverify/mod_exp_otbn_mock.h"
+#include "sw/device/silicon_creator/lib/sigverify/mock_mod_exp_otbn.h"
 #include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
 #include "sw/device/silicon_creator/rom/sigverify_keys.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"

--- a/sw/device/silicon_creator/rom/sigverify_keys_unittest.cc
+++ b/sw/device/silicon_creator/rom/sigverify_keys_unittest.cc
@@ -16,7 +16,7 @@
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_rnd.h"
 #include "sw/device/silicon_creator/lib/error.h"
-#include "sw/device/silicon_creator/lib/sigverify/mod_exp_otbn_mock.h"
+#include "sw/device/silicon_creator/lib/sigverify/mock_mod_exp_otbn.h"
 #include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 

--- a/util/coverage/BUILD
+++ b/util/coverage/BUILD
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@ot_python_deps//:requirements.bzl", "requirement")
+
+py_test(
+    name = "coverage_off_target_test",
+    srcs = [
+        "coverage_off_target.py",
+        "coverage_off_target_test.py",
+    ],
+    deps = [
+        requirement("typer"),
+    ],
+)

--- a/util/coverage/coverage_off_target.py
+++ b/util/coverage/coverage_off_target.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Measure unit test coverage of silicon creator code.
+
+Given a directory `out_root_dir` the coverage artifacts will be saved in
+`out_root_dir`/<HEAD_TIMESTAMP>-<HEAD_HASH>/unittest/`.
+
+Typical usage:
+    util/coverage/coverage_off_target.py --print-text-report
+"""
+
+import logging as log
+import subprocess
+from enum import Enum
+from pathlib import Path, PurePath
+from pprint import pformat
+from typing import List
+
+import typer
+
+app = typer.Typer(pretty_exceptions_enable=False, add_completion=False)
+
+# Commands that this script uses
+BAZEL = "./bazelisk.sh"
+LLD = "ld.lld"
+LLVM_COV = "llvm-cov"
+LLVM_PROFDATA = "llvm-profdata"
+
+# Title of the HTML coverage report
+REPORT_TITLE = "OpenTitan Unit Test Coverage"
+
+
+class LogLevel(str, Enum):
+    none = "none"
+    info = "info"
+    debug = "debug"
+
+
+def run(*args) -> List[str]:
+    """Run the given command in a subprocess.
+
+    Args:
+        args: Command (the first parameter) and arguments (remaining arguments).
+
+    Returns:
+        Stdout lines in a list. Empty lines are filtered out.
+    """
+    log.debug(f"command: {' '.join(args)}")
+    try:
+        res = subprocess.run(args,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             encoding="utf-8",
+                             check=True)
+    except subprocess.CalledProcessError as e:
+        log.error(f"stdout: {e.stdout if e.stdout else '(empty)'}")
+        log.error(f"stderr: {e.stderr if e.stderr else '(empty)'}")
+        raise
+    log.debug(f"stdout: {res.stdout if res.stdout else '(empty)'}")
+    log.debug(f"stderr: {res.stderr if res.stderr else '(empty)'}")
+    return [line for line in res.stdout.splitlines() if line]
+
+
+def gather_and_build_libs() -> List[str]:
+    """Find all device libraries that can be built on the host and build them with
+    coverage instrumentation.
+
+    Returns:
+        The list of device libraries that can be built on the host.
+    """
+    # Query for device libraries to be instrumented.
+    DEVICE_LIBS_INC = [
+        "//sw/device/silicon_creator/...",
+        "//sw/device/lib/...",
+    ]
+    DEVICE_LIBS_EXC = [
+        "//sw/device/lib/dif/...",
+        "//sw/device/lib/testing/... ",
+        "//sw/device/lib/runtime/...",
+        "//sw/device/lib/crypto/...",
+        "//sw/device/lib/arch/...",
+        "//sw/device/lib/ujson/...",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/base:mmio_on_device_do_not_use_directly",
+        "//sw/device/lib/base:mmio_on_host_do_not_use_directly",
+        "//sw/device/silicon_creator/rom_ext/...",
+        "//sw/device/silicon_creator/rom/keys/real:real",
+    ]
+    DEVICE_LIBS_QUERY = (f"kind(cc_library, ({' + '.join(DEVICE_LIBS_INC)}) "
+                         f"- ({' + '.join(DEVICE_LIBS_EXC)}))")
+
+    # Gather and build all device libs that can be built on host. We handle everything in
+    # a single query instead of one query per test target since each invocation incurs
+    # an additional startup cost.
+    device_libs_all = run(BAZEL, "query", DEVICE_LIBS_QUERY)
+    device_libs_incompat = run(
+        BAZEL, "cquery", DEVICE_LIBS_QUERY, "--output=starlark",
+        ("--starlark:expr=target.label "
+         "if 'IncompatiblePlatformProvider' in providers(target) "
+         "else ''"))
+    log.info(f"incompatible libraries: {pformat(device_libs_incompat)}")
+    device_libs = list(set(device_libs_all) - set(device_libs_incompat))
+    log.info(f"instrumented libraries: {pformat(device_libs)}")
+    run(BAZEL, "build", "--config=coverage_clang", *device_libs)
+
+    return device_libs
+
+
+def create_merged_library(device_libs: List[str], merged_so: Path):
+    """Create a single shared library from the given device libraries.
+
+    A coverage report can be created from multiple object files as long as they have
+    coverage data. However, unused inline functions can trigger confusing warnings and
+    functions that appear in more than one object file can cause undercounting. Linking
+    the object files of the sources that we are interested in into a single shared
+    library avoids such problems.
+
+    Args:
+        device_libs: List of device libraries whose object files will be linked into a
+        shared library.
+        merged_so: Path where to write the shared library.
+    """
+    # Gather all the object files and link a combined shared library with all the
+    # coverage data. This eliminates hash-mismatch warnings for multiple copies of
+    # unused inline functions. Note that we exclude mock_*.o since they contain
+    # duplicate symbols.
+    obj_files = run(
+        BAZEL, "cquery", f"({' + '.join(device_libs)})", "--output=starlark",
+        ("--starlark:expr='\\n'.join("
+         "[f.path for f in target.output_groups.compilation_outputs.to_list()]"
+         ")"))
+    obj_files = [
+        o for o in obj_files if not PurePath(o).name.startswith("mock_")
+    ]
+    log.info(f"object files with coverage data: {pformat(obj_files)}")
+    run(LLD, "--shared", "-o", str(merged_so), *obj_files)
+
+
+def measure_unit_test_coverage(merged_profile: Path):
+    """Measure unit test coverage of silicon creator code.
+
+    This function measures unit test coverage of silicon creator and several base
+    libraries and creates a merged profile.
+
+    Args:
+        merged_profile: Path where to save the merged profile.
+    """
+    # Query for unit test targets
+    TEST_TARGETS_INC = [
+        "//sw/device/silicon_creator/...",
+        "//sw/device/lib/base:hardened_memory_unittest",
+        "//sw/device/lib/base:math_unittest",
+        "//sw/device/lib/base:math_builtins_unittest",
+        "//sw/device/lib/base:memory_unittest",
+    ]
+    TEST_TARGETS_EXC = ["//sw/device/silicon_creator/rom_ext/..."]
+    TEST_TARGETS_QUERY = (f"kind(cc_test, ({' + '.join(TEST_TARGETS_INC)}) "
+                          f"- ({' + '.join(TEST_TARGETS_EXC)}))")
+    # Gather and run all test targets.
+    test_targets = run(BAZEL, "query", TEST_TARGETS_QUERY)
+    log.info(f"test targets: {pformat(test_targets)}")
+    run(BAZEL, "coverage", "--config=coverage_clang", *test_targets)
+    # Merge profile data of individual tests.
+    [TESTLOGS] = run(BAZEL, "info", "bazel-testlogs")
+    profile_files = [
+        f"{Path(TESTLOGS)}/{t[2:].replace(':', '/')}/coverage.dat"
+        for t in test_targets
+    ]
+    run(LLVM_PROFDATA, "merge", "--sparse", "--output", str(merged_profile),
+        *profile_files)
+
+
+def generate_report(out_dir: Path, merged_profile: Path, merged_so: Path,
+                    print_text_report: bool):
+    """Generate a coverage report.
+
+    This function generates a coverage report from the given merged profile and shared
+    library.
+
+    Args:
+        out_dir: Path where to save the html report.
+        merged_profile: Path of merged profile data.
+        merged_so: Path of the shared library with coverage data.
+        print_text_report: Whether to print the text report.
+    """
+    # Generate html coverage report.
+    run(LLVM_COV, "show", "-show-line-counts", "-show-regions",
+        f"--project-title={REPORT_TITLE}", "--format=html",
+        f"--output-dir=./{out_dir}", "--instr-profile", str(merged_profile),
+        str(merged_so))
+    # Generate text coverage report.
+    with (out_dir / "report.txt").open("w") as f:
+        f.write("\n".join(
+            run(LLVM_COV, "report", "--instr-profile", str(merged_profile),
+                str(merged_so))))
+    if print_text_report:
+        print("\n".join(
+            run(LLVM_COV, "report", "--use-color", "--instr-profile",
+                str(merged_profile), str(merged_so))))
+    print(f"Saved coverage artifacts in {out_dir}.")
+
+
+def create_out_dir(out_root_dir: Path):
+    """Create the directory for coverage report.
+
+    The report will be saved in `out_root_dir`/<HEAD_TIMESTAMP>-<HEAD_HASH>/unittest/`.
+
+    Args:
+        out_root_dir: Root of the output directory.
+
+    Returns:
+        Path where to save the coverage report.
+    """
+    # Report artifacts are placed under `out_root_dir`/<head_timestamp>-<head_hash>/unittest/.
+    [head_hash] = run("git", "rev-parse", "HEAD")
+    [head_timestamp] = run("git", "show", "-s", "--format=%ct", "HEAD")
+    out_dir = out_root_dir / f"{head_timestamp}-{head_hash}/unittest/"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+@app.command()
+def main(log_level: LogLevel = LogLevel.none,
+         out_root_dir: Path = Path("coverage"),
+         print_text_report: bool = False):
+    """Measures unit test coverage of silicon creator code."""
+    if log_level != LogLevel.none:
+        log.basicConfig(level=log.getLevelName(log_level.upper()))
+
+    out_dir = create_out_dir(out_root_dir)
+    # Merged profile data path
+    merged_profile = out_dir / "merged.profdata"
+    # Merged shared library path with all coverage data we want
+    merged_so = out_dir / "merged.so"
+
+    # Build device libs and create a merged shared library to avoid hash-mismatch
+    # warnings related to unused inline functions.
+    device_libs = gather_and_build_libs()
+    create_merged_library(device_libs, merged_so)
+    # Coverage report is generated from merged profile data from unit tests and merged
+    # coverage data from the combined shared library.
+    measure_unit_test_coverage(merged_profile)
+    generate_report(out_dir, merged_profile, merged_so, print_text_report)
+
+
+if __name__ == "__main__":
+    app()

--- a/util/coverage/coverage_off_target_test.py
+++ b/util/coverage/coverage_off_target_test.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+import subprocess
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import coverage_off_target
+
+
+class AnyStringWith(str):
+
+    def __eq__(self, other):
+        return self in other
+
+
+class TestExtractProfileData(unittest.TestCase):
+
+    @patch("coverage_off_target.subprocess.run")
+    def test_run_single_arg_error(self, mock_run):
+        mock_run.side_effect = Exception("foo")
+        with self.assertRaisesRegex(Exception, "foo"):
+            coverage_off_target.run("ls")
+        mock_run.assert_called_once_with(("ls",),
+                                         stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE,
+                                         encoding="utf-8",
+                                         check=True)
+
+    @patch("coverage_off_target.subprocess.run")
+    def test_run_multi_arg_error(self, mock_run):
+        mock_run.side_effect = Exception("foo")
+        with self.assertRaisesRegex(Exception, "foo"):
+            coverage_off_target.run("ls", "-la", "./")
+        mock_run.assert_called_once_with(("ls", "-la", "./"),
+                                         stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE,
+                                         encoding="utf-8",
+                                         check=True)
+
+    @patch("coverage_off_target.subprocess.run")
+    def test_run_single_arg_success(self, mock_run):
+        coverage_off_target.run("ls")
+        mock_run.assert_called_once_with(("ls",),
+                                         stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE,
+                                         encoding="utf-8",
+                                         check=True)
+
+    @patch("coverage_off_target.subprocess.run")
+    def test_run_multi_arg_success(self, mock_run):
+        coverage_off_target.run("ls", "-la", "./")
+        mock_run.assert_called_once_with(("ls", "-la", "./"),
+                                         stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE,
+                                         encoding="utf-8",
+                                         check=True)
+
+    @patch("coverage_off_target.run")
+    def test_gather_and_build_libs(self, mock_run):
+        libs_all = ["//foo/bar1", "//foo/bar2", "//foo/incompat"]
+        libs_incompat = ["//foo/incompat"]
+        libs = list(set(libs_all) - set(libs_incompat))
+        # (1) return all libs, (2) return incompat., (3) build
+        mock_run.side_effect = (libs_all, libs_incompat, [])
+
+        self.assertEqual(coverage_off_target.gather_and_build_libs(), libs)
+
+        calls = mock_run.call_args_list
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(calls[0][0][:2], (coverage_off_target.BAZEL, "query"))
+        self.assertEqual(calls[1][0][:2], (coverage_off_target.BAZEL, "cquery"))
+        self.assertEqual(calls[2][0], (coverage_off_target.BAZEL, "build",
+                                       "--config=coverage_clang", *libs))
+
+    @patch("coverage_off_target.run")
+    def test_create_merged_library(self, mock_run):
+        libs = ["//foo/bar1", "//foo/bar2"]
+        libs_query = "(//foo/bar1 + //foo/bar2)"
+        merged_so = Path("merged.so")
+        objs = ["foo/bar1.o", "foo/bar2.o"]
+        # (1) return object files, (2) link.
+        mock_run.side_effect = (objs, [])
+
+        coverage_off_target.create_merged_library(libs, merged_so)
+
+        calls = mock_run.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0][:3],
+                         (coverage_off_target.BAZEL, "cquery", libs_query))
+        self.assertEqual(
+            calls[1][0],
+            (coverage_off_target.LLD, "--shared", "-o", str(merged_so), *objs))
+
+    @patch("coverage_off_target.run")
+    def test_measure_unit_test_coverage(self, mock_run):
+        tests = ["//foo:test1", "//foo:test2"]
+        testlogs = ["/some/long/path"]
+        profiles = [
+            "/some/long/path/foo/test1/coverage.dat",
+            "/some/long/path/foo/test2/coverage.dat"
+        ]
+        merged_profile = Path("merged.profdata")
+        # (1) find test targets, (2) measure coverage, (3) get testlogs dir, (4) merge
+        # profile data.
+        mock_run.side_effect = (tests, [], testlogs, [])
+
+        coverage_off_target.measure_unit_test_coverage(merged_profile)
+
+        calls = mock_run.call_args_list
+        self.assertEqual(len(calls), 4)
+        self.assertEqual(calls[0][0][:2], (coverage_off_target.BAZEL, "query"))
+        self.assertEqual(calls[1][0], (coverage_off_target.BAZEL, "coverage",
+                                       "--config=coverage_clang", *tests))
+        self.assertEqual(calls[2][0],
+                         (coverage_off_target.BAZEL, "info", "bazel-testlogs"))
+        self.assertEqual(
+            calls[3][0],
+            (coverage_off_target.LLVM_PROFDATA, "merge", "--sparse", "--output",
+             str(merged_profile), *profiles))
+
+    @patch("coverage_off_target.print")
+    @patch("pathlib.Path.open", new_callable=mock_open)
+    @patch("pathlib.Path.__truediv__",
+           side_effect=Path.__truediv__,
+           autospec=True)
+    @patch("coverage_off_target.run")
+    def test_generate_report(self, mock_run, mock_path_div, mock_path_open,
+                             mock_print):
+        for print_text_report in (True, False):
+            for m in [mock_run, mock_path_div, mock_path_open, mock_print]:
+                m.reset_mock()
+            with self.subTest(f"print_text_report:{print_text_report}"):
+                out_dir = Path("foo")
+                merged_profile = Path("merged.profdata")
+                merged_so = Path("merged.so")
+                text_report_content = [
+                    "<contents of coverage report in text format>"
+                ]
+                # (1) html report, (2) text report, (3) print text report (if requested)
+                mock_run.side_effect = ([], text_report_content,
+                                        text_report_content)
+
+                coverage_off_target.generate_report(out_dir, merged_profile,
+                                                    merged_so,
+                                                    print_text_report)
+
+                calls_run = mock_run.call_args_list
+                self.assertEqual(
+                    (*calls_run[0][0][:2], *calls_run[0][0][-5:]),
+                    (coverage_off_target.LLVM_COV, "show",
+                     "--format=html", "--output-dir=./foo", "--instr-profile",
+                     str(merged_profile), str(merged_so)))
+                self.assertEqual(
+                    calls_run[1][0],
+                    (coverage_off_target.LLVM_COV, "report", "--instr-profile",
+                     str(merged_profile), str(merged_so)))
+                mock_path_div.assert_called_once_with(out_dir, "report.txt")
+                mock_path_open.assert_called_once_with("w")
+                mock_path_open().write.assert_called_once_with(
+                    *text_report_content)
+
+                if print_text_report:
+                    self.assertEqual(len(calls_run), 3)
+                    self.assertEqual(calls_run[2][0],
+                                     (coverage_off_target.LLVM_COV, "report",
+                                      "--use-color", "--instr-profile",
+                                      str(merged_profile), str(merged_so)))
+
+                    calls_print = mock_print.call_args_list
+                    self.assertEqual(len(calls_print), 2)
+                    self.assertEqual(calls_print[0][0], (*text_report_content,))
+                    self.assertEqual(calls_print[1][0],
+                                     AnyStringWith("coverage artifacts in"))
+                else:
+                    self.assertEqual(len(calls_run), 2)
+                    mock_print.assert_called_once_with(
+                        AnyStringWith("coverage artifacts in"))
+
+    # Use `autospec=True` to mock the unbounded `Path.mkdir` and `Path.__truediv__`
+    # methods so that we can assert the values of both the `self` and the `other`
+    # arguments of calls.
+    @patch("pathlib.Path.mkdir", autospec=True)
+    @patch("pathlib.Path.__truediv__", autospec=True)
+    @patch("coverage_off_target.run")
+    def test_create_out_dir(self, mock_run, mock_path_div, mock_path_mkdir):
+        out_root_dir = Path("foo")
+        head_hash = ["123abc"]
+        head_timestamp = ["123456"]
+        out_dir = Path(
+            f"{out_root_dir}/{head_timestamp[0]}-{head_hash[0]}/unittest/")
+
+        mock_run.side_effect = (head_hash, head_timestamp)
+        mock_path_div.side_effect = (out_dir,)
+
+        self.assertEqual(coverage_off_target.create_out_dir(out_root_dir),
+                         out_dir)
+
+        calls = mock_run.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0], ("git", "rev-parse", "HEAD"))
+        self.assertEqual(calls[1][0],
+                         ("git", "show", "-s", "--format=%ct", "HEAD"))
+
+        mock_path_div.assert_called_once_with(out_root_dir,
+                                              "123456-123abc/unittest/")
+        mock_path_mkdir.assert_called_once_with(out_dir,
+                                                parents=True,
+                                                exist_ok=True)
+
+    @patch("coverage_off_target.generate_report")
+    @patch("coverage_off_target.measure_unit_test_coverage")
+    @patch("coverage_off_target.create_merged_library")
+    @patch("coverage_off_target.gather_and_build_libs")
+    @patch("coverage_off_target.create_out_dir")
+    def test_main(self, mock_create_out_dir, mock_gather_and_build_libs,
+                  mock_create_merged_library, mock_measure_unit_test_coverage,
+                  mock_generate_report):
+        out_dir = Path("foo")
+        merged_so = out_dir / "merged.so"
+        merged_profile = out_dir / "merged.profdata"
+        libs = ["//foo/bar1", "//foo/bar2"]
+
+        mock_create_out_dir.side_effect = (out_dir,)
+        mock_gather_and_build_libs.side_effect = (libs,)
+
+        coverage_off_target.main()
+
+        mock_create_out_dir.assert_called_once_with(Path("coverage"))
+        mock_gather_and_build_libs.assert_called()
+        mock_create_merged_library.assert_called_once_with(libs, merged_so)
+        mock_measure_unit_test_coverage.assert_called_once_with(merged_profile)
+        mock_generate_report.assert_called_once_with(out_dir, merged_profile,
+                                                     merged_so, False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds initial support for measuring unit test coverage of silicon creator code. The approach that I decided to follow consists of 4 main steps (implemented as a python script):

1. Determine and build the libraries to be instrumented.
1. Link the object files of the libraries built in the previous step to obtain a single shared library with coverage data. AFAICT this is the best way to generate coverage reports from multiple executables. While `llvm-cov` supports generating coverage reports from multiple object files, things like unused inline functions (hash-mismatch warning) and symbols appearing in more than one object file trigger confusing warnings or cause undercounting.
3. Run unit tests and create a merged profile.
4. Generate a coverage report from the shared library created in step 2 and merged profile in step 3

```
$ util/coverage/coverage_off_target.py --help
Usage: coverage_off_target.py [OPTIONS]

  Measures unit test coverage of silicon creator code.

Options:
  --log-level [none|info|debug]   [default: LogLevel.none]
  --out-root-dir PATH             [default: coverage]
  --print-text-report / --no-print-text-report
                                  [default: no-print-text-report]
  --help                          Show this message and exit.
```


Coverage artifacts are saved in `out_root_dir/<HEAD_TIMESTAMP>-<HEAD_HASH>/unittest`, where `out_root_dir = ./coverage` by default:
```
$ util/coverage/coverage_off_target.py
Saved coverage artifacts in coverage/1671406921-cff595d592d39c770127d71904b1d84d3d6d470d/unittest.

```

This directory contains both the html and the text report, the merged profile, and the shared library.
```
$ tree -L 1 -- coverage/1671406921-cff595d592d39c770127d71904b1d84d3d6d470d/unittest
coverage/1671406921-cff595d592d39c770127d71904b1d84d3d6d470d/unittest
├── coverage
├── index.html
├── merged.profdata
├── merged.so
├── report.txt
└── style.css
```

[Sample report](https://storage.googleapis.com/sw-coverage/1671406921-cff595d592d39c770127d71904b1d84d3d6d470d/unittest/index.html)

See individual commits for additional details. I intentionally hard-coded targets and queries in `coverage_off_target.py` for the sake of simplicity. I'll have plenty of refactoring opportunities as I work on #16761. Also, I'm not sure if we want to create a `py_binary` (or some other) target for this script or not -- mostly due to sandboxing and external tool dependencies (`git`, `llvm-cov`, and `llvm-profdata`). IIRC we can define a `execution_requirements = {"no-sandbox": "1"}` rule.