### PR TITLE
[test] configure SPI host in for passthrough mode in power virus test

### DIFF
--- a/sw/device/lib/dif/dif_pinmux.h
+++ b/sw/device/lib/dif/dif_pinmux.h
@@ -160,7 +160,7 @@ typedef struct dif_pinmux_pad_attr {
    */
   dif_pinmux_pad_drive_strength_t drive_strength;
   /**
-   * A bit map of single-bit attribute flags. @sa dif_pinmux_pad_attr_flags_t
+   * A bit map of single-bit attribute flags. See dif_pinmux_pad_attr_flags_t
    * for the mapping and definitions.
    */
   dif_pinmux_pad_attr_flags_t flags;

--- a/sw/device/lib/testing/pinmux_testutils.c
+++ b/sw/device/lib/testing/pinmux_testutils.c
@@ -171,3 +171,16 @@ uint32_t pinmux_testutils_read_straps(dif_pinmux_t *pinmux, dif_gpio_t *gpio) {
            << 4;
   return strap;
 }
+
+void pinmux_testutils_configure_pads(const dif_pinmux_t *pinmux,
+                                     const pinmux_pad_attributes_t *attrs,
+                                     size_t num_attrs) {
+  for (size_t i = 0; i < num_attrs; ++i) {
+    dif_pinmux_pad_attr_t desired_attr, actual_attr;
+    CHECK_DIF_OK(dif_pinmux_pad_get_attrs(pinmux, attrs[i].pad, attrs[i].kind,
+                                          &desired_attr));
+    desired_attr.flags = attrs[i].flags;
+    CHECK_DIF_OK(dif_pinmux_pad_write_attrs(pinmux, attrs[i].pad, attrs[i].kind,
+                                            desired_attr, &actual_attr));
+  }
+}

--- a/sw/device/lib/testing/pinmux_testutils.h
+++ b/sw/device/lib/testing/pinmux_testutils.h
@@ -73,4 +73,20 @@ uint32_t pinmux_testutils_read_strap_pin(dif_pinmux_t *pinmux, dif_gpio_t *gpio,
  */
 uint32_t pinmux_testutils_read_straps(dif_pinmux_t *pinmux, dif_gpio_t *gpio);
 
+/**
+ * A convenience struct to associate pad attributes with a specific pad.
+ */
+typedef struct pinmux_pad_attributes {
+  dif_pinmux_index_t pad;
+  dif_pinmux_pad_kind_t kind;
+  dif_pinmux_pad_attr_flags_t flags;
+} pinmux_pad_attributes_t;
+
+/**
+ * Configures several pad attributes.
+ */
+void pinmux_testutils_configure_pads(const dif_pinmux_t *pinmux,
+                                     const pinmux_pad_attributes_t *attrs,
+                                     size_t num_attrs);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_PINMUX_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2072,6 +2072,7 @@ opentitan_functest(
         "//sw/device/lib/dif:kmac",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/dif:spi_host",
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aes_testutils",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2077,6 +2077,7 @@ opentitan_functest(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aes_testutils",
         "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing:spi_device_testutils",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/sim_dv/spi_passthrough_test.c
+++ b/sw/device/tests/sim_dv/spi_passthrough_test.c
@@ -38,15 +38,6 @@ static dif_spi_device_handle_t spi_device;
 static dif_spi_host_t spi_host0;
 static dif_spi_host_t spi_host1;
 
-/**
- * A convenience struct to associate pad attributes with a specific pad.
- */
-typedef struct pinmux_pad_attributes {
-  dif_pinmux_index_t pad;
-  dif_pinmux_pad_kind_t kind;
-  dif_pinmux_pad_attr_flags_t flags;
-} pinmux_pad_attributes_t;
-
 // Enable pull-ups for spi_host data pins to avoid floating inputs.
 static const pinmux_pad_attributes_t pinmux_pad_config[] = {
     {
@@ -484,16 +475,8 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_pinmux_init(
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
   pinmux_testutils_init(&pinmux);
-  for (int i = 0; i < ARRAYSIZE(pinmux_pad_config); ++i) {
-    dif_pinmux_pad_attr_t attr, attr_check;
-    pinmux_pad_attributes_t config = pinmux_pad_config[i];
-    CHECK_DIF_OK(
-        dif_pinmux_pad_get_attrs(&pinmux, config.pad, config.kind, &attr));
-    attr.flags = config.flags;
-    CHECK_DIF_OK(dif_pinmux_pad_write_attrs(&pinmux, config.pad, config.kind,
-                                            attr, &attr_check));
-    // Check that attributes were accepted?
-  }
+  pinmux_testutils_configure_pads(&pinmux, pinmux_pad_config,
+                                  ARRAYSIZE(pinmux_pad_config));
   for (int i = 0; i < ARRAYSIZE(pinmux_in_config); ++i) {
     pinmux_select_t setting = pinmux_in_config[i];
     CHECK_DIF_OK(


### PR DESCRIPTION
This PR configures the SPI host (0) in for passthrough mode in power virus test. Additionally, it move pinmux pad configuration code from the `spi_passthrough_test` to a testutil function so it can be reused between both tests.