### PR TITLE
[i2c,dv] bad address  / agent reset tests

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -16,6 +16,8 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
 
   bit     host_scl_start;
   bit     host_scl_stop;
+  bit     host_scl_force_high;
+  bit     host_scl_force_low;
 
   // In i2c test, between every transaction, assuming a new timing
   // parameter is programmed. This means during a transaction,
@@ -41,6 +43,21 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   // ack followed by stop test mode
   bit     allow_ack_stop = 0;
   bit     ack_stop_det = 0;
+  bit     allow_bad_addr = 0;
+  // target address is stored when dut is programmed
+  bit [6:0] target_addr0;
+  bit [6:0] target_addr1;
+  // store history of good and bad read target address
+  // '1' good. '0' bad
+  bit       read_addr_q[$];
+  bit       valid_addr;
+  bit       is_read;
+
+  // when this is set, driver can send 's' or 'p' in the middle of txn
+  bit       hot_glitch;
+
+  // reset agent only without resetting dut
+  bit       agent_rst = 0;
 
   `uvm_object_utils_begin(i2c_agent_cfg)
     `uvm_field_int(en_monitor,                                UVM_DEFAULT)

--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -21,6 +21,16 @@ package i2c_agent_pkg;
     HostNAck, HostStop
   } drv_type_e;
 
+  // Driver phase
+  typedef enum int {
+    DrvIdle,
+    DrvStart,
+    DrvAddr,
+    DrvWr,
+    DrvRd,
+    DrvStop
+  } drv_phase_e;
+
   // register values
   typedef struct {
     // derived parameters

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -27,6 +27,9 @@ interface i2c_if(
 
   int scl_spinwait_timeout_ns = 10_000_000; // 10ms
 
+  // Trace drivers' status
+  drv_phase_e drv_phase;
+
   clocking cb @(posedge clk_i);
     input scl_i;
     input sda_i;
@@ -67,10 +70,14 @@ interface i2c_if(
   task automatic wait_for_host_start(ref timing_cfg_t tc);
     forever begin
       @(negedge sda_i);
+      if (scl_i) begin
       wait_for_dly(tc.tHoldStart);
+      end else continue;
       @(negedge scl_i);
+      if (!sda_i) begin
       wait_for_dly(tc.tClockStart);
       break;
+      end else continue;
     end
   endtask: wait_for_host_start
 

--- a/hw/ip/i2c/dv/env/i2c_dv_if.sv
+++ b/hw/ip/i2c/dv/env/i2c_dv_if.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface i2c_dv_if (
+  input logic clk,
+  input logic rst_n
+);
+
+  logic [5:0] i2c_state;
+  bit         got_state;
+
+  clocking cb @(posedge clk);
+    default input #1step output #2;
+  endclocking
+endinterface

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:ip:i2c
     files:
       - i2c_env_pkg.sv
+      - i2c_dv_if.sv
       - i2c_seq_cfg.sv: {is_include_file: true}
       - i2c_env_cfg.sv: {is_include_file: true}
       - i2c_env_cov.sv: {is_include_file: true}
@@ -49,6 +50,7 @@ filesets:
       - seq_lib/i2c_target_fifo_reset_acq_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_fifo_reset_tx_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_hrst_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env.sv
+++ b/hw/ip/i2c/dv/env/i2c_env.sv
@@ -16,6 +16,10 @@ class i2c_env extends cip_base_env #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+    if (!uvm_config_db#(virtual i2c_dv_if)::get(
+      this, "", "i2c_dv_vif", cfg.i2c_dv_vif)) begin
+      `uvm_fatal(`gfn, "failed to get i2c_dv_vif from uvm_config_db")
+    end
     m_i2c_agent = i2c_agent::type_id::create("m_i2c_agent", this);
     uvm_config_db#(i2c_agent_cfg)::set(this, "m_i2c_agent*", "cfg", cfg.m_i2c_agent_cfg);
     cfg.m_i2c_agent_cfg.en_cov = cfg.en_cov;

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -16,13 +16,14 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   bit [7:0]  lastbyte;
 
   int        spinwait_timeout_ns = 10_000_000; // 10ms
-  int        long_spinwait_timeout_ns = 200_000_000;
+  int        long_spinwait_timeout_ns = 400_000_000;
   int        sent_acq_cnt;
   int        rcvd_acq_cnt;
 
   // Ratio between write and read
   int        wr_pct = 1;
   int        rd_pct = 1;
+  int        bad_addr_pct = 0;
 
   // re-start injection rate between 1~10
   int        rs_pct = 1;
@@ -51,6 +52,7 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   int        rcvd_ack_stop = 0;
 
   i2c_scoreboard scb_h;
+  virtual    i2c_dv_if i2c_dv_vif;
 
   `uvm_object_utils_begin(i2c_env_cfg)
     `uvm_field_object(m_i2c_agent_cfg, UVM_DEFAULT)

--- a/hw/ip/i2c/dv/env/i2c_env_cov.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cov.sv
@@ -3,14 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 covergroup i2c_fifo_level_cg (uint fifo_depth)
-  with function sample(int lvl, bit irq, bit rst);
+  with function sample(int fmtlvl, int rxlvl, bit irq, bit rst);
 
   option.per_instance = 1;
   cp_rst: coverpoint rst;
   cp_irq: coverpoint irq;
-  cp_lvl: coverpoint lvl {bins all_levels[] = {[0:fifo_depth]};}
-
-  cr_fifo_lvl_irq_rst: cross cp_rst, cp_irq, cp_lvl;
+  cp_fmtlvl: coverpoint fmtlvl {
+    bins lvl[] = {1, 4, 8, 16};
+    bins others = {[0:fifo_depth]} with (!(item inside {1, 4, 8, 16}));
+  }
+  cp_rxlvl: coverpoint rxlvl {
+    bins lvl[] = {1, 4, 8, 16, 30};
+    bins others = {[0:fifo_depth]} with (!(item inside {1, 4, 8, 16, 30}));
+  }
 endgroup : i2c_fifo_level_cg
 
 class i2c_env_cov extends cip_base_env_cov #(.CFG_T(i2c_env_cfg));

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -55,6 +55,10 @@ class i2c_scoreboard extends cip_base_scoreboard #(
   bit                        read_rnd_data = 0;
   bit [7:0]                  mirrored_txdata[$];
 
+  // skip segment comparison
+  bit                        skip_target_txn_comp = 0;
+  bit                        skip_target_rd_comp = 0;
+
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -88,12 +92,14 @@ class i2c_scoreboard extends cip_base_scoreboard #(
             fork
               begin
                 target_mode_wr_obs_fifo.get(obs_wr_item);
-                obs_wr_item.tran_id = obs_wr_id++;
-                target_mode_wr_exp_fifo.get(exp_wr_item);
-                str = (exp_wr_item.start) ? "addr" : (exp_wr_item.stop) ? "stop" : "wr";
-                `uvm_info(`gfn, $sformatf("exp_%s_txn %0d\n %s", str,
-                                          exp_wr_item.tran_id, exp_wr_item.sprint()), UVM_MEDIUM)
-                target_txn_comp(obs_wr_item, exp_wr_item, str);
+                if (!skip_target_txn_comp) begin
+                  obs_wr_item.tran_id = obs_wr_id++;
+                  target_mode_wr_exp_fifo.get(exp_wr_item);
+                  str = (exp_wr_item.start) ? "addr" : (exp_wr_item.stop) ? "stop" : "wr";
+                  `uvm_info(`gfn, $sformatf("exp_%s_txn %0d\n %s", str,
+                            exp_wr_item.tran_id, exp_wr_item.sprint()), UVM_MEDIUM)
+                  target_txn_comp(obs_wr_item, exp_wr_item, str);
+                end
               end
               begin
                 wait(skip_acq_comp);
@@ -105,23 +111,25 @@ class i2c_scoreboard extends cip_base_scoreboard #(
         end
         forever begin
           target_mode_rd_obs_fifo.get(obs_rd_item);
-          obs_rd_item.pname = "obs_rd";
-          obs_rd_item.tran_id = num_obs_rd++;
-          if (read_rnd_data) begin
-            // With read_rnd_data mode, only read data can be compared.
-            // Other variables cannot be predictable.
-            `uvm_create_obj(i2c_item, exp_rd_item);
-            exp_rd_item.tran_id = obs_rd_item.tran_id;
-            exp_rd_item.num_data = obs_rd_item.num_data;
-            repeat (exp_rd_item.num_data) begin
-              exp_rd_item.data_q.push_back(mirrored_txdata.pop_front);
+          if (!skip_target_rd_comp) begin
+            obs_rd_item.pname = "obs_rd";
+            obs_rd_item.tran_id = num_obs_rd++;
+            if (read_rnd_data) begin
+              // With read_rnd_data mode, only read data can be compared.
+              // Other variables cannot be predictable.
+              `uvm_create_obj(i2c_item, exp_rd_item);
+              exp_rd_item.tran_id = obs_rd_item.tran_id;
+              exp_rd_item.num_data = obs_rd_item.num_data;
+              repeat (exp_rd_item.num_data) begin
+                exp_rd_item.data_q.push_back(mirrored_txdata.pop_front);
+              end
+            end else begin
+              target_mode_rd_exp_fifo.get(exp_rd_item);
             end
-          end else begin
-            target_mode_rd_exp_fifo.get(exp_rd_item);
+            exp_rd_item.pname = "exp_rd";
+            `uvm_info(`gfn, $sformatf("\n%s", exp_rd_item.convert2string()), UVM_MEDIUM)
+            target_rd_comp(obs_rd_item, exp_rd_item);
           end
-          exp_rd_item.pname = "exp_rd";
-          `uvm_info(`gfn, $sformatf("\n%s", exp_rd_item.convert2string()), UVM_MEDIUM)
-          target_rd_comp(obs_rd_item, exp_rd_item);
         end
       join_none
     end else begin
@@ -171,6 +179,10 @@ class i2c_scoreboard extends cip_base_scoreboard #(
         // add individual case item for each csr
         "ctrl": begin
           host_init = ral.ctrl.enablehost.get_mirrored_value();
+        end
+        "target_id": begin
+           cfg.m_i2c_agent_cfg.target_addr0 = get_field_val(ral.target_id.address0, item.a_data);
+           cfg.m_i2c_agent_cfg.target_addr1 = get_field_val(ral.target_id.address1, item.a_data);
         end
         "fdata": begin
           bit [7:0] fbyte;
@@ -280,12 +292,14 @@ class i2c_scoreboard extends cip_base_scoreboard #(
           end
           if (cfg.en_cov) begin
             cov.fmt_fifo_level_cg.sample(.irq(cfg.intr_vif.pins[FmtWatermark]),
-                                         .lvl(`gmv(ral.fifo_status.fmtlvl)),
+                                         .fmtlvl(`gmv(ral.fifo_status.fmtlvl)),
+                                         .rxlvl(0),
                                          .rst(fmtrst_val));
           end
           if (cfg.en_cov) begin
             cov.rx_fifo_level_cg.sample(.irq(cfg.intr_vif.pins[RxWatermark]),
-                                        .lvl(`gmv(ral.fifo_status.rxlvl)),
+                                        .fmtlvl(0),
+                                        .rxlvl(`gmv(ral.fifo_status.rxlvl)),
                                         .rst(rxrst_val));
           end
         end

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_hrst_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_hrst_vseq.sv
@@ -1,0 +1,247 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Host agent reset test
+class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
+  `uvm_object_utils(i2c_target_hrst_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    super.pre_start();
+    expected_intr[UnexpStop] = 1;
+  endtask
+
+  virtual task body();
+    i2c_target_base_seq m_i2c_host_seq;
+    i2c_item txn_q[$];
+    int reset_txn_num = 1;
+    bit reset_drv_st = 0;
+    bit resume_sb = 0;
+
+    // Add some config noise to stretch coverage
+    ral.ctrl.enablehost.set(1'b0);
+    ral.ctrl.enabletarget.set(1'b1);
+    csr_update(ral.ctrl);
+    ral.ctrl.enablehost.set(1'b1);
+    ral.ctrl.enabletarget.set(1'b0);
+    csr_update(ral.ctrl);
+
+    // Intialize dut in device mode and agent in host mode
+    initialization(Device);
+    `uvm_info("cfg_summary",
+              $sformatf("target_addr0:0x%x target_addr1:0x%x illegal_addr:0x%x num_trans:%0d",
+                        target_addr0, target_addr1, illegal_addr, num_trans), UVM_MEDIUM)
+    print_time_property();
+
+    fork
+      begin
+        `uvm_info(`gfn, $sformatf("num_trans:%0d", num_trans), UVM_MEDIUM)
+        num_trans = 5;
+        reset_txn_num = $urandom_range(1, 3);
+
+        for (int i = 0; i < num_trans; i++) begin
+          `uvm_info("seq", $sformatf("round %0d reset_txn_num:%0d", i, reset_txn_num), UVM_MEDIUM)
+          if (i > 0) begin
+            // wait for previous stop before program a new timing param.
+            `DV_WAIT(cfg.m_i2c_agent_cfg.got_stop,, cfg.spinwait_timeout_ns, "target_hrst_vseq")
+            cfg.m_i2c_agent_cfg.got_stop = 0;
+          end
+          // exclude timing param update right after runt transaction
+          if (i != (reset_txn_num + 1)) begin
+            get_timing_values();
+            program_registers();
+          end
+          `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
+
+          // Make sure error txn has long enough to have various transaction segment
+          if (i == reset_txn_num) begin
+            cfg.min_data = 20;
+          end
+          create_txn(txn_q);
+          if (i == reset_txn_num) begin
+            `uvm_info("seq", $sformatf("test skip comparison is set %0d", i), UVM_HIGH)
+            reset_drv_st = 1;
+            fetch_no_tb_txn(txn_q, m_i2c_host_seq.req_q);
+          end else begin
+            fetch_txn(txn_q, m_i2c_host_seq.req_q);
+          end
+          m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
+          if (i == reset_txn_num) begin
+            resume_sb = 1;
+            `uvm_info("seq", $sformatf("resume test comparison %0d", i), UVM_HIGH)
+          end
+
+          sent_txn_cnt++;
+        end
+      end
+      process_target_interrupts();
+      stop_target_interrupt_handler();
+      begin
+        `DV_WAIT(reset_drv_st,, cfg.spinwait_timeout_ns, "tb_comp_off")
+        while (!cfg.scb_h.target_mode_wr_exp_fifo.is_empty()) begin
+          cfg.clk_rst_vif.wait_clks(1);
+        end
+        cfg.scb_h.skip_target_txn_comp = 1;
+        while (!cfg.scb_h.target_mode_rd_exp_fifo.is_empty()) begin
+          cfg.clk_rst_vif.wait_clks(1);
+        end
+        cfg.scb_h.skip_target_rd_comp = 1;
+        `DV_WAIT(resume_sb,, cfg.spinwait_timeout_ns, "resume_sb")
+      end
+      begin
+        `DV_WAIT(reset_drv_st,, cfg.spinwait_timeout_ns, "set hot_glitch")
+        cfg.m_i2c_agent_cfg.hot_glitch = 1;
+        `DV_WAIT(!cfg.m_i2c_agent_cfg.hot_glitch,, cfg.spinwait_timeout_ns, "unset hot_glitch")
+      end
+    join
+  endtask : body
+
+  // Feed txn to driver only. This doesn't create expected txn.
+  function void fetch_no_tb_txn(ref i2c_item src_q[$], i2c_item dst_q[$]);
+    i2c_item txn;
+    i2c_item rs_txn;
+    i2c_item full_txn;
+    int read_size;
+    bit is_read = get_read_write();
+    bit [6:0] t_addr;
+    bit       valid_addr;
+
+    `uvm_info("seq", $sformatf("ntb idx %0d:is_read:%0b size:%0d fetch_txn:%0d",
+                               start_cnt++, is_read, src_q.size(), full_txn_num++), UVM_MEDIUM)
+
+    // From target mode, read data is corresponds to txdata from DUT.
+    // While dut's sda is always 1, tb can drive sda freely.
+    // Update read data to all 1's to recevie any incoming data bits.
+    update_rd_data(is_read, src_q);
+    print_wr_data(is_read, src_q);
+    `uvm_create_obj(i2c_item, full_txn)
+
+    // Add 'START' to the front
+    `uvm_create_obj(i2c_item, txn)
+    txn.drv_type = HostStart;
+    dst_q.push_back(txn);
+    full_txn.start = 1;
+    if (is_read) full_txn.tran_id = this.exp_rd_id;
+    // Address
+    `uvm_create_obj(i2c_item, txn)
+    txn.drv_type = HostData;
+    txn.start = 1;
+    txn.wdata[7:1] = get_target_addr(); //target_addr0;
+    txn.wdata[0] = is_read;
+    valid_addr = is_target_addr(txn.wdata[7:1]);
+
+    txn.tran_id = this.tran_id;
+    dst_q.push_back(txn);
+    full_txn.addr = txn.wdata[7:1];
+    full_txn.read = is_read;
+
+    // Start command acq entry
+    read_size = get_read_data_size(src_q, is_read, read_rcvd);
+
+    // Data
+    while (src_q.size() > 0) begin
+      `uvm_create_obj(i2c_item, txn)
+      txn = src_q.pop_front();
+      if (txn.drv_type != HostRStart) begin
+        // Restart only has empty data for address holder
+        full_txn.data_q.push_back(txn.wdata);
+      end
+
+      // RS creates 2 extra acq entry
+      // one for RS
+      // the other for a new start acq_entry with address
+      if (txn.drv_type == HostRStart) begin
+        bit prv_read = 0;
+        bit prv_valid = valid_addr;
+
+        t_addr = get_target_addr();
+        valid_addr = is_target_addr(t_addr);
+
+        `uvm_create_obj(i2c_item, rs_txn)
+        `downcast(rs_txn, txn.clone())
+        dst_q.push_back(txn);
+
+        rs_txn.drv_type = HostData;
+        rs_txn.start = 1;
+        rs_txn.rstart = 0;
+        rs_txn.wdata[7:1] = t_addr;
+        prv_read = is_read;
+        is_read = rs_txn.read;
+        rs_txn.wdata[0] = is_read;
+        dst_q.push_back(rs_txn);
+
+        // fetch previous full_txn and creat a new one
+        if (prv_read) begin
+          full_txn.stop = 1;
+        end
+        `uvm_create_obj(i2c_item, full_txn)
+        `downcast(full_txn, rs_txn);
+        if (is_read) begin
+          full_txn.tran_id = exp_rd_id;
+        end
+      end else begin
+        if (is_read) begin
+          i2c_item read_txn;
+          `uvm_create_obj(i2c_item, read_txn)
+          `downcast(read_txn, txn.clone())
+          full_txn.num_data++;
+          if (src_q.size() == 0) begin
+            txn.drv_type = get_eos(.is_stop(1));
+          end else begin
+            // if your next item is restart Do nack
+            if (src_q[0].drv_type == HostRStart) txn.drv_type = get_eos();
+            else txn.drv_type = HostAck;
+          end
+          if (!cfg.use_drooling_tx) read_txn_q.push_back(read_txn);
+        end
+
+        dst_q.push_back(txn);
+
+      end
+    end // while (src_q.size() > 0)
+
+    // Stop
+    `uvm_create_obj(i2c_item, txn)
+    txn.tran_id = this.tran_id;
+    txn.stop = 1;
+    txn.drv_type = HostStop;
+    dst_q.push_back(txn);
+    full_txn.stop = 1;
+  endfunction
+
+  task stop_target_interrupt_handler();
+    string id = "stop_interrupt_handler";
+    int    acq_rd_cyc;
+    acq_rd_cyc = 9 * (thigh + tlow);
+    `DV_WAIT(cfg.sent_acq_cnt > 0,, cfg.spinwait_timeout_ns, id)
+    `DV_WAIT(sent_txn_cnt == num_trans,, cfg.long_spinwait_timeout_ns, id)
+    cfg.read_all_acq_entries = 1;
+    if (cfg.rd_pct != 0) begin
+      `DV_WAIT(cfg.m_i2c_agent_cfg.sent_rd_byte > 0,, cfg.spinwait_timeout_ns, id)
+      `uvm_info(id, $sformatf("st3 sent_acq:%0d rcvd_acq:%0d",
+                              cfg.sent_acq_cnt, cfg.rcvd_acq_cnt), UVM_HIGH)
+    end
+    `DV_WAIT(cfg.sent_acq_cnt <= cfg.rcvd_acq_cnt,, cfg.spinwait_timeout_ns, id)
+    csr_spinwait(.ptr(ral.status.acqempty), .exp_data(1'b1));
+
+    // add drain time before stop interrupt handler
+    cfg.clk_rst_vif.wait_clks(1000);
+    // Add extra draintime for tx overflow test
+    cfg.stop_intr_handler = 1;
+    `uvm_info(id, "called stop_intr_handler", UVM_MEDIUM)
+  endtask // stop_target_interrupt_handler
+
+  // Replace read data to all 1's.
+  function void update_rd_data(bit is_read, ref i2c_item myq[$]);
+    bit read = is_read;
+    foreach (myq[i]) begin
+      if (myq[i].rstart) begin
+        read = myq[i].read;
+      end else begin
+        if (read) myq[i].wdata = 8'hff;
+      end
+    end
+  endfunction
+
+endclass : i2c_target_hrst_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -51,6 +51,7 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
       expected_intr[CmdComplete] = 1;
       for (int i = 0; i < NumI2cIntr; i++) intr_q.push_back(i);
     end
+    if (cfg.bad_addr_pct > 0) cfg.m_i2c_agent_cfg.allow_bad_addr = 1;
   endtask
 
   virtual task body();
@@ -60,8 +61,9 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
     `uvm_info(`gfn, $sformatf("num_trans:%0d", num_trans), UVM_MEDIUM)
     // Intialize dut in device mode and agent in host mode
     initialization(Device);
-    `uvm_info("cfg_summary", $sformatf("target_addr0:0x%x target_addr1:0x%x num_trans:%0d",
-                             target_addr0, target_addr1, num_trans), UVM_MEDIUM)
+    `uvm_info("cfg_summary",
+              $sformatf("target_addr0:0x%x target_addr1:0x%x illegal_addr:0x%x num_trans:%0d",
+                             target_addr0, target_addr1, illegal_addr, num_trans), UVM_MEDIUM)
     print_time_property();
 
     fork

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -32,3 +32,4 @@
 `include "i2c_target_fifo_reset_acq_vseq.sv"
 `include "i2c_target_fifo_reset_tx_vseq.sv"
 `include "i2c_target_stress_all_vseq.sv"
+`include "i2c_target_hrst_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -117,39 +117,39 @@
     {
       name: i2c_target_smoke
       uvm_test_seq: i2c_target_smoke_vseq
-      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=10_000_000"]
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=100_000_000"]
     }
     {
       name: i2c_target_stress_wr
       uvm_test_seq: i2c_target_stress_wr_vseq
-      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=200_000_000"]
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=600_000_000"]
     }
     {
       name: i2c_target_stress_rd
       uvm_test_seq: i2c_target_stress_rd_vseq
-      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=50_000_000"]
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=100_000_000"]
     }
     {
       name: i2c_target_stretch
       uvm_test_seq: i2c_target_stretch_vseq
-      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=80_000_000"]
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=400_000_000"]
     }
     {
       name: i2c_target_intr_smoke
       uvm_test_seq: i2c_target_smoke_vseq
-      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=200_000_000",
                  "+use_intr_handler=1"]
     }
     {
       name: i2c_target_intr_stress_wr
       uvm_test_seq: i2c_target_stress_wr_vseq
-      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=300_000_000",
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=600_000_000",
                  "+use_intr_handler=1", "+slow_acq=1"]
     }
     {
       name: i2c_target_tx_ovf
       uvm_test_seq: i2c_target_tx_ovf_vseq
-      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=50_000_000",
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=100_000_000",
                  "+use_intr_handler=1"]
     }
     {
@@ -186,6 +186,18 @@
       name: i2c_target_stress_all
       uvm_test_seq: i2c_target_stress_all_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=200_000_000",
+                 "+use_intr_handler=1"]
+    }
+    {
+      name: i2c_target_bad_addr
+      uvm_test_seq: i2c_target_smoke_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
+                 "+use_intr_handler=1", "+i2c_bad_addr_pct=5"]
+    }
+    {
+      name: i2c_target_hrst
+      uvm_test_seq: i2c_target_hrst_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
     }
   ]

--- a/hw/ip/i2c/dv/tb/tb.sv
+++ b/hw/ip/i2c/dv/tb/tb.sv
@@ -52,6 +52,15 @@ module tb;
     .sda_io(sda)
   );
 
+  i2c_dv_if i2c_dv_if(
+    .clk(clk),
+    .rst_n(rst_n)
+  );
+
+  `define I2C_HIER tb.dut.i2c_core
+
+  assign i2c_dv_if.i2c_state = `I2C_HIER.u_i2c_fsm.state_q;
+
   // Model PAD behavior
   i2c_port_conv i2c_port_conv (
     .scl_oe_i(cio_scl_en),
@@ -129,8 +138,8 @@ module tb;
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual i2c_if)::set(null, "*.env.m_i2c_agent*", "vif", i2c_if);
+    uvm_config_db#(virtual i2c_dv_if)::set(null, "*.env", "i2c_dv_vif", i2c_dv_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end
-
 endmodule : tb

--- a/hw/ip/i2c/dv/tests/i2c_base_test.sv
+++ b/hw/ip/i2c/dv/tests/i2c_base_test.sv
@@ -23,7 +23,9 @@ class i2c_base_test extends cip_base_test #(.ENV_T(i2c_env),
     cfg.m_i2c_agent_cfg.if_mode = mode;
     void'($value$plusargs("use_intr_handler=%0b", cfg.use_intr_handler));
     void'($value$plusargs("slow_acq=%0b", cfg.slow_acq));
-
+    void'($value$plusargs("i2c_wr_pct=%0d", cfg.wr_pct));
+    void'($value$plusargs("i2c_rd_pct=%0d", cfg.rd_pct));
+    void'($value$plusargs("i2c_bad_addr_pct=%0d", cfg.bad_addr_pct));
   endfunction : build_phase
 
 endclass : i2c_base_test


### PR DESCRIPTION
Two designated tests are added.
1. Bad address test
    Test sends 'txn' with a bad address from time to time.
    txn with a bad address will be silently dropped.
2. Agent hot reset test
   Test sends 'start' or 'stop' in the middle of 'txn'.
   Previous 'runt txn' will be ignored in the test and a new transaction will be captured successfully.
  'Agent hot reset' is required to create such transaction and that is where the name comes from.


Signed-off-by: Jaedon Kim <jdonjdon@google.com>