### PR TITLE
[coverage] Exclude //sw/device/lib/base:hardened_status

### DIFF
--- a/util/coverage/coverage_off_target.py
+++ b/util/coverage/coverage_off_target.py
@@ -82,6 +82,7 @@ def gather_and_build_libs() -> List[str]:
         "//sw/device/lib/crypto/...",
         "//sw/device/lib/arch/...",
         "//sw/device/lib/ujson/...",
+        "//sw/device/lib/base:hardened_status",
         "//sw/device/lib/base:status",
         "//sw/device/lib/base:mmio_on_device_do_not_use_directly",
         "//sw/device/lib/base:mmio_on_host_do_not_use_directly",


### PR DESCRIPTION
ROM code doesn't depend on `//sw/device/lib/base:hardened_status`. This PR removes this target from the set of device libraries that are instrumented.

Signed-off-by: Alphan Ulusoy <alphan@google.com>