### PR TITLE
[edn] Disallow software command writes when in auto mode

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -199,7 +199,10 @@
                 Any CSRNG action can be initiated by writing a CSRNG command to this
                 register. The application interface must wait for the "ack" to
                 return before issuing new commands. This interface is intended
-                to be controlled solely by software. If !!CTRL.AUTO_REQ_MODE is set, this
+                to be controlled solely by software.
+
+                If !!CTRL.AUTO_REQ_MODE is set, only the first instantiate command has any
+                effect.  After that command has been processed, writes to this register
                 register will have no effect on operation.
                 Note that CSRNG command format details can be found
                 in the CSRNG documentation.

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -109,6 +109,7 @@ module edn_core import edn_pkg::*;
   logic                    send_gencmd;
   logic                    boot_send_gencmd;
   logic                    sw_cmd_req_load;
+  logic                    sw_cmd_valid;
   logic [31:0]             sw_cmd_req_bus;
   logic                    reseed_cmd_load;
   logic [31:0]             reseed_cmd_bus;
@@ -460,7 +461,7 @@ module edn_core import edn_pkg::*;
 
   // SW interface connection
   // cmd req
-  assign sw_cmd_req_load = reg2hw.sw_cmd_req.qe;
+  assign sw_cmd_req_load = reg2hw.sw_cmd_req.qe & sw_cmd_valid;
   assign sw_cmd_req_bus = reg2hw.sw_cmd_req.q;
 
   assign max_reqs_between_reseed_load = reg2hw.max_num_reqs_between_reseeds.qe;
@@ -647,6 +648,7 @@ module edn_core import edn_pkg::*;
     .boot_req_mode_i        (boot_req_mode_fo[1]),
     .auto_req_mode_i        (auto_req_mode_pfe),
     .sw_cmd_req_load_i      (sw_cmd_req_load),
+    .sw_cmd_valid_o         (sw_cmd_valid),
     .boot_wr_cmd_reg_o      (boot_wr_cmd_reg),
     .boot_wr_cmd_genfifo_o  (boot_wr_cmd_genfifo),
     .auto_set_intr_gate_o   (auto_set_intr_gate),

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -16,6 +16,7 @@ module edn_main_sm import edn_pkg::*; #(
   input logic                   boot_req_mode_i,
   input logic                   auto_req_mode_i,
   input logic                   sw_cmd_req_load_i,
+  output logic                  sw_cmd_valid_o,
   output logic                  boot_wr_cmd_reg_o,
   output logic                  boot_wr_cmd_genfifo_o,
   output logic                  auto_set_intr_gate_o,
@@ -80,6 +81,7 @@ module edn_main_sm import edn_pkg::*; #(
     send_rescmd_o          = 1'b0;
     main_sm_done_pulse_o   = 1'b0;
     main_sm_err_o          = 1'b0;
+    sw_cmd_valid_o         = 1'b1;
     unique case (state_q)
       Idle: begin
         if (boot_req_mode_i && edn_enable_i) begin
@@ -141,6 +143,7 @@ module edn_main_sm import edn_pkg::*; #(
         end
       end
       AutoAckWait: begin
+        sw_cmd_valid_o = 1'b0;
         auto_req_mode_busy_o = 1'b1;
         if (csrng_cmd_ack_i) begin
           state_d = AutoDispatch;
@@ -148,6 +151,7 @@ module edn_main_sm import edn_pkg::*; #(
       end
       AutoDispatch: begin
         auto_req_mode_busy_o = 1'b1;
+        sw_cmd_valid_o = 1'b0;
         if (!auto_req_mode_i) begin
           main_sm_done_pulse_o = 1'b1;
           state_d = Idle;
@@ -160,11 +164,13 @@ module edn_main_sm import edn_pkg::*; #(
         end
       end
       AutoCaptGenCnt: begin
+        sw_cmd_valid_o = 1'b0;
         auto_req_mode_busy_o = 1'b1;
         capt_gencmd_fifo_cnt_o = 1'b1;
         state_d = AutoSendGenCmd;
       end
       AutoSendGenCmd: begin
+        sw_cmd_valid_o = 1'b0;
         auto_req_mode_busy_o = 1'b1;
         send_gencmd_o = 1'b1;
         if (cmd_sent_i) begin
@@ -172,11 +178,13 @@ module edn_main_sm import edn_pkg::*; #(
         end
       end
       AutoCaptReseedCnt: begin
+        sw_cmd_valid_o = 1'b0;
         auto_req_mode_busy_o = 1'b1;
         capt_rescmd_fifo_cnt_o = 1'b1;
         state_d = AutoSendReseedCmd;
       end
       AutoSendReseedCmd: begin
+        sw_cmd_valid_o = 1'b0;
         auto_req_mode_busy_o = 1'b1;
         send_rescmd_o = 1'b1;
         if (cmd_sent_i) begin


### PR DESCRIPTION
- Fixes #16039
- Update documentation
- Also update design such that output commands / requests are not populated by software loads during auto mode

Signed-off-by: Timothy Chen <timothytim@google.com>