### PR TITLE
[dif/uart] split datapath enabled parameter into two

### DIFF
--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -147,14 +147,15 @@ void _ottf_main(void) {
 
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
-  CHECK_DIF_OK(dif_uart_configure(&uart,
-                                  (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleDisabled,
-                                      .parity = kDifUartParityEven,
-                                  },
-                                  kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart, (dif_uart_config_t){
+                                    .baudrate = kUartBaudrate,
+                                    .clk_freq_hz = kClockFreqPeripheralHz,
+                                    .parity_enable = kDifToggleDisabled,
+                                    .parity = kDifUartParityEven,
+                                    .tx_enable = kDifToggleEnabled,
+                                    .rx_enable = kDifToggleEnabled,
+                                }));
   base_uart_stdout(&uart);
 
   CHECK_DIF_OK(dif_spi_device_init_handle(

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -59,14 +59,15 @@ void _ottf_main(void) {
 
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
-  CHECK_DIF_OK(dif_uart_configure(&uart,
-                                  (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleDisabled,
-                                      .parity = kDifUartParityEven,
-                                  },
-                                  kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart, (dif_uart_config_t){
+                                    .baudrate = kUartBaudrate,
+                                    .clk_freq_hz = kClockFreqPeripheralHz,
+                                    .parity_enable = kDifToggleDisabled,
+                                    .parity = kDifUartParityEven,
+                                    .tx_enable = kDifToggleEnabled,
+                                    .rx_enable = kDifToggleEnabled,
+                                }));
   base_uart_stdout(&uart);
 
   CHECK_DIF_OK(dif_spi_device_init_handle(

--- a/sw/device/examples/sram_program/sram_program.c
+++ b/sw/device/examples/sram_program/sram_program.c
@@ -34,14 +34,15 @@ void sram_main() {
     // Initialize UART.
     CHECK_DIF_OK(dif_uart_init(
         mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-    CHECK_DIF_OK(dif_uart_configure(&uart0,
-                                    (dif_uart_config_t){
-                                        .baudrate = kUartBaudrate,
-                                        .clk_freq_hz = kClockFreqPeripheralHz,
-                                        .parity_enable = kDifToggleDisabled,
-                                        .parity = kDifUartParityEven,
-                                    },
-                                    kDifToggleEnabled));
+    CHECK_DIF_OK(
+        dif_uart_configure(&uart0, (dif_uart_config_t){
+                                       .baudrate = kUartBaudrate,
+                                       .clk_freq_hz = kClockFreqPeripheralHz,
+                                       .parity_enable = kDifToggleDisabled,
+                                       .parity = kDifUartParityEven,
+                                       .tx_enable = kDifToggleEnabled,
+                                       .rx_enable = kDifToggleEnabled,
+                                   }));
     base_uart_stdout(&uart0);
   }
 

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -222,6 +222,39 @@ dif_result_t dif_uart_watermark_tx_set(const dif_uart_t *uart,
   return kDifOk;
 }
 
+dif_result_t dif_uart_set_enable(const dif_uart_t *uart,
+                                 dif_uart_datapath_t datapath,
+                                 dif_toggle_t enabled) {
+  if (uart == NULL || !dif_is_valid_toggle(enabled)) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg = mmio_region_read32(uart->base_addr, UART_CTRL_REG_OFFSET);
+
+  switch (datapath) {
+    case kDifUartDatapathRx:
+      reg = bitfield_bit32_write(reg, UART_CTRL_RX_BIT,
+                                 dif_toggle_to_bool(enabled));
+      break;
+    case kDifUartDatapathTx:
+      reg = bitfield_bit32_write(reg, UART_CTRL_TX_BIT,
+                                 dif_toggle_to_bool(enabled));
+      break;
+    case kDifUartDatapathAll:
+      reg = bitfield_bit32_write(reg, UART_CTRL_RX_BIT,
+                                 dif_toggle_to_bool(enabled));
+      reg = bitfield_bit32_write(reg, UART_CTRL_TX_BIT,
+                                 dif_toggle_to_bool(enabled));
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  mmio_region_write32(uart->base_addr, UART_CTRL_REG_OFFSET, reg);
+
+  return kDifOk;
+}
+
 dif_result_t dif_uart_bytes_send(const dif_uart_t *uart, const uint8_t *data,
                                  size_t bytes_requested,
                                  size_t *bytes_written) {

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -88,10 +88,10 @@ static size_t uart_bytes_receive(const dif_uart_t *uart, size_t bytes_requested,
 }
 
 dif_result_t dif_uart_configure(const dif_uart_t *uart,
-                                dif_uart_config_t config,
-                                dif_toggle_t enabled) {
+                                dif_uart_config_t config) {
   if (uart == NULL || config.baudrate == 0 || config.clk_freq_hz == 0 ||
-      !dif_is_valid_toggle(enabled)) {
+      !dif_is_valid_toggle(config.tx_enable) ||
+      !dif_is_valid_toggle(config.rx_enable)) {
     return kDifBadArg;
   }
 
@@ -130,8 +130,10 @@ dif_result_t dif_uart_configure(const dif_uart_t *uart,
   // Set baudrate, enable RX and TX, configure parity.
   uint32_t reg = 0;
   reg = bitfield_field32_write(reg, UART_CTRL_NCO_FIELD, nco_masked);
-  if (dif_toggle_to_bool(enabled)) {
+  if (dif_toggle_to_bool(config.tx_enable)) {
     reg = bitfield_bit32_write(reg, UART_CTRL_TX_BIT, true);
+  }
+  if (dif_toggle_to_bool(config.rx_enable)) {
     reg = bitfield_bit32_write(reg, UART_CTRL_RX_BIT, true);
   }
   if (config.parity_enable == kDifToggleEnabled) {

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -319,19 +319,26 @@ dif_result_t dif_uart_tx_bytes_available(const dif_uart_t *uart,
 }
 
 dif_result_t dif_uart_fifo_reset(const dif_uart_t *uart,
-                                 dif_uart_fifo_reset_t reset) {
+                                 dif_uart_datapath_t fifo) {
   if (uart == NULL) {
     return kDifBadArg;
   }
 
   uint32_t reg = mmio_region_read32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET);
 
-  if (reset == kDifUartFifoResetRx || reset == kDifUartFifoResetAll) {
-    reg = bitfield_bit32_write(reg, UART_FIFO_CTRL_RXRST_BIT, true);
-  }
-
-  if (reset == kDifUartFifoResetTx || reset == kDifUartFifoResetAll) {
-    reg = bitfield_bit32_write(reg, UART_FIFO_CTRL_TXRST_BIT, true);
+  switch (fifo) {
+    case kDifUartDatapathRx:
+      reg = bitfield_bit32_write(reg, UART_FIFO_CTRL_RXRST_BIT, true);
+      break;
+    case kDifUartDatapathTx:
+      reg = bitfield_bit32_write(reg, UART_FIFO_CTRL_TXRST_BIT, true);
+      break;
+    case kDifUartDatapathAll:
+      reg = bitfield_bit32_write(reg, UART_FIFO_CTRL_RXRST_BIT, true);
+      reg = bitfield_bit32_write(reg, UART_FIFO_CTRL_TXRST_BIT, true);
+      break;
+    default:
+      return kDifBadArg;
   }
 
   mmio_region_write32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET, reg);

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -57,6 +57,14 @@ typedef struct dif_uart_config {
    * The parity to set.
    */
   dif_uart_parity_t parity;
+  /**
+   * Whether to enable TX datapath.
+   */
+  dif_toggle_t tx_enable;
+  /**
+   * Whether to enable RX datapath.
+   */
+  dif_toggle_t rx_enable;
 } dif_uart_config_t;
 
 /**
@@ -133,7 +141,7 @@ extern const uint32_t kDifUartFifoSizeBytes;
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_uart_configure(const dif_uart_t *uart,
-                                dif_uart_config_t config, dif_toggle_t enabled);
+                                dif_uart_config_t config);
 
 /**
  * Sets the RX FIFO watermark.

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -94,22 +94,22 @@ typedef enum dif_uart_watermark {
 } dif_uart_watermark_t;
 
 /**
- * A UART FIFO reset selection.
+ * A UART datapath to select various enables / FIFO resets.
  */
-typedef enum dif_uart_fifo_reset {
+typedef enum dif_uart_datapath {
   /**
-   * Indicates that the RX FIFO should be reset.
+   * Selects the RX datapath for enablement / reset.
    */
-  kDifUartFifoResetRx = 0,
+  kDifUartDatapathRx = 0,
   /**
-   * Indicates that the TX FIFO should be reset.
+   * Selects the TX datapath for enablement / reset.
    */
-  kDifUartFifoResetTx,
+  kDifUartDatapathTx,
   /**
-   * Indicates that both FIFOs should be reset.
+   * Selects both the RX and TX datapaths for enablement / reset.
    */
-  kDifUartFifoResetAll,
-} dif_uart_fifo_reset_t;
+  kDifUartDatapathAll,
+} dif_uart_datapath_t;
 
 /**
  * A UART system/line loopback configuration.
@@ -276,12 +276,12 @@ dif_result_t dif_uart_tx_bytes_available(const dif_uart_t *uart,
  * not abort the operation.
  *
  * @param uart A UART handle.
- * @param reset FIFO to reset (RX, TX or both).
+ * @param fifo The FIFO to reset (RX, TX or both).
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_uart_fifo_reset(const dif_uart_t *uart,
-                                 dif_uart_fifo_reset_t reset);
+                                 dif_uart_datapath_t fifo);
 
 /**
  * Enables or disables a transmit/receive loopback.

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -174,6 +174,18 @@ dif_result_t dif_uart_watermark_tx_set(const dif_uart_t *uart,
                                        dif_uart_watermark_t watermark);
 
 /**
+ * Sets the enablement state of one or both (TX/RX) datapaths.
+ *
+ * @param uart A UART handle.
+ * @param datapath The datapath to set the enablement state of (RX, TX or both).
+ * @param enabled The enablement state to set.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_set_enable(const dif_uart_t *uart,
+                                 dif_uart_datapath_t datapath,
+                                 dif_toggle_t enabled);
+/**
  * Sends bytes over UART.
  *
  * Can be used from inside an UART ISR.
@@ -270,10 +282,8 @@ dif_result_t dif_uart_tx_bytes_available(const dif_uart_t *uart,
                                          size_t *num_bytes);
 
 /**
- * UART TX reset RX/TX FIFO.
- *
- * Resets one or both FIFOs. If the byte is in transit, this function will
- * not abort the operation.
+ * Resets one or both datapath FIFOs. If the byte is in transit, this function
+ * will not abort the operation.
  *
  * @param uart A UART handle.
  * @param fifo The FIFO to reset (RX, TX or both).

--- a/sw/device/lib/dif/dif_uart_unittest.cc
+++ b/sw/device/lib/dif/dif_uart_unittest.cc
@@ -200,6 +200,97 @@ TEST_F(WatermarkTxSetTest, Success) {
   EXPECT_DIF_OK(dif_uart_watermark_tx_set(&uart_, kDifUartWatermarkByte16));
 }
 
+class SetEnableTest : public UartTest {};
+
+TEST_F(SetEnableTest, NullArg) {
+  EXPECT_DIF_BADARG(
+      dif_uart_set_enable(nullptr, kDifUartDatapathAll, kDifToggleEnabled));
+}
+
+TEST_F(SetEnableTest, BadEnabled) {
+  EXPECT_DIF_BADARG(dif_uart_set_enable(&uart_, kDifUartDatapathAll,
+                                        static_cast<dif_toggle_t>(2)));
+}
+
+TEST_F(SetEnableTest, BadDatapath) {
+  EXPECT_READ32(UART_CTRL_REG_OFFSET, 0);
+  EXPECT_DIF_BADARG(dif_uart_set_enable(
+      &uart_, static_cast<dif_uart_datapath_t>(kDifUartDatapathAll + 1),
+      kDifToggleEnabled));
+}
+
+TEST_F(SetEnableTest, SuccessRxEnabledDisabled) {
+  EXPECT_READ32(UART_CTRL_REG_OFFSET, {
+                                          {UART_CTRL_RX_BIT, 0},
+                                          {UART_CTRL_TX_BIT, 1},
+                                      });
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_RX_BIT, 1},
+                                           {UART_CTRL_TX_BIT, 1},
+                                       });
+  EXPECT_DIF_OK(
+      dif_uart_set_enable(&uart_, kDifUartDatapathRx, kDifToggleEnabled));
+
+  EXPECT_READ32(UART_CTRL_REG_OFFSET, {
+                                          {UART_CTRL_RX_BIT, 1},
+                                          {UART_CTRL_TX_BIT, 1},
+                                      });
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_RX_BIT, 0},
+                                           {UART_CTRL_TX_BIT, 1},
+                                       });
+  EXPECT_DIF_OK(
+      dif_uart_set_enable(&uart_, kDifUartDatapathRx, kDifToggleDisabled));
+}
+
+TEST_F(SetEnableTest, SuccessTxEnabledDisabled) {
+  EXPECT_READ32(UART_CTRL_REG_OFFSET, {
+                                          {UART_CTRL_RX_BIT, 1},
+                                          {UART_CTRL_TX_BIT, 0},
+                                      });
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_RX_BIT, 1},
+                                           {UART_CTRL_TX_BIT, 1},
+                                       });
+  EXPECT_DIF_OK(
+      dif_uart_set_enable(&uart_, kDifUartDatapathTx, kDifToggleEnabled));
+
+  EXPECT_READ32(UART_CTRL_REG_OFFSET, {
+                                          {UART_CTRL_RX_BIT, 1},
+                                          {UART_CTRL_TX_BIT, 1},
+                                      });
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_RX_BIT, 1},
+                                           {UART_CTRL_TX_BIT, 0},
+                                       });
+  EXPECT_DIF_OK(
+      dif_uart_set_enable(&uart_, kDifUartDatapathTx, kDifToggleDisabled));
+}
+
+TEST_F(SetEnableTest, SuccessRxTxEnabledDisabled) {
+  EXPECT_READ32(UART_CTRL_REG_OFFSET, {
+                                          {UART_CTRL_RX_BIT, 0},
+                                          {UART_CTRL_TX_BIT, 0},
+                                      });
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_RX_BIT, 1},
+                                           {UART_CTRL_TX_BIT, 1},
+                                       });
+  EXPECT_DIF_OK(
+      dif_uart_set_enable(&uart_, kDifUartDatapathAll, kDifToggleEnabled));
+
+  EXPECT_READ32(UART_CTRL_REG_OFFSET, {
+                                          {UART_CTRL_RX_BIT, 1},
+                                          {UART_CTRL_TX_BIT, 1},
+                                      });
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_RX_BIT, 0},
+                                           {UART_CTRL_TX_BIT, 0},
+                                       });
+  EXPECT_DIF_OK(
+      dif_uart_set_enable(&uart_, kDifUartDatapathAll, kDifToggleDisabled));
+}
+
 class BytesSendTest : public UartTest {
  protected:
   /**

--- a/sw/device/lib/dif/dif_uart_unittest.cc
+++ b/sw/device/lib/dif/dif_uart_unittest.cc
@@ -428,18 +428,18 @@ TEST_F(TxBytesAvailableTest, FifoEmpty) {
 class FifoResetTest : public UartTest {};
 
 TEST_F(FifoResetTest, NullArgs) {
-  dif_result_t result = dif_uart_fifo_reset(nullptr, kDifUartFifoResetRx);
+  dif_result_t result = dif_uart_fifo_reset(nullptr, kDifUartDatapathRx);
   EXPECT_DIF_BADARG(result);
 }
 
 TEST_F(FifoResetTest, Success) {
   EXPECT_READ32(UART_FIFO_CTRL_REG_OFFSET, 0);
   EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET, {{UART_FIFO_CTRL_RXRST_BIT, true}});
-  EXPECT_DIF_OK(dif_uart_fifo_reset(&uart_, kDifUartFifoResetRx));
+  EXPECT_DIF_OK(dif_uart_fifo_reset(&uart_, kDifUartDatapathRx));
 
   EXPECT_READ32(UART_FIFO_CTRL_REG_OFFSET, 0);
   EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET, {{UART_FIFO_CTRL_TXRST_BIT, true}});
-  EXPECT_DIF_OK(dif_uart_fifo_reset(&uart_, kDifUartFifoResetTx));
+  EXPECT_DIF_OK(dif_uart_fifo_reset(&uart_, kDifUartDatapathTx));
 
   EXPECT_READ32(UART_FIFO_CTRL_REG_OFFSET, 0);
   EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
@@ -447,7 +447,7 @@ TEST_F(FifoResetTest, Success) {
                      {UART_FIFO_CTRL_RXRST_BIT, true},
                      {UART_FIFO_CTRL_TXRST_BIT, true},
                  });
-  EXPECT_DIF_OK(dif_uart_fifo_reset(&uart_, kDifUartFifoResetAll));
+  EXPECT_DIF_OK(dif_uart_fifo_reset(&uart_, kDifUartDatapathAll));
 }
 
 class LoopbackSetTest : public UartTest {};

--- a/sw/device/lib/dif/dif_uart_unittest.cc
+++ b/sw/device/lib/dif/dif_uart_unittest.cc
@@ -53,16 +53,18 @@ class UartTest : public Test, public MmioTest {
       .clk_freq_hz = 1048576,
       .parity_enable = kDifToggleDisabled,
       .parity = kDifUartParityEven,
+      .tx_enable = kDifToggleEnabled,
+      .rx_enable = kDifToggleEnabled,
   };
 };
 
 class ConfigTest : public UartTest {};
 
 TEST_F(ConfigTest, NullArgs) {
-  EXPECT_DIF_BADARG(dif_uart_configure(nullptr, config_, kDifToggleEnabled));
+  EXPECT_DIF_BADARG(dif_uart_configure(nullptr, config_));
 }
 
-TEST_F(ConfigTest, DefaultEnabled) {
+TEST_F(ConfigTest, DefaultTxRxEnabled) {
   ExpectDeviceReset();
   EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
                                            {UART_CTRL_TX_BIT, true},
@@ -70,14 +72,38 @@ TEST_F(ConfigTest, DefaultEnabled) {
                                            {UART_CTRL_NCO_OFFSET, 1},
                                        });
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_, kDifToggleEnabled));
+  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
 }
 
-TEST_F(ConfigTest, DefaultDisabled) {
+TEST_F(ConfigTest, DefaultTxEnabled) {
+  ExpectDeviceReset();
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_TX_BIT, true},
+                                           {UART_CTRL_NCO_OFFSET, 1},
+                                       });
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+  config_.rx_enable = kDifToggleDisabled;
+  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
+}
+
+TEST_F(ConfigTest, DefaultRxEnabled) {
+  ExpectDeviceReset();
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_RX_BIT, true},
+                                           {UART_CTRL_NCO_OFFSET, 1},
+                                       });
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+  config_.tx_enable = kDifToggleDisabled;
+  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
+}
+
+TEST_F(ConfigTest, DefaultTxRxDisabled) {
   ExpectDeviceReset();
   EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {{UART_CTRL_NCO_OFFSET, 1}});
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_, kDifToggleDisabled));
+  config_.tx_enable = kDifToggleDisabled;
+  config_.rx_enable = kDifToggleDisabled;
+  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
 }
 
 TEST_F(ConfigTest, ParityEven) {
@@ -95,7 +121,7 @@ TEST_F(ConfigTest, ParityEven) {
 
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
 
-  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_, kDifToggleEnabled));
+  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
 }
 
 TEST_F(ConfigTest, ParityOdd) {
@@ -114,7 +140,7 @@ TEST_F(ConfigTest, ParityOdd) {
 
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
 
-  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_, kDifToggleEnabled));
+  EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
 }
 
 class WatermarkRxSetTest : public UartTest {};

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -82,14 +82,15 @@ char *ottf_task_get_self_name(void) {
 static void init_uart(void) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK_DIF_OK(dif_uart_configure(&uart0,
-                                  (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleDisabled,
-                                      .parity = kDifUartParityEven,
-                                  },
-                                  kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart0, (dif_uart_config_t){
+                                     .baudrate = kUartBaudrate,
+                                     .clk_freq_hz = kClockFreqPeripheralHz,
+                                     .parity_enable = kDifToggleDisabled,
+                                     .parity = kDifUartParityEven,
+                                     .tx_enable = kDifToggleEnabled,
+                                     .rx_enable = kDifToggleEnabled,
+                                 }));
   base_uart_stdout(&uart0);
 }
 

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -119,14 +119,15 @@ bool rom_test_main(void) {
   if (kDeviceType != kDeviceSimDV) {
     CHECK_DIF_OK(dif_uart_init(
         mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-    CHECK_DIF_OK(dif_uart_configure(&uart0,
-                                    (dif_uart_config_t){
-                                        .baudrate = kUartBaudrate,
-                                        .clk_freq_hz = kClockFreqPeripheralHz,
-                                        .parity_enable = kDifToggleDisabled,
-                                        .parity = kDifUartParityEven,
-                                    },
-                                    kDifToggleEnabled));
+    CHECK_DIF_OK(
+        dif_uart_configure(&uart0, (dif_uart_config_t){
+                                       .baudrate = kUartBaudrate,
+                                       .clk_freq_hz = kClockFreqPeripheralHz,
+                                       .parity_enable = kDifToggleDisabled,
+                                       .parity = kDifUartParityEven,
+                                       .tx_enable = kDifToggleEnabled,
+                                       .rx_enable = kDifToggleEnabled,
+                                   }));
     base_uart_stdout(&uart0);
   }
 

--- a/sw/device/riscv_compliance_support/support.c
+++ b/sw/device/riscv_compliance_support/support.c
@@ -22,14 +22,15 @@ static dif_uart_t uart0;
 int opentitan_compliance_main(int argc, char **argv) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK_DIF_OK(dif_uart_configure(&uart0,
-                                  (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleDisabled,
-                                      .parity = kDifUartParityEven,
-                                  },
-                                  kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart0, (dif_uart_config_t){
+                                     .baudrate = kUartBaudrate,
+                                     .clk_freq_hz = kClockFreqPeripheralHz,
+                                     .parity_enable = kDifToggleDisabled,
+                                     .parity = kDifUartParityEven,
+                                     .tx_enable = kDifToggleEnabled,
+                                     .rx_enable = kDifToggleEnabled,
+                                 }));
   base_uart_stdout(&uart0);
 
   run_rvc_test();

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -77,17 +77,19 @@ static void sca_init_uart(void) {
       .clk_freq_hz = kClockFreqPeripheralHz,
       .parity_enable = kDifToggleDisabled,
       .parity = kDifUartParityEven,
+      .tx_enable = kDifToggleEnabled,
+      .rx_enable = kDifToggleEnabled,
   };
 
   OT_DISCARD(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
                            &uart0));
-  OT_DISCARD(dif_uart_configure(&uart0, uart_config, kDifToggleEnabled));
+  OT_DISCARD(dif_uart_configure(&uart0, uart_config));
   base_uart_stdout(&uart0);
 
 #if !OT_IS_ENGLISH_BREAKFAST
   OT_DISCARD(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART1_BASE_ADDR),
                            &uart1));
-  OT_DISCARD(dif_uart_configure(&uart1, uart_config, kDifToggleEnabled));
+  OT_DISCARD(dif_uart_configure(&uart1, uart_config));
 #endif
 }
 

--- a/sw/device/tests/crt_test.c
+++ b/sw/device/tests/crt_test.c
@@ -45,14 +45,15 @@ static dif_uart_t uart0;
 static void init_uart(void) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK_DIF_OK(dif_uart_configure(&uart0,
-                                  (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleDisabled,
-                                      .parity = kDifUartParityEven,
-                                  },
-                                  kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart0, (dif_uart_config_t){
+                                     .baudrate = kUartBaudrate,
+                                     .clk_freq_hz = kClockFreqPeripheralHz,
+                                     .parity_enable = kDifToggleDisabled,
+                                     .parity = kDifUartParityEven,
+                                     .tx_enable = kDifToggleEnabled,
+                                     .rx_enable = kDifToggleEnabled,
+                                 }));
   base_uart_stdout(&uart0);
 }
 

--- a/sw/device/tests/example_test_from_rom.c
+++ b/sw/device/tests/example_test_from_rom.c
@@ -31,14 +31,15 @@ bool rom_test_main(void) {
   if (kDeviceType != kDeviceSimDV) {
     CHECK_DIF_OK(dif_uart_init(
         mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-    CHECK_DIF_OK(dif_uart_configure(&uart0,
-                                    (dif_uart_config_t){
-                                        .baudrate = kUartBaudrate,
-                                        .clk_freq_hz = kClockFreqPeripheralHz,
-                                        .parity_enable = kDifToggleDisabled,
-                                        .parity = kDifUartParityEven,
-                                    },
-                                    kDifToggleEnabled));
+    CHECK_DIF_OK(
+        dif_uart_configure(&uart0, (dif_uart_config_t){
+                                       .baudrate = kUartBaudrate,
+                                       .clk_freq_hz = kClockFreqPeripheralHz,
+                                       .parity_enable = kDifToggleDisabled,
+                                       .parity = kDifUartParityEven,
+                                       .tx_enable = kDifToggleEnabled,
+                                       .rx_enable = kDifToggleEnabled,
+                                   }));
     base_uart_stdout(&uart0);
   }
 

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -425,14 +425,15 @@ static void configure_kmac(void) {
 }
 
 static void configure_uart(dif_uart_t *uart) {
-  CHECK_DIF_OK(dif_uart_configure(uart,
-                                  (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleEnabled,
-                                      .parity = kDifUartParityEven,
-                                  },
-                                  kDifToggleDisabled));
+  CHECK_DIF_OK(
+      dif_uart_configure(uart, (dif_uart_config_t){
+                                   .baudrate = kUartBaudrate,
+                                   .clk_freq_hz = kClockFreqPeripheralHz,
+                                   .parity_enable = kDifToggleEnabled,
+                                   .parity = kDifUartParityEven,
+                                   .tx_enable = kDifToggleEnabled,
+                                   .rx_enable = kDifToggleEnabled,
+                               }));
   CHECK_DIF_OK(
       dif_uart_loopback_set(uart, kDifUartLoopbackSystem, kDifToggleEnabled));
 }

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -86,14 +86,15 @@ void ottf_external_isr(void) {
 
 static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
   CHECK_DIF_OK(dif_uart_init(base_addr, uart));
-  CHECK_DIF_OK(dif_uart_configure(uart,
-                                  (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleDisabled,
-                                      .parity = kDifUartParityEven,
-                                  },
-                                  kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_configure(uart, (dif_uart_config_t){
+                                   .baudrate = kUartBaudrate,
+                                   .clk_freq_hz = kClockFreqPeripheralHz,
+                                   .parity_enable = kDifToggleDisabled,
+                                   .parity = kDifUartParityEven,
+                                   .tx_enable = kDifToggleEnabled,
+                                   .rx_enable = kDifToggleEnabled,
+                               }));
 }
 
 /**

--- a/sw/device/tests/sim_dv/flash_init_test.c
+++ b/sw/device/tests/sim_dv/flash_init_test.c
@@ -291,14 +291,15 @@ bool rom_test_main(void) {
   if (kDeviceType != kDeviceSimDV) {
     CHECK_DIF_OK(dif_uart_init(
         mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-    CHECK_DIF_OK(dif_uart_configure(&uart0,
-                                    (dif_uart_config_t){
-                                        .baudrate = kUartBaudrate,
-                                        .clk_freq_hz = kClockFreqPeripheralHz,
-                                        .parity_enable = kDifToggleDisabled,
-                                        .parity = kDifUartParityEven,
-                                    },
-                                    kDifToggleEnabled));
+    CHECK_DIF_OK(
+        dif_uart_configure(&uart0, (dif_uart_config_t){
+                                       .baudrate = kUartBaudrate,
+                                       .clk_freq_hz = kClockFreqPeripheralHz,
+                                       .parity_enable = kDifToggleDisabled,
+                                       .parity = kDifUartParityEven,
+                                       .tx_enable = kDifToggleEnabled,
+                                       .rx_enable = kDifToggleEnabled,
+                                   }));
     base_uart_stdout(&uart0);
   }
 

--- a/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
+++ b/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
@@ -236,14 +236,15 @@ bool rom_test_main(void) {
   if (kDeviceType != kDeviceSimDV) {
     CHECK_DIF_OK(dif_uart_init(
         mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-    CHECK_DIF_OK(dif_uart_configure(&uart0,
-                                    (dif_uart_config_t){
-                                        .baudrate = kUartBaudrate,
-                                        .clk_freq_hz = kClockFreqPeripheralHz,
-                                        .parity_enable = kDifToggleDisabled,
-                                        .parity = kDifUartParityEven,
-                                    },
-                                    kDifToggleEnabled));
+    CHECK_DIF_OK(
+        dif_uart_configure(&uart0, (dif_uart_config_t){
+                                       .baudrate = kUartBaudrate,
+                                       .clk_freq_hz = kClockFreqPeripheralHz,
+                                       .parity_enable = kDifToggleDisabled,
+                                       .parity = kDifUartParityEven,
+                                       .tx_enable = kDifToggleEnabled,
+                                       .rx_enable = kDifToggleEnabled,
+                                   }));
     base_uart_stdout(&uart0);
   }
 

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -287,14 +287,15 @@ static void uart_init_with_irqs(mmio_region_t base_addr, dif_uart_t *uart) {
   LOG_INFO("Initializing the UART.");
 
   CHECK_DIF_OK(dif_uart_init(base_addr, uart));
-  CHECK_DIF_OK(dif_uart_configure(uart,
-                                  (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleDisabled,
-                                      .parity = kDifUartParityEven,
-                                  },
-                                  kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_configure(uart, (dif_uart_config_t){
+                                   .baudrate = kUartBaudrate,
+                                   .clk_freq_hz = kClockFreqPeripheralHz,
+                                   .parity_enable = kDifToggleDisabled,
+                                   .parity = kDifUartParityEven,
+                                   .tx_enable = kDifToggleEnabled,
+                                   .rx_enable = kDifToggleEnabled,
+                               }));
 
   // Set the TX and RX watermark to 16 bytes.
   CHECK_DIF_OK(dif_uart_watermark_tx_set(uart, kDifUartWatermarkByte16));

--- a/sw/device/tests/uart_smoketest.c
+++ b/sw/device/tests/uart_smoketest.c
@@ -31,7 +31,7 @@ bool test_main(void) {
                                 }));
   CHECK_DIF_OK(
       dif_uart_loopback_set(&uart, kDifUartLoopbackSystem, kDifToggleEnabled));
-  CHECK_DIF_OK(dif_uart_fifo_reset(&uart, kDifUartFifoResetAll));
+  CHECK_DIF_OK(dif_uart_fifo_reset(&uart, kDifUartDatapathAll));
 
   // Send all bytes in `kSendData`, and check that they are received via
   // the loopback mechanism.

--- a/sw/device/tests/uart_smoketest.c
+++ b/sw/device/tests/uart_smoketest.c
@@ -20,14 +20,15 @@ bool test_main(void) {
   dif_uart_t uart;
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
-  CHECK_DIF_OK(dif_uart_configure(&uart,
-                                  (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleDisabled,
-                                      .parity = kDifUartParityEven,
-                                  },
-                                  kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart, (dif_uart_config_t){
+                                    .baudrate = kUartBaudrate,
+                                    .clk_freq_hz = kClockFreqPeripheralHz,
+                                    .parity_enable = kDifToggleDisabled,
+                                    .parity = kDifUartParityEven,
+                                    .tx_enable = kDifToggleEnabled,
+                                    .rx_enable = kDifToggleEnabled,
+                                }));
   CHECK_DIF_OK(
       dif_uart_loopback_set(&uart, kDifUartLoopbackSystem, kDifToggleEnabled));
   CHECK_DIF_OK(dif_uart_fifo_reset(&uart, kDifUartFifoResetAll));

--- a/third_party/coremark/top_earlgrey/core_portme.c
+++ b/third_party/coremark/top_earlgrey/core_portme.c
@@ -166,7 +166,9 @@ portable_init(core_portable *p, int *argc, char *argv[])
                                             .clk_freq_hz = kClockFreqPeripheralHz,
                                             .parity_enable = kDifToggleDisabled,
                                             .parity = kDifUartParityEven,
-                                            }, kDifToggleEnabled));
+                                            .tx_enable = kDifToggleEnabled,
+                                            .rx_enable = kDifToggleEnabled,
+                                            }));
     base_uart_stdout(&uart);
 }
 


### PR DESCRIPTION
This PR contains several commits that:
- split the datapath enablement parameter of `dif_uart_configure()` into two parameters (one for TX, one for RX) to address a review [comment](https://github.com/lowRISC/opentitan/pull/17030#discussion_r1067321668) in #17030, and
- adds a UART DIF to toggle the each datapath's enablement configuration.