### PR TITLE
[dv] Change alert_test to run with default build mode

### DIFF
--- a/hw/dv/tools/dvsim/tests/alert_test.hjson
+++ b/hw/dv/tools/dvsim/tests/alert_test.hjson
@@ -11,7 +11,6 @@
   tests: [
     {
       name: "{name}_alert_test"
-      build_mode: "cover_reg_top"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_alert_test", "+en_scb=0"]
       reseed: 50


### PR DESCRIPTION
alert_test logic is [under IP top](https://cs.opensource.google/search?q=%22assign%20alert_test%22&sq=&ss=opentitan%2Fopentitan:hw%2F), instead of reg_top, so we should use `cover_reg_top` build mode for it,
otherwise, we will have 2 uncovered line coverage on that statement.

It's also not worth adding another build mode just for this test, so use the default one.

Signed-off-by: Weicai Yang <weicai@google.com>