### PR TITLE
[rv_dm,dv] Update testplan

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -152,7 +152,7 @@
             - Read the target DMI register to verify the write did not succeed.
             '''
       stage: V2
-      tests: []
+      tests: [] // TODO(#15670)
     }
     {
       name: jtag_dtm_idle_hint
@@ -166,7 +166,7 @@
               successfully, without dmistat reflecting an error.
             '''
       stage: V2
-      tests: []
+      tests: [] // TODO(#17033)
     }
     {
       name: jtag_dmi_failed_op
@@ -182,7 +182,7 @@
             - TBO - unclear how to generate other types of failed DMI transactions.
             '''
       stage: V2
-      tests: []
+      tests: [] // TODO(#17034)
     }
     {
       name: jtag_dmi_dm_inactive
@@ -194,7 +194,7 @@
             - Read all DMI registers back and verify they reflect POR values.
             '''
       stage: V2
-      tests: []
+      tests: [] // TODO(#17035)
     }
 
     {
@@ -276,7 +276,7 @@
               originally written value.
             '''
       stage: V2
-      tests: []
+      tests: [] // TODO(#15667)
     }
 
     {
@@ -294,7 +294,7 @@
             - Verify via assertion checks, no transactions were seen on the SBA TL interface.
             '''
       stage: V2
-      tests: []
+      tests: [] // TODO(#15668)
     }
     {
       name: debug_mem_debug_disabled
@@ -312,7 +312,7 @@
               originally written value.
             '''
       stage: V2
-      tests: []
+      tests: [] // TODO (#15669)
     }
     {
       name: ndmreset_req
@@ -336,7 +336,7 @@
               written value, proving that ndmreset assertion had no effect on them.
             '''
       stage: V2
-      tests: []
+      tests: [] // TODO(#15666)
     }
     {
       name: hart_unavail
@@ -350,7 +350,7 @@
               `unavailable` input value
             '''
       stage: V2
-      tests: []
+      tests: [] // TODO(#17036)
     }
     {
       name: tap_ctrl_transitions
@@ -360,7 +360,7 @@
             This test should verify that the standardized JTAG TAP FSM is working correctly.
             '''
       stage: V2
-      tests: []
+      tests: [] // TODO(#17032)
     }
     {
       name: stress_all

--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -297,24 +297,6 @@
       tests: [] // TODO(#15668)
     }
     {
-      name: debug_mem_debug_disabled
-      desc: '''
-            Verify that access to the debug mem via TL host interface results in error response.
-
-            - Set lc_hw_debug_en to true and activate the dm.
-            - Write a known value to a randomly picked debug mem CSR.
-            - Set lc_hw_debug_en to non-true value.
-            - Attempt to write a different value to the same CSR - verify error response.
-            - Attempt to read that CSR - verify error response.
-            - Attempt a number of legal accesses to any of the CSRs or memories in this space - they
-              all should result in error response.
-            - Set lc_hw_debug_en to true and again, read the debug mem CSR - it should reflect the
-              originally written value.
-            '''
-      stage: V2
-      tests: [] // TODO (#15669)
-    }
-    {
       name: ndmreset_req
       desc: '''
             Verify that the debugger can issue a non-debug reset to the rest of the system.

--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -171,7 +171,7 @@
     {
       name: jtag_dmi_failed_op
       desc: '''
-            Verify that the a failed DMI op is reflected properly in dtmcs register.
+            Verify that a failed DMI op is reflected properly in dtmcs register.
 
             - Issue a random legal DMI write to a chosen DMI register.
             - Before that access completes, issue another random legal DMI access.
@@ -270,9 +270,9 @@
             - Set pinmux_hw_debug_en to non-true value.
             - Write a different value to the same DMI CSR.
             - Attempt to read that DMI CSR - it should read all 0s.
-            - Note that the above steps are rendered moot becuase the JTAG DTM itself will not
+            - Note that the above steps are rendered moot because the JTAG DTM itself will not
               receive any incoming JTAG transactions.
-            - Set pinmux_hw_debug_en to true and again, read the DMI CSR - it should reflect the
+            - Set pinmux_hw_debug_en to true and again read the DMI CSR - it should reflect the
               originally written value.
             '''
       stage: V2


### PR DESCRIPTION
Update the testplan for `rv_dm` as follows:
- Add links to GitHub issues that track the implementation of the missing tests.
- Remove `debug_mem_debug_disabled` from testplan (see #15669).
- Fix a few typos in test descriptions.