### PR TITLE
[bitstreams] Splice bazel-built ROMs by default

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,17 +222,27 @@ jobs:
       #   because //... effectively asks to build //hw:verilator_real and other
       #   targets in //hw:all that depend on it. Note that this is only a
       #   shallow exclusion; tests deeper under //hw will still be found.
+      # * It excludes targets that depend on bitstream_splice rules, since the
+      #   environment does not have access to Vivado.
       export GCP_BAZEL_CACHE_KEY=$(bazelCacheGcpKeyPath)
+      TARGET_PATTERN_FILE=$(mktemp)
+      echo //... > "${TARGET_PATTERN_FILE}"
+      echo -//quality/... >> "${TARGET_PATTERN_FILE}"
+      echo -//third_party/riscv-compliance/... >> "${TARGET_PATTERN_FILE}"
+      echo -//hw:all >> "${TARGET_PATTERN_FILE}"
+      ./bazelisk.sh cquery \
+        --noinclude_aspects \
+        --output=starlark \
+        --starlark:expr='"-{}".format(target.label)' \
+        --define DISABLE_VERILATOR_BUILD=true \
+        -- "rdeps(//..., kind(bitstream_splice, //...))" \
+        >> "${TARGET_PATTERN_FILE}"
       ci/bazelisk.sh test \
-      --build_tests_only=false \
-      --test_output=errors \
-      --define DISABLE_VERILATOR_BUILD=true \
-      --build_tag_filters=-vivado \
-      --test_tag_filters=-broken,-cw310,-verilator,-dv \
-      -- //... \
-      -//quality/... \
-      -//third_party/riscv-compliance/... \
-      -//hw:all
+        --build_tests_only=false \
+        --test_output=errors \
+        --define DISABLE_VERILATOR_BUILD=true \
+        --test_tag_filters=-broken,-cw310,-verilator,-dv \
+        --target_pattern_file="${TARGET_PATTERN_FILE}"
     displayName: Build & test SW
   - bash: |
       set -x -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -562,6 +562,7 @@ jobs:
   - bash: |
       set -e
       . util/build_consts.sh
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
       ci/scripts/run-fpga-cw310-tests.sh cw310_test_rom,-jtag || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
 

--- a/doc/getting_started/install_vivado/index.md
+++ b/doc/getting_started/install_vivado/index.md
@@ -7,6 +7,10 @@ Generating a bitstream for Xilinx devices requires a
 Please note that the "WebPACK" edition __does not__ support the Xilinx Kintex 7
 XC7K410T used on the CW310 board.
 
+For software development, Vivado is still necessary for most workflows.
+However, the (free) Lab Edition is sufficient, and it has a significantly smaller installation footprint.
+For example, Vivado's `updatemem` tool is used to splice ROM images into the bitstream, and this is included in the Lab Edition.
+
 ## Install Xilinx Vivado
 
 _**Vivado Version:** The recommendation is to use Vivado {{< tool_version "vivado" >}}._
@@ -18,8 +22,9 @@ See [Download and
 Installation](https://docs.xilinx.com/r/{{< tool_version "vivado" >}}-English/ug973-vivado-release-notes-install-license/Download-and-Installation)
 for installation instructions.
 
-When asked what edition to install, choose "Vivado HL Design Edition". On the
-feature selection screen, select at least the following features:
+When asked what edition to install, choose "Vivado HL Design Edition".
+_Note: If you are only developing software, you may select the "Lab Edition" instead._
+On the feature selection screen, select at least the following features:
 
 ![Vivado features selection screen](features.png)
 
@@ -30,7 +35,7 @@ for instructions.
 
 ## Device permissions: udev rules
 
-To program an FPGAs the user using Vivado typically needs to have permissions to access USB devices connected to the PC.
+To program any FPGAs the user using Vivado typically needs to have permissions to access USB devices connected to the PC.
 Depending on your security policy you can take different steps to enable this access.
 One way of doing so is given in the udev rule outlined below.
 

--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -41,8 +41,8 @@ tar -xvf bitstream-latest.tar.gz
 
 By default, the bitstream is built with a version of the boot ROM used for testing (called the _test ROM_; pulled from `sw/device/lib/testing/test_rom`).
 There is also a version of the boot ROM used in production (called the _ROM_; pulled from `sw/device/silicon_creator/rom`).
-This can be spliced into the bitstream to overwrite the testing boot ROM as described in the [FPGA Reference Manual]({{< relref "ref_manual_fpga.md#boot-rom-development" >}}).
-However, if you do not want to do the splicing yourself, both versions of the bitstream are available in the download as `*.bit.orig` and `*.bit.splice` (containing the test ROM and the ROM respectively).
+When the bitstream cache is used in bazel flows, the ROMs from the cache are not used.
+Instead, the bazel-built ROMs are spliced into the image to create new bitstreams, using the mechanism described in the [FPGA Reference Manual]({{< relref "ref_manual_fpga.md#boot-rom-development" >}}).
 The metadata for the latest bitstream (the approximate creation time and the associated commit hash) is also available as a text file and can be [downloaded separately](https://storage.googleapis.com/opentitan-bitstreams/master/latest.txt).
 
 ### Using the `@bitstreams` repository
@@ -75,6 +75,7 @@ bazel build //hw/bitstream/vivado:fpga_cw310_rom
 ```
 
 Note, building these bitstreams will require Vivado be installed on your system, with access to the proper licenses, described [here]({{< relref "doc/getting_started/install_vivado" >}}).
+For general software development on the FPGA, Vivado must still be installed, but the Lab Edition is sufficient.
 
 #### Dealing with FPGA Congestion Issues
 

--- a/doc/rm/ref_manual_fpga.md
+++ b/doc/rm/ref_manual_fpga.md
@@ -10,6 +10,7 @@ Refer to the [FPGA Setup]({{< relref "doc/getting_started/setup_fpga" >}}) guide
 
 The FPGA is meant for both boot ROM and general software development.
 The flow for each is different, as the boot ROM is meant to be fairly static while general software can change very frequently.
+However, for both flows, Vivado must be installed, with instructions described [here]({{< relref "doc/getting_started/install_vivado" >}}).
 
 ### Boot ROM development
 

--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -60,7 +60,7 @@ filegroup(
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_test_rom"],
         "bitstream_gcp_splice": [":gcp_spliced_test_rom"],
-        "//conditions:default": ["@bitstreams//:bitstream_test_rom"],
+        "//conditions:default": [":gcp_spliced_test_rom"],
     }),
     tags = ["manual"],
 )
@@ -72,7 +72,7 @@ filegroup(
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_rom"],
         "bitstream_gcp_splice": [":gcp_spliced_rom"],
-        "//conditions:default": ["@bitstreams//:bitstream_rom"],
+        "//conditions:default": [":gcp_spliced_rom"],
     }),
     tags = ["manual"],
 )
@@ -107,11 +107,6 @@ filegroup(
             "bitstream_skip": ["skip.bit"],
             "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_rom_otp_" + otp_name],
             "bitstream_gcp_splice": [":gcp_spliced_rom_otp_" + otp_name],
-
-            # FIXME(#13807) By default, this will actually do a local splice
-            # instead of retrieving the pre-spliced bitstream from the cache.
-            # Before we cache OTP-spliced bitstreams, we need to work out the
-            # details of the naming scheme.
             "//conditions:default": [":gcp_spliced_rom_otp_" + otp_name],
         }),
         tags = ["manual"],

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@nonhermetic//:env.bzl", "ENV")
+load("@ot_python_deps//:requirements.bzl", "entry_point")
 
 """Rules for running FuseSoC.
 
@@ -71,9 +72,9 @@ def _fusesoc_build_impl(ctx):
     ctx.actions.run(
         mnemonic = "FuseSoC",
         outputs = outputs,
-        inputs = ctx.files.srcs + ctx.files.cores,
+        inputs = ctx.files.srcs + ctx.files.cores + ctx.files._fusesoc,
         arguments = [args],
-        executable = "fusesoc",
+        executable = ctx.executable._fusesoc,
         use_default_shell_env = False,
         execution_requirements = {
             "no-sandbox": "",
@@ -103,5 +104,10 @@ fusesoc_build = rule(
         ),
         "verilator_options": attr.label(),
         "make_options": attr.label(),
+        "_fusesoc": attr.label(
+            default = entry_point("fusesoc"),
+            executable = True,
+            cfg = "exec",
+        ),
     },
 )

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -151,6 +151,8 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @python3_toolchains//... \
     @remotejdk11_linux//... \
     @riscv-compliance//... \
+    @rules_foreign_cc//toolchains/... \
+    @rust_analyzer_nightly-2022-09-21_srcs//... \
     @rust_linux_x86_64__x86_64-unknown-linux-gnu_tools//... \
     @rust_opentitan_rv32imc__riscv32imc-unknown-none-elf//... \
     @rust_opentitan_rv32imc__riscv32imc-unknown-none-elf_tools//...

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -166,7 +166,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   readonly LATEST_BISTREAM_HASH_FILE="${SYSTEM_BITSTREAM_CACHE}/latest.txt"
   # The revision named in latest.txt is not necessarily on disk. Induce the
   # cache backend to fetch the latest bitstreams.
-  BITSTREAM=latest ${BAZELISK} build //hw/bitstream:rom
+  BITSTREAM=latest ${BAZELISK} build @bitstreams//:bitstream_test_rom
   cp "${LATEST_BISTREAM_HASH_FILE}" \
     "${BAZEL_AIRGAPPED_DIR}/${BAZEL_BITSTREAMS_CACHE}/"
   LATEST_BISTREAM_HASH=$(cat "${LATEST_BISTREAM_HASH_FILE}")


### PR DESCRIPTION
Change the default to use bazel-built ROMs for bitstreams instead of
whatever was in the bitstream when it was uploaded to the cache. This
makes the default bazel flow use the ROMs that are part of the current
source tree and avoids relying on a particular variant being available
in the cache.

As a side effect, software development on the FPGA now firmly requires
the FPGA lab tools by default. Update the documentation to reflect the
new behavior and tool requirements.

Also fix up the fusesoc rule to use the bazel-provided python interpreter.