### PR TITLE
[otbn/sca] Add new sca features for otbn_ecdsa_256

### DIFF
--- a/sw/otbn/crypto/p256_ecdsa_sca.s
+++ b/sw/otbn/crypto/p256_ecdsa_sca.s
@@ -33,7 +33,7 @@ p256_ecdsa_verify:
   jal      x1, p256_verify
   ecall
 
-.bss
+.data
 
 /* Freely available DMEM space. */
 
@@ -41,7 +41,7 @@ p256_ecdsa_verify:
 .globl mode
 .balign 4
 mode:
-  .zero 4
+  .word 0x1
 
 /* All constants below must be 256b-aligned. */
 
@@ -49,17 +49,47 @@ mode:
 .global k0
 .balign 32
 k0:
-  .zero 32
+  /* k0 = 0x0000000...ffffffff */
+  /* Note: Byte order in a word is little-endian */
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+
 .global k1
 .balign 32
 k1:
-  .zero 32
+  /* k1= 0x0000000...00000000 */
+  /* Note: Byte order in a word is little-endian */
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+
 
 /* message digest */
 .globl msg
 .balign 32
 msg:
-  .zero 32
+  /* msg = "Hello OTBN."*/
+  /* msg = 0x06d71207...4456fd21 */
+  /* Note: Byte order in a word is little-endian */
+  .word 0x4456fd21
+  .word 0x400bdd7d
+  .word 0xb54d7452
+  .word 0x17d015f1
+  .word 0x90d4d90b
+  .word 0xb028ad8a
+  .word 0x6ce90fef
+  .word 0x06d71207
 
 /* signature R */
 .globl r
@@ -77,23 +107,60 @@ s:
 .globl x
 .balign 32
 x:
-  .zero 32
+  /* x = 0x6b17d1f2...d898c296 */
+  /* Note: Byte order in a word is little-endian */
+  .word 0xd898c296
+  .word 0xf4a13945
+  .word 0x2deb33a0
+  .word 0x77037d81
+  .word 0x63a440f2
+  .word 0xf8bce6e5
+  .word 0xe12c4247
+  .word 0x6b17d1f2
 
 /* public key y-coordinate */
 .globl y
 .balign 32
 y:
-  .zero 32
+  /* y= 0x4fe342e2...37bf51f5 */
+  /* Note: Byte order in a word is little-endian */
+  .word  0x37bf51f5
+  .word  0xcbb64068
+  .word  0x6b315ece
+  .word  0x2bce3357
+  .word  0x7c0f9e16
+  .word  0x8ee7eb4a
+  .word  0xfe1a7f9b
+  .word  0x4fe342e2
 
 /* private key d (in two shares) */
 .globl d0
 .balign 32
 d0:
-  .zero 32
+  /* d0= 0x5545a0b7...af57b4cd */
+  /* Note: Byte order in a word is little-endian */
+  .word 0xaf57b4cd
+  .word 0x744c9f1c
+  .word 0x8b7e0c02
+  .word 0x283e93e9
+  .word 0x0d18f00c
+  .word 0xda0b6cf4
+  .word 0x8fe6bb7a
+  .word 0x5545a0b7
+
 .globl d1
 .balign 32
 d1:
-  .zero 32
+  /* d1 = 0x00000000...00000000 */
+  /* Note: Byte order in a word is little-endian */
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
 
 /* verification result x_r (aka x_1) */
 .globl x_r


### PR DESCRIPTION
Enable OTBNsim simulation of p256_ecdsa_sca.s, and enable receiving of all secret input shares(k0, k1, d0, d1) from the host-side Python code.

*.s file:
   - Change file to enable OTBNsim simulation.
   - Set default values for k0, k1, msg, x, y, d0, d1.
   - This values can be modified to compare the OTBNsim results to FPGA results.

*.c file:
   - Remove all the LOG_INFO between the two triggers to make sure the measured ECDSA operation's timing will be same for all runs.
   - Enable receiving of k0, k1, d0, d1 from the host-side Python code.
   - Add a new simpleserial command ('k') to separate the start_ecdsa,'p', and set secret scalar 'k'.

Signed-off-by: Bilgiday Yuce <bilgiday@google.com>