### PR TITLE
[sw/silicon_creator] Fix OTBN sec_mmio regression

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -33,11 +33,11 @@ enum {
  * Example:
  * ```
  *  otbn_execute();
- *  SEC_MMIO_WRITE_INCREMENT(kOtbnSecMMioExecute);
+ *  SEC_MMIO_WRITE_INCREMENT(kOtbnSecMmioExecute);
  * ```
  */
 enum {
-  kOtbnSecMmioExecute = 2,
+  kOtbnSecMmioExecute = 1,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.c
+++ b/sw/device/silicon_creator/lib/sigverify/mod_exp_otbn.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/otbn.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/sigverify/rsa_key.h"
@@ -79,6 +80,7 @@ rom_error_t run_otbn_rsa_3072_modexp(
 
   // Start the OTBN routine.
   HARDENED_RETURN_IF_ERROR(otbn_execute());
+  SEC_MMIO_WRITE_INCREMENT(kOtbnSecMmioExecute);
 
   // Check that the instruction count falls within the expected range. If the
   // instruction count falls outside this range, it indicates that there was a


### PR DESCRIPTION
This commit corrects the value of the `kOtbnSecMmioExecute` constant and adds a missing `SEC_MMIO_WRITE_INCREMENT()` after the `otbn_execute()` call in `mod_exp_otbn.c`.

Fixes #16916

Signed-off-by: Alphan Ulusoy <alphan@google.com>