### PR TITLE
[dv/alert_handler] regression failure fix

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -30,6 +30,9 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   // Control if ping response will timeout or not.
   bit ping_timeout = 0;
 
+  // Monitor will set this value to 1 when the agent is under ping handshake.
+  bit under_ping_handshake = 0;
+
   // dut clk frequency, used to generate alert async_clk frequency
   int clk_freq_mhz;
 

--- a/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
@@ -45,6 +45,7 @@ class alert_esc_base_monitor extends dv_base_monitor #(
 
   // this function can be used in derived classes to reset local signals/variables if needed
   virtual function void reset_signals();
+    cfg.under_ping_handshake = 0;
   endfunction
 
 endclass

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -155,7 +155,11 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   // error: after clearing intr_state, intr_state might come back to 1 in the next cycle.
   virtual task check_alert_interrupts();
     bit [TL_DW-1:0] intr;
+    // Wait until there is no ping handshake.
+    // This will avoid the case where interrupt is set and cleared at the same cycle.
+    `DV_WAIT((cfg.alert_handler_vif.alert_ping_reqs || cfg.alert_handler_vif.esc_ping_reqs) == 0)
     csr_rd(.ptr(ral.intr_state), .value(intr));
+    `DV_WAIT((cfg.alert_handler_vif.alert_ping_reqs || cfg.alert_handler_vif.esc_ping_reqs) == 0)
     csr_wr(.ptr(ral.intr_state), .value('1));
   endtask
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -155,7 +155,11 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   // error: after clearing intr_state, intr_state might come back to 1 in the next cycle.
   virtual task check_alert_interrupts();
     bit [TL_DW-1:0] intr;
+    // Wait until there is no ping handshake.
+    // This will avoid the case where interrupt is set and cleared at the same cycle.
+    `DV_WAIT((cfg.alert_handler_vif.alert_ping_reqs || cfg.alert_handler_vif.esc_ping_reqs) == 0)
     csr_rd(.ptr(ral.intr_state), .value(intr));
+    `DV_WAIT((cfg.alert_handler_vif.alert_ping_reqs || cfg.alert_handler_vif.esc_ping_reqs) == 0)
     csr_wr(.ptr(ral.intr_state), .value('1));
   endtask
 


### PR DESCRIPTION
This PR fixes the regression failure where interrupt is set and cleared at the same cycle.
To fix this issue, this PR did two clean ups:
1). Use one signal to flag under_ping_handshake. This signal will be
  used in the next PR to check ping_handshake in scb.
2). In sequence, wait for ping handshake done, then issue interrupt.
  This will avoid the case where ping related error is set and cleared
  at the same cycle.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>