### PR TITLE
[cleanup] Bazel hex and _hex cleanup

### DIFF
--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -115,16 +115,22 @@ def lcv_hw_to_sw(hw_lc_state_val):
     }
     sw_lcv = lcv_map.get(hw_lc_state_val)
     if sw_lcv == None:
-        fail("Could not find software LCV for hardware LCV: 0x{}".format(hex(hw_lc_state_val)))
+        fail("Could not find software LCV for hardware LCV: {}".format(hex(hw_lc_state_val)))
     return sw_lcv
 
 _HEX_MAP = "0123456789abcdef"
 
-def hex(v):
+def hex_digits(v):
+    """Convert an int into a hex string without 0x prefix"""
+
     # First "cast" `v` to a 32-bit unsigned int
     v &= 0xffffffff
     hex_digits = [_HEX_MAP[(v >> i) & 0xf] for i in range(0, 32, 4)]
     return "".join(reversed(hex_digits))
+
+def hex(v):
+    """Convert an int into a hex string with 0x prefix"""
+    return "0x{}".format(hex_digits(v))
 
 _REDACTION_MAP = {
     CONST.SHUTDOWN.REDACT.NONE: 0xffffffff,

--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -9,52 +9,46 @@ _SEL_MANUF_STATE_CREATOR = (1 << 8)
 _SEL_MANUF_STATE_OWNER = (1 << 9)
 _SEL_LIFE_CYCLE_STATE = (1 << 10)
 
-def _hex(v):
-    """Expects v to be an int or a hex-encoded string."""
-    if type(v) == "string":
-        v = int(v, base = 16)
-    return "0x{}".format(hex(v))
-
 def _manifest_impl(ctx):
     mf = {}
 
     # All the easy parameters are simple assignments
     if ctx.attr.signature:
-        mf["signature"] = _hex(ctx.attr.signature)
+        mf["signature"] = ctx.attr.signature
     if ctx.attr.modulus:
-        mf["modulus"] = _hex(ctx.attr.modulus)
+        mf["modulus"] = ctx.attr.modulus
     if ctx.attr.identifier:
-        mf["identifier"] = _hex(ctx.attr.identifier)
+        mf["identifier"] = ctx.attr.identifier
     if ctx.attr.length:
-        mf["length"] = _hex(ctx.attr.length)
+        mf["length"] = ctx.attr.length
     if ctx.attr.version_major:
-        mf["version_major"] = _hex(ctx.attr.version_major)
+        mf["version_major"] = ctx.attr.version_major
     if ctx.attr.version_minor:
-        mf["version_minor"] = _hex(ctx.attr.version_minor)
+        mf["version_minor"] = ctx.attr.version_minor
     if ctx.attr.security_version:
-        mf["security_version"] = _hex(ctx.attr.security_version)
+        mf["security_version"] = ctx.attr.security_version
     if ctx.attr.timestamp:
-        mf["timestamp"] = _hex(ctx.attr.timestamp)
+        mf["timestamp"] = ctx.attr.timestamp
     if ctx.attr.max_key_version:
-        mf["max_key_version"] = _hex(ctx.attr.max_key_version)
+        mf["max_key_version"] = ctx.attr.max_key_version
     if ctx.attr.code_start:
-        mf["code_start"] = _hex(ctx.attr.code_start)
+        mf["code_start"] = ctx.attr.code_start
     if ctx.attr.code_end:
-        mf["code_end"] = _hex(ctx.attr.code_end)
+        mf["code_end"] = ctx.attr.code_end
     if ctx.attr.entry_point:
-        mf["entry_point"] = _hex(ctx.attr.entry_point)
+        mf["entry_point"] = ctx.attr.entry_point
 
     # Address Translation is a bool, but encoded as an int so we can have
     # a special value mean "unset" and so we can set to non-standard values
     # for testing.
     if ctx.attr.address_translation:
-        mf["address_translation"] = _hex(ctx.attr.address_translation)
+        mf["address_translation"] = ctx.attr.address_translation
 
     # The binding_value, if provided, must be exactly 8 words.
     if ctx.attr.binding_value:
         if len(ctx.attr.binding_value) != 8:
             fail("The binding_value must be exactly 8 words.")
-        mf["binding_value"] = [_hex(v) for v in ctx.attr.binding_value]
+        mf["binding_value"] = [v for v in ctx.attr.binding_value]
 
     # The selector_bits are set based on the values of the usage_constraints.
     uc = {}
@@ -66,41 +60,41 @@ def _manifest_impl(ctx):
     # Extend the device_id to 8 words, then set the selector_bits for each
     # non-default word.
     if len(device_id) < 8:
-        device_id.extend([CONST.DEFAULT_USAGE_CONSTRAINTS] * (8 - len(device_id)))
+        device_id.extend([hex(CONST.DEFAULT_USAGE_CONSTRAINTS)] * (8 - len(device_id)))
     for i, d in enumerate(device_id):
-        if _hex(d) != _hex(CONST.DEFAULT_USAGE_CONSTRAINTS):
+        if d != hex(CONST.DEFAULT_USAGE_CONSTRAINTS):
             selector_bits |= _SEL_DEVICE_ID << i
-        device_id[i] = _hex(d)
+        device_id[i] = d
     uc["device_id"] = device_id
 
     # Set the selector bits for the remaining non-default values.
     if ctx.attr.manuf_state_creator:
-        uc["manuf_state_creator"] = _hex(ctx.attr.manuf_state_creator)
+        uc["manuf_state_creator"] = ctx.attr.manuf_state_creator
         selector_bits |= _SEL_MANUF_STATE_CREATOR
     else:
-        uc["manuf_state_creator"] = _hex(CONST.DEFAULT_USAGE_CONSTRAINTS)
+        uc["manuf_state_creator"] = hex(CONST.DEFAULT_USAGE_CONSTRAINTS)
 
     if ctx.attr.manuf_state_owner:
-        uc["manuf_state_owner"] = _hex(ctx.attr.manuf_state_owner)
+        uc["manuf_state_owner"] = ctx.attr.manuf_state_owner
         selector_bits |= _SEL_MANUF_STATE_OWNER
     else:
-        uc["manuf_state_owner"] = _hex(CONST.DEFAULT_USAGE_CONSTRAINTS)
+        uc["manuf_state_owner"] = hex(CONST.DEFAULT_USAGE_CONSTRAINTS)
 
     if ctx.attr.life_cycle_state:
-        uc["life_cycle_state"] = _hex(ctx.attr.life_cycle_state)
+        uc["life_cycle_state"] = ctx.attr.life_cycle_state
         selector_bits |= _SEL_LIFE_CYCLE_STATE
     else:
-        uc["life_cycle_state"] = _hex(CONST.DEFAULT_USAGE_CONSTRAINTS)
+        uc["life_cycle_state"] = hex(CONST.DEFAULT_USAGE_CONSTRAINTS)
 
     # If the user supplied selector_bits, check if they make sense.
     if ctx.attr.selector_bits:
         # If they don't match, fail unless explicitly permitted to set a
         # bad value.
         if int(ctx.attr.selector_bits, base = 16) != selector_bits and ctx.attr.selector_mismatch_is_failure:
-            fail("User provided selector_bits ({}) don't match computed selector_bits ({})".format(ctx.attr.selector_bits, _hex(selector_bits)))
-        uc["selector_bits"] = _hex(ctx.attr.selector_bits)
+            fail("User provided selector_bits ({}) don't match computed selector_bits ({})".format(ctx.attr.selector_bits, selector_bits))
+        uc["selector_bits"] = ctx.attr.selector_bits
     else:
-        uc["selector_bits"] = _hex(selector_bits)
+        uc["selector_bits"] = selector_bits
 
     mf["usage_constraints"] = uc
 
@@ -115,26 +109,26 @@ _manifest = rule(
     implementation = _manifest_impl,
     # Manifest attrs are supplied as strings due to Bazel limiting int types to 32-bit signed integers
     attrs = {
-        "signature": attr.string(doc = "Image signature as a hex-encoded string"),
-        "modulus": attr.string(doc = "Signing key modulus as a hex-encoded string"),
-        "selector_bits": attr.string(doc = "Usage constraint selector bits as a hex-encoded string"),
+        "signature": attr.string(doc = "Image signature as a 0x-prefixed hex-encoded string"),
+        "modulus": attr.string(doc = "Signing key modulus as a 0x-prefixed hex-encoded string"),
+        "selector_bits": attr.string(doc = "Usage constraint selector bits as a 0x-prefixed hex-encoded string"),
         "selector_mismatch_is_failure": attr.bool(default = True, doc = "A mismatch in computed selector bits is a failure"),
-        "device_id": attr.string_list(doc = "Usage constraint device ID as a hex-encoded string"),
-        "manuf_state_creator": attr.string(doc = "Usage constraint for silicon creator manufacturing status as a hex-encoded string"),
-        "manuf_state_owner": attr.string(doc = "Usage constraint for silicon owner manufacturing status as a hex-encoded string"),
-        "life_cycle_state": attr.string(doc = "Usage constraint for life cycle status as a hex-encoded string"),
-        "address_translation": attr.string(doc = "Whether this image uses address translation as a hex-encoded string"),
-        "identifier": attr.string(doc = "Manifest identifier as a hex-encoded string"),
-        "length": attr.string(doc = "Length of this image as a hex-encoded string"),
-        "version_major": attr.string(doc = "Image major version as a hex-encoded string"),
-        "version_minor": attr.string(doc = "Image minor version as a hex-encoded string"),
-        "security_version": attr.string(doc = "Security version for anti-rollback protection as a hex-encoded string"),
-        "timestamp": attr.string(doc = "Unix timestamp of the image as a hex-encoded string"),
-        "binding_value": attr.string_list(doc = "Binding value used by key manager to derive secrets as a hex-encoded string"),
-        "max_key_version": attr.string(doc = "Maximum allowed version for keys generated at the next boot stage as a hex-encoded string"),
-        "code_start": attr.string(doc = "Start offset of the executable region in the image as a hex-encoded string"),
-        "code_end": attr.string(doc = "End offset of the executable region in the image as a hex-encoded string"),
-        "entry_point": attr.string(doc = "Offset of the first instruction in the image as a hex-encoded string"),
+        "device_id": attr.string_list(doc = "Usage constraint device ID as a 0x-prefixed hex-encoded string"),
+        "manuf_state_creator": attr.string(doc = "Usage constraint for silicon creator manufacturing status as a 0x-prefixed hex-encoded string"),
+        "manuf_state_owner": attr.string(doc = "Usage constraint for silicon owner manufacturing status as a 0x-prefixed hex-encoded string"),
+        "life_cycle_state": attr.string(doc = "Usage constraint for life cycle status as a 0x-prefixed hex-encoded string"),
+        "address_translation": attr.string(doc = "Whether this image uses address translation as a 0x-prefixed hex-encoded string"),
+        "identifier": attr.string(doc = "Manifest identifier as a 0x-prefixed hex-encoded string"),
+        "length": attr.string(doc = "Length of this image as a 0x-prefixed hex-encoded string"),
+        "version_major": attr.string(doc = "Image major version as a 0x-prefixed hex-encoded string"),
+        "version_minor": attr.string(doc = "Image minor version as a 0x-prefixed hex-encoded string"),
+        "security_version": attr.string(doc = "Security version for anti-rollback protection as a 0x-prefixed hex-encoded string"),
+        "timestamp": attr.string(doc = "Unix timestamp of the image as a 0x-prefixed hex-encoded string"),
+        "binding_value": attr.string_list(doc = "Binding value used by key manager to derive secrets as a 0x-prefixed hex-encoded string"),
+        "max_key_version": attr.string(doc = "Maximum allowed version for keys generated at the next boot stage as a 0x-prefixed hex-encoded string"),
+        "code_start": attr.string(doc = "Start offset of the executable region in the image as a 0x-prefixed hex-encoded string"),
+        "code_end": attr.string(doc = "End offset of the executable region in the image as a 0x-prefixed hex-encoded string"),
+        "entry_point": attr.string(doc = "Offset of the first instruction in the image as a 0x-prefixed hex-encoded string"),
     },
 )
 

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -90,7 +90,7 @@ def _otp_json_impl(ctx):
     for partition in otp["partitions"]:
         if "items" in partition.keys():
             items = partition["items"]
-            partition["items"] = [{"name": k, "value": items[k]} for k in items.keys()]
+            partition["items"] = [{"name": k, "value": v} for k, v in items.items()]
 
     file = ctx.actions.declare_file("{}.json".format(ctx.attr.name))
     ctx.actions.write(file, json.encode_indent(otp))

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -11,7 +11,7 @@ load(
     "opentitan_functest",
     "verilator_params",
 )
-load("//rules:const.bzl", "CONST", "error_redact", "get_lc_items", "hex", "lcv_hw_to_sw")
+load("//rules:const.bzl", "CONST", "error_redact", "get_lc_items", "hex", "hex_digits", "lcv_hw_to_sw")
 load(
     "//rules:opentitan.bzl",
     "bin_to_vmem",
@@ -185,7 +185,7 @@ opentitan_functest(
         # Note: This test never prints a failure message so it will fail only
         # when it times out.
         exit_failure = "NO_FAILURE_MESSAGE",
-        exit_success = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.INTERRUPT.INSTRUCTION_ACCESS)),
+        exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.INSTRUCTION_ACCESS)),
     ),
     dv = dv_params(
         rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
@@ -199,7 +199,7 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "eternal",
         exit_failure = "NO_FAILURE_MESSAGE",
-        exit_success = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.INTERRUPT.INSTRUCTION_ACCESS)),
+        exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.INSTRUCTION_ACCESS)),
         rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
     ),
     deps = [
@@ -290,7 +290,7 @@ rom_e2e_keymgr_init_configs = [
             otp_partition(
                 name = "OWNER_SW_CFG",
                 items = {
-                    "OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN": "0x{}".format(hex(config["value"])),
+                    "OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN": "0x{}".format(hex_digits(config["value"])),
                 },
             ),
         ],
@@ -574,7 +574,7 @@ opentitan_functest(
     name = "rom_ext_a_flash_b",
     cw310 = cw310_params(
         exit_failure = MSG_STARTING_ROM_EXT,
-        exit_success = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.INTERRUPT.STORE_ACCESS)),
+        exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.STORE_ACCESS)),
     ),
     key = "multislot",
     ot_flash_binary = ":rom_ext_a_flash_b_image",
@@ -595,7 +595,7 @@ opentitan_functest(
     name = "rom_ext_b_flash_a",
     cw310 = cw310_params(
         exit_failure = MSG_STARTING_ROM_EXT,
-        exit_success = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.INTERRUPT.STORE_ACCESS)),
+        exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.STORE_ACCESS)),
     ),
     key = "multislot",
     ot_flash_binary = ":rom_ext_b_flash_a_image",
@@ -637,7 +637,7 @@ opentitan_functest(
     name = "rom_ext_a_flash_a_bad_addr_trans",
     cw310 = cw310_params(
         exit_failure = MSG_STARTING_ROM_EXT,
-        exit_success = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)),
+        exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)),
     ),
     ot_flash_binary = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a_bad_address_translation",
     targets = ["cw310_rom"],
@@ -661,7 +661,7 @@ opentitan_functest(
     name = "sigverify_key_auth",
     cw310 = cw310_params(
         exit_failure = MSG_PASS,
-        exit_success = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.SIGVERIFY.BAD_KEY)),
+        exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.SIGVERIFY.BAD_KEY)),
     ),
     key = "unauthorized_0",
     ot_flash_binary = ":empty_test_slot_a",
@@ -699,8 +699,8 @@ manifest({
         bitstream = ":bitstream_shutdown_output_{}".format(lc_state),
         exit_failure = MSG_PASS,
         exit_success = MSG_TEMPLATE_BFV_LCV.format(
-            hex(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
-            hex(lc_state_val),
+            hex_digits(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
+            hex_digits(lc_state_val),
         ),
         otp = ":otp_img_shutdown_output_{}".format(lc_state),
         tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
@@ -820,7 +820,7 @@ BOOT_POLICY_NEWER_CASES = [
     ),
     cw310 = cw310_params(
         bitstream = ":bitstream_boot_policy_newer_{}".format(lc_state.lower()),
-        exit_success = t["exit_success"].format(hex(lc_state_val)),
+        exit_success = t["exit_success"].format(hex_digits(lc_state_val)),
         tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
     ),
     key = "multislot",
@@ -845,7 +845,7 @@ BOOT_POLICY_ROLLBACK_CASES = [
     {
         "a": 0,
         "b": 0,
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.BOOT_POLICY.ROLLBACK)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
     },
     {
         "a": 0,
@@ -1153,46 +1153,46 @@ otp_json(
             name = "OWNER_SW_CFG",
             items = {
                 # Enable bootstrap.
-                "OWNER_SW_CFG_ROM_BOOTSTRAP_EN": "0x{}".format(hex(CONST.TRUE)),
+                "OWNER_SW_CFG_ROM_BOOTSTRAP_EN": hex(CONST.TRUE),
                 # Report errors without any redaction.
-                "OWNER_SW_CFG_ROM_ERROR_REPORTING": "0x{}".format(hex(CONST.SHUTDOWN.REDACT.NONE)),
+                "OWNER_SW_CFG_ROM_ERROR_REPORTING": hex(CONST.SHUTDOWN.REDACT.NONE),
                 # Enable class A alerts.
-                "OWNER_SW_CFG_ROM_ALERT_CLASS_EN": "0x{}".format(hex(
+                "OWNER_SW_CFG_ROM_ALERT_CLASS_EN": hex(
                     CONST.ALERT.NONE << 24 |
                     CONST.ALERT.NONE << 16 |
                     CONST.ALERT.NONE << 8 |
                     CONST.ALERT.ENABLE,
-                )),
+                ),
                 # Configure class A to escalate until phase 3 and disable other classes.
-                "OWNER_SW_CFG_ROM_ALERT_ESCALATION": "0x{}".format(hex(
+                "OWNER_SW_CFG_ROM_ALERT_ESCALATION": hex(
                     CONST.ALERT.ESC_NONE << 24 |
                     CONST.ALERT.ESC_NONE << 16 |
                     CONST.ALERT.ESC_NONE << 8 |
                     CONST.ALERT.ESC_PHASE_3,
-                )),
+                ),
                 # Classify UART0 alerts (alert source 0) as class A and leave others as unconfigured.
                 "OWNER_SW_CFG_ROM_ALERT_CLASSIFICATION": [
-                    "0x{}".format(hex(
+                    hex(
                         CONST.ALERT.CLASS_A << 24 |
                         CONST.ALERT.CLASS_A << 16 |
                         CONST.ALERT.CLASS_A << 8 |
                         CONST.ALERT.CLASS_A,
-                    )),
+                    ),
                 ] + [
-                    "0x{}".format(hex(
+                    hex(
                         CONST.ALERT.CLASS_X << 24 |
                         CONST.ALERT.CLASS_X << 16 |
                         CONST.ALERT.CLASS_X << 8 |
                         CONST.ALERT.CLASS_X,
-                    )),
+                    ),
                 ] * 79,
                 # Leave local alert classification as unconfigured.
-                "OWNER_SW_CFG_ROM_LOCAL_ALERT_CLASSIFICATION": ["0x{}".format(hex(
+                "OWNER_SW_CFG_ROM_LOCAL_ALERT_CLASSIFICATION": [hex(
                     CONST.ALERT.CLASS_X << 24 |
                     CONST.ALERT.CLASS_X << 16 |
                     CONST.ALERT.CLASS_X << 8 |
                     CONST.ALERT.CLASS_X,
-                ))] * 16,
+                )] * 16,
                 # Set the alert accumulation thresholds to 0.
                 "OWNER_SW_CFG_ROM_ALERT_ACCUM_THRESH": ["0x00000000"] * 4,
                 # Set the alert timeout cycles to 0.
@@ -1284,7 +1284,7 @@ SIGVERIFY_MOD_EXP_CASES = [
         "name": "invalid",
         "use_sw_rsa_verify": 0,
         "exit_success": {
-            lc_state: MSG_TEMPLATE_BFV.format(hex(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)) if lc_state_val != CONST.LCV.TEST_UNLOCKED0 else "use_sw_rsa_verify=0x00000000"
+            lc_state: MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)) if lc_state_val != CONST.LCV.TEST_UNLOCKED0 else "use_sw_rsa_verify=0x00000000"
             for lc_state, lc_state_val in get_lc_items()
         },
     },
@@ -1316,7 +1316,7 @@ opentitan_flash_binary(
         partitions = [
             otp_partition(
                 name = "CREATOR_SW_CFG",
-                items = {"CREATOR_SW_CFG_USE_SW_RSA_VERIFY": "0x{}".format(hex(t["use_sw_rsa_verify"]))},
+                items = {"CREATOR_SW_CFG_USE_SW_RSA_VERIFY": hex(t["use_sw_rsa_verify"])},
             ),
         ],
     )
@@ -1397,7 +1397,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
         "manifest": {
             "identifier": "0",
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER)),
     },
     {
         "name": "too_small",
@@ -1405,7 +1405,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "identifier": hex(CONST.ROM_EXT),
             "length": hex(CONST.ROM_EXT_SIZE_MIN - 1),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.BOOT_POLICY.BAD_LENGTH)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.BAD_LENGTH)),
     },
     {
         "name": "too_large",
@@ -1413,7 +1413,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "identifier": hex(CONST.ROM_EXT),
             "length": hex(CONST.ROM_EXT_SIZE_MAX + 1),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.BOOT_POLICY.BAD_LENGTH)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.BAD_LENGTH)),
     },
     {
         "name": "empty_code",
@@ -1423,7 +1423,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "code_start": hex(CONST.MANIFEST_SIZE + 12),
             "code_end": hex(CONST.MANIFEST_SIZE + 12),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
     },
     {
         "name": "code_in_manifest",
@@ -1433,7 +1433,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "code_end": hex(CONST.MANIFEST_SIZE + 12),
             "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
     },
     {
         "name": "code_outside_image",
@@ -1443,7 +1443,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "code_end": hex(CONST.MANIFEST_SIZE + 12),
             "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
     },
     {
         "name": "code_start_unaligned",
@@ -1453,7 +1453,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "code_end": hex(CONST.MANIFEST_SIZE + 12),
             "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
     },
     {
         "name": "code_end_unaligned",
@@ -1463,7 +1463,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "code_end": hex(CONST.MANIFEST_SIZE + 10),
             "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
     },
     {
         "name": "entry_before_code_start",
@@ -1473,7 +1473,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "code_end": hex(CONST.MANIFEST_SIZE + 12),
             "entry_point": hex(CONST.MANIFEST_SIZE + 4),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
     },
     {
         "name": "entry_at_code_end",
@@ -1483,7 +1483,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "code_end": hex(CONST.MANIFEST_SIZE + 12),
             "entry_point": hex(CONST.MANIFEST_SIZE + 12),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
     },
     {
         "name": "entry_unaligned",
@@ -1493,7 +1493,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "code_end": hex(CONST.MANIFEST_SIZE + 12),
             "entry_point": hex(CONST.MANIFEST_SIZE + 10),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
     },
     {
         "name": "rollback",
@@ -1504,7 +1504,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "entry_point": hex(CONST.MANIFEST_SIZE + 8),
             "security_version": "0",
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex(CONST.BFV.BOOT_POLICY.ROLLBACK)),
+        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
         "sec_ver": 1,
     },
 ]
@@ -1723,11 +1723,11 @@ BOOT_DATA_RECOVERY_CASES = [
             name = "CREATOR_SW_CFG",
             items = {
                 # Set the min_sec version.
-                "CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT": "0x{}".format(hex(case["min_sec_ver"])),
+                "CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT": hex(case["min_sec_ver"]),
                 # Set allowing use of default boot data in PROD LC state.
-                "CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN": "0x{}".format(hex(
+                "CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN": hex(
                     CONST.TRUE if case["default_boot_data"] == "default" else CONST.FALSE,
-                )),
+                ),
             },
         ),
     ],
@@ -1801,7 +1801,7 @@ BOOT_DATA_RECOVERY_CASES = [
                 case["lc_state"],
                 case["default_boot_data"],
             ),
-            exit_success = MSG_TEMPLATE_BFV.format(hex(case["expected_bfv"])) if case["expected_bfv"] != None else MSG_PASS,
+            exit_success = MSG_TEMPLATE_BFV.format(hex_digits(case["expected_bfv"])) if case["expected_bfv"] != None else MSG_PASS,
             tags = ["vivado"] + maybe_skip_in_ci(getattr(
                 CONST.LCV,
                 case["lc_state"].upper(),
@@ -1871,7 +1871,7 @@ SHUTDOWN_WATCHDOG_CASES = [
         partitions = [
             otp_partition(
                 name = "OWNER_SW_CFG",
-                items = {"OWNER_SW_CFG_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES": "0x{}".format(hex(t["bite_threshold"]))},
+                items = {"OWNER_SW_CFG_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES": hex(t["bite_threshold"])},
             ),
         ],
     )
@@ -2082,7 +2082,7 @@ BOOT_POLICY_VALID_CASES = [
         cw310 = cw310_params(
             bitstream = "bitstream_boot_policy_valid_{}".format(lc_state),
             exit_failure = MSG_PASS if a["desc"] == b["desc"] and a["desc"] == "bad" else DEFAULT_TEST_FAILURE_MSG,
-            exit_success = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG)) if a["desc"] == b["desc"] and a["desc"] == "bad" else MSG_PASS,
+            exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG)) if a["desc"] == b["desc"] and a["desc"] == "bad" else MSG_PASS,
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
         key = "multislot",
@@ -2657,7 +2657,7 @@ REDACT.update({"INVALID": 0x0})
             otp_partition(
                 name = "OWNER_SW_CFG",
                 items = {
-                    "OWNER_SW_CFG_ROM_ERROR_REPORTING": "0x{}".format(hex(v)),
+                    "OWNER_SW_CFG_ROM_ERROR_REPORTING": hex(v),
                 },
             ),
         ],
@@ -2712,7 +2712,7 @@ REDACT.update({"INVALID": 0x0})
                 redact.lower(),
             ),
             exit_failure = MSG_PASS,
-            exit_success = MSG_TEMPLATE_BFV.format(hex(error_redact(
+            exit_success = MSG_TEMPLATE_BFV.format(hex_digits(error_redact(
                 CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER,
                 lc_state_val,
                 redact_val,
@@ -2854,22 +2854,22 @@ SIGVERIFY_BAD_CASES = [
     {
         "a": "nothing",
         "b": "bad",
-        "expected_bfv": hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG),
+        "expected_bfv": hex_digits(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG),
     },
     {
         "a": "bad",
         "b": "nothing",
-        "expected_bfv": hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG),
+        "expected_bfv": hex_digits(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG),
     },
     {
         "a": "bad",
         "b": "bad",
-        "expected_bfv": hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG),
+        "expected_bfv": hex_digits(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG),
     },
     {
         "a": "nothing",
         "b": "nothing",
-        "expected_bfv": hex(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
+        "expected_bfv": hex_digits(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
     },
 ]
 
@@ -2893,7 +2893,7 @@ SIGVERIFY_LCS_2_VALID_KEY = {
             exit_failure = MSG_PASS,
             exit_success = MSG_TEMPLATE_BFV_LCV.format(
                 case["expected_bfv"],
-                hex(lc_state_val),
+                hex_digits(lc_state_val),
             ),
             otp = ":otp_img_sigverify_always_{}".format(lc_state),
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
@@ -2972,12 +2972,12 @@ SIGVERIFY_KEY_TYPE_KEYS = [
         cw310 = cw310_params(
             bitstream = ":bitstream_sigverify_key_type_{}".format(lc_state),
             exit_failure = MSG_PASS if key not in LC_KEY_TYPES[lc_state_val] else MSG_TEMPLATE_BFV_LCV.format(
-                hex(CONST.BFV.SIGVERIFY.BAD_KEY),
-                hex(lc_state_val),
+                hex_digits(CONST.BFV.SIGVERIFY.BAD_KEY),
+                hex_digits(lc_state_val),
             ),
             exit_success = MSG_PASS if key in LC_KEY_TYPES[lc_state_val] else MSG_TEMPLATE_BFV_LCV.format(
-                hex(CONST.BFV.SIGVERIFY.BAD_KEY),
-                hex(lc_state_val),
+                hex_digits(CONST.BFV.SIGVERIFY.BAD_KEY),
+                hex_digits(lc_state_val),
             ),
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
@@ -3051,12 +3051,12 @@ otp_json(
         cw310 = cw310_params(
             bitstream = ":bitstream_sigverify_key_validity_{}".format(lc_state),
             exit_failure = MSG_PASS if lc_state_val != CONST.LCV.TEST_UNLOCKED0 else MSG_TEMPLATE_BFV_LCV.format(
-                hex(CONST.BFV.SIGVERIFY.BAD_KEY),
-                hex(lc_state_val),
+                hex_digits(CONST.BFV.SIGVERIFY.BAD_KEY),
+                hex_digits(lc_state_val),
             ),
             exit_success = MSG_TEMPLATE_BFV_LCV.format(
-                hex(CONST.BFV.SIGVERIFY.BAD_KEY),
-                hex(lc_state_val),
+                hex_digits(CONST.BFV.SIGVERIFY.BAD_KEY),
+                hex_digits(lc_state_val),
             ) if lc_state_val != CONST.LCV.TEST_UNLOCKED0 else MSG_PASS,
             tags = ["vivado"] + maybe_skip_in_ci(lc_state_val),
         ),
@@ -3085,29 +3085,31 @@ test_suite(
 
 # Sigverify usage constraint tests
 _test_device_id = [
-    "a0a1a2a3",  # Least-significant word
-    "12345678",
-    "00000003",
-    "abababab",
-    "cdcdcdcd",
-    "01010101",
-    "10101010",
-    "f0f1f2f3",  # Most-significant word
+    "0xa0a1a2a3",  # Least-significant word
+    "0x12345678",
+    "0x00000003",
+    "0xabababab",
+    "0xcdcdcdcd",
+    "0x01010101",
+    "0x10101010",
+    "0xf0f1f2f3",  # Most-significant word
 ]
 
 _test_manuf_states = {
-    "creator": "fedcba98",
-    "owner": "12345678",
+    "creator": "0xfedcba98",
+    "owner": "0x12345678",
 }
 
 # Generate OTP image with a specific device ID, creator manufacturing state,
 # and owner manufacturing state
+_test_device_id_joined = "0x" + "".join([word[2:] for word in reversed(_test_device_id)])
+
 otp_json(
     name = "otp_json_set_usage_constraint_params_overlay",
     partitions = [
         otp_partition(
             name = "HW_CFG",
-            items = {"DEVICE_ID": "0x" + "".join(_test_device_id[::-1])},
+            items = {"DEVICE_ID": _test_device_id_joined},
         ),
         otp_partition(
             name = "CREATOR_SW_CFG",
@@ -3138,7 +3140,7 @@ otp_json(
     visibility = ["//visibility:private"],
 ) for lc_state, lc_state_val in get_lc_items()]
 
-_SIGVERIFY_FAIL_MSG = MSG_TEMPLATE_BFV.format(hex(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG))
+_SIGVERIFY_FAIL_MSG = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.SIGVERIFY.BAD_ENCODED_MSG))
 
 device_id_test_cases = [
     {
@@ -3517,7 +3519,7 @@ opentitan_functest(
     cw310 = cw310_params(
         # Fail if we see version 3, because the test has updated twice, FAIL, version 0 twice, or PASS
         exit_failure = "(min_security_version_rom_ext:[^01])|(FAIL)|((min_security_version_rom_ext:0(?s:.*)){2,})|(PASS)",
-        exit_success = "min_security_version_rom_ext:0(?s:.*)min_security_version_rom_ext:1(?s:.*)" + MSG_TEMPLATE_BFV.format(hex(CONST.BFV.BOOT_POLICY.ROLLBACK)),
+        exit_success = "min_security_version_rom_ext:0(?s:.*)min_security_version_rom_ext:1(?s:.*)" + MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
         test_cmds = [
             "--exec=\"fpga load-bitstream --rom-kind=rom $(rootpath {bitstream})\"",
             "--exec=\"bootstrap --clear-uart=true $(rootpath {flash})\"",
@@ -3615,7 +3617,7 @@ manifest({
     "name": "manifest_rom_ext_upgrade_interrupt",
     "address_translation": hex(CONST.FALSE),
     "identifier": hex(CONST.ROM_EXT),
-    "security_version": "0x{}".format(hex(10)),
+    "security_version": hex(10),
 })
 
 otp_json(
@@ -3624,7 +3626,7 @@ otp_json(
         otp_partition(
             name = "CREATOR_SW_CFG",
             items = {
-                "CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN": "0x{}".format(hex(CONST.TRUE)),
+                "CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN": hex(CONST.TRUE),
             },
         ),
     ],


### PR DESCRIPTION
This PR renames the `hex` method to `hex_digits` and changes the `_hex` method to `hex` to simplify the logic in `manifest.bzl` and improve readability. This also makes our custom `hex` method consistent with Python's `hex` builtin.

There's also a small cleanup in the dictionary iteration in the OTP generation.