### PR TITLE
[otbn, pre_sca] Enable using COCO-Alma with the OTBN

### DIFF
--- a/hw/ip/otbn/pre_sca/alma/README.md
+++ b/hw/ip/otbn/pre_sca/alma/README.md
@@ -1,0 +1,193 @@
+# OTBN Formal Masking Verification Using Alma
+
+This directory contains support files to formally verify the OTBN core using the
+tool [Alma:
+Execution-aware Masking Verification](https://github.com/IAIK/coco-alma).
+
+## Prerequisites
+
+Note that this flow is experimental. It has been developed using Yosys v0.15
+(this also works: v0.9+4306 (git sha1 3931b3a03)), sv2v v0.0.9-24-gf868f06 and
+Verilator 4.106 (2020-12-02 rev v4.106). Other tool versions might not be
+compatible.
+
+1. Download the Alma tool from this specific repo and check out to the
+   `coco-otbn` branch of the tool
+   ```sh
+   git clone git@github.com:abdullahvarici/coco-alma.git -b coco-otbn-latest
+   ```
+   Enter the directory using
+   ```sh
+   cd coco-alma
+   ```
+   Set up a new virtual Python environment
+   ```sh
+   python3 -m venv dev
+   source dev/bin/activate
+   ```
+   And install the Python requirements
+   ```sh
+   pip3 install -r requirements.txt
+   ```
+   Update `examples/otbn/config.json` to point correct locations for `asm`,
+   `objdump` and `rv_objdump`.
+
+1. Generate a Verilog netlist
+
+   A netlist of the DUT can be generated using the Yosys synthesis flow from
+   the OpenTitan repository. From the OpenTitan top level, run
+   ```sh
+   cd hw/ip/otbn/pre_syn
+   ```
+   Set up the synthesis flow as described in the corresponding README. Then run
+   the synthesis
+   ```sh
+   ./syn_yosys.sh
+   ```
+
+## Formally verifying the masking of the OTBN core
+
+After downloading the Alma tool, installing dependencies and synthesizing OTBN,
+the masking can finally be formally verified.
+
+1. Enter the directory where you have downloaded Alma and load the virtual
+   Python environment
+   ```sh
+   source dev/bin/activate
+   ```
+
+1. Make sure to source the `build_consts.sh` script from the OpenTitan
+   repository in order to set up some shell variables.
+   ```sh
+   source ../opentitan/util/build_consts.sh
+   ```
+
+1. Launch the Alma tool to parse, assemble, trace (simulate) and formally verify
+   the netlist. For simplicity, a single script is provided to launch all the
+   required steps with a single command. Simply run
+   ```sh
+   ${REPO_TOP}/hw/ip/otbn/pre_sca/alma/verify_otbn.sh
+   ```
+   This should produce output similar to the one below:
+   ```sh
+   Verifying OTBN using Alma
+   Starting yosys synthesis...
+   | CircuitGraph | Total: 222852 | Linear: 22351 | Non-linear: 107350 | Registers: 17594 | Mux: 33864 |
+   parse.py successful (732.40s)
+   INSTR_LIMIT =  64
+   Using program file:  programs/st_ok_tr_ok.S
+   Using build directory: [build_directory]
+   Using netlist path: ../../tmp/circuit.v
+   Wrote verilator testbench to [build_directory]/verilator_tb.c
+   It produces output VCD at [build_directory]/circuit.vcd
+   1: Running verilator on given netlist
+   2: Compiling verilated netlist library
+   3: Compiling provided verilator testbench
+   4: Simulating circuit and generating VCD
+   | CircuitGraph | Total: 222852 | Linear: 22351 | Non-linear: 107350 | Registers: 17594 | Mux: 33864 |
+   tmp/circuit.vcd:53125: [WARNING] Entry for name clk_sys already exists in namemap (clk_sys -> }c2)
+   tmp/circuit.vcd:53144: [WARNING] Entry for name imem_wdata_i already exists in namemap (imem_wdata_i -> ~c2)
+   tmp/circuit.vcd:53145: [WARNING] Entry for name imem_we_i already exists in namemap (imem_we_i -> \"d2)
+   tmp/circuit.vcd:53146: [WARNING] Entry for name imem_wmask_i already exists in namemap (imem_wmask_i -> #d2)
+   tmp/circuit.vcd:53150: [WARNING] Entry for name rst_sys_n already exists in namemap (rst_sys_n -> %d2)
+   RST value:  1
+   1
+   Building formula for cycle 0:
+   vars 0 clauses 0
+   Checking cycle 0:
+   Checking secret 0 [1, 2]:
+   RST value:  1
+   1
+   Building formula for cycle 1:
+   vars 7 clauses 9
+   Checking cycle 1:
+   Checking secret 0 [8, 9]:
+   RST value:  1
+   1
+   Building formula for cycle 2:
+   vars 14 clauses 18
+   Checking cycle 2:
+   Checking secret 0 [15, 16]:
+   ...
+   RST value:  1
+   1
+   Building formula for cycle 173:
+   vars 1211 clauses 1557
+   Checking cycle 173:
+   Checking secret 0 [1212, 1213]:
+   RST value:  1
+   1
+   Building formula for cycle 174:
+   vars 1218 clauses 1566
+   Checking cycle 174:
+   Checking secret 0 [1219, 1220]:
+   Finished in 65.81
+   The execution is secure
+   ```
+
+## Individual steps in detail
+
+Below we outline the individual steps performed by the `verify_otbn.sh` script.
+This is useful if you, e.g., want to verify the masking of your own module.
+
+For more details, please refer to the [Alma
+tutorial](https://github.com/IAIK/coco-alma/tree/hw-verif#usage)
+
+1. Make sure to source the `build_consts.sh` script from the OpenTitan
+   repository in order to set up some shell variables.
+   ```sh
+   source ../opentitan/util/build_consts.sh
+   ```
+
+1. The first step involves the parsing of the synthesized netlist.
+   ```sh
+   python3 parse.py --keep --top-module otbn_top_coco --log-yosys \
+      --source ${REPO_TOP}/hw/ip/otbn/pre_sca/alma/rtl/ram_1p.v \
+      ${REPO_TOP}/hw/ip/otbn/pre_syn/syn_out/latest/generated/otbn_core.alma.v \
+      ${REPO_TOP}/hw/ip/otbn/pre_sca/alma/rtl/otbn_top_coco.v
+   ```
+
+1. Next, run the `assemble.py` script to generate memory initialization file for
+   OTBN.
+   ```sh
+   program=st_ok_tr_ok
+   cd examples/otbn
+   python3 assemble.py --program programs/${program}.S \
+      --netlist ../../tmp/circuit.v
+   cd ../../
+   ```
+
+1. Then, the Verilator testbench can be compiled and run. This step is required
+   to identify control signals.
+   ```sh
+   python3 trace.py --testbench tmp/verilator_tb.c \
+      --netlist tmp/circuit.v \
+      --c-compiler gcc \
+      --make-jobs 16
+   ```
+   Add `-b` argument to use cached object files from a previous Verilator run
+   and save some time.
+
+1. Next, the automatically generated labeling file `tmp/labels.txt` needs to be
+   adapted. This file tells Alma which inputs of the DUT correspond to the
+   secret shares and which ones are used to provide randomness for
+   (re-)masking. Update the labels file or use an existing one.
+
+1. Finally the verification of the masking implementation can be started.
+   ```sh
+   python3 verify.py --json tmp/circuit.json \
+      --top-module otbn_top_coco \
+      --label examples/otbn/labels/${program}_labels.txt \
+      --vcd tmp/circuit.vcd \
+      --mode stable \
+      --rst-name rst_sys_n \
+      --rst-phase 0 \
+      --rst-cycles 2 \
+      --cycles 175 \
+      --from-cycle 140
+   ```
+
+Run the following command to see the waveform:
+   ```sh
+   gtkwave tmp/circuit.vcd
+   ```

--- a/hw/ip/otbn/pre_sca/alma/rtl/otbn_top_coco.v
+++ b/hw/ip/otbn/pre_sca/alma/rtl/otbn_top_coco.v
@@ -1,0 +1,228 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module otbn_top_coco #(
+  // Instruction data width
+  parameter ImemDataWidth = 39
+) (
+  input clk_sys,
+  input rst_sys_n,
+  input imem_we_i,
+  input [ImemDataWidth-1:0] imem_wdata_i,
+  input [ImemDataWidth-1:0] imem_wmask_i
+);
+  // Size of the instruction memory, in bytes
+  localparam ImemSizeByte = 128*4;  //32'h1000;
+  // Size of the data memory, in bytes
+  localparam DmemSizeByte = 8*32;  //32'h1000;
+  // Data path width for BN (wide) instructions, in bits.
+  localparam WLEN = 256;
+  // Sideload key data width
+  localparam SideloadKeyWidth = 384;
+  // "Extended" WLEN: the size of the datapath with added integrity bits
+  localparam ExtWLEN = WLEN * ImemDataWidth / 32;
+
+  /* Math function: Number of bits needed to address |value| items.
+   * This function is taken from prim_util_pkg.sv and re-coded
+   *
+   *                  0        for value == 0
+   * vbits =          1        for value == 1
+   *         ceil(log2(value)) for value > 1
+   */
+  function automatic [31:0] vbits;
+    input [31:0] value;
+    begin : fclog2
+      integer result;
+      if (value == 1) begin
+        vbits = 1;
+      end else begin
+        value = value - 1;
+        for (result = 0; value > 0; result = result + 1) begin
+          value = value >> 1;
+        end
+        vbits = result;
+      end
+    end : fclog2
+  endfunction
+
+  // Instruction memory adress width
+  localparam ImemAddrWidth = vbits(ImemSizeByte);
+  // Data memory adress width
+  localparam DmemAddrWidth = vbits(DmemSizeByte);
+
+  reg                      otbn_start;
+  // Intialise otbn_start_done to 1 so that we only signal otbn_start after we have seen a reset. If
+  // you don't do this, we start OTBN before the reset, which can generate confusing trace messages.
+  reg                      otbn_start_done = 1'b1;
+  wire                     secure_wipe_running;
+
+  // Instruction memory (IMEM) signals
+  wire                     imem_req;
+  wire [ImemAddrWidth-1:0] imem_addr;
+  wire [ImemDataWidth-1:0] imem_rdata;
+  wire                     imem_rvalid;
+
+  // Data memory (DMEM) signals
+  wire                     dmem_req;
+  wire                     dmem_write;
+  wire [DmemAddrWidth-1:0] dmem_addr;
+  wire [      ExtWLEN-1:0] dmem_wdata;
+  wire [      ExtWLEN-1:0] dmem_wmask;
+  wire [      ExtWLEN-1:0] dmem_rdata;
+  wire                     dmem_rvalid;
+  wire                     dmem_rerror;
+
+  // Entropy Distribution Network (EDN)
+  wire edn_rnd_req, edn_urnd_req;
+  wire edn_rnd_ack, edn_urnd_ack;
+  localparam [WLEN-1:0] FixedEdnVal = {{4{64'hAAAA_AAAA_9999_9999}}};
+  assign edn_rnd_ack  = edn_rnd_req;
+  assign edn_urnd_ack = edn_urnd_req;
+
+  // Sideload Key
+  wire [2*SideloadKeyWidth-1:0] sideload_key_shares;
+  assign sideload_key_shares[SideloadKeyWidth-1:0] = {12{32'hDEADBEEF}};
+  assign sideload_key_shares[2*SideloadKeyWidth-1:SideloadKeyWidth] = {12{32'hBAADF00D}};
+
+  localparam [3:0] MuBi4False = 4'h9;
+
+  otbn_core u_otbn_core (
+    .clk_i (clk_sys),
+    .rst_ni(rst_sys_n),
+
+    .start_i              (otbn_start),
+    .done_o               (),
+    .locking_o            (),
+    .secure_wipe_running_o(secure_wipe_running),
+
+    .err_bits_o       (),
+    .recoverable_err_o(),
+
+    .imem_req_o   (imem_req),
+    .imem_addr_o  (imem_addr),
+    .imem_rdata_i (imem_rdata),
+    .imem_rvalid_i(imem_rvalid),
+
+    .dmem_req_o   (dmem_req),
+    .dmem_write_o (dmem_write),
+    .dmem_addr_o  (dmem_addr),
+    .dmem_wdata_o (dmem_wdata),
+    .dmem_wmask_o (dmem_wmask),
+    .dmem_rmask_o (),
+    .dmem_rdata_i (dmem_rdata),
+    .dmem_rvalid_i(dmem_rvalid),
+    .dmem_rerror_i(dmem_rerror),
+
+    .edn_rnd_req_o (edn_rnd_req),
+    .edn_rnd_ack_i (edn_rnd_ack),
+    .edn_rnd_data_i(FixedEdnVal),
+    .edn_rnd_fips_i(1'b1),
+    .edn_rnd_err_i (1'b0),
+
+    .edn_urnd_req_o (edn_urnd_req),
+    .edn_urnd_ack_i (edn_urnd_ack),
+    .edn_urnd_data_i(FixedEdnVal),
+
+    .insn_cnt_o      (),
+    .insn_cnt_clear_i(1'b0),
+
+    .mems_sec_wipe_o         (),
+    .dmem_sec_wipe_urnd_key_o(),
+    .imem_sec_wipe_urnd_key_o(),
+    .req_sec_wipe_urnd_keys_i(1'b0),
+
+    .escalate_en_i(MuBi4False),
+    .rma_req_i    (MuBi4False),
+    .rma_ack_o    (),
+
+    .software_errs_fatal_i(1'b0),
+
+    .sideload_key_shares_i      (sideload_key_shares),
+    .sideload_key_shares_valid_i(2'b11)
+  );
+
+  // Track when OTBN is done with its initial secure wipe of the internal state.  We use this to
+  // wait for the OTBN core to complete the initial secure wipe before we send it the start signal.
+  // Also keep a delayed copy of the done signal.  This is necessary to align with the status of
+  // OTBN and the model, which lags one cycle behind the completion of the OTBN core.
+  reg init_sec_wipe_done_q;
+  always @(posedge clk_sys, negedge rst_sys_n) begin
+    if (!rst_sys_n) begin
+      init_sec_wipe_done_q <= 1'b0;
+    end else begin
+      if (!secure_wipe_running) begin
+        init_sec_wipe_done_q <= 1'b1;
+      end
+    end
+  end
+
+  // Pulse otbn_start for 1 cycle after the initial secure wipe is done.
+  // Flop `done_o` from otbn_core to match up with model done signal.
+  always @(posedge clk_sys or negedge rst_sys_n) begin
+    if (!rst_sys_n) begin
+      otbn_start      <= 1'b0;
+      otbn_start_done <= 1'b0;
+    end else begin
+      if (!otbn_start_done && init_sec_wipe_done_q) begin
+        otbn_start      <= 1'b1;
+        otbn_start_done <= 1'b1;
+      end else if (otbn_start) begin
+        otbn_start <= 1'b0;
+      end
+    end
+  end
+
+  localparam DmemSizeWords = DmemSizeByte / (WLEN / 8);
+  localparam DmemIndexWidth = vbits(DmemSizeWords);
+
+  wire [DmemIndexWidth-1:0] dmem_index;
+  wire [DmemAddrWidth-DmemIndexWidth-1:0] unused_dmem_addr;
+
+  assign dmem_index = dmem_addr[DmemAddrWidth-1:DmemAddrWidth-DmemIndexWidth];
+  assign unused_dmem_addr = dmem_addr[DmemAddrWidth-DmemIndexWidth-1:0];
+
+  assign dmem_rerror = 1'b0;
+
+  ram_1p #(
+    .DataWidth(ExtWLEN),
+    .AddrWidth(DmemIndexWidth),
+    .Depth(DmemSizeWords)
+  ) u_dmem (
+    .clk_i(clk_sys),
+    .rst_ni(rst_sys_n),
+    .req_i(dmem_req),
+    .we_i(dmem_write),
+    .addr_i(dmem_index),
+    .wdata_i(dmem_wdata),
+    .wmask_i(dmem_wmask),
+    .rvalid_o(dmem_rvalid),
+    .rdata_o(dmem_rdata)
+  );
+
+  localparam ImemSizeWords = ImemSizeByte / 4;
+  localparam ImemIndexWidth = vbits(ImemSizeWords);
+
+  wire [ImemIndexWidth-1:0] imem_index;
+  wire [1:0] unused_imem_addr;
+
+  assign imem_index = imem_addr[ImemAddrWidth-1:2];
+  assign unused_imem_addr = imem_addr[1:0];
+
+  ram_1p #(
+    .DataWidth(ImemDataWidth),
+    .AddrWidth(ImemIndexWidth),
+    .Depth(ImemSizeWords)
+  ) u_imem (
+    .clk_i(clk_sys),
+    .rst_ni(rst_sys_n),
+    .req_i(imem_req),
+    .we_i(imem_we_i),
+    .addr_i(imem_index),
+    .wdata_i(imem_wdata_i),
+    .wmask_i(imem_wmask_i),
+    .rvalid_o(imem_rvalid),
+    .rdata_o(imem_rdata)
+  );
+
+endmodule

--- a/hw/ip/otbn/pre_sca/alma/rtl/ram_1p.v
+++ b/hw/ip/otbn/pre_sca/alma/rtl/ram_1p.v
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This module is coded to be similar to the ram_1p.v in COCO-IBEX project
+// Single-port RAM with 1 cycle read/write delay
+
+module ram_1p #(
+  parameter DataWidth = 32,
+  parameter AddrWidth = 2,
+  parameter Depth = 4
+) (
+  input                      clk_i,
+  input                      rst_ni,
+  input                      req_i,
+  input                      we_i,
+  input      [AddrWidth-1:0] addr_i,
+  input      [DataWidth-1:0] wdata_i,
+  input      [DataWidth-1:0] wmask_i,
+  output reg                 rvalid_o,
+  output reg [DataWidth-1:0] rdata_o
+);
+
+  reg [DataWidth-1:0] mem[Depth-1:0];
+
+  always @(posedge clk_i) begin
+    if (req_i) begin
+      if (we_i) begin
+        mem[addr_i] <= (mem[addr_i] & ~wmask_i) | (wdata_i & wmask_i);
+      end
+      rdata_o <= mem[addr_i];
+    end
+  end
+
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvalid_o <= 1'sb0;
+    end else begin
+      rvalid_o <= req_i;
+    end
+  end
+
+endmodule

--- a/hw/ip/otbn/pre_sca/alma/verify_otbn.sh
+++ b/hw/ip/otbn/pre_sca/alma/verify_otbn.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Script to formally verify the masking of the OTBN using Alma.
+
+echo "Verifying OTBN using Alma"
+
+# Parse
+python3 parse.py --keep --top-module otbn_top_coco --log-yosys \
+  --source ${REPO_TOP}/hw/ip/otbn/pre_sca/alma/rtl/ram_1p.v \
+  ${REPO_TOP}/hw/ip/otbn/pre_syn/syn_out/latest/generated/otbn_core.alma.v \
+  ${REPO_TOP}/hw/ip/otbn/pre_sca/alma/rtl/otbn_top_coco.v
+
+# Assemble the program
+program=st_ok_tr_ok
+cd examples/otbn || exit
+python3 assemble.py --program programs/${program}.S \
+  --netlist ../../tmp/circuit.v
+cd ../../ || exit
+
+# Trace
+python3 trace.py --testbench tmp/verilator_tb.c \
+  --netlist tmp/circuit.v \
+  --c-compiler gcc \
+  --make-jobs 16
+
+# Verify
+python3 verify.py --json tmp/circuit.json \
+  --top-module otbn_top_coco \
+  --label examples/otbn/labels/${program}_labels.txt \
+  --vcd tmp/circuit.vcd \
+  --mode stable \
+  --rst-name rst_sys_n \
+  --rst-phase 0 \
+  --rst-cycles 2 \
+  --cycles 175 \
+  --from-cycle 140


### PR DESCRIPTION
Create a top module instantiating otbn_core and a simple memory. Create a single script to launch all the required steps to verify OTBN. Add a readme file explaining how to use Alma framework with OTBN.

Signed-off-by: Abdullah Varici <abdullah.varici@lowrisc.org>