### PR TITLE
[sram_ctrl/dv] Add a simple connectivity test for sram_ctrl.cfg_i

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_testplan.hjson
@@ -167,6 +167,14 @@
       tests: ["{name}_regwen"]
     }
     {
+      name: ram_cfg
+      desc: '''Test `cfg_i` connectivity between sram_ctrl and prim_ram_1p.
+
+               Randomly set `dut.cfg_i` and check its value is propagated to `prim_mem_1p`.'''
+      stage: V2
+      tests: ["{name}_ram_cfg"]
+    }
+    {
       name: stress_all
       desc: '''
             - Combine above sequences in one test to run sequentially, except csr sequence and

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_ram_cfg_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_ram_cfg_vseq.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Randomly set dut.cfg_i and check this value is propagated to prim_generic_ram_1p.
+class sram_ctrl_ram_cfg_vseq extends sram_ctrl_base_vseq;
+
+  `uvm_object_utils(sram_ctrl_ram_cfg_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    prim_ram_1p_pkg::ram_1p_cfg_t src_ram_cfg, dst_ram_cfg;
+    string src_path = "tb.dut.cfg_i";
+    string dst_path =
+        "tb.dut.u_prim_ram_1p_scr.u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic.cfg_i";
+
+    repeat (100) begin
+      `DV_CHECK_STD_RANDOMIZE_FATAL(src_ram_cfg)
+      `DV_CHECK(uvm_hdl_deposit(src_path, src_ram_cfg))
+      #($urandom_range(1, 100) * 1ns);
+      `DV_CHECK(uvm_hdl_read(dst_path, dst_ram_cfg))
+      `DV_CHECK_CASE_EQ(src_ram_cfg, dst_ram_cfg)
+    end
+  endtask
+endclass

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
@@ -13,4 +13,5 @@
 `include "sram_ctrl_access_during_key_req_vseq.sv"
 `include "sram_ctrl_executable_vseq.sv"
 `include "sram_ctrl_regwen_vseq.sv"
+`include "sram_ctrl_ram_cfg_vseq.sv"
 `include "sram_ctrl_stress_all_vseq.sv"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
@@ -34,6 +34,7 @@ filesets:
       - seq_lib/sram_ctrl_access_during_key_req_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_executable_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_regwen_vseq.sv: {is_include_file: true}
+      - seq_lib/sram_ctrl_ram_cfg_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -123,6 +123,10 @@
       name: "{name}_regwen"
       uvm_test_seq: sram_ctrl_regwen_vseq
     }
+    {
+      name: "{name}_ram_cfg"
+      uvm_test_seq: "{name}_ram_cfg_vseq"
+    }
     // Below 2 tests are same as the tests in dvsim/tests/mem_tests.hjson
     // Replicate them here in order to enable scb
     {


### PR DESCRIPTION
Test it's connected correctly to prim_mem_1p
This improves the toggle coverage.

Signed-off-by: Weicai Yang <weicai@google.com>