### PR TITLE
[fpv/prim_count] Add expected failure hjson

### DIFF
--- a/hw/ip/prim/fpv/prim_count_expected_failure.hjson
+++ b/hw/ip/prim/fpv/prim_count_expected_failure.hjson
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// These two assertions are unreachable in the prim_count environment unless the counters are
+// forced to have different output.
+{
+  unreachable:
+  [
+    prim_count_tb.u_counter.CntErrForward_A:precondition1
+    prim_count_tb.u_counter.CntErrBackward_A:precondition1
+  ]
+}

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
@@ -96,6 +96,7 @@
                build_opts: ["-define ResetValue -1"]
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                cov: true
+               exp_fail_hjson: "{proj_root}/hw/ip/prim/fpv/prim_count_expected_failure.hjson"
              }
              {
                name: prim_count_zero_reset_fpv
@@ -105,6 +106,7 @@
                build_opts: ["-define ResetValue 0"]
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                cov: true
+               exp_fail_hjson: "{proj_root}/hw/ip/prim/fpv/prim_count_expected_failure.hjson"
              }
              {
                name: prim_esc_rxtx_fpv


### PR DESCRIPTION
In normal `prim_count` fpv enviornment, the two error related assertions should be reported as unreacheable. Because excepting forcing the failures, we should not see the two counters mismatch.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>