### PR TITLE
[tool_requirements] Increase minimum VCS version to 2022.06-SP2

### DIFF
--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -34,7 +34,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'vcs': {
-        'min_version': '2020.12-SP2',
+        'min_version': '2022.06-SP2',
         'as_needed': True
     },
     'rust': {


### PR DESCRIPTION
This updated version contains some fixes relevant for coverage closure and collaborators have thus agreed to switch to this one. To avoid any issues due to discrepancies between tool outputs of collaborators towards ES, it has been decided to enforce this version.

This resolves lowRISC/OpenTitan#16617.