### PR TITLE
[dv, rv_dm] Enable randomization of JTAG TCK clock

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
@@ -112,6 +112,27 @@ package dv_base_reg_pkg;
     get_field_val = (value >> shift) & mask;
   endfunction : get_field_val
 
+  // Returns a mask value from the provided fields. All fields must belong to the same CSR.
+  function automatic uvm_reg_data_t get_mask_from_fields(uvm_reg_field fields[$]);
+    uvm_reg_data_t mask = '0;
+    uvm_reg csr;
+    if (fields.size() == 0) return '1;
+    foreach (fields[i]) begin
+      uvm_reg_data_t fmask;
+      uint           fshift;
+      if (csr == null) csr = fields[i].get_parent();
+      else if (csr != fields[i].get_parent()) begin
+        `uvm_fatal(msg_id, $sformatf({"The provided fields belong to at least two different CSRs: ",
+                                      "%s, %s. All fields must belong to the same CSR"},
+                                     fields[i-1].`gfn, fields[i].`gfn))
+      end
+      fmask = (1 << fields[i].get_n_bits()) - 1;
+      fshift = fields[i].get_lsb_pos();
+      mask |= fmask << fshift;
+    end
+    return mask;
+  endfunction
+
   `include "csr_excl_item.sv"
   `include "dv_base_lockable_field_cov.sv"
   `include "dv_base_shadowed_field_cov.sv"

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -573,10 +573,14 @@
 `endif // UVM
 
 // Macros for constrain clk with common frequencies
-// constrain clock to run at 24Mhz - 100Mhz and use higher weights on 24, 25, 48, 50, 100
+//
+// Nominal clock frequency range is 24Mhz - 100Mhz and use higher weights on 24, 25, 48, 50, 100,
+// To mimic manufacturing conditions (when clocks are uncalibrated), we need to be able to go as 
+// low as 5MHz.
 `ifndef DV_COMMON_CLK_CONSTRAINT
 `define DV_COMMON_CLK_CONSTRAINT(FREQ_) \
   FREQ_ dist { \
+    [5:23]  :/ 2, \
     [24:25] :/ 2, \
     [26:47] :/ 1, \
     [48:50] :/ 2, \

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -575,7 +575,7 @@
 // Macros for constrain clk with common frequencies
 //
 // Nominal clock frequency range is 24Mhz - 100Mhz and use higher weights on 24, 25, 48, 50, 100,
-// To mimic manufacturing conditions (when clocks are uncalibrated), we need to be able to go as 
+// To mimic manufacturing conditions (when clocks are uncalibrated), we need to be able to go as
 // low as 5MHz.
 `ifndef DV_COMMON_CLK_CONSTRAINT
 `define DV_COMMON_CLK_CONSTRAINT(FREQ_) \

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_frontdoor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_frontdoor.sv
@@ -84,7 +84,7 @@ class jtag_dmi_reg_frontdoor extends uvm_reg_frontdoor;
         fork
           wait(jtag_agent_cfg_h.in_reset);
           // TODO: Make timeout more configurable.
-          `DV_WAIT_TIMEOUT(jtag_agent_cfg_h.vif.tck_period_ns * 10000)
+          `DV_WAIT_TIMEOUT(jtag_agent_cfg_h.vif.tck_period_ps * 10_000_000 /*10 ms*/)
         join_any
       end
     )

--- a/hw/dv/sv/jtag_dmi_agent/jtag_rv_debugger.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_rv_debugger.sv
@@ -1116,7 +1116,7 @@ class jtag_rv_debugger extends uvm_object;
           wait(cfg.in_reset);
           begin
             // TODO: Make this timeout controllable.
-            #(cfg.vif.tck_period_ns * 100000 * 1ns);
+            #(cfg.vif.tck_period_ps * 100000 * 1ps);
             req.timed_out = 1'b1;
             `uvm_info(`gfn, $sformatf("SBA req timed out: %0s",
                                       req.sprint(uvm_default_line_printer)), UVM_LOW)


### PR DESCRIPTION
The first commit adds a util function to dv_base_reg_pkg.

The second comment expands the DV_CLOCK_CONSTRAINT ranges within which the clock frequencies are randomized. This ensures that the clock freqs go as low as 5MHz, which is what it will be during manufacturing. 

The 3rd commit enables the randomization of the TCK clock for the RV_DM testbench. 

The last commit fixes an error in the RV_DM scoreboard introduced by the previous changes. 