### PR TITLE
[aon_timer,dv] Set scoreboard timer enables to 0 at reset

### DIFF
--- a/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
@@ -266,8 +266,9 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
           `uvm_info(`gfn, $sformatf("WKUP Timer check passed."), UVM_HIGH)
         end
         begin
-          wait (!wkup_en);
+          wait (!wkup_en || cfg.aon_clk_rst_vif.rst_n);
           `uvm_info(`gfn, $sformatf("WKUP Timer disabled, quit scoring"), UVM_HIGH)
+          wkup_en = 0;
         end
       join_any
       disable fork;
@@ -306,8 +307,9 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
                     UVM_HIGH)
         end
         begin
-          wait (!wdog_en);
+          wait (!wdog_en || cfg.aon_clk_rst_vif.rst_n);
           `uvm_info(`gfn, $sformatf("WDOG Timer disabled, quit scoring"), UVM_HIGH)
+          wdog_en = 0;
         end
       join_any
       disable fork;
@@ -317,8 +319,6 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
     // reset local fifos queues and variables
-    wkup_en = 0;
-    wdog_en = 0;
   endfunction
 
   function void check_phase(uvm_phase phase);


### PR DESCRIPTION
Fixes `aon_timer_stress_all_with_rand_reset` test failures by turning off the timer scoreboard in the cases of resets. Previously it was not catching small non-reset windows between two resets.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>