### PR TITLE
[dv/alert_handler] Fix sig_int_err

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -67,7 +67,7 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task alert_handler_rand_wr_class_ctrl(bit [NUM_ALERT_CLASSES-1:0] lock_bit,
-                                                bit [NUM_ALERT_CLASSES-1:0] class_en = $urandom());
+                                                bit [NUM_ALERT_CLASSES-1:0] class_en);
     `RAND_WRITE_CLASS_CTRL(a, class_en[0], lock_bit[0])
     `RAND_WRITE_CLASS_CTRL(b, class_en[1], lock_bit[1])
     `RAND_WRITE_CLASS_CTRL(c, class_en[2], lock_bit[2])

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -67,7 +67,7 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task alert_handler_rand_wr_class_ctrl(bit [NUM_ALERT_CLASSES-1:0] lock_bit,
-                                                bit [NUM_ALERT_CLASSES-1:0] class_en = $urandom());
+                                                bit [NUM_ALERT_CLASSES-1:0] class_en);
     `RAND_WRITE_CLASS_CTRL(a, class_en[0], lock_bit[0])
     `RAND_WRITE_CLASS_CTRL(b, class_en[1], lock_bit[1])
     `RAND_WRITE_CLASS_CTRL(c, class_en[2], lock_bit[2])


### PR DESCRIPTION
This PR constraints the sig_int_error to only alert integrity, or esc standalone interity. The esc_sig_int that mixes with esc signal is hard to write a common sequence, because we will need to make sure not issue intr clear during esc error.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>