### PR TITLE
[kmac] Expose the number and size of message FIFO entries.

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -98,6 +98,18 @@
       desc:    "Number of words for Encoded NsPrefix."
       local:   "true"
     }
+    { name:    "NumEntriesMsgFifo"
+      type:    "int"
+      default: "10"
+      desc:    "Number of entries in the message FIFO."
+      local:   "true"
+    }
+    { name:    "NumBytesMsgFifoEntry"
+      type:    "int"
+      default: "8"
+      desc:    "Number of bytes in a single entry of the message FIFO."
+      local:   "true"
+    }
     { name:    "HashCntW"
       type:    "int unsigned"
       default: "10"
@@ -579,7 +591,7 @@
         }
         { bits: "12:8"
           name: "fifo_depth"
-          desc: "Message FIFO entry count"
+          desc: "Count of occupied entries in the message FIFO."
         }
         { bits: "14"
           name: "fifo_empty"

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -101,13 +101,13 @@
     { name:    "NumEntriesMsgFifo"
       type:    "int"
       default: "10"
-      desc:    "Number of entries in the message FIFO."
+      desc:    "Number of entries in the message FIFO. Must match kmac_pkg::MsgFifoDepth."
       local:   "true"
     }
     { name:    "NumBytesMsgFifoEntry"
       type:    "int"
       default: "8"
-      desc:    "Number of bytes in a single entry of the message FIFO."
+      desc:    "Number of bytes in a single entry of the message FIFO. Must match kmac_pkg::MsgWidth."
       local:   "true"
     }
     { name:    "HashCntW"

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -189,9 +189,9 @@ module kmac
                kmac_reg_pkg::NumEntriesMsgFifo == kmac_pkg::MsgFifoDepth)
 
   // NumBytesMsgFifoEntry from kmac_reg_pkg must match the MsgWidth calculated
-  // in kmac_pkg.
+  // in kmac_pkg (although MsgWidth is in bits, so we multiply by 8).
   `ASSERT_INIT(EntrySizeRegSameToEntrySizePkg_A,
-               kmac_reg_pkg::NumBytesMsgFifoEntry == kmac_pkg::MsgWidth)
+               kmac_reg_pkg::NumBytesMsgFifoEntry * 8 == kmac_pkg::MsgWidth)
 
   // Output state: this is used to redirect the digest to KeyMgr or Software
   // depends on the configuration.

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -183,6 +183,16 @@ module kmac
   `ASSERT_INIT(PrefixRegSameToPrefixPkg_A,
                kmac_reg_pkg::NumWordsPrefix*4 == sha3_pkg::NSRegisterSize)
 
+  // NumEntriesMsgFifo from kmac_reg_pkg must match calculated MsgFifoDepth
+  // from kmac_pkg.
+  `ASSERT_INIT(NumEntriesRegSameToNumEntriesPkg_A,
+               kmac_reg_pkg::NumEntriesMsgFifo == kmac_pkg::MsgFifoDepth)
+
+  // NumBytesMsgFifoEntry from kmac_reg_pkg must match the MsgWidth calculated
+  // in kmac_pkg.
+  `ASSERT_INIT(EntrySizeRegSameToEntrySizePkg_A,
+               kmac_reg_pkg::NumBytesMsgFifoEntry == kmac_pkg::MsgWidth)
+
   // Output state: this is used to redirect the digest to KeyMgr or Software
   // depends on the configuration.
   logic state_valid;

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -9,6 +9,8 @@ package kmac_reg_pkg;
   // Param list
   parameter int NumWordsKey = 16;
   parameter int NumWordsPrefix = 11;
+  parameter int NumEntriesMsgFifo = 10;
+  parameter int NumBytesMsgFifoEntry = 8;
   parameter int unsigned HashCntW = 10;
   parameter int NumSeedsEntropyLfsr = 5;
   parameter int NumAlerts = 2;

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -610,12 +610,12 @@ dif_result_t dif_kmac_mode_kmac_start(
 /**
  * Absorb bytes from the message provided.
  *
- * If `kDifKmacIncomplete` is returned then the message FIFO is full and the
- * message was only partially absorbed. The message pointer and length should be
- * updated according to the number of bytes processed and the absorb operation
- * continued at a later time.
+ * If `processed` is non-NULL, then this function will write the remaining
+ * space in the FIFO and update `processed` with the number of bytes written.
+ * The caller should adjust the `msg` pointer and `len` parameters and call
+ * again as needed until all input has been written.
  *
- * If `processed` is not provided then this function will block until the entire
+ * If `processed` is NULL, then this function will block until the entire
  * message has been processed or an error occurs.
  *
  * If big-endian mode is enabled for messages (`message_big_endian`) only the

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -718,11 +718,11 @@ TEST_F(KmacStatusTest, IdleFifoEmptySuccess) {
 TEST_F(KmacStatusTest, AbsorbingFifoPartialSuccess) {
   EXPECT_READ32(KMAC_STATUS_REG_OFFSET,
                 {{KMAC_STATUS_SHA3_ABSORB_BIT, true},
-                 {KMAC_STATUS_FIFO_DEPTH_OFFSET, KMAC_STATUS_FIFO_DEPTH_MASK}});
+                 {KMAC_STATUS_FIFO_DEPTH_OFFSET, KMAC_PARAM_NUM_ENTRIES_MSG_FIFO}});
   EXPECT_DIF_OK(dif_kmac_get_status(&kmac_, &status_));
 
   EXPECT_EQ(status_.sha3_state, kDifKmacSha3StateAbsorbing);
-  EXPECT_EQ(status_.fifo_depth, KMAC_STATUS_FIFO_DEPTH_MASK);
+  EXPECT_EQ(status_.fifo_depth, KMAC_PARAM_NUM_ENTRIES_MSG_FIFO);
   EXPECT_EQ(status_.fifo_state, kDifKmacFifoStatePartial);
   EXPECT_EQ(status_.faults, kDifKmacAlertNone);
 }


### PR DESCRIPTION
This change arose from a conversation with @eunchan about the KMAC message FIFO. Existing documentation recommended that software write messages by:
1. Reading the `FIFO_DEPTH` field from the status register.
2. Calculating the remaining space in the FIFO and writing that amount of input.
3. Repeat.

However, it was unclear from the documentation (a) what exactly `FIFO_DEPTH` meant (bytes? words? Space free or space occupied?) and (b) how software should calculate the remaining space. With @eunchan , we confirmed that `FIFO_DEPTH` means "the number of entries currently occupied", and therefore software actually needs more information in order to calculate the remaining space -- the number of entries occupied is not useful unless you also know the number of total entries (10) and their size (64b). Rather than hard-code these into the drivers, we thought it would be better to expose them through `kmac_regs.h` and include checks against SV parameters to make sure their values are correct.

This PR:
- Exposes FIFO entry number and size as parameters in `kmac.hjson`
- Adds checks that compare these parameters to specific SV variables
- Changes the depth value noted in the docs from 9 to 10 (it was previously incorrect)
- Updates the KMAC docs to be clearer about `FIFO_DEPTH` and include a code snippet showing how to write input
- Updates `dif_kmac_absorb()` to use the new parameters and match the recommended way of writing
  - Previously, it did not monitor the FIFO at all and would have simply continued writing if the FIFO became full

See also: https://github.com/lowRISC/opentitan/issues/16902 (possibilities for a future KMAC/software interface)

@ballifatih It may be a good idea to use these values in the cryptolib KMAC driver as well; what do you think?