### PR TITLE
[dv/shadowed_reg] Reduce a env_cfg variable

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -33,10 +33,18 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
                                                              cfg.devmode_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get devmode_vif from uvm_config_db")
     end
-    if (cfg.has_shadowed_regs &&
-        !uvm_config_db#(rst_shadowed_vif)::get(this, "", "rst_shadowed_vif", cfg.rst_shadowed_vif))
-        begin
-      `uvm_fatal(get_full_name(), "failed to get rst_shadowed_vif from uvm_config_db")
+
+    // Only get rst_shadowed_vif if it is an IP level testbench,
+    // and the IP contains shadowed registers.
+    if (cfg.is_chip == 0) begin
+      foreach(cfg.ral_models[i]) begin
+        if (cfg.ral_models[i].has_shadowed_regs() &&
+            !uvm_config_db#(rst_shadowed_vif)::get(this, "", "rst_shadowed_vif",
+                                                   cfg.rst_shadowed_vif)) begin
+          `uvm_fatal(get_full_name(), "failed to get rst_shadowed_vif from uvm_config_db")
+          break;
+        end
+      end
     end
 
     // Create & configure the TL agent.

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -29,6 +29,9 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // Flag to indicate tl mem acess are gated due to local or global escalation.
   bit                 tl_mem_access_gated;
 
+  // Flag to indicate if it is an IP or chip level testbench.
+  bit                 is_chip;
+
   // Similar to the associative array above, if DUT has shadow registers, these two associative
   // arrays contains register fields related to shadow register's update and storage error status.
   uvm_reg_data_t      shadow_update_err_status_fields[dv_base_reg_field];
@@ -51,7 +54,6 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // TODO(#16739): enable random drive devmode once design supports
   bit  has_devmode = 1;
   bit  en_devmode = 1;
-  bit  has_shadowed_regs = 0;
 
   // If the data intg is passthru for the memory and the data intg value in mem is incorrect, it
   // won't trigger d_error in this mem block and the check is done in the processor

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -161,6 +161,12 @@ class dv_base_reg_block extends uvm_reg_block;
     end
   endfunction
 
+  function bit has_shadowed_regs();
+    dv_base_reg regs[$];
+    get_shadowed_regs(regs);
+    return (regs.size() > 0);
+  endfunction
+
   // Internal function, used to compute the address mask for this register block.
   //
   // This is quite an expensive computation, so we memoize the results in addr_mask[map].

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -222,7 +222,6 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
                                 ::create("keymgr_sideload_agent_cfg");
     keymgr_sideload_agent_cfg.start_default_seq = 0;
     num_edn = 1;
-    has_shadowed_regs = 1;
     super.initialize(csr_base_addr);
     tl_intg_alert_fields[ral.status.alert_fatal_fault] = 1;
     shadow_update_err_status_fields[ral.status.alert_recov_ctrl_update_err] = 1;

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_cfg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_cfg.sv
@@ -29,7 +29,6 @@ class clkmgr_env_cfg extends cip_base_env_cfg #(
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = clkmgr_env_pkg::LIST_OF_ALERTS;
-    has_shadowed_regs = 1;
     super.initialize(csr_base_addr);
 
     // This is for the integrity error test.

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -271,7 +271,6 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     string prim_ral_name = "flash_ctrl_prim_reg_block";
 
     list_of_alerts = flash_ctrl_env_pkg::LIST_OF_ALERTS;
-    has_shadowed_regs = 1;
     tl_intg_alert_name = "fatal_std_err";
     sec_cm_alert_name = tl_intg_alert_name;
     // Set up second RAL model for Flash memory

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -20,7 +20,6 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
     tl_intg_alert_name = "fatal_fault_err";
     sec_cm_alert_name  = tl_intg_alert_name;
     num_edn = 1;
-    has_shadowed_regs = 1;
     super.initialize(csr_base_addr);
     tl_intg_alert_fields[ral.fault_status.regfile_intg] = 1;
     shadow_update_err_status_fields[ral.err_code.invalid_shadow_update] = 1;

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -31,7 +31,6 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     num_edn = 1;
-    has_shadowed_regs = 1;
     list_of_alerts = kmac_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_fault_err";
     sec_cm_alert_name  = "fatal_fault_err";

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cfg.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cfg.sv
@@ -20,7 +20,6 @@ class alert_handler_env_cfg extends cip_base_env_cfg #(.RAL_T(alert_handler_reg_
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     num_edn = 1;
-    has_shadowed_regs = 1;
     super.initialize(csr_base_addr);
     shadow_update_err_status_fields[ral.loc_alert_cause[LocalShadowRegUpdateErr].la] = 1;
     shadow_storage_err_status_fields[ral.loc_alert_cause[LocalShadowRegStorageErr].la] = 1;

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -124,6 +124,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     has_devmode = 0;
     list_of_alerts = chip_common_pkg::LIST_OF_ALERTS;
+    is_chip = 1;
 
     // No need to cover all kinds of interity errors as they are tested in block-level.
     en_tl_intg_err_cov = 0;

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cfg.sv
@@ -20,7 +20,6 @@ class alert_handler_env_cfg extends cip_base_env_cfg #(.RAL_T(alert_handler_reg_
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     num_edn = 1;
-    has_shadowed_regs = 1;
     super.initialize(csr_base_addr);
     shadow_update_err_status_fields[ral.loc_alert_cause[LocalShadowRegUpdateErr].la] = 1;
     shadow_storage_err_status_fields[ral.loc_alert_cause[LocalShadowRegStorageErr].la] = 1;


### PR DESCRIPTION
This PR fixes issue #10538.
It suggested to reduce varaible `has_shadowed_regs` by automatically check auto-generated RAL regs.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>