### PR TITLE
[ibex] Change ichache scramble key assertion

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -943,22 +943,12 @@ module rv_core_ibex
 
     // Ensure that when a scramble key is received, it is correctly applied to the icache scrambled
     // memory primitives.
-    for (genvar way = 0; way < ibex_pkg::IC_NUM_WAYS; way++) begin : gen_ways
-      `ASSERT(IbexIcacheScrambleKeyAppliedAtTagBank_A,
-          icache_otp_key_i.ack
-          |-> ##[0:10] // upper bound is not exact, but it should not take more than a few cycles
-          u_core.gen_rams.gen_rams_inner[way].gen_scramble_rams.tag_bank.key_valid_i
-          && (u_core.gen_rams.gen_rams_inner[way].gen_scramble_rams.tag_bank.key_i
-              == icache_otp_key_q)
-      )
-      `ASSERT(IbexIcacheScrambleKeyAppliedAtDataBank_A,
-          icache_otp_key_i.ack
-          |-> ##[0:10] // upper bound is not exact, but it should not take more than a few cycles
-          u_core.gen_rams.gen_rams_inner[way].gen_scramble_rams.data_bank.key_valid_i
-          && (u_core.gen_rams.gen_rams_inner[way].gen_scramble_rams.data_bank.key_i
-              == icache_otp_key_q)
-      )
-    end
+    `ASSERT(IbexIcacheScrambleKeyApplied_A,
+        icache_otp_key_i.ack
+        |-> ##[0:10] // upper bound is not exact, but it should not take more than a few cycles
+        u_core.scramble_key_valid_q
+        && (u_core.scramble_key_q == icache_otp_key_q)
+    )
 
     // Ensure that when a FENCE.I is executed, a new icache scramble key is requested.
     `ASSERT(IbexIcacheScrambleKeyRequestAfterFenceI_A,


### PR DESCRIPTION
Signed-off-by: Sharon Topaz <sharon.topaz@nuvoton.com>

Changing the assertion not to check individual bank ports, but the key register connected to all these banks.
This due to the issues some DFT tools have with generate loops.