### PR TITLE
[rom_ctrl,dv] Minor fixes for coverage improvement

### DIFF
--- a/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
+++ b/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
@@ -50,14 +50,17 @@ interface prim_onehot_check_if #(
 
       cp_onehot_fault: coverpoint onehot_fault_type {
         option.weight = AddrWidth > 1;  // set to 0 to disable it if it's not supported
+        option.at_least = AddrWidth > 1; // If 0, we expect 0 hits.
         bins hit = {OnehotFault};
       }
       cp_onehot_enable_fault: coverpoint onehot_fault_type {
         option.weight = EnableCheck;  // set to 0 to disable it if it's not supported
+        option.at_least = EnableCheck; // If 0, we expect 0 hits.
         bins hit = {OnehotEnableFault};
       }
       cp_onehot_addr_fault: coverpoint onehot_fault_type {
         option.weight = AddrCheck;  // set to 0 to disable it if it's not supported
+        option.at_least = AddrCheck; // If 0, we expect 0 hits.
         bins hit = {OnehotAddrFault};
       }
     endgroup

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -60,6 +60,7 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
     m_kmac_agent_cfg.constant_share_means_error = 1'b0;
 
     m_tl_agent_cfgs["rom_ctrl_rom_reg_block"].max_outstanding_req = 2;
+    m_tl_agent_cfgs["rom_ctrl_regs_reg_block"].max_outstanding_req = 1;
 
     // Tell the CIP base code what bit gets set if we see a TL fault.
     tl_intg_alert_fields[ral.fatal_alert_cause.integrity_error] = 1;


### PR DESCRIPTION
1st commit sets `max_outstanding_req` of rom_ctrl register TLUL agent to 1. That is because TLUL agent for registers of rom_ctrl is autogenerated using `tlul_adapter_reg`. That module allows a `max_outstanding_req` of only 1.

2nd commit improves coverage score of `onehot_fault_cg` by setting `option.at_least` to 0 in coverpoints that we set `option.weight` 0.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>

Needed to close up functional coverage of `rom_ctrl`