### PR TITLE
[tests] ensure example manufacturer tests run on FPGA

### DIFF
--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -44,12 +44,12 @@ trap 'ci/bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=cw310 
 # by clearing the bitstream.
 # FIXME: #16543 The following step sometimes has trouble reading the I2C we'll
 # log it better and continue even if it fails (the pll is mostly correctly set
-# anyway
+# anyway).
 ci/bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=cw310 --logging debug fpga set-pll || true
 ci/bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=cw310 fpga clear-bitstream
 
 for tag in "${cw310_tags[@]}"; do
-    ci/bazelisk.sh test //...\
+    ci/bazelisk.sh test //... @manufacturer_test_hooks//...\
         --define DISABLE_VERILATOR_BUILD=true \
         --nokeep_going \
         --test_tag_filters="${tag}",-broken,-skip_in_ci \

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -248,7 +248,7 @@ def opentitan_functest(
         test_in_rom = False,
         ot_flash_binary = None,
         signed = True,
-        manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+        manifest = "@//sw/device/silicon_creator/rom_ext:manifest_standard",
         slot = "silicon_creator_a",
         test_harness = "@//sw/host/opentitantool",
         key = "fake_prod_key_0",

--- a/sw/device/tests/closed_source/BUILD.bazel
+++ b/sw/device/tests/closed_source/BUILD.bazel
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@//rules:opentitan_test.bzl", "opentitan_functest")
+load("@//rules:opentitan_test.bzl", "dv_params", "opentitan_functest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -131,8 +131,12 @@ cc_library(
 opentitan_functest(
     name = "example_test",
     srcs = ["example_test.c"],
-    signed = False,
+    dv = dv_params(
+        rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
+    ),
+    key = "fake_test_key_0",
     targets = [
+        "cw310_rom",
         "cw310_test_rom",
         "dv",
     ],
@@ -162,8 +166,12 @@ opentitan_functest(
 opentitan_functest(
     name = "statically_hooked_opensource_test",
     srcs = ["@//sw/device/tests:example_test_from_flash.c"],
-    signed = False,
+    dv = dv_params(
+        rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
+    ),
+    key = "fake_test_key_0",
     targets = [
+        "cw310_rom",
         "cw310_test_rom",
         "dv",
     ],

--- a/sw/device/tests/closed_source/BUILD.bazel
+++ b/sw/device/tests/closed_source/BUILD.bazel
@@ -132,7 +132,10 @@ opentitan_functest(
     name = "example_test",
     srcs = ["example_test.c"],
     signed = False,
-    targets = ["dv"],
+    targets = [
+        "cw310_test_rom",
+        "dv",
+    ],
     deps = [
         "@//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -160,7 +163,10 @@ opentitan_functest(
     name = "statically_hooked_opensource_test",
     srcs = ["@//sw/device/tests:example_test_from_flash.c"],
     signed = False,
-    targets = ["dv"],
+    targets = [
+        "cw310_test_rom",
+        "dv",
+    ],
     deps = [
         "@//sw/device/lib/testing/test_framework:ottf_main",
         "@manufacturer_test_hooks//:test_hooks_1",


### PR DESCRIPTION
This runs the example (open source) manufacturer tests on the FPGA, with both test ROM and ROM (with fake keys), which were removed in #15005 as part of a test target refactoring. Additionally, we run these examples in CI so manufacturing partners always have a working example to build off of.