### PR TITLE
[dv] Make prim_secded_* toggle coverage 100%

### DIFF
--- a/hw/dv/tools/vcs/common_cov_excl.cfg
+++ b/hw/dv/tools/vcs/common_cov_excl.cfg
@@ -13,6 +13,8 @@
 -node tb.dut *tl_o.d_sink
 // [UNR] due to the ECC logics
 -node tb.dut *tl_o.d_user.rsp_intg[6]
+// [UNR] unused inputs at prim_secded_* in reg_top and mem.
+-node tb.dut*_chk.u_chk data_i[56:43]
 
 // [LOW_RISK] Verified in prim_alert_sender/receiver TB."
 -node tb.dut* *alert_rx_i*.ping_p

--- a/hw/dv/tools/vcs/cover_reg_top.cfg
+++ b/hw/dv/tools/vcs/cover_reg_top.cfg
@@ -15,8 +15,6 @@
 begin assert
   +moduletree *csr_assert_fpv
   +moduletree tlul_assert
-  +module prim_secded_inv_64_57_dec
-  +module prim_secded_inv_39_32_dec
 end
 
 // Remove everything else from toggle coverage except:
@@ -25,4 +23,6 @@ end
 begin tgl
   -tree tb
   +module prim_alert_sender
+  +module prim_secded_inv_64_57_dec
+  +module prim_secded_inv_39_32_dec
 end

--- a/hw/dv/tools/xcelium/common_cov_excl.tcl
+++ b/hw/dv/tools/xcelium/common_cov_excl.tcl
@@ -7,5 +7,6 @@ exclude -inst $::env(DUT_TOP) -toggle '*tl_i.a_param' -comment "\[UNSUPPORTED\] 
 exclude -inst $::env(DUT_TOP) -toggle '*tl_o.d_param' -comment "\[UNR\] Follows tl_i.a_param which is unsupported."
 exclude -inst $::env(DUT_TOP) -toggle '*tl_o.d_sink' -comment "\[UNR\] Based on our Comportability Spec."
 exclude -inst $::env(DUT_TOP) -toggle '*tl_o.d_user.rsp_intg'\[6\] -comment "\[UNR\] Due to the ECC logics"
-exclude -inst $::env(DUT_TOP) -toggle '*alert_rx_*.ping_*' -comment "\[LOW_RISK\] Verified in prim_alert_receiver TB."
+exclude -inst $::env(DUT_TOP).gen_alert_tx*.u_prim_alert_sender -toggle '*alert*.ping_*' -comment "\[LOW_RISK\] Verified in prim_alert_receiver TB."
+exclude -inst $::env(DUT_TOP).*_chk.u_chk -toggle 'data_i[56:43]' -comment "\[UNR\] unused inputs at prim_secded_* in reg_top and mem."
 exclude -inst $::env(DUT_TOP).gen_alert_tx*.u_prim_alert_sender -toggle '*alert*.ping_*' -comment "\[LOW_RISK\] Verified in prim_alert_receiver TB."


### PR DESCRIPTION
1. fixed misplacing prim_secded in cover_reg_top, so that toggle coverage isn't enabled for csr tests.
2. excluded unused inputs at prim_secded_*, which are tied to 0.

Addressed item 1 in #17103

Signed-off-by: Weicai Yang <weicai@google.com>