### PR TITLE
[dv] Add inline coverage off in tlul_cmd_intg_chk

### DIFF
--- a/hw/ip/sram_ctrl/dv/cov/sram_ctrl_cov_excl.el
+++ b/hw/ip/sram_ctrl/dv/cov/sram_ctrl_cov_excl.el
@@ -34,11 +34,6 @@ INSTANCE: tb.dut.u_reg_regs.u_status_escalated.wr_en_data_arb
 ANNOTATION: "[UNR] all inputs are constant"
 Block 2 "1620753216" "assign wr_data = d;"
 
-CHECKSUM: "1738953883 3087984712"
-INSTANCE: tb.dut.u_reg_regs.u_chk
-ANNOTATION: "[LOWRISK] when a_valid is low, we drive X on data, so this condition isn't covered"
-Condition 1 "899198529" "(tl_i.a_valid & (((|err)) | ((|data_err)))) 1 -1" (1 "01")
-
 CHECKSUM: "1296247128 1854270750"
 INSTANCE: tb.dut
 ANNOTATION: "[UNSUPPORTED] ACK can't come without REQ"

--- a/hw/ip/tlul/rtl/tlul_cmd_intg_chk.sv
+++ b/hw/ip/tlul/rtl/tlul_cmd_intg_chk.sv
@@ -35,8 +35,15 @@ module tlul_cmd_intg_chk import tlul_pkg::*; (
 
   // error output is transactional, it is up to the instantiating module
   // to determine if a permanent latch is feasible
+  // [LOWRISC] err and data_err is unknown when a_valid is low, so we can't cover
+  // the condition coverage - (|err | (|data_err)) == 0/1, when a_valid = 0, which is
+  // fine as driving unknown is better. `err_o` is used as a condition in other places,
+  // which needs to be covered with 0 and 1, so it's OK to disable the entire coverage.
+  //VCS coverage off
+  // pragma coverage off
   assign err_o = tl_i.a_valid & (|err | (|data_err));
-
+  //VCS coverage on
+  // pragma coverage on
 
   logic unused_tl;
   assign unused_tl = |tl_i;


### PR DESCRIPTION
see the code comments for details
It's better to exclude it for all blocks, so use inline pragma and remove it from sram_ctrl_cov_excl.

Addressed item 2 in https://github.com/lowRISC/opentitan/issues/17103

Signed-off-by: Weicai Yang <weicai@google.com>