### PR TITLE
[dv/alert_handler] Add a knob to enable running tl_intg with csr_rw

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -32,6 +32,9 @@ class cip_base_vseq #(
   // knob to enable/disable running csr_vseq with passthru_mem_tl_intg_err
   bit en_csr_vseq_w_passthru_mem_intg = 1;
 
+  // knob to enable/disable running csr_vseq with tl_intg_err
+  bit en_csr_vseq_w_tl_intg = 1;
+
   // csr queues
   dv_base_reg all_csrs[$];
   dv_base_reg intr_state_csrs[$];

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -301,8 +301,10 @@ virtual task run_tl_intg_err_vseq_sub(string ral_name);
   fork
     // run csr_rw seq to send some normal CSR accesses in parallel
     begin
-      `uvm_info(`gfn, "Run csr_rw seq", UVM_HIGH)
-      run_csr_vseq(.csr_test_type("rw"), .ral_name(ral_name));
+      if (en_csr_vseq_w_tl_intg) begin
+        `uvm_info(`gfn, "Run csr_rw seq", UVM_HIGH)
+        run_csr_vseq(.csr_test_type("rw"), .ral_name(ral_name));
+      end
     end
     begin
       // check integrity status before injecting fault


### PR DESCRIPTION
This PR adds a knob to enable/disable running tl_intg and csr_rw in parallel.
In alert_handler, tl_intg error if the sequence enable this local alert, it might eventually cause escalation, so the csr_rw sequence prediction might not work.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>