### PR TITLE
[opentitantool] Run "nice"r sims

### DIFF
--- a/sw/host/opentitanlib/src/transport/verilator/subprocess.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/subprocess.rs
@@ -35,9 +35,10 @@ pub struct Subprocess {
 impl Subprocess {
     /// Starts a verilator [`Subprocess`] based on [`Options`].
     pub fn from_options(options: Options) -> Result<Self> {
-        let mut command = Command::new(&options.executable);
+        let mut command = Command::new(String::from("nice"));
         let mut args = Vec::new();
-
+        args.push(String::from("-5"));
+        args.push(options.executable.to_string());
         if !options.rom_image.is_empty() {
             args.push(format!("--meminit=rom,{}", options.rom_image));
         }


### PR DESCRIPTION
Fix some timing issues by running sims with nice -5 to ensure test harnesses don't get starved of threads. This should solve some batch testing problems with a large number of threads serving verilator simulations.

I think it might help for: #16831 (Though that may just be a port collision which could require additional machinery)

It protects both the verilator and the cw310 test harnesses from heavy sim workloads which will be important to running cw310 tests that aren't exclusive.

Signed-off-by: Drew Macrae <drewmacrae@google.com>