### PR TITLE
[sram_ctrl] Fix RMW corner case when escalating

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -519,6 +519,7 @@ module flash_ctrl
     .tl_d2h_i(prog_tl_d2h),
     .flush_req_i('0),
     .flush_ack_o(),
+    .resp_pending_o(),
     .lc_en_i(lc_ctrl_pkg::mubi4_to_lc_inv(flash_disable[ProgFifoIdx])),
     .err_o(tl_prog_gate_intg_err)
   );
@@ -1308,6 +1309,7 @@ module flash_ctrl
     .tl_d2h_i(gate_tl_d2h),
     .flush_req_i('0),
     .flush_ack_o(),
+    .resp_pending_o(),
     .lc_en_i(host_enable),
     .err_o(tl_gate_intg_err)
   );

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -520,6 +520,7 @@ module flash_ctrl
     .tl_d2h_i(prog_tl_d2h),
     .flush_req_i('0),
     .flush_ack_o(),
+    .resp_pending_o(),
     .lc_en_i(lc_ctrl_pkg::mubi4_to_lc_inv(flash_disable[ProgFifoIdx])),
     .err_o(tl_prog_gate_intg_err)
   );
@@ -1309,6 +1310,7 @@ module flash_ctrl
     .tl_d2h_i(gate_tl_d2h),
     .flush_req_i('0),
     .flush_ack_o(),
+    .resp_pending_o(),
     .lc_en_i(host_enable),
     .err_o(tl_gate_intg_err)
   );

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -752,6 +752,7 @@ module otp_ctrl
     .lc_en_i (lc_dft_en[0]),
     .flush_req_i('0),
     .flush_ack_o(),
+    .resp_pending_o(),
     .err_o   (intg_error[2])
   );
 

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -242,7 +242,8 @@ module rv_dm
     .lc_en_i (lc_hw_debug_en[LcEnSba]),
     .err_o   (sba_gate_intg_error),
     .flush_req_i('0),
-    .flush_ack_o()
+    .flush_ack_o(),
+    .resp_pending_o()
   );
 
   tlul_adapter_host #(
@@ -374,6 +375,7 @@ module rv_dm
     .tl_d2h_i(mem_tl_win_d2h_gated),
     .flush_req_i(ndmreset_req),
     .flush_ack_o(ndmreset_req_qual),
+    .resp_pending_o(),
     .lc_en_i (lc_hw_debug_en[LcEnRom]),
     .err_o   (rom_gate_intg_error)
   );

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -526,6 +526,7 @@ module flash_ctrl
     .tl_d2h_i(prog_tl_d2h),
     .flush_req_i('0),
     .flush_ack_o(),
+    .resp_pending_o(),
     .lc_en_i(lc_ctrl_pkg::mubi4_to_lc_inv(flash_disable[ProgFifoIdx])),
     .err_o(tl_prog_gate_intg_err)
   );
@@ -1315,6 +1316,7 @@ module flash_ctrl
     .tl_d2h_i(gate_tl_d2h),
     .flush_req_i('0),
     .flush_ack_o(),
+    .resp_pending_o(),
     .lc_en_i(host_enable),
     .err_o(tl_gate_intg_err)
   );


### PR DESCRIPTION
If a global escalation request and a RMW transaction come in at the same time, the RMW transaction will not be able to complete even though the TL gate allows for transactions that are already pending inside the device to respond back (to make the bus behavior less erratic for a better SW debug experience).

The reason for this is the write part of the RMW transaction, since the scrambling device blocks any transaction in case the keys have been invalidated due to escalation.

This patch fixes this corner case by specifically allowing pending writes to complete upon escalation.

The rationale is that a write won't give an attacker any advantage, especially since the scrambling keys are already clobbered at that point, and the TL gate is not accepting any additional transactions from the bus.

Fixes #17064.

Signed-off-by: Michael Schaffner <msf@google.com>