### PR TITLE
[opentitantool] Lock serial port before using

### DIFF
--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -2,23 +2,31 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
+use nix::fcntl::{flock, FlockArg};
+use nix::sys::signal;
+use nix::unistd::Pid;
 use serialport::ClearBuffer;
 //use serialport::{FlowControl, SerialPort};
-use serialport::SerialPort;
+use serialport::{SerialPort, TTYPort};
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
-use std::io::ErrorKind;
+use std::fs::OpenOptions;
+use std::io::{ErrorKind, Read, Write};
+use std::os::unix::io::AsRawFd;
 use std::time::Duration;
 
 //use crate::io::uart::{Uart, UartError};
 use crate::io::uart::{FlowControl, Uart, UartError};
+use crate::transport::TransportError;
 
 /// Implementation of the `Uart` trait on top of a serial device, such as `/dev/ttyUSB0`.
 pub struct SerialPortUart {
     flow_control: Cell<FlowControl>,
-    port: RefCell<Box<dyn SerialPort>>,
+    port: RefCell<TTYPort>,
     rxbuf: RefCell<VecDeque<u8>>,
+    /// Lock field, will remove lock file via the `Drop` trait.
+    _lock: SerialPortExclusiveLock,
 }
 
 impl SerialPortUart {
@@ -31,14 +39,15 @@ impl SerialPortUart {
 
     /// Open the given serial device, such as `/dev/ttyUSB0`.
     pub fn open(port_name: &str) -> Result<Self> {
+        let lock = SerialPortExclusiveLock::lock(port_name)?;
+        let port = TTYPort::open(&serialport::new(port_name, 115200))
+            .map_err(|e| UartError::OpenError(e.to_string()))?;
+        flock_serial(&port, port_name)?;
         Ok(SerialPortUart {
             flow_control: Cell::new(FlowControl::None),
-            port: RefCell::new(
-                serialport::new(port_name, 115200)
-                    .open()
-                    .map_err(|e| UartError::OpenError(e.to_string()))?,
-            ),
+            port: RefCell::new(port),
             rxbuf: RefCell::default(),
+            _lock: lock,
         })
     }
 
@@ -155,4 +164,80 @@ impl Uart for SerialPortUart {
         self.port.borrow_mut().clear(ClearBuffer::Input)?;
         Ok(())
     }
+}
+
+const PID_FILE_LEN: usize = 11;
+
+/// Struct for managing a lock file in `/var/lock` corresponding to a particular serial port.  The
+/// `Drop` trait of this struct will delete the lock file, so the `SerialPortExclusiveLock`
+/// instance should be kept alive for as long as the serial port handle it is guarding.  Should
+/// this process terminate without `drop()` getting a chance to run, other processes will
+/// recognize that the lock file is stale, as they verify whether a process with the given PID is
+/// still running.
+pub struct SerialPortExclusiveLock {
+    lockfilename: String,
+}
+
+impl SerialPortExclusiveLock {
+    pub fn lock(port_name: &str) -> Result<Self> {
+        let start_of_last = match port_name.rfind('/') {
+            Some(n) => n + 1,
+            None => 0,
+        };
+        let lockfilename = format!("/var/lock/LCK..{}", &port_name[start_of_last..]);
+        if let Ok(mut lockfile) = OpenOptions::new().read(true).open(&lockfilename) {
+            // The following code attempts to parse a PID from the lock file, and send a "no-op"
+            // signal to the process identified by it.  If successful, that means that the process
+            // is still running (no actual signal will be delivered), and we should refrain from
+            // also opening the same port.  On any parsing error or failure to deliver the signal,
+            // we proceed to overwrite the lock file with our own PID.
+            match (|| -> Result<()> {
+                let mut buf = [0u8; PID_FILE_LEN];
+                match lockfile.read(&mut buf) {
+                    Ok(PID_FILE_LEN) => {
+                        let line = std::str::from_utf8(&buf)?;
+                        let pid = line.trim().parse()?;
+                        signal::kill(Pid::from_raw(pid), None)?;
+                        Ok(()) // This will result in "Device is locked" error.
+                    }
+                    _ => bail!(""),
+                }
+            })() {
+                Ok(()) => bail!(TransportError::OpenError(
+                    port_name.to_string(),
+                    "Device is locked".to_string()
+                )),
+                Err(_) => {
+                    log::info!("Lockfile is stale. Overriding it...");
+                    std::fs::remove_file(&lockfilename)?;
+                }
+            }
+        }
+        let mut lockfile = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lockfilename)?;
+        if PID_FILE_LEN != lockfile.write(format!("{:10}\n", nix::unistd::getpid()).as_bytes())? {
+            bail!(TransportError::OpenError(
+                port_name.to_string(),
+                "Error writing lockfile".to_string()
+            ));
+        }
+        Ok(Self { lockfilename })
+    }
+}
+
+impl Drop for SerialPortExclusiveLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.lockfilename);
+    }
+}
+
+/// Invoke Linux `flock()` on the given serial port, lock will be released when the file
+/// descriptor is closed (or when the process terminates).
+pub fn flock_serial(port: &TTYPort, port_name: &str) -> Result<()> {
+    flock(port.as_raw_fd(), FlockArg::LockExclusiveNonblock).map_err(|_| {
+        TransportError::OpenError(port_name.to_string(), "Device is locked".to_string())
+    })?;
+    Ok(())
 }


### PR DESCRIPTION
By default Unix character devices can be opened by multiple processed simultaneously.  For serial ports, doing so will result in the arriving data to be arbitrarily divided between the multiple readers.  It is hard to imagine a scenario in which that would be desirable.  When done by accident, by e.g. forgetting about a `minicom` in the background, as one runs `opentitantool console`, the result often will be that a few characters seem to be "dropped" now and then (when really those few characters appear in the background `minicom`).  This can lead to wasted engineering time spent looking for loose cables or firmware bugs, when none exist.

For that reason, programs such as `minicom` will attempt to atomically create a file under `/var/lock`, to prevent multiple instances from opening the same serial port.  (See specification of the exact file format here:
https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s09.html )

Another terminal program, 'tio` (used by the author), uses the Linux system call `flock()` on the serial device itself for the same effect (with the unfortunate result that one `minicom` instance and one `tio` intance could simultaneously open the same port.)

This CL makes OpenTitanTool use BOTH `/var/lock` and `flock()`, to prevent accidentally opening the same serial port with `opentitantool console` that is used by either another `opentitantool` instance, or by `minicom` or `tio`.