### PR TITLE
[i2c,dv] mapped unmapped test and fix i2c_target_hrst test failure

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -419,5 +419,30 @@
       stage: V2
       tests: ["i2c_target_stretch"]
     }
+    {
+      name: bad_address
+      desc: '''
+            Test sends transactions with a randomized address including two legal (programmed) addresses.
+            Run this test with dut target mode.
+
+            Checking:
+            All transactions with illegal addresses should be dropped silently and should not disturb
+            transactions with legal address
+            '''
+      stage: V2
+      tests: ["i2c_target_bad_addr"]
+    }
+    {
+      name: runt_frame
+      desc: '''
+            Create tests to interrupt normal transaction by a new 'start' or reset.
+            Run those test with dut host and target mode if possible.
+
+            Checking:
+            Dut can accept a new transaction after discarding interrupted transaction.
+            '''
+      stage: V2
+      tests: ["i2c_target_hrst"]
+    }
   ]
 }

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_hrst_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_hrst_vseq.sv
@@ -47,8 +47,8 @@ class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
             `DV_WAIT(cfg.m_i2c_agent_cfg.got_stop,, cfg.spinwait_timeout_ns, "target_hrst_vseq")
             cfg.m_i2c_agent_cfg.got_stop = 0;
           end
-          // exclude timing param update right after runt transaction
-          if (i != (reset_txn_num + 1)) begin
+          // exclude timing param update during and right after runt transaction
+          if (!(i inside {reset_txn_num, (reset_txn_num + 1)})) begin
             get_timing_values();
             program_registers();
           end


### PR DESCRIPTION
- Add missing tests to the testplan
- fix i2c_target_hrst test
  There was a test fail due to 
  address in the dut is programmed with a new value while old expected transaction 
  is in the expected data q.
  Keep address the same during transaction disturbance period.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>