### PR TITLE
[crypto] Port HMAC driver to new cryptolib status codes.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -140,6 +140,7 @@ cc_library(
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
+        "//sw/device/lib/crypto/impl:status",
     ],
 )
 

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/impl/status.h"
 
 #include "hmac_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -35,9 +36,9 @@ void hmac_sha256_init(void) {
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
 }
 
-hmac_error_t hmac_sha256_update(const void *data, size_t len) {
+status_t hmac_sha256_update(const void *data, size_t len) {
   if (data == NULL) {
-    return kHmacErrorBadArg;
+    return OTCRYPTO_BAD_ARGS;
   }
   const uint8_t *data_sent = (const uint8_t *)data;
 
@@ -59,12 +60,12 @@ hmac_error_t hmac_sha256_update(const void *data, size_t len) {
     abs_mmio_write8(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
                     *data_sent++);
   }
-  return kHmacOk;
+  return OTCRYPTO_OK;
 }
 
-hmac_error_t hmac_sha256_final(hmac_digest_t *digest) {
+status_t hmac_sha256_final(hmac_digest_t *digest) {
   if (digest == NULL) {
-    return kHmacErrorBadArg;
+    return OTCRYPTO_BAD_ARGS;
   }
 
   uint32_t reg = 0;
@@ -85,5 +86,5 @@ hmac_error_t hmac_sha256_final(hmac_digest_t *digest) {
         abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_DIGEST_7_REG_OFFSET -
                         (i * sizeof(uint32_t)));
   }
-  return kHmacOk;
+  return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/drivers/hmac.h
+++ b/sw/device/lib/crypto/drivers/hmac.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/status.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,19 +22,6 @@ enum {
   /* Number of words in an HMAC or SHA-256 digest. */
   kHmacDigestNumWords = kHmacDigestNumBytes / sizeof(uint32_t),
 };
-
-/**
- * Error types for the HMAC driver.
- */
-typedef enum hmac_error {
-  kHmacOk = 0,
-  /* Invalid argument.*/
-  kHmacErrorBadArg = 1,
-  /* HMAC device is still processing. */
-  kHmacErrorBusy = 2,
-  /* Attempt to push when FIFO is full. */
-  kHmacErrorFifoFull = 3,
-} hmac_error_t;
 
 /**
  * A typed representation of the HMAC digest.
@@ -63,7 +51,7 @@ void hmac_sha256_init(void);
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-hmac_error_t hmac_sha256_update(const void *data, size_t len);
+status_t hmac_sha256_update(const void *data, size_t len);
 
 /**
  * Finalizes SHA256 operation and writes `digest` buffer.
@@ -74,7 +62,7 @@ hmac_error_t hmac_sha256_update(const void *data, size_t len);
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-hmac_error_t hmac_sha256_final(hmac_digest_t *digest);
+status_t hmac_sha256_final(hmac_digest_t *digest);
 
 #ifdef __cplusplus
 }

--- a/sw/device/lib/crypto/impl/rsa_3072/rsa_3072_verify.h
+++ b/sw/device/lib/crypto/impl/rsa_3072/rsa_3072_verify.h
@@ -105,8 +105,8 @@ otbn_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
  * @param result Resulting 3072-bit message representative
  * @return Result of the operation (OK or error).
  */
-hmac_error_t rsa_3072_encode_sha256(const uint8_t *msg, size_t msgLen,
-                                    rsa_3072_int_t *result);
+status_t rsa_3072_encode_sha256(const uint8_t *msg, size_t msgLen,
+                                rsa_3072_int_t *result);
 
 /**
  * Verifies an RSA-3072 signature.

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -34,23 +34,15 @@ static const ecdsa_p256_private_key_t kPrivateKey = {
     .d1 = {0},
 };
 
-hmac_error_t compute_digest(void) {
+static void compute_digest(void) {
   // Compute the SHA-256 digest using the HMAC device.
   hmac_sha256_init();
-  hmac_error_t err = hmac_sha256_update(&kMessage, sizeof(kMessage) - 1);
-  if (err != kHmacOk) {
-    return err;
-  }
+  CHECK_STATUS_OK(hmac_sha256_update(&kMessage, sizeof(kMessage) - 1));
   hmac_digest_t hmac_digest;
-  err = hmac_sha256_final(&hmac_digest);
-  if (err != kHmacOk) {
-    return err;
-  }
+  CHECK_STATUS_OK(hmac_sha256_final(&hmac_digest));
 
   // Copy digest into the destination array.
   memcpy(digest.h, hmac_digest.digest, sizeof(hmac_digest.digest));
-
-  return kHmacOk;
 }
 
 bool sign_then_verify_test(void) {
@@ -96,7 +88,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   entropy_testutils_auto_mode_init();
 
-  CHECK(compute_digest() == kHmacOk);
+  compute_digest();
 
   return sign_then_verify_test();
 }

--- a/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
@@ -15,33 +15,22 @@
 // the version of this file matching the Bazel rule under test.
 #include "ecdsa_p256_verify_testvectors.h"
 
-hmac_error_t compute_digest(size_t msg_len, const uint8_t *msg,
-                            ecdsa_p256_message_digest_t *digest) {
+static void compute_digest(size_t msg_len, const uint8_t *msg,
+                           ecdsa_p256_message_digest_t *digest) {
   // Compute the SHA-256 digest using the HMAC device.
   hmac_sha256_init();
-  hmac_error_t err = hmac_sha256_update(msg, msg_len);
-  if (err != kHmacOk) {
-    return err;
-  }
+  CHECK_STATUS_OK(hmac_sha256_update(msg, msg_len));
   hmac_digest_t hmac_digest;
-  err = hmac_sha256_final(&hmac_digest);
-  if (err != kHmacOk) {
-    return err;
-  }
+  CHECK_STATUS_OK(hmac_sha256_final(&hmac_digest));
 
   // Copy digest into the destination array.
   memcpy(digest->h, hmac_digest.digest, sizeof(hmac_digest.digest));
-
-  return kHmacOk;
 }
 
 bool ecdsa_p256_verify_test(const ecdsa_p256_verify_test_vector_t *testvec) {
   // Hash message.
   ecdsa_p256_message_digest_t digest;
-  hmac_error_t hash_err =
-      compute_digest(testvec->msg_len, testvec->msg, &digest);
-  CHECK(hash_err == kHmacOk, "Error from HMAC during hashing: 0x%08x.",
-        hash_err);
+  compute_digest(testvec->msg_len, testvec->msg, &digest);
 
   // Attempt to verify signature.
   hardened_bool_t result;

--- a/sw/device/tests/crypto/rsa_3072_verify_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_verify_functest.c
@@ -18,12 +18,8 @@
 bool rsa_3072_verify_test(const rsa_3072_verify_test_vector_t *testvec) {
   // Encode message
   rsa_3072_int_t encodedMessage;
-  hmac_error_t encode_err =
-      rsa_3072_encode_sha256(testvec->msg, testvec->msgLen, &encodedMessage);
-  if (encode_err != kHmacOk) {
-    LOG_ERROR("Error from HMAC during message encoding: 0x%08x.", encode_err);
-    return false;
-  }
+  CHECK_STATUS_OK(
+      rsa_3072_encode_sha256(testvec->msg, testvec->msgLen, &encodedMessage));
 
   // Precompute Montgomery constants
   rsa_3072_constants_t constants;


### PR DESCRIPTION
PR #16930 introduced status_t based error codes for the cryptolib. This change ports the HMAC driver and the tests that depend on it to use those error codes instead of a custom error enum.

Related: https://github.com/lowRISC/opentitan/issues/14549