### PR TITLE
[bazel,doc,util] Update @bitstreams repository with Git hook

### DIFF
--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -45,6 +45,16 @@ This can be spliced into the bitstream to overwrite the testing boot ROM as desc
 However, if you do not want to do the splicing yourself, both versions of the bitstream are available in the download as `*.bit.orig` and `*.bit.splice` (containing the test ROM and the ROM respectively).
 The metadata for the latest bitstream (the approximate creation time and the associated commit hash) is also available as a text file and can be [downloaded separately](https://storage.googleapis.com/opentitan-bitstreams/master/latest.txt).
 
+### Using the `@bitstreams` repository
+
+OpenTitan's build system automatically fetches pre-built bitstreams via the `@bitstreams` repository.
+
+To keep the `@bitstreams` repository in sync with the current Git revision, install the Git post-checkout hook:
+
+```sh
+cp util/git/hooks/post-checkout .git/hooks/
+```
+
 ### Build an FPGA bitstream
 
 Synthesizing a design for an FPGA board is simple with Bazel.

--- a/rules/bitstreams.bzl
+++ b/rules/bitstreams.bzl
@@ -24,9 +24,9 @@ def _bitstreams_repo_impl(rctx):
     if result.return_code != 0:
         fail("Bitstream cache not initialized properly.")
 
-# The bitstream repo is evaluated on every invocation of bazel.
-# Once the cache is initialized, a typical invocation will find the latest
-# cached bitstream and configure it for use as a test artifact.
+# The bitstream repo should be evaluated with `bazel sync --configure` after
+# every Git checkout. Once the cache is initialized, a typical invocation will
+# find the latest cached artifacts and map them to Bazel targets.
 #
 # The `refresh_time` sets the interval at which the cache manager will
 # check for new bitstreams.
@@ -75,5 +75,10 @@ bitstreams_repo = repository_rule(
         ),
     },
     environ = ["BAZEL_BITSTREAMS_CACHE", "BITSTREAM"],
-    local = True,
+    # This rule depends on the Git repository, but there's no ergonomic way to
+    # encode the dependency in Bazel. Instead, indicate that the rule depends on
+    # something outside of Bazel's dependency graph and rely on the user calling
+    # `bazel sync --configure` when checking out new revisions. For historical
+    # context, see <https://github.com/lowRISC/opentitan/issues/16832>.
+    configure = True,
 )

--- a/util/git/hooks/post-checkout
+++ b/util/git/hooks/post-checkout
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+exec ./bazelisk.sh sync --configure


### PR DESCRIPTION
(This PR fixes a bug that enabled the `@bitstreams` repo to become stale. We discovered in #16832 that we were splicing bitstreams with the wrong inputs because the `@bitstreams`  workspace had not been refreshed after checking out a different commit.)

This PR updates the Bazel rule that implements the `@bitstreams` repository. It sets `configure = True` to indicate that the rule depends on something outside Bazel's dependency graph. It also removes `local = True` because the rule actually does hit the network. I think this was set to true originally as a hack to force re-evaluation of the repo.

Additionally, this PR adds a Git post-checkout hook that invokes `./bazelisk.sh sync --configure` and updates the FPGA docs with instructions for installing the hook.

This PR is an alternative to PR #16863, which worked by dirtying the tree. This PR does not generate files in the source tree.

Fixes https://github.com/lowRISC/opentitan/issues/16832
Closes https://github.com/lowRISC/opentitan/pull/16863

Signed-off-by: Dan McArdle <dmcardle@google.com>