### PR TITLE
[dv/chip] Add an apply_reset hook for chip_callback_vseq

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -37,6 +37,7 @@ class chip_base_vseq #(
 
   virtual task apply_reset(string kind = "HARD");
     lc_ctrl_state_pkg::lc_state_e lc_state;
+    callback_vseq.pre_apply_reset();
     // Note: The JTAG reset does not have a dedicated pad and is muxed with other chip IOs.
     // These IOs have pad attributes that are driven from registers, and as long as
     // the reset line of those registers is X, the registers and hence the pad outputs
@@ -55,6 +56,7 @@ class chip_base_vseq #(
     cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.do_trst_n();
     super.apply_reset(kind);
     if (jtag_dmi_ral != null) jtag_dmi_ral.reset(kind);
+    callback_vseq.post_apply_reset();
   endtask
 
   virtual task apply_resets_concurrently(int reset_duration_ps = 0);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_callback_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_callback_vseq.sv
@@ -12,6 +12,14 @@ class chip_callback_vseq extends cip_base_vseq #(
   `uvm_object_utils(chip_callback_vseq)
   `uvm_object_new
 
+  virtual task pre_apply_reset();
+    // Do nothing but can be overridden in closed source environment.
+  endtask
+
+  virtual task post_apply_reset(string reset_kind = "HARD");
+    // Do nothing but can be overridden in closed source environment.
+  endtask
+
   virtual task pre_dut_init();
     // Do nothing but can be overridden in closed source environment.
   endtask


### PR DESCRIPTION
Hi,
This small PR is adding additional hooks for the **chip_callback_vseq** before and after the **apply_reset** in the **chip_base_vseq** to be used by the extending environments.
It has been found that the hooks in the **dut_init** are needed but not enough.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>