### PR TITLE
[ci] Move the spliced bitstream to the correct location

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -394,7 +394,7 @@ jobs:
       module load "xilinx/vivado/$(VIVADO_VERSION)"
       ci/scripts/prepare-cached-bitstream.sh
     condition: eq(variables.bitstreamStrategy, 'cached')
-    displayName: Prepare cached bitstream
+    displayName: Splice cached bitstream
   - bash: |
       set -ex
       trap 'get_logs' EXIT

--- a/ci/scripts/prepare-cached-bitstream.sh
+++ b/ci/scripts/prepare-cached-bitstream.sh
@@ -9,20 +9,24 @@ set -ex
 
 . util/build_consts.sh
 
-TOPLEVEL=top_earlgrey
-TOPLEVEL_BIN_DIR="${BIN_DIR}/hw/${TOPLEVEL}"
-
-BITSTREAM=HEAD ci/bazelisk.sh build --define bitstream=gcp_splice \
-  //hw/bitstream:test_rom \
-  //hw/bitstream:rom \
-  //hw/bitstream:rom_otp_dev \
-  //hw/bitstream:rom_mmi \
+readonly TOPLEVEL=top_earlgrey
+readonly TOPLEVEL_BIN_DIR="${BIN_DIR}/hw/${TOPLEVEL}"
+readonly TARGETS=(
+  //hw/bitstream:test_rom
+  //hw/bitstream:rom
+  //hw/bitstream:rom_otp_dev
+  //hw/bitstream:rom_mmi
   //hw/bitstream:otp_mmi
+)
+readonly BAZEL_OPTS=(
+  "--define"
+  "bitstream=gcp_splice"
+)
 
-mkdir -p ${TOPLEVEL_BIN_DIR}
-cp -rLvt "${TOPLEVEL_BIN_DIR}" \
-  "$(ci/scripts/target-location.sh //hw/bitstream:test_rom)" \
-  "$(ci/scripts/target-location.sh //hw/bitstream:rom)" \
-  "$(ci/scripts/target-location.sh //hw/bitstream:rom_otp_dev)"\
-  "$(ci/scripts/target-location.sh //hw/bitstream:rom_mmi)" \
-  "$(ci/scripts/target-location.sh //hw/bitstream:otp_mmi)"
+BITSTREAM=HEAD ci/bazelisk.sh build "${BAZEL_OPTS[@]}" "${TARGETS[@]}"
+mkdir -p "${TOPLEVEL_BIN_DIR}"
+for target in "${TARGETS[@]}"; do
+  src="$(ci/scripts/target-location.sh "${target}" "${BAZEL_OPTS[@]}")"
+  dst="${TOPLEVEL_BIN_DIR}/$(basename "$(ci/scripts/target-location.sh "${target}")")"
+  cp -vL "${src}" "${dst}"
+done

--- a/ci/scripts/target-location.sh
+++ b/ci/scripts/target-location.sh
@@ -11,7 +11,7 @@ readonly REPO_TOP
 
 verbose='false'
 print_usage() {
-  printf "Usage: $0 [-v] <bazel target label>"
+  printf "Usage: $0 [-v] <bazel target label> [bazel options...]"
 }
 
 while getopts 'v' flag; do


### PR DESCRIPTION
This PR fixes prepare-cached-bitstream.sh so that freshly spliced bitstreams are moved to the locations expected by subsequent steps and renames the corresponding CI step to "Splice cached bitstream".

[Post-mortem](https://docs.google.com/document/d/14FJYy_9QN8zquoJMcJcwA-gOEa_QQweaExf7gH89eRs/edit#)