### PR TITLE
[ci] Force pipeline to print logs even on Vivado failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -469,6 +469,7 @@ jobs:
       echo "Implementation log"
       cat $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/build.fpga_cw310_hyperdebug/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.runs/impl_1/runme.log || true
     displayName: Display synthesis & implementation logs
+    condition: succeededOrFailed()
   - template: ci/upload-artifacts-template.yml
     parameters:
       includePatterns:


### PR DESCRIPTION
I did not notice in #16823 that the Hyperdebug build step doesn't explicitly specify a `condition` on the step that displays the logs. According the the Azure Pipeline [docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml%2Cstages), not specifying a condition in the YAML is equivalent to `condition: success()` which would prevent the logs from printing if the previous Vivado step failed.

The "standard" (non-hyperdebug) bitstream build does not need to be changed because it specifies a custom condition already which overrides this default behavior. 