### PR TITLE
[sysrst_ctrl] Add pre-condition feature for combos

### DIFF
--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -678,6 +678,77 @@
       ]
     }
     { multireg: {
+        name: "COM_PRE_SEL_CTL",
+        desc: '''
+              To define the keys that define the pre-condition of the combo
+              [0]: key0_in_sel
+              [1]: key1_in_sel
+              [2]: key2_in_sel
+              [3]: pwrb_in_sel
+              [4]: ac_present_sel
+              HW will start matching the combo as defined by !!COM_SEL_CTL if this precondition is fulfilled.
+
+              If no keys are configured for the pre-condition, the pre-condition always evaluates to true.
+
+              The debounce timing is defined via !!KEY_INTR_DEBOUNCE_CTL whereas the pre-condition pressed timing is defined via !!COM_PRE_DET_CTL.
+              ''',
+        count: "NumCombo",
+        cname: "sysrst_ctrl",
+        swaccess: "rw",
+        hwaccess: "hro",
+        regwen:   "REGWEN",
+        resval:   "0",
+        async: "clk_aon_i",
+        fields: [
+          { bits:   "0",
+            name:   "key0_in_sel",
+            desc:   "0: disable, 1: enable",
+            resval: "0",
+          }
+          { bits:   "1",
+            name:   "key1_in_sel",
+            desc:   "0: disable, 1: enable",
+            resval: "0",
+          }
+          { bits:   "2",
+            name:   "key2_in_sel",
+            desc:   "0: disable, 1: enable",
+            resval: "0",
+          }
+          { bits:   "3",
+            name:   "pwrb_in_sel",
+            desc:   "0: disable, 1: enable",
+            resval: "0",
+          }
+          { bits:   "4",
+            name:   "ac_present_sel",
+            desc:   "0: disable, 1: enable",
+            resval: "0",
+          }
+        ],
+      }
+    }
+    { multireg: {
+        name: "COM_PRE_DET_CTL",
+        desc: '''To define the duration that the combo pre-condition should be pressed
+              0-60s, each step is 5us(200KHz clock)
+                    ''',
+        count: "NumCombo",
+        cname: "sysrst_ctrl",
+        swaccess: "rw",
+        hwaccess: "hro",
+        regwen:   "REGWEN",
+        resval:   "0",
+        async: "clk_aon_i",
+        fields: [
+          { bits: "DetTimerWidth-1:0",
+            name: "precondition_timer",
+            desc: "0-60s, each step is 5us(200KHz clock)",
+          }
+        ],
+      }
+    }
+    { multireg: {
         name: "COM_SEL_CTL",
         desc: '''
               To define the keys that trigger the combo
@@ -686,7 +757,13 @@
               [2]: key2_in_sel
               [3]: pwrb_in_sel
               [4]: ac_present_sel
-              HW will detect H2L transition in the combo use case
+              HW will detect H2L transition in the combo use case.
+
+              Optionally, a pre-condition can be configured for the combo detection via !!COM_PRE_SEL_CTL.
+
+              If no keys are configured for the combo, the combo detection is disabled.
+
+              The debounce timing is defined via !!KEY_INTR_DEBOUNCE_CTL whereas the key-pressed timing is defined via !!COM_DET_CTL.
               ''',
         count: "NumCombo",
         cname: "sysrst_ctrl",

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl.sv
@@ -240,6 +240,8 @@ module sysrst_ctrl
     // CSRs synced to AON clock
     .ec_rst_ctl_i(reg2hw.ec_rst_ctl),
     .key_intr_debounce_ctl_i(reg2hw.key_intr_debounce_ctl),
+    .com_pre_sel_ctl_i(reg2hw.com_pre_sel_ctl),
+    .com_pre_det_ctl_i(reg2hw.com_pre_det_ctl),
     .com_sel_ctl_i(reg2hw.com_sel_ctl),
     .com_det_ctl_i(reg2hw.com_det_ctl),
     .com_out_ctl_i(reg2hw.com_out_ctl),

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
@@ -300,6 +300,28 @@ package sysrst_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } ac_present_sel;
+  } sysrst_ctrl_reg2hw_com_pre_sel_ctl_mreg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } sysrst_ctrl_reg2hw_com_pre_det_ctl_mreg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } key0_in_sel;
+    struct packed {
+      logic        q;
+    } key1_in_sel;
+    struct packed {
+      logic        q;
+    } key2_in_sel;
+    struct packed {
+      logic        q;
+    } pwrb_in_sel;
+    struct packed {
+      logic        q;
+    } ac_present_sel;
   } sysrst_ctrl_reg2hw_com_sel_ctl_mreg_t;
 
   typedef struct packed {
@@ -451,24 +473,26 @@ package sysrst_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    sysrst_ctrl_reg2hw_intr_state_reg_t intr_state; // [332:332]
-    sysrst_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [331:331]
-    sysrst_ctrl_reg2hw_intr_test_reg_t intr_test; // [330:329]
-    sysrst_ctrl_reg2hw_alert_test_reg_t alert_test; // [328:327]
-    sysrst_ctrl_reg2hw_ec_rst_ctl_reg_t ec_rst_ctl; // [326:311]
-    sysrst_ctrl_reg2hw_ulp_ac_debounce_ctl_reg_t ulp_ac_debounce_ctl; // [310:295]
-    sysrst_ctrl_reg2hw_ulp_lid_debounce_ctl_reg_t ulp_lid_debounce_ctl; // [294:279]
-    sysrst_ctrl_reg2hw_ulp_pwrb_debounce_ctl_reg_t ulp_pwrb_debounce_ctl; // [278:263]
-    sysrst_ctrl_reg2hw_ulp_ctl_reg_t ulp_ctl; // [262:262]
-    sysrst_ctrl_reg2hw_wkup_status_reg_t wkup_status; // [261:261]
-    sysrst_ctrl_reg2hw_key_invert_ctl_reg_t key_invert_ctl; // [260:249]
-    sysrst_ctrl_reg2hw_pin_allowed_ctl_reg_t pin_allowed_ctl; // [248:233]
-    sysrst_ctrl_reg2hw_pin_out_ctl_reg_t pin_out_ctl; // [232:225]
-    sysrst_ctrl_reg2hw_pin_out_value_reg_t pin_out_value; // [224:217]
-    sysrst_ctrl_reg2hw_key_intr_ctl_reg_t key_intr_ctl; // [216:203]
-    sysrst_ctrl_reg2hw_key_intr_debounce_ctl_reg_t key_intr_debounce_ctl; // [202:187]
-    sysrst_ctrl_reg2hw_auto_block_debounce_ctl_reg_t auto_block_debounce_ctl; // [186:170]
-    sysrst_ctrl_reg2hw_auto_block_out_ctl_reg_t auto_block_out_ctl; // [169:164]
+    sysrst_ctrl_reg2hw_intr_state_reg_t intr_state; // [480:480]
+    sysrst_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [479:479]
+    sysrst_ctrl_reg2hw_intr_test_reg_t intr_test; // [478:477]
+    sysrst_ctrl_reg2hw_alert_test_reg_t alert_test; // [476:475]
+    sysrst_ctrl_reg2hw_ec_rst_ctl_reg_t ec_rst_ctl; // [474:459]
+    sysrst_ctrl_reg2hw_ulp_ac_debounce_ctl_reg_t ulp_ac_debounce_ctl; // [458:443]
+    sysrst_ctrl_reg2hw_ulp_lid_debounce_ctl_reg_t ulp_lid_debounce_ctl; // [442:427]
+    sysrst_ctrl_reg2hw_ulp_pwrb_debounce_ctl_reg_t ulp_pwrb_debounce_ctl; // [426:411]
+    sysrst_ctrl_reg2hw_ulp_ctl_reg_t ulp_ctl; // [410:410]
+    sysrst_ctrl_reg2hw_wkup_status_reg_t wkup_status; // [409:409]
+    sysrst_ctrl_reg2hw_key_invert_ctl_reg_t key_invert_ctl; // [408:397]
+    sysrst_ctrl_reg2hw_pin_allowed_ctl_reg_t pin_allowed_ctl; // [396:381]
+    sysrst_ctrl_reg2hw_pin_out_ctl_reg_t pin_out_ctl; // [380:373]
+    sysrst_ctrl_reg2hw_pin_out_value_reg_t pin_out_value; // [372:365]
+    sysrst_ctrl_reg2hw_key_intr_ctl_reg_t key_intr_ctl; // [364:351]
+    sysrst_ctrl_reg2hw_key_intr_debounce_ctl_reg_t key_intr_debounce_ctl; // [350:335]
+    sysrst_ctrl_reg2hw_auto_block_debounce_ctl_reg_t auto_block_debounce_ctl; // [334:318]
+    sysrst_ctrl_reg2hw_auto_block_out_ctl_reg_t auto_block_out_ctl; // [317:312]
+    sysrst_ctrl_reg2hw_com_pre_sel_ctl_mreg_t [3:0] com_pre_sel_ctl; // [311:292]
+    sysrst_ctrl_reg2hw_com_pre_det_ctl_mreg_t [3:0] com_pre_det_ctl; // [291:164]
     sysrst_ctrl_reg2hw_com_sel_ctl_mreg_t [3:0] com_sel_ctl; // [163:144]
     sysrst_ctrl_reg2hw_com_det_ctl_mreg_t [3:0] com_det_ctl; // [143:16]
     sysrst_ctrl_reg2hw_com_out_ctl_mreg_t [3:0] com_out_ctl; // [15:0]
@@ -506,20 +530,28 @@ package sysrst_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] SYSRST_CTRL_KEY_INTR_DEBOUNCE_CTL_OFFSET = 8'h 48;
   parameter logic [BlockAw-1:0] SYSRST_CTRL_AUTO_BLOCK_DEBOUNCE_CTL_OFFSET = 8'h 4c;
   parameter logic [BlockAw-1:0] SYSRST_CTRL_AUTO_BLOCK_OUT_CTL_OFFSET = 8'h 50;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_SEL_CTL_0_OFFSET = 8'h 54;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_SEL_CTL_1_OFFSET = 8'h 58;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_SEL_CTL_2_OFFSET = 8'h 5c;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_SEL_CTL_3_OFFSET = 8'h 60;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_DET_CTL_0_OFFSET = 8'h 64;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_DET_CTL_1_OFFSET = 8'h 68;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_DET_CTL_2_OFFSET = 8'h 6c;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_DET_CTL_3_OFFSET = 8'h 70;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_OUT_CTL_0_OFFSET = 8'h 74;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_OUT_CTL_1_OFFSET = 8'h 78;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_OUT_CTL_2_OFFSET = 8'h 7c;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_OUT_CTL_3_OFFSET = 8'h 80;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_COMBO_INTR_STATUS_OFFSET = 8'h 84;
-  parameter logic [BlockAw-1:0] SYSRST_CTRL_KEY_INTR_STATUS_OFFSET = 8'h 88;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_PRE_SEL_CTL_0_OFFSET = 8'h 54;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_PRE_SEL_CTL_1_OFFSET = 8'h 58;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_PRE_SEL_CTL_2_OFFSET = 8'h 5c;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_PRE_SEL_CTL_3_OFFSET = 8'h 60;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_PRE_DET_CTL_0_OFFSET = 8'h 64;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_PRE_DET_CTL_1_OFFSET = 8'h 68;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_PRE_DET_CTL_2_OFFSET = 8'h 6c;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_PRE_DET_CTL_3_OFFSET = 8'h 70;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_SEL_CTL_0_OFFSET = 8'h 74;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_SEL_CTL_1_OFFSET = 8'h 78;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_SEL_CTL_2_OFFSET = 8'h 7c;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_SEL_CTL_3_OFFSET = 8'h 80;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_DET_CTL_0_OFFSET = 8'h 84;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_DET_CTL_1_OFFSET = 8'h 88;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_DET_CTL_2_OFFSET = 8'h 8c;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_DET_CTL_3_OFFSET = 8'h 90;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_OUT_CTL_0_OFFSET = 8'h 94;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_OUT_CTL_1_OFFSET = 8'h 98;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_OUT_CTL_2_OFFSET = 8'h 9c;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COM_OUT_CTL_3_OFFSET = 8'h a0;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_COMBO_INTR_STATUS_OFFSET = 8'h a4;
+  parameter logic [BlockAw-1:0] SYSRST_CTRL_KEY_INTR_STATUS_OFFSET = 8'h a8;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] SYSRST_CTRL_INTR_TEST_RESVAL = 1'h 0;
@@ -550,6 +582,14 @@ package sysrst_ctrl_reg_pkg;
     SYSRST_CTRL_KEY_INTR_DEBOUNCE_CTL,
     SYSRST_CTRL_AUTO_BLOCK_DEBOUNCE_CTL,
     SYSRST_CTRL_AUTO_BLOCK_OUT_CTL,
+    SYSRST_CTRL_COM_PRE_SEL_CTL_0,
+    SYSRST_CTRL_COM_PRE_SEL_CTL_1,
+    SYSRST_CTRL_COM_PRE_SEL_CTL_2,
+    SYSRST_CTRL_COM_PRE_SEL_CTL_3,
+    SYSRST_CTRL_COM_PRE_DET_CTL_0,
+    SYSRST_CTRL_COM_PRE_DET_CTL_1,
+    SYSRST_CTRL_COM_PRE_DET_CTL_2,
+    SYSRST_CTRL_COM_PRE_DET_CTL_3,
     SYSRST_CTRL_COM_SEL_CTL_0,
     SYSRST_CTRL_COM_SEL_CTL_1,
     SYSRST_CTRL_COM_SEL_CTL_2,
@@ -567,7 +607,7 @@ package sysrst_ctrl_reg_pkg;
   } sysrst_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SYSRST_CTRL_PERMIT [35] = '{
+  parameter logic [3:0] SYSRST_CTRL_PERMIT [43] = '{
     4'b 0001, // index[ 0] SYSRST_CTRL_INTR_STATE
     4'b 0001, // index[ 1] SYSRST_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] SYSRST_CTRL_INTR_TEST
@@ -589,20 +629,28 @@ package sysrst_ctrl_reg_pkg;
     4'b 0011, // index[18] SYSRST_CTRL_KEY_INTR_DEBOUNCE_CTL
     4'b 0111, // index[19] SYSRST_CTRL_AUTO_BLOCK_DEBOUNCE_CTL
     4'b 0001, // index[20] SYSRST_CTRL_AUTO_BLOCK_OUT_CTL
-    4'b 0001, // index[21] SYSRST_CTRL_COM_SEL_CTL_0
-    4'b 0001, // index[22] SYSRST_CTRL_COM_SEL_CTL_1
-    4'b 0001, // index[23] SYSRST_CTRL_COM_SEL_CTL_2
-    4'b 0001, // index[24] SYSRST_CTRL_COM_SEL_CTL_3
-    4'b 1111, // index[25] SYSRST_CTRL_COM_DET_CTL_0
-    4'b 1111, // index[26] SYSRST_CTRL_COM_DET_CTL_1
-    4'b 1111, // index[27] SYSRST_CTRL_COM_DET_CTL_2
-    4'b 1111, // index[28] SYSRST_CTRL_COM_DET_CTL_3
-    4'b 0001, // index[29] SYSRST_CTRL_COM_OUT_CTL_0
-    4'b 0001, // index[30] SYSRST_CTRL_COM_OUT_CTL_1
-    4'b 0001, // index[31] SYSRST_CTRL_COM_OUT_CTL_2
-    4'b 0001, // index[32] SYSRST_CTRL_COM_OUT_CTL_3
-    4'b 0001, // index[33] SYSRST_CTRL_COMBO_INTR_STATUS
-    4'b 0011  // index[34] SYSRST_CTRL_KEY_INTR_STATUS
+    4'b 0001, // index[21] SYSRST_CTRL_COM_PRE_SEL_CTL_0
+    4'b 0001, // index[22] SYSRST_CTRL_COM_PRE_SEL_CTL_1
+    4'b 0001, // index[23] SYSRST_CTRL_COM_PRE_SEL_CTL_2
+    4'b 0001, // index[24] SYSRST_CTRL_COM_PRE_SEL_CTL_3
+    4'b 1111, // index[25] SYSRST_CTRL_COM_PRE_DET_CTL_0
+    4'b 1111, // index[26] SYSRST_CTRL_COM_PRE_DET_CTL_1
+    4'b 1111, // index[27] SYSRST_CTRL_COM_PRE_DET_CTL_2
+    4'b 1111, // index[28] SYSRST_CTRL_COM_PRE_DET_CTL_3
+    4'b 0001, // index[29] SYSRST_CTRL_COM_SEL_CTL_0
+    4'b 0001, // index[30] SYSRST_CTRL_COM_SEL_CTL_1
+    4'b 0001, // index[31] SYSRST_CTRL_COM_SEL_CTL_2
+    4'b 0001, // index[32] SYSRST_CTRL_COM_SEL_CTL_3
+    4'b 1111, // index[33] SYSRST_CTRL_COM_DET_CTL_0
+    4'b 1111, // index[34] SYSRST_CTRL_COM_DET_CTL_1
+    4'b 1111, // index[35] SYSRST_CTRL_COM_DET_CTL_2
+    4'b 1111, // index[36] SYSRST_CTRL_COM_DET_CTL_3
+    4'b 0001, // index[37] SYSRST_CTRL_COM_OUT_CTL_0
+    4'b 0001, // index[38] SYSRST_CTRL_COM_OUT_CTL_1
+    4'b 0001, // index[39] SYSRST_CTRL_COM_OUT_CTL_2
+    4'b 0001, // index[40] SYSRST_CTRL_COM_OUT_CTL_3
+    4'b 0001, // index[41] SYSRST_CTRL_COMBO_INTR_STATUS
+    4'b 0011  // index[42] SYSRST_CTRL_KEY_INTR_STATUS
   };
 
 endpackage

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -57,9 +57,9 @@ module sysrst_ctrl_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [34:0] reg_we_check;
+  logic [42:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(35)
+    .OneHotWidth(43)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -192,6 +192,30 @@ module sysrst_ctrl_reg_top (
   logic auto_block_out_ctl_we;
   logic [6:0] auto_block_out_ctl_qs;
   logic auto_block_out_ctl_busy;
+  logic com_pre_sel_ctl_0_we;
+  logic [4:0] com_pre_sel_ctl_0_qs;
+  logic com_pre_sel_ctl_0_busy;
+  logic com_pre_sel_ctl_1_we;
+  logic [4:0] com_pre_sel_ctl_1_qs;
+  logic com_pre_sel_ctl_1_busy;
+  logic com_pre_sel_ctl_2_we;
+  logic [4:0] com_pre_sel_ctl_2_qs;
+  logic com_pre_sel_ctl_2_busy;
+  logic com_pre_sel_ctl_3_we;
+  logic [4:0] com_pre_sel_ctl_3_qs;
+  logic com_pre_sel_ctl_3_busy;
+  logic com_pre_det_ctl_0_we;
+  logic [31:0] com_pre_det_ctl_0_qs;
+  logic com_pre_det_ctl_0_busy;
+  logic com_pre_det_ctl_1_we;
+  logic [31:0] com_pre_det_ctl_1_qs;
+  logic com_pre_det_ctl_1_busy;
+  logic com_pre_det_ctl_2_we;
+  logic [31:0] com_pre_det_ctl_2_qs;
+  logic com_pre_det_ctl_2_busy;
+  logic com_pre_det_ctl_3_we;
+  logic [31:0] com_pre_det_ctl_3_qs;
+  logic com_pre_det_ctl_3_busy;
   logic com_sel_ctl_0_we;
   logic [4:0] com_sel_ctl_0_qs;
   logic com_sel_ctl_0_busy;
@@ -944,6 +968,350 @@ module sysrst_ctrl_reg_top (
   );
   assign unused_aon_auto_block_out_ctl_wdata =
       ^aon_auto_block_out_ctl_wdata;
+
+  logic  aon_com_pre_sel_ctl_0_key0_in_sel_0_qs_int;
+  logic  aon_com_pre_sel_ctl_0_key1_in_sel_0_qs_int;
+  logic  aon_com_pre_sel_ctl_0_key2_in_sel_0_qs_int;
+  logic  aon_com_pre_sel_ctl_0_pwrb_in_sel_0_qs_int;
+  logic  aon_com_pre_sel_ctl_0_ac_present_sel_0_qs_int;
+  logic [4:0] aon_com_pre_sel_ctl_0_qs;
+  logic [4:0] aon_com_pre_sel_ctl_0_wdata;
+  logic aon_com_pre_sel_ctl_0_we;
+  logic unused_aon_com_pre_sel_ctl_0_wdata;
+  logic aon_com_pre_sel_ctl_0_regwen;
+
+  always_comb begin
+    aon_com_pre_sel_ctl_0_qs = 5'h0;
+    aon_com_pre_sel_ctl_0_qs[0] = aon_com_pre_sel_ctl_0_key0_in_sel_0_qs_int;
+    aon_com_pre_sel_ctl_0_qs[1] = aon_com_pre_sel_ctl_0_key1_in_sel_0_qs_int;
+    aon_com_pre_sel_ctl_0_qs[2] = aon_com_pre_sel_ctl_0_key2_in_sel_0_qs_int;
+    aon_com_pre_sel_ctl_0_qs[3] = aon_com_pre_sel_ctl_0_pwrb_in_sel_0_qs_int;
+    aon_com_pre_sel_ctl_0_qs[4] = aon_com_pre_sel_ctl_0_ac_present_sel_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f),
+    .DstWrReq(0)
+  ) u_com_pre_sel_ctl_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_pre_sel_ctl_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (com_pre_sel_ctl_0_busy),
+    .src_qs_o     (com_pre_sel_ctl_0_qs), // for software read back
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_pre_sel_ctl_0_qs),
+    .dst_we_o     (aon_com_pre_sel_ctl_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_pre_sel_ctl_0_regwen),
+    .dst_wd_o     (aon_com_pre_sel_ctl_0_wdata)
+  );
+  assign unused_aon_com_pre_sel_ctl_0_wdata =
+      ^aon_com_pre_sel_ctl_0_wdata;
+
+  logic  aon_com_pre_sel_ctl_1_key0_in_sel_1_qs_int;
+  logic  aon_com_pre_sel_ctl_1_key1_in_sel_1_qs_int;
+  logic  aon_com_pre_sel_ctl_1_key2_in_sel_1_qs_int;
+  logic  aon_com_pre_sel_ctl_1_pwrb_in_sel_1_qs_int;
+  logic  aon_com_pre_sel_ctl_1_ac_present_sel_1_qs_int;
+  logic [4:0] aon_com_pre_sel_ctl_1_qs;
+  logic [4:0] aon_com_pre_sel_ctl_1_wdata;
+  logic aon_com_pre_sel_ctl_1_we;
+  logic unused_aon_com_pre_sel_ctl_1_wdata;
+  logic aon_com_pre_sel_ctl_1_regwen;
+
+  always_comb begin
+    aon_com_pre_sel_ctl_1_qs = 5'h0;
+    aon_com_pre_sel_ctl_1_qs[0] = aon_com_pre_sel_ctl_1_key0_in_sel_1_qs_int;
+    aon_com_pre_sel_ctl_1_qs[1] = aon_com_pre_sel_ctl_1_key1_in_sel_1_qs_int;
+    aon_com_pre_sel_ctl_1_qs[2] = aon_com_pre_sel_ctl_1_key2_in_sel_1_qs_int;
+    aon_com_pre_sel_ctl_1_qs[3] = aon_com_pre_sel_ctl_1_pwrb_in_sel_1_qs_int;
+    aon_com_pre_sel_ctl_1_qs[4] = aon_com_pre_sel_ctl_1_ac_present_sel_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f),
+    .DstWrReq(0)
+  ) u_com_pre_sel_ctl_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_pre_sel_ctl_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (com_pre_sel_ctl_1_busy),
+    .src_qs_o     (com_pre_sel_ctl_1_qs), // for software read back
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_pre_sel_ctl_1_qs),
+    .dst_we_o     (aon_com_pre_sel_ctl_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_pre_sel_ctl_1_regwen),
+    .dst_wd_o     (aon_com_pre_sel_ctl_1_wdata)
+  );
+  assign unused_aon_com_pre_sel_ctl_1_wdata =
+      ^aon_com_pre_sel_ctl_1_wdata;
+
+  logic  aon_com_pre_sel_ctl_2_key0_in_sel_2_qs_int;
+  logic  aon_com_pre_sel_ctl_2_key1_in_sel_2_qs_int;
+  logic  aon_com_pre_sel_ctl_2_key2_in_sel_2_qs_int;
+  logic  aon_com_pre_sel_ctl_2_pwrb_in_sel_2_qs_int;
+  logic  aon_com_pre_sel_ctl_2_ac_present_sel_2_qs_int;
+  logic [4:0] aon_com_pre_sel_ctl_2_qs;
+  logic [4:0] aon_com_pre_sel_ctl_2_wdata;
+  logic aon_com_pre_sel_ctl_2_we;
+  logic unused_aon_com_pre_sel_ctl_2_wdata;
+  logic aon_com_pre_sel_ctl_2_regwen;
+
+  always_comb begin
+    aon_com_pre_sel_ctl_2_qs = 5'h0;
+    aon_com_pre_sel_ctl_2_qs[0] = aon_com_pre_sel_ctl_2_key0_in_sel_2_qs_int;
+    aon_com_pre_sel_ctl_2_qs[1] = aon_com_pre_sel_ctl_2_key1_in_sel_2_qs_int;
+    aon_com_pre_sel_ctl_2_qs[2] = aon_com_pre_sel_ctl_2_key2_in_sel_2_qs_int;
+    aon_com_pre_sel_ctl_2_qs[3] = aon_com_pre_sel_ctl_2_pwrb_in_sel_2_qs_int;
+    aon_com_pre_sel_ctl_2_qs[4] = aon_com_pre_sel_ctl_2_ac_present_sel_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f),
+    .DstWrReq(0)
+  ) u_com_pre_sel_ctl_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_pre_sel_ctl_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (com_pre_sel_ctl_2_busy),
+    .src_qs_o     (com_pre_sel_ctl_2_qs), // for software read back
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_pre_sel_ctl_2_qs),
+    .dst_we_o     (aon_com_pre_sel_ctl_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_pre_sel_ctl_2_regwen),
+    .dst_wd_o     (aon_com_pre_sel_ctl_2_wdata)
+  );
+  assign unused_aon_com_pre_sel_ctl_2_wdata =
+      ^aon_com_pre_sel_ctl_2_wdata;
+
+  logic  aon_com_pre_sel_ctl_3_key0_in_sel_3_qs_int;
+  logic  aon_com_pre_sel_ctl_3_key1_in_sel_3_qs_int;
+  logic  aon_com_pre_sel_ctl_3_key2_in_sel_3_qs_int;
+  logic  aon_com_pre_sel_ctl_3_pwrb_in_sel_3_qs_int;
+  logic  aon_com_pre_sel_ctl_3_ac_present_sel_3_qs_int;
+  logic [4:0] aon_com_pre_sel_ctl_3_qs;
+  logic [4:0] aon_com_pre_sel_ctl_3_wdata;
+  logic aon_com_pre_sel_ctl_3_we;
+  logic unused_aon_com_pre_sel_ctl_3_wdata;
+  logic aon_com_pre_sel_ctl_3_regwen;
+
+  always_comb begin
+    aon_com_pre_sel_ctl_3_qs = 5'h0;
+    aon_com_pre_sel_ctl_3_qs[0] = aon_com_pre_sel_ctl_3_key0_in_sel_3_qs_int;
+    aon_com_pre_sel_ctl_3_qs[1] = aon_com_pre_sel_ctl_3_key1_in_sel_3_qs_int;
+    aon_com_pre_sel_ctl_3_qs[2] = aon_com_pre_sel_ctl_3_key2_in_sel_3_qs_int;
+    aon_com_pre_sel_ctl_3_qs[3] = aon_com_pre_sel_ctl_3_pwrb_in_sel_3_qs_int;
+    aon_com_pre_sel_ctl_3_qs[4] = aon_com_pre_sel_ctl_3_ac_present_sel_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f),
+    .DstWrReq(0)
+  ) u_com_pre_sel_ctl_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_pre_sel_ctl_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (com_pre_sel_ctl_3_busy),
+    .src_qs_o     (com_pre_sel_ctl_3_qs), // for software read back
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_pre_sel_ctl_3_qs),
+    .dst_we_o     (aon_com_pre_sel_ctl_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_pre_sel_ctl_3_regwen),
+    .dst_wd_o     (aon_com_pre_sel_ctl_3_wdata)
+  );
+  assign unused_aon_com_pre_sel_ctl_3_wdata =
+      ^aon_com_pre_sel_ctl_3_wdata;
+
+  logic [31:0]  aon_com_pre_det_ctl_0_qs_int;
+  logic [31:0] aon_com_pre_det_ctl_0_qs;
+  logic [31:0] aon_com_pre_det_ctl_0_wdata;
+  logic aon_com_pre_det_ctl_0_we;
+  logic unused_aon_com_pre_det_ctl_0_wdata;
+  logic aon_com_pre_det_ctl_0_regwen;
+
+  always_comb begin
+    aon_com_pre_det_ctl_0_qs = 32'h0;
+    aon_com_pre_det_ctl_0_qs = aon_com_pre_det_ctl_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'hffffffff),
+    .DstWrReq(0)
+  ) u_com_pre_det_ctl_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_pre_det_ctl_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (com_pre_det_ctl_0_busy),
+    .src_qs_o     (com_pre_det_ctl_0_qs), // for software read back
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_pre_det_ctl_0_qs),
+    .dst_we_o     (aon_com_pre_det_ctl_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_pre_det_ctl_0_regwen),
+    .dst_wd_o     (aon_com_pre_det_ctl_0_wdata)
+  );
+  assign unused_aon_com_pre_det_ctl_0_wdata =
+      ^aon_com_pre_det_ctl_0_wdata;
+
+  logic [31:0]  aon_com_pre_det_ctl_1_qs_int;
+  logic [31:0] aon_com_pre_det_ctl_1_qs;
+  logic [31:0] aon_com_pre_det_ctl_1_wdata;
+  logic aon_com_pre_det_ctl_1_we;
+  logic unused_aon_com_pre_det_ctl_1_wdata;
+  logic aon_com_pre_det_ctl_1_regwen;
+
+  always_comb begin
+    aon_com_pre_det_ctl_1_qs = 32'h0;
+    aon_com_pre_det_ctl_1_qs = aon_com_pre_det_ctl_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'hffffffff),
+    .DstWrReq(0)
+  ) u_com_pre_det_ctl_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_pre_det_ctl_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (com_pre_det_ctl_1_busy),
+    .src_qs_o     (com_pre_det_ctl_1_qs), // for software read back
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_pre_det_ctl_1_qs),
+    .dst_we_o     (aon_com_pre_det_ctl_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_pre_det_ctl_1_regwen),
+    .dst_wd_o     (aon_com_pre_det_ctl_1_wdata)
+  );
+  assign unused_aon_com_pre_det_ctl_1_wdata =
+      ^aon_com_pre_det_ctl_1_wdata;
+
+  logic [31:0]  aon_com_pre_det_ctl_2_qs_int;
+  logic [31:0] aon_com_pre_det_ctl_2_qs;
+  logic [31:0] aon_com_pre_det_ctl_2_wdata;
+  logic aon_com_pre_det_ctl_2_we;
+  logic unused_aon_com_pre_det_ctl_2_wdata;
+  logic aon_com_pre_det_ctl_2_regwen;
+
+  always_comb begin
+    aon_com_pre_det_ctl_2_qs = 32'h0;
+    aon_com_pre_det_ctl_2_qs = aon_com_pre_det_ctl_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'hffffffff),
+    .DstWrReq(0)
+  ) u_com_pre_det_ctl_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_pre_det_ctl_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (com_pre_det_ctl_2_busy),
+    .src_qs_o     (com_pre_det_ctl_2_qs), // for software read back
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_pre_det_ctl_2_qs),
+    .dst_we_o     (aon_com_pre_det_ctl_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_pre_det_ctl_2_regwen),
+    .dst_wd_o     (aon_com_pre_det_ctl_2_wdata)
+  );
+  assign unused_aon_com_pre_det_ctl_2_wdata =
+      ^aon_com_pre_det_ctl_2_wdata;
+
+  logic [31:0]  aon_com_pre_det_ctl_3_qs_int;
+  logic [31:0] aon_com_pre_det_ctl_3_qs;
+  logic [31:0] aon_com_pre_det_ctl_3_wdata;
+  logic aon_com_pre_det_ctl_3_we;
+  logic unused_aon_com_pre_det_ctl_3_wdata;
+  logic aon_com_pre_det_ctl_3_regwen;
+
+  always_comb begin
+    aon_com_pre_det_ctl_3_qs = 32'h0;
+    aon_com_pre_det_ctl_3_qs = aon_com_pre_det_ctl_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'hffffffff),
+    .DstWrReq(0)
+  ) u_com_pre_det_ctl_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_pre_det_ctl_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (com_pre_det_ctl_3_busy),
+    .src_qs_o     (com_pre_det_ctl_3_qs), // for software read back
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_com_pre_det_ctl_3_qs),
+    .dst_we_o     (aon_com_pre_det_ctl_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_pre_det_ctl_3_regwen),
+    .dst_wd_o     (aon_com_pre_det_ctl_3_wdata)
+  );
+  assign unused_aon_com_pre_det_ctl_3_wdata =
+      ^aon_com_pre_det_ctl_3_wdata;
 
   logic  aon_com_sel_ctl_0_key0_in_sel_0_qs_int;
   logic  aon_com_sel_ctl_0_key1_in_sel_0_qs_int;
@@ -3937,6 +4305,674 @@ module sysrst_ctrl_reg_top (
   );
 
 
+  // Subregister 0 of Multireg com_pre_sel_ctl
+  // R[com_pre_sel_ctl_0]: V(False)
+  // Create REGWEN-gated WE signal
+  logic aon_com_pre_sel_ctl_0_gated_we;
+  assign aon_com_pre_sel_ctl_0_gated_we = aon_com_pre_sel_ctl_0_we & aon_com_pre_sel_ctl_0_regwen;
+  //   F[key0_in_sel_0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_0_key0_in_sel_0 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_0_gated_we),
+    .wd     (aon_com_pre_sel_ctl_0_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[0].key0_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_0_key0_in_sel_0_qs_int)
+  );
+
+  //   F[key1_in_sel_0]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_0_key1_in_sel_0 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_0_gated_we),
+    .wd     (aon_com_pre_sel_ctl_0_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[0].key1_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_0_key1_in_sel_0_qs_int)
+  );
+
+  //   F[key2_in_sel_0]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_0_key2_in_sel_0 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_0_gated_we),
+    .wd     (aon_com_pre_sel_ctl_0_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[0].key2_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_0_key2_in_sel_0_qs_int)
+  );
+
+  //   F[pwrb_in_sel_0]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_0_pwrb_in_sel_0 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_0_gated_we),
+    .wd     (aon_com_pre_sel_ctl_0_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[0].pwrb_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_0_pwrb_in_sel_0_qs_int)
+  );
+
+  //   F[ac_present_sel_0]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_0_ac_present_sel_0 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_0_gated_we),
+    .wd     (aon_com_pre_sel_ctl_0_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[0].ac_present_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_0_ac_present_sel_0_qs_int)
+  );
+
+
+  // Subregister 1 of Multireg com_pre_sel_ctl
+  // R[com_pre_sel_ctl_1]: V(False)
+  // Create REGWEN-gated WE signal
+  logic aon_com_pre_sel_ctl_1_gated_we;
+  assign aon_com_pre_sel_ctl_1_gated_we = aon_com_pre_sel_ctl_1_we & aon_com_pre_sel_ctl_1_regwen;
+  //   F[key0_in_sel_1]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_1_key0_in_sel_1 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_1_gated_we),
+    .wd     (aon_com_pre_sel_ctl_1_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[1].key0_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_1_key0_in_sel_1_qs_int)
+  );
+
+  //   F[key1_in_sel_1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_1_key1_in_sel_1 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_1_gated_we),
+    .wd     (aon_com_pre_sel_ctl_1_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[1].key1_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_1_key1_in_sel_1_qs_int)
+  );
+
+  //   F[key2_in_sel_1]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_1_key2_in_sel_1 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_1_gated_we),
+    .wd     (aon_com_pre_sel_ctl_1_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[1].key2_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_1_key2_in_sel_1_qs_int)
+  );
+
+  //   F[pwrb_in_sel_1]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_1_pwrb_in_sel_1 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_1_gated_we),
+    .wd     (aon_com_pre_sel_ctl_1_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[1].pwrb_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_1_pwrb_in_sel_1_qs_int)
+  );
+
+  //   F[ac_present_sel_1]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_1_ac_present_sel_1 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_1_gated_we),
+    .wd     (aon_com_pre_sel_ctl_1_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[1].ac_present_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_1_ac_present_sel_1_qs_int)
+  );
+
+
+  // Subregister 2 of Multireg com_pre_sel_ctl
+  // R[com_pre_sel_ctl_2]: V(False)
+  // Create REGWEN-gated WE signal
+  logic aon_com_pre_sel_ctl_2_gated_we;
+  assign aon_com_pre_sel_ctl_2_gated_we = aon_com_pre_sel_ctl_2_we & aon_com_pre_sel_ctl_2_regwen;
+  //   F[key0_in_sel_2]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_2_key0_in_sel_2 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_2_gated_we),
+    .wd     (aon_com_pre_sel_ctl_2_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[2].key0_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_2_key0_in_sel_2_qs_int)
+  );
+
+  //   F[key1_in_sel_2]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_2_key1_in_sel_2 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_2_gated_we),
+    .wd     (aon_com_pre_sel_ctl_2_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[2].key1_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_2_key1_in_sel_2_qs_int)
+  );
+
+  //   F[key2_in_sel_2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_2_key2_in_sel_2 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_2_gated_we),
+    .wd     (aon_com_pre_sel_ctl_2_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[2].key2_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_2_key2_in_sel_2_qs_int)
+  );
+
+  //   F[pwrb_in_sel_2]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_2_pwrb_in_sel_2 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_2_gated_we),
+    .wd     (aon_com_pre_sel_ctl_2_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[2].pwrb_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_2_pwrb_in_sel_2_qs_int)
+  );
+
+  //   F[ac_present_sel_2]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_2_ac_present_sel_2 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_2_gated_we),
+    .wd     (aon_com_pre_sel_ctl_2_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[2].ac_present_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_2_ac_present_sel_2_qs_int)
+  );
+
+
+  // Subregister 3 of Multireg com_pre_sel_ctl
+  // R[com_pre_sel_ctl_3]: V(False)
+  // Create REGWEN-gated WE signal
+  logic aon_com_pre_sel_ctl_3_gated_we;
+  assign aon_com_pre_sel_ctl_3_gated_we = aon_com_pre_sel_ctl_3_we & aon_com_pre_sel_ctl_3_regwen;
+  //   F[key0_in_sel_3]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_3_key0_in_sel_3 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_3_gated_we),
+    .wd     (aon_com_pre_sel_ctl_3_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[3].key0_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_3_key0_in_sel_3_qs_int)
+  );
+
+  //   F[key1_in_sel_3]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_3_key1_in_sel_3 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_3_gated_we),
+    .wd     (aon_com_pre_sel_ctl_3_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[3].key1_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_3_key1_in_sel_3_qs_int)
+  );
+
+  //   F[key2_in_sel_3]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_3_key2_in_sel_3 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_3_gated_we),
+    .wd     (aon_com_pre_sel_ctl_3_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[3].key2_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_3_key2_in_sel_3_qs_int)
+  );
+
+  //   F[pwrb_in_sel_3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_3_pwrb_in_sel_3 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_3_gated_we),
+    .wd     (aon_com_pre_sel_ctl_3_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[3].pwrb_in_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_3_pwrb_in_sel_3_qs_int)
+  );
+
+  //   F[ac_present_sel_3]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_com_pre_sel_ctl_3_ac_present_sel_3 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_sel_ctl_3_gated_we),
+    .wd     (aon_com_pre_sel_ctl_3_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_sel_ctl[3].ac_present_sel.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_sel_ctl_3_ac_present_sel_3_qs_int)
+  );
+
+
+  // Subregister 0 of Multireg com_pre_det_ctl
+  // R[com_pre_det_ctl_0]: V(False)
+  // Create REGWEN-gated WE signal
+  logic aon_com_pre_det_ctl_0_gated_we;
+  assign aon_com_pre_det_ctl_0_gated_we = aon_com_pre_det_ctl_0_we & aon_com_pre_det_ctl_0_regwen;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_com_pre_det_ctl_0 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_det_ctl_0_gated_we),
+    .wd     (aon_com_pre_det_ctl_0_wdata[31:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_det_ctl[0].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_det_ctl_0_qs_int)
+  );
+
+
+  // Subregister 1 of Multireg com_pre_det_ctl
+  // R[com_pre_det_ctl_1]: V(False)
+  // Create REGWEN-gated WE signal
+  logic aon_com_pre_det_ctl_1_gated_we;
+  assign aon_com_pre_det_ctl_1_gated_we = aon_com_pre_det_ctl_1_we & aon_com_pre_det_ctl_1_regwen;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_com_pre_det_ctl_1 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_det_ctl_1_gated_we),
+    .wd     (aon_com_pre_det_ctl_1_wdata[31:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_det_ctl[1].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_det_ctl_1_qs_int)
+  );
+
+
+  // Subregister 2 of Multireg com_pre_det_ctl
+  // R[com_pre_det_ctl_2]: V(False)
+  // Create REGWEN-gated WE signal
+  logic aon_com_pre_det_ctl_2_gated_we;
+  assign aon_com_pre_det_ctl_2_gated_we = aon_com_pre_det_ctl_2_we & aon_com_pre_det_ctl_2_regwen;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_com_pre_det_ctl_2 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_det_ctl_2_gated_we),
+    .wd     (aon_com_pre_det_ctl_2_wdata[31:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_det_ctl[2].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_det_ctl_2_qs_int)
+  );
+
+
+  // Subregister 3 of Multireg com_pre_det_ctl
+  // R[com_pre_det_ctl_3]: V(False)
+  // Create REGWEN-gated WE signal
+  logic aon_com_pre_det_ctl_3_gated_we;
+  assign aon_com_pre_det_ctl_3_gated_we = aon_com_pre_det_ctl_3_we & aon_com_pre_det_ctl_3_regwen;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_com_pre_det_ctl_3 (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_pre_det_ctl_3_gated_we),
+    .wd     (aon_com_pre_det_ctl_3_wdata[31:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_pre_det_ctl[3].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (aon_com_pre_det_ctl_3_qs_int)
+  );
+
+
   // Subregister 0 of Multireg com_sel_ctl
   // R[com_sel_ctl_0]: V(False)
   // Create REGWEN-gated WE signal
@@ -5522,7 +6558,7 @@ module sysrst_ctrl_reg_top (
 
 
 
-  logic [34:0] addr_hit;
+  logic [42:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SYSRST_CTRL_INTR_STATE_OFFSET);
@@ -5546,20 +6582,28 @@ module sysrst_ctrl_reg_top (
     addr_hit[18] = (reg_addr == SYSRST_CTRL_KEY_INTR_DEBOUNCE_CTL_OFFSET);
     addr_hit[19] = (reg_addr == SYSRST_CTRL_AUTO_BLOCK_DEBOUNCE_CTL_OFFSET);
     addr_hit[20] = (reg_addr == SYSRST_CTRL_AUTO_BLOCK_OUT_CTL_OFFSET);
-    addr_hit[21] = (reg_addr == SYSRST_CTRL_COM_SEL_CTL_0_OFFSET);
-    addr_hit[22] = (reg_addr == SYSRST_CTRL_COM_SEL_CTL_1_OFFSET);
-    addr_hit[23] = (reg_addr == SYSRST_CTRL_COM_SEL_CTL_2_OFFSET);
-    addr_hit[24] = (reg_addr == SYSRST_CTRL_COM_SEL_CTL_3_OFFSET);
-    addr_hit[25] = (reg_addr == SYSRST_CTRL_COM_DET_CTL_0_OFFSET);
-    addr_hit[26] = (reg_addr == SYSRST_CTRL_COM_DET_CTL_1_OFFSET);
-    addr_hit[27] = (reg_addr == SYSRST_CTRL_COM_DET_CTL_2_OFFSET);
-    addr_hit[28] = (reg_addr == SYSRST_CTRL_COM_DET_CTL_3_OFFSET);
-    addr_hit[29] = (reg_addr == SYSRST_CTRL_COM_OUT_CTL_0_OFFSET);
-    addr_hit[30] = (reg_addr == SYSRST_CTRL_COM_OUT_CTL_1_OFFSET);
-    addr_hit[31] = (reg_addr == SYSRST_CTRL_COM_OUT_CTL_2_OFFSET);
-    addr_hit[32] = (reg_addr == SYSRST_CTRL_COM_OUT_CTL_3_OFFSET);
-    addr_hit[33] = (reg_addr == SYSRST_CTRL_COMBO_INTR_STATUS_OFFSET);
-    addr_hit[34] = (reg_addr == SYSRST_CTRL_KEY_INTR_STATUS_OFFSET);
+    addr_hit[21] = (reg_addr == SYSRST_CTRL_COM_PRE_SEL_CTL_0_OFFSET);
+    addr_hit[22] = (reg_addr == SYSRST_CTRL_COM_PRE_SEL_CTL_1_OFFSET);
+    addr_hit[23] = (reg_addr == SYSRST_CTRL_COM_PRE_SEL_CTL_2_OFFSET);
+    addr_hit[24] = (reg_addr == SYSRST_CTRL_COM_PRE_SEL_CTL_3_OFFSET);
+    addr_hit[25] = (reg_addr == SYSRST_CTRL_COM_PRE_DET_CTL_0_OFFSET);
+    addr_hit[26] = (reg_addr == SYSRST_CTRL_COM_PRE_DET_CTL_1_OFFSET);
+    addr_hit[27] = (reg_addr == SYSRST_CTRL_COM_PRE_DET_CTL_2_OFFSET);
+    addr_hit[28] = (reg_addr == SYSRST_CTRL_COM_PRE_DET_CTL_3_OFFSET);
+    addr_hit[29] = (reg_addr == SYSRST_CTRL_COM_SEL_CTL_0_OFFSET);
+    addr_hit[30] = (reg_addr == SYSRST_CTRL_COM_SEL_CTL_1_OFFSET);
+    addr_hit[31] = (reg_addr == SYSRST_CTRL_COM_SEL_CTL_2_OFFSET);
+    addr_hit[32] = (reg_addr == SYSRST_CTRL_COM_SEL_CTL_3_OFFSET);
+    addr_hit[33] = (reg_addr == SYSRST_CTRL_COM_DET_CTL_0_OFFSET);
+    addr_hit[34] = (reg_addr == SYSRST_CTRL_COM_DET_CTL_1_OFFSET);
+    addr_hit[35] = (reg_addr == SYSRST_CTRL_COM_DET_CTL_2_OFFSET);
+    addr_hit[36] = (reg_addr == SYSRST_CTRL_COM_DET_CTL_3_OFFSET);
+    addr_hit[37] = (reg_addr == SYSRST_CTRL_COM_OUT_CTL_0_OFFSET);
+    addr_hit[38] = (reg_addr == SYSRST_CTRL_COM_OUT_CTL_1_OFFSET);
+    addr_hit[39] = (reg_addr == SYSRST_CTRL_COM_OUT_CTL_2_OFFSET);
+    addr_hit[40] = (reg_addr == SYSRST_CTRL_COM_OUT_CTL_3_OFFSET);
+    addr_hit[41] = (reg_addr == SYSRST_CTRL_COMBO_INTR_STATUS_OFFSET);
+    addr_hit[42] = (reg_addr == SYSRST_CTRL_KEY_INTR_STATUS_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -5601,7 +6645,15 @@ module sysrst_ctrl_reg_top (
                (addr_hit[31] & (|(SYSRST_CTRL_PERMIT[31] & ~reg_be))) |
                (addr_hit[32] & (|(SYSRST_CTRL_PERMIT[32] & ~reg_be))) |
                (addr_hit[33] & (|(SYSRST_CTRL_PERMIT[33] & ~reg_be))) |
-               (addr_hit[34] & (|(SYSRST_CTRL_PERMIT[34] & ~reg_be)))));
+               (addr_hit[34] & (|(SYSRST_CTRL_PERMIT[34] & ~reg_be))) |
+               (addr_hit[35] & (|(SYSRST_CTRL_PERMIT[35] & ~reg_be))) |
+               (addr_hit[36] & (|(SYSRST_CTRL_PERMIT[36] & ~reg_be))) |
+               (addr_hit[37] & (|(SYSRST_CTRL_PERMIT[37] & ~reg_be))) |
+               (addr_hit[38] & (|(SYSRST_CTRL_PERMIT[38] & ~reg_be))) |
+               (addr_hit[39] & (|(SYSRST_CTRL_PERMIT[39] & ~reg_be))) |
+               (addr_hit[40] & (|(SYSRST_CTRL_PERMIT[40] & ~reg_be))) |
+               (addr_hit[41] & (|(SYSRST_CTRL_PERMIT[41] & ~reg_be))) |
+               (addr_hit[42] & (|(SYSRST_CTRL_PERMIT[42] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -5709,64 +6761,96 @@ module sysrst_ctrl_reg_top (
 
 
 
-  assign com_sel_ctl_0_we = addr_hit[21] & reg_we & !reg_error;
+  assign com_pre_sel_ctl_0_we = addr_hit[21] & reg_we & !reg_error;
 
 
 
 
 
-  assign com_sel_ctl_1_we = addr_hit[22] & reg_we & !reg_error;
+  assign com_pre_sel_ctl_1_we = addr_hit[22] & reg_we & !reg_error;
 
 
 
 
 
-  assign com_sel_ctl_2_we = addr_hit[23] & reg_we & !reg_error;
+  assign com_pre_sel_ctl_2_we = addr_hit[23] & reg_we & !reg_error;
 
 
 
 
 
-  assign com_sel_ctl_3_we = addr_hit[24] & reg_we & !reg_error;
+  assign com_pre_sel_ctl_3_we = addr_hit[24] & reg_we & !reg_error;
 
 
 
 
 
-  assign com_det_ctl_0_we = addr_hit[25] & reg_we & !reg_error;
+  assign com_pre_det_ctl_0_we = addr_hit[25] & reg_we & !reg_error;
 
-  assign com_det_ctl_1_we = addr_hit[26] & reg_we & !reg_error;
+  assign com_pre_det_ctl_1_we = addr_hit[26] & reg_we & !reg_error;
 
-  assign com_det_ctl_2_we = addr_hit[27] & reg_we & !reg_error;
+  assign com_pre_det_ctl_2_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign com_det_ctl_3_we = addr_hit[28] & reg_we & !reg_error;
+  assign com_pre_det_ctl_3_we = addr_hit[28] & reg_we & !reg_error;
 
-  assign com_out_ctl_0_we = addr_hit[29] & reg_we & !reg_error;
-
-
-
-
-  assign com_out_ctl_1_we = addr_hit[30] & reg_we & !reg_error;
+  assign com_sel_ctl_0_we = addr_hit[29] & reg_we & !reg_error;
 
 
 
 
-  assign com_out_ctl_2_we = addr_hit[31] & reg_we & !reg_error;
+
+  assign com_sel_ctl_1_we = addr_hit[30] & reg_we & !reg_error;
 
 
 
 
-  assign com_out_ctl_3_we = addr_hit[32] & reg_we & !reg_error;
+
+  assign com_sel_ctl_2_we = addr_hit[31] & reg_we & !reg_error;
 
 
 
 
-  assign combo_intr_status_we = addr_hit[33] & reg_we & !reg_error;
+
+  assign com_sel_ctl_3_we = addr_hit[32] & reg_we & !reg_error;
 
 
 
 
-  assign key_intr_status_we = addr_hit[34] & reg_we & !reg_error;
+
+  assign com_det_ctl_0_we = addr_hit[33] & reg_we & !reg_error;
+
+  assign com_det_ctl_1_we = addr_hit[34] & reg_we & !reg_error;
+
+  assign com_det_ctl_2_we = addr_hit[35] & reg_we & !reg_error;
+
+  assign com_det_ctl_3_we = addr_hit[36] & reg_we & !reg_error;
+
+  assign com_out_ctl_0_we = addr_hit[37] & reg_we & !reg_error;
+
+
+
+
+  assign com_out_ctl_1_we = addr_hit[38] & reg_we & !reg_error;
+
+
+
+
+  assign com_out_ctl_2_we = addr_hit[39] & reg_we & !reg_error;
+
+
+
+
+  assign com_out_ctl_3_we = addr_hit[40] & reg_we & !reg_error;
+
+
+
+
+  assign combo_intr_status_we = addr_hit[41] & reg_we & !reg_error;
+
+
+
+
+  assign key_intr_status_we = addr_hit[42] & reg_we & !reg_error;
 
 
 
@@ -5806,20 +6890,28 @@ module sysrst_ctrl_reg_top (
     reg_we_check[18] = key_intr_debounce_ctl_we;
     reg_we_check[19] = auto_block_debounce_ctl_we;
     reg_we_check[20] = auto_block_out_ctl_we;
-    reg_we_check[21] = com_sel_ctl_0_we;
-    reg_we_check[22] = com_sel_ctl_1_we;
-    reg_we_check[23] = com_sel_ctl_2_we;
-    reg_we_check[24] = com_sel_ctl_3_we;
-    reg_we_check[25] = com_det_ctl_0_we;
-    reg_we_check[26] = com_det_ctl_1_we;
-    reg_we_check[27] = com_det_ctl_2_we;
-    reg_we_check[28] = com_det_ctl_3_we;
-    reg_we_check[29] = com_out_ctl_0_we;
-    reg_we_check[30] = com_out_ctl_1_we;
-    reg_we_check[31] = com_out_ctl_2_we;
-    reg_we_check[32] = com_out_ctl_3_we;
-    reg_we_check[33] = combo_intr_status_we;
-    reg_we_check[34] = key_intr_status_we;
+    reg_we_check[21] = com_pre_sel_ctl_0_we;
+    reg_we_check[22] = com_pre_sel_ctl_1_we;
+    reg_we_check[23] = com_pre_sel_ctl_2_we;
+    reg_we_check[24] = com_pre_sel_ctl_3_we;
+    reg_we_check[25] = com_pre_det_ctl_0_we;
+    reg_we_check[26] = com_pre_det_ctl_1_we;
+    reg_we_check[27] = com_pre_det_ctl_2_we;
+    reg_we_check[28] = com_pre_det_ctl_3_we;
+    reg_we_check[29] = com_sel_ctl_0_we;
+    reg_we_check[30] = com_sel_ctl_1_we;
+    reg_we_check[31] = com_sel_ctl_2_we;
+    reg_we_check[32] = com_sel_ctl_3_we;
+    reg_we_check[33] = com_det_ctl_0_we;
+    reg_we_check[34] = com_det_ctl_1_we;
+    reg_we_check[35] = com_det_ctl_2_we;
+    reg_we_check[36] = com_det_ctl_3_we;
+    reg_we_check[37] = com_out_ctl_0_we;
+    reg_we_check[38] = com_out_ctl_1_we;
+    reg_we_check[39] = com_out_ctl_2_we;
+    reg_we_check[40] = com_out_ctl_3_we;
+    reg_we_check[41] = combo_intr_status_we;
+    reg_we_check[42] = key_intr_status_we;
   end
 
   // Read data return
@@ -5903,45 +6995,69 @@ module sysrst_ctrl_reg_top (
         reg_rdata_next = DW'(auto_block_out_ctl_qs);
       end
       addr_hit[21]: begin
-        reg_rdata_next = DW'(com_sel_ctl_0_qs);
+        reg_rdata_next = DW'(com_pre_sel_ctl_0_qs);
       end
       addr_hit[22]: begin
-        reg_rdata_next = DW'(com_sel_ctl_1_qs);
+        reg_rdata_next = DW'(com_pre_sel_ctl_1_qs);
       end
       addr_hit[23]: begin
-        reg_rdata_next = DW'(com_sel_ctl_2_qs);
+        reg_rdata_next = DW'(com_pre_sel_ctl_2_qs);
       end
       addr_hit[24]: begin
-        reg_rdata_next = DW'(com_sel_ctl_3_qs);
+        reg_rdata_next = DW'(com_pre_sel_ctl_3_qs);
       end
       addr_hit[25]: begin
-        reg_rdata_next = DW'(com_det_ctl_0_qs);
+        reg_rdata_next = DW'(com_pre_det_ctl_0_qs);
       end
       addr_hit[26]: begin
-        reg_rdata_next = DW'(com_det_ctl_1_qs);
+        reg_rdata_next = DW'(com_pre_det_ctl_1_qs);
       end
       addr_hit[27]: begin
-        reg_rdata_next = DW'(com_det_ctl_2_qs);
+        reg_rdata_next = DW'(com_pre_det_ctl_2_qs);
       end
       addr_hit[28]: begin
-        reg_rdata_next = DW'(com_det_ctl_3_qs);
+        reg_rdata_next = DW'(com_pre_det_ctl_3_qs);
       end
       addr_hit[29]: begin
-        reg_rdata_next = DW'(com_out_ctl_0_qs);
+        reg_rdata_next = DW'(com_sel_ctl_0_qs);
       end
       addr_hit[30]: begin
-        reg_rdata_next = DW'(com_out_ctl_1_qs);
+        reg_rdata_next = DW'(com_sel_ctl_1_qs);
       end
       addr_hit[31]: begin
-        reg_rdata_next = DW'(com_out_ctl_2_qs);
+        reg_rdata_next = DW'(com_sel_ctl_2_qs);
       end
       addr_hit[32]: begin
-        reg_rdata_next = DW'(com_out_ctl_3_qs);
+        reg_rdata_next = DW'(com_sel_ctl_3_qs);
       end
       addr_hit[33]: begin
-        reg_rdata_next = DW'(combo_intr_status_qs);
+        reg_rdata_next = DW'(com_det_ctl_0_qs);
       end
       addr_hit[34]: begin
+        reg_rdata_next = DW'(com_det_ctl_1_qs);
+      end
+      addr_hit[35]: begin
+        reg_rdata_next = DW'(com_det_ctl_2_qs);
+      end
+      addr_hit[36]: begin
+        reg_rdata_next = DW'(com_det_ctl_3_qs);
+      end
+      addr_hit[37]: begin
+        reg_rdata_next = DW'(com_out_ctl_0_qs);
+      end
+      addr_hit[38]: begin
+        reg_rdata_next = DW'(com_out_ctl_1_qs);
+      end
+      addr_hit[39]: begin
+        reg_rdata_next = DW'(com_out_ctl_2_qs);
+      end
+      addr_hit[40]: begin
+        reg_rdata_next = DW'(com_out_ctl_3_qs);
+      end
+      addr_hit[41]: begin
+        reg_rdata_next = DW'(combo_intr_status_qs);
+      end
+      addr_hit[42]: begin
         reg_rdata_next = DW'(key_intr_status_qs);
       end
       default: begin
@@ -6006,45 +7122,69 @@ module sysrst_ctrl_reg_top (
         reg_busy_sel = auto_block_out_ctl_busy;
       end
       addr_hit[21]: begin
-        reg_busy_sel = com_sel_ctl_0_busy;
+        reg_busy_sel = com_pre_sel_ctl_0_busy;
       end
       addr_hit[22]: begin
-        reg_busy_sel = com_sel_ctl_1_busy;
+        reg_busy_sel = com_pre_sel_ctl_1_busy;
       end
       addr_hit[23]: begin
-        reg_busy_sel = com_sel_ctl_2_busy;
+        reg_busy_sel = com_pre_sel_ctl_2_busy;
       end
       addr_hit[24]: begin
-        reg_busy_sel = com_sel_ctl_3_busy;
+        reg_busy_sel = com_pre_sel_ctl_3_busy;
       end
       addr_hit[25]: begin
-        reg_busy_sel = com_det_ctl_0_busy;
+        reg_busy_sel = com_pre_det_ctl_0_busy;
       end
       addr_hit[26]: begin
-        reg_busy_sel = com_det_ctl_1_busy;
+        reg_busy_sel = com_pre_det_ctl_1_busy;
       end
       addr_hit[27]: begin
-        reg_busy_sel = com_det_ctl_2_busy;
+        reg_busy_sel = com_pre_det_ctl_2_busy;
       end
       addr_hit[28]: begin
-        reg_busy_sel = com_det_ctl_3_busy;
+        reg_busy_sel = com_pre_det_ctl_3_busy;
       end
       addr_hit[29]: begin
-        reg_busy_sel = com_out_ctl_0_busy;
+        reg_busy_sel = com_sel_ctl_0_busy;
       end
       addr_hit[30]: begin
-        reg_busy_sel = com_out_ctl_1_busy;
+        reg_busy_sel = com_sel_ctl_1_busy;
       end
       addr_hit[31]: begin
-        reg_busy_sel = com_out_ctl_2_busy;
+        reg_busy_sel = com_sel_ctl_2_busy;
       end
       addr_hit[32]: begin
-        reg_busy_sel = com_out_ctl_3_busy;
+        reg_busy_sel = com_sel_ctl_3_busy;
       end
       addr_hit[33]: begin
-        reg_busy_sel = combo_intr_status_busy;
+        reg_busy_sel = com_det_ctl_0_busy;
       end
       addr_hit[34]: begin
+        reg_busy_sel = com_det_ctl_1_busy;
+      end
+      addr_hit[35]: begin
+        reg_busy_sel = com_det_ctl_2_busy;
+      end
+      addr_hit[36]: begin
+        reg_busy_sel = com_det_ctl_3_busy;
+      end
+      addr_hit[37]: begin
+        reg_busy_sel = com_out_ctl_0_busy;
+      end
+      addr_hit[38]: begin
+        reg_busy_sel = com_out_ctl_1_busy;
+      end
+      addr_hit[39]: begin
+        reg_busy_sel = com_out_ctl_2_busy;
+      end
+      addr_hit[40]: begin
+        reg_busy_sel = com_out_ctl_3_busy;
+      end
+      addr_hit[41]: begin
+        reg_busy_sel = combo_intr_status_busy;
+      end
+      addr_hit[42]: begin
         reg_busy_sel = key_intr_status_busy;
       end
       default: begin


### PR DESCRIPTION
This adds support for programmable pre-conditions to the combo detection circuit. See #16928 for more details.

Signed-off-by: Michael Schaffner <msf@google.com>