### PR TITLE
[reggen] Add missing validation for simple block syntax

### DIFF
--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -92,6 +92,7 @@ class RegBlock:
             block.add_raw_registers(raw,
                                     'registers field at top-level', clocks,
                                     bus.device_async.get(None), is_alias)
+            block.validate()
             return {None: block}
 
         # This is the more complicated syntax


### PR DESCRIPTION
This validate function was only invoked on the complex block syntax before.

Signed-off-by: Michael Schaffner <msf@google.com>