### PR TITLE
[crypto] Port the OTBN driver to use status_t.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -132,5 +132,6 @@ cc_library(
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/crypto/impl:status",
     ],
 )

--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -7,33 +7,11 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/status.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otbn_regs.h"  // Generated.
-
-#define ASSERT_ERR_BIT_MATCH(enum_val, autogen_val) \
-  static_assert(enum_val == 1 << (autogen_val),     \
-                "OTBN register bit doesn't match autogen value.");
-
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsBadDataAddr, OTBN_ERR_BITS_BAD_DATA_ADDR_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsBadInsnAddr, OTBN_ERR_BITS_BAD_INSN_ADDR_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsCallStack, OTBN_ERR_BITS_CALL_STACK_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsIllegalInsn, OTBN_ERR_BITS_ILLEGAL_INSN_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsLoop, OTBN_ERR_BITS_LOOP_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsImemIntgViolation,
-                     OTBN_ERR_BITS_IMEM_INTG_VIOLATION_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsDmemIntgViolation,
-                     OTBN_ERR_BITS_DMEM_INTG_VIOLATION_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsRegIntgViolation,
-                     OTBN_ERR_BITS_REG_INTG_VIOLATION_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsBusIntgViolation,
-                     OTBN_ERR_BITS_BUS_INTG_VIOLATION_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsIllegalBusAccess,
-                     OTBN_ERR_BITS_ILLEGAL_BUS_ACCESS_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsLifecycleEscalation,
-                     OTBN_ERR_BITS_LIFECYCLE_ESCALATION_BIT);
-ASSERT_ERR_BIT_MATCH(kOtbnErrBitsFatalSoftware,
-                     OTBN_ERR_BITS_FATAL_SOFTWARE_BIT);
 
 enum {
   /**
@@ -48,6 +26,15 @@ enum {
    * IMEM size in bytes.
    */
   kOtbnIMemSizeBytes = OTBN_IMEM_SIZE_BYTES,
+  /**
+   * ERR_BITS register value in the case of no errors.
+   *
+   * Although some parts of the ERR_BITS register are marked reserved, the OTBN
+   * documentation explicitly guarantees that ERR_BITS is zero for a successful
+   * execution:
+   *   https://docs.opentitan.org/hw/ip/otbn/doc/#design-details-software-execution
+   */
+  kOtbnErrBitsNoError = 0,
 };
 
 /**
@@ -72,38 +59,43 @@ typedef enum otbn_status {
 } otbn_status_t;
 
 /**
- * Ensures that `offset_bytes` and `len` are valid for a given `mem_size`.
+ * Ensures that a memory access fits within the given memory size.
+ *
+ * @param offset_bytes Memory offset at which to start.
+ * @param num_words Number of 32b words to access.
+ * @param mem_size Size of memory.
+ * @return Result of the operation.
  */
-static otbn_error_t check_offset_len(uint32_t offset_bytes, size_t num_words,
-                                     size_t mem_size) {
+static status_t check_offset_len(uint32_t offset_bytes, size_t num_words,
+                                 size_t mem_size) {
   if (offset_bytes + num_words * sizeof(uint32_t) <
           num_words * sizeof(uint32_t) ||
       offset_bytes + num_words * sizeof(uint32_t) > mem_size) {
-    return kOtbnErrorBadOffsetLen;
+    return OTCRYPTO_BAD_ARGS;
   }
-  return kOtbnErrorOk;
+  return OTCRYPTO_OK;
 }
 
 /**
  * Ensures OTBN is idle.
  *
  * If OTBN is busy or locked, this function will return
- * `kOtbnErrorUnavailable`; otherwise it will return `kOtbnErrorOk`.
+ * `OTCRYPTO_ASYNC_INCOMPLETE`; otherwise it will return `OTCRYPTO_OK`.
  *
  * @return Result of the operation.
  */
-static otbn_error_t otbn_assert_idle(void) {
+static status_t otbn_assert_idle(void) {
   uint32_t status = launder32(~kOtbnStatusIdle);
-  otbn_error_t res = launder32(kOtbnErrorOk ^ status);
+  status_t res = (status_t){.value = launder32(OTCRYPTO_OK.value ^ status)};
   status = abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET);
-  res ^= ~status;
-  if (launder32(res) == kOtbnErrorOk) {
-    HARDENED_CHECK_EQ(res, kOtbnErrorOk);
+  res.value ^= ~status;
+  if (launder32(hardened_status_ok(res)) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(hardened_status_ok(res), kHardenedBoolTrue);
     HARDENED_CHECK_EQ(abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET),
                       kOtbnStatusIdle);
     return res;
   }
-  return kOtbnErrorUnavailable;
+  return OTCRYPTO_ASYNC_INCOMPLETE;
 }
 
 /**
@@ -131,23 +123,22 @@ static void otbn_write(uint32_t dest_addr, const uint32_t *src,
   HARDENED_CHECK_EQ(iter_cnt, num_words);
 }
 
-static otbn_error_t otbn_imem_write(size_t num_words, const uint32_t *src,
-                                    otbn_addr_t dest) {
-  OTBN_RETURN_IF_ERROR(check_offset_len(dest, num_words, kOtbnIMemSizeBytes));
+static status_t otbn_imem_write(size_t num_words, const uint32_t *src,
+                                otbn_addr_t dest) {
+  HARDENED_TRY(check_offset_len(dest, num_words, kOtbnIMemSizeBytes));
   otbn_write(kBase + OTBN_IMEM_REG_OFFSET + dest, src, num_words);
-  return kOtbnErrorOk;
+  return OTCRYPTO_OK;
 }
 
-otbn_error_t otbn_dmem_write(size_t num_words, const uint32_t *src,
-                             otbn_addr_t dest) {
-  OTBN_RETURN_IF_ERROR(check_offset_len(dest, num_words, kOtbnDMemSizeBytes));
+status_t otbn_dmem_write(size_t num_words, const uint32_t *src,
+                         otbn_addr_t dest) {
+  HARDENED_TRY(check_offset_len(dest, num_words, kOtbnDMemSizeBytes));
   otbn_write(kBase + OTBN_DMEM_REG_OFFSET + dest, src, num_words);
-  return kOtbnErrorOk;
+  return OTCRYPTO_OK;
 }
 
-otbn_error_t otbn_dmem_set(size_t num_words, const uint32_t src,
-                           otbn_addr_t dest) {
-  OTBN_RETURN_IF_ERROR(check_offset_len(dest, num_words, kOtbnDMemSizeBytes));
+status_t otbn_dmem_set(size_t num_words, const uint32_t src, otbn_addr_t dest) {
+  HARDENED_TRY(check_offset_len(dest, num_words, kOtbnDMemSizeBytes));
 
   // No need to randomize here, since all the values are the same.
   size_t i = 0;
@@ -157,11 +148,11 @@ otbn_error_t otbn_dmem_set(size_t num_words, const uint32_t src,
     HARDENED_CHECK_LT(i, num_words);
   }
   HARDENED_CHECK_EQ(i, num_words);
-  return kOtbnErrorOk;
+  return OTCRYPTO_OK;
 }
 
-otbn_error_t otbn_dmem_read(size_t num_words, otbn_addr_t src, uint32_t *dest) {
-  OTBN_RETURN_IF_ERROR(check_offset_len(src, num_words, kOtbnDMemSizeBytes));
+status_t otbn_dmem_read(size_t num_words, otbn_addr_t src, uint32_t *dest) {
+  HARDENED_TRY(check_offset_len(src, num_words, kOtbnDMemSizeBytes));
 
   size_t i = 0;
   for (; launder32(i) < num_words; ++i) {
@@ -170,66 +161,74 @@ otbn_error_t otbn_dmem_read(size_t num_words, otbn_addr_t src, uint32_t *dest) {
   }
   HARDENED_CHECK_EQ(i, num_words);
 
-  return kOtbnErrorOk;
+  return OTCRYPTO_OK;
 }
 
-otbn_error_t otbn_execute(void) {
+status_t otbn_execute(void) {
   // Ensure OTBN is idle before attempting to run a command.
-  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+  HARDENED_TRY(otbn_assert_idle());
 
   abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdExecute);
-  return kOtbnErrorOk;
+  return OTCRYPTO_OK;
 }
 
-otbn_error_t otbn_busy_wait_for_done(void) {
+status_t otbn_busy_wait_for_done(void) {
   uint32_t status = launder32(UINT32_MAX);
-  otbn_error_t res = launder32(kOtbnErrorOk ^ status);
+  status_t res = (status_t){.value = launder32(OTCRYPTO_OK.value ^ status)};
   do {
     status = abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET);
   } while (launder32(status) != kOtbnStatusIdle &&
            launder32(status) != kOtbnStatusLocked);
-  res ^= ~status;
+  res.value ^= ~status;
 
-  otbn_err_bits_t err_bits;
-  otbn_err_bits_get(&err_bits);
+  uint32_t err_bits = otbn_err_bits_get();
 
-  if (launder32(res) == kOtbnErrorOk &&
+  if (launder32(hardened_status_ok(res)) == kHardenedBoolTrue &&
       launder32(err_bits) == kOtbnErrBitsNoError) {
-    HARDENED_CHECK_EQ(res, kOtbnErrorOk);
-    otbn_err_bits_get(&err_bits);
+    HARDENED_CHECK_EQ(hardened_status_ok(res), kHardenedBoolTrue);
+    err_bits = otbn_err_bits_get();
     HARDENED_CHECK_EQ(err_bits, kOtbnErrBitsNoError);
     HARDENED_CHECK_EQ(abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET),
                       kOtbnStatusIdle);
     return res;
   }
-  return kOtbnErrorExecutionFailed;
+
+  // If OTBN is idle (not locked), then return a recoverable error.
+  if (launder32(status) == kOtbnStatusIdle) {
+    HARDENED_CHECK_EQ(status, kOtbnStatusIdle);
+    return OTCRYPTO_RECOV_ERR;
+  }
+
+  // OTBN is locked; return a fatal error.
+  HARDENED_CHECK_EQ(status, kOtbnStatusLocked);
+  return OTCRYPTO_FATAL_ERR;
 }
 
-void otbn_err_bits_get(otbn_err_bits_t *err_bits) {
-  *err_bits = abs_mmio_read32(kBase + OTBN_ERR_BITS_REG_OFFSET);
+uint32_t otbn_err_bits_get(void) {
+  return abs_mmio_read32(kBase + OTBN_ERR_BITS_REG_OFFSET);
 }
 
 uint32_t otbn_instruction_count_get(void) {
   return abs_mmio_read32(kBase + OTBN_INSN_CNT_REG_OFFSET);
 }
 
-otbn_error_t otbn_imem_sec_wipe(void) {
-  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+status_t otbn_imem_sec_wipe(void) {
+  HARDENED_TRY(otbn_assert_idle());
   abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdSecWipeImem);
-  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done());
-  return kOtbnErrorOk;
+  HARDENED_TRY(otbn_busy_wait_for_done());
+  return OTCRYPTO_OK;
 }
 
-otbn_error_t otbn_dmem_sec_wipe(void) {
-  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+status_t otbn_dmem_sec_wipe(void) {
+  HARDENED_TRY(otbn_assert_idle());
   abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdSecWipeDmem);
-  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done());
-  return kOtbnErrorOk;
+  HARDENED_TRY(otbn_busy_wait_for_done());
+  return OTCRYPTO_OK;
 }
 
-otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
+status_t otbn_set_ctrl_software_errs_fatal(bool enable) {
   // Ensure OTBN is idle (otherwise CTRL writes will be ignored).
-  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+  HARDENED_TRY(otbn_assert_idle());
 
   // Only one bit in the CTRL register so no need to read current value.
   uint32_t new_ctrl;
@@ -242,7 +241,7 @@ otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
 
   abs_mmio_write32(kBase + OTBN_CTRL_REG_OFFSET, new_ctrl);
 
-  return kOtbnErrorOk;
+  return OTCRYPTO_OK;
 }
 
 /**
@@ -254,47 +253,45 @@ otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
  * - The IMEM range must be non-empty.
  *
  * @param app the OTBN application to check
- * @return `kHardenedBoolTrue` if checks pass, otherwise `kHardenedBoolFalse`.
+ * @return `OTCRYPTO_OK` if checks pass, otherwise `OTCRYPTO_BAD_ARGS`.
  */
-static hardened_bool_t check_app_address_ranges(const otbn_app_t *app) {
+static status_t check_app_address_ranges(const otbn_app_t *app) {
   // IMEM must not be backwards or empty.
   if (app->imem_end <= app->imem_start) {
-    return kHardenedBoolFalse;
+    return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_LT(app->imem_start, app->imem_end);
 
   // DMEM data section must not be backwards.
   if (app->dmem_data_end < app->dmem_data_start) {
-    return kHardenedBoolFalse;
+    return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_LE(app->dmem_data_start, app->dmem_data_end);
 
-  return kHardenedBoolTrue;
+  return OTCRYPTO_OK;
 }
 
-otbn_error_t otbn_load_app(const otbn_app_t app) {
-  if (!check_app_address_ranges(&app)) {
-    return kOtbnErrorInvalidArgument;
-  }
+status_t otbn_load_app(const otbn_app_t app) {
+  HARDENED_TRY(check_app_address_ranges(&app));
 
   // Ensure OTBN is idle.
-  OTBN_RETURN_IF_ERROR(otbn_assert_idle());
+  HARDENED_TRY(otbn_assert_idle());
 
   const size_t imem_num_words = app.imem_end - app.imem_start;
   const size_t data_num_words = app.dmem_data_end - app.dmem_data_start;
 
-  OTBN_RETURN_IF_ERROR(otbn_imem_sec_wipe());
-  OTBN_RETURN_IF_ERROR(otbn_dmem_sec_wipe());
+  HARDENED_TRY(otbn_imem_sec_wipe());
+  HARDENED_TRY(otbn_dmem_sec_wipe());
 
   // IMEM always starts at zero.
   otbn_addr_t imem_start_addr = 0;
-  OTBN_RETURN_IF_ERROR(
+  HARDENED_TRY(
       otbn_imem_write(imem_num_words, app.imem_start, imem_start_addr));
 
   if (data_num_words > 0) {
-    OTBN_RETURN_IF_ERROR(otbn_dmem_write(data_num_words, app.dmem_data_start,
-                                         app.dmem_data_start_addr));
+    HARDENED_TRY(otbn_dmem_write(data_num_words, app.dmem_data_start,
+                                 app.dmem_data_start_addr));
   }
 
-  return kOtbnErrorOk;
+  return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.h
+++ b/sw/device/lib/crypto/impl/ecdsa_p256/ecdsa_p256.h
@@ -91,23 +91,31 @@ typedef struct ecdsa_p256_message_digest_t {
  * @param result Buffer in which to store the generated signature.
  * @return Result of the operation (OK or error).
  */
-otbn_error_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
-                             const ecdsa_p256_private_key_t *private_key,
-                             ecdsa_p256_signature_t *result);
+status_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
+                         const ecdsa_p256_private_key_t *private_key,
+                         ecdsa_p256_signature_t *result);
 
 /**
  * Verifies an ECDSA/P-256 signature.
  *
+ * If the signature is valid, writes `kHardenedBoolTrue` to `result`;
+ * otherwise, writes `kHardenedBoolFalse`.
+ *
+ * Note: the caller must check the `result` buffer in order to determine if a
+ * signature passed verification. If a signature is invalid, but nothing goes
+ * wrong during computation (e.g. hardware errors, failed preconditions), the
+ * status will be OK but `result` will be `kHardenedBoolFalse`.
+ *
  * @param signature Signature to be verified.
  * @param message_digest Digest of the message to check the signature against.
  * @param public_key Key to check the signature against.
- * @param result Buffer in which to store output (true iff signature is valid)
+ * @param result Output buffer (true if signature is valid, false otherwise)
  * @return Result of the operation (OK or error).
  */
-otbn_error_t ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
-                               const ecdsa_p256_message_digest_t *digest,
-                               const ecdsa_p256_public_key_t *public_key,
-                               hardened_bool_t *result);
+status_t ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
+                           const ecdsa_p256_message_digest_t *digest,
+                           const ecdsa_p256_public_key_t *public_key,
+                           hardened_bool_t *result);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/impl/rsa_3072/rsa_3072_verify.h
+++ b/sw/device/lib/crypto/impl/rsa_3072/rsa_3072_verify.h
@@ -11,6 +11,7 @@
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/status.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,8 +67,8 @@ typedef struct rsa_3072_constants_t {
  * @param result Buffer in which to store output
  * @return Result of the operation (OK or error).
  */
-otbn_error_t rsa_3072_compute_rr(const rsa_3072_public_key_t *public_key,
-                                 rsa_3072_int_t *result);
+status_t rsa_3072_compute_rr(const rsa_3072_public_key_t *public_key,
+                             rsa_3072_int_t *result);
 
 /**
  * Computes Montgomery constant m0_inv for an RSA-3072 public key.
@@ -76,8 +77,8 @@ otbn_error_t rsa_3072_compute_rr(const rsa_3072_public_key_t *public_key,
  * @param result Buffer in which to store output
  * @return Result of the operation (OK or error).
  */
-otbn_error_t rsa_3072_compute_m0_inv(const rsa_3072_public_key_t *public_key,
-                                     uint32_t result[kOtbnWideWordNumWords]);
+status_t rsa_3072_compute_m0_inv(const rsa_3072_public_key_t *public_key,
+                                 uint32_t result[kOtbnWideWordNumWords]);
 
 /**
  * Computes Montgomery constants for an RSA-3072 public key.
@@ -86,8 +87,8 @@ otbn_error_t rsa_3072_compute_m0_inv(const rsa_3072_public_key_t *public_key,
  * @param result Buffer in which to store output
  * @return Result of the operation (OK or error).
  */
-otbn_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
-                                        rsa_3072_constants_t *result);
+status_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
+                                    rsa_3072_constants_t *result);
 
 /**
  * Encode the message according to RFC 8017, section 9.2, with a SHA2-256 hash
@@ -118,9 +119,9 @@ status_t rsa_3072_encode_sha256(const uint8_t *msg, size_t msgLen,
  * @param constants Precomputed Montgomery constants for the public_key.
  * @return Result of the operation (OK or error).
  */
-otbn_error_t rsa_3072_verify_start(const rsa_3072_int_t *signature,
-                                   const rsa_3072_public_key_t *public_key,
-                                   const rsa_3072_constants_t *constants);
+status_t rsa_3072_verify_start(const rsa_3072_int_t *signature,
+                               const rsa_3072_public_key_t *public_key,
+                               const rsa_3072_constants_t *constants);
 
 /**
  * Waits for an RSA-3072 signature verification to complete.
@@ -132,8 +133,8 @@ otbn_error_t rsa_3072_verify_start(const rsa_3072_int_t *signature,
  * @param message Encoded message representative to check the signature against.
  * @return Result of the operation (OK or error).
  */
-otbn_error_t rsa_3072_verify_finalize(const rsa_3072_int_t *message,
-                                      hardened_bool_t *result);
+status_t rsa_3072_verify_finalize(const rsa_3072_int_t *message,
+                                  hardened_bool_t *result);
 
 /**
  * Verifies an RSA-3072 signature; blocks until complete.
@@ -147,11 +148,11 @@ otbn_error_t rsa_3072_verify_finalize(const rsa_3072_int_t *message,
  * @param result Buffer in which to store output (true iff signature is valid)
  * @return Result of the operation (OK or error).
  */
-otbn_error_t rsa_3072_verify(const rsa_3072_int_t *signature,
-                             const rsa_3072_int_t *message,
-                             const rsa_3072_public_key_t *public_key,
-                             const rsa_3072_constants_t *constants,
-                             hardened_bool_t *result);
+status_t rsa_3072_verify(const rsa_3072_int_t *signature,
+                         const rsa_3072_int_t *message,
+                         const rsa_3072_public_key_t *public_key,
+                         const rsa_3072_constants_t *constants,
+                         hardened_bool_t *result);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/sca/ecc384_serial.c
+++ b/sw/device/sca/ecc384_serial.c
@@ -135,8 +135,8 @@ static const otbn_addr_t kOtbnVarK = OTBN_ADDR_T_INIT(p384_ecdsa_sca, k);
  */
 static void setup_data_pointer(const otbn_addr_t dptr,
                                const otbn_addr_t value) {
-  SS_CHECK(otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr) ==
-           kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(
+      otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr));
 }
 
 /**
@@ -204,8 +204,8 @@ static void ecc384_set_msg(const uint8_t *msg, size_t msg_len) {
 static void p384_dmem_write(const uint32_t src[kEcc384NumWords],
                             const otbn_addr_t dest) {
   static const uint32_t zero[kEcc384NumWords % kOtbnWideWordNumWords] = {0};
-  SS_CHECK(otbn_dmem_write(kEcc384NumWords, src, dest) == kOtbnErrorOk);
-  SS_CHECK(otbn_dmem_write(ARRAYSIZE(zero), zero, dest) == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_dmem_write(kEcc384NumWords, src, dest));
+  SS_CHECK_STATUS_OK(otbn_dmem_write(ARRAYSIZE(zero), zero, dest));
 }
 
 /**
@@ -232,23 +232,20 @@ static void p384_ecdsa_sign(const uint32_t *msg, const uint32_t *private_key_d,
 
   uint32_t mode = 1;  // mode 1 => sign
   LOG_INFO("Copy data");
-  SS_CHECK(otbn_dmem_write(/*num_words=*/1, &mode, kOtbnVarMode) ==
-           kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_dmem_write(/*num_words=*/1, &mode, kOtbnVarMode));
   p384_dmem_write(msg, kOtbnVarMsg);
   p384_dmem_write(private_key_d, kOtbnVarD);
 
-  SS_CHECK(otbn_dmem_write(kEcc384NumWords, k, kOtbnVarK) == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_dmem_write(kEcc384NumWords, k, kOtbnVarK));
 
   LOG_INFO("Execute");
-  SS_CHECK(otbn_execute() == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_execute());
   LOG_INFO("Wait for done");
-  SS_CHECK(otbn_busy_wait_for_done() == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_busy_wait_for_done());
 
   LOG_INFO("Get results");
-  SS_CHECK(otbn_dmem_read(kEcc384NumWords, kOtbnVarR, signature_r) ==
-           kOtbnErrorOk);
-  SS_CHECK(otbn_dmem_read(kEcc384NumWords, kOtbnVarS, signature_s) ==
-           kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_dmem_read(kEcc384NumWords, kOtbnVarR, signature_r));
+  SS_CHECK_STATUS_OK(otbn_dmem_read(kEcc384NumWords, kOtbnVarS, signature_s));
   LOG_INFO("r[0]: 0x%02x", signature_r[0]);
   LOG_INFO("s[0]: 0x%02x", signature_s[0]);
 }
@@ -277,7 +274,7 @@ static void ecc_384_ecdsa(const uint8_t *ecc384_secret_k_bytes,
   memcpy(ecc384_secret_k, ecc384_secret_k_bytes, kEcc384NumBytes);
 
   LOG_INFO("SSECDSA starting...");
-  SS_CHECK(otbn_load_app(kOtbnAppP384Ecdsa) == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_load_app(kOtbnAppP384Ecdsa));
 
   uint32_t ecc384_signature_r[kEcc384NumWords];
   uint32_t ecc384_signature_s[kEcc384NumWords];
@@ -305,8 +302,8 @@ static void ecc_384_ecdsa(const uint8_t *ecc384_secret_k_bytes,
   simple_serial_send_packet('r', ecc384_signature_s_bytes, kEcc384NumBytes);
 
   LOG_INFO("Clearing OTBN memory");
-  SS_CHECK(otbn_dmem_sec_wipe() == kOtbnErrorOk);
-  SS_CHECK(otbn_imem_sec_wipe() == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_dmem_sec_wipe());
+  SS_CHECK_STATUS_OK(otbn_imem_sec_wipe());
 }
 
 /**

--- a/sw/device/sca/ecc_serial.c
+++ b/sw/device/sca/ecc_serial.c
@@ -203,29 +203,26 @@ static void p256_ecdsa_sign(const uint32_t *msg, const uint32_t *private_key_d,
                             const uint32_t *k) {
   uint32_t mode = 1;  // mode 1 => sign
   // Send operation mode to OTBN
-  SS_CHECK(otbn_dmem_write(/*num_words=*/1, &mode, kOtbnVarMode) ==
-           kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_dmem_write(/*num_words=*/1, &mode, kOtbnVarMode));
   // Send Msg to OTBN
-  SS_CHECK(otbn_dmem_write(kEcc256NumWords, msg, kOtbnVarMsg) == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_dmem_write(kEcc256NumWords, msg, kOtbnVarMsg));
   // Send two shares of private_key_d to OTBN
-  SS_CHECK(otbn_dmem_write(kEcc256NumWords, private_key_d, kOtbnVarD0) ==
-           kOtbnErrorOk);
-  SS_CHECK(otbn_dmem_write(kEcc256NumWords, private_key_d + kEcc256NumWords,
-                           kOtbnVarD1) == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(
+      otbn_dmem_write(kEcc256NumWords, private_key_d, kOtbnVarD0));
+  SS_CHECK_STATUS_OK(otbn_dmem_write(
+      kEcc256NumWords, private_key_d + kEcc256NumWords, kOtbnVarD1));
   // Send two shares of secret_k to OTBN
-  SS_CHECK(otbn_dmem_write(kEcc256NumWords, k, kOtbnVarK0) == kOtbnErrorOk);
-  SS_CHECK(otbn_dmem_write(kEcc256NumWords, k + kEcc256NumWords, kOtbnVarK1) ==
-           kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_dmem_write(kEcc256NumWords, k, kOtbnVarK0));
+  SS_CHECK_STATUS_OK(
+      otbn_dmem_write(kEcc256NumWords, k + kEcc256NumWords, kOtbnVarK1));
 
   // Start OTBN execution
-  SS_CHECK(otbn_execute() == kOtbnErrorOk);
-  SS_CHECK(otbn_busy_wait_for_done() == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_execute());
+  SS_CHECK_STATUS_OK(otbn_busy_wait_for_done());
 
   // Read the results back (sig_r, sig_s)
-  SS_CHECK(otbn_dmem_read(kEcc256NumWords, kOtbnVarR, signature_r) ==
-           kOtbnErrorOk);
-  SS_CHECK(otbn_dmem_read(kEcc256NumWords, kOtbnVarS, signature_s) ==
-           kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_dmem_read(kEcc256NumWords, kOtbnVarR, signature_r));
+  SS_CHECK_STATUS_OK(otbn_dmem_read(kEcc256NumWords, kOtbnVarS, signature_s));
 }
 
 /**
@@ -236,7 +233,7 @@ static void p256_ecdsa_sign(const uint32_t *msg, const uint32_t *private_key_d,
  */
 static void ecc256_ecdsa() {
   LOG_INFO("SSECDSA starting...");
-  SS_CHECK(otbn_load_app(kOtbnAppP256Ecdsa) == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_load_app(kOtbnAppP256Ecdsa));
   LOG_INFO("otbn_status: 0x%08x", abs_mmio_read32(TOP_EARLGREY_OTBN_BASE_ADDR +
                                                   OTBN_STATUS_REG_OFFSET));
 
@@ -262,8 +259,8 @@ static void ecc256_ecdsa() {
   simple_serial_send_packet('r', ecc256_signature_s_bytes, kEcc256NumBytes);
 
   // Clear OTBN memory
-  SS_CHECK(otbn_dmem_sec_wipe() == kOtbnErrorOk);
-  SS_CHECK(otbn_imem_sec_wipe() == kOtbnErrorOk);
+  SS_CHECK_STATUS_OK(otbn_dmem_sec_wipe());
+  SS_CHECK_STATUS_OK(otbn_imem_sec_wipe());
 }
 
 /**

--- a/sw/device/sca/lib/simple_serial.h
+++ b/sw/device/sca/lib/simple_serial.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/dif/dif_uart.h"
 
@@ -31,6 +32,19 @@
       simple_serial_send_status(kSimpleSerialError); \
       return;                                        \
     }                                                \
+  } while (false)
+
+/**
+ * Sends an error message over UART if the status represents an error.
+ */
+#define SS_CHECK_STATUS_OK(expr)                                  \
+  do {                                                            \
+    status_t status_ = expr;                                      \
+    if (!(status_ok(status_))) {                                  \
+      unsigned char *buf = (unsigned char *)&status_.value;       \
+      simple_serial_send_packet('z', buf, sizeof(status_.value)); \
+      return;                                                     \
+    }                                                             \
   } while (false)
 
 /**

--- a/sw/device/tests/crypto/rsa_3072_verify_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_verify_functest.c
@@ -15,7 +15,7 @@
 // the version of this file matching the Bazel rule under test.
 #include "rsa_3072_verify_testvectors.h"
 
-bool rsa_3072_verify_test(const rsa_3072_verify_test_vector_t *testvec) {
+status_t rsa_3072_verify_test(const rsa_3072_verify_test_vector_t *testvec) {
   // Encode message
   rsa_3072_int_t encodedMessage;
   CHECK_STATUS_OK(
@@ -23,27 +23,36 @@ bool rsa_3072_verify_test(const rsa_3072_verify_test_vector_t *testvec) {
 
   // Precompute Montgomery constants
   rsa_3072_constants_t constants;
-  otbn_error_t err =
-      rsa_3072_compute_constants(&testvec->publicKey, &constants);
-  if (err != kOtbnErrorOk) {
-    LOG_ERROR("Error from OTBN while computing constants: 0x%08x.", err);
-    return false;
-  }
+  TRY(rsa_3072_compute_constants(&testvec->publicKey, &constants));
 
   // Attempt to verify signature
   hardened_bool_t result;
-  err = rsa_3072_verify(&testvec->signature, &encodedMessage,
-                        &testvec->publicKey, &constants, &result);
+  status_t err = rsa_3072_verify(&testvec->signature, &encodedMessage,
+                                 &testvec->publicKey, &constants, &result);
 
   if (testvec->valid) {
-    CHECK(err == kOtbnErrorOk);
-    CHECK(result == kHardenedBoolTrue);
+    // Return the error value if not OK.
+    TRY(err);
+    // Check result.
+    if (result != kHardenedBoolTrue) {
+      LOG_ERROR("Valid signature failed verification.");
+      return OTCRYPTO_RECOV_ERR;
+    }
   } else {
-    CHECK(err == kOtbnErrorOk || err == kOtbnErrorInvalidArgument);
-    CHECK(result == kHardenedBoolFalse);
+    // Signature is expected to be invalid.
+    if (result != kHardenedBoolFalse) {
+      LOG_ERROR("Invalid signature passed verification.");
+      return OTCRYPTO_RECOV_ERR;
+    }
+    // Error code may be OK or BAD_ARGS, but other errors indicate a problem.
+    if (!status_ok(err) &&
+        crypto_status_interpret(err) != kCryptoStatusBadArgs) {
+      LOG_ERROR("Unexpected error on invalid signature: %r.", err);
+      return err;
+    }
   }
 
-  return true;
+  return OTCRYPTO_OK;
 }
 
 OTTF_DEFINE_TEST_CONFIG();
@@ -66,15 +75,19 @@ bool test_main(void) {
     }
 
     // Run test and print out result.
-    bool local_result = rsa_3072_verify_test(&testvec);
-    if (local_result) {
+    status_t err = rsa_3072_verify_test(&testvec);
+    if (status_ok(err)) {
       LOG_INFO("Finished rsa_3072_verify_test on test vector %d : ok", i + 1);
     } else {
-      LOG_ERROR("Finished rsa_3072_verify_test on test vector %d : error",
-                i + 1);
+      LOG_ERROR("Finished rsa_3072_verify_test on test vector %d : error %r",
+                i + 1, err);
+      // For help with debugging, print the OTBN error bits, instruction
+      // count, and test vector notes.
+      LOG_INFO("OTBN error bits: 0x%08x", otbn_err_bits_get());
+      LOG_INFO("OTBN instruction count: 0x%08x", otbn_instruction_count_get());
       LOG_INFO("Test notes: %s", testvec.comment);
+      result = false;
     }
-    result &= local_result;
   }
   LOG_INFO("Finished rsa_3072_verify_test:%s", RULE_NAME);
 


### PR DESCRIPTION
PR #16930 introduced status_t based error codes for the cryptolib. This change ports the OTBN driver and everything that depends on it to use those error codes instead of a custom error enum.

Related: #14549