### PR TITLE
[dv/otp] remove unused declaration

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
@@ -16,7 +16,4 @@ class otp_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
   push_pull_sequencer#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_pull_sequencer_h;
   push_pull_sequencer#(.DeviceDataWidth(1), .HostDataWidth(LC_PROG_DATA_SIZE))
                        lc_prog_pull_sequencer_h;
-
-  // TODO: reggen tool optimization. Temp set up a prim_tl_sequencer.
-  tl_sequencer prim_tl_sequencer_h;
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
@@ -25,8 +25,6 @@ class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
 
   constraint rd_check_after_wr_c {
     rand_wr == rand_rd;
-    // TODO: enable this sw read
-    rd_sw_tlul_rd == 0;
   }
 
   function void pre_randomize();


### PR DESCRIPTION
This PR removes the temp sequencer that is replaced by regtool auto-generate tlul agent.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>