### PR TITLE
[bazel] //hw/bitstream:otp_mmi is testonly

### DIFF
--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -79,6 +79,7 @@ filegroup(
 
 filegroup(
     name = "rom_mmi",
+    testonly = True,
     srcs = select({
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:rom_mmi"],
@@ -89,6 +90,7 @@ filegroup(
 
 filegroup(
     name = "otp_mmi",
+    testonly = True,
     srcs = select({
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:otp_mmi"],


### PR DESCRIPTION
I assume this is ok because it's in the bitstream directory and FPGA bitstreams can't be used outside of a testing context.

Fixes: #16931 

Signed-off-by: Drew Macrae <drewmacrae@google.com>