### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@ec32fb1a64

### DIFF
--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 9696b80c88250afeb57b866e39c032f2f47478f1
+    rev: ec32fb1a6460d8512f9192a84d5fc395502c13f5
   }
 }

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/exception_interrupts.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/exception_interrupts.rst
@@ -76,13 +76,13 @@ Internal interrupts are considered to be non-recoverable in general.
 Specific details of how an internal interrupt relates to the event that triggers it are listed below.
 Given these details it may be possible for software to recover from an internal interrupt under specific circumstances.
 
-The possible ``mcause`` values for an internal interrupt as listed below:
+The possible ``mcause`` values for an internal interrupt are listed below:
 
 +-------------+-------------------------------------------------------------------------------------------------------------+
 | ``mcause``  | Description                                                                                                 |
 +-------------+-------------------------------------------------------------------------------------------------------------+
 | 0xFFFFFFE0  | Load integrity error internal interrupt.                                                                    |
-|             | Only generated when SecureIbex == 0.                                                                        |
+|             | Only generated when SecureIbex == 1.                                                                        |
 |             | ``mtval`` gives the faulting address.                                                                       |
 |             | The interrupt will be taken at most one instruction after the faulting load.                                |
 |             | In particular a load or store immediately after a faulting load may execute before the interrupt is taken.  |
@@ -125,6 +125,9 @@ Ibex can trigger an exception due to the following exception causes:
 
 The illegal instruction exception, instruction access fault, LSU error exceptions and ECALL instruction exceptions cannot be disabled and are always active.
 
+Note that Ibex cannot generated an 'instruction address misaligned' exception as all configurations implement the 'C' extension.
+Under the RISC-V architecture it is simply not possible to branch or otherwise start executing from a PC that isn't 16-bit aligned.
+So with 'C' implemented all possible PCs are appropriately aligned.
 
 Nested Interrupt/Exception Handling
 -----------------------------------

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
@@ -126,17 +126,17 @@ module ibex_cs_registers #(
   // Is a PMP config a locked one that allows M-mode execution when MSECCFG.MML is set (either
   // M mode alone or shared M/U mode execution)?
   function automatic logic is_mml_m_exec_cfg(ibex_pkg::pmp_cfg_t pmp_cfg);
-    logic unused_cfg;
-    unused_cfg = ^{pmp_cfg.mode};
+    logic unused_cfg = ^{pmp_cfg.mode};
+    logic value = 1'b0;
 
     if (pmp_cfg.lock) begin
       unique case ({pmp_cfg.read, pmp_cfg.write, pmp_cfg.exec})
-        3'b001, 3'b010, 3'b011, 3'b101: return 1'b1;
-        default: return 1'b0;
+        3'b001, 3'b010, 3'b011, 3'b101: value = 1'b1;
+        default: value = 1'b0;
       endcase
     end
 
-    return 1'b0;
+    return value;
   endfunction
 
   localparam int unsigned RV32BExtra = (RV32B == RV32BOTEarlGrey) || (RV32B == RV32BFull) ? 1 : 0;


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
ec32fb1a6460d8512f9192a84d5fc395502c13f5

* [rtl] Change code to be more xprop-friendly (Guillermo Maturana)
* [doc] Fixes and clarifications for exceptions and interrupts (Greg Chadwick)

The xprop change resolves #16791.