### PR TITLE
[coremark] Add missing dif_uart_configure() argument

### DIFF
--- a/third_party/coremark/top_earlgrey/core_portme.c
+++ b/third_party/coremark/top_earlgrey/core_portme.c
@@ -166,7 +166,7 @@ portable_init(core_portable *p, int *argc, char *argv[])
                                             .clk_freq_hz = kClockFreqPeripheralHz,
                                             .parity_enable = kDifToggleDisabled,
                                             .parity = kDifUartParityEven,
-                                            }));
+                                            }, kDifToggleEnabled));
     base_uart_stdout(&uart);
 }
 


### PR DESCRIPTION
This is related to lowRISC/OpenTitan#17030.

It seems we forgot to update this coremark file accordingly. As a result, the Build & test SW CI step is failing at the moment.