### PR TITLE
[sram_ctrl/dv] Get rid of `en_build_modes`

### DIFF
--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -61,19 +61,6 @@
     }
   ]
 
-  build_modes: [
-    {
-      name: sram_ctrl_main
-      build_opts: ["+define+SRAM_ADDR_WIDTH=15",
-                   "+define+INSTR_EXEC=1"]
-    }
-    {
-      name: sram_ctrl_ret
-      build_opts: ["+define+SRAM_ADDR_WIDTH=10",
-                   "+define+INSTR_EXEC=0"]
-    }
-  ]
-
   // Default UVM test and seq class name.
   uvm_test: sram_ctrl_base_test
   uvm_test_seq: sram_ctrl_base_vseq

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson
@@ -10,6 +10,7 @@
   // Import the base sram_ctrl sim_cfg file
   import_cfgs: ["{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson"]
 
-  // Enable the appropriate build mode for all tests
-  en_build_modes: ["sram_ctrl_main"]
+  // These parameters are used for top_earlgrey main sram
+  build_opts: ["+define+SRAM_ADDR_WIDTH=15",
+               "+define+INSTR_EXEC=1"]
 }

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson
@@ -10,6 +10,7 @@
   // Import the base sram_ctrl sim_cfg file
   import_cfgs: ["{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson"]
 
-  // Enable the appropriate build mode for all tests
-  en_build_modes: ["sram_ctrl_ret"]
+  // These parameters are used for top_earlgrey retention sram
+  build_opts: ["+define+SRAM_ADDR_WIDTH=10",
+               "+define+INSTR_EXEC=0"]
 }


### PR DESCRIPTION
dvsim cov-unr doesn't support `en_build_modes` #16988
Since all the tests use the same mode, we could just add additonal defines in `build_opts`. Then, these defines will be picked up for cov-unr

Signed-off-by: Weicai Yang <weicai@google.com>