### PR TITLE
[dv/alert_handler] Add alert_accum saturation test

### DIFF
--- a/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
@@ -143,7 +143,22 @@
       stage: V2
       tests: ["alert_handler_entropy_stress"]
     }
-  ]
+
+    {
+      name: alert_handler_alert_accum_saturation
+      desc: '''
+            This sequence forces all four alert classes' accumulate counters to a large value that
+            is close to the max saturation value.
+            Then the sequence triggers alerts until the count saturates.
+
+            Checks:
+            - Check `accum_cnt` register does not overflow, but stays at the max value.
+            - Check the correct interrupt fires if even the count saturates.
+            '''
+      stage: V2
+      tests: ["alert_handler_alert_accum_saturation"]
+    }
+ ]
 
   covergroups: [
     {

--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -124,6 +124,15 @@
       run_opts: ["+test_timeout_ns=500_000_000"]
       run_timeout_mins: 120
     }
+
+    {
+      name: alert_handler_alert_accum_saturation
+      uvm_test_seq: alert_handler_alert_accum_saturation_vseq
+      // This is a direct sequence that forces the accum_cnt to a large number, so does not support
+      // scb checkings.
+      run_opts: ["+en_scb=0"]
+      reseed: 20
+    }
   ]
 
   // List of regressions.

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env.core
@@ -33,6 +33,7 @@ filesets:
       - seq_lib/alert_handler_lpg_stub_clk_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_entropy_stress_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/alert_handler_alert_accum_saturation_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_alert_accum_saturation_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_alert_accum_saturation_vseq.sv
@@ -1,0 +1,108 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence force the alert accumulation count to large value, then check if the accum count
+// will saturate and won't overflow.
+
+`define CLASS_CNT_PATH(class_i, i) \
+    string class_``class_i``_path_0 = \
+           "tb.dut.gen_classes[``i``].u_accu.u_prim_count.cnt_q[0]"; \
+    string class_``class_i``_path_1 = \
+           "tb.dut.gen_classes[``i``].u_accu.u_prim_count.cnt_q[1]";
+
+`define CHECK_ALERT_ACCUM_CNT(class_i, i) \
+    csr_rd_check(.ptr(ral.class``class_i``_accum_cnt), \
+                 .compare_value(saturated_class == ``i`` ? \
+                  MAX_ACCUM_CNT : MAX_ACCUM_CNT - num_alerts_to_saturate));
+
+class alert_handler_alert_accum_saturation_vseq extends alert_handler_smoke_vseq;
+  `uvm_object_utils(alert_handler_alert_accum_saturation_vseq)
+
+  `uvm_object_new
+
+  parameter uint MAX_ACCUM_CNT = 'hffff;
+  rand int num_alerts_to_saturate;
+  rand bit [1:0] saturated_class; // only 4 classes: a, b, c, d
+
+  `CLASS_CNT_PATH(a, 0)
+  `CLASS_CNT_PATH(b, 1)
+  `CLASS_CNT_PATH(c, 2)
+  `CLASS_CNT_PATH(d, 3)
+
+  constraint num_alerts_to_saturate_c {
+    num_alerts_to_saturate inside {[1 : 10]};
+    $countones(alert_trigger) == 1;
+  }
+
+  function void pre_randomize();
+    this.enable_one_alert_c.constraint_mode(0);
+    this.enable_classa_only_c.constraint_mode(0);
+  endfunction
+
+  virtual task pre_start();
+    // Force accum counts to a large value.
+    `DV_CHECK(uvm_hdl_force(class_a_path_0, (MAX_ACCUM_CNT - num_alerts_to_saturate)));
+    `DV_CHECK(uvm_hdl_force(class_a_path_1, (num_alerts_to_saturate)));
+
+    `DV_CHECK(uvm_hdl_force(class_b_path_0, (MAX_ACCUM_CNT - num_alerts_to_saturate)));
+    `DV_CHECK(uvm_hdl_force(class_b_path_1, (num_alerts_to_saturate)));
+
+    `DV_CHECK(uvm_hdl_force(class_c_path_0, (MAX_ACCUM_CNT - num_alerts_to_saturate)));
+    `DV_CHECK(uvm_hdl_force(class_c_path_1, (num_alerts_to_saturate)));
+
+    `DV_CHECK(uvm_hdl_force(class_d_path_0, (MAX_ACCUM_CNT - num_alerts_to_saturate)));
+    `DV_CHECK(uvm_hdl_force(class_d_path_1, (num_alerts_to_saturate)));
+
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    // Assign all alerts to one class.
+    foreach (alert_class_map[i]) alert_class_map[i] = saturated_class;
+    alert_handler_init(.intr_en('1),
+                       .alert_en('1),
+                       .alert_class(alert_class_map),
+                       .loc_alert_en(0),
+                       .loc_alert_class(0));
+    csr_wr(ral.classa_accum_thresh_shadowed, '1);
+    csr_wr(ral.classb_accum_thresh_shadowed, '1);
+    csr_wr(ral.classc_accum_thresh_shadowed, '1);
+    csr_wr(ral.classd_accum_thresh_shadowed, '1);
+
+    // Enable and lock all alert classes.
+    csr_wr(ral.classa_ctrl_shadowed.en, 1);
+    csr_wr(ral.classb_ctrl_shadowed.en, 1);
+    csr_wr(ral.classc_ctrl_shadowed.en, 1);
+    csr_wr(ral.classd_ctrl_shadowed.en, 1);
+
+    `DV_CHECK(uvm_hdl_release(class_a_path_0));
+    `DV_CHECK(uvm_hdl_release(class_a_path_1));
+    `DV_CHECK(uvm_hdl_release(class_b_path_0));
+    `DV_CHECK(uvm_hdl_release(class_b_path_1));
+    `DV_CHECK(uvm_hdl_release(class_c_path_0));
+    `DV_CHECK(uvm_hdl_release(class_c_path_1));
+    `DV_CHECK(uvm_hdl_release(class_d_path_0));
+    `DV_CHECK(uvm_hdl_release(class_d_path_1));
+
+    `uvm_info(`gfn, $sformatf("Saturate class %0d, alerts to saturate %0d", saturated_class,
+                              num_alerts_to_saturate), UVM_LOW)
+
+    // First round will reach the max count value, afterwards check if the max value saturates and
+    // won't overflow.
+    repeat ($urandom_range(2, 5)) begin
+      repeat (num_alerts_to_saturate) begin
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(alert_trigger)
+        drive_alert(alert_trigger, alert_int_err);
+        csr_rd_check(.ptr(ral.intr_state), .compare_value(1 << saturated_class));
+        csr_wr(.ptr(ral.intr_state), .value(1 << saturated_class));
+      end
+
+      `CHECK_ALERT_ACCUM_CNT(a, 0)
+      `CHECK_ALERT_ACCUM_CNT(b, 1)
+      `CHECK_ALERT_ACCUM_CNT(c, 2)
+      `CHECK_ALERT_ACCUM_CNT(d, 3)
+    end
+ endtask
+
+endclass : alert_handler_alert_accum_saturation_vseq

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -16,8 +16,9 @@
   csr_update(ral.class``i``_phase2_cyc_shadowed);                         \
   csr_update(ral.class``i``_phase3_cyc_shadowed);
 
-`define RAND_WRITE_CLASS_CTRL(i, lock_bit) \
-  `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.class``i``_ctrl_shadowed, lock.value == lock_bit;)  \
+`define RAND_WRITE_CLASS_CTRL(i, en_bit, lock_bit) \
+  `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.class``i``_ctrl_shadowed, \
+                                 en.value == en_bit; lock.value == lock_bit;)  \
   csr_wr(.ptr(ral.class``i``_ctrl_shadowed), .value(ral.class``i``_ctrl_shadowed.get()));
 
 class alert_handler_base_vseq extends cip_base_vseq #(
@@ -67,10 +68,10 @@ class alert_handler_base_vseq extends cip_base_vseq #(
 
   virtual task alert_handler_rand_wr_class_ctrl(bit [NUM_ALERT_CLASSES-1:0] lock_bit,
                                                 bit [NUM_ALERT_CLASSES-1:0] class_en = $urandom());
-    if (class_en[0]) `RAND_WRITE_CLASS_CTRL(a, lock_bit[0])
-    if (class_en[1]) `RAND_WRITE_CLASS_CTRL(b, lock_bit[1])
-    if (class_en[2]) `RAND_WRITE_CLASS_CTRL(c, lock_bit[2])
-    if (class_en[3]) `RAND_WRITE_CLASS_CTRL(d, lock_bit[3])
+    `RAND_WRITE_CLASS_CTRL(a, class_en[0], lock_bit[0])
+    `RAND_WRITE_CLASS_CTRL(b, class_en[1], lock_bit[1])
+    `RAND_WRITE_CLASS_CTRL(c, class_en[2], lock_bit[2])
+    `RAND_WRITE_CLASS_CTRL(d, class_en[3], lock_bit[3])
   endtask
 
   virtual task alert_handler_wr_regwen_regs(bit [NUM_ALERT_CLASSES-1:0] regwen = 0,

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_vseq_list.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_vseq_list.sv
@@ -16,3 +16,4 @@
 `include "alert_handler_lpg_stub_clk_vseq.sv"
 `include "alert_handler_entropy_stress_vseq.sv"
 `include "alert_handler_stress_all_vseq.sv"
+`include "alert_handler_alert_accum_saturation_vseq.sv"

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
@@ -143,7 +143,22 @@
       stage: V2
       tests: ["alert_handler_entropy_stress"]
     }
-  ]
+
+    {
+      name: alert_handler_alert_accum_saturation
+      desc: '''
+            This sequence forces all four alert classes' accumulate counters to a large value that
+            is close to the max saturation value.
+            Then the sequence triggers alerts until the count saturates.
+
+            Checks:
+            - Check `accum_cnt` register does not overflow, but stays at the max value.
+            - Check the correct interrupt fires if even the count saturates.
+            '''
+      stage: V2
+      tests: ["alert_handler_alert_accum_saturation"]
+    }
+ ]
 
   covergroups: [
     {

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -124,6 +124,15 @@
       run_opts: ["+test_timeout_ns=500_000_000"]
       run_timeout_mins: 120
     }
+
+    {
+      name: alert_handler_alert_accum_saturation
+      uvm_test_seq: alert_handler_alert_accum_saturation_vseq
+      // This is a direct sequence that forces the accum_cnt to a large number, so does not support
+      // scb checkings.
+      run_opts: ["+en_scb=0"]
+      reseed: 20
+    }
   ]
 
   // List of regressions.

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
@@ -33,6 +33,7 @@ filesets:
       - seq_lib/alert_handler_lpg_stub_clk_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_entropy_stress_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/alert_handler_alert_accum_saturation_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_alert_accum_saturation_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_alert_accum_saturation_vseq.sv
@@ -1,0 +1,108 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence force the alert accumulation count to large value, then check if the accum count
+// will saturate and won't overflow.
+
+`define CLASS_CNT_PATH(class_i, i) \
+    string class_``class_i``_path_0 = \
+           "tb.dut.gen_classes[``i``].u_accu.u_prim_count.cnt_q[0]"; \
+    string class_``class_i``_path_1 = \
+           "tb.dut.gen_classes[``i``].u_accu.u_prim_count.cnt_q[1]";
+
+`define CHECK_ALERT_ACCUM_CNT(class_i, i) \
+    csr_rd_check(.ptr(ral.class``class_i``_accum_cnt), \
+                 .compare_value(saturated_class == ``i`` ? \
+                  MAX_ACCUM_CNT : MAX_ACCUM_CNT - num_alerts_to_saturate));
+
+class alert_handler_alert_accum_saturation_vseq extends alert_handler_smoke_vseq;
+  `uvm_object_utils(alert_handler_alert_accum_saturation_vseq)
+
+  `uvm_object_new
+
+  parameter uint MAX_ACCUM_CNT = 'hffff;
+  rand int num_alerts_to_saturate;
+  rand bit [1:0] saturated_class; // only 4 classes: a, b, c, d
+
+  `CLASS_CNT_PATH(a, 0)
+  `CLASS_CNT_PATH(b, 1)
+  `CLASS_CNT_PATH(c, 2)
+  `CLASS_CNT_PATH(d, 3)
+
+  constraint num_alerts_to_saturate_c {
+    num_alerts_to_saturate inside {[1 : 10]};
+    $countones(alert_trigger) == 1;
+  }
+
+  function void pre_randomize();
+    this.enable_one_alert_c.constraint_mode(0);
+    this.enable_classa_only_c.constraint_mode(0);
+  endfunction
+
+  virtual task pre_start();
+    // Force accum counts to a large value.
+    `DV_CHECK(uvm_hdl_force(class_a_path_0, (MAX_ACCUM_CNT - num_alerts_to_saturate)));
+    `DV_CHECK(uvm_hdl_force(class_a_path_1, (num_alerts_to_saturate)));
+
+    `DV_CHECK(uvm_hdl_force(class_b_path_0, (MAX_ACCUM_CNT - num_alerts_to_saturate)));
+    `DV_CHECK(uvm_hdl_force(class_b_path_1, (num_alerts_to_saturate)));
+
+    `DV_CHECK(uvm_hdl_force(class_c_path_0, (MAX_ACCUM_CNT - num_alerts_to_saturate)));
+    `DV_CHECK(uvm_hdl_force(class_c_path_1, (num_alerts_to_saturate)));
+
+    `DV_CHECK(uvm_hdl_force(class_d_path_0, (MAX_ACCUM_CNT - num_alerts_to_saturate)));
+    `DV_CHECK(uvm_hdl_force(class_d_path_1, (num_alerts_to_saturate)));
+
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    // Assign all alerts to one class.
+    foreach (alert_class_map[i]) alert_class_map[i] = saturated_class;
+    alert_handler_init(.intr_en('1),
+                       .alert_en('1),
+                       .alert_class(alert_class_map),
+                       .loc_alert_en(0),
+                       .loc_alert_class(0));
+    csr_wr(ral.classa_accum_thresh_shadowed, '1);
+    csr_wr(ral.classb_accum_thresh_shadowed, '1);
+    csr_wr(ral.classc_accum_thresh_shadowed, '1);
+    csr_wr(ral.classd_accum_thresh_shadowed, '1);
+
+    // Enable and lock all alert classes.
+    csr_wr(ral.classa_ctrl_shadowed.en, 1);
+    csr_wr(ral.classb_ctrl_shadowed.en, 1);
+    csr_wr(ral.classc_ctrl_shadowed.en, 1);
+    csr_wr(ral.classd_ctrl_shadowed.en, 1);
+
+    `DV_CHECK(uvm_hdl_release(class_a_path_0));
+    `DV_CHECK(uvm_hdl_release(class_a_path_1));
+    `DV_CHECK(uvm_hdl_release(class_b_path_0));
+    `DV_CHECK(uvm_hdl_release(class_b_path_1));
+    `DV_CHECK(uvm_hdl_release(class_c_path_0));
+    `DV_CHECK(uvm_hdl_release(class_c_path_1));
+    `DV_CHECK(uvm_hdl_release(class_d_path_0));
+    `DV_CHECK(uvm_hdl_release(class_d_path_1));
+
+    `uvm_info(`gfn, $sformatf("Saturate class %0d, alerts to saturate %0d", saturated_class,
+                              num_alerts_to_saturate), UVM_LOW)
+
+    // First round will reach the max count value, afterwards check if the max value saturates and
+    // won't overflow.
+    repeat ($urandom_range(2, 5)) begin
+      repeat (num_alerts_to_saturate) begin
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(alert_trigger)
+        drive_alert(alert_trigger, alert_int_err);
+        csr_rd_check(.ptr(ral.intr_state), .compare_value(1 << saturated_class));
+        csr_wr(.ptr(ral.intr_state), .value(1 << saturated_class));
+      end
+
+      `CHECK_ALERT_ACCUM_CNT(a, 0)
+      `CHECK_ALERT_ACCUM_CNT(b, 1)
+      `CHECK_ALERT_ACCUM_CNT(c, 2)
+      `CHECK_ALERT_ACCUM_CNT(d, 3)
+    end
+ endtask
+
+endclass : alert_handler_alert_accum_saturation_vseq

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -16,8 +16,9 @@
   csr_update(ral.class``i``_phase2_cyc_shadowed);                         \
   csr_update(ral.class``i``_phase3_cyc_shadowed);
 
-`define RAND_WRITE_CLASS_CTRL(i, lock_bit) \
-  `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.class``i``_ctrl_shadowed, lock.value == lock_bit;)  \
+`define RAND_WRITE_CLASS_CTRL(i, en_bit, lock_bit) \
+  `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.class``i``_ctrl_shadowed, \
+                                 en.value == en_bit; lock.value == lock_bit;)  \
   csr_wr(.ptr(ral.class``i``_ctrl_shadowed), .value(ral.class``i``_ctrl_shadowed.get()));
 
 class alert_handler_base_vseq extends cip_base_vseq #(
@@ -67,10 +68,10 @@ class alert_handler_base_vseq extends cip_base_vseq #(
 
   virtual task alert_handler_rand_wr_class_ctrl(bit [NUM_ALERT_CLASSES-1:0] lock_bit,
                                                 bit [NUM_ALERT_CLASSES-1:0] class_en = $urandom());
-    if (class_en[0]) `RAND_WRITE_CLASS_CTRL(a, lock_bit[0])
-    if (class_en[1]) `RAND_WRITE_CLASS_CTRL(b, lock_bit[1])
-    if (class_en[2]) `RAND_WRITE_CLASS_CTRL(c, lock_bit[2])
-    if (class_en[3]) `RAND_WRITE_CLASS_CTRL(d, lock_bit[3])
+    `RAND_WRITE_CLASS_CTRL(a, class_en[0], lock_bit[0])
+    `RAND_WRITE_CLASS_CTRL(b, class_en[1], lock_bit[1])
+    `RAND_WRITE_CLASS_CTRL(c, class_en[2], lock_bit[2])
+    `RAND_WRITE_CLASS_CTRL(d, class_en[3], lock_bit[3])
   endtask
 
   virtual task alert_handler_wr_regwen_regs(bit [NUM_ALERT_CLASSES-1:0] regwen = 0,

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_vseq_list.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_vseq_list.sv
@@ -16,3 +16,4 @@
 `include "alert_handler_lpg_stub_clk_vseq.sv"
 `include "alert_handler_entropy_stress_vseq.sv"
 `include "alert_handler_stress_all_vseq.sv"
+`include "alert_handler_alert_accum_saturation_vseq.sv"


### PR DESCRIPTION
This PR adds a direct sequence test to force the alert accumulation count to a large value that is close to saturate. Then trigger alerts. This sequence check the accum_count will stay at the max value and won't overflow.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>