### PR TITLE
[test] add several tasks to power virus tests to actuate IPs

### DIFF
--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -147,13 +147,14 @@ void _ottf_main(void) {
 
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
-  CHECK_DIF_OK(
-      dif_uart_configure(&uart, (dif_uart_config_t){
-                                    .baudrate = kUartBaudrate,
-                                    .clk_freq_hz = kClockFreqPeripheralHz,
-                                    .parity_enable = kDifToggleDisabled,
-                                    .parity = kDifUartParityEven,
-                                }));
+  CHECK_DIF_OK(dif_uart_configure(&uart,
+                                  (dif_uart_config_t){
+                                      .baudrate = kUartBaudrate,
+                                      .clk_freq_hz = kClockFreqPeripheralHz,
+                                      .parity_enable = kDifToggleDisabled,
+                                      .parity = kDifUartParityEven,
+                                  },
+                                  kDifToggleEnabled));
   base_uart_stdout(&uart);
 
   CHECK_DIF_OK(dif_spi_device_init_handle(

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -59,13 +59,14 @@ void _ottf_main(void) {
 
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
-  CHECK_DIF_OK(
-      dif_uart_configure(&uart, (dif_uart_config_t){
-                                    .baudrate = kUartBaudrate,
-                                    .clk_freq_hz = kClockFreqPeripheralHz,
-                                    .parity_enable = kDifToggleDisabled,
-                                    .parity = kDifUartParityEven,
-                                }));
+  CHECK_DIF_OK(dif_uart_configure(&uart,
+                                  (dif_uart_config_t){
+                                      .baudrate = kUartBaudrate,
+                                      .clk_freq_hz = kClockFreqPeripheralHz,
+                                      .parity_enable = kDifToggleDisabled,
+                                      .parity = kDifUartParityEven,
+                                  },
+                                  kDifToggleEnabled));
   base_uart_stdout(&uart);
 
   CHECK_DIF_OK(dif_spi_device_init_handle(

--- a/sw/device/examples/sram_program/sram_program.c
+++ b/sw/device/examples/sram_program/sram_program.c
@@ -34,13 +34,14 @@ void sram_main() {
     // Initialize UART.
     CHECK_DIF_OK(dif_uart_init(
         mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-    CHECK_DIF_OK(
-        dif_uart_configure(&uart0, (dif_uart_config_t){
-                                       .baudrate = kUartBaudrate,
-                                       .clk_freq_hz = kClockFreqPeripheralHz,
-                                       .parity_enable = kDifToggleDisabled,
-                                       .parity = kDifUartParityEven,
-                                   }));
+    CHECK_DIF_OK(dif_uart_configure(&uart0,
+                                    (dif_uart_config_t){
+                                        .baudrate = kUartBaudrate,
+                                        .clk_freq_hz = kClockFreqPeripheralHz,
+                                        .parity_enable = kDifToggleDisabled,
+                                        .parity = kDifUartParityEven,
+                                    },
+                                    kDifToggleEnabled));
     base_uart_stdout(&uart0);
   }
 

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -88,12 +88,10 @@ static size_t uart_bytes_receive(const dif_uart_t *uart, size_t bytes_requested,
 }
 
 dif_result_t dif_uart_configure(const dif_uart_t *uart,
-                                dif_uart_config_t config) {
-  if (uart == NULL) {
-    return kDifBadArg;
-  }
-
-  if (config.baudrate == 0 || config.clk_freq_hz == 0) {
+                                dif_uart_config_t config,
+                                dif_toggle_t enabled) {
+  if (uart == NULL || config.baudrate == 0 || config.clk_freq_hz == 0 ||
+      !dif_is_valid_toggle(enabled)) {
     return kDifBadArg;
   }
 
@@ -132,8 +130,10 @@ dif_result_t dif_uart_configure(const dif_uart_t *uart,
   // Set baudrate, enable RX and TX, configure parity.
   uint32_t reg = 0;
   reg = bitfield_field32_write(reg, UART_CTRL_NCO_FIELD, nco_masked);
-  reg = bitfield_bit32_write(reg, UART_CTRL_TX_BIT, true);
-  reg = bitfield_bit32_write(reg, UART_CTRL_RX_BIT, true);
+  if (dif_toggle_to_bool(enabled)) {
+    reg = bitfield_bit32_write(reg, UART_CTRL_TX_BIT, true);
+    reg = bitfield_bit32_write(reg, UART_CTRL_RX_BIT, true);
+  }
   if (config.parity_enable == kDifToggleEnabled) {
     reg = bitfield_bit32_write(reg, UART_CTRL_PARITY_EN_BIT, true);
   }

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -133,7 +133,7 @@ extern const uint32_t kDifUartFifoSizeBytes;
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_uart_configure(const dif_uart_t *uart,
-                                dif_uart_config_t config);
+                                dif_uart_config_t config, dif_toggle_t enabled);
 
 /**
  * Sets the RX FIFO watermark.

--- a/sw/device/lib/dif/dif_uart_unittest.cc
+++ b/sw/device/lib/dif/dif_uart_unittest.cc
@@ -59,21 +59,25 @@ class UartTest : public Test, public MmioTest {
 class ConfigTest : public UartTest {};
 
 TEST_F(ConfigTest, NullArgs) {
-  EXPECT_DIF_BADARG(dif_uart_configure(nullptr, config_));
+  EXPECT_DIF_BADARG(dif_uart_configure(nullptr, config_, kDifToggleEnabled));
 }
 
-TEST_F(ConfigTest, Default) {
+TEST_F(ConfigTest, DefaultEnabled) {
   ExpectDeviceReset();
-
   EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
                                            {UART_CTRL_TX_BIT, true},
                                            {UART_CTRL_RX_BIT, true},
                                            {UART_CTRL_NCO_OFFSET, 1},
                                        });
-
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_, kDifToggleEnabled));
+}
 
-  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
+TEST_F(ConfigTest, DefaultDisabled) {
+  ExpectDeviceReset();
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {{UART_CTRL_NCO_OFFSET, 1}});
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_, kDifToggleDisabled));
 }
 
 TEST_F(ConfigTest, ParityEven) {
@@ -91,7 +95,7 @@ TEST_F(ConfigTest, ParityEven) {
 
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
 
-  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
+  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_, kDifToggleEnabled));
 }
 
 TEST_F(ConfigTest, ParityOdd) {
@@ -110,7 +114,7 @@ TEST_F(ConfigTest, ParityOdd) {
 
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
 
-  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
+  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_, kDifToggleEnabled));
 }
 
 class WatermarkRxSetTest : public UartTest {};

--- a/sw/device/lib/testing/hmac_testutils.c
+++ b/sw/device/lib/testing/hmac_testutils.c
@@ -8,9 +8,9 @@
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-const char kRefData[34] = "Sample message for keylen=blocklen";
+const char kHmacRefData[34] = "Sample message for keylen=blocklen";
 
-const uint8_t kRefHmacLongKey[100] = {
+const uint8_t kHmacRefLongKey[100] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
     0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
     0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23,
@@ -25,7 +25,7 @@ const uint8_t kRefHmacLongKey[100] = {
  * Big endian representation of the hashed "long" key, which is used as the
  * input key into the HMAC mode digest generation.
  */
-const dif_hmac_digest_t kRefExpectedShaDigest = {
+const dif_hmac_digest_t kHmacRefExpectedLongKeyDigest = {
     .digest =
         {
             0x5C954D52,
@@ -42,7 +42,7 @@ const dif_hmac_digest_t kRefExpectedShaDigest = {
 /**
  * Big endian representation of the final HMAC mode digest.
  */
-const dif_hmac_digest_t kRefExpectedHmacDigest = {
+const dif_hmac_digest_t kHmacRefExpectedDigest = {
     .digest =
         {
             0x1B78378D,

--- a/sw/device/lib/testing/hmac_testutils.h
+++ b/sw/device/lib/testing/hmac_testutils.h
@@ -63,23 +63,23 @@
 /**
  * This should be hashed with SHA-256 to generate the key.
  */
-extern const uint8_t kRefHmacLongKey[100];
+extern const uint8_t kHmacRefLongKey[100];
 
 /**
- * Expected SHA digest for kRefHmacLongKey data above.
+ * Expected SHA digest for kHmacRefLongKey data above.
  */
-extern const dif_hmac_digest_t kRefExpectedShaDigest;
+extern const dif_hmac_digest_t kHmacRefExpectedLongKeyDigest;
 
 /**
- * This is used as data for the MAC computation, using kRefExpectedShaDigest
- * as the key.
+ * This is used as data for the MAC computation, using
+ * kHmacRefExpectedLongKeyDigest as the key.
  */
-extern const char kRefData[34];
+extern const char kHmacRefData[34];
 
 /**
- * Expected MAC digest for kRefData data above.
+ * Expected MAC digest for kHmacRefData data above.
  */
-extern const dif_hmac_digest_t kRefExpectedHmacDigest;
+extern const dif_hmac_digest_t kHmacRefExpectedDigest;
 
 /**
  * Reads and compares the actual sent message length against expected.

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -82,13 +82,14 @@ char *ottf_task_get_self_name(void) {
 static void init_uart(void) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK_DIF_OK(
-      dif_uart_configure(&uart0, (dif_uart_config_t){
-                                     .baudrate = kUartBaudrate,
-                                     .clk_freq_hz = kClockFreqPeripheralHz,
-                                     .parity_enable = kDifToggleDisabled,
-                                     .parity = kDifUartParityEven,
-                                 }));
+  CHECK_DIF_OK(dif_uart_configure(&uart0,
+                                  (dif_uart_config_t){
+                                      .baudrate = kUartBaudrate,
+                                      .clk_freq_hz = kClockFreqPeripheralHz,
+                                      .parity_enable = kDifToggleDisabled,
+                                      .parity = kDifUartParityEven,
+                                  },
+                                  kDifToggleEnabled));
   base_uart_stdout(&uart0);
 }
 

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -119,13 +119,14 @@ bool rom_test_main(void) {
   if (kDeviceType != kDeviceSimDV) {
     CHECK_DIF_OK(dif_uart_init(
         mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-    CHECK_DIF_OK(
-        dif_uart_configure(&uart0, (dif_uart_config_t){
-                                       .baudrate = kUartBaudrate,
-                                       .clk_freq_hz = kClockFreqPeripheralHz,
-                                       .parity_enable = kDifToggleDisabled,
-                                       .parity = kDifUartParityEven,
-                                   }));
+    CHECK_DIF_OK(dif_uart_configure(&uart0,
+                                    (dif_uart_config_t){
+                                        .baudrate = kUartBaudrate,
+                                        .clk_freq_hz = kClockFreqPeripheralHz,
+                                        .parity_enable = kDifToggleDisabled,
+                                        .parity = kDifUartParityEven,
+                                    },
+                                    kDifToggleEnabled));
     base_uart_stdout(&uart0);
   }
 

--- a/sw/device/riscv_compliance_support/support.c
+++ b/sw/device/riscv_compliance_support/support.c
@@ -22,13 +22,14 @@ static dif_uart_t uart0;
 int opentitan_compliance_main(int argc, char **argv) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK_DIF_OK(
-      dif_uart_configure(&uart0, (dif_uart_config_t){
-                                     .baudrate = kUartBaudrate,
-                                     .clk_freq_hz = kClockFreqPeripheralHz,
-                                     .parity_enable = kDifToggleDisabled,
-                                     .parity = kDifUartParityEven,
-                                 }));
+  CHECK_DIF_OK(dif_uart_configure(&uart0,
+                                  (dif_uart_config_t){
+                                      .baudrate = kUartBaudrate,
+                                      .clk_freq_hz = kClockFreqPeripheralHz,
+                                      .parity_enable = kDifToggleDisabled,
+                                      .parity = kDifUartParityEven,
+                                  },
+                                  kDifToggleEnabled));
   base_uart_stdout(&uart0);
 
   run_rvc_test();

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -81,13 +81,13 @@ static void sca_init_uart(void) {
 
   OT_DISCARD(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
                            &uart0));
-  OT_DISCARD(dif_uart_configure(&uart0, uart_config));
+  OT_DISCARD(dif_uart_configure(&uart0, uart_config, kDifToggleEnabled));
   base_uart_stdout(&uart0);
 
 #if !OT_IS_ENGLISH_BREAKFAST
   OT_DISCARD(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART1_BASE_ADDR),
                            &uart1));
-  OT_DISCARD(dif_uart_configure(&uart1, uart_config));
+  OT_DISCARD(dif_uart_configure(&uart1, uart_config, kDifToggleEnabled));
 #endif
 }
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2057,7 +2057,10 @@ opentitan_functest(
     deps = [
         "//hw/ip/adc_ctrl/data:adc_ctrl_regs",
         "//hw/ip/aes:model",
+        "//hw/ip/aes/data:aes_regs",
         "//hw/ip/entropy_src/data:entropy_src_regs",
+        "//hw/ip/hmac/data:hmac_regs",
+        "//hw/ip/kmac/data:kmac_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:math",
         "//sw/device/lib/dif:adc_ctrl",
@@ -2077,6 +2080,7 @@ opentitan_functest(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aes_testutils",
         "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:hmac_testutils",
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing:spi_device_testutils",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2061,6 +2061,7 @@ opentitan_functest(
         "//hw/ip/entropy_src/data:entropy_src_regs",
         "//hw/ip/hmac/data:hmac_regs",
         "//hw/ip/kmac/data:kmac_regs",
+        "//hw/ip/uart/data:uart_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:math",
         "//sw/device/lib/dif:adc_ctrl",

--- a/sw/device/tests/crt_test.c
+++ b/sw/device/tests/crt_test.c
@@ -45,13 +45,14 @@ static dif_uart_t uart0;
 static void init_uart(void) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK_DIF_OK(
-      dif_uart_configure(&uart0, (dif_uart_config_t){
-                                     .baudrate = kUartBaudrate,
-                                     .clk_freq_hz = kClockFreqPeripheralHz,
-                                     .parity_enable = kDifToggleDisabled,
-                                     .parity = kDifUartParityEven,
-                                 }));
+  CHECK_DIF_OK(dif_uart_configure(&uart0,
+                                  (dif_uart_config_t){
+                                      .baudrate = kUartBaudrate,
+                                      .clk_freq_hz = kClockFreqPeripheralHz,
+                                      .parity_enable = kDifToggleDisabled,
+                                      .parity = kDifUartParityEven,
+                                  },
+                                  kDifToggleEnabled));
   base_uart_stdout(&uart0);
 }
 

--- a/sw/device/tests/example_test_from_rom.c
+++ b/sw/device/tests/example_test_from_rom.c
@@ -31,13 +31,14 @@ bool rom_test_main(void) {
   if (kDeviceType != kDeviceSimDV) {
     CHECK_DIF_OK(dif_uart_init(
         mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-    CHECK_DIF_OK(
-        dif_uart_configure(&uart0, (dif_uart_config_t){
-                                       .baudrate = kUartBaudrate,
-                                       .clk_freq_hz = kClockFreqPeripheralHz,
-                                       .parity_enable = kDifToggleDisabled,
-                                       .parity = kDifUartParityEven,
-                                   }));
+    CHECK_DIF_OK(dif_uart_configure(&uart0,
+                                    (dif_uart_config_t){
+                                        .baudrate = kUartBaudrate,
+                                        .clk_freq_hz = kClockFreqPeripheralHz,
+                                        .parity_enable = kDifToggleDisabled,
+                                        .parity = kDifUartParityEven,
+                                    },
+                                    kDifToggleEnabled));
     base_uart_stdout(&uart0);
   }
 

--- a/sw/device/tests/hmac_enc_idle_test.c
+++ b/sw/device/tests/hmac_enc_idle_test.c
@@ -84,12 +84,12 @@ bool test_main(void) {
   CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
       clkmgr, kHmacClock, kDifToggleEnabled, kDifToggleEnabled);
 
-  // Use HMAC in SHA256 mode to generate a 256bit key from `kRefHmacLongKey`.
+  // Use HMAC in SHA256 mode to generate a 256bit key from `kHmacRefLongKey`.
   CHECK_DIF_OK(dif_hmac_mode_sha256_start(&hmac, kHmacTransactionConfig));
-  hmac_testutils_push_message(&hmac, (char *)kRefHmacLongKey,
-                              sizeof(kRefHmacLongKey));
+  hmac_testutils_push_message(&hmac, (char *)kHmacRefLongKey,
+                              sizeof(kHmacRefLongKey));
   LOG_INFO("Pushed message");
-  hmac_testutils_check_message_length(&hmac, sizeof(kRefHmacLongKey) * 8);
+  hmac_testutils_check_message_length(&hmac, sizeof(kHmacRefLongKey) * 8);
   CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
       clkmgr, kHmacClock, kDifToggleDisabled, kDifToggleEnabled);
   LOG_INFO("Cleared hints");
@@ -100,24 +100,24 @@ bool test_main(void) {
 
   dif_hmac_digest_t key_digest;
   hmac_testutils_finish_polled(&hmac, &key_digest);
-  CHECK_ARRAYS_EQ(key_digest.digest, kRefExpectedShaDigest.digest,
+  CHECK_ARRAYS_EQ(key_digest.digest, kHmacRefExpectedLongKeyDigest.digest,
                   ARRAYSIZE(key_digest.digest));
 
   // Generate HMAC final digest, using the resulted SHA256 digest over the
-  // `kRefHmacLongKey`.
+  // `kHmacRefLongKey`.
   CHECK_DIF_OK(dif_hmac_mode_hmac_start(&hmac, (uint8_t *)&key_digest.digest[0],
                                         kHmacTransactionConfig));
   CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
       clkmgr, kHmacClock, kDifToggleDisabled, kDifToggleEnabled);
   LOG_INFO("Cleared hints");
-  hmac_testutils_push_message(&hmac, kRefData, sizeof(kRefData));
-  hmac_testutils_check_message_length(&hmac, sizeof(kRefData) * 8);
+  hmac_testutils_push_message(&hmac, kHmacRefData, sizeof(kHmacRefData));
+  hmac_testutils_check_message_length(&hmac, sizeof(kHmacRefData) * 8);
   CHECK_DIF_OK(dif_hmac_process(&hmac));
   LOG_INFO("Process");
 
   handle_end_of_process(kHmacClock);
 
-  hmac_testutils_finish_and_check_polled(&hmac, &kRefExpectedHmacDigest);
+  hmac_testutils_finish_and_check_polled(&hmac, &kHmacRefExpectedDigest);
 
   return true;
 }

--- a/sw/device/tests/hmac_enc_test.c
+++ b/sw/device/tests/hmac_enc_test.c
@@ -82,13 +82,13 @@ bool test_main(void) {
   // Expect the fifo empty irq after pushing data.
   hmac_ctx.expected_irq = kDifHmacIrqFifoEmpty;
   irq_serviced = UINT32_MAX;
-  // Use HMAC in SHA256 mode to generate a 256bit key from `kRefHmacLongKey`.
+  // Use HMAC in SHA256 mode to generate a 256bit key from `kHmacRefLongKey`.
   CHECK_DIF_OK(
       dif_hmac_mode_sha256_start(hmac_ctx.hmac, kHmacTransactionConfig));
-  hmac_testutils_push_message(hmac_ctx.hmac, (char *)kRefHmacLongKey,
-                              sizeof(kRefHmacLongKey));
+  hmac_testutils_push_message(hmac_ctx.hmac, (char *)kHmacRefLongKey,
+                              sizeof(kHmacRefLongKey));
   hmac_testutils_check_message_length(hmac_ctx.hmac,
-                                      sizeof(kRefHmacLongKey) * 8);
+                                      sizeof(kHmacRefLongKey) * 8);
 
   // If the irq has't fired yet, wait for the `fifoEmpty` interrupt .
   if (irq_serviced != hmac_ctx.expected_irq) {
@@ -103,20 +103,21 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_hmac_process(hmac_ctx.hmac));
   dif_hmac_digest_t key_digest;
   hmac_testutils_finish_polled(hmac_ctx.hmac, &key_digest);
-  CHECK_ARRAYS_EQ(key_digest.digest, kRefExpectedShaDigest.digest,
+  CHECK_ARRAYS_EQ(key_digest.digest, kHmacRefExpectedLongKeyDigest.digest,
                   ARRAYSIZE(key_digest.digest));
 
   CHECK(irq_serviced == hmac_ctx.expected_irq);
 
   // Generate HMAC final digest, using the resulted SHA256 digest over the
-  // `kRefHmacLongKey`.
+  // `kHmacRefLongKey`.
   CHECK_DIF_OK(dif_hmac_mode_hmac_start(
       hmac_ctx.hmac, (uint8_t *)&key_digest.digest[0], kHmacTransactionConfig));
-  hmac_testutils_push_message(hmac_ctx.hmac, kRefData, sizeof(kRefData));
-  hmac_testutils_check_message_length(hmac_ctx.hmac, sizeof(kRefData) * 8);
+  hmac_testutils_push_message(hmac_ctx.hmac, kHmacRefData,
+                              sizeof(kHmacRefData));
+  hmac_testutils_check_message_length(hmac_ctx.hmac, sizeof(kHmacRefData) * 8);
   CHECK_DIF_OK(dif_hmac_process(hmac_ctx.hmac));
   LOG_INFO("Waiting for HMAC pooling to finish");
   hmac_testutils_finish_and_check_polled(hmac_ctx.hmac,
-                                         &kRefExpectedHmacDigest);
+                                         &kHmacRefExpectedDigest);
   return true;
 }

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -417,13 +417,14 @@ static void configure_kmac() {
 }
 
 static void configure_uart(dif_uart_t *uart) {
-  CHECK_DIF_OK(
-      dif_uart_configure(uart, (dif_uart_config_t){
-                                   .baudrate = kUartBaudrate,
-                                   .clk_freq_hz = kClockFreqPeripheralHz,
-                                   .parity_enable = kDifToggleEnabled,
-                                   .parity = kDifUartParityEven,
-                               }));
+  CHECK_DIF_OK(dif_uart_configure(uart,
+                                  (dif_uart_config_t){
+                                      .baudrate = kUartBaudrate,
+                                      .clk_freq_hz = kClockFreqPeripheralHz,
+                                      .parity_enable = kDifToggleEnabled,
+                                      .parity = kDifUartParityEven,
+                                  },
+                                  kDifToggleDisabled));
   CHECK_DIF_OK(
       dif_uart_loopback_set(uart, kDifUartLoopbackSystem, kDifToggleEnabled));
 }

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -86,13 +86,14 @@ void ottf_external_isr(void) {
 
 static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
   CHECK_DIF_OK(dif_uart_init(base_addr, uart));
-  CHECK_DIF_OK(
-      dif_uart_configure(uart, (dif_uart_config_t){
-                                   .baudrate = kUartBaudrate,
-                                   .clk_freq_hz = kClockFreqPeripheralHz,
-                                   .parity_enable = kDifToggleDisabled,
-                                   .parity = kDifUartParityEven,
-                               }));
+  CHECK_DIF_OK(dif_uart_configure(uart,
+                                  (dif_uart_config_t){
+                                      .baudrate = kUartBaudrate,
+                                      .clk_freq_hz = kClockFreqPeripheralHz,
+                                      .parity_enable = kDifToggleDisabled,
+                                      .parity = kDifUartParityEven,
+                                  },
+                                  kDifToggleEnabled));
 }
 
 /**

--- a/sw/device/tests/sim_dv/flash_init_test.c
+++ b/sw/device/tests/sim_dv/flash_init_test.c
@@ -291,13 +291,14 @@ bool rom_test_main(void) {
   if (kDeviceType != kDeviceSimDV) {
     CHECK_DIF_OK(dif_uart_init(
         mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-    CHECK_DIF_OK(
-        dif_uart_configure(&uart0, (dif_uart_config_t){
-                                       .baudrate = kUartBaudrate,
-                                       .clk_freq_hz = kClockFreqPeripheralHz,
-                                       .parity_enable = kDifToggleDisabled,
-                                       .parity = kDifUartParityEven,
-                                   }));
+    CHECK_DIF_OK(dif_uart_configure(&uart0,
+                                    (dif_uart_config_t){
+                                        .baudrate = kUartBaudrate,
+                                        .clk_freq_hz = kClockFreqPeripheralHz,
+                                        .parity_enable = kDifToggleDisabled,
+                                        .parity = kDifUartParityEven,
+                                    },
+                                    kDifToggleEnabled));
     base_uart_stdout(&uart0);
   }
 

--- a/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
+++ b/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
@@ -236,13 +236,14 @@ bool rom_test_main(void) {
   if (kDeviceType != kDeviceSimDV) {
     CHECK_DIF_OK(dif_uart_init(
         mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-    CHECK_DIF_OK(
-        dif_uart_configure(&uart0, (dif_uart_config_t){
-                                       .baudrate = kUartBaudrate,
-                                       .clk_freq_hz = kClockFreqPeripheralHz,
-                                       .parity_enable = kDifToggleDisabled,
-                                       .parity = kDifUartParityEven,
-                                   }));
+    CHECK_DIF_OK(dif_uart_configure(&uart0,
+                                    (dif_uart_config_t){
+                                        .baudrate = kUartBaudrate,
+                                        .clk_freq_hz = kClockFreqPeripheralHz,
+                                        .parity_enable = kDifToggleDisabled,
+                                        .parity = kDifUartParityEven,
+                                    },
+                                    kDifToggleEnabled));
     base_uart_stdout(&uart0);
   }
 

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -287,13 +287,14 @@ static void uart_init_with_irqs(mmio_region_t base_addr, dif_uart_t *uart) {
   LOG_INFO("Initializing the UART.");
 
   CHECK_DIF_OK(dif_uart_init(base_addr, uart));
-  CHECK_DIF_OK(
-      dif_uart_configure(uart, (dif_uart_config_t){
-                                   .baudrate = kUartBaudrate,
-                                   .clk_freq_hz = kClockFreqPeripheralHz,
-                                   .parity_enable = kDifToggleDisabled,
-                                   .parity = kDifUartParityEven,
-                               }));
+  CHECK_DIF_OK(dif_uart_configure(uart,
+                                  (dif_uart_config_t){
+                                      .baudrate = kUartBaudrate,
+                                      .clk_freq_hz = kClockFreqPeripheralHz,
+                                      .parity_enable = kDifToggleDisabled,
+                                      .parity = kDifUartParityEven,
+                                  },
+                                  kDifToggleEnabled));
 
   // Set the TX and RX watermark to 16 bytes.
   CHECK_DIF_OK(dif_uart_watermark_tx_set(uart, kDifUartWatermarkByte16));

--- a/sw/device/tests/uart_smoketest.c
+++ b/sw/device/tests/uart_smoketest.c
@@ -20,15 +20,14 @@ bool test_main(void) {
   dif_uart_t uart;
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
-  CHECK(dif_uart_configure(&uart,
-                           (dif_uart_config_t){
-                               .baudrate = kUartBaudrate,
-                               .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifToggleDisabled,
-                               .parity = kDifUartParityEven,
-                           }) == kDifOk,
-        "UART config failed!");
-
+  CHECK_DIF_OK(dif_uart_configure(&uart,
+                                  (dif_uart_config_t){
+                                      .baudrate = kUartBaudrate,
+                                      .clk_freq_hz = kClockFreqPeripheralHz,
+                                      .parity_enable = kDifToggleDisabled,
+                                      .parity = kDifUartParityEven,
+                                  },
+                                  kDifToggleEnabled));
   CHECK_DIF_OK(
       dif_uart_loopback_set(&uart, kDifUartLoopbackSystem, kDifToggleEnabled));
   CHECK_DIF_OK(dif_uart_fifo_reset(&uart, kDifUartFifoResetAll));


### PR DESCRIPTION
This PR contains several commits that add (OTTF/FreeRTOS) tasks to drive crypto and UART blocks in power virus test.

Additionally, one commit updates the UART DIF to allow configuring a UART device without enabling it to help pre-fill UART FIFOs before enabling them to align crypto and UART operations. 