### PR TITLE
[sram_ctrl/dv] Update lc_esc test

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
@@ -18,8 +18,8 @@ class sram_ctrl_executable_vseq extends sram_ctrl_multiple_keys_vseq;
     super.pre_start();
   endtask
 
-  task req_mem_init();
-    super.req_mem_init();
+  task req_mem_init(bit wait_done);
+    super.req_mem_init(wait_done);
     randomize_and_drive_ifetch_en();
   endtask
 

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
@@ -54,6 +54,19 @@ class sram_ctrl_lc_escalation_vseq extends sram_ctrl_multiple_keys_vseq;
       fork
         begin
           bit [TL_DW-1:0] status;
+
+          // issue req key or init after lc_esc, which will fail.
+          if ($urandom_range(0, 1)) begin
+            // key valid or init done won't be set due to lc_esc
+            randcase
+              1: req_scr_key(.wait_valid(0));
+              1: req_mem_init(.wait_done(0));
+            endcase
+            // a regular init for sram_ret (4kb) takes 1024 cycles
+            // add some big delay before checking status, so that we know the status
+            // always fails.
+            cfg.clk_rst_vif.wait_clks($urandom_range(0, 2 ** (`SRAM_ADDR_WIDTH + 1)));
+          end
           // read out STATUS csr, scoreboard will check that proper updates have been made
           csr_rd(.ptr(ral.status), .value(status));
           csr_wr(.ptr(ral.status), .value(status));

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_regwen_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_regwen_vseq.sv
@@ -12,8 +12,8 @@ class sram_ctrl_regwen_vseq extends sram_ctrl_executable_vseq;
   `uvm_object_utils(sram_ctrl_regwen_vseq)
   `uvm_object_new
 
-  task req_mem_init();
-    super.req_mem_init();
+  task req_mem_init(bit wait_done);
+    super.req_mem_init(wait_done);
     `DV_CHECK_RANDOMIZE_FATAL(ral.exec_regwen)
     csr_update(ral.exec_regwen);
     `DV_CHECK_RANDOMIZE_FATAL(ral.ctrl_regwen)


### PR DESCRIPTION
Tested key request and sram init after lc_esc
This fix made `key_seed_valid_cg` 100% covered.

Signed-off-by: Weicai Yang <weicai@google.com>