### PR TITLE
[rom] Fix rnd_functest breakage

### DIFF
--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -215,14 +215,14 @@ typedef struct dif_entropy_src_health_test_config {
   /**
    * The high threshold for the health test.
    */
-  uint16_t high_threshold;
+  uint32_t high_threshold;
   /**
    * The low threshold for the health test.
    *
    * If the corresponding health test has no low threshold, set to 0, otherwise
    * `dif_entropy_src_health_test_configure()` will return `kDifBadArg`.
    */
-  uint16_t low_threshold;
+  uint32_t low_threshold;
 } dif_entropy_src_health_test_config_t;
 
 /**


### PR DESCRIPTION
This commit introduces the following changes:

1. Switch high and low test config thresholds from uint16 to uint32 in `dif_entropy_src`. This is required to configure the thresholds for both boot and continous entropy modes.
2. Test OTP values before random values in `rnd_functest`. This needed given that entropy_src only allows reducing the size of the test windows at runtime.

Fixes #17101.