### PR TITLE
[flash_ctrl,dv] asymmetric read path test 

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -392,23 +392,26 @@
     }
     {
       name: rma_write_process_error
-      desc: '''Verify error handling process duing the rma wipe process.
-      In normal rma process, inject bit error at the write path
-      (tb.dut.u_eflash.gen_flash_cores[0].u_core.gen_prog_data.u_prog.pack_data).
-      This should make debug_state to flash_ctrl_env_pkg::FlashLcIvalid and
-      fatal error (std_fault_status.lcmgr_err) should be triggered.
-      '''
+      desc: '''
+            Verify error handling process duing the rma wipe process.
+            In normal rma process, inject bit error at the write path
+            (tb.dut.u_eflash.gen_flash_cores[0].u_core.gen_prog_data.u_prog.pack_data).
+            This should make debug_state to flash_ctrl_env_pkg::FlashLcIvalid and
+            fatal error (std_fault_status.lcmgr_err) should be triggered.
+            '''
       stage: V2
       tests: ["flash_ctrl_rma_err", "flash_ctrl_hw_prog_rma_wipe_err"]
     }
     {
-      name: robustness
+      name: asymmetric_read_path
       desc: '''
-            Enable full randomization in order to fully stress DUT. Perform illegal accesses in
-            order to gain robustness.
+            Create 'fast' and 'slow' read path using scramble enable.
+            Send flash read requst over slow path followed by fast path.
+            While return data comes from fast path first but they are expected
+            to be returned in request order.
             '''
       stage: V3
-      tests: []
+      tests: ["flash_ctrl_rd_ooo"]
     }
   ]
 

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -94,6 +94,7 @@ filesets:
       - seq_lib/flash_ctrl_lcmgr_intg_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_hw_read_seed_err_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_hw_prog_rma_wipe_err_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_rd_ooo_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -1347,8 +1347,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end
   endtask // flash_ctrl_default_info_cfg
 
-  task flash_otf_region_cfg(otf_cfg_mode_e scr_mode = OTFCfgFalse,
-                            otf_cfg_mode_e ecc_mode = OTFCfgFalse);
+  virtual task flash_otf_region_cfg(otf_cfg_mode_e scr_mode = OTFCfgFalse,
+                                    otf_cfg_mode_e ecc_mode = OTFCfgFalse);
     mubi4_t scr_en, ecc_en;
     // If scr/ecc mode is random,
     // follow rand_regions_c

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_ooo_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_ooo_vseq.sv
@@ -1,0 +1,92 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test sends 'host read' over 'slow' and 'fast' return data path.
+// 'slow' and 'fast' return data path is created by
+// enabling and disabling scramble for each region.
+// In this test, scramble is enabled all pages in bank 0 while
+// scramble is disabled in all pages in bank 1.
+// Data from bank 1 return earlier than bank 0 but that should
+// be re-arranged in request order at the end of read data pipe line.
+
+class flash_ctrl_rd_ooo_vseq extends flash_ctrl_legacy_base_vseq;
+  `uvm_object_utils(flash_ctrl_rd_ooo_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    flash_op_t ctrl;
+    int num, bank;
+
+    flash_program_data_c.constraint_mode(0);
+    cfg.clk_rst_vif.wait_clks(5);
+    fork
+      begin
+        for (int i = 0; i < cfg.otf_num_hr; ++i) begin
+          fork
+            send_host_rd(i);
+          join_none
+          #0;
+        end
+        csr_utils_pkg::wait_no_outstanding_access();
+      end
+      begin
+        repeat(cfg.otf_num_rw) begin
+          `DV_CHECK_RANDOMIZE_FATAL(this)
+          ctrl = rand_op;
+          bank = rand_op.addr[OTFBankId];
+          if (ctrl.partition == FlashPartData) begin
+            num = ctrl_num;
+          end else begin
+            num = ctrl_info_num;
+          end
+          read_flash(ctrl, bank, num, fractions);
+        end
+      end
+    join
+  endtask
+
+  task send_host_rd(int idx);
+    flash_op_t host;
+    int host_num, host_bank;
+
+    host.otf_addr[OTFHostId-2:0] = $urandom();
+    host.otf_addr[1:0] = 'h0;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(host_num,
+                                       host_num dist {1 := 5,
+                                                      [2:4] := 1};)
+    host_bank = $urandom_range(0,1);
+
+    otf_direct_read(host.otf_addr, host_bank, host_num, 0);
+  endtask
+
+  task flash_otf_region_cfg(otf_cfg_mode_e scr_mode = OTFCfgFalse,
+                            otf_cfg_mode_e ecc_mode = OTFCfgFalse);
+
+    // Make default config scramble disable, ecc enable.
+    flash_ctrl_default_region_cfg(.scramble_en(MuBi4False),
+                                  .ecc_en(MuBi4True));
+    // Scramble enable in Bank 0 only
+    foreach (cfg.mp_regions[i]) begin
+      cfg.mp_regions[i] = rand_regions[i];
+      if (i < 2) cfg.mp_regions[i].en = MuBi4True;
+      else cfg.mp_regions[i].en = MuBi4False;
+      if (i == 0) begin
+        cfg.mp_regions[i].scramble_en = MuBi4True;
+        cfg.mp_regions[i].start_page = 0;
+        cfg.mp_regions[i].num_pages = 256;
+      end
+      if (i == 1) begin
+        cfg.mp_regions[i].scramble_en = MuBi4False;
+        cfg.mp_regions[i].start_page = 256;
+        cfg.mp_regions[i].num_pages = 256;
+      end
+      cfg.mp_regions[i].ecc_en = MuBi4True;
+      flash_ctrl_mp_region_cfg(i, cfg.mp_regions[i]);
+      `uvm_info("otf_region_cfg", $sformatf("region[%0d] = %p", i, cfg.mp_regions[i]), UVM_MEDIUM)
+    end
+    `uvm_info("otf_region_cfg", $sformatf("default = %p", cfg.default_region_cfg), UVM_MEDIUM)
+    flash_ctrl_default_info_cfg(scr_mode, ecc_mode);
+    update_p2r_map(cfg.mp_regions);
+  endtask // flash_otf_region_cfg
+endclass // flash_ctrl_rd_ooo_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -63,3 +63,4 @@
 `include "flash_ctrl_lcmgr_intg_vseq.sv"
 `include "flash_ctrl_hw_read_seed_err_vseq.sv"
 `include "flash_ctrl_hw_prog_rma_wipe_err_vseq.sv"
+`include "flash_ctrl_rd_ooo_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -446,6 +446,13 @@
                  "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
       reseed: 20
     }
+    {
+      name: flash_ctrl_rd_ooo
+      uvm_test_seq: flash_ctrl_rd_ooo_vseq
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=10", "+otf_num_hr=100",
+                 "+ecc_mode=1"]
+      reseed: 1
+    }
  ]
 
   // List of regressions.


### PR DESCRIPTION
This test creates 'fast' and 'slow' read path using scramble enable.
Compared to scramble disabled page, return data will come slower in scramble enabled page.
Send flash read request over slow path followed by fast path and see
read data come back in request order.