### PR TITLE
[crypto] Add and test cryptolib-specific status macros.

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -145,9 +145,6 @@ cc_library(
 cc_test(
     name = "hardened_unittest",
     srcs = ["hardened_unittest.cc"],
-    defines = [
-        "OT_OFF_TARGET_TEST",
-    ],
     deps = [
         ":hardened",
         "@googletest//:gtest_main",

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -169,9 +169,6 @@ cc_library(
 cc_test(
     name = "hardened_status_unittest",
     srcs = ["hardened_status_unittest.cc"],
-    defines = [
-        "OT_OFF_TARGET_TEST",
-    ],
     deps = [
         ":hardened_status",
         "@googletest//:gtest_main",

--- a/sw/device/lib/base/hardened_status.c
+++ b/sw/device/lib/base/hardened_status.c
@@ -9,7 +9,7 @@
 
 hardened_bool_t hardened_status_ok(status_t s) {
   if (launder32(s.value) >= 0 && launder32(s.value) == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(s.value, kHardenedBoolTrue);
+    HARDENED_CHECK_EQ((hardened_bool_t)s.value, kHardenedBoolTrue);
     return s.value;
   }
   return kHardenedBoolFalse;

--- a/sw/device/lib/base/hardened_status.h
+++ b/sw/device/lib/base/hardened_status.h
@@ -23,7 +23,7 @@ extern "C" {
  * This passes `kHardenedBoolTrue` as the status code argument, for extra bits
  * of redundancy in `HARDENED_TRY` and others.
  */
-#define HARDENED_OK_STATUS OK_STATUS(kHardenedBoolTrue)
+#define HARDENED_OK_STATUS ((status_t){.value = kHardenedBoolTrue})
 
 /**
  * Hardened version of the `TRY` macro from `status.h`.
@@ -31,21 +31,21 @@ extern "C" {
  * @param expr_ An expression that evaluates to a `status_t`.
  * @return The enclosed OK value.
  */
-#define HARDENED_TRY(expr_)                                            \
-  ({                                                                   \
-    status_t status_ = expr_;                                          \
-    if (!(status_ok(status_) && status_.value == kHardenedBoolTrue)) { \
-      return status_;                                                  \
-    }                                                                  \
-    HARDENED_CHECK_EQ(status_.value, kHardenedBoolTrue);               \
-    status_.value;                                                     \
+#define HARDENED_TRY(expr_)                                 \
+  ({                                                        \
+    status_t status_ = expr_;                               \
+    if (hardened_status_ok(status_) != kHardenedBoolTrue) { \
+      return status_;                                       \
+    }                                                       \
+    HARDENED_CHECK_EQ(status_.value, kHardenedBoolTrue);    \
+    status_.value;                                          \
   })
 
 /**
  * Hardened version of `status_ok`.
  *
  * Returns `kHardenedBoolTrue` if the status is OK with an argument code of
- * `kHardenedBoolTrue` (i.e. a result of `HARDENED_OK()`), and
+ * `kHardenedBoolTrue` (i.e. equal to `HARDENED_OK_STATUS`), and
  * `kHardenedBoolFalse` otherwise.
  *
  * @param s The status code.

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -9,10 +9,10 @@ cc_library(
     srcs = ["integrity_check.c"],
     hdrs = [
         "integrity_check.h",
-        "//sw/device/lib/crypto/include:datatypes.h",
     ],
     deps = [
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/crypto/include:datatypes",
     ],
 )
 
@@ -21,11 +21,32 @@ cc_library(
     srcs = ["hash.c"],
     hdrs = [
         "//sw/device/lib/crypto/drivers:kmac.h",
-        "//sw/device/lib/crypto/include:datatypes.h",
         "//sw/device/lib/crypto/include:hash.h",
     ],
     deps = [
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/crypto/drivers:kmac",
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
+cc_library(
+    name = "status",
+    srcs = ["status.c"],
+    hdrs = [
+        "status.h",
+    ],
+    deps = [
+        "//sw/device/lib/base:hardened_status",
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
+cc_test(
+    name = "status_unittest",
+    srcs = ["status_unittest.cc"],
+    deps = [
+        ":status",
+        "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/lib/crypto/impl/status.c
+++ b/sw/device/lib/crypto/impl/status.c
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/status.h"
+
+#include "sw/device/lib/base/hardened_status.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+crypto_status_t crypto_status_interpret(status_t status) {
+  // First, check for a hardened-ok status.
+  uint32_t res = launder32(kCryptoStatusOK ^ kHardenedBoolTrue);
+  hardened_bool_t is_ok = hardened_status_ok(status);
+  if (launder32(is_ok) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(is_ok, kHardenedBoolTrue);
+    return res ^ is_ok;
+  }
+  HARDENED_CHECK_NE(is_ok, kHardenedBoolTrue);
+
+  switch (status_err(status)) {
+    case kOk:
+      // This status indicates OK but the hardened value doesn't match; return
+      // an error.
+      return kCryptoStatusInternalError;
+    case kInvalidArgument:
+      return kCryptoStatusBadArgs;
+    case kUnavailable:
+      return kCryptoStatusAsyncIncomplete;
+    case kCancelled:
+      return kCryptoStatusInternalError;
+    case kDeadlineExceeded:
+      return kCryptoStatusInternalError;
+    case kNotFound:
+      return kCryptoStatusInternalError;
+    case kAlreadyExists:
+      return kCryptoStatusInternalError;
+    case kPermissionDenied:
+      return kCryptoStatusInternalError;
+    case kResourceExhausted:
+      return kCryptoStatusInternalError;
+    case kAborted:
+      return kCryptoStatusInternalError;
+    case kOutOfRange:
+      return kCryptoStatusInternalError;
+    case kUnimplemented:
+      return kCryptoStatusInternalError;
+    case kUnauthenticated:
+      return kCryptoStatusInternalError;
+    case kUnknown:
+      return kCryptoStatusFatalError;
+    case kFailedPrecondition:
+      return kCryptoStatusFatalError;
+    case kInternal:
+      return kCryptoStatusFatalError;
+    case kDataLoss:
+      return kCryptoStatusFatalError;
+    default:
+      // Conservatively return a fatal error in case we encounter something
+      // unexpected.
+      return kCryptoStatusFatalError;
+  }
+
+  HARDENED_UNREACHABLE();
+  return kCryptoStatusFatalError;
+}

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -1,0 +1,98 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_STATUS_H_
+
+#include "sw/device/lib/base/hardened_status.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Values in `status_t` that are guaranteed to correspond to each
+ * `crypto_status_t` value.
+ *
+ * Note: These values bypass `status_create` to avoid having a function call in
+ * error cases, where we may be under attack and complexity should be
+ * minimized.
+ */
+#define OTCRYPTO_OK HARDENED_OK_STATUS
+#define OTCRYPTO_RECOV_ERR                                      \
+  ((status_t){.value = (int32_t)(0x80000000 | kStatusModuleId | \
+                                 ((__LINE__ & 0x7ff) << 5) | kAborted)})
+#define OTCRYPTO_FATAL_ERR                                 \
+  ((status_t){.value =                                     \
+                  (int32_t)(0x80000000 | kStatusModuleId | \
+                            ((__LINE__ & 0x7ff) << 5) | kFailedPrecondition)})
+#define OTCRYPTO_BAD_ARGS                                  \
+  ((status_t){.value =                                     \
+                  (int32_t)(0x80000000 | kStatusModuleId | \
+                            ((__LINE__ & 0x7ff) << 5) | kInvalidArgument)})
+#define OTCRYPTO_ASYNC_INCOMPLETE                               \
+  ((status_t){.value = (int32_t)(0x80000000 | kStatusModuleId | \
+                                 ((__LINE__ & 0x7ff) << 5) | kUnavailable)})
+
+/**
+ * Convert a `status_t` into a `crypto_status_t`.
+ *
+ * For OK statuses, this routine will only convert to `kCryptoStatusOK` if the
+ * `hardened_status_ok` passes. An OK status with a different value will be
+ * rejected and result in `kCryptoStatusInternalError`.
+ *
+ * The status mapping is as follows:
+ *
+ *   | status code         | cryptolib status code        |
+ *   |---------------------|------------------------------|
+ *   | kOk                 | kCryptoStatusOK OR           |
+ *   |                     |   kCryptoStatusInternalError |
+ *   | kInvalidArgument    | kCryptoStatusBadArgs         |
+ *   | kUnavailable        | kCryptoStatusAsyncIncomplete |
+ *   | kCancelled          | kCryptoStatusInternalError   |
+ *   | kDeadlineExceeded   | kCryptoStatusInternalError   |
+ *   | kNotFound           | kCryptoStatusInternalError   |
+ *   | kAlreadyExists      | kCryptoStatusInternalError   |
+ *   | kPermissionDenied   | kCryptoStatusInternalError   |
+ *   | kResourceExhausted  | kCryptoStatusInternalError   |
+ *   | kAborted            | kCryptoStatusInternalError   |
+ *   | kOutOfRange         | kCryptoStatusInternalError   |
+ *   | kUnimplemented      | kCryptoStatusInternalError   |
+ *   | kUnauthenticated    | kCryptoStatusInternalError   |
+ *   | kUnknown            | kCryptoStatusFatalError      |
+ *   | kFailedPrecondition | kCryptoStatusFatalError      |
+ *   | kInternal           | kCryptoStatusFatalError      |
+ *   | kDataLoss           | kCryptoStatusFatalError      |
+ *
+ * @param status Initial `status_t` value.
+ * @return Equivalent `crypto_status_t` error code.
+ */
+crypto_status_t crypto_status_interpret(status_t status);
+
+/**
+ * Checks a `status_t` and returns a `crypto_status_t` on error.
+ *
+ * This is equvalent to `HARDENED_TRY` except that in the error case, it
+ * converts the error to `crypto_status_t` before returning.
+ *
+ * @param expr_ An expression that evaluates to a `status_t`.
+ * @return The enclosed OK value.
+ */
+#define OTCRYPTO_TRY_INTERPRET(expr_)                       \
+  ({                                                        \
+    status_t status_ = expr_;                               \
+    if (hardened_status_ok(status_) != kHardenedBoolTrue) { \
+      return crypto_status_interpret(status_);              \
+    }                                                       \
+    HARDENED_CHECK_EQ(status_.value, kHardenedBoolTrue);    \
+    status_.value;                                          \
+  })
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_STATUS_H_

--- a/sw/device/lib/crypto/impl/status_unittest.cc
+++ b/sw/device/lib/crypto/impl/status_unittest.cc
@@ -1,0 +1,139 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/status.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// NOTE: This test does not verify hardening measures; it only checks that the
+// "normal" contract of the functions is upheld.
+
+namespace status_unittest {
+namespace {
+
+TEST(Status, OkIsHardenedOk) {
+  EXPECT_EQ(hardened_status_ok(OTCRYPTO_OK), kHardenedBoolTrue);
+}
+
+TEST(Status, OkIsNonHardenedOk) { EXPECT_EQ(status_ok(OTCRYPTO_OK), true); }
+
+TEST(Status, ErrorMacrosNotOk) {
+  // Error macros should evaluate to non-OK statuses.
+  EXPECT_EQ(status_ok(OTCRYPTO_BAD_ARGS), false);
+  EXPECT_EQ(status_ok(OTCRYPTO_RECOV_ERR), false);
+  EXPECT_EQ(status_ok(OTCRYPTO_FATAL_ERR), false);
+  EXPECT_EQ(status_ok(OTCRYPTO_ASYNC_INCOMPLETE), false);
+}
+
+TEST(Status, ErrorMacrosNotHardenedOk) {
+  // Error macros should evaluate to non-OK statuses.
+  EXPECT_EQ(hardened_status_ok(OTCRYPTO_BAD_ARGS), kHardenedBoolFalse);
+  EXPECT_EQ(hardened_status_ok(OTCRYPTO_RECOV_ERR), kHardenedBoolFalse);
+  EXPECT_EQ(hardened_status_ok(OTCRYPTO_FATAL_ERR), kHardenedBoolFalse);
+  EXPECT_EQ(hardened_status_ok(OTCRYPTO_ASYNC_INCOMPLETE), kHardenedBoolFalse);
+}
+
+TEST(Status, InterpretErrorMacros) {
+  // Error macros should translate to the crypto status implied by their name.
+  EXPECT_EQ(crypto_status_interpret(OTCRYPTO_OK), kCryptoStatusOK);
+  EXPECT_EQ(crypto_status_interpret(OTCRYPTO_BAD_ARGS), kCryptoStatusBadArgs);
+  EXPECT_EQ(crypto_status_interpret(OTCRYPTO_RECOV_ERR),
+            kCryptoStatusInternalError);
+  EXPECT_EQ(crypto_status_interpret(OTCRYPTO_FATAL_ERR),
+            kCryptoStatusFatalError);
+  EXPECT_EQ(crypto_status_interpret(OTCRYPTO_ASYNC_INCOMPLETE),
+            kCryptoStatusAsyncIncomplete);
+}
+
+__attribute__((noinline)) crypto_status_t try_interpret(status_t status) {
+  OTCRYPTO_TRY_INTERPRET(status);
+  return kCryptoStatusOK;
+}
+
+TEST(Status, TryInterpretOk) {
+  // Hardened OK should result in an OK status.
+  EXPECT_EQ(try_interpret(OTCRYPTO_OK), kCryptoStatusOK);
+}
+
+TEST(Status, TryInterpretNonHardenedOk) {
+  // Non-hardened OK should result in an error.
+  EXPECT_EQ(try_interpret(OK_STATUS()), kCryptoStatusInternalError);
+}
+
+TEST(Status, TryInterpretErrors) {
+  // Error macros should result in error statuses.
+  EXPECT_EQ(try_interpret(OTCRYPTO_BAD_ARGS), kCryptoStatusBadArgs);
+  EXPECT_EQ(try_interpret(OTCRYPTO_RECOV_ERR), kCryptoStatusInternalError);
+  EXPECT_EQ(try_interpret(OTCRYPTO_FATAL_ERR), kCryptoStatusFatalError);
+  EXPECT_EQ(try_interpret(OTCRYPTO_ASYNC_INCOMPLETE),
+            kCryptoStatusAsyncIncomplete);
+}
+
+constexpr char kTestModId[3] = {'X', 'Y', 'Z'};
+DECLARE_MODULE_ID(kTestModId[0], kTestModId[1], kTestModId[2]);
+
+TEST(Status, ExtractStatusFieldsBadArgs) {
+  const char *code = NULL;
+  char mod_id[3] = {0};
+  int32_t line = 0;
+  const char expected_code[] = "InvalidArgument";
+  int32_t expected_line = __LINE__ + 1;
+  EXPECT_EQ(status_extract(OTCRYPTO_BAD_ARGS, &code, &line, mod_id), true);
+
+  // Check the fields to ensure that the format of cryptolib errors matches the
+  // error format from the main status library.
+  EXPECT_EQ(memcmp(code, expected_code, ARRAYSIZE(expected_code)), 0);
+  EXPECT_THAT(mod_id, testing::ElementsAreArray(kTestModId));
+  EXPECT_EQ(line, expected_line);
+}
+
+TEST(Status, ExtractStatusFieldsRecovErr) {
+  const char *code = NULL;
+  char mod_id[3] = {0};
+  int32_t line = 0;
+  const char expected_code[] = "Aborted";
+  int32_t expected_line = __LINE__ + 1;
+  EXPECT_EQ(status_extract(OTCRYPTO_RECOV_ERR, &code, &line, mod_id), true);
+
+  // Check the fields to ensure that the format of cryptolib errors matches the
+  // error format from the main status library.
+  EXPECT_EQ(memcmp(code, expected_code, ARRAYSIZE(expected_code)), 0);
+  EXPECT_THAT(mod_id, testing::ElementsAreArray(kTestModId));
+  EXPECT_EQ(line, expected_line);
+}
+
+TEST(Status, ExtractStatusFieldsFatalErr) {
+  const char *code = NULL;
+  char mod_id[3] = {0};
+  int32_t line = 0;
+  const char expected_code[] = "FailedPrecondition";
+  int32_t expected_line = __LINE__ + 1;
+  EXPECT_EQ(status_extract(OTCRYPTO_FATAL_ERR, &code, &line, mod_id), true);
+
+  // Check the fields to ensure that the format of cryptolib errors matches the
+  // error format from the main status library.
+  EXPECT_EQ(memcmp(code, expected_code, ARRAYSIZE(expected_code)), 0);
+  EXPECT_THAT(mod_id, testing::ElementsAreArray(kTestModId));
+  EXPECT_EQ(line, expected_line);
+}
+
+TEST(Status, ExtractStatusFieldsAsyncIncomplete) {
+  const char *code = NULL;
+  char mod_id[3] = {0};
+  int32_t line = 0;
+  const char expected_code[] = "Unavailable";
+  int32_t expected_line = __LINE__ + 1;
+  EXPECT_EQ(status_extract(OTCRYPTO_ASYNC_INCOMPLETE, &code, &line, mod_id),
+            true);
+
+  // Check the fields to ensure that the format of cryptolib errors matches the
+  // error format from the main status library.
+  EXPECT_EQ(memcmp(code, expected_code, ARRAYSIZE(expected_code)), 0);
+  EXPECT_THAT(mod_id, testing::ElementsAreArray(kTestModId));
+  EXPECT_EQ(line, expected_line);
+}
+
+}  // namespace
+}  // namespace status_unittest

--- a/sw/device/lib/crypto/include/BUILD
+++ b/sw/device/lib/crypto/include/BUILD
@@ -9,3 +9,9 @@ load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 
 # Export all headers.
 exports_files(glob(["*.h"]))
+
+cc_library(
+    name = "datatypes",
+    hdrs = ["datatypes.h"],
+    deps = ["//sw/device/lib/base:hardened"],
+)

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -66,6 +66,7 @@ cc_library(
         ":status",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",
+        "//sw/device/lib/base:status",
         "//sw/device/lib/dif:base",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",

--- a/sw/device/lib/testing/test_framework/check.h
+++ b/sw/device/lib/testing/test_framework/check.h
@@ -9,6 +9,7 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
@@ -207,6 +208,22 @@
          or not this is a test.*/                                    \
       test_status_set(kTestStatusFailed);                            \
     }                                                                \
+  } while (false)
+
+/**
+ * Checks that the `status_t` represents a non-error value.
+ *
+ * Prints a human-readable error message if the status represents an error.
+ *
+ * @param expr An expression which evaluates to a `status_t`.
+ */
+#define CHECK_STATUS_OK(expr, ...)                 \
+  do {                                             \
+    status_t status_ = expr;                       \
+    if (!status_ok(status_)) {                     \
+      LOG_ERROR("CHECK-STATUS-fail: %r", status_); \
+      test_status_set(kTestStatusFailed);          \
+    }                                              \
   } while (false)
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_CHECK_H_


### PR DESCRIPTION
Follows #16649, part of moving the cryptolib to `status_t` as described in https://github.com/lowRISC/opentitan/issues/14549

This PR:
- Applies some fixups from code review in #16649 to `lib/base/hardened_status`
- Adds a `CHECK_STATUS` macro to `check.h` that prints `status_t` errors in human-readable form (I found this really useful when debugging)
- Introduces a small library for cryptolib errors, which includes:
  - a function `status_interpret` that interprets a `status_t` as a `crypto_status_t`, the error type of the top-level API
  - macros for `status_t`s that will be interpreted as specific `crypto_status_t`s (e.g. `OTCRYPTO_BAD_ARGS` -> `kCryptoStatusBadArgs`)
  - a `HARDENED_TRY_INTERPRET` macro that runs non-hardened-OK status codes through `status_interpret` before returning (so it is suitable for use in top-level API functions).

The idea is that cryptolib code will mostly just use `status_t` and `HARDENED_TRY` internally, but  will convert to `crypto_status_t` before  returning from a top-level API function. The additional information contained in the `status_t` will be useful for debugging lower layers.