### PR TITLE
[dv] some updates on `variant` for parameterized blocks

### DIFF
--- a/hw/ip/aes/doc/dv/index.md
+++ b/hw/ip/aes/doc/dv/index.md
@@ -144,7 +144,8 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/aes/dv/aes_sim_cfg.hjson -i aes_
 ```
 Here's how to run a basic test without DPI calls:
 ```console
-$ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/aes/dv/aes_sim_cfg.hjson -i aes_wakeup
+$ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/aes/dv/aes_${VARIANT}_sim_cfg.hjson -i aes_wakeup
 ```
+In this run command, $VARIANT can be `masking` or `no_masking`.
 ## Testplan
 {{< incGenFromIpDesc "../../data/aes_testplan.hjson" "testplan" >}}

--- a/hw/ip/aes/dv/aes_base_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_base_sim_cfg.hjson
@@ -54,11 +54,11 @@
   overrides: [
     {
       name: scratch_path
-      value: "{scratch_base_path}/{variant}-{flow}-{tool}"
+      value: "{scratch_base_path}/{name}_{variant}-{flow}-{tool}"
     }
     {
       name: rel_path
-      value: "hw/ip/{variant}/dv"
+      value: "hw/ip/{name}_{variant}/dv"
     }
   ]
 

--- a/hw/ip/aes/dv/aes_masking_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_masking_sim_cfg.hjson
@@ -5,7 +5,7 @@
 // sim cfg file for AES with masking
 {
   // Name of the sim cfg variant
-  variant: aes_masking
+  variant: masking
 
   // Import the base sram_ctrl sim_cfg file
   import_cfgs: ["{proj_root}/hw/ip/aes/dv/aes_base_sim_cfg.hjson"]

--- a/hw/ip/aes/dv/aes_no_masking_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_no_masking_sim_cfg.hjson
@@ -5,7 +5,7 @@
 // sim cfg file for AES without masking
 {
   // Name of the sim cfg variant
-  variant: aes_no_masking
+  variant: no_masking
 
   // Import the base sram_ctrl sim_cfg file
   import_cfgs: ["{proj_root}/hw/ip/aes/dv/aes_base_sim_cfg.hjson"]

--- a/hw/ip/kmac/doc/dv/index.md
+++ b/hw/ip/kmac/doc/dv/index.md
@@ -146,8 +146,9 @@ We are using our in-house developed [regression tool]({{< relref "hw/dv/tools/do
 Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
 Here's how to run a smoke test:
 ```console
-$ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/kmac/dv/kmac_sim_cfg.hjson -i kmac_smoke
+$ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/kmac/dv/kmac_${VARIANT}_sim_cfg.hjson -i kmac_smoke
 ```
+In this run command, $VARIANT can be `masked` or `unmasked`.
 
 ## Testplan
 {{< incGenFromIpDesc "../../data/kmac_testplan.hjson" "testplan" >}}

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -52,11 +52,11 @@
   overrides: [
     {
       name: scratch_path
-      value: "{scratch_base_path}/{variant}-{flow}-{tool}"
+      value: "{scratch_base_path}/{name}_{variant}-{flow}-{tool}"
     }
     {
       name: rel_path
-      value: "hw/ip/{variant}/dv"
+      value: "hw/ip/{name}_{variant}/dv"
     }
   ]
 

--- a/hw/ip/sram_ctrl/doc/dv/index.md
+++ b/hw/ip/sram_ctrl/doc/dv/index.md
@@ -188,8 +188,9 @@ We are using our in-house developed [regression tool]({{< relref "hw/dv/tools/do
 Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
 Here's how to run a smoke test:
 ```console
-$ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/sram_ctrl/dv/sram_ctrl_sim_cfg.hjson -i sram_ctrl_smoke
+$ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/sram_ctrl/dv/sram_ctrl_${VARIANT}_sim_cfg.hjson -i sram_ctrl_smoke
 ```
+In this run command, $VARIANT can be `main` or `ret`.
 
 ## Testplan
 {{< incGenFromIpDesc "../../data/sram_ctrl_testplan.hjson" "testplan" >}}

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -53,11 +53,11 @@
   overrides: [
     {
       name: scratch_path
-      value: "{scratch_base_path}/{variant}-{flow}-{tool}"
+      value: "{scratch_base_path}/{name}_{variant}-{flow}-{tool}"
     }
     {
       name: rel_path
-      value: "hw/ip/{variant}/dv"
+      value: "hw/ip/{name}_{variant}/dv"
     }
   ]
 


### PR DESCRIPTION
Some cleanup for #16887
1. update the run commands in dv_doc
2. update aes sim_cfg, variant only doesn't contain the block name
3. fix the scratch output paths to `{name}_{variant}_*`

Signed-off-by: Weicai Yang <weicai@google.com>