### PR TITLE
[flash_ctrl,dv] regression fix - invalid_op and intr_wr_slow

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -64,7 +64,7 @@
             the Flash.  After RMA entry, verify that the content of the flash is wiped out.
             '''
       stage: V2
-      tests: ["flash_ctrl_hw_rma", "flash_ctrl_hw_rma_reset"]
+      tests: ["flash_ctrl_hw_rma", "flash_ctrl_hw_rma_reset", "flash_ctrl_lcmgr_intg"]
     }
     {
       name: host_controller_arb
@@ -88,6 +88,15 @@
             '''
       stage: V2
       tests: ["flash_ctrl_erase_suspend"]
+    }
+    {
+      name: program_reset
+      desc: '''
+            Reset controller at every state of programming operation and check
+            if controller doesn't have any residue for the next operation.
+            '''
+      stage: V2
+      tests: ["flash_ctrl_prog_reset"]
     }
     {
       name: full_memory_access
@@ -118,7 +127,7 @@
             including scramble and ecc enable.
             '''
       stage: V2
-      tests: ["flash_ctrl_rw_evict", "flash_ctrl_re_evict"]
+      tests: ["flash_ctrl_rw_evict", "flash_ctrl_re_evict", "flash_ctrl_rw_evict_all_en"]
     }
     {
       name: host_arb
@@ -202,6 +211,15 @@
       tests: ["flash_ctrl_error_prog_type"]
     }
     {
+      name: error_read_seed
+      desc: '''
+            Create sw read error during hw seed read process.
+            Check all errors are properly detected.
+            '''
+      stage: V2
+      tests: ["flash_ctrl_hw_read_seed_err"]
+    }
+    {
       name: read_write_overflow
       desc: '''
             Send following error transactions with normal traffic and see
@@ -274,7 +292,8 @@
             Check behaviour of Interrupt Enable and Status Registers.
             '''
       stage: V2
-      tests: ["flash_ctrl_intr_rd", "flash_ctrl_intr_wr"]
+      tests: ["flash_ctrl_intr_rd", "flash_ctrl_intr_wr",
+              "flash_ctrl_intr_rd_slow_flash", "flash_ctrl_intr_wr_slow_flash"]
     }
     {
       name: invalid_op
@@ -380,7 +399,7 @@
       fatal error (std_fault_status.lcmgr_err) should be triggered.
       '''
       stage: V2
-      tests: ["flash_ctrl_rma_err"]
+      tests: ["flash_ctrl_rma_err", "flash_ctrl_hw_prog_rma_wipe_err"]
     }
     {
       name: robustness

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -205,6 +205,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   bit                  skip_init = 0;
   bit                  skip_init_buf_en = 0;
   bit                  wr_rnd_data = 1;
+  int                  wait_rd_buf_en_timeout_ns = 100_000; // 100 us
 
   `uvm_object_utils(flash_ctrl_env_cfg)
   `uvm_object_new

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -109,7 +109,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
        csr_wr(.ptr(ral.init), .value(1));
        `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rd_buf_en == 1 || cfg.skip_init_buf_en == 1);,
                     "Timed out waiting for rd_buf_en",
-                    50_000)
+                    cfg.wait_rd_buf_en_timeout_ns)
     end
   endtask : pre_start
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -93,6 +93,14 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     };
   }
 
+  virtual task pre_start();
+    super.pre_start();
+    // This test requires fast alert hand shake to avoid overlapping
+    // multiple alert expected / completed.
+    cfg.m_alert_agent_cfgs["recov_err"].ack_delay_max = 1;
+    cfg.m_alert_agent_cfgs["recov_err"].ack_stable_max = 1;
+  endtask // pre_start
+
   virtual task body();
     cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::On;
     cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::On;
@@ -169,7 +177,6 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     flash_ctrl_start_op(flash_op_rd);
     flash_ctrl_read(flash_op_rd.num_words, flash_op_data, poll_fifo_status);
     wait_flash_op_done();
-
     flash_op_er.op = FlashOpErase;
     flash_ctrl_start_op(flash_op_er);
     wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));


### PR DESCRIPTION
Following regression failures are fixed.
1. flash_ctrl_invalid_op:
  reduce alert agent handshake time to accept finer back to back recov_err alert.
2. flash_ctrl_intr_wr_slow_flash
  increase wait timeout for init rd_buf_en

Signed-off-by: Jaedon Kim <jdonjdon@google.com>