### PR TITLE
[sram_ctrl/dv] Improve functional coverage

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -460,7 +460,8 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       // these errors all have the same outcome. Only sample coverages when there is just one
       // error, so that we know the error actually triggers the outcome
       if (cfg.en_tl_err_cov && $onehot({unmapped_err, mem_byte_access_err, mem_wo_err, mem_ro_err,
-                   bus_intg_err, byte_wr_err, csr_size_err, tl_item_err})) begin
+                   bus_intg_err, byte_wr_err, csr_size_err, tl_item_err, write_w_instr_type_err,
+                   instr_type_err})) begin
         tl_errors_cgs_wrap[ral_name].sample(.unmapped_err(unmapped_err),
                                             .csr_size_err(csr_size_err),
                                             .mem_byte_access_err(mem_byte_access_err),

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -457,6 +457,9 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
         check_tl_read_value_after_error(item, ral_name);
       end
 
+      // we don't have cross coverage for simultaneous errors because 1) they're not important,
+      // 2) there are so many errors and combinations, 3) if we do cross them, we need to take
+      // out many invalid combinations.
       // these errors all have the same outcome. Only sample coverages when there is just one
       // error, so that we know the error actually triggers the outcome
       if (cfg.en_tl_err_cov && $onehot({unmapped_err, mem_byte_access_err, mem_wo_err, mem_ro_err,

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -136,11 +136,11 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
       allow_ifetch = 0;
     end
 
-    if (a_user.instr_type == prim_mubi_pkg::MuBi4True) begin
+    if (a_user.instr_type == prim_mubi_pkg::MuBi4True && item.a_opcode == tlul_pkg::Get) begin
       // 2 error cases if an InstrType transaction is seen:
-      // - if it is a write transaction
+      // - if it is a write transaction (handled in cip_base_scoreboard::predict_tl_err)
       // - if the SRAM is not configured in executable mode
-      is_tl_err = (allow_ifetch) ? (item.a_opcode != tlul_pkg::Get) : 1'b1;
+      is_tl_err = !allow_ifetch;
     end
 
     if (status_lc_esc) is_tl_err |= 1;

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -137,9 +137,11 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     end
 
     if (a_user.instr_type == prim_mubi_pkg::MuBi4True && item.a_opcode == tlul_pkg::Get) begin
-      // 2 error cases if an InstrType transaction is seen:
-      // - if it is a write transaction (handled in cip_base_scoreboard::predict_tl_err)
-      // - if the SRAM is not configured in executable mode
+      // 2 error cases (which lead to d_error = 1) if the InstrType is True:
+      // - it is a write transaction (handled in cip_base_scoreboard::predict_tl_err, as it's a
+      // common case for all blocks and that place also samples fcov.)
+      // - the SRAM is not configured in executable mode (handled here, as it's a special case
+      // for sram only)
       is_tl_err = !allow_ifetch;
     end
 

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -61,19 +61,6 @@
     }
   ]
 
-  build_modes: [
-    {
-      name: sram_ctrl_main
-      build_opts: ["+define+SRAM_ADDR_WIDTH=15",
-                   "+define+INSTR_EXEC=1"]
-    }
-    {
-      name: sram_ctrl_ret
-      build_opts: ["+define+SRAM_ADDR_WIDTH=10",
-                   "+define+INSTR_EXEC=0"]
-    }
-  ]
-
   // Default UVM test and seq class name.
   uvm_test: sram_ctrl_base_test
   uvm_test_seq: sram_ctrl_base_vseq

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson
@@ -10,6 +10,7 @@
   // Import the base sram_ctrl sim_cfg file
   import_cfgs: ["{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson"]
 
-  // Enable the appropriate build mode for all tests
-  en_build_modes: ["sram_ctrl_main"]
+  // These parameters are used for top_earlgrey main sram
+  build_opts: ["+define+SRAM_ADDR_WIDTH=15",
+               "+define+INSTR_EXEC=1"]
 }

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson
@@ -10,6 +10,7 @@
   // Import the base sram_ctrl sim_cfg file
   import_cfgs: ["{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson"]
 
-  // Enable the appropriate build mode for all tests
-  en_build_modes: ["sram_ctrl_ret"]
+  // These parameters are used for top_earlgrey retention sram
+  build_opts: ["+define+SRAM_ADDR_WIDTH=10",
+               "+define+INSTR_EXEC=0"]
 }


### PR DESCRIPTION
Let cip_base_scoreboard handle a TL error case - InstrType transaction with write,
as cip_base_scoreboard::predict_tl_err also collects coverage for it.

With this fix, fcov will be 100%.

Signed-off-by: Weicai Yang <weicai@google.com>