### PR TITLE
[alert_handler_reverse_ping] More verbose failures

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -185,6 +185,7 @@ opentitan_functest(
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:alert_handler",
         "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/dif:rv_plic",


### PR DESCRIPTION
If a class A alert is fired we can help debugging by identifying it, and then failing.

Signed-off-by: Drew Macrae <drewmacrae@google.com>

Fixes:#16864