### PR TITLE
[flash_ctrl,dv] info_part_access test update

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -207,6 +207,10 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   bit                  wr_rnd_data = 1;
   int                  wait_rd_buf_en_timeout_ns = 100_000; // 100 us
 
+  // hw info cfg override
+  mubi4_t ovrd_scr_dis = MuBi4False;
+  mubi4_t ovrd_ecc_dis = MuBi4False;
+
   `uvm_object_utils(flash_ctrl_env_cfg)
   `uvm_object_new
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -113,6 +113,9 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     end
   endtask : pre_start
 
+  virtual task hw_info_cfg_update();
+  endtask
+
   virtual task dut_shutdown();
     // check for pending flash_ctrl operations and wait for them to complete
     // TODO
@@ -150,6 +153,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     end
 
     if (cfg.seq_cfg.en_init_keys_seeds == 1) begin
+      // Update hw_info_cfg if necessary
+      hw_info_cfg_update();
       csr_wr(.ptr(ral.init), .value(1));  // Enable Secret Seed Output during INIT
     end
 
@@ -668,7 +673,6 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     // Note 'some values' appear in both branches of this fork, this is OK because the
     // branches never run together by design.
     // The order is always 'addr' followed by 'data'.
-
     fork
       forever begin  // addr
         @(posedge cfg.clk_rst_vif.rst_n);
@@ -1420,8 +1424,17 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
         item.dq.push_back(data[31:0]);
         item.dq.push_back(data[63:32]);
         // only scr/ecc enable counts.
-        item.region.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
-        item.region.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
+        if (page != 3) begin
+          item.region.scramble_en = prim_mubi_pkg::mubi4_and_hi(
+                                    flash_ctrl_pkg::CfgAllowRead.scramble_en,
+                                    mubi4_t'(~cfg.ovrd_scr_dis));
+          item.region.ecc_en = prim_mubi_pkg::mubi4_and_hi(
+                               flash_ctrl_pkg::CfgAllowRead.ecc_en,
+                               mubi4_t'(~cfg.ovrd_ecc_dis));
+        end else begin
+          item.region.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
+          item.region.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
+        end
         item.scramble(otp_addr_key, otp_data_key, addr, dis);
         cfg.mem_bkdr_util_h[FlashPartInfo][0].write(addr, item.fq[0]);
         mem_addr = addr >> 3;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
@@ -19,6 +19,15 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
   } test_type_e;
   int          round = 0;
 
+  task hw_info_cfg_update();
+    // Randomize hw_info_cfg_override
+    cfg.ovrd_scr_dis = get_rand_mubi4_val(.t_weight(2), .f_weight(1), .other_weight(1));
+    cfg.ovrd_ecc_dis = get_rand_mubi4_val(.t_weight(2), .f_weight(1), .other_weight(1));
+    ral.hw_info_cfg_override.scramble_dis.set(cfg.ovrd_scr_dis);
+    ral.hw_info_cfg_override.ecc_dis.set(cfg.ovrd_ecc_dis);
+    csr_update(ral.hw_info_cfg_override);
+  endtask // hw_info_cfg_update
+
   virtual task body();
     // INITIALIZE FLASH REGIONS
     // All on to configure secret info_page_cfg
@@ -101,11 +110,12 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
 
     flash_op_data = '{};
     `uvm_info(`gfn, $sformatf("iter%0d:info:%s is_valid:%0b op:%p",
-                              round, part.name, is_valid, flash_op), UVM_HIGH)
+                              round, part.name, is_valid, flash_op), UVM_MEDIUM)
     if (part == FlashIsolPart) begin
       scr_en = 1;
     end else begin
-      scr_en = (flash_ctrl_pkg::CfgAllowRead.scramble_en == MuBi4True);
+      scr_en = ((flash_ctrl_pkg::CfgAllowRead.scramble_en == MuBi4True) &&
+                (mubi4_t'(~cfg.ovrd_scr_dis) == MuBi4True));
     end
     case (op)
       FlashOpErase: begin
@@ -149,8 +159,15 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
     flash_bank_mp_info_page_cfg_t info_regions = '{default: MuBi4True};
     for (int i = 1; i < 4; i++) begin
       if (i < 3) begin
-         info_regions.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
-         info_regions.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
+         info_regions.scramble_en = prim_mubi_pkg::mubi4_and_hi(
+                                    flash_ctrl_pkg::CfgAllowRead.scramble_en,
+                                    mubi4_t'(~cfg.ovrd_scr_dis));
+         info_regions.ecc_en = prim_mubi_pkg::mubi4_and_hi(
+                               flash_ctrl_pkg::CfgAllowRead.ecc_en,
+                               mubi4_t'(~cfg.ovrd_ecc_dis));
+      end else begin
+        info_regions.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
+        info_regions.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
       end
       flash_ctrl_mp_info_page_cfg(0, 0, i, info_regions);
     end


### PR DESCRIPTION
Address issue #16812 by updating info_part_access test as follows:
Before key init, update flash_ctrl.hw_info_cfg_override with random value.
While key init, key value can be either scramble enabled or disabled.
Program sw config same as hw config.
Read back info partition and check expected data.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>