### PR TITLE
[dv/alert_handler] fix entropy_stress regression failure

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -227,8 +227,8 @@ class alert_monitor extends alert_esc_base_monitor;
   endtask : int_fail_thread
 
   virtual task wait_ping_thread();
-    alert_esc_seq_item req = alert_esc_seq_item::type_id::create("req");
     forever begin
+      alert_esc_seq_item req = alert_esc_seq_item::type_id::create("req");
       logic ping_p_value;
       req.alert_esc_type = AlertEscPingTrans;
       wait (!under_reset && !cfg.en_alert_lpg);

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_if.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_if.sv
@@ -49,4 +49,8 @@ interface alert_handler_if(input clk, input rst_n);
       force tb.dut.u_ping_timer.wait_cyc_mask_i = val_static;
     end
   endtask
+
+  task automatic release_wait_cyc_mask();
+    release tb.dut.u_ping_timer.wait_cyc_mask_i;
+  endtask
 endinterface

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
@@ -35,12 +35,6 @@ class alert_handler_entropy_stress_vseq extends alert_handler_smoke_vseq;
     foreach (cfg.alert_host_cfg[i]) begin
       cfg.alert_host_cfg[i].alert_delay_max = 0;
       cfg.alert_host_cfg[i].ping_delay_max = 0;
-
-      // Bypass alert and escalation ready_to_end check.
-      // In this test, we force the alert/esc ping requests to have very short wait cycles.
-      // So alert or escalation ports might always have incoming traffic and will never end.
-      cfg.alert_host_cfg[i].bypass_alert_ready_to_end_check = 1;
-      cfg.alert_host_cfg[i].bypass_esc_ready_to_end_check = 1;
     end
     super.pre_start();
   endtask
@@ -97,6 +91,13 @@ class alert_handler_entropy_stress_vseq extends alert_handler_smoke_vseq;
     foreach (ral.loc_alert_cause[i]) begin
       csr_rd_check(.ptr(ral.loc_alert_cause[i]), .compare_value(0));
     end
+
+    // Wait some random delays, then release the force signal, issue reset.
+    // This will allow the test to pass ok_to_end check from alert/esc_monitors and
+    // push_pull_agent.
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 5));
+    cfg.alert_handler_vif.release_wait_cyc_mask();
+    dut_init();
   endtask
 
 endclass : alert_handler_entropy_stress_vseq

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_if.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_if.sv
@@ -49,4 +49,8 @@ interface alert_handler_if(input clk, input rst_n);
       force tb.dut.u_ping_timer.wait_cyc_mask_i = val_static;
     end
   endtask
+
+  task automatic release_wait_cyc_mask();
+    release tb.dut.u_ping_timer.wait_cyc_mask_i;
+  endtask
 endinterface

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
@@ -35,12 +35,6 @@ class alert_handler_entropy_stress_vseq extends alert_handler_smoke_vseq;
     foreach (cfg.alert_host_cfg[i]) begin
       cfg.alert_host_cfg[i].alert_delay_max = 0;
       cfg.alert_host_cfg[i].ping_delay_max = 0;
-
-      // Bypass alert and escalation ready_to_end check.
-      // In this test, we force the alert/esc ping requests to have very short wait cycles.
-      // So alert or escalation ports might always have incoming traffic and will never end.
-      cfg.alert_host_cfg[i].bypass_alert_ready_to_end_check = 1;
-      cfg.alert_host_cfg[i].bypass_esc_ready_to_end_check = 1;
     end
     super.pre_start();
   endtask
@@ -97,6 +91,13 @@ class alert_handler_entropy_stress_vseq extends alert_handler_smoke_vseq;
     foreach (ral.loc_alert_cause[i]) begin
       csr_rd_check(.ptr(ral.loc_alert_cause[i]), .compare_value(0));
     end
+
+    // Wait some random delays, then release the force signal, issue reset.
+    // This will allow the test to pass ok_to_end check from alert/esc_monitors and
+    // push_pull_agent.
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 5));
+    cfg.alert_handler_vif.release_wait_cyc_mask();
+    dut_init();
   endtask
 
 endclass : alert_handler_entropy_stress_vseq


### PR DESCRIPTION
Fix entropy_stress test timeout error due to `ok_to_end` check.
To pass the `ok_to_end` check, this PR release the forced value and
issue a hard reset.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>