### PR TITLE
[spid] Passthrough to support CPOL 1

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1781,6 +1781,8 @@ module spi_device
     .clk_out_i (clk_spi_out_buf),
 
     // Configurations
+    .cfg_cpol_i (cpol),
+
     .cfg_cmd_filter_i (cmd_filter),
 
     .cfg_addr_mask_i  (addr_swap_mask),
@@ -1800,6 +1802,7 @@ module spi_device
 
     // Host SPI
     .host_sck_i  (cio_sck_i),
+    .host_isck_i (sck_n    ), // inverted cio_sck_i
     .host_csb_i  (cio_csb_i),
     .host_s_i    (cio_sd_i),
     .host_s_o    (passthrough_sd),


### PR DESCRIPTION
_Related Issue: https://github.com/lowRISC/opentitan/issues/16339 _

Previously, passthrough logic had a bug when CPOL is 1. When SCK is inverted, meaning that the SCK remains high when CSb is de-asserted, the filtering logic did not behave correctly.

The reason is the clock gating cell. To filter out the current command, passthrough logic gates the output clock then delays the CSb and release the CSb. The clock enable signal drops when the command needs to be filtered. The logic sets the enable signal when CSb is released.

However, if CPOL is 1, then setting the enable signal enables the SCK at the next low period of SCK, which is the beginning of the next transaction. So, the next transaction misses one clock edge.

This commit tries to address the issue by:

1. Adding inverter in front of/ and at the end of the CG cell
2. Adding a CG for inverted clock.
3. Adding a MUX between normal SCK and inverted SCK selected by CPOL

This solution adds 2x inverter and one AND delay onto the SCK path.
