### PR TITLE
[dv/otp] fix a timing related error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -176,6 +176,9 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
         // Backdoor restore injected ECC error, but should not affect fatal alerts.
         if (ecc_otp_err != OtpNoEccErr && dai_addr < LifeCycleOffset) begin
           cfg.mem_bkdr_util_h.write32({dai_addr[TL_DW-3:2], 2'b00}, backdoor_rd_val);
+          // Wait for two lock cycles to make sure the local escalation error propogates to other
+          // patitions and err_code reg.
+          cfg.clk_rst_vif.wait_clks(2);
         end
 
         // Random lock sw partitions


### PR DESCRIPTION
When inject ECC error and causes fatal alerts, it takes two clock cycle to propogates to other partitions and err_code register. So I added a two clock cycle wait.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>