### PR TITLE
[dv/alert_test] Fix alert_test regression failure

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -54,11 +54,18 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
     foreach(cfg.list_of_alerts[i]) begin
       string alert_name = cfg.list_of_alerts[i];
       string agent_name = {"m_alert_agent_", alert_name};
+      string common_seq_type;
+      void'($value$plusargs("run_%0s", common_seq_type));
       m_alert_agent[alert_name] = alert_esc_agent::type_id::create(agent_name, this);
       uvm_config_db#(alert_esc_agent_cfg)::set(this, agent_name, "cfg",
           cfg.m_alert_agent_cfgs[alert_name]);
       cfg.m_alert_agent_cfgs[alert_name].en_cov = cfg.en_cov;
       cfg.m_alert_agent_cfgs[alert_name].clk_freq_mhz = int'(cfg.clk_freq_mhz);
+
+      // Alert_test sequence will wait until alert checked then drive response manually.
+      if (common_seq_type == "alert_test") begin
+        cfg.m_alert_agent_cfgs[alert_name].start_default_rsp_seq = 0;
+      end
     end
 
     // Create and configure the EDN agent if available.

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -109,13 +109,6 @@ class cip_base_vseq #(
 
   task pre_start();
     if (common_seq_type == "") void'($value$plusargs("run_%0s", common_seq_type));
-    if (common_seq_type == "alert_test") begin
-      // The sequence will wait until alert checked then drive response manually.
-      foreach (cfg.m_alert_agent_cfgs[alert_name]) begin
-        cfg.m_alert_agent_cfgs[alert_name].start_default_rsp_seq = 0;
-      end
-    end
-
     csr_utils_pkg::max_outstanding_accesses = 1 << BUS_AIW;
     super.pre_start();
     extract_common_csrs();


### PR DESCRIPTION
PR #16896 uses agent to automatically drive alert response sequences for each IP.
But alert_test needs to disable auto response. The current design disabled at pre_start stage, but it is too late.
The auto-response sequence runs from the beginning of run_phase. So this PR moves the disablement to the build_phase.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>