### PR TITLE
[dv/alert_handler] Update cover_reg_top

### DIFF
--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -42,6 +42,13 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  overrides: [
+    {
+      name: cover_reg_top_vcs_cov_cfg_file
+      value: "-cm_hier {proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/cov/alert_handler_cover_reg_top.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
+    }
+  ]
+
   // Add ALERT_HANDLER specific exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/alert_handler_cov_excl.el"]
 

--- a/hw/ip_templates/alert_handler/dv/cov/alert_handler_cover_reg_top.cfg
+++ b/hw/ip_templates/alert_handler/dv/cov/alert_handler_cover_reg_top.cfg
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Limits coverage collection only to the *_reg_top module and the TL interface
+// of the DUT.
+// Alert_handler wraps alert_handler_reg_top with alert_handler_reg_wrap, so this overwrites the
+// common cfg file to include the alert_handler_reg_wrap module.
+
++moduletree *_reg_wrap
++node tb.dut tl_*
+-module prim_cdc_rand_delay  // DV construct.
+-module prim_onehot_check    // FPV verified
+
+begin assert
+  +moduletree *csr_assert_fpv
+  +moduletree tlul_assert
+end
+
+// Remove everything else from toggle coverage except:
+// - `prim_alert_sender`: the `alert_test` task under `cip_base_vseq` drives `alert_test_i` and
+// verifies `alert_rx/tx` handshake in each IP.
+begin tgl
+  -tree tb
+  +module prim_alert_sender
+end

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -42,6 +42,13 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  overrides: [
+    {
+      name: cover_reg_top_vcs_cov_cfg_file
+      value: "-cm_hier {proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/cov/alert_handler_cover_reg_top.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
+    }
+  ]
+
   // Add ALERT_HANDLER specific exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/alert_handler_cov_excl.el"]
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/cov/alert_handler_cover_reg_top.cfg
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/cov/alert_handler_cover_reg_top.cfg
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Limits coverage collection only to the *_reg_top module and the TL interface
+// of the DUT.
+// Alert_handler wraps alert_handler_reg_top with alert_handler_reg_wrap, so this overwrites the
+// common cfg file to include the alert_handler_reg_wrap module.
+
++moduletree *_reg_wrap
++node tb.dut tl_*
+-module prim_cdc_rand_delay  // DV construct.
+-module prim_onehot_check    // FPV verified
+
+begin assert
+  +moduletree *csr_assert_fpv
+  +moduletree tlul_assert
+end
+
+// Remove everything else from toggle coverage except:
+// - `prim_alert_sender`: the `alert_test` task under `cip_base_vseq` drives `alert_test_i` and
+// verifies `alert_rx/tx` handshake in each IP.
+begin tgl
+  -tree tb
+  +module prim_alert_sender
+end


### PR DESCRIPTION
Alert_handler has another layer of wrapper over
alert_handler_reg_top module, so this PR overrides the default cover_reg_top.cfg to the wrapper module.
@weicaiyang thank you for the suggestion.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>