### PR TITLE
[gpiodpi] Removed extraneous commas after ports

### DIFF
--- a/hw/dv/dpi/gpiodpi/gpiodpi.sv
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.sv
@@ -14,7 +14,7 @@ module gpiodpi
   input  logic [N_GPIO-1:0] gpio_d2p,
   input  logic [N_GPIO-1:0] gpio_en_d2p,
   input  logic [N_GPIO-1:0] gpio_pull_en,
-  input  logic [N_GPIO-1:0] gpio_pull_sel,
+  input  logic [N_GPIO-1:0] gpio_pull_sel
 );
    import "DPI-C" function
      chandle gpiodpi_create(input string name, input int n_bits);

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
@@ -74,7 +74,7 @@ module chip_sim_tb (
     .gpio_d2p   (cio_gpio_d2p),
     .gpio_en_d2p(cio_gpio_en_d2p),
     .gpio_pull_en(cio_gpio_pull_en),
-    .gpio_pull_sel(cio_gpio_pull_select),
+    .gpio_pull_sel(cio_gpio_pull_select)
   );
 
   // UART DPI


### PR DESCRIPTION
Syntax error after final port declaration and its connection

Signed-off-by: Adrian Lees <a.lees@lowrisc.org>