### PR TITLE
[sram_ctr/dv] Fix stress_test_with_rand_reset timeout

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -192,6 +192,7 @@ endtask
 virtual task run_tl_errors_vseq(int num_times = 1, bit do_wait_clk = 0);
   set_tl_assert_en(.enable(0));
   for (int trans = 1; trans <= num_times; trans++) begin
+    if (cfg.under_reset) return;
     `uvm_info(`gfn, $sformatf("Running run_tl_errors_vseq %0d/%0d", trans, num_times), UVM_LOW)
     `loop_ral_models_to_create_threads(run_tl_errors_vseq_sub(do_wait_clk, ral_name);)
   end

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_common_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_common_vseq.sv
@@ -15,6 +15,16 @@ class sram_ctrl_common_vseq extends sram_ctrl_base_vseq;
   string path_sram_key = {`DUT_HIER_STR, ".key_q"};
   string path_sram_nonce = {`DUT_HIER_STR, ".nonce_q"};
 
+  // adjust delay to issue reset for stress_all_with_rand_reset test,
+  // as sram_ctrl tests usually don't run very long
+  constraint rand_reset_delay_c {
+    rand_reset_delay dist {
+      [1 : 1000]             :/ 1,
+      [1001 : 10_000]        :/ 4,
+      [10_001 : 100_000]     :/ 1
+    };
+  }
+
   virtual task pre_start();
     string common_seq_type;
 


### PR DESCRIPTION
Reduced the delay to issue reset so that it doesn't run 3+ hr
Also, return earlier if reset happens before printing `run_tl_errors_vseq`, which reduces some tedious logs after reset.

Signed-off-by: Weicai Yang <weicai@google.com>