### PR TITLE
[test] add initial SV host component for power virus test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1747,6 +1747,13 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=200_000_000"]
     }
+    {
+      name: chip_sw_power_virus
+      uvm_test_seq: chip_sw_power_virus_vseq
+      sw_images: ["//sw/device/tests:power_virus_systemtest:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=200_000_000"]
+    }
   ]
 
   // List of regressions.

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -138,6 +138,7 @@ filesets:
       - seq_lib/chip_sw_rom_e2e_jtag_inject_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_power_idle_load_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_power_sleep_load_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_power_virus_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_ast_clk_rst_inputs_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - alerts_if.sv

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
@@ -15,5 +15,4 @@ class chip_sw_i2c_tx_rx_vseq extends chip_sw_base_vseq;
   int clock_period_cycles = ((i2c_clock_period_nanos - 1) / clock_period_nanos) + 1;
   int half_period_cycles = ((i2c_clock_period_nanos/2 - 1) / clock_period_nanos) + 1;
 
-
-  endclass : chip_sw_i2c_tx_rx_vseq
+endclass : chip_sw_i2c_tx_rx_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_virus_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_virus_vseq.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_power_virus_vseq)
+
+  `uvm_object_new
+
+  virtual task body();
+    super.body();
+  endtask
+
+endclass : chip_sw_power_virus_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_virus_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_virus_vseq.sv
@@ -7,8 +7,48 @@ class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
 
   `uvm_object_new
 
+  virtual function int sw_symbol_backdoor_read32(string symbol);
+    bit [7:0] byte_array[4];
+    sw_symbol_backdoor_read(symbol, byte_array);
+    return {<<byte{byte_array}};
+  endfunction
+
+  virtual task i2c_device_autoresponder(int i2c_idx);
+    i2c_device_response_seq seq = i2c_device_response_seq::type_id::create("seq");
+    fork seq.start(p_sequencer.i2c_sequencer_hs[i2c_idx]); join_none
+  endtask
+
   virtual task body();
+    bit [31:0] i2c_scl_period_ns;          // `kI2cSclPeriodNs` in SW
+    bit [31:0] peripheral_clock_period_ns; // `peripheral_clock_period_ns` in SW
+    bit [31:0] half_cycles_in_i2c_period;
+
     super.body();
+
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Computed peripheral clock period.");
+
+    // Backdoor read I2C configuration parameters.
+    i2c_scl_period_ns = sw_symbol_backdoor_read32("kI2cSclPeriodNs");
+    peripheral_clock_period_ns = sw_symbol_backdoor_read32("peripheral_clock_period_ns");
+    `uvm_info(`gfn, $sformatf("kI2cSclPeriodNs = %0d", i2c_scl_period_ns), UVM_LOW);
+    `uvm_info(`gfn, $sformatf("peripheral_clock_period_ns = %0d", peripheral_clock_period_ns),
+      UVM_LOW);
+
+    half_cycles_in_i2c_period = ((int'(i2c_scl_period_ns) / 2 - 1) /
+      int'(peripheral_clock_period_ns)) + 1;
+    `uvm_info(`gfn, $sformatf("Half (peripheral) cycles in I2C clock period: %d",
+      half_cycles_in_i2c_period), UVM_LOW);
+
+    // Enable I2C monitors.
+    foreach (cfg.m_i2c_agent_cfgs[i]) begin
+      cfg.m_i2c_agent_cfgs[i].en_monitor = 1'b1;
+      cfg.m_i2c_agent_cfgs[i].if_mode = Device;
+      cfg.chip_vif.enable_i2c(.inst_num(i), .enable(1));
+      cfg.m_i2c_agent_cfgs[i].timing_cfg.tClockLow = half_cycles_in_i2c_period - 2;
+      cfg.m_i2c_agent_cfgs[i].timing_cfg.tClockPulse = half_cycles_in_i2c_period + 1;
+      i2c_device_autoresponder(i);
+    end
+
   endtask
 
 endclass : chip_sw_power_virus_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -96,3 +96,4 @@
 `include "chip_sw_power_idle_load_vseq.sv"
 `include "chip_sw_power_sleep_load_vseq.sv"
 `include "chip_sw_ast_clk_rst_inputs_vseq.sv"
+`include "chip_sw_power_virus_vseq.sv"

--- a/sw/device/lib/dif/dif_adc_ctrl.c
+++ b/sw/device/lib/dif/dif_adc_ctrl.c
@@ -29,14 +29,16 @@ dif_result_t dif_adc_ctrl_configure(const dif_adc_ctrl_t *adc_ctrl,
                                     dif_adc_ctrl_config_t config) {
   if (adc_ctrl == NULL ||
       config.power_up_time_aon_cycles > ADC_CTRL_ADC_PD_CTL_PWRUP_TIME_MASK ||
-      config.wake_up_time_aon_cycles > ADC_CTRL_ADC_PD_CTL_WAKEUP_TIME_MASK) {
+      config.wake_up_time_aon_cycles > ADC_CTRL_ADC_PD_CTL_WAKEUP_TIME_MASK ||
+      config.num_low_power_samples == 0 ||
+      config.num_normal_power_samples == 0) {
     return kDifBadArg;
   }
 
-  uint32_t en_ctrl_reg = 0;
-  uint32_t pd_ctrl_reg = 0;
-  uint32_t lp_sample_ctrl_reg = 0;
-  uint32_t np_sample_ctrl_reg = 0;
+  uint32_t en_ctrl_reg = ADC_CTRL_ADC_EN_CTL_REG_RESVAL;
+  uint32_t pd_ctrl_reg = ADC_CTRL_ADC_PD_CTL_REG_RESVAL;
+  uint32_t lp_sample_ctrl_reg = ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_RESVAL;
+  uint32_t np_sample_ctrl_reg = ADC_CTRL_ADC_SAMPLE_CTL_REG_RESVAL;
 
   switch (config.mode) {
     case kDifAdcCtrlLowPowerScanMode:

--- a/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
@@ -59,6 +59,16 @@ TEST_F(ConfigTest, BadWakeUpTime) {
   EXPECT_DIF_BADARG(dif_adc_ctrl_configure(&adc_ctrl_, config_));
 }
 
+TEST_F(ConfigTest, BadNumLowPowerSamples) {
+  config_.num_low_power_samples = 0;
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure(&adc_ctrl_, config_));
+}
+
+TEST_F(ConfigTest, BadNumNormalPowerSamples) {
+  config_.num_normal_power_samples = 0;
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure(&adc_ctrl_, config_));
+}
+
 TEST_F(ConfigTest, LowPowerModeSuccess) {
   EXPECT_WRITE32(ADC_CTRL_ADC_EN_CTL_REG_OFFSET, 0);
   EXPECT_WRITE32(ADC_CTRL_ADC_PD_CTL_REG_OFFSET,
@@ -81,8 +91,10 @@ TEST_F(ConfigTest, NormalPowerModeSuccess) {
   EXPECT_WRITE32(ADC_CTRL_ADC_EN_CTL_REG_OFFSET, 0);
   EXPECT_WRITE32(ADC_CTRL_ADC_PD_CTL_REG_OFFSET,
                  {{ADC_CTRL_ADC_PD_CTL_PWRUP_TIME_OFFSET,
-                   config_.power_up_time_aon_cycles}});
-  EXPECT_WRITE32(ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_OFFSET, 0);
+                   config_.power_up_time_aon_cycles},
+                  {ADC_CTRL_ADC_PD_CTL_WAKEUP_TIME_OFFSET, 0x640}});
+  EXPECT_WRITE32(ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_OFFSET,
+                 ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_RESVAL);
   EXPECT_WRITE32(ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET,
                  {{ADC_CTRL_ADC_SAMPLE_CTL_NP_SAMPLE_CNT_OFFSET,
                    config_.num_normal_power_samples}});
@@ -95,9 +107,12 @@ TEST_F(ConfigTest, OneshotModeSuccess) {
                  {{ADC_CTRL_ADC_EN_CTL_ONESHOT_MODE_BIT, true}});
   EXPECT_WRITE32(ADC_CTRL_ADC_PD_CTL_REG_OFFSET,
                  {{ADC_CTRL_ADC_PD_CTL_PWRUP_TIME_OFFSET,
-                   config_.power_up_time_aon_cycles}});
-  EXPECT_WRITE32(ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_OFFSET, 0);
-  EXPECT_WRITE32(ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET, 0);
+                   config_.power_up_time_aon_cycles},
+                  {ADC_CTRL_ADC_PD_CTL_WAKEUP_TIME_OFFSET, 0x640}});
+  EXPECT_WRITE32(ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_OFFSET,
+                 ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_RESVAL);
+  EXPECT_WRITE32(ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET,
+                 ADC_CTRL_ADC_SAMPLE_CTL_REG_RESVAL);
   EXPECT_DIF_OK(dif_adc_ctrl_configure(&adc_ctrl_, config_));
 }
 


### PR DESCRIPTION
This adds the initial SV host component for the power virus test and configure the I2C agents. Additionally this adds checks for the UART transmission.