### PR TITLE
[rom_ctrl,dv] Regression fix and minor TODO cleanup

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
@@ -9,6 +9,7 @@
                      "hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      "rom_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {

--- a/hw/ip/rom_ctrl/doc/dv/index.md
+++ b/hw/ip/rom_ctrl/doc/dv/index.md
@@ -60,7 +60,16 @@ Some of the most commonly used tasks / functions are as follows:
 #### Functional coverage
 To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
 The following covergroups have been developed to prove that the test intent has been adequately met:
-* TODO
+
+`rom_ctrl_kmac_cg`:
+  * Collect coverage on the rom_ctrl / kmac interface, specifically around stalling and back-pressure behavior.
+
+`rom_ctrl_tlul_cg`:
+  * Collect coverage on the two TLUL interfaces, specifically checking that we see requests around the same time as the rom check completes.
+  * Collect coverage to ensure that a_valid goes high when rom check is in progress. This ensures that the scenario where TL accesses are blocked until the ROM check is done is covered.
+
+`rom_ctrl_check_cg`:
+  * Collect coverage on the outputs sent to the power manager to confirm that we see pass and fail results.
 
 ### Self-checking strategy
 #### Scoreboard

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -37,11 +37,4 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
     `DV_CHECK_EQ(cfg.rom_ctrl_vif.checker_fsm_state, rom_ctrl_pkg::Invalid)
   endtask : check_sec_cm_fi_resp
 
-  virtual function void sec_cm_fi_ctrl_svas(sec_cm_base_if_proxy if_proxy, bit enable);
-    if (enable) begin
-      $asserton(0, "tb.dut.KeymgrValidChk_A");
-    end else begin
-      $assertoff(0, "tb.dut.KeymgrValidChk_A");
-    end
-  endfunction: sec_cm_fi_ctrl_svas
 endclass

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -36,7 +36,6 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
         // addr_q in the counter is corrupted with any value other than the ROM's top address.
         CheckerCtrConsistency: begin
           bit [12:0] invalid_addr;
-          $assertoff(0, "tb.dut.KeymgrValidChk_A");
           wait (mubi4_test_true_strict(cfg.rom_ctrl_vif.pwrmgr_data.done));
           wait_with_bound(10000);
           // Pick the index of a ROM word other than the top one
@@ -72,7 +71,6 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
         // signal from rom_ctrl_fsm is asserted randomly.
         CompareCtrlFlowConsistency: begin
           bit rdata;
-          $assertoff(0, "tb.dut.KeymgrValidChk_A");
           pick_err_inj_point();
           do begin
             uvm_hdl_read("tb.dut.gen_fsm_scramble_enabled.u_checker_fsm.start_checker_q", rdata);
@@ -87,7 +85,6 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
         // comparison ends then a fatal alert is generated.
         CompareCtrConsistency: begin
           bit [2:0] invalid_addr;
-          $assertoff(0, "tb.dut.KeymgrValidChk_A");
           wait_with_bound(10000);
           `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(invalid_addr, invalid_addr > 0;);
           force_sig("tb.dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.addr_q",
@@ -199,7 +196,6 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
       endcase
       wait_with_bound(10);
       dut_init();
-      $asserton(0, "tb.dut.KeymgrValidChk_A");
       $asserton(0, "tb.dut.BusRomIndicesMatch_A");
     end
   endtask : body

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -526,10 +526,12 @@ module rom_ctrl
 
   // Check that pwrmgr_data_o.done is never de-asserted once asserted
   `ASSERT(PwrmgrDataChk_A, $rose(pwrmgr_data_o.done == prim_mubi_pkg::MuBi4True) |->
-          always !$fell(pwrmgr_data_o.done == prim_mubi_pkg::MuBi4True))
+          always !$fell(pwrmgr_data_o.done == prim_mubi_pkg::MuBi4True),
+          clk_i, !rst_ni || internal_alert)
 
   // Check that keymgr_data_o.valid is never de-asserted once asserted
-  `ASSERT(KeymgrValidChk_A, $rose(keymgr_data_o.valid) |-> always !$fell(keymgr_data_o.valid))
+  `ASSERT(KeymgrValidChk_A, $rose(keymgr_data_o.valid) |-> always !$fell(keymgr_data_o.valid),
+          clk_i, !rst_ni || internal_alert)
 
   // Check that rom_tl_o.d_valid is not asserted unless pwrmgr_data_o.done is asseterd.
   // This check ensures that all tl accesses are blocked until rom check is completed. You might


### PR DESCRIPTION
First two commits are minor cleanup to cross some TODOs from V3 scoping list. Third commit fixes `rom_ctrl_corrupt_sig_fatal_chk` test.