### PR TITLE
[python-requirements] Pin setuptools version to < 66.0.0

### DIFF
--- a/ci/install-package-dependencies.sh
+++ b/ci/install-package-dependencies.sh
@@ -98,7 +98,7 @@ export PATH=$HOME/.local/bin:$PATH
 # specify that an older version of a package must be used for a certain
 # Python version. If that information is not read, pip installs the latest
 # version, which then fails to run.
-python3 -m pip install --user -U pip setuptools
+python3 -m pip install --user -U pip "setuptools<66.0.0"
 
 pip3 install --user -r python-requirements.txt
 

--- a/doc/getting_started/_index.md
+++ b/doc/getting_started/_index.md
@@ -69,7 +69,7 @@ Some tools in this repository are written in Python 3 and require Python depende
 We recommend installing the latest version of `pip` and `setuptools` (especially if on older systems such as Ubuntu 18.04) using:
 
 ```console
-python3 -m pip install --user -U pip setuptools
+python3 -m pip install --user -U pip "setuptools<66.0.0"
 ```
 
 The `pip` installation instructions use the `--user` flag to install without root permissions.

--- a/site/docs/builder.Dockerfile
+++ b/site/docs/builder.Dockerfile
@@ -19,5 +19,5 @@ ENV PATH "/root/.local/bin:${PATH}"
 # specify that an older version of a package must be used for a certain
 # Python version. If that information is not read, pip installs the latest
 # version, which then fails to run.
-RUN python3 -m pip install --user -U pip setuptools
+RUN python3 -m pip install --user -U pip "setuptools<66.0.0"
 RUN pip3 install --user -r python-requirements.txt

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -186,7 +186,7 @@ RUN /tmp/rustup-init.sh -y --default-toolchain ${RUST_VERSION} \
 # version, which then fails to run.
 ENV PATH "/home/dev/.local/bin:${PATH}"
 COPY --chown=dev:dev python-requirements.txt /tmp/python-requirements.txt
-RUN python3 -m pip install --user -U pip setuptools \
+RUN python3 -m pip install --user -U pip "setuptools<66.0.0" \
     && python3 -m pip install --user -r /tmp/python-requirements.txt \
         --no-warn-script-location \
     && rm -f /tmp/python-requirements.txt


### PR DESCRIPTION
Starting with setuptools version 66.0.0, legacy package version names such as 0.23ubuntu1 are no longer supported. Since some of our Python dependencies use this format, we pin the setuptools version to the last version before this change. This unblocks CI and gives us time to upgrade/rebase our dependencies.

