### PR TITLE
[vendor] Add bazel vendor file for XKCP (i.e. standard KMAC impl)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -92,6 +92,10 @@ riscv_compliance_repos()
 load("//third_party/coremark:repos.bzl", "coremark_repos")
 coremark_repos()
 
+# The standard Keccak algorithms
+load("//third_party/xkcp:repos.bzl", "xkcp_repos")
+xkcp_repos()
+
 # Bitstreams from https://storage.googleapis.com/opentitan-bitstreams/
 load("//rules:bitstreams.bzl", "bitstreams_repo")
 bitstreams_repo(name = "bitstreams")

--- a/third_party/xkcp/BUILD
+++ b/third_party/xkcp/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/xkcp/BUILD.xkcp.bazel
+++ b/third_party/xkcp/BUILD.xkcp.bazel
@@ -1,0 +1,51 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "nist_fips_202",
+    srcs = [
+        "common/align.h",
+        "common/brg_endian.h",
+        "config.h",
+        "high/Keccak/FIPS202/KeccakHash.c",
+        "high/Keccak/FIPS202/KeccakHash.h",
+        "high/Keccak/FIPS202/SimpleFIPS202.c",
+        "high/Keccak/KeccakSponge.c",
+        "high/Keccak/KeccakSponge.h",
+        "high/Keccak/KeccakSponge.inc",
+        "low/KeccakP-1600/ref-64bits/KeccakP-1600-SnP.h",
+        "low/KeccakP-1600/ref-64bits/KeccakP-1600-reference.c",
+        "low/KeccakP-1600/ref-64bits/KeccakP-1600-reference.h",
+    ],
+    hdrs = [
+        "high/Keccak/FIPS202/SimpleFIPS202.h",
+    ],
+    includes = [
+        "common",
+        "high/Keccak",
+        "high/Keccak/FIPS202",
+        "low/KeccakP-1600/ref-64bits",
+    ],
+)
+
+cc_library(
+    name = "nist_sp_800_185",
+    srcs = [
+        "high/Keccak/SP800-185/SP800-185.c",
+        "high/Keccak/SP800-185/SP800-185.inc",
+        "high/common/Phases.h",
+    ],
+    hdrs = [
+        "high/Keccak/SP800-185/SP800-185.h",
+    ],
+    includes = [
+        "high/Keccak/SP800-185",
+        "high/common",
+    ],
+    deps = [
+        "nist_fips_202",
+    ],
+)

--- a/third_party/xkcp/add_config_header.patch
+++ b/third_party/xkcp/add_config_header.patch
@@ -1,0 +1,10 @@
+diff --git a/config.h b/config.h
+new file mode 100644
+index 0000000..d5adbae
+--- /dev/null
++++ b/config.h
+@@ -0,0 +1,4 @@
++#define XKCP_has_FIPS202
++#define XKCP_has_SP800_185
++#define XKCP_has_Sponge_Keccak
++#define XKCP_has_KeccakP1600

--- a/third_party/xkcp/add_main_license.patch
+++ b/third_party/xkcp/add_main_license.patch
@@ -1,0 +1,80 @@
+diff --git a/LICENSE b/LICENSE
+new file mode 100644
+index 0000000..662709a
+--- /dev/null
++++ b/LICENSE
+@@ -0,0 +1,74 @@
++Note: This repo uses only some part of the code from XKCP library, therefore only the corresponding license notices are given below for the used part of the source code. The full version of the library and its comprehensive license can be found at https://github.com/XKCP/XKCP.
++
++The redistribution and use of this software (with or without changes) is allowed without the payment of fees or royalties provided that the terms of the licenses of the different source files used is respected. Most of the source and header files in the XKCP are released to the public domain and associated to the CC0 (http://creativecommons.org/publicdomain/zero/1.0/) deed, but there are exceptions.
++
++In general, the redistribution of this software should include a copy of this file. However, if only a part of the software is redistributed or used, the portions that are no longer relevant may be removed. Hints are given below whether a file is used in libXKCP, UnitTests, Benchmarks or KeccakSum.
++
++
++For ./common/brg_endian.h (used in libXKCP, UnitTests, Benchmarks and KeccakSum):
++
++    ---------------------------------------------------------------------------
++    Copyright (c) 1998-2008, Brian Gladman, Worcester, UK. All rights reserved.
++
++    LICENSE TERMS
++
++    The redistribution and use of this software (with or without changes)
++    is allowed without the payment of fees or royalties provided that:
++
++    1. source code distributions include the above copyright notice, this
++        list of conditions and the following disclaimer;
++
++    2. binary distributions include the above copyright notice, this list
++        of conditions and the following disclaimer in their documentation;
++
++    3. the name of the copyright holder is not used to endorse products
++        built using this software without specific written permission.
++
++    DISCLAIMER
++
++    This software is provided 'as is' with no explicit or implied warranties
++    in respect of its properties, including, but not limited to, correctness
++    and/or fitness for purpose.
++    ---------------------------------------------------------------------------
++
++
++For ./low/KeccakP-1600/AVX2/KeccakP-1600-AVX2.s and ./low/KeccakP-1600/AVX512/KeccakP-1600-AVX512.s (potentially used in libXKCP, UnitTests, Benchmarks and KeccakSum, depending on the target platform):
++
++    Copyright (c) 2006-2017, CRYPTOGAMS by <appro@openssl.org>
++    All rights reserved.
++
++    Redistribution and use in source and binary forms, with or without
++    modification, are permitted provided that the following conditions
++    are met:
++
++        *	Redistributions of source code must retain copyright notices,
++        this list of conditions and the following disclaimer.
++
++        *	Redistributions in binary form must reproduce the above
++        copyright notice, this list of conditions and the following
++        disclaimer in the documentation and/or other materials
++        provided with the distribution.
++
++        *	Neither the name of the CRYPTOGAMS nor the names of its
++        copyright holder and contributors may be used to endorse or
++        promote products derived from this software without specific
++        prior written permission.
++
++    ALTERNATIVELY, provided that this notice is retained in full, this
++    product may be distributed under the terms of the GNU General Public
++    License (GPL), in which case the provisions of the GPL apply INSTEAD OF
++    those given above.
++
++    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
++    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
++

--- a/third_party/xkcp/repos.bzl
+++ b/third_party/xkcp/repos.bzl
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def xkcp_repos():
+    http_archive(
+        name = "xkcp",
+        build_file = Label("//third_party/xkcp:BUILD.xkcp.bazel"),
+        sha256 = "bfd50261e0196988f7c4f45871b82e5ec9c3a74e18276f50dda48ab51f3cdb53",
+        # We only need lib of XKCP, so drop everything else except lib
+        strip_prefix = "XKCP-56ae09923153c3e801a6891eb19e4a3b5bb6f6e2/lib",
+        urls = [
+            "https://github.com/XKCP/XKCP/archive/56ae09923153c3e801a6891eb19e4a3b5bb6f6e2.tar.gz",
+        ],
+        patches = [
+            Label("//third_party/xkcp:add_config_header.patch"),
+            Label("//third_party/xkcp:add_main_license.patch"),
+        ],
+        patch_args = ["-p1"],
+    )


### PR DESCRIPTION
Follow-up of #16873 on vendoring XKCP.  This is an item on the list #16410. Again, with do-not-merge-yet warning.

I mostly followed the [example](https://github.com/lowRISC/opentitan/tree/master/third_party/freertos) @timothytrippel mentioned. Similar questions again:

- Are bazel scripts in the right place? Do they look sane?
- Is the example code generator in the right place `sw/device/lib/testing/kmac`?

The example code `kmac_generator_code.c` is not really necessary for this PR and I didn't yet implement the vector generator code. I am currently thinking about generating some C header files like [this](https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/crypto/drivers/kmac_test_vectors.c), but feel free chime in. Thanks.