### PR TITLE
[dv/xprop] Enable per-IP xprop configuration file

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -136,6 +136,7 @@
   // Project defaults for VCS
   vcs_cov_cfg_file: "{{build_mode}_vcs_cov_cfg_file}"
   vcs_unr_cfg_file: "{dv_root}/tools/vcs/unr.cfg"
+  vcs_xprop_cfg_file: "{dv_root}/tools/vcs/xprop.cfg"
   vcs_fsm_reset_cov_cfg_file: "{dv_root}/tools/vcs/fsm_reset_cov.cfg"
   vcs_cov_excl_files: []
 

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -319,7 +319,7 @@
     {
       name: vcs_xprop
       is_sim_mode: 1
-      build_opts: ["-xprop={dv_root}/tools/vcs/xprop.cfg",
+      build_opts: ["-xprop={vcs_xprop_cfg_file}",
                    // Enable xmerge mode specific performance optimization
                    "-xprop=mmsopt"]
     }

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -89,6 +89,11 @@
       value: "{top_dv_path}/cov/unr.cfg"
     }
 
+    // Used for xprop config.
+    {
+      name: vcs_xprop_cfg_file
+      value: "{top_dv_path}/vcs_xprop.cfg"
+    }
     // This defaults to 'ip' in `hw/data/common_project_cfg.hjson`.
     {
       name: design_level

--- a/hw/top_earlgrey/dv/vcs_xprop.cfg
+++ b/hw/top_earlgrey/dv/vcs_xprop.cfg
@@ -9,4 +9,12 @@ merge = xmerge;
 instance { tb.dut } { xpropOn };
 
 // Modules excluded from xprop instrumentation.
+module { ast_ext_clk_if } { xpropOff };
+module { ast_supply_if } { xpropOff };
+module { chip_if } { xpropOff };
+module { clk_rst_if } { xpropOff };
+module { i2c_if } { xpropOff };
+module { jtag_if } { xpropOff };
 module { prim_cdc_rand_delay } { xpropOff };
+module { spi_if } { xpropOff };
+module { uart_if } { xpropOff };


### PR DESCRIPTION
Create a top_earlgrey xprop configuration.
Regular IPs keep using default xprop configuration file.

Partially addresses #16723

Signed-off-by: Guillermo Maturana <maturana@google.com>