### PR TITLE
[top/dv] Fix waiting for instr/data_rvalid_i usage in Ibex lockstep test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_core_ibex_lockstep_glitch_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_core_ibex_lockstep_glitch_vseq.sv
@@ -330,12 +330,17 @@ class chip_sw_rv_core_ibex_lockstep_glitch_vseq extends chip_sw_base_vseq;
             wait_core_signal_value("instr_req_o", glitch_lockstep_core, 1'b1, 1);
           end
           "instr_rvalid_i": begin
+            // `instr_open_cnt` is updated on the negative edge. If it's greater than zero one delta
+            // delay later, we know `instr_rvalid_i` is being used in the next clock cycle.
             `DV_SPINWAIT(
               forever begin
+                #1step;
                 if (instr_open_cnt[glitch_lockstep_core] > 0) break;
                 @(cfg.chip_vif.cpu_clk_rst_if.cbn);
               end
             )
+            // `rvalid` gets used in the cycle after `req & gnt`, so wait one more clock cycle.
+            @(cfg.chip_vif.cpu_clk_rst_if.cbn);
           end
           "instr_rdata_i", "instr_err_i": begin
             wait_core_signal_value("instr_rvalid_i", glitch_lockstep_core, 1'b1, 1);
@@ -344,12 +349,17 @@ class chip_sw_rv_core_ibex_lockstep_glitch_vseq extends chip_sw_base_vseq;
             wait_core_signal_value("data_req_o", glitch_lockstep_core, 1'b1, 1);
           end
           "data_rvalid_i": begin
+            // `data_open_cnt` is updated on the negative edge. If it's greater than zero one delta
+            // delay later, we know `data_rvalid_i` is being used in the next clock cycle.
             `DV_SPINWAIT(
               forever begin
+                #1step;
                 if (data_open_cnt[glitch_lockstep_core] > 0) break;
                 @(cfg.chip_vif.cpu_clk_rst_if.cbn);
               end
             )
+            // `rvalid` gets used in the cycle after `req & gnt`, so wait one more clock cycle.
+            @(cfg.chip_vif.cpu_clk_rst_if.cbn);
           end
           "data_rdata_i", "data_err_i": begin
             wait_core_signal_value("data_rvalid_i", glitch_lockstep_core, 1'b1, 1);
@@ -407,7 +417,11 @@ class chip_sw_rv_core_ibex_lockstep_glitch_vseq extends chip_sw_base_vseq;
                                  1'b1);
           end
           "instr_rvalid_i": begin
+            // `instr_open_cnt` is updated on the negative edge. If it's greater than zero one delta
+            // delay later, we know `instr_rvalid_i` is being used in the next clock cycle.
+            #1step;
             glitched_inp_used = (instr_open_cnt[glitch_lockstep_core] > 0);
+            @(cfg.chip_vif.cpu_clk_rst_if.cbn);
           end
           "instr_rdata_i", "instr_err_i": begin
             glitched_inp_used = (hdl_read_core_signal("instr_rvalid_i", glitch_lockstep_core, 1) ==
@@ -418,7 +432,11 @@ class chip_sw_rv_core_ibex_lockstep_glitch_vseq extends chip_sw_base_vseq;
                                  1'b1);
           end
           "data_rvalid_i": begin
+            // `data_open_cnt` is updated on the negative edge. If it's greater than zero one delta
+            // delay later, we know `data_rvalid_i` is being used in the next clock cycle.
+            #1step;
             glitched_inp_used = (data_open_cnt[glitch_lockstep_core] > 0);
+            @(cfg.chip_vif.cpu_clk_rst_if.cbn);
           end
           "data_rdata_i", "data_err_i": begin
             glitched_inp_used = (hdl_read_core_signal("data_rvalid_i", glitch_lockstep_core, 1) ==


### PR DESCRIPTION
The rvalid signals are used by the design one clock cycle after the req/gnt handshake and the test logic for tracking outstanding accesses always updates on the negative edge. Previously, the test erroneously applied the glitch on the same negative edge when detecting the handshake. As a result, some glitches weren't actually effective even though the test expected this and thus failed.

This is related to lowRISC/OpenTitan#16758.

Without this PR
```
./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i chip_sw_rv_core_ibex_lockstep_glitch --build-seed 710109159 --fixed-seed 4067394497 --waves vpd
```
Results in the following waves:
![ibex_lockstep_test_data_rvalid_0](https://user-images.githubusercontent.com/20307557/210883203-b3164aad-d59c-420d-a3cc-b22e8c2d6197.png)
You can see that `data_rvalid_i` of the shadow core (bottom) is glitched on the negedge after `req` and `gnt` going high. At this point the design is not using `rvalid`. It becomes only used in the next clock cycle, more precisely, on the positive clock edge after the pink cursor. This edge is unfortunately no longer in the screenshot, but the force is removed on the second yellow mark. The signals still stays high because now the signal from the bus comes through. The glitch is not effective.

With the PR applied, the following waves result:
![ibex_lockstep_test_data_rvalid_1](https://user-images.githubusercontent.com/20307557/210883811-00dbe20b-230e-44f7-b987-bfaff3753b1c.png)
The test now waits for the next positive edge after req/gnt being high on a negative edge. This positive edge is also when the design samples the handshake. It then waits for the next negedge to apply the glitch. Because at this point the rvalid from the bus comes through, the glitch is now from 1 to 0. But obviously this glitch now has an impact on the design.