### PR TITLE
[opentitantool] Move TAP_STRAPn to Sam3X-specific conf

### DIFF
--- a/sw/host/opentitanlib/src/app/config/opentitan.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan.json
@@ -24,18 +24,6 @@
       "level": false,
       "pull_mode": "None",
       "alias_of": "IOC2"
-    },
-    {
-      "name": "TAP_STRAP0",
-      "mode": "PushPull",
-      "level": false,
-      "pull_mode": "None"
-    },
-    {
-      "name": "TAP_STRAP1",
-      "mode": "PushPull",
-      "level": false,
-      "pull_mode": "None"
     }
   ],
   "strappings": [
@@ -62,10 +50,6 @@
         {
           "name": "RESET",
           "level": false
-        },
-        {
-          "name": "TAP_STRAP1",
-          "level": true
         }
       ]
     }

--- a/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
@@ -22,11 +22,28 @@
     },
     {
       "name": "TAP_STRAP0",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None"
       "alias_of": "USB_A18"
     },
     {
       "name": "TAP_STRAP1",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None"
       "alias_of": "USB_A19"
+    }
+  ],
+  "strappings": [
+    {
+      "name": "RESET",
+      "pins": [
+        {
+          "name": "TAP_STRAP1",
+          "level": true
+        }
+      ]
     }
   ],
   "spi": [


### PR DESCRIPTION
Avoid mentioning TAP_STRAPn in the shared opentitan.json, as the HyperDebug transport does not have those signals.  Instead, declare them in opentitan_cw310.json, taking advantage of the ability for several configuration files to add pins into the same "RESET" strapping.
