### PR TITLE
[dv/alert_handler] auto alert response

### DIFF
--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_alert_rsp_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_alert_rsp_seq.sv
@@ -13,4 +13,39 @@ class alert_receiver_alert_rsp_seq extends alert_receiver_base_seq;
     r_alert_rsp       == 1;
   }
 
+  virtual task body();
+    if (cfg.start_default_rsp_seq) begin
+      default_rsp_thread();
+    end else begin
+      super.body();
+    end
+  endtask
+
+  // Sends alert rsps back to host.
+  virtual task default_rsp_thread();
+    alert_esc_seq_item req_q[$];
+    fork
+      forever begin : get_req
+        p_sequencer.req_analysis_fifo.get(req);
+        if (req.alert_esc_type == AlertEscSigTrans) req_q.push_back(req);
+      end : get_req
+      forever begin : send_rsp
+        if (cfg.in_reset) begin
+          req_q.delete();
+          wait (!cfg.in_reset);
+        end
+        wait (req_q.size());
+        rsp = req_q.pop_front();
+        start_item(rsp);
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+            r_alert_ping_send == 0;
+            r_alert_rsp       == 1;
+            int_err           == 0;
+        )
+        finish_item(rsp);
+        get_response(rsp);
+      end : send_rsp
+    join
+  endtask
+
 endclass : alert_receiver_alert_rsp_seq

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_base_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_base_seq.sv
@@ -23,7 +23,7 @@ class alert_receiver_base_seq extends dv_base_seq #(
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
         r_alert_ping_send == local::r_alert_ping_send;
         r_alert_rsp       == local::r_alert_rsp;
-        int_err           == 0; // TODO: current do not support alert_receiver int_err
+        int_err           == 0; // This agent do not support alert_receiver int_err
     )
     `uvm_info(`gfn, $sformatf("seq_item: ping_send=%0b alert_rsp=%0b int_err=%0b",
                               req.r_alert_ping_send, req.r_alert_rsp, req.int_err), UVM_MEDIUM)

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_ping_rsp_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_ping_rsp_seq.sv
@@ -27,7 +27,7 @@ class alert_sender_ping_rsp_seq extends alert_sender_base_seq;
     fork
       forever begin : get_req
         p_sequencer.req_analysis_fifo.get(req);
-        req_q.push_back(req);
+        if (req.alert_esc_type == AlertEscPingTrans) req_q.push_back(req);
       end : get_req
       forever begin : send_rsp
         if (cfg.in_reset) begin

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
@@ -87,9 +87,6 @@ class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_lock_vseq;
 
     if (!cfg.under_reset) cfg.otp_ctrl_vif.drive_lc_escalate_en(get_rand_lc_tx_val(.f_weight(0)));
 
-    // TODO: in alert_esc_monitor, makes it auto-response like push-pull agent
-    if (en_auto_alerts_response && cfg.list_of_alerts.size()) run_alert_rsp_seq_nonblocking();
-
     // Wait 5 clock cycles until async lc_escalate_en propogate to each state machine.
     cfg.clk_rst_vif.wait_clks(5);
 


### PR DESCRIPTION
This PR fixed #16374, where it is recommended to use alert auto-response instead of a nonblocking sequence.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>