### PR TITLE
[dv/lc_ctrl] Fix stress_all_with_rand_reset

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -28,6 +28,7 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task apply_resets_concurrently(int reset_duration_ps = 0);
+    cfg.escalate_injected = 0;
     cfg.otp_vendor_test_status = 0;
     cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.trst_n = 0;
     super.apply_resets_concurrently(reset_duration_ps);


### PR DESCRIPTION
When error injected to kmac interface and reset is issue. The injected error is released but cfg flag is not cleared.
So in scb, I added a statement to reset the flag back to 0 when reset is issued.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>