### PR TITLE
[bazel] allocate additional core per verilator test to allow for harness and overhead

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,12 +43,12 @@ coverage:coverage_clang --repo_env=BAZEL_LLVM_COV=/usr/bin/llvm-cov
 # cached previously. See https://bazel.build/configure/coverage?hl=en#remote-execution
 coverage:coverage_clang --nocache_test_results
 
-# Verilator is built for 4 cores and can time out if bazel is running more
-# than 1 test per four cores.
-# Until we get the built-in tag "cpu:4" to work for verilator tests, we can run
-# 1 test per 4 cores to avoid verilator performance falloff and timeouts we'd
-# otherwise see on machines with fewer than 40 cores.
-test --local_test_jobs=HOST_CPUS*0.25
+# Configuration to override resource constrained test
+# scheduling. Enable with `--config=local_test_jobs_per_cpus`
+test:local_test_jobs_per_cpus --local_test_jobs=HOST_CPUS*0.22
+# Verilator is built for 4 cores, but requires a harness and additional overhead.
+# Empirically 72 cores can support 16 simultaneous tests, but not 17. Setting
+# this will ignore tags like "cpu:5"
 
 # We have verilator tests that take more than an hour to complete
 test --test_timeout=60,300,1500,7200

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -152,7 +152,7 @@ def verilator_params(
         "@//hw:verilator",
         "@//hw:fusesoc_ignore",
     ]
-    required_tags = ["verilator", "cpu:4"]
+    required_tags = ["verilator", "cpu:5"]
     kwargs.update(
         args = default_args + args,
         data = required_data + data,


### PR DESCRIPTION
An alternative to #16913 to prevent harnesses from getting pre-empted by a simulation load.

Running 17 verilator tests and 1 fpga test on 72 cores will cause problems unless the test harnesses are prioritized above the verilated model. An alternative to this prioritization is to recognize that verilated tests require 4 cpus for the simulation alone and further resources for appropriate overhead.  Empirically 17/72ths of a core is too little to prevent issues but 16/72nds is safe, but bazel requires cpu:<int> (it parses up to the decimal and stops without throwing an error).

Won't fix: https://github.com/lowRISC/opentitan/issues/16831 because it uses local_test_job based scheduling that overrides resource constrained scheduling. For #16831, similar methods would cause a 30% performance hit.

Signed-off-by: Drew Macrae <drewmacrae@google.com>