### PR TITLE
[dv/otp] Fix otp warning

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -48,11 +48,12 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   logic              pwr_otp_done_o, pwr_otp_idle_o;
 
   // Inputs to DUT
-  logic                  pwr_otp_init_i, scan_en_i, scan_rst_ni, ext_voltage_h_io;
-  lc_ctrl_pkg::lc_tx_t   lc_dft_en_i, lc_escalate_en_i, lc_check_byp_en_i,
-                         lc_creator_seed_sw_rw_en_i, lc_seed_hw_rd_en_i;
-  prim_mubi_pkg::mubi4_t scanmode_i;
-  otp_ast_rsp_t          otp_ast_pwr_seq_h_i;
+  logic                   pwr_otp_init_i, scan_en_i, scan_rst_ni, ext_voltage_h_io;
+  lc_ctrl_pkg::lc_tx_t    lc_dft_en_i, lc_escalate_en_i, lc_check_byp_en_i,
+                          lc_creator_seed_sw_rw_en_i, lc_seed_hw_rd_en_i;
+  prim_mubi_pkg::mubi4_t  scanmode_i;
+  otp_ast_rsp_t           otp_ast_pwr_seq_h_i;
+  ast_pkg::ast_obs_ctrl_t obs_ctrl_i;
 
   // Unused in prim_generic_otp memory.
   logic [OtpTestCtrlWidth-1:0]   otp_vendor_test_ctrl_i;

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -42,7 +42,10 @@ module tb;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire intr_otp_operation_done, intr_otp_error;
 
+  // Output from close-source OTP, not checked in open-source env.
   wire otp_ctrl_pkg::otp_ast_req_t ast_req;
+  wire [7:0] otp_obs_o;
+
   tlul_pkg::tl_d2h_t prim_tl_o;
 
   // interfaces
@@ -107,14 +110,16 @@ module tb;
     .alert_rx_i                 (alert_rx   ),
     .alert_tx_o                 (alert_tx   ),
     // ast
+    .obs_ctrl_i                 (otp_ctrl_if.obs_ctrl_i),
+    .otp_obs_o                  (otp_obs_o),
     .otp_ast_pwr_seq_o          (ast_req),
     .otp_ast_pwr_seq_h_i        (otp_ctrl_if.otp_ast_pwr_seq_h_i),
     // pwrmgr
     .pwr_otp_i                  (otp_ctrl_if.pwr_otp_init_i),
     .pwr_otp_o                  ({otp_ctrl_if.pwr_otp_done_o, otp_ctrl_if.pwr_otp_idle_o}),
     // lc
-    .lc_otp_vendor_test_o       (otp_ctrl_if.otp_vendor_test_status_o),
     .lc_otp_vendor_test_i       (otp_ctrl_if.otp_vendor_test_ctrl_i),
+    .lc_otp_vendor_test_o       (otp_ctrl_if.otp_vendor_test_status_o),
     .lc_otp_program_i           ({lc_prog_if.req, lc_prog_if.h_data}),
     .lc_otp_program_o           ({lc_prog_if.d_data, lc_prog_if.ack}),
     .lc_creator_seed_sw_rw_en_i (otp_ctrl_if.lc_creator_seed_sw_rw_en_i),


### PR DESCRIPTION
Fix vcs otp warning due to missing port assignment on DUT.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>