### PR TITLE
[secded/fpv] Remove data input constraint

### DIFF
--- a/hw/ip/prim/fpv/vip/prim_secded_22_16_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_22_16_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_22_16_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_28_22_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_28_22_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_28_22_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_39_32_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_39_32_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_39_32_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_64_57_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_64_57_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_64_57_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_72_64_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_72_64_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_72_64_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_hamming_22_16_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_hamming_22_16_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_hamming_22_16_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_hamming_39_32_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_hamming_39_32_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_hamming_39_32_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_hamming_72_64_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_hamming_72_64_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_hamming_72_64_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_hamming_76_68_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_hamming_76_68_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_hamming_76_68_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_inv_22_16_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_inv_22_16_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_inv_22_16_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_inv_28_22_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_inv_28_22_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_inv_28_22_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_inv_39_32_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_inv_39_32_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_inv_39_32_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_inv_64_57_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_inv_64_57_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_inv_64_57_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_inv_72_64_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_inv_72_64_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_inv_72_64_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_inv_hamming_22_16_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_inv_hamming_22_16_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_inv_hamming_22_16_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_inv_hamming_39_32_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_inv_hamming_39_32_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_inv_hamming_39_32_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_inv_hamming_72_64_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_inv_hamming_72_64_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_inv_hamming_72_64_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/hw/ip/prim/fpv/vip/prim_secded_inv_hamming_76_68_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_secded_inv_hamming_76_68_assert_fpv.sv
@@ -17,8 +17,6 @@ module prim_secded_inv_hamming_76_68_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)

--- a/util/design/secded_gen.py
+++ b/util/design/secded_gen.py
@@ -796,8 +796,6 @@ module {}_assert_fpv (
 
   // Inject a maximum of two errors simultaneously.
   `ASSUME_FPV(MaxTwoErrors_M, $countones(error_inject_i) <= 2)
-  // This bounds the input data state space to make sure the solver converges.
-  `ASSUME_FPV(DataLimit_M, $onehot0(data_i) || $onehot0(~data_i))
   // Single bit error detection
   `ASSERT(SingleErrorDetect_A, $countones(error_inject_i) == 1 |-> err_o[0])
   `ASSERT(SingleErrorDetectReverse_A, err_o[0] |-> $countones(error_inject_i) == 1)


### PR DESCRIPTION
With the newest jaspergold version, the `DataLimit_M` assumption does not seem to be needed anymore - all FPV tests converge in about 3 minutes:

```
|               name                |  pass_rate  |  stimuli_cov  |  coi_cov  |  prove_cov  |
|:---------------------------------:|:-----------:|:-------------:|:---------:|:-----------:|
|       prim_secded_22_16_fpv       |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|       prim_secded_28_22_fpv       |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|       prim_secded_39_32_fpv       |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|       prim_secded_64_57_fpv       |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|       prim_secded_72_64_fpv       |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|   prim_secded_hamming_22_16_fpv   |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|   prim_secded_hamming_39_32_fpv   |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|   prim_secded_hamming_72_64_fpv   |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|     prim_secded_inv_22_16_fpv     |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|     prim_secded_inv_28_22_fpv     |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|     prim_secded_inv_39_32_fpv     |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|     prim_secded_inv_64_57_fpv     |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
|     prim_secded_inv_72_64_fpv     |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
| prim_secded_inv_hamming_22_16_fpv |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
| prim_secded_inv_hamming_39_32_fpv |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |
| prim_secded_inv_hamming_72_64_fpv |  100.00 %   |   100.00 %    | 100.00 %  |  100.00 %   |

```



Signed-off-by: Michael Schaffner <msf@google.com>